### PR TITLE
client-go: type-safe informers and indexers

### DIFF
--- a/hack/apidiff-changelog/main.go
+++ b/hack/apidiff-changelog/main.go
@@ -191,8 +191,10 @@ with three dots (...).`
 		updated  string
 	}
 	var dirsWithChanges []string
+	dirLabel := make(map[string]string) // per-dir annotation: "documented", "added placeholder documentation", or "undocumented"
 	var changelogEntries []changelogEntry
-	documentedDirs := 0
+	foundDirs := 0
+	addedDirs := 0
 
 	fmt.Println()
 
@@ -227,7 +229,8 @@ with three dots (...).`
 		verifyErr := verifyChangelog(changelog, incompatible)
 		if verifyErr == nil {
 			// Already documented; not a failure.
-			documentedDirs++
+			dirLabel[dir] = "documented"
+			foundDirs++
 			continue
 		}
 		if !errors.Is(verifyErr, errVerificationFail) {
@@ -246,7 +249,8 @@ with three dots (...).`
 				return fmt.Errorf("inserting changelog entry for %s: %w", dir, err)
 			}
 			// Now it's documented, so don't treat as failure.
-			documentedDirs++
+			dirLabel[dir] = "added placeholder documentation"
+			addedDirs++
 		} else {
 			// Write the entry into a temp copy for patch generation later.
 			tempChangelog := filepath.Join(tempDir, dir, changelogFilename)
@@ -275,7 +279,11 @@ with three dots (...).`
 Detected incompatible changes on modules:
 `)
 	for _, f := range dirsWithChanges {
-		fmt.Println(f)
+		label := dirLabel[f]
+		if label == "" {
+			label = "undocumented"
+		}
+		fmt.Printf("%s (%s)\n", f, label)
 	}
 	fmt.Print(`
 For more information about incompatible changes, see
@@ -320,9 +328,17 @@ vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 
 	// 3 indicates to apidiff.sh that it should consider the check a success, despite having
 	// some incompatible changes.
-	if len(dirsWithChanges) == documentedDirs {
-		//nolint:staticcheck // ST1005: error strings should not be capitalized - ignored here because exit errors get dumped to stderr as-is and this is more readable.
-		return fmt.Errorf("Found or added documentation of changes in %d module(s)%w", documentedDirs, exitError{3})
+	if len(dirsWithChanges) == foundDirs+addedDirs {
+		var parts []string
+		if foundDirs > 0 {
+			//nolint:staticcheck // ST1005: error strings should not be capitalized - ignored here because exit errors get dumped to stderr as-is and this is more readable.
+			parts = append(parts, fmt.Sprintf("Found documentation of changes in %d module(s)", foundDirs))
+		}
+		if addedDirs > 0 {
+			//nolint:staticcheck // ST1005: error strings should not be capitalized - ignored here because exit errors get dumped to stderr as-is and this is more readable.
+			parts = append(parts, fmt.Sprintf("Added documentation of changes in %d module(s)", addedDirs))
+		}
+		return fmt.Errorf("%s%w", strings.Join(parts, "\n"), exitError{3})
 	}
 
 	// 2 indicates that there's missing documentation or some action must be taken

--- a/hack/update-go-apidocs.sh
+++ b/hack/update-go-apidocs.sh
@@ -28,16 +28,4 @@ dirs=()
 kube::util::read-array dirs < <(grep -v -e'^#' -e '^$' "${KUBE_ROOT}/hack/go-apidocs.conf")
 
 # Base and target revisions are detected automatically by the script.
-if "${KUBE_ROOT}/hack/apidiff.sh" -u "${dirs[@]}"; then
-    cat <<EOF
-
-Congratulations, no Go API changes need to be documented in CHANGELOG.md files!
-EOF
-else
-    cat <<EOF
-
-One or more CHANGELOG.md files were updated using placeholder text.
-Replace that text and include the documentation of your change in
-your branch.
-EOF
-fi
+"${KUBE_ROOT}/hack/apidiff.sh" -u "${dirs[@]}"

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/cr/v1/example.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/cr/v1/example.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ExampleInformer provides access to a shared informer and lister for
-// Examples.
+// Examples. Prefer using the type-safe variant (see [TypedExampleInformer]).
 type ExampleInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() crv1.ExampleLister
 }
+
+// TypedExampleInformer provides access to a shared informer and lister for
+// Examples, including the type-safe TypedInformer variant.
+// It is a superset of ExampleInformer.
+type TypedExampleInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ExampleIndexInformer
+	Lister() crv1.ExampleLister
+}
+
+// ExampleIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ExampleIndexInformer cache.TypedSharedIndexInformer[*apiscrv1.Example]
+
+// ExampleHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Example.
+type ExampleHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiscrv1.Example]
+
+// ExampleDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Example.
+type ExampleDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiscrv1.Example]
+
+// ExampleFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Example.
+type ExampleFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiscrv1.Example]
+
+// ExampleIndexers is a specialization of [cache.TypedIndexers] for Example.
+type ExampleIndexers = cache.TypedIndexers[*apiscrv1.Example]
+
+// DeletedExample is a specialization of [cache.DeletedObject] for Example.
+type DeletedExample = cache.DeletedObject[*apiscrv1.Example]
 
 type exampleInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type exampleInformer struct {
 // NewExampleInformer constructs a new informer for Example type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedExampleInformer]).
 func NewExampleInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewExampleInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedExampleInformer constructs a new informer for Example type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedExampleInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers ExampleIndexers) ExampleIndexInformer {
+	return NewTypedExampleInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredExampleInformer constructs a new informer for Example type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredExampleInformer]).
 func NewFilteredExampleInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewExampleInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedExampleInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredExampleInformer constructs a new informer for Example type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredExampleInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers ExampleIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ExampleIndexInformer {
+	return NewTypedExampleInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewExampleInformerWithOptions constructs a new informer for Example type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedExampleInformerWithOptions]).
 func NewExampleInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedExampleInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedExampleInformerWithOptions constructs a new informer for Example type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedExampleInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) ExampleIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "cr.example.apiextensions.k8s.io", Version: "v1", Resource: "examples"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiscrv1.Example](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewExampleInformerWithOptions(client versioned.Interface, namespace string,
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *exampleInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewExampleInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedExampleInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *exampleInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiscrv1.Example{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *exampleInformer) TypedInformer() ExampleIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiscrv1.Example](f.factory.InformerFor(&apiscrv1.Example{}, f.defaultInformer))
 }
 
 func (f *exampleInformer) Lister() crv1.ExampleLister {
 	return crv1.NewExampleLister(f.Informer().GetIndexer())
+}
+
+// ToTypedExampleInformer converts an untyped informer into a TypedExampleInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Example. If that is not the case, calling type-safe methods of the returned
+// TypedExampleInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedExampleInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedExampleInformer(informer ExampleInformer) TypedExampleInformer {
+	if informer, ok := informer.(TypedExampleInformer); ok {
+		return informer
+	}
+	return &exampleTypedInformerAdapter{informer}
+}
+
+type exampleTypedInformerAdapter struct {
+	ExampleInformer
+}
+
+func (a *exampleTypedInformerAdapter) TypedInformer() ExampleIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiscrv1.Example](a.Informer())
+}
+
+// ToExampleIndexInformer converts an untyped informer into a ExampleIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Example. If that is not the case, calling type-safe methods of the returned
+// ExampleIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ExampleIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToExampleIndexInformer(informer cache.SharedIndexInformer) ExampleIndexInformer {
+	if informer, ok := informer.(ExampleIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiscrv1.Example](informer)
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/cr/v1/interface.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/cr/v1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// Examples returns a ExampleInformer.
-	Examples() ExampleInformer
+	Examples() TypedExampleInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// Examples returns a ExampleInformer.
-func (v *version) Examples() ExampleInformer {
+// Examples returns a TypedExampleInformer.
+func (v *version) Examples() TypedExampleInformer {
 	return &exampleInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1/customresourcedefinition.go
@@ -34,11 +34,39 @@ import (
 )
 
 // CustomResourceDefinitionInformer provides access to a shared informer and lister for
-// CustomResourceDefinitions.
+// CustomResourceDefinitions. Prefer using the type-safe variant (see [TypedCustomResourceDefinitionInformer]).
 type CustomResourceDefinitionInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() apiextensionsv1.CustomResourceDefinitionLister
 }
+
+// TypedCustomResourceDefinitionInformer provides access to a shared informer and lister for
+// CustomResourceDefinitions, including the type-safe TypedInformer variant.
+// It is a superset of CustomResourceDefinitionInformer.
+type TypedCustomResourceDefinitionInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() CustomResourceDefinitionIndexInformer
+	Lister() apiextensionsv1.CustomResourceDefinitionLister
+}
+
+// CustomResourceDefinitionIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type CustomResourceDefinitionIndexInformer cache.TypedSharedIndexInformer[*apisapiextensionsv1.CustomResourceDefinition]
+
+// CustomResourceDefinitionHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for CustomResourceDefinition.
+type CustomResourceDefinitionHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apisapiextensionsv1.CustomResourceDefinition]
+
+// CustomResourceDefinitionDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for CustomResourceDefinition.
+type CustomResourceDefinitionDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apisapiextensionsv1.CustomResourceDefinition]
+
+// CustomResourceDefinitionFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for CustomResourceDefinition.
+type CustomResourceDefinitionFilteringHandler = cache.TypedFilteringResourceEventHandler[*apisapiextensionsv1.CustomResourceDefinition]
+
+// CustomResourceDefinitionIndexers is a specialization of [cache.TypedIndexers] for CustomResourceDefinition.
+type CustomResourceDefinitionIndexers = cache.TypedIndexers[*apisapiextensionsv1.CustomResourceDefinition]
+
+// DeletedCustomResourceDefinition is a specialization of [cache.DeletedObject] for CustomResourceDefinition.
+type DeletedCustomResourceDefinition = cache.DeletedObject[*apisapiextensionsv1.CustomResourceDefinition]
 
 type customResourceDefinitionInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type customResourceDefinitionInformer struct {
 // NewCustomResourceDefinitionInformer constructs a new informer for CustomResourceDefinition type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCustomResourceDefinitionInformer]).
 func NewCustomResourceDefinitionInformer(client clientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewCustomResourceDefinitionInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedCustomResourceDefinitionInformer constructs a new informer for CustomResourceDefinition type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCustomResourceDefinitionInformer(client clientset.Interface, resyncPeriod time.Duration, indexers CustomResourceDefinitionIndexers) CustomResourceDefinitionIndexInformer {
+	return NewTypedCustomResourceDefinitionInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredCustomResourceDefinitionInformer constructs a new informer for CustomResourceDefinition type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredCustomResourceDefinitionInformer]).
 func NewFilteredCustomResourceDefinitionInformer(client clientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewCustomResourceDefinitionInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedCustomResourceDefinitionInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredCustomResourceDefinitionInformer constructs a new informer for CustomResourceDefinition type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredCustomResourceDefinitionInformer(client clientset.Interface, resyncPeriod time.Duration, indexers CustomResourceDefinitionIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) CustomResourceDefinitionIndexInformer {
+	return NewTypedCustomResourceDefinitionInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewCustomResourceDefinitionInformerWithOptions constructs a new informer for CustomResourceDefinition type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCustomResourceDefinitionInformerWithOptions]).
 func NewCustomResourceDefinitionInformerWithOptions(client clientset.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedCustomResourceDefinitionInformerWithOptions(client, options)
+}
+
+// NewTypedCustomResourceDefinitionInformerWithOptions constructs a new informer for CustomResourceDefinition type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCustomResourceDefinitionInformerWithOptions(client clientset.Interface, options internalinterfaces.InformerOptions) CustomResourceDefinitionIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apisapiextensionsv1.CustomResourceDefinition](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewCustomResourceDefinitionInformerWithOptions(client clientset.Interface, 
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *customResourceDefinitionInformer) defaultInformer(client clientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewCustomResourceDefinitionInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedCustomResourceDefinitionInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *customResourceDefinitionInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apisapiextensionsv1.CustomResourceDefinition{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *customResourceDefinitionInformer) TypedInformer() CustomResourceDefinitionIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisapiextensionsv1.CustomResourceDefinition](f.factory.InformerFor(&apisapiextensionsv1.CustomResourceDefinition{}, f.defaultInformer))
 }
 
 func (f *customResourceDefinitionInformer) Lister() apiextensionsv1.CustomResourceDefinitionLister {
 	return apiextensionsv1.NewCustomResourceDefinitionLister(f.Informer().GetIndexer())
+}
+
+// ToTypedCustomResourceDefinitionInformer converts an untyped informer into a TypedCustomResourceDefinitionInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CustomResourceDefinition. If that is not the case, calling type-safe methods of the returned
+// TypedCustomResourceDefinitionInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedCustomResourceDefinitionInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedCustomResourceDefinitionInformer(informer CustomResourceDefinitionInformer) TypedCustomResourceDefinitionInformer {
+	if informer, ok := informer.(TypedCustomResourceDefinitionInformer); ok {
+		return informer
+	}
+	return &customResourceDefinitionTypedInformerAdapter{informer}
+}
+
+type customResourceDefinitionTypedInformerAdapter struct {
+	CustomResourceDefinitionInformer
+}
+
+func (a *customResourceDefinitionTypedInformerAdapter) TypedInformer() CustomResourceDefinitionIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisapiextensionsv1.CustomResourceDefinition](a.Informer())
+}
+
+// ToCustomResourceDefinitionIndexInformer converts an untyped informer into a CustomResourceDefinitionIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CustomResourceDefinition. If that is not the case, calling type-safe methods of the returned
+// CustomResourceDefinitionIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a CustomResourceDefinitionIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToCustomResourceDefinitionIndexInformer(informer cache.SharedIndexInformer) CustomResourceDefinitionIndexInformer {
+	if informer, ok := informer.(CustomResourceDefinitionIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apisapiextensionsv1.CustomResourceDefinition](informer)
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1/interface.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// CustomResourceDefinitions returns a CustomResourceDefinitionInformer.
-	CustomResourceDefinitions() CustomResourceDefinitionInformer
+	CustomResourceDefinitions() TypedCustomResourceDefinitionInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// CustomResourceDefinitions returns a CustomResourceDefinitionInformer.
-func (v *version) CustomResourceDefinitions() CustomResourceDefinitionInformer {
+// CustomResourceDefinitions returns a TypedCustomResourceDefinitionInformer.
+func (v *version) CustomResourceDefinitions() TypedCustomResourceDefinitionInformer {
 	return &customResourceDefinitionInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1/customresourcedefinition.go
@@ -34,11 +34,39 @@ import (
 )
 
 // CustomResourceDefinitionInformer provides access to a shared informer and lister for
-// CustomResourceDefinitions.
+// CustomResourceDefinitions. Prefer using the type-safe variant (see [TypedCustomResourceDefinitionInformer]).
 type CustomResourceDefinitionInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() apiextensionsv1beta1.CustomResourceDefinitionLister
 }
+
+// TypedCustomResourceDefinitionInformer provides access to a shared informer and lister for
+// CustomResourceDefinitions, including the type-safe TypedInformer variant.
+// It is a superset of CustomResourceDefinitionInformer.
+type TypedCustomResourceDefinitionInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() CustomResourceDefinitionIndexInformer
+	Lister() apiextensionsv1beta1.CustomResourceDefinitionLister
+}
+
+// CustomResourceDefinitionIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type CustomResourceDefinitionIndexInformer cache.TypedSharedIndexInformer[*apisapiextensionsv1beta1.CustomResourceDefinition]
+
+// CustomResourceDefinitionHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for CustomResourceDefinition.
+type CustomResourceDefinitionHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apisapiextensionsv1beta1.CustomResourceDefinition]
+
+// CustomResourceDefinitionDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for CustomResourceDefinition.
+type CustomResourceDefinitionDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apisapiextensionsv1beta1.CustomResourceDefinition]
+
+// CustomResourceDefinitionFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for CustomResourceDefinition.
+type CustomResourceDefinitionFilteringHandler = cache.TypedFilteringResourceEventHandler[*apisapiextensionsv1beta1.CustomResourceDefinition]
+
+// CustomResourceDefinitionIndexers is a specialization of [cache.TypedIndexers] for CustomResourceDefinition.
+type CustomResourceDefinitionIndexers = cache.TypedIndexers[*apisapiextensionsv1beta1.CustomResourceDefinition]
+
+// DeletedCustomResourceDefinition is a specialization of [cache.DeletedObject] for CustomResourceDefinition.
+type DeletedCustomResourceDefinition = cache.DeletedObject[*apisapiextensionsv1beta1.CustomResourceDefinition]
 
 type customResourceDefinitionInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type customResourceDefinitionInformer struct {
 // NewCustomResourceDefinitionInformer constructs a new informer for CustomResourceDefinition type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCustomResourceDefinitionInformer]).
 func NewCustomResourceDefinitionInformer(client clientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewCustomResourceDefinitionInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedCustomResourceDefinitionInformer constructs a new informer for CustomResourceDefinition type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCustomResourceDefinitionInformer(client clientset.Interface, resyncPeriod time.Duration, indexers CustomResourceDefinitionIndexers) CustomResourceDefinitionIndexInformer {
+	return NewTypedCustomResourceDefinitionInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredCustomResourceDefinitionInformer constructs a new informer for CustomResourceDefinition type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredCustomResourceDefinitionInformer]).
 func NewFilteredCustomResourceDefinitionInformer(client clientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewCustomResourceDefinitionInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedCustomResourceDefinitionInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredCustomResourceDefinitionInformer constructs a new informer for CustomResourceDefinition type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredCustomResourceDefinitionInformer(client clientset.Interface, resyncPeriod time.Duration, indexers CustomResourceDefinitionIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) CustomResourceDefinitionIndexInformer {
+	return NewTypedCustomResourceDefinitionInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewCustomResourceDefinitionInformerWithOptions constructs a new informer for CustomResourceDefinition type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCustomResourceDefinitionInformerWithOptions]).
 func NewCustomResourceDefinitionInformerWithOptions(client clientset.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedCustomResourceDefinitionInformerWithOptions(client, options)
+}
+
+// NewTypedCustomResourceDefinitionInformerWithOptions constructs a new informer for CustomResourceDefinition type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCustomResourceDefinitionInformerWithOptions(client clientset.Interface, options internalinterfaces.InformerOptions) CustomResourceDefinitionIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1beta1", Resource: "customresourcedefinitions"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apisapiextensionsv1beta1.CustomResourceDefinition](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewCustomResourceDefinitionInformerWithOptions(client clientset.Interface, 
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *customResourceDefinitionInformer) defaultInformer(client clientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewCustomResourceDefinitionInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedCustomResourceDefinitionInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *customResourceDefinitionInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apisapiextensionsv1beta1.CustomResourceDefinition{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *customResourceDefinitionInformer) TypedInformer() CustomResourceDefinitionIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisapiextensionsv1beta1.CustomResourceDefinition](f.factory.InformerFor(&apisapiextensionsv1beta1.CustomResourceDefinition{}, f.defaultInformer))
 }
 
 func (f *customResourceDefinitionInformer) Lister() apiextensionsv1beta1.CustomResourceDefinitionLister {
 	return apiextensionsv1beta1.NewCustomResourceDefinitionLister(f.Informer().GetIndexer())
+}
+
+// ToTypedCustomResourceDefinitionInformer converts an untyped informer into a TypedCustomResourceDefinitionInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CustomResourceDefinition. If that is not the case, calling type-safe methods of the returned
+// TypedCustomResourceDefinitionInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedCustomResourceDefinitionInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedCustomResourceDefinitionInformer(informer CustomResourceDefinitionInformer) TypedCustomResourceDefinitionInformer {
+	if informer, ok := informer.(TypedCustomResourceDefinitionInformer); ok {
+		return informer
+	}
+	return &customResourceDefinitionTypedInformerAdapter{informer}
+}
+
+type customResourceDefinitionTypedInformerAdapter struct {
+	CustomResourceDefinitionInformer
+}
+
+func (a *customResourceDefinitionTypedInformerAdapter) TypedInformer() CustomResourceDefinitionIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisapiextensionsv1beta1.CustomResourceDefinition](a.Informer())
+}
+
+// ToCustomResourceDefinitionIndexInformer converts an untyped informer into a CustomResourceDefinitionIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CustomResourceDefinition. If that is not the case, calling type-safe methods of the returned
+// CustomResourceDefinitionIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a CustomResourceDefinitionIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToCustomResourceDefinitionIndexInformer(informer cache.SharedIndexInformer) CustomResourceDefinitionIndexInformer {
+	if informer, ok := informer.(CustomResourceDefinitionIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apisapiextensionsv1beta1.CustomResourceDefinition](informer)
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1/interface.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// CustomResourceDefinitions returns a CustomResourceDefinitionInformer.
-	CustomResourceDefinitions() CustomResourceDefinitionInformer
+	CustomResourceDefinitions() TypedCustomResourceDefinitionInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// CustomResourceDefinitions returns a CustomResourceDefinitionInformer.
-func (v *version) CustomResourceDefinitions() CustomResourceDefinitionInformer {
+// CustomResourceDefinitions returns a TypedCustomResourceDefinitionInformer.
+func (v *version) CustomResourceDefinitions() TypedCustomResourceDefinitionInformer {
 	return &customResourceDefinitionInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/CHANGELOG.md
+++ b/staging/src/k8s.io/client-go/CHANGELOG.md
@@ -4,6 +4,35 @@ Go API changes are typically not included in the Kubernetes release notes, so
 noteworthy Go API changes *may* be documented here. This is currently not
 *required*, so consult the git history to see all changes.
 
+### Type-safe informers
+
+All code using the result of the generated client-go Informer() methods (a
+cache.SharedIndexInformer) constantly has to do type casts from "any" to the
+actual type of the objects managed by the informer.
+
+This is:
+- annoying at best
+- often done inconsistently (should failed type assertions be logged and if so, how?)
+- a source of bugs (not handling DeletedFinalStateUnknown, type in event handler not matching the type in the informer)
+
+In contrast, the Lister() result is typed. Now the new TypedInformer() methods
+return a variant of the traditional interfaces where event handlers are called
+with objects already cast to the correct type.
+
+Adding this method to each generated informer interface is a breaking
+change. Someone who mocks those interfaces may have to add the TypedInformer
+method to their mock.
+
+
+```
+...
+- ./informers/apps/v1.Interface.ControllerRevisions: changed from func() ControllerRevisionInformer to func() TypedControllerRevisionInformer
+- ./informers/apps/v1.Interface.DaemonSets: changed from func() DaemonSetInformer to func() TypedDaemonSetInformer
+- ./informers/apps/v1.Interface.Deployments: changed from func() DeploymentInformer to func() TypedDeploymentInformer
+- ./informers/apps/v1.ReplicaSetInformer: changed from ReplicaSetInformer to ReplicaSetInformer
+...
+```
+
 ### mutation cache: support informer events
 
 Calling OnAddOrUpdate and OnDelete from event handlers is optional. Calling

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1/interface.go
@@ -25,17 +25,17 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// MutatingAdmissionPolicies returns a MutatingAdmissionPolicyInformer.
-	MutatingAdmissionPolicies() MutatingAdmissionPolicyInformer
+	MutatingAdmissionPolicies() TypedMutatingAdmissionPolicyInformer
 	// MutatingAdmissionPolicyBindings returns a MutatingAdmissionPolicyBindingInformer.
-	MutatingAdmissionPolicyBindings() MutatingAdmissionPolicyBindingInformer
+	MutatingAdmissionPolicyBindings() TypedMutatingAdmissionPolicyBindingInformer
 	// MutatingWebhookConfigurations returns a MutatingWebhookConfigurationInformer.
-	MutatingWebhookConfigurations() MutatingWebhookConfigurationInformer
+	MutatingWebhookConfigurations() TypedMutatingWebhookConfigurationInformer
 	// ValidatingAdmissionPolicies returns a ValidatingAdmissionPolicyInformer.
-	ValidatingAdmissionPolicies() ValidatingAdmissionPolicyInformer
+	ValidatingAdmissionPolicies() TypedValidatingAdmissionPolicyInformer
 	// ValidatingAdmissionPolicyBindings returns a ValidatingAdmissionPolicyBindingInformer.
-	ValidatingAdmissionPolicyBindings() ValidatingAdmissionPolicyBindingInformer
+	ValidatingAdmissionPolicyBindings() TypedValidatingAdmissionPolicyBindingInformer
 	// ValidatingWebhookConfigurations returns a ValidatingWebhookConfigurationInformer.
-	ValidatingWebhookConfigurations() ValidatingWebhookConfigurationInformer
+	ValidatingWebhookConfigurations() TypedValidatingWebhookConfigurationInformer
 }
 
 type version struct {
@@ -49,32 +49,32 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// MutatingAdmissionPolicies returns a MutatingAdmissionPolicyInformer.
-func (v *version) MutatingAdmissionPolicies() MutatingAdmissionPolicyInformer {
+// MutatingAdmissionPolicies returns a TypedMutatingAdmissionPolicyInformer.
+func (v *version) MutatingAdmissionPolicies() TypedMutatingAdmissionPolicyInformer {
 	return &mutatingAdmissionPolicyInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// MutatingAdmissionPolicyBindings returns a MutatingAdmissionPolicyBindingInformer.
-func (v *version) MutatingAdmissionPolicyBindings() MutatingAdmissionPolicyBindingInformer {
+// MutatingAdmissionPolicyBindings returns a TypedMutatingAdmissionPolicyBindingInformer.
+func (v *version) MutatingAdmissionPolicyBindings() TypedMutatingAdmissionPolicyBindingInformer {
 	return &mutatingAdmissionPolicyBindingInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// MutatingWebhookConfigurations returns a MutatingWebhookConfigurationInformer.
-func (v *version) MutatingWebhookConfigurations() MutatingWebhookConfigurationInformer {
+// MutatingWebhookConfigurations returns a TypedMutatingWebhookConfigurationInformer.
+func (v *version) MutatingWebhookConfigurations() TypedMutatingWebhookConfigurationInformer {
 	return &mutatingWebhookConfigurationInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// ValidatingAdmissionPolicies returns a ValidatingAdmissionPolicyInformer.
-func (v *version) ValidatingAdmissionPolicies() ValidatingAdmissionPolicyInformer {
+// ValidatingAdmissionPolicies returns a TypedValidatingAdmissionPolicyInformer.
+func (v *version) ValidatingAdmissionPolicies() TypedValidatingAdmissionPolicyInformer {
 	return &validatingAdmissionPolicyInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// ValidatingAdmissionPolicyBindings returns a ValidatingAdmissionPolicyBindingInformer.
-func (v *version) ValidatingAdmissionPolicyBindings() ValidatingAdmissionPolicyBindingInformer {
+// ValidatingAdmissionPolicyBindings returns a TypedValidatingAdmissionPolicyBindingInformer.
+func (v *version) ValidatingAdmissionPolicyBindings() TypedValidatingAdmissionPolicyBindingInformer {
 	return &validatingAdmissionPolicyBindingInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// ValidatingWebhookConfigurations returns a ValidatingWebhookConfigurationInformer.
-func (v *version) ValidatingWebhookConfigurations() ValidatingWebhookConfigurationInformer {
+// ValidatingWebhookConfigurations returns a TypedValidatingWebhookConfigurationInformer.
+func (v *version) ValidatingWebhookConfigurations() TypedValidatingWebhookConfigurationInformer {
 	return &validatingWebhookConfigurationInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1/mutatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1/mutatingadmissionpolicy.go
@@ -34,11 +34,39 @@ import (
 )
 
 // MutatingAdmissionPolicyInformer provides access to a shared informer and lister for
-// MutatingAdmissionPolicies.
+// MutatingAdmissionPolicies. Prefer using the type-safe variant (see [TypedMutatingAdmissionPolicyInformer]).
 type MutatingAdmissionPolicyInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() admissionregistrationv1.MutatingAdmissionPolicyLister
 }
+
+// TypedMutatingAdmissionPolicyInformer provides access to a shared informer and lister for
+// MutatingAdmissionPolicies, including the type-safe TypedInformer variant.
+// It is a superset of MutatingAdmissionPolicyInformer.
+type TypedMutatingAdmissionPolicyInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() MutatingAdmissionPolicyIndexInformer
+	Lister() admissionregistrationv1.MutatingAdmissionPolicyLister
+}
+
+// MutatingAdmissionPolicyIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type MutatingAdmissionPolicyIndexInformer cache.TypedSharedIndexInformer[*apiadmissionregistrationv1.MutatingAdmissionPolicy]
+
+// MutatingAdmissionPolicyHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for MutatingAdmissionPolicy.
+type MutatingAdmissionPolicyHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiadmissionregistrationv1.MutatingAdmissionPolicy]
+
+// MutatingAdmissionPolicyDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for MutatingAdmissionPolicy.
+type MutatingAdmissionPolicyDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiadmissionregistrationv1.MutatingAdmissionPolicy]
+
+// MutatingAdmissionPolicyFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for MutatingAdmissionPolicy.
+type MutatingAdmissionPolicyFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiadmissionregistrationv1.MutatingAdmissionPolicy]
+
+// MutatingAdmissionPolicyIndexers is a specialization of [cache.TypedIndexers] for MutatingAdmissionPolicy.
+type MutatingAdmissionPolicyIndexers = cache.TypedIndexers[*apiadmissionregistrationv1.MutatingAdmissionPolicy]
+
+// DeletedMutatingAdmissionPolicy is a specialization of [cache.DeletedObject] for MutatingAdmissionPolicy.
+type DeletedMutatingAdmissionPolicy = cache.DeletedObject[*apiadmissionregistrationv1.MutatingAdmissionPolicy]
 
 type mutatingAdmissionPolicyInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type mutatingAdmissionPolicyInformer struct {
 // NewMutatingAdmissionPolicyInformer constructs a new informer for MutatingAdmissionPolicy type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedMutatingAdmissionPolicyInformer]).
 func NewMutatingAdmissionPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewMutatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedMutatingAdmissionPolicyInformer constructs a new informer for MutatingAdmissionPolicy type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedMutatingAdmissionPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers MutatingAdmissionPolicyIndexers) MutatingAdmissionPolicyIndexInformer {
+	return NewTypedMutatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredMutatingAdmissionPolicyInformer constructs a new informer for MutatingAdmissionPolicy type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredMutatingAdmissionPolicyInformer]).
 func NewFilteredMutatingAdmissionPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewMutatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedMutatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredMutatingAdmissionPolicyInformer constructs a new informer for MutatingAdmissionPolicy type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredMutatingAdmissionPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers MutatingAdmissionPolicyIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) MutatingAdmissionPolicyIndexInformer {
+	return NewTypedMutatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewMutatingAdmissionPolicyInformerWithOptions constructs a new informer for MutatingAdmissionPolicy type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedMutatingAdmissionPolicyInformerWithOptions]).
 func NewMutatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedMutatingAdmissionPolicyInformerWithOptions(client, options)
+}
+
+// NewTypedMutatingAdmissionPolicyInformerWithOptions constructs a new informer for MutatingAdmissionPolicy type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedMutatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) MutatingAdmissionPolicyIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1", Resource: "mutatingadmissionpolicys"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1.MutatingAdmissionPolicy](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewMutatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface, 
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *mutatingAdmissionPolicyInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewMutatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedMutatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *mutatingAdmissionPolicyInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiadmissionregistrationv1.MutatingAdmissionPolicy{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *mutatingAdmissionPolicyInformer) TypedInformer() MutatingAdmissionPolicyIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1.MutatingAdmissionPolicy](f.factory.InformerFor(&apiadmissionregistrationv1.MutatingAdmissionPolicy{}, f.defaultInformer))
 }
 
 func (f *mutatingAdmissionPolicyInformer) Lister() admissionregistrationv1.MutatingAdmissionPolicyLister {
 	return admissionregistrationv1.NewMutatingAdmissionPolicyLister(f.Informer().GetIndexer())
+}
+
+// ToTypedMutatingAdmissionPolicyInformer converts an untyped informer into a TypedMutatingAdmissionPolicyInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *MutatingAdmissionPolicy. If that is not the case, calling type-safe methods of the returned
+// TypedMutatingAdmissionPolicyInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedMutatingAdmissionPolicyInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedMutatingAdmissionPolicyInformer(informer MutatingAdmissionPolicyInformer) TypedMutatingAdmissionPolicyInformer {
+	if informer, ok := informer.(TypedMutatingAdmissionPolicyInformer); ok {
+		return informer
+	}
+	return &mutatingAdmissionPolicyTypedInformerAdapter{informer}
+}
+
+type mutatingAdmissionPolicyTypedInformerAdapter struct {
+	MutatingAdmissionPolicyInformer
+}
+
+func (a *mutatingAdmissionPolicyTypedInformerAdapter) TypedInformer() MutatingAdmissionPolicyIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1.MutatingAdmissionPolicy](a.Informer())
+}
+
+// ToMutatingAdmissionPolicyIndexInformer converts an untyped informer into a MutatingAdmissionPolicyIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *MutatingAdmissionPolicy. If that is not the case, calling type-safe methods of the returned
+// MutatingAdmissionPolicyIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a MutatingAdmissionPolicyIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToMutatingAdmissionPolicyIndexInformer(informer cache.SharedIndexInformer) MutatingAdmissionPolicyIndexInformer {
+	if informer, ok := informer.(MutatingAdmissionPolicyIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1.MutatingAdmissionPolicy](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1/mutatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1/mutatingadmissionpolicybinding.go
@@ -34,11 +34,39 @@ import (
 )
 
 // MutatingAdmissionPolicyBindingInformer provides access to a shared informer and lister for
-// MutatingAdmissionPolicyBindings.
+// MutatingAdmissionPolicyBindings. Prefer using the type-safe variant (see [TypedMutatingAdmissionPolicyBindingInformer]).
 type MutatingAdmissionPolicyBindingInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() admissionregistrationv1.MutatingAdmissionPolicyBindingLister
 }
+
+// TypedMutatingAdmissionPolicyBindingInformer provides access to a shared informer and lister for
+// MutatingAdmissionPolicyBindings, including the type-safe TypedInformer variant.
+// It is a superset of MutatingAdmissionPolicyBindingInformer.
+type TypedMutatingAdmissionPolicyBindingInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() MutatingAdmissionPolicyBindingIndexInformer
+	Lister() admissionregistrationv1.MutatingAdmissionPolicyBindingLister
+}
+
+// MutatingAdmissionPolicyBindingIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type MutatingAdmissionPolicyBindingIndexInformer cache.TypedSharedIndexInformer[*apiadmissionregistrationv1.MutatingAdmissionPolicyBinding]
+
+// MutatingAdmissionPolicyBindingHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for MutatingAdmissionPolicyBinding.
+type MutatingAdmissionPolicyBindingHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiadmissionregistrationv1.MutatingAdmissionPolicyBinding]
+
+// MutatingAdmissionPolicyBindingDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for MutatingAdmissionPolicyBinding.
+type MutatingAdmissionPolicyBindingDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiadmissionregistrationv1.MutatingAdmissionPolicyBinding]
+
+// MutatingAdmissionPolicyBindingFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for MutatingAdmissionPolicyBinding.
+type MutatingAdmissionPolicyBindingFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiadmissionregistrationv1.MutatingAdmissionPolicyBinding]
+
+// MutatingAdmissionPolicyBindingIndexers is a specialization of [cache.TypedIndexers] for MutatingAdmissionPolicyBinding.
+type MutatingAdmissionPolicyBindingIndexers = cache.TypedIndexers[*apiadmissionregistrationv1.MutatingAdmissionPolicyBinding]
+
+// DeletedMutatingAdmissionPolicyBinding is a specialization of [cache.DeletedObject] for MutatingAdmissionPolicyBinding.
+type DeletedMutatingAdmissionPolicyBinding = cache.DeletedObject[*apiadmissionregistrationv1.MutatingAdmissionPolicyBinding]
 
 type mutatingAdmissionPolicyBindingInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type mutatingAdmissionPolicyBindingInformer struct {
 // NewMutatingAdmissionPolicyBindingInformer constructs a new informer for MutatingAdmissionPolicyBinding type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedMutatingAdmissionPolicyBindingInformer]).
 func NewMutatingAdmissionPolicyBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewMutatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedMutatingAdmissionPolicyBindingInformer constructs a new informer for MutatingAdmissionPolicyBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedMutatingAdmissionPolicyBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers MutatingAdmissionPolicyBindingIndexers) MutatingAdmissionPolicyBindingIndexInformer {
+	return NewTypedMutatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredMutatingAdmissionPolicyBindingInformer constructs a new informer for MutatingAdmissionPolicyBinding type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredMutatingAdmissionPolicyBindingInformer]).
 func NewFilteredMutatingAdmissionPolicyBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewMutatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedMutatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredMutatingAdmissionPolicyBindingInformer constructs a new informer for MutatingAdmissionPolicyBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredMutatingAdmissionPolicyBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers MutatingAdmissionPolicyBindingIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) MutatingAdmissionPolicyBindingIndexInformer {
+	return NewTypedMutatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewMutatingAdmissionPolicyBindingInformerWithOptions constructs a new informer for MutatingAdmissionPolicyBinding type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedMutatingAdmissionPolicyBindingInformerWithOptions]).
 func NewMutatingAdmissionPolicyBindingInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedMutatingAdmissionPolicyBindingInformerWithOptions(client, options)
+}
+
+// NewTypedMutatingAdmissionPolicyBindingInformerWithOptions constructs a new informer for MutatingAdmissionPolicyBinding type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedMutatingAdmissionPolicyBindingInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) MutatingAdmissionPolicyBindingIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1", Resource: "mutatingadmissionpolicybindings"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1.MutatingAdmissionPolicyBinding](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewMutatingAdmissionPolicyBindingInformerWithOptions(client kubernetes.Inte
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *mutatingAdmissionPolicyBindingInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewMutatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedMutatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *mutatingAdmissionPolicyBindingInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiadmissionregistrationv1.MutatingAdmissionPolicyBinding{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *mutatingAdmissionPolicyBindingInformer) TypedInformer() MutatingAdmissionPolicyBindingIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1.MutatingAdmissionPolicyBinding](f.factory.InformerFor(&apiadmissionregistrationv1.MutatingAdmissionPolicyBinding{}, f.defaultInformer))
 }
 
 func (f *mutatingAdmissionPolicyBindingInformer) Lister() admissionregistrationv1.MutatingAdmissionPolicyBindingLister {
 	return admissionregistrationv1.NewMutatingAdmissionPolicyBindingLister(f.Informer().GetIndexer())
+}
+
+// ToTypedMutatingAdmissionPolicyBindingInformer converts an untyped informer into a TypedMutatingAdmissionPolicyBindingInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *MutatingAdmissionPolicyBinding. If that is not the case, calling type-safe methods of the returned
+// TypedMutatingAdmissionPolicyBindingInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedMutatingAdmissionPolicyBindingInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedMutatingAdmissionPolicyBindingInformer(informer MutatingAdmissionPolicyBindingInformer) TypedMutatingAdmissionPolicyBindingInformer {
+	if informer, ok := informer.(TypedMutatingAdmissionPolicyBindingInformer); ok {
+		return informer
+	}
+	return &mutatingAdmissionPolicyBindingTypedInformerAdapter{informer}
+}
+
+type mutatingAdmissionPolicyBindingTypedInformerAdapter struct {
+	MutatingAdmissionPolicyBindingInformer
+}
+
+func (a *mutatingAdmissionPolicyBindingTypedInformerAdapter) TypedInformer() MutatingAdmissionPolicyBindingIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1.MutatingAdmissionPolicyBinding](a.Informer())
+}
+
+// ToMutatingAdmissionPolicyBindingIndexInformer converts an untyped informer into a MutatingAdmissionPolicyBindingIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *MutatingAdmissionPolicyBinding. If that is not the case, calling type-safe methods of the returned
+// MutatingAdmissionPolicyBindingIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a MutatingAdmissionPolicyBindingIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToMutatingAdmissionPolicyBindingIndexInformer(informer cache.SharedIndexInformer) MutatingAdmissionPolicyBindingIndexInformer {
+	if informer, ok := informer.(MutatingAdmissionPolicyBindingIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1.MutatingAdmissionPolicyBinding](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1/mutatingwebhookconfiguration.go
@@ -34,11 +34,39 @@ import (
 )
 
 // MutatingWebhookConfigurationInformer provides access to a shared informer and lister for
-// MutatingWebhookConfigurations.
+// MutatingWebhookConfigurations. Prefer using the type-safe variant (see [TypedMutatingWebhookConfigurationInformer]).
 type MutatingWebhookConfigurationInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() admissionregistrationv1.MutatingWebhookConfigurationLister
 }
+
+// TypedMutatingWebhookConfigurationInformer provides access to a shared informer and lister for
+// MutatingWebhookConfigurations, including the type-safe TypedInformer variant.
+// It is a superset of MutatingWebhookConfigurationInformer.
+type TypedMutatingWebhookConfigurationInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() MutatingWebhookConfigurationIndexInformer
+	Lister() admissionregistrationv1.MutatingWebhookConfigurationLister
+}
+
+// MutatingWebhookConfigurationIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type MutatingWebhookConfigurationIndexInformer cache.TypedSharedIndexInformer[*apiadmissionregistrationv1.MutatingWebhookConfiguration]
+
+// MutatingWebhookConfigurationHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for MutatingWebhookConfiguration.
+type MutatingWebhookConfigurationHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiadmissionregistrationv1.MutatingWebhookConfiguration]
+
+// MutatingWebhookConfigurationDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for MutatingWebhookConfiguration.
+type MutatingWebhookConfigurationDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiadmissionregistrationv1.MutatingWebhookConfiguration]
+
+// MutatingWebhookConfigurationFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for MutatingWebhookConfiguration.
+type MutatingWebhookConfigurationFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiadmissionregistrationv1.MutatingWebhookConfiguration]
+
+// MutatingWebhookConfigurationIndexers is a specialization of [cache.TypedIndexers] for MutatingWebhookConfiguration.
+type MutatingWebhookConfigurationIndexers = cache.TypedIndexers[*apiadmissionregistrationv1.MutatingWebhookConfiguration]
+
+// DeletedMutatingWebhookConfiguration is a specialization of [cache.DeletedObject] for MutatingWebhookConfiguration.
+type DeletedMutatingWebhookConfiguration = cache.DeletedObject[*apiadmissionregistrationv1.MutatingWebhookConfiguration]
 
 type mutatingWebhookConfigurationInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type mutatingWebhookConfigurationInformer struct {
 // NewMutatingWebhookConfigurationInformer constructs a new informer for MutatingWebhookConfiguration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedMutatingWebhookConfigurationInformer]).
 func NewMutatingWebhookConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewMutatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedMutatingWebhookConfigurationInformer constructs a new informer for MutatingWebhookConfiguration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedMutatingWebhookConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers MutatingWebhookConfigurationIndexers) MutatingWebhookConfigurationIndexInformer {
+	return NewTypedMutatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredMutatingWebhookConfigurationInformer constructs a new informer for MutatingWebhookConfiguration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredMutatingWebhookConfigurationInformer]).
 func NewFilteredMutatingWebhookConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewMutatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedMutatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredMutatingWebhookConfigurationInformer constructs a new informer for MutatingWebhookConfiguration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredMutatingWebhookConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers MutatingWebhookConfigurationIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) MutatingWebhookConfigurationIndexInformer {
+	return NewTypedMutatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewMutatingWebhookConfigurationInformerWithOptions constructs a new informer for MutatingWebhookConfiguration type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedMutatingWebhookConfigurationInformerWithOptions]).
 func NewMutatingWebhookConfigurationInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedMutatingWebhookConfigurationInformerWithOptions(client, options)
+}
+
+// NewTypedMutatingWebhookConfigurationInformerWithOptions constructs a new informer for MutatingWebhookConfiguration type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedMutatingWebhookConfigurationInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) MutatingWebhookConfigurationIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1", Resource: "mutatingwebhookconfigurations"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1.MutatingWebhookConfiguration](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewMutatingWebhookConfigurationInformerWithOptions(client kubernetes.Interf
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *mutatingWebhookConfigurationInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewMutatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedMutatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *mutatingWebhookConfigurationInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiadmissionregistrationv1.MutatingWebhookConfiguration{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *mutatingWebhookConfigurationInformer) TypedInformer() MutatingWebhookConfigurationIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1.MutatingWebhookConfiguration](f.factory.InformerFor(&apiadmissionregistrationv1.MutatingWebhookConfiguration{}, f.defaultInformer))
 }
 
 func (f *mutatingWebhookConfigurationInformer) Lister() admissionregistrationv1.MutatingWebhookConfigurationLister {
 	return admissionregistrationv1.NewMutatingWebhookConfigurationLister(f.Informer().GetIndexer())
+}
+
+// ToTypedMutatingWebhookConfigurationInformer converts an untyped informer into a TypedMutatingWebhookConfigurationInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *MutatingWebhookConfiguration. If that is not the case, calling type-safe methods of the returned
+// TypedMutatingWebhookConfigurationInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedMutatingWebhookConfigurationInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedMutatingWebhookConfigurationInformer(informer MutatingWebhookConfigurationInformer) TypedMutatingWebhookConfigurationInformer {
+	if informer, ok := informer.(TypedMutatingWebhookConfigurationInformer); ok {
+		return informer
+	}
+	return &mutatingWebhookConfigurationTypedInformerAdapter{informer}
+}
+
+type mutatingWebhookConfigurationTypedInformerAdapter struct {
+	MutatingWebhookConfigurationInformer
+}
+
+func (a *mutatingWebhookConfigurationTypedInformerAdapter) TypedInformer() MutatingWebhookConfigurationIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1.MutatingWebhookConfiguration](a.Informer())
+}
+
+// ToMutatingWebhookConfigurationIndexInformer converts an untyped informer into a MutatingWebhookConfigurationIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *MutatingWebhookConfiguration. If that is not the case, calling type-safe methods of the returned
+// MutatingWebhookConfigurationIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a MutatingWebhookConfigurationIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToMutatingWebhookConfigurationIndexInformer(informer cache.SharedIndexInformer) MutatingWebhookConfigurationIndexInformer {
+	if informer, ok := informer.(MutatingWebhookConfigurationIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1.MutatingWebhookConfiguration](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1/validatingadmissionpolicy.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ValidatingAdmissionPolicyInformer provides access to a shared informer and lister for
-// ValidatingAdmissionPolicies.
+// ValidatingAdmissionPolicies. Prefer using the type-safe variant (see [TypedValidatingAdmissionPolicyInformer]).
 type ValidatingAdmissionPolicyInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() admissionregistrationv1.ValidatingAdmissionPolicyLister
 }
+
+// TypedValidatingAdmissionPolicyInformer provides access to a shared informer and lister for
+// ValidatingAdmissionPolicies, including the type-safe TypedInformer variant.
+// It is a superset of ValidatingAdmissionPolicyInformer.
+type TypedValidatingAdmissionPolicyInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ValidatingAdmissionPolicyIndexInformer
+	Lister() admissionregistrationv1.ValidatingAdmissionPolicyLister
+}
+
+// ValidatingAdmissionPolicyIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ValidatingAdmissionPolicyIndexInformer cache.TypedSharedIndexInformer[*apiadmissionregistrationv1.ValidatingAdmissionPolicy]
+
+// ValidatingAdmissionPolicyHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ValidatingAdmissionPolicy.
+type ValidatingAdmissionPolicyHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiadmissionregistrationv1.ValidatingAdmissionPolicy]
+
+// ValidatingAdmissionPolicyDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ValidatingAdmissionPolicy.
+type ValidatingAdmissionPolicyDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiadmissionregistrationv1.ValidatingAdmissionPolicy]
+
+// ValidatingAdmissionPolicyFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ValidatingAdmissionPolicy.
+type ValidatingAdmissionPolicyFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiadmissionregistrationv1.ValidatingAdmissionPolicy]
+
+// ValidatingAdmissionPolicyIndexers is a specialization of [cache.TypedIndexers] for ValidatingAdmissionPolicy.
+type ValidatingAdmissionPolicyIndexers = cache.TypedIndexers[*apiadmissionregistrationv1.ValidatingAdmissionPolicy]
+
+// DeletedValidatingAdmissionPolicy is a specialization of [cache.DeletedObject] for ValidatingAdmissionPolicy.
+type DeletedValidatingAdmissionPolicy = cache.DeletedObject[*apiadmissionregistrationv1.ValidatingAdmissionPolicy]
 
 type validatingAdmissionPolicyInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type validatingAdmissionPolicyInformer struct {
 // NewValidatingAdmissionPolicyInformer constructs a new informer for ValidatingAdmissionPolicy type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedValidatingAdmissionPolicyInformer]).
 func NewValidatingAdmissionPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewValidatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedValidatingAdmissionPolicyInformer constructs a new informer for ValidatingAdmissionPolicy type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedValidatingAdmissionPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ValidatingAdmissionPolicyIndexers) ValidatingAdmissionPolicyIndexInformer {
+	return NewTypedValidatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredValidatingAdmissionPolicyInformer constructs a new informer for ValidatingAdmissionPolicy type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredValidatingAdmissionPolicyInformer]).
 func NewFilteredValidatingAdmissionPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewValidatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedValidatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredValidatingAdmissionPolicyInformer constructs a new informer for ValidatingAdmissionPolicy type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredValidatingAdmissionPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ValidatingAdmissionPolicyIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ValidatingAdmissionPolicyIndexInformer {
+	return NewTypedValidatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewValidatingAdmissionPolicyInformerWithOptions constructs a new informer for ValidatingAdmissionPolicy type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedValidatingAdmissionPolicyInformerWithOptions]).
 func NewValidatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedValidatingAdmissionPolicyInformerWithOptions(client, options)
+}
+
+// NewTypedValidatingAdmissionPolicyInformerWithOptions constructs a new informer for ValidatingAdmissionPolicy type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedValidatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ValidatingAdmissionPolicyIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1", Resource: "validatingadmissionpolicys"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1.ValidatingAdmissionPolicy](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewValidatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *validatingAdmissionPolicyInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewValidatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedValidatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *validatingAdmissionPolicyInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiadmissionregistrationv1.ValidatingAdmissionPolicy{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *validatingAdmissionPolicyInformer) TypedInformer() ValidatingAdmissionPolicyIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1.ValidatingAdmissionPolicy](f.factory.InformerFor(&apiadmissionregistrationv1.ValidatingAdmissionPolicy{}, f.defaultInformer))
 }
 
 func (f *validatingAdmissionPolicyInformer) Lister() admissionregistrationv1.ValidatingAdmissionPolicyLister {
 	return admissionregistrationv1.NewValidatingAdmissionPolicyLister(f.Informer().GetIndexer())
+}
+
+// ToTypedValidatingAdmissionPolicyInformer converts an untyped informer into a TypedValidatingAdmissionPolicyInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ValidatingAdmissionPolicy. If that is not the case, calling type-safe methods of the returned
+// TypedValidatingAdmissionPolicyInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedValidatingAdmissionPolicyInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedValidatingAdmissionPolicyInformer(informer ValidatingAdmissionPolicyInformer) TypedValidatingAdmissionPolicyInformer {
+	if informer, ok := informer.(TypedValidatingAdmissionPolicyInformer); ok {
+		return informer
+	}
+	return &validatingAdmissionPolicyTypedInformerAdapter{informer}
+}
+
+type validatingAdmissionPolicyTypedInformerAdapter struct {
+	ValidatingAdmissionPolicyInformer
+}
+
+func (a *validatingAdmissionPolicyTypedInformerAdapter) TypedInformer() ValidatingAdmissionPolicyIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1.ValidatingAdmissionPolicy](a.Informer())
+}
+
+// ToValidatingAdmissionPolicyIndexInformer converts an untyped informer into a ValidatingAdmissionPolicyIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ValidatingAdmissionPolicy. If that is not the case, calling type-safe methods of the returned
+// ValidatingAdmissionPolicyIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ValidatingAdmissionPolicyIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToValidatingAdmissionPolicyIndexInformer(informer cache.SharedIndexInformer) ValidatingAdmissionPolicyIndexInformer {
+	if informer, ok := informer.(ValidatingAdmissionPolicyIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1.ValidatingAdmissionPolicy](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1/validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1/validatingadmissionpolicybinding.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ValidatingAdmissionPolicyBindingInformer provides access to a shared informer and lister for
-// ValidatingAdmissionPolicyBindings.
+// ValidatingAdmissionPolicyBindings. Prefer using the type-safe variant (see [TypedValidatingAdmissionPolicyBindingInformer]).
 type ValidatingAdmissionPolicyBindingInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() admissionregistrationv1.ValidatingAdmissionPolicyBindingLister
 }
+
+// TypedValidatingAdmissionPolicyBindingInformer provides access to a shared informer and lister for
+// ValidatingAdmissionPolicyBindings, including the type-safe TypedInformer variant.
+// It is a superset of ValidatingAdmissionPolicyBindingInformer.
+type TypedValidatingAdmissionPolicyBindingInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ValidatingAdmissionPolicyBindingIndexInformer
+	Lister() admissionregistrationv1.ValidatingAdmissionPolicyBindingLister
+}
+
+// ValidatingAdmissionPolicyBindingIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ValidatingAdmissionPolicyBindingIndexInformer cache.TypedSharedIndexInformer[*apiadmissionregistrationv1.ValidatingAdmissionPolicyBinding]
+
+// ValidatingAdmissionPolicyBindingHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ValidatingAdmissionPolicyBinding.
+type ValidatingAdmissionPolicyBindingHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiadmissionregistrationv1.ValidatingAdmissionPolicyBinding]
+
+// ValidatingAdmissionPolicyBindingDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ValidatingAdmissionPolicyBinding.
+type ValidatingAdmissionPolicyBindingDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiadmissionregistrationv1.ValidatingAdmissionPolicyBinding]
+
+// ValidatingAdmissionPolicyBindingFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ValidatingAdmissionPolicyBinding.
+type ValidatingAdmissionPolicyBindingFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiadmissionregistrationv1.ValidatingAdmissionPolicyBinding]
+
+// ValidatingAdmissionPolicyBindingIndexers is a specialization of [cache.TypedIndexers] for ValidatingAdmissionPolicyBinding.
+type ValidatingAdmissionPolicyBindingIndexers = cache.TypedIndexers[*apiadmissionregistrationv1.ValidatingAdmissionPolicyBinding]
+
+// DeletedValidatingAdmissionPolicyBinding is a specialization of [cache.DeletedObject] for ValidatingAdmissionPolicyBinding.
+type DeletedValidatingAdmissionPolicyBinding = cache.DeletedObject[*apiadmissionregistrationv1.ValidatingAdmissionPolicyBinding]
 
 type validatingAdmissionPolicyBindingInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type validatingAdmissionPolicyBindingInformer struct {
 // NewValidatingAdmissionPolicyBindingInformer constructs a new informer for ValidatingAdmissionPolicyBinding type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedValidatingAdmissionPolicyBindingInformer]).
 func NewValidatingAdmissionPolicyBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewValidatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedValidatingAdmissionPolicyBindingInformer constructs a new informer for ValidatingAdmissionPolicyBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedValidatingAdmissionPolicyBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ValidatingAdmissionPolicyBindingIndexers) ValidatingAdmissionPolicyBindingIndexInformer {
+	return NewTypedValidatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredValidatingAdmissionPolicyBindingInformer constructs a new informer for ValidatingAdmissionPolicyBinding type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredValidatingAdmissionPolicyBindingInformer]).
 func NewFilteredValidatingAdmissionPolicyBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewValidatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedValidatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredValidatingAdmissionPolicyBindingInformer constructs a new informer for ValidatingAdmissionPolicyBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredValidatingAdmissionPolicyBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ValidatingAdmissionPolicyBindingIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ValidatingAdmissionPolicyBindingIndexInformer {
+	return NewTypedValidatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewValidatingAdmissionPolicyBindingInformerWithOptions constructs a new informer for ValidatingAdmissionPolicyBinding type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedValidatingAdmissionPolicyBindingInformerWithOptions]).
 func NewValidatingAdmissionPolicyBindingInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedValidatingAdmissionPolicyBindingInformerWithOptions(client, options)
+}
+
+// NewTypedValidatingAdmissionPolicyBindingInformerWithOptions constructs a new informer for ValidatingAdmissionPolicyBinding type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedValidatingAdmissionPolicyBindingInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ValidatingAdmissionPolicyBindingIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1", Resource: "validatingadmissionpolicybindings"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1.ValidatingAdmissionPolicyBinding](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewValidatingAdmissionPolicyBindingInformerWithOptions(client kubernetes.In
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *validatingAdmissionPolicyBindingInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewValidatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedValidatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *validatingAdmissionPolicyBindingInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiadmissionregistrationv1.ValidatingAdmissionPolicyBinding{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *validatingAdmissionPolicyBindingInformer) TypedInformer() ValidatingAdmissionPolicyBindingIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1.ValidatingAdmissionPolicyBinding](f.factory.InformerFor(&apiadmissionregistrationv1.ValidatingAdmissionPolicyBinding{}, f.defaultInformer))
 }
 
 func (f *validatingAdmissionPolicyBindingInformer) Lister() admissionregistrationv1.ValidatingAdmissionPolicyBindingLister {
 	return admissionregistrationv1.NewValidatingAdmissionPolicyBindingLister(f.Informer().GetIndexer())
+}
+
+// ToTypedValidatingAdmissionPolicyBindingInformer converts an untyped informer into a TypedValidatingAdmissionPolicyBindingInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ValidatingAdmissionPolicyBinding. If that is not the case, calling type-safe methods of the returned
+// TypedValidatingAdmissionPolicyBindingInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedValidatingAdmissionPolicyBindingInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedValidatingAdmissionPolicyBindingInformer(informer ValidatingAdmissionPolicyBindingInformer) TypedValidatingAdmissionPolicyBindingInformer {
+	if informer, ok := informer.(TypedValidatingAdmissionPolicyBindingInformer); ok {
+		return informer
+	}
+	return &validatingAdmissionPolicyBindingTypedInformerAdapter{informer}
+}
+
+type validatingAdmissionPolicyBindingTypedInformerAdapter struct {
+	ValidatingAdmissionPolicyBindingInformer
+}
+
+func (a *validatingAdmissionPolicyBindingTypedInformerAdapter) TypedInformer() ValidatingAdmissionPolicyBindingIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1.ValidatingAdmissionPolicyBinding](a.Informer())
+}
+
+// ToValidatingAdmissionPolicyBindingIndexInformer converts an untyped informer into a ValidatingAdmissionPolicyBindingIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ValidatingAdmissionPolicyBinding. If that is not the case, calling type-safe methods of the returned
+// ValidatingAdmissionPolicyBindingIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ValidatingAdmissionPolicyBindingIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToValidatingAdmissionPolicyBindingIndexInformer(informer cache.SharedIndexInformer) ValidatingAdmissionPolicyBindingIndexInformer {
+	if informer, ok := informer.(ValidatingAdmissionPolicyBindingIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1.ValidatingAdmissionPolicyBinding](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1/validatingwebhookconfiguration.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ValidatingWebhookConfigurationInformer provides access to a shared informer and lister for
-// ValidatingWebhookConfigurations.
+// ValidatingWebhookConfigurations. Prefer using the type-safe variant (see [TypedValidatingWebhookConfigurationInformer]).
 type ValidatingWebhookConfigurationInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() admissionregistrationv1.ValidatingWebhookConfigurationLister
 }
+
+// TypedValidatingWebhookConfigurationInformer provides access to a shared informer and lister for
+// ValidatingWebhookConfigurations, including the type-safe TypedInformer variant.
+// It is a superset of ValidatingWebhookConfigurationInformer.
+type TypedValidatingWebhookConfigurationInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ValidatingWebhookConfigurationIndexInformer
+	Lister() admissionregistrationv1.ValidatingWebhookConfigurationLister
+}
+
+// ValidatingWebhookConfigurationIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ValidatingWebhookConfigurationIndexInformer cache.TypedSharedIndexInformer[*apiadmissionregistrationv1.ValidatingWebhookConfiguration]
+
+// ValidatingWebhookConfigurationHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ValidatingWebhookConfiguration.
+type ValidatingWebhookConfigurationHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiadmissionregistrationv1.ValidatingWebhookConfiguration]
+
+// ValidatingWebhookConfigurationDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ValidatingWebhookConfiguration.
+type ValidatingWebhookConfigurationDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiadmissionregistrationv1.ValidatingWebhookConfiguration]
+
+// ValidatingWebhookConfigurationFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ValidatingWebhookConfiguration.
+type ValidatingWebhookConfigurationFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiadmissionregistrationv1.ValidatingWebhookConfiguration]
+
+// ValidatingWebhookConfigurationIndexers is a specialization of [cache.TypedIndexers] for ValidatingWebhookConfiguration.
+type ValidatingWebhookConfigurationIndexers = cache.TypedIndexers[*apiadmissionregistrationv1.ValidatingWebhookConfiguration]
+
+// DeletedValidatingWebhookConfiguration is a specialization of [cache.DeletedObject] for ValidatingWebhookConfiguration.
+type DeletedValidatingWebhookConfiguration = cache.DeletedObject[*apiadmissionregistrationv1.ValidatingWebhookConfiguration]
 
 type validatingWebhookConfigurationInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type validatingWebhookConfigurationInformer struct {
 // NewValidatingWebhookConfigurationInformer constructs a new informer for ValidatingWebhookConfiguration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedValidatingWebhookConfigurationInformer]).
 func NewValidatingWebhookConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewValidatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedValidatingWebhookConfigurationInformer constructs a new informer for ValidatingWebhookConfiguration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedValidatingWebhookConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ValidatingWebhookConfigurationIndexers) ValidatingWebhookConfigurationIndexInformer {
+	return NewTypedValidatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredValidatingWebhookConfigurationInformer constructs a new informer for ValidatingWebhookConfiguration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredValidatingWebhookConfigurationInformer]).
 func NewFilteredValidatingWebhookConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewValidatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedValidatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredValidatingWebhookConfigurationInformer constructs a new informer for ValidatingWebhookConfiguration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredValidatingWebhookConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ValidatingWebhookConfigurationIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ValidatingWebhookConfigurationIndexInformer {
+	return NewTypedValidatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewValidatingWebhookConfigurationInformerWithOptions constructs a new informer for ValidatingWebhookConfiguration type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedValidatingWebhookConfigurationInformerWithOptions]).
 func NewValidatingWebhookConfigurationInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedValidatingWebhookConfigurationInformerWithOptions(client, options)
+}
+
+// NewTypedValidatingWebhookConfigurationInformerWithOptions constructs a new informer for ValidatingWebhookConfiguration type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedValidatingWebhookConfigurationInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ValidatingWebhookConfigurationIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1", Resource: "validatingwebhookconfigurations"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1.ValidatingWebhookConfiguration](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewValidatingWebhookConfigurationInformerWithOptions(client kubernetes.Inte
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *validatingWebhookConfigurationInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewValidatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedValidatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *validatingWebhookConfigurationInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiadmissionregistrationv1.ValidatingWebhookConfiguration{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *validatingWebhookConfigurationInformer) TypedInformer() ValidatingWebhookConfigurationIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1.ValidatingWebhookConfiguration](f.factory.InformerFor(&apiadmissionregistrationv1.ValidatingWebhookConfiguration{}, f.defaultInformer))
 }
 
 func (f *validatingWebhookConfigurationInformer) Lister() admissionregistrationv1.ValidatingWebhookConfigurationLister {
 	return admissionregistrationv1.NewValidatingWebhookConfigurationLister(f.Informer().GetIndexer())
+}
+
+// ToTypedValidatingWebhookConfigurationInformer converts an untyped informer into a TypedValidatingWebhookConfigurationInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ValidatingWebhookConfiguration. If that is not the case, calling type-safe methods of the returned
+// TypedValidatingWebhookConfigurationInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedValidatingWebhookConfigurationInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedValidatingWebhookConfigurationInformer(informer ValidatingWebhookConfigurationInformer) TypedValidatingWebhookConfigurationInformer {
+	if informer, ok := informer.(TypedValidatingWebhookConfigurationInformer); ok {
+		return informer
+	}
+	return &validatingWebhookConfigurationTypedInformerAdapter{informer}
+}
+
+type validatingWebhookConfigurationTypedInformerAdapter struct {
+	ValidatingWebhookConfigurationInformer
+}
+
+func (a *validatingWebhookConfigurationTypedInformerAdapter) TypedInformer() ValidatingWebhookConfigurationIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1.ValidatingWebhookConfiguration](a.Informer())
+}
+
+// ToValidatingWebhookConfigurationIndexInformer converts an untyped informer into a ValidatingWebhookConfigurationIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ValidatingWebhookConfiguration. If that is not the case, calling type-safe methods of the returned
+// ValidatingWebhookConfigurationIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ValidatingWebhookConfigurationIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToValidatingWebhookConfigurationIndexInformer(informer cache.SharedIndexInformer) ValidatingWebhookConfigurationIndexInformer {
+	if informer, ok := informer.(ValidatingWebhookConfigurationIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1.ValidatingWebhookConfiguration](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/interface.go
@@ -25,13 +25,13 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// MutatingAdmissionPolicies returns a MutatingAdmissionPolicyInformer.
-	MutatingAdmissionPolicies() MutatingAdmissionPolicyInformer
+	MutatingAdmissionPolicies() TypedMutatingAdmissionPolicyInformer
 	// MutatingAdmissionPolicyBindings returns a MutatingAdmissionPolicyBindingInformer.
-	MutatingAdmissionPolicyBindings() MutatingAdmissionPolicyBindingInformer
+	MutatingAdmissionPolicyBindings() TypedMutatingAdmissionPolicyBindingInformer
 	// ValidatingAdmissionPolicies returns a ValidatingAdmissionPolicyInformer.
-	ValidatingAdmissionPolicies() ValidatingAdmissionPolicyInformer
+	ValidatingAdmissionPolicies() TypedValidatingAdmissionPolicyInformer
 	// ValidatingAdmissionPolicyBindings returns a ValidatingAdmissionPolicyBindingInformer.
-	ValidatingAdmissionPolicyBindings() ValidatingAdmissionPolicyBindingInformer
+	ValidatingAdmissionPolicyBindings() TypedValidatingAdmissionPolicyBindingInformer
 }
 
 type version struct {
@@ -45,22 +45,22 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// MutatingAdmissionPolicies returns a MutatingAdmissionPolicyInformer.
-func (v *version) MutatingAdmissionPolicies() MutatingAdmissionPolicyInformer {
+// MutatingAdmissionPolicies returns a TypedMutatingAdmissionPolicyInformer.
+func (v *version) MutatingAdmissionPolicies() TypedMutatingAdmissionPolicyInformer {
 	return &mutatingAdmissionPolicyInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// MutatingAdmissionPolicyBindings returns a MutatingAdmissionPolicyBindingInformer.
-func (v *version) MutatingAdmissionPolicyBindings() MutatingAdmissionPolicyBindingInformer {
+// MutatingAdmissionPolicyBindings returns a TypedMutatingAdmissionPolicyBindingInformer.
+func (v *version) MutatingAdmissionPolicyBindings() TypedMutatingAdmissionPolicyBindingInformer {
 	return &mutatingAdmissionPolicyBindingInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// ValidatingAdmissionPolicies returns a ValidatingAdmissionPolicyInformer.
-func (v *version) ValidatingAdmissionPolicies() ValidatingAdmissionPolicyInformer {
+// ValidatingAdmissionPolicies returns a TypedValidatingAdmissionPolicyInformer.
+func (v *version) ValidatingAdmissionPolicies() TypedValidatingAdmissionPolicyInformer {
 	return &validatingAdmissionPolicyInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// ValidatingAdmissionPolicyBindings returns a ValidatingAdmissionPolicyBindingInformer.
-func (v *version) ValidatingAdmissionPolicyBindings() ValidatingAdmissionPolicyBindingInformer {
+// ValidatingAdmissionPolicyBindings returns a TypedValidatingAdmissionPolicyBindingInformer.
+func (v *version) ValidatingAdmissionPolicyBindings() TypedValidatingAdmissionPolicyBindingInformer {
 	return &validatingAdmissionPolicyBindingInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/mutatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/mutatingadmissionpolicy.go
@@ -34,11 +34,39 @@ import (
 )
 
 // MutatingAdmissionPolicyInformer provides access to a shared informer and lister for
-// MutatingAdmissionPolicies.
+// MutatingAdmissionPolicies. Prefer using the type-safe variant (see [TypedMutatingAdmissionPolicyInformer]).
 type MutatingAdmissionPolicyInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() admissionregistrationv1alpha1.MutatingAdmissionPolicyLister
 }
+
+// TypedMutatingAdmissionPolicyInformer provides access to a shared informer and lister for
+// MutatingAdmissionPolicies, including the type-safe TypedInformer variant.
+// It is a superset of MutatingAdmissionPolicyInformer.
+type TypedMutatingAdmissionPolicyInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() MutatingAdmissionPolicyIndexInformer
+	Lister() admissionregistrationv1alpha1.MutatingAdmissionPolicyLister
+}
+
+// MutatingAdmissionPolicyIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type MutatingAdmissionPolicyIndexInformer cache.TypedSharedIndexInformer[*apiadmissionregistrationv1alpha1.MutatingAdmissionPolicy]
+
+// MutatingAdmissionPolicyHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for MutatingAdmissionPolicy.
+type MutatingAdmissionPolicyHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiadmissionregistrationv1alpha1.MutatingAdmissionPolicy]
+
+// MutatingAdmissionPolicyDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for MutatingAdmissionPolicy.
+type MutatingAdmissionPolicyDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiadmissionregistrationv1alpha1.MutatingAdmissionPolicy]
+
+// MutatingAdmissionPolicyFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for MutatingAdmissionPolicy.
+type MutatingAdmissionPolicyFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiadmissionregistrationv1alpha1.MutatingAdmissionPolicy]
+
+// MutatingAdmissionPolicyIndexers is a specialization of [cache.TypedIndexers] for MutatingAdmissionPolicy.
+type MutatingAdmissionPolicyIndexers = cache.TypedIndexers[*apiadmissionregistrationv1alpha1.MutatingAdmissionPolicy]
+
+// DeletedMutatingAdmissionPolicy is a specialization of [cache.DeletedObject] for MutatingAdmissionPolicy.
+type DeletedMutatingAdmissionPolicy = cache.DeletedObject[*apiadmissionregistrationv1alpha1.MutatingAdmissionPolicy]
 
 type mutatingAdmissionPolicyInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type mutatingAdmissionPolicyInformer struct {
 // NewMutatingAdmissionPolicyInformer constructs a new informer for MutatingAdmissionPolicy type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedMutatingAdmissionPolicyInformer]).
 func NewMutatingAdmissionPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewMutatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedMutatingAdmissionPolicyInformer constructs a new informer for MutatingAdmissionPolicy type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedMutatingAdmissionPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers MutatingAdmissionPolicyIndexers) MutatingAdmissionPolicyIndexInformer {
+	return NewTypedMutatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredMutatingAdmissionPolicyInformer constructs a new informer for MutatingAdmissionPolicy type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredMutatingAdmissionPolicyInformer]).
 func NewFilteredMutatingAdmissionPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewMutatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedMutatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredMutatingAdmissionPolicyInformer constructs a new informer for MutatingAdmissionPolicy type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredMutatingAdmissionPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers MutatingAdmissionPolicyIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) MutatingAdmissionPolicyIndexInformer {
+	return NewTypedMutatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewMutatingAdmissionPolicyInformerWithOptions constructs a new informer for MutatingAdmissionPolicy type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedMutatingAdmissionPolicyInformerWithOptions]).
 func NewMutatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedMutatingAdmissionPolicyInformerWithOptions(client, options)
+}
+
+// NewTypedMutatingAdmissionPolicyInformerWithOptions constructs a new informer for MutatingAdmissionPolicy type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedMutatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) MutatingAdmissionPolicyIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1alpha1", Resource: "mutatingadmissionpolicys"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1alpha1.MutatingAdmissionPolicy](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewMutatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface, 
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *mutatingAdmissionPolicyInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewMutatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedMutatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *mutatingAdmissionPolicyInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiadmissionregistrationv1alpha1.MutatingAdmissionPolicy{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *mutatingAdmissionPolicyInformer) TypedInformer() MutatingAdmissionPolicyIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1alpha1.MutatingAdmissionPolicy](f.factory.InformerFor(&apiadmissionregistrationv1alpha1.MutatingAdmissionPolicy{}, f.defaultInformer))
 }
 
 func (f *mutatingAdmissionPolicyInformer) Lister() admissionregistrationv1alpha1.MutatingAdmissionPolicyLister {
 	return admissionregistrationv1alpha1.NewMutatingAdmissionPolicyLister(f.Informer().GetIndexer())
+}
+
+// ToTypedMutatingAdmissionPolicyInformer converts an untyped informer into a TypedMutatingAdmissionPolicyInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *MutatingAdmissionPolicy. If that is not the case, calling type-safe methods of the returned
+// TypedMutatingAdmissionPolicyInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedMutatingAdmissionPolicyInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedMutatingAdmissionPolicyInformer(informer MutatingAdmissionPolicyInformer) TypedMutatingAdmissionPolicyInformer {
+	if informer, ok := informer.(TypedMutatingAdmissionPolicyInformer); ok {
+		return informer
+	}
+	return &mutatingAdmissionPolicyTypedInformerAdapter{informer}
+}
+
+type mutatingAdmissionPolicyTypedInformerAdapter struct {
+	MutatingAdmissionPolicyInformer
+}
+
+func (a *mutatingAdmissionPolicyTypedInformerAdapter) TypedInformer() MutatingAdmissionPolicyIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1alpha1.MutatingAdmissionPolicy](a.Informer())
+}
+
+// ToMutatingAdmissionPolicyIndexInformer converts an untyped informer into a MutatingAdmissionPolicyIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *MutatingAdmissionPolicy. If that is not the case, calling type-safe methods of the returned
+// MutatingAdmissionPolicyIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a MutatingAdmissionPolicyIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToMutatingAdmissionPolicyIndexInformer(informer cache.SharedIndexInformer) MutatingAdmissionPolicyIndexInformer {
+	if informer, ok := informer.(MutatingAdmissionPolicyIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1alpha1.MutatingAdmissionPolicy](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/mutatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/mutatingadmissionpolicybinding.go
@@ -34,11 +34,39 @@ import (
 )
 
 // MutatingAdmissionPolicyBindingInformer provides access to a shared informer and lister for
-// MutatingAdmissionPolicyBindings.
+// MutatingAdmissionPolicyBindings. Prefer using the type-safe variant (see [TypedMutatingAdmissionPolicyBindingInformer]).
 type MutatingAdmissionPolicyBindingInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() admissionregistrationv1alpha1.MutatingAdmissionPolicyBindingLister
 }
+
+// TypedMutatingAdmissionPolicyBindingInformer provides access to a shared informer and lister for
+// MutatingAdmissionPolicyBindings, including the type-safe TypedInformer variant.
+// It is a superset of MutatingAdmissionPolicyBindingInformer.
+type TypedMutatingAdmissionPolicyBindingInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() MutatingAdmissionPolicyBindingIndexInformer
+	Lister() admissionregistrationv1alpha1.MutatingAdmissionPolicyBindingLister
+}
+
+// MutatingAdmissionPolicyBindingIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type MutatingAdmissionPolicyBindingIndexInformer cache.TypedSharedIndexInformer[*apiadmissionregistrationv1alpha1.MutatingAdmissionPolicyBinding]
+
+// MutatingAdmissionPolicyBindingHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for MutatingAdmissionPolicyBinding.
+type MutatingAdmissionPolicyBindingHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiadmissionregistrationv1alpha1.MutatingAdmissionPolicyBinding]
+
+// MutatingAdmissionPolicyBindingDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for MutatingAdmissionPolicyBinding.
+type MutatingAdmissionPolicyBindingDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiadmissionregistrationv1alpha1.MutatingAdmissionPolicyBinding]
+
+// MutatingAdmissionPolicyBindingFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for MutatingAdmissionPolicyBinding.
+type MutatingAdmissionPolicyBindingFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiadmissionregistrationv1alpha1.MutatingAdmissionPolicyBinding]
+
+// MutatingAdmissionPolicyBindingIndexers is a specialization of [cache.TypedIndexers] for MutatingAdmissionPolicyBinding.
+type MutatingAdmissionPolicyBindingIndexers = cache.TypedIndexers[*apiadmissionregistrationv1alpha1.MutatingAdmissionPolicyBinding]
+
+// DeletedMutatingAdmissionPolicyBinding is a specialization of [cache.DeletedObject] for MutatingAdmissionPolicyBinding.
+type DeletedMutatingAdmissionPolicyBinding = cache.DeletedObject[*apiadmissionregistrationv1alpha1.MutatingAdmissionPolicyBinding]
 
 type mutatingAdmissionPolicyBindingInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type mutatingAdmissionPolicyBindingInformer struct {
 // NewMutatingAdmissionPolicyBindingInformer constructs a new informer for MutatingAdmissionPolicyBinding type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedMutatingAdmissionPolicyBindingInformer]).
 func NewMutatingAdmissionPolicyBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewMutatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedMutatingAdmissionPolicyBindingInformer constructs a new informer for MutatingAdmissionPolicyBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedMutatingAdmissionPolicyBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers MutatingAdmissionPolicyBindingIndexers) MutatingAdmissionPolicyBindingIndexInformer {
+	return NewTypedMutatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredMutatingAdmissionPolicyBindingInformer constructs a new informer for MutatingAdmissionPolicyBinding type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredMutatingAdmissionPolicyBindingInformer]).
 func NewFilteredMutatingAdmissionPolicyBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewMutatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedMutatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredMutatingAdmissionPolicyBindingInformer constructs a new informer for MutatingAdmissionPolicyBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredMutatingAdmissionPolicyBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers MutatingAdmissionPolicyBindingIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) MutatingAdmissionPolicyBindingIndexInformer {
+	return NewTypedMutatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewMutatingAdmissionPolicyBindingInformerWithOptions constructs a new informer for MutatingAdmissionPolicyBinding type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedMutatingAdmissionPolicyBindingInformerWithOptions]).
 func NewMutatingAdmissionPolicyBindingInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedMutatingAdmissionPolicyBindingInformerWithOptions(client, options)
+}
+
+// NewTypedMutatingAdmissionPolicyBindingInformerWithOptions constructs a new informer for MutatingAdmissionPolicyBinding type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedMutatingAdmissionPolicyBindingInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) MutatingAdmissionPolicyBindingIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1alpha1", Resource: "mutatingadmissionpolicybindings"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1alpha1.MutatingAdmissionPolicyBinding](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewMutatingAdmissionPolicyBindingInformerWithOptions(client kubernetes.Inte
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *mutatingAdmissionPolicyBindingInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewMutatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedMutatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *mutatingAdmissionPolicyBindingInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiadmissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *mutatingAdmissionPolicyBindingInformer) TypedInformer() MutatingAdmissionPolicyBindingIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1alpha1.MutatingAdmissionPolicyBinding](f.factory.InformerFor(&apiadmissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{}, f.defaultInformer))
 }
 
 func (f *mutatingAdmissionPolicyBindingInformer) Lister() admissionregistrationv1alpha1.MutatingAdmissionPolicyBindingLister {
 	return admissionregistrationv1alpha1.NewMutatingAdmissionPolicyBindingLister(f.Informer().GetIndexer())
+}
+
+// ToTypedMutatingAdmissionPolicyBindingInformer converts an untyped informer into a TypedMutatingAdmissionPolicyBindingInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *MutatingAdmissionPolicyBinding. If that is not the case, calling type-safe methods of the returned
+// TypedMutatingAdmissionPolicyBindingInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedMutatingAdmissionPolicyBindingInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedMutatingAdmissionPolicyBindingInformer(informer MutatingAdmissionPolicyBindingInformer) TypedMutatingAdmissionPolicyBindingInformer {
+	if informer, ok := informer.(TypedMutatingAdmissionPolicyBindingInformer); ok {
+		return informer
+	}
+	return &mutatingAdmissionPolicyBindingTypedInformerAdapter{informer}
+}
+
+type mutatingAdmissionPolicyBindingTypedInformerAdapter struct {
+	MutatingAdmissionPolicyBindingInformer
+}
+
+func (a *mutatingAdmissionPolicyBindingTypedInformerAdapter) TypedInformer() MutatingAdmissionPolicyBindingIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1alpha1.MutatingAdmissionPolicyBinding](a.Informer())
+}
+
+// ToMutatingAdmissionPolicyBindingIndexInformer converts an untyped informer into a MutatingAdmissionPolicyBindingIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *MutatingAdmissionPolicyBinding. If that is not the case, calling type-safe methods of the returned
+// MutatingAdmissionPolicyBindingIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a MutatingAdmissionPolicyBindingIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToMutatingAdmissionPolicyBindingIndexInformer(informer cache.SharedIndexInformer) MutatingAdmissionPolicyBindingIndexInformer {
+	if informer, ok := informer.(MutatingAdmissionPolicyBindingIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1alpha1.MutatingAdmissionPolicyBinding](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/validatingadmissionpolicy.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ValidatingAdmissionPolicyInformer provides access to a shared informer and lister for
-// ValidatingAdmissionPolicies.
+// ValidatingAdmissionPolicies. Prefer using the type-safe variant (see [TypedValidatingAdmissionPolicyInformer]).
 type ValidatingAdmissionPolicyInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() admissionregistrationv1alpha1.ValidatingAdmissionPolicyLister
 }
+
+// TypedValidatingAdmissionPolicyInformer provides access to a shared informer and lister for
+// ValidatingAdmissionPolicies, including the type-safe TypedInformer variant.
+// It is a superset of ValidatingAdmissionPolicyInformer.
+type TypedValidatingAdmissionPolicyInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ValidatingAdmissionPolicyIndexInformer
+	Lister() admissionregistrationv1alpha1.ValidatingAdmissionPolicyLister
+}
+
+// ValidatingAdmissionPolicyIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ValidatingAdmissionPolicyIndexInformer cache.TypedSharedIndexInformer[*apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicy]
+
+// ValidatingAdmissionPolicyHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ValidatingAdmissionPolicy.
+type ValidatingAdmissionPolicyHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicy]
+
+// ValidatingAdmissionPolicyDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ValidatingAdmissionPolicy.
+type ValidatingAdmissionPolicyDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicy]
+
+// ValidatingAdmissionPolicyFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ValidatingAdmissionPolicy.
+type ValidatingAdmissionPolicyFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicy]
+
+// ValidatingAdmissionPolicyIndexers is a specialization of [cache.TypedIndexers] for ValidatingAdmissionPolicy.
+type ValidatingAdmissionPolicyIndexers = cache.TypedIndexers[*apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicy]
+
+// DeletedValidatingAdmissionPolicy is a specialization of [cache.DeletedObject] for ValidatingAdmissionPolicy.
+type DeletedValidatingAdmissionPolicy = cache.DeletedObject[*apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicy]
 
 type validatingAdmissionPolicyInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type validatingAdmissionPolicyInformer struct {
 // NewValidatingAdmissionPolicyInformer constructs a new informer for ValidatingAdmissionPolicy type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedValidatingAdmissionPolicyInformer]).
 func NewValidatingAdmissionPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewValidatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedValidatingAdmissionPolicyInformer constructs a new informer for ValidatingAdmissionPolicy type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedValidatingAdmissionPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ValidatingAdmissionPolicyIndexers) ValidatingAdmissionPolicyIndexInformer {
+	return NewTypedValidatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredValidatingAdmissionPolicyInformer constructs a new informer for ValidatingAdmissionPolicy type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredValidatingAdmissionPolicyInformer]).
 func NewFilteredValidatingAdmissionPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewValidatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedValidatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredValidatingAdmissionPolicyInformer constructs a new informer for ValidatingAdmissionPolicy type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredValidatingAdmissionPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ValidatingAdmissionPolicyIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ValidatingAdmissionPolicyIndexInformer {
+	return NewTypedValidatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewValidatingAdmissionPolicyInformerWithOptions constructs a new informer for ValidatingAdmissionPolicy type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedValidatingAdmissionPolicyInformerWithOptions]).
 func NewValidatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedValidatingAdmissionPolicyInformerWithOptions(client, options)
+}
+
+// NewTypedValidatingAdmissionPolicyInformerWithOptions constructs a new informer for ValidatingAdmissionPolicy type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedValidatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ValidatingAdmissionPolicyIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1alpha1", Resource: "validatingadmissionpolicys"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicy](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewValidatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *validatingAdmissionPolicyInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewValidatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedValidatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *validatingAdmissionPolicyInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicy{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *validatingAdmissionPolicyInformer) TypedInformer() ValidatingAdmissionPolicyIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicy](f.factory.InformerFor(&apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicy{}, f.defaultInformer))
 }
 
 func (f *validatingAdmissionPolicyInformer) Lister() admissionregistrationv1alpha1.ValidatingAdmissionPolicyLister {
 	return admissionregistrationv1alpha1.NewValidatingAdmissionPolicyLister(f.Informer().GetIndexer())
+}
+
+// ToTypedValidatingAdmissionPolicyInformer converts an untyped informer into a TypedValidatingAdmissionPolicyInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ValidatingAdmissionPolicy. If that is not the case, calling type-safe methods of the returned
+// TypedValidatingAdmissionPolicyInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedValidatingAdmissionPolicyInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedValidatingAdmissionPolicyInformer(informer ValidatingAdmissionPolicyInformer) TypedValidatingAdmissionPolicyInformer {
+	if informer, ok := informer.(TypedValidatingAdmissionPolicyInformer); ok {
+		return informer
+	}
+	return &validatingAdmissionPolicyTypedInformerAdapter{informer}
+}
+
+type validatingAdmissionPolicyTypedInformerAdapter struct {
+	ValidatingAdmissionPolicyInformer
+}
+
+func (a *validatingAdmissionPolicyTypedInformerAdapter) TypedInformer() ValidatingAdmissionPolicyIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicy](a.Informer())
+}
+
+// ToValidatingAdmissionPolicyIndexInformer converts an untyped informer into a ValidatingAdmissionPolicyIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ValidatingAdmissionPolicy. If that is not the case, calling type-safe methods of the returned
+// ValidatingAdmissionPolicyIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ValidatingAdmissionPolicyIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToValidatingAdmissionPolicyIndexInformer(informer cache.SharedIndexInformer) ValidatingAdmissionPolicyIndexInformer {
+	if informer, ok := informer.(ValidatingAdmissionPolicyIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicy](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/validatingadmissionpolicybinding.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ValidatingAdmissionPolicyBindingInformer provides access to a shared informer and lister for
-// ValidatingAdmissionPolicyBindings.
+// ValidatingAdmissionPolicyBindings. Prefer using the type-safe variant (see [TypedValidatingAdmissionPolicyBindingInformer]).
 type ValidatingAdmissionPolicyBindingInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() admissionregistrationv1alpha1.ValidatingAdmissionPolicyBindingLister
 }
+
+// TypedValidatingAdmissionPolicyBindingInformer provides access to a shared informer and lister for
+// ValidatingAdmissionPolicyBindings, including the type-safe TypedInformer variant.
+// It is a superset of ValidatingAdmissionPolicyBindingInformer.
+type TypedValidatingAdmissionPolicyBindingInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ValidatingAdmissionPolicyBindingIndexInformer
+	Lister() admissionregistrationv1alpha1.ValidatingAdmissionPolicyBindingLister
+}
+
+// ValidatingAdmissionPolicyBindingIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ValidatingAdmissionPolicyBindingIndexInformer cache.TypedSharedIndexInformer[*apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding]
+
+// ValidatingAdmissionPolicyBindingHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ValidatingAdmissionPolicyBinding.
+type ValidatingAdmissionPolicyBindingHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding]
+
+// ValidatingAdmissionPolicyBindingDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ValidatingAdmissionPolicyBinding.
+type ValidatingAdmissionPolicyBindingDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding]
+
+// ValidatingAdmissionPolicyBindingFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ValidatingAdmissionPolicyBinding.
+type ValidatingAdmissionPolicyBindingFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding]
+
+// ValidatingAdmissionPolicyBindingIndexers is a specialization of [cache.TypedIndexers] for ValidatingAdmissionPolicyBinding.
+type ValidatingAdmissionPolicyBindingIndexers = cache.TypedIndexers[*apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding]
+
+// DeletedValidatingAdmissionPolicyBinding is a specialization of [cache.DeletedObject] for ValidatingAdmissionPolicyBinding.
+type DeletedValidatingAdmissionPolicyBinding = cache.DeletedObject[*apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding]
 
 type validatingAdmissionPolicyBindingInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type validatingAdmissionPolicyBindingInformer struct {
 // NewValidatingAdmissionPolicyBindingInformer constructs a new informer for ValidatingAdmissionPolicyBinding type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedValidatingAdmissionPolicyBindingInformer]).
 func NewValidatingAdmissionPolicyBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewValidatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedValidatingAdmissionPolicyBindingInformer constructs a new informer for ValidatingAdmissionPolicyBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedValidatingAdmissionPolicyBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ValidatingAdmissionPolicyBindingIndexers) ValidatingAdmissionPolicyBindingIndexInformer {
+	return NewTypedValidatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredValidatingAdmissionPolicyBindingInformer constructs a new informer for ValidatingAdmissionPolicyBinding type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredValidatingAdmissionPolicyBindingInformer]).
 func NewFilteredValidatingAdmissionPolicyBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewValidatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedValidatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredValidatingAdmissionPolicyBindingInformer constructs a new informer for ValidatingAdmissionPolicyBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredValidatingAdmissionPolicyBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ValidatingAdmissionPolicyBindingIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ValidatingAdmissionPolicyBindingIndexInformer {
+	return NewTypedValidatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewValidatingAdmissionPolicyBindingInformerWithOptions constructs a new informer for ValidatingAdmissionPolicyBinding type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedValidatingAdmissionPolicyBindingInformerWithOptions]).
 func NewValidatingAdmissionPolicyBindingInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedValidatingAdmissionPolicyBindingInformerWithOptions(client, options)
+}
+
+// NewTypedValidatingAdmissionPolicyBindingInformerWithOptions constructs a new informer for ValidatingAdmissionPolicyBinding type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedValidatingAdmissionPolicyBindingInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ValidatingAdmissionPolicyBindingIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1alpha1", Resource: "validatingadmissionpolicybindings"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewValidatingAdmissionPolicyBindingInformerWithOptions(client kubernetes.In
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *validatingAdmissionPolicyBindingInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewValidatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedValidatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *validatingAdmissionPolicyBindingInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *validatingAdmissionPolicyBindingInformer) TypedInformer() ValidatingAdmissionPolicyBindingIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding](f.factory.InformerFor(&apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding{}, f.defaultInformer))
 }
 
 func (f *validatingAdmissionPolicyBindingInformer) Lister() admissionregistrationv1alpha1.ValidatingAdmissionPolicyBindingLister {
 	return admissionregistrationv1alpha1.NewValidatingAdmissionPolicyBindingLister(f.Informer().GetIndexer())
+}
+
+// ToTypedValidatingAdmissionPolicyBindingInformer converts an untyped informer into a TypedValidatingAdmissionPolicyBindingInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ValidatingAdmissionPolicyBinding. If that is not the case, calling type-safe methods of the returned
+// TypedValidatingAdmissionPolicyBindingInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedValidatingAdmissionPolicyBindingInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedValidatingAdmissionPolicyBindingInformer(informer ValidatingAdmissionPolicyBindingInformer) TypedValidatingAdmissionPolicyBindingInformer {
+	if informer, ok := informer.(TypedValidatingAdmissionPolicyBindingInformer); ok {
+		return informer
+	}
+	return &validatingAdmissionPolicyBindingTypedInformerAdapter{informer}
+}
+
+type validatingAdmissionPolicyBindingTypedInformerAdapter struct {
+	ValidatingAdmissionPolicyBindingInformer
+}
+
+func (a *validatingAdmissionPolicyBindingTypedInformerAdapter) TypedInformer() ValidatingAdmissionPolicyBindingIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding](a.Informer())
+}
+
+// ToValidatingAdmissionPolicyBindingIndexInformer converts an untyped informer into a ValidatingAdmissionPolicyBindingIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ValidatingAdmissionPolicyBinding. If that is not the case, calling type-safe methods of the returned
+// ValidatingAdmissionPolicyBindingIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ValidatingAdmissionPolicyBindingIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToValidatingAdmissionPolicyBindingIndexInformer(informer cache.SharedIndexInformer) ValidatingAdmissionPolicyBindingIndexInformer {
+	if informer, ok := informer.(ValidatingAdmissionPolicyBindingIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/interface.go
@@ -25,17 +25,17 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// MutatingAdmissionPolicies returns a MutatingAdmissionPolicyInformer.
-	MutatingAdmissionPolicies() MutatingAdmissionPolicyInformer
+	MutatingAdmissionPolicies() TypedMutatingAdmissionPolicyInformer
 	// MutatingAdmissionPolicyBindings returns a MutatingAdmissionPolicyBindingInformer.
-	MutatingAdmissionPolicyBindings() MutatingAdmissionPolicyBindingInformer
+	MutatingAdmissionPolicyBindings() TypedMutatingAdmissionPolicyBindingInformer
 	// MutatingWebhookConfigurations returns a MutatingWebhookConfigurationInformer.
-	MutatingWebhookConfigurations() MutatingWebhookConfigurationInformer
+	MutatingWebhookConfigurations() TypedMutatingWebhookConfigurationInformer
 	// ValidatingAdmissionPolicies returns a ValidatingAdmissionPolicyInformer.
-	ValidatingAdmissionPolicies() ValidatingAdmissionPolicyInformer
+	ValidatingAdmissionPolicies() TypedValidatingAdmissionPolicyInformer
 	// ValidatingAdmissionPolicyBindings returns a ValidatingAdmissionPolicyBindingInformer.
-	ValidatingAdmissionPolicyBindings() ValidatingAdmissionPolicyBindingInformer
+	ValidatingAdmissionPolicyBindings() TypedValidatingAdmissionPolicyBindingInformer
 	// ValidatingWebhookConfigurations returns a ValidatingWebhookConfigurationInformer.
-	ValidatingWebhookConfigurations() ValidatingWebhookConfigurationInformer
+	ValidatingWebhookConfigurations() TypedValidatingWebhookConfigurationInformer
 }
 
 type version struct {
@@ -49,32 +49,32 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// MutatingAdmissionPolicies returns a MutatingAdmissionPolicyInformer.
-func (v *version) MutatingAdmissionPolicies() MutatingAdmissionPolicyInformer {
+// MutatingAdmissionPolicies returns a TypedMutatingAdmissionPolicyInformer.
+func (v *version) MutatingAdmissionPolicies() TypedMutatingAdmissionPolicyInformer {
 	return &mutatingAdmissionPolicyInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// MutatingAdmissionPolicyBindings returns a MutatingAdmissionPolicyBindingInformer.
-func (v *version) MutatingAdmissionPolicyBindings() MutatingAdmissionPolicyBindingInformer {
+// MutatingAdmissionPolicyBindings returns a TypedMutatingAdmissionPolicyBindingInformer.
+func (v *version) MutatingAdmissionPolicyBindings() TypedMutatingAdmissionPolicyBindingInformer {
 	return &mutatingAdmissionPolicyBindingInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// MutatingWebhookConfigurations returns a MutatingWebhookConfigurationInformer.
-func (v *version) MutatingWebhookConfigurations() MutatingWebhookConfigurationInformer {
+// MutatingWebhookConfigurations returns a TypedMutatingWebhookConfigurationInformer.
+func (v *version) MutatingWebhookConfigurations() TypedMutatingWebhookConfigurationInformer {
 	return &mutatingWebhookConfigurationInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// ValidatingAdmissionPolicies returns a ValidatingAdmissionPolicyInformer.
-func (v *version) ValidatingAdmissionPolicies() ValidatingAdmissionPolicyInformer {
+// ValidatingAdmissionPolicies returns a TypedValidatingAdmissionPolicyInformer.
+func (v *version) ValidatingAdmissionPolicies() TypedValidatingAdmissionPolicyInformer {
 	return &validatingAdmissionPolicyInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// ValidatingAdmissionPolicyBindings returns a ValidatingAdmissionPolicyBindingInformer.
-func (v *version) ValidatingAdmissionPolicyBindings() ValidatingAdmissionPolicyBindingInformer {
+// ValidatingAdmissionPolicyBindings returns a TypedValidatingAdmissionPolicyBindingInformer.
+func (v *version) ValidatingAdmissionPolicyBindings() TypedValidatingAdmissionPolicyBindingInformer {
 	return &validatingAdmissionPolicyBindingInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// ValidatingWebhookConfigurations returns a ValidatingWebhookConfigurationInformer.
-func (v *version) ValidatingWebhookConfigurations() ValidatingWebhookConfigurationInformer {
+// ValidatingWebhookConfigurations returns a TypedValidatingWebhookConfigurationInformer.
+func (v *version) ValidatingWebhookConfigurations() TypedValidatingWebhookConfigurationInformer {
 	return &validatingWebhookConfigurationInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/mutatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/mutatingadmissionpolicy.go
@@ -34,11 +34,39 @@ import (
 )
 
 // MutatingAdmissionPolicyInformer provides access to a shared informer and lister for
-// MutatingAdmissionPolicies.
+// MutatingAdmissionPolicies. Prefer using the type-safe variant (see [TypedMutatingAdmissionPolicyInformer]).
 type MutatingAdmissionPolicyInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() admissionregistrationv1beta1.MutatingAdmissionPolicyLister
 }
+
+// TypedMutatingAdmissionPolicyInformer provides access to a shared informer and lister for
+// MutatingAdmissionPolicies, including the type-safe TypedInformer variant.
+// It is a superset of MutatingAdmissionPolicyInformer.
+type TypedMutatingAdmissionPolicyInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() MutatingAdmissionPolicyIndexInformer
+	Lister() admissionregistrationv1beta1.MutatingAdmissionPolicyLister
+}
+
+// MutatingAdmissionPolicyIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type MutatingAdmissionPolicyIndexInformer cache.TypedSharedIndexInformer[*apiadmissionregistrationv1beta1.MutatingAdmissionPolicy]
+
+// MutatingAdmissionPolicyHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for MutatingAdmissionPolicy.
+type MutatingAdmissionPolicyHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiadmissionregistrationv1beta1.MutatingAdmissionPolicy]
+
+// MutatingAdmissionPolicyDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for MutatingAdmissionPolicy.
+type MutatingAdmissionPolicyDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiadmissionregistrationv1beta1.MutatingAdmissionPolicy]
+
+// MutatingAdmissionPolicyFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for MutatingAdmissionPolicy.
+type MutatingAdmissionPolicyFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiadmissionregistrationv1beta1.MutatingAdmissionPolicy]
+
+// MutatingAdmissionPolicyIndexers is a specialization of [cache.TypedIndexers] for MutatingAdmissionPolicy.
+type MutatingAdmissionPolicyIndexers = cache.TypedIndexers[*apiadmissionregistrationv1beta1.MutatingAdmissionPolicy]
+
+// DeletedMutatingAdmissionPolicy is a specialization of [cache.DeletedObject] for MutatingAdmissionPolicy.
+type DeletedMutatingAdmissionPolicy = cache.DeletedObject[*apiadmissionregistrationv1beta1.MutatingAdmissionPolicy]
 
 type mutatingAdmissionPolicyInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type mutatingAdmissionPolicyInformer struct {
 // NewMutatingAdmissionPolicyInformer constructs a new informer for MutatingAdmissionPolicy type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedMutatingAdmissionPolicyInformer]).
 func NewMutatingAdmissionPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewMutatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedMutatingAdmissionPolicyInformer constructs a new informer for MutatingAdmissionPolicy type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedMutatingAdmissionPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers MutatingAdmissionPolicyIndexers) MutatingAdmissionPolicyIndexInformer {
+	return NewTypedMutatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredMutatingAdmissionPolicyInformer constructs a new informer for MutatingAdmissionPolicy type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredMutatingAdmissionPolicyInformer]).
 func NewFilteredMutatingAdmissionPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewMutatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedMutatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredMutatingAdmissionPolicyInformer constructs a new informer for MutatingAdmissionPolicy type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredMutatingAdmissionPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers MutatingAdmissionPolicyIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) MutatingAdmissionPolicyIndexInformer {
+	return NewTypedMutatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewMutatingAdmissionPolicyInformerWithOptions constructs a new informer for MutatingAdmissionPolicy type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedMutatingAdmissionPolicyInformerWithOptions]).
 func NewMutatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedMutatingAdmissionPolicyInformerWithOptions(client, options)
+}
+
+// NewTypedMutatingAdmissionPolicyInformerWithOptions constructs a new informer for MutatingAdmissionPolicy type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedMutatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) MutatingAdmissionPolicyIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "mutatingadmissionpolicys"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1beta1.MutatingAdmissionPolicy](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewMutatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface, 
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *mutatingAdmissionPolicyInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewMutatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedMutatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *mutatingAdmissionPolicyInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiadmissionregistrationv1beta1.MutatingAdmissionPolicy{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *mutatingAdmissionPolicyInformer) TypedInformer() MutatingAdmissionPolicyIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1beta1.MutatingAdmissionPolicy](f.factory.InformerFor(&apiadmissionregistrationv1beta1.MutatingAdmissionPolicy{}, f.defaultInformer))
 }
 
 func (f *mutatingAdmissionPolicyInformer) Lister() admissionregistrationv1beta1.MutatingAdmissionPolicyLister {
 	return admissionregistrationv1beta1.NewMutatingAdmissionPolicyLister(f.Informer().GetIndexer())
+}
+
+// ToTypedMutatingAdmissionPolicyInformer converts an untyped informer into a TypedMutatingAdmissionPolicyInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *MutatingAdmissionPolicy. If that is not the case, calling type-safe methods of the returned
+// TypedMutatingAdmissionPolicyInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedMutatingAdmissionPolicyInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedMutatingAdmissionPolicyInformer(informer MutatingAdmissionPolicyInformer) TypedMutatingAdmissionPolicyInformer {
+	if informer, ok := informer.(TypedMutatingAdmissionPolicyInformer); ok {
+		return informer
+	}
+	return &mutatingAdmissionPolicyTypedInformerAdapter{informer}
+}
+
+type mutatingAdmissionPolicyTypedInformerAdapter struct {
+	MutatingAdmissionPolicyInformer
+}
+
+func (a *mutatingAdmissionPolicyTypedInformerAdapter) TypedInformer() MutatingAdmissionPolicyIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1beta1.MutatingAdmissionPolicy](a.Informer())
+}
+
+// ToMutatingAdmissionPolicyIndexInformer converts an untyped informer into a MutatingAdmissionPolicyIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *MutatingAdmissionPolicy. If that is not the case, calling type-safe methods of the returned
+// MutatingAdmissionPolicyIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a MutatingAdmissionPolicyIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToMutatingAdmissionPolicyIndexInformer(informer cache.SharedIndexInformer) MutatingAdmissionPolicyIndexInformer {
+	if informer, ok := informer.(MutatingAdmissionPolicyIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1beta1.MutatingAdmissionPolicy](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/mutatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/mutatingadmissionpolicybinding.go
@@ -34,11 +34,39 @@ import (
 )
 
 // MutatingAdmissionPolicyBindingInformer provides access to a shared informer and lister for
-// MutatingAdmissionPolicyBindings.
+// MutatingAdmissionPolicyBindings. Prefer using the type-safe variant (see [TypedMutatingAdmissionPolicyBindingInformer]).
 type MutatingAdmissionPolicyBindingInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() admissionregistrationv1beta1.MutatingAdmissionPolicyBindingLister
 }
+
+// TypedMutatingAdmissionPolicyBindingInformer provides access to a shared informer and lister for
+// MutatingAdmissionPolicyBindings, including the type-safe TypedInformer variant.
+// It is a superset of MutatingAdmissionPolicyBindingInformer.
+type TypedMutatingAdmissionPolicyBindingInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() MutatingAdmissionPolicyBindingIndexInformer
+	Lister() admissionregistrationv1beta1.MutatingAdmissionPolicyBindingLister
+}
+
+// MutatingAdmissionPolicyBindingIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type MutatingAdmissionPolicyBindingIndexInformer cache.TypedSharedIndexInformer[*apiadmissionregistrationv1beta1.MutatingAdmissionPolicyBinding]
+
+// MutatingAdmissionPolicyBindingHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for MutatingAdmissionPolicyBinding.
+type MutatingAdmissionPolicyBindingHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiadmissionregistrationv1beta1.MutatingAdmissionPolicyBinding]
+
+// MutatingAdmissionPolicyBindingDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for MutatingAdmissionPolicyBinding.
+type MutatingAdmissionPolicyBindingDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiadmissionregistrationv1beta1.MutatingAdmissionPolicyBinding]
+
+// MutatingAdmissionPolicyBindingFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for MutatingAdmissionPolicyBinding.
+type MutatingAdmissionPolicyBindingFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiadmissionregistrationv1beta1.MutatingAdmissionPolicyBinding]
+
+// MutatingAdmissionPolicyBindingIndexers is a specialization of [cache.TypedIndexers] for MutatingAdmissionPolicyBinding.
+type MutatingAdmissionPolicyBindingIndexers = cache.TypedIndexers[*apiadmissionregistrationv1beta1.MutatingAdmissionPolicyBinding]
+
+// DeletedMutatingAdmissionPolicyBinding is a specialization of [cache.DeletedObject] for MutatingAdmissionPolicyBinding.
+type DeletedMutatingAdmissionPolicyBinding = cache.DeletedObject[*apiadmissionregistrationv1beta1.MutatingAdmissionPolicyBinding]
 
 type mutatingAdmissionPolicyBindingInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type mutatingAdmissionPolicyBindingInformer struct {
 // NewMutatingAdmissionPolicyBindingInformer constructs a new informer for MutatingAdmissionPolicyBinding type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedMutatingAdmissionPolicyBindingInformer]).
 func NewMutatingAdmissionPolicyBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewMutatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedMutatingAdmissionPolicyBindingInformer constructs a new informer for MutatingAdmissionPolicyBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedMutatingAdmissionPolicyBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers MutatingAdmissionPolicyBindingIndexers) MutatingAdmissionPolicyBindingIndexInformer {
+	return NewTypedMutatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredMutatingAdmissionPolicyBindingInformer constructs a new informer for MutatingAdmissionPolicyBinding type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredMutatingAdmissionPolicyBindingInformer]).
 func NewFilteredMutatingAdmissionPolicyBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewMutatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedMutatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredMutatingAdmissionPolicyBindingInformer constructs a new informer for MutatingAdmissionPolicyBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredMutatingAdmissionPolicyBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers MutatingAdmissionPolicyBindingIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) MutatingAdmissionPolicyBindingIndexInformer {
+	return NewTypedMutatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewMutatingAdmissionPolicyBindingInformerWithOptions constructs a new informer for MutatingAdmissionPolicyBinding type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedMutatingAdmissionPolicyBindingInformerWithOptions]).
 func NewMutatingAdmissionPolicyBindingInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedMutatingAdmissionPolicyBindingInformerWithOptions(client, options)
+}
+
+// NewTypedMutatingAdmissionPolicyBindingInformerWithOptions constructs a new informer for MutatingAdmissionPolicyBinding type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedMutatingAdmissionPolicyBindingInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) MutatingAdmissionPolicyBindingIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "mutatingadmissionpolicybindings"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1beta1.MutatingAdmissionPolicyBinding](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewMutatingAdmissionPolicyBindingInformerWithOptions(client kubernetes.Inte
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *mutatingAdmissionPolicyBindingInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewMutatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedMutatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *mutatingAdmissionPolicyBindingInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiadmissionregistrationv1beta1.MutatingAdmissionPolicyBinding{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *mutatingAdmissionPolicyBindingInformer) TypedInformer() MutatingAdmissionPolicyBindingIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1beta1.MutatingAdmissionPolicyBinding](f.factory.InformerFor(&apiadmissionregistrationv1beta1.MutatingAdmissionPolicyBinding{}, f.defaultInformer))
 }
 
 func (f *mutatingAdmissionPolicyBindingInformer) Lister() admissionregistrationv1beta1.MutatingAdmissionPolicyBindingLister {
 	return admissionregistrationv1beta1.NewMutatingAdmissionPolicyBindingLister(f.Informer().GetIndexer())
+}
+
+// ToTypedMutatingAdmissionPolicyBindingInformer converts an untyped informer into a TypedMutatingAdmissionPolicyBindingInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *MutatingAdmissionPolicyBinding. If that is not the case, calling type-safe methods of the returned
+// TypedMutatingAdmissionPolicyBindingInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedMutatingAdmissionPolicyBindingInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedMutatingAdmissionPolicyBindingInformer(informer MutatingAdmissionPolicyBindingInformer) TypedMutatingAdmissionPolicyBindingInformer {
+	if informer, ok := informer.(TypedMutatingAdmissionPolicyBindingInformer); ok {
+		return informer
+	}
+	return &mutatingAdmissionPolicyBindingTypedInformerAdapter{informer}
+}
+
+type mutatingAdmissionPolicyBindingTypedInformerAdapter struct {
+	MutatingAdmissionPolicyBindingInformer
+}
+
+func (a *mutatingAdmissionPolicyBindingTypedInformerAdapter) TypedInformer() MutatingAdmissionPolicyBindingIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1beta1.MutatingAdmissionPolicyBinding](a.Informer())
+}
+
+// ToMutatingAdmissionPolicyBindingIndexInformer converts an untyped informer into a MutatingAdmissionPolicyBindingIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *MutatingAdmissionPolicyBinding. If that is not the case, calling type-safe methods of the returned
+// MutatingAdmissionPolicyBindingIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a MutatingAdmissionPolicyBindingIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToMutatingAdmissionPolicyBindingIndexInformer(informer cache.SharedIndexInformer) MutatingAdmissionPolicyBindingIndexInformer {
+	if informer, ok := informer.(MutatingAdmissionPolicyBindingIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1beta1.MutatingAdmissionPolicyBinding](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
@@ -34,11 +34,39 @@ import (
 )
 
 // MutatingWebhookConfigurationInformer provides access to a shared informer and lister for
-// MutatingWebhookConfigurations.
+// MutatingWebhookConfigurations. Prefer using the type-safe variant (see [TypedMutatingWebhookConfigurationInformer]).
 type MutatingWebhookConfigurationInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() admissionregistrationv1beta1.MutatingWebhookConfigurationLister
 }
+
+// TypedMutatingWebhookConfigurationInformer provides access to a shared informer and lister for
+// MutatingWebhookConfigurations, including the type-safe TypedInformer variant.
+// It is a superset of MutatingWebhookConfigurationInformer.
+type TypedMutatingWebhookConfigurationInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() MutatingWebhookConfigurationIndexInformer
+	Lister() admissionregistrationv1beta1.MutatingWebhookConfigurationLister
+}
+
+// MutatingWebhookConfigurationIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type MutatingWebhookConfigurationIndexInformer cache.TypedSharedIndexInformer[*apiadmissionregistrationv1beta1.MutatingWebhookConfiguration]
+
+// MutatingWebhookConfigurationHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for MutatingWebhookConfiguration.
+type MutatingWebhookConfigurationHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiadmissionregistrationv1beta1.MutatingWebhookConfiguration]
+
+// MutatingWebhookConfigurationDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for MutatingWebhookConfiguration.
+type MutatingWebhookConfigurationDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiadmissionregistrationv1beta1.MutatingWebhookConfiguration]
+
+// MutatingWebhookConfigurationFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for MutatingWebhookConfiguration.
+type MutatingWebhookConfigurationFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiadmissionregistrationv1beta1.MutatingWebhookConfiguration]
+
+// MutatingWebhookConfigurationIndexers is a specialization of [cache.TypedIndexers] for MutatingWebhookConfiguration.
+type MutatingWebhookConfigurationIndexers = cache.TypedIndexers[*apiadmissionregistrationv1beta1.MutatingWebhookConfiguration]
+
+// DeletedMutatingWebhookConfiguration is a specialization of [cache.DeletedObject] for MutatingWebhookConfiguration.
+type DeletedMutatingWebhookConfiguration = cache.DeletedObject[*apiadmissionregistrationv1beta1.MutatingWebhookConfiguration]
 
 type mutatingWebhookConfigurationInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type mutatingWebhookConfigurationInformer struct {
 // NewMutatingWebhookConfigurationInformer constructs a new informer for MutatingWebhookConfiguration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedMutatingWebhookConfigurationInformer]).
 func NewMutatingWebhookConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewMutatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedMutatingWebhookConfigurationInformer constructs a new informer for MutatingWebhookConfiguration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedMutatingWebhookConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers MutatingWebhookConfigurationIndexers) MutatingWebhookConfigurationIndexInformer {
+	return NewTypedMutatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredMutatingWebhookConfigurationInformer constructs a new informer for MutatingWebhookConfiguration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredMutatingWebhookConfigurationInformer]).
 func NewFilteredMutatingWebhookConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewMutatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedMutatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredMutatingWebhookConfigurationInformer constructs a new informer for MutatingWebhookConfiguration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredMutatingWebhookConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers MutatingWebhookConfigurationIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) MutatingWebhookConfigurationIndexInformer {
+	return NewTypedMutatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewMutatingWebhookConfigurationInformerWithOptions constructs a new informer for MutatingWebhookConfiguration type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedMutatingWebhookConfigurationInformerWithOptions]).
 func NewMutatingWebhookConfigurationInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedMutatingWebhookConfigurationInformerWithOptions(client, options)
+}
+
+// NewTypedMutatingWebhookConfigurationInformerWithOptions constructs a new informer for MutatingWebhookConfiguration type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedMutatingWebhookConfigurationInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) MutatingWebhookConfigurationIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "mutatingwebhookconfigurations"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1beta1.MutatingWebhookConfiguration](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewMutatingWebhookConfigurationInformerWithOptions(client kubernetes.Interf
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *mutatingWebhookConfigurationInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewMutatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedMutatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *mutatingWebhookConfigurationInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiadmissionregistrationv1beta1.MutatingWebhookConfiguration{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *mutatingWebhookConfigurationInformer) TypedInformer() MutatingWebhookConfigurationIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1beta1.MutatingWebhookConfiguration](f.factory.InformerFor(&apiadmissionregistrationv1beta1.MutatingWebhookConfiguration{}, f.defaultInformer))
 }
 
 func (f *mutatingWebhookConfigurationInformer) Lister() admissionregistrationv1beta1.MutatingWebhookConfigurationLister {
 	return admissionregistrationv1beta1.NewMutatingWebhookConfigurationLister(f.Informer().GetIndexer())
+}
+
+// ToTypedMutatingWebhookConfigurationInformer converts an untyped informer into a TypedMutatingWebhookConfigurationInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *MutatingWebhookConfiguration. If that is not the case, calling type-safe methods of the returned
+// TypedMutatingWebhookConfigurationInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedMutatingWebhookConfigurationInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedMutatingWebhookConfigurationInformer(informer MutatingWebhookConfigurationInformer) TypedMutatingWebhookConfigurationInformer {
+	if informer, ok := informer.(TypedMutatingWebhookConfigurationInformer); ok {
+		return informer
+	}
+	return &mutatingWebhookConfigurationTypedInformerAdapter{informer}
+}
+
+type mutatingWebhookConfigurationTypedInformerAdapter struct {
+	MutatingWebhookConfigurationInformer
+}
+
+func (a *mutatingWebhookConfigurationTypedInformerAdapter) TypedInformer() MutatingWebhookConfigurationIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1beta1.MutatingWebhookConfiguration](a.Informer())
+}
+
+// ToMutatingWebhookConfigurationIndexInformer converts an untyped informer into a MutatingWebhookConfigurationIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *MutatingWebhookConfiguration. If that is not the case, calling type-safe methods of the returned
+// MutatingWebhookConfigurationIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a MutatingWebhookConfigurationIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToMutatingWebhookConfigurationIndexInformer(informer cache.SharedIndexInformer) MutatingWebhookConfigurationIndexInformer {
+	if informer, ok := informer.(MutatingWebhookConfigurationIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1beta1.MutatingWebhookConfiguration](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/validatingadmissionpolicy.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ValidatingAdmissionPolicyInformer provides access to a shared informer and lister for
-// ValidatingAdmissionPolicies.
+// ValidatingAdmissionPolicies. Prefer using the type-safe variant (see [TypedValidatingAdmissionPolicyInformer]).
 type ValidatingAdmissionPolicyInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() admissionregistrationv1beta1.ValidatingAdmissionPolicyLister
 }
+
+// TypedValidatingAdmissionPolicyInformer provides access to a shared informer and lister for
+// ValidatingAdmissionPolicies, including the type-safe TypedInformer variant.
+// It is a superset of ValidatingAdmissionPolicyInformer.
+type TypedValidatingAdmissionPolicyInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ValidatingAdmissionPolicyIndexInformer
+	Lister() admissionregistrationv1beta1.ValidatingAdmissionPolicyLister
+}
+
+// ValidatingAdmissionPolicyIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ValidatingAdmissionPolicyIndexInformer cache.TypedSharedIndexInformer[*apiadmissionregistrationv1beta1.ValidatingAdmissionPolicy]
+
+// ValidatingAdmissionPolicyHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ValidatingAdmissionPolicy.
+type ValidatingAdmissionPolicyHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiadmissionregistrationv1beta1.ValidatingAdmissionPolicy]
+
+// ValidatingAdmissionPolicyDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ValidatingAdmissionPolicy.
+type ValidatingAdmissionPolicyDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiadmissionregistrationv1beta1.ValidatingAdmissionPolicy]
+
+// ValidatingAdmissionPolicyFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ValidatingAdmissionPolicy.
+type ValidatingAdmissionPolicyFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiadmissionregistrationv1beta1.ValidatingAdmissionPolicy]
+
+// ValidatingAdmissionPolicyIndexers is a specialization of [cache.TypedIndexers] for ValidatingAdmissionPolicy.
+type ValidatingAdmissionPolicyIndexers = cache.TypedIndexers[*apiadmissionregistrationv1beta1.ValidatingAdmissionPolicy]
+
+// DeletedValidatingAdmissionPolicy is a specialization of [cache.DeletedObject] for ValidatingAdmissionPolicy.
+type DeletedValidatingAdmissionPolicy = cache.DeletedObject[*apiadmissionregistrationv1beta1.ValidatingAdmissionPolicy]
 
 type validatingAdmissionPolicyInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type validatingAdmissionPolicyInformer struct {
 // NewValidatingAdmissionPolicyInformer constructs a new informer for ValidatingAdmissionPolicy type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedValidatingAdmissionPolicyInformer]).
 func NewValidatingAdmissionPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewValidatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedValidatingAdmissionPolicyInformer constructs a new informer for ValidatingAdmissionPolicy type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedValidatingAdmissionPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ValidatingAdmissionPolicyIndexers) ValidatingAdmissionPolicyIndexInformer {
+	return NewTypedValidatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredValidatingAdmissionPolicyInformer constructs a new informer for ValidatingAdmissionPolicy type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredValidatingAdmissionPolicyInformer]).
 func NewFilteredValidatingAdmissionPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewValidatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedValidatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredValidatingAdmissionPolicyInformer constructs a new informer for ValidatingAdmissionPolicy type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredValidatingAdmissionPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ValidatingAdmissionPolicyIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ValidatingAdmissionPolicyIndexInformer {
+	return NewTypedValidatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewValidatingAdmissionPolicyInformerWithOptions constructs a new informer for ValidatingAdmissionPolicy type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedValidatingAdmissionPolicyInformerWithOptions]).
 func NewValidatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedValidatingAdmissionPolicyInformerWithOptions(client, options)
+}
+
+// NewTypedValidatingAdmissionPolicyInformerWithOptions constructs a new informer for ValidatingAdmissionPolicy type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedValidatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ValidatingAdmissionPolicyIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "validatingadmissionpolicys"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1beta1.ValidatingAdmissionPolicy](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewValidatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *validatingAdmissionPolicyInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewValidatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedValidatingAdmissionPolicyInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *validatingAdmissionPolicyInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiadmissionregistrationv1beta1.ValidatingAdmissionPolicy{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *validatingAdmissionPolicyInformer) TypedInformer() ValidatingAdmissionPolicyIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1beta1.ValidatingAdmissionPolicy](f.factory.InformerFor(&apiadmissionregistrationv1beta1.ValidatingAdmissionPolicy{}, f.defaultInformer))
 }
 
 func (f *validatingAdmissionPolicyInformer) Lister() admissionregistrationv1beta1.ValidatingAdmissionPolicyLister {
 	return admissionregistrationv1beta1.NewValidatingAdmissionPolicyLister(f.Informer().GetIndexer())
+}
+
+// ToTypedValidatingAdmissionPolicyInformer converts an untyped informer into a TypedValidatingAdmissionPolicyInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ValidatingAdmissionPolicy. If that is not the case, calling type-safe methods of the returned
+// TypedValidatingAdmissionPolicyInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedValidatingAdmissionPolicyInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedValidatingAdmissionPolicyInformer(informer ValidatingAdmissionPolicyInformer) TypedValidatingAdmissionPolicyInformer {
+	if informer, ok := informer.(TypedValidatingAdmissionPolicyInformer); ok {
+		return informer
+	}
+	return &validatingAdmissionPolicyTypedInformerAdapter{informer}
+}
+
+type validatingAdmissionPolicyTypedInformerAdapter struct {
+	ValidatingAdmissionPolicyInformer
+}
+
+func (a *validatingAdmissionPolicyTypedInformerAdapter) TypedInformer() ValidatingAdmissionPolicyIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1beta1.ValidatingAdmissionPolicy](a.Informer())
+}
+
+// ToValidatingAdmissionPolicyIndexInformer converts an untyped informer into a ValidatingAdmissionPolicyIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ValidatingAdmissionPolicy. If that is not the case, calling type-safe methods of the returned
+// ValidatingAdmissionPolicyIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ValidatingAdmissionPolicyIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToValidatingAdmissionPolicyIndexInformer(informer cache.SharedIndexInformer) ValidatingAdmissionPolicyIndexInformer {
+	if informer, ok := informer.(ValidatingAdmissionPolicyIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1beta1.ValidatingAdmissionPolicy](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/validatingadmissionpolicybinding.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ValidatingAdmissionPolicyBindingInformer provides access to a shared informer and lister for
-// ValidatingAdmissionPolicyBindings.
+// ValidatingAdmissionPolicyBindings. Prefer using the type-safe variant (see [TypedValidatingAdmissionPolicyBindingInformer]).
 type ValidatingAdmissionPolicyBindingInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() admissionregistrationv1beta1.ValidatingAdmissionPolicyBindingLister
 }
+
+// TypedValidatingAdmissionPolicyBindingInformer provides access to a shared informer and lister for
+// ValidatingAdmissionPolicyBindings, including the type-safe TypedInformer variant.
+// It is a superset of ValidatingAdmissionPolicyBindingInformer.
+type TypedValidatingAdmissionPolicyBindingInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ValidatingAdmissionPolicyBindingIndexInformer
+	Lister() admissionregistrationv1beta1.ValidatingAdmissionPolicyBindingLister
+}
+
+// ValidatingAdmissionPolicyBindingIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ValidatingAdmissionPolicyBindingIndexInformer cache.TypedSharedIndexInformer[*apiadmissionregistrationv1beta1.ValidatingAdmissionPolicyBinding]
+
+// ValidatingAdmissionPolicyBindingHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ValidatingAdmissionPolicyBinding.
+type ValidatingAdmissionPolicyBindingHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiadmissionregistrationv1beta1.ValidatingAdmissionPolicyBinding]
+
+// ValidatingAdmissionPolicyBindingDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ValidatingAdmissionPolicyBinding.
+type ValidatingAdmissionPolicyBindingDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiadmissionregistrationv1beta1.ValidatingAdmissionPolicyBinding]
+
+// ValidatingAdmissionPolicyBindingFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ValidatingAdmissionPolicyBinding.
+type ValidatingAdmissionPolicyBindingFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiadmissionregistrationv1beta1.ValidatingAdmissionPolicyBinding]
+
+// ValidatingAdmissionPolicyBindingIndexers is a specialization of [cache.TypedIndexers] for ValidatingAdmissionPolicyBinding.
+type ValidatingAdmissionPolicyBindingIndexers = cache.TypedIndexers[*apiadmissionregistrationv1beta1.ValidatingAdmissionPolicyBinding]
+
+// DeletedValidatingAdmissionPolicyBinding is a specialization of [cache.DeletedObject] for ValidatingAdmissionPolicyBinding.
+type DeletedValidatingAdmissionPolicyBinding = cache.DeletedObject[*apiadmissionregistrationv1beta1.ValidatingAdmissionPolicyBinding]
 
 type validatingAdmissionPolicyBindingInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type validatingAdmissionPolicyBindingInformer struct {
 // NewValidatingAdmissionPolicyBindingInformer constructs a new informer for ValidatingAdmissionPolicyBinding type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedValidatingAdmissionPolicyBindingInformer]).
 func NewValidatingAdmissionPolicyBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewValidatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedValidatingAdmissionPolicyBindingInformer constructs a new informer for ValidatingAdmissionPolicyBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedValidatingAdmissionPolicyBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ValidatingAdmissionPolicyBindingIndexers) ValidatingAdmissionPolicyBindingIndexInformer {
+	return NewTypedValidatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredValidatingAdmissionPolicyBindingInformer constructs a new informer for ValidatingAdmissionPolicyBinding type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredValidatingAdmissionPolicyBindingInformer]).
 func NewFilteredValidatingAdmissionPolicyBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewValidatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedValidatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredValidatingAdmissionPolicyBindingInformer constructs a new informer for ValidatingAdmissionPolicyBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredValidatingAdmissionPolicyBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ValidatingAdmissionPolicyBindingIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ValidatingAdmissionPolicyBindingIndexInformer {
+	return NewTypedValidatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewValidatingAdmissionPolicyBindingInformerWithOptions constructs a new informer for ValidatingAdmissionPolicyBinding type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedValidatingAdmissionPolicyBindingInformerWithOptions]).
 func NewValidatingAdmissionPolicyBindingInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedValidatingAdmissionPolicyBindingInformerWithOptions(client, options)
+}
+
+// NewTypedValidatingAdmissionPolicyBindingInformerWithOptions constructs a new informer for ValidatingAdmissionPolicyBinding type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedValidatingAdmissionPolicyBindingInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ValidatingAdmissionPolicyBindingIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "validatingadmissionpolicybindings"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1beta1.ValidatingAdmissionPolicyBinding](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewValidatingAdmissionPolicyBindingInformerWithOptions(client kubernetes.In
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *validatingAdmissionPolicyBindingInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewValidatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedValidatingAdmissionPolicyBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *validatingAdmissionPolicyBindingInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiadmissionregistrationv1beta1.ValidatingAdmissionPolicyBinding{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *validatingAdmissionPolicyBindingInformer) TypedInformer() ValidatingAdmissionPolicyBindingIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1beta1.ValidatingAdmissionPolicyBinding](f.factory.InformerFor(&apiadmissionregistrationv1beta1.ValidatingAdmissionPolicyBinding{}, f.defaultInformer))
 }
 
 func (f *validatingAdmissionPolicyBindingInformer) Lister() admissionregistrationv1beta1.ValidatingAdmissionPolicyBindingLister {
 	return admissionregistrationv1beta1.NewValidatingAdmissionPolicyBindingLister(f.Informer().GetIndexer())
+}
+
+// ToTypedValidatingAdmissionPolicyBindingInformer converts an untyped informer into a TypedValidatingAdmissionPolicyBindingInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ValidatingAdmissionPolicyBinding. If that is not the case, calling type-safe methods of the returned
+// TypedValidatingAdmissionPolicyBindingInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedValidatingAdmissionPolicyBindingInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedValidatingAdmissionPolicyBindingInformer(informer ValidatingAdmissionPolicyBindingInformer) TypedValidatingAdmissionPolicyBindingInformer {
+	if informer, ok := informer.(TypedValidatingAdmissionPolicyBindingInformer); ok {
+		return informer
+	}
+	return &validatingAdmissionPolicyBindingTypedInformerAdapter{informer}
+}
+
+type validatingAdmissionPolicyBindingTypedInformerAdapter struct {
+	ValidatingAdmissionPolicyBindingInformer
+}
+
+func (a *validatingAdmissionPolicyBindingTypedInformerAdapter) TypedInformer() ValidatingAdmissionPolicyBindingIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1beta1.ValidatingAdmissionPolicyBinding](a.Informer())
+}
+
+// ToValidatingAdmissionPolicyBindingIndexInformer converts an untyped informer into a ValidatingAdmissionPolicyBindingIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ValidatingAdmissionPolicyBinding. If that is not the case, calling type-safe methods of the returned
+// ValidatingAdmissionPolicyBindingIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ValidatingAdmissionPolicyBindingIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToValidatingAdmissionPolicyBindingIndexInformer(informer cache.SharedIndexInformer) ValidatingAdmissionPolicyBindingIndexInformer {
+	if informer, ok := informer.(ValidatingAdmissionPolicyBindingIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1beta1.ValidatingAdmissionPolicyBinding](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ValidatingWebhookConfigurationInformer provides access to a shared informer and lister for
-// ValidatingWebhookConfigurations.
+// ValidatingWebhookConfigurations. Prefer using the type-safe variant (see [TypedValidatingWebhookConfigurationInformer]).
 type ValidatingWebhookConfigurationInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() admissionregistrationv1beta1.ValidatingWebhookConfigurationLister
 }
+
+// TypedValidatingWebhookConfigurationInformer provides access to a shared informer and lister for
+// ValidatingWebhookConfigurations, including the type-safe TypedInformer variant.
+// It is a superset of ValidatingWebhookConfigurationInformer.
+type TypedValidatingWebhookConfigurationInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ValidatingWebhookConfigurationIndexInformer
+	Lister() admissionregistrationv1beta1.ValidatingWebhookConfigurationLister
+}
+
+// ValidatingWebhookConfigurationIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ValidatingWebhookConfigurationIndexInformer cache.TypedSharedIndexInformer[*apiadmissionregistrationv1beta1.ValidatingWebhookConfiguration]
+
+// ValidatingWebhookConfigurationHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ValidatingWebhookConfiguration.
+type ValidatingWebhookConfigurationHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiadmissionregistrationv1beta1.ValidatingWebhookConfiguration]
+
+// ValidatingWebhookConfigurationDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ValidatingWebhookConfiguration.
+type ValidatingWebhookConfigurationDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiadmissionregistrationv1beta1.ValidatingWebhookConfiguration]
+
+// ValidatingWebhookConfigurationFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ValidatingWebhookConfiguration.
+type ValidatingWebhookConfigurationFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiadmissionregistrationv1beta1.ValidatingWebhookConfiguration]
+
+// ValidatingWebhookConfigurationIndexers is a specialization of [cache.TypedIndexers] for ValidatingWebhookConfiguration.
+type ValidatingWebhookConfigurationIndexers = cache.TypedIndexers[*apiadmissionregistrationv1beta1.ValidatingWebhookConfiguration]
+
+// DeletedValidatingWebhookConfiguration is a specialization of [cache.DeletedObject] for ValidatingWebhookConfiguration.
+type DeletedValidatingWebhookConfiguration = cache.DeletedObject[*apiadmissionregistrationv1beta1.ValidatingWebhookConfiguration]
 
 type validatingWebhookConfigurationInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type validatingWebhookConfigurationInformer struct {
 // NewValidatingWebhookConfigurationInformer constructs a new informer for ValidatingWebhookConfiguration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedValidatingWebhookConfigurationInformer]).
 func NewValidatingWebhookConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewValidatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedValidatingWebhookConfigurationInformer constructs a new informer for ValidatingWebhookConfiguration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedValidatingWebhookConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ValidatingWebhookConfigurationIndexers) ValidatingWebhookConfigurationIndexInformer {
+	return NewTypedValidatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredValidatingWebhookConfigurationInformer constructs a new informer for ValidatingWebhookConfiguration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredValidatingWebhookConfigurationInformer]).
 func NewFilteredValidatingWebhookConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewValidatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedValidatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredValidatingWebhookConfigurationInformer constructs a new informer for ValidatingWebhookConfiguration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredValidatingWebhookConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ValidatingWebhookConfigurationIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ValidatingWebhookConfigurationIndexInformer {
+	return NewTypedValidatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewValidatingWebhookConfigurationInformerWithOptions constructs a new informer for ValidatingWebhookConfiguration type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedValidatingWebhookConfigurationInformerWithOptions]).
 func NewValidatingWebhookConfigurationInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedValidatingWebhookConfigurationInformerWithOptions(client, options)
+}
+
+// NewTypedValidatingWebhookConfigurationInformerWithOptions constructs a new informer for ValidatingWebhookConfiguration type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedValidatingWebhookConfigurationInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ValidatingWebhookConfigurationIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "validatingwebhookconfigurations"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1beta1.ValidatingWebhookConfiguration](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewValidatingWebhookConfigurationInformerWithOptions(client kubernetes.Inte
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *validatingWebhookConfigurationInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewValidatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedValidatingWebhookConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *validatingWebhookConfigurationInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiadmissionregistrationv1beta1.ValidatingWebhookConfiguration{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *validatingWebhookConfigurationInformer) TypedInformer() ValidatingWebhookConfigurationIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1beta1.ValidatingWebhookConfiguration](f.factory.InformerFor(&apiadmissionregistrationv1beta1.ValidatingWebhookConfiguration{}, f.defaultInformer))
 }
 
 func (f *validatingWebhookConfigurationInformer) Lister() admissionregistrationv1beta1.ValidatingWebhookConfigurationLister {
 	return admissionregistrationv1beta1.NewValidatingWebhookConfigurationLister(f.Informer().GetIndexer())
+}
+
+// ToTypedValidatingWebhookConfigurationInformer converts an untyped informer into a TypedValidatingWebhookConfigurationInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ValidatingWebhookConfiguration. If that is not the case, calling type-safe methods of the returned
+// TypedValidatingWebhookConfigurationInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedValidatingWebhookConfigurationInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedValidatingWebhookConfigurationInformer(informer ValidatingWebhookConfigurationInformer) TypedValidatingWebhookConfigurationInformer {
+	if informer, ok := informer.(TypedValidatingWebhookConfigurationInformer); ok {
+		return informer
+	}
+	return &validatingWebhookConfigurationTypedInformerAdapter{informer}
+}
+
+type validatingWebhookConfigurationTypedInformerAdapter struct {
+	ValidatingWebhookConfigurationInformer
+}
+
+func (a *validatingWebhookConfigurationTypedInformerAdapter) TypedInformer() ValidatingWebhookConfigurationIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1beta1.ValidatingWebhookConfiguration](a.Informer())
+}
+
+// ToValidatingWebhookConfigurationIndexInformer converts an untyped informer into a ValidatingWebhookConfigurationIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ValidatingWebhookConfiguration. If that is not the case, calling type-safe methods of the returned
+// ValidatingWebhookConfigurationIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ValidatingWebhookConfigurationIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToValidatingWebhookConfigurationIndexInformer(informer cache.SharedIndexInformer) ValidatingWebhookConfigurationIndexInformer {
+	if informer, ok := informer.(ValidatingWebhookConfigurationIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1beta1.ValidatingWebhookConfiguration](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/apiserverinternal/v1alpha1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/apiserverinternal/v1alpha1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// StorageVersions returns a StorageVersionInformer.
-	StorageVersions() StorageVersionInformer
+	StorageVersions() TypedStorageVersionInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// StorageVersions returns a StorageVersionInformer.
-func (v *version) StorageVersions() StorageVersionInformer {
+// StorageVersions returns a TypedStorageVersionInformer.
+func (v *version) StorageVersions() TypedStorageVersionInformer {
 	return &storageVersionInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/apiserverinternal/v1alpha1/storageversion.go
+++ b/staging/src/k8s.io/client-go/informers/apiserverinternal/v1alpha1/storageversion.go
@@ -34,11 +34,39 @@ import (
 )
 
 // StorageVersionInformer provides access to a shared informer and lister for
-// StorageVersions.
+// StorageVersions. Prefer using the type-safe variant (see [TypedStorageVersionInformer]).
 type StorageVersionInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() apiserverinternalv1alpha1.StorageVersionLister
 }
+
+// TypedStorageVersionInformer provides access to a shared informer and lister for
+// StorageVersions, including the type-safe TypedInformer variant.
+// It is a superset of StorageVersionInformer.
+type TypedStorageVersionInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() StorageVersionIndexInformer
+	Lister() apiserverinternalv1alpha1.StorageVersionLister
+}
+
+// StorageVersionIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type StorageVersionIndexInformer cache.TypedSharedIndexInformer[*apiapiserverinternalv1alpha1.StorageVersion]
+
+// StorageVersionHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for StorageVersion.
+type StorageVersionHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiapiserverinternalv1alpha1.StorageVersion]
+
+// StorageVersionDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for StorageVersion.
+type StorageVersionDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiapiserverinternalv1alpha1.StorageVersion]
+
+// StorageVersionFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for StorageVersion.
+type StorageVersionFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiapiserverinternalv1alpha1.StorageVersion]
+
+// StorageVersionIndexers is a specialization of [cache.TypedIndexers] for StorageVersion.
+type StorageVersionIndexers = cache.TypedIndexers[*apiapiserverinternalv1alpha1.StorageVersion]
+
+// DeletedStorageVersion is a specialization of [cache.DeletedObject] for StorageVersion.
+type DeletedStorageVersion = cache.DeletedObject[*apiapiserverinternalv1alpha1.StorageVersion]
 
 type storageVersionInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type storageVersionInformer struct {
 // NewStorageVersionInformer constructs a new informer for StorageVersion type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedStorageVersionInformer]).
 func NewStorageVersionInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewStorageVersionInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedStorageVersionInformer constructs a new informer for StorageVersion type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedStorageVersionInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers StorageVersionIndexers) StorageVersionIndexInformer {
+	return NewTypedStorageVersionInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredStorageVersionInformer constructs a new informer for StorageVersion type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredStorageVersionInformer]).
 func NewFilteredStorageVersionInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewStorageVersionInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedStorageVersionInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredStorageVersionInformer constructs a new informer for StorageVersion type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredStorageVersionInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers StorageVersionIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) StorageVersionIndexInformer {
+	return NewTypedStorageVersionInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewStorageVersionInformerWithOptions constructs a new informer for StorageVersion type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedStorageVersionInformerWithOptions]).
 func NewStorageVersionInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedStorageVersionInformerWithOptions(client, options)
+}
+
+// NewTypedStorageVersionInformerWithOptions constructs a new informer for StorageVersion type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedStorageVersionInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) StorageVersionIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "internal.apiserver.k8s.io", Version: "v1alpha1", Resource: "storageversions"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiapiserverinternalv1alpha1.StorageVersion](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewStorageVersionInformerWithOptions(client kubernetes.Interface, options i
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *storageVersionInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewStorageVersionInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedStorageVersionInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *storageVersionInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiapiserverinternalv1alpha1.StorageVersion{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *storageVersionInformer) TypedInformer() StorageVersionIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiapiserverinternalv1alpha1.StorageVersion](f.factory.InformerFor(&apiapiserverinternalv1alpha1.StorageVersion{}, f.defaultInformer))
 }
 
 func (f *storageVersionInformer) Lister() apiserverinternalv1alpha1.StorageVersionLister {
 	return apiserverinternalv1alpha1.NewStorageVersionLister(f.Informer().GetIndexer())
+}
+
+// ToTypedStorageVersionInformer converts an untyped informer into a TypedStorageVersionInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *StorageVersion. If that is not the case, calling type-safe methods of the returned
+// TypedStorageVersionInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedStorageVersionInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedStorageVersionInformer(informer StorageVersionInformer) TypedStorageVersionInformer {
+	if informer, ok := informer.(TypedStorageVersionInformer); ok {
+		return informer
+	}
+	return &storageVersionTypedInformerAdapter{informer}
+}
+
+type storageVersionTypedInformerAdapter struct {
+	StorageVersionInformer
+}
+
+func (a *storageVersionTypedInformerAdapter) TypedInformer() StorageVersionIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiapiserverinternalv1alpha1.StorageVersion](a.Informer())
+}
+
+// ToStorageVersionIndexInformer converts an untyped informer into a StorageVersionIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *StorageVersion. If that is not the case, calling type-safe methods of the returned
+// StorageVersionIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a StorageVersionIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToStorageVersionIndexInformer(informer cache.SharedIndexInformer) StorageVersionIndexInformer {
+	if informer, ok := informer.(StorageVersionIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiapiserverinternalv1alpha1.StorageVersion](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/apps/v1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/controllerrevision.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ControllerRevisionInformer provides access to a shared informer and lister for
-// ControllerRevisions.
+// ControllerRevisions. Prefer using the type-safe variant (see [TypedControllerRevisionInformer]).
 type ControllerRevisionInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() appsv1.ControllerRevisionLister
 }
+
+// TypedControllerRevisionInformer provides access to a shared informer and lister for
+// ControllerRevisions, including the type-safe TypedInformer variant.
+// It is a superset of ControllerRevisionInformer.
+type TypedControllerRevisionInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ControllerRevisionIndexInformer
+	Lister() appsv1.ControllerRevisionLister
+}
+
+// ControllerRevisionIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ControllerRevisionIndexInformer cache.TypedSharedIndexInformer[*apiappsv1.ControllerRevision]
+
+// ControllerRevisionHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ControllerRevision.
+type ControllerRevisionHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiappsv1.ControllerRevision]
+
+// ControllerRevisionDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ControllerRevision.
+type ControllerRevisionDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiappsv1.ControllerRevision]
+
+// ControllerRevisionFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ControllerRevision.
+type ControllerRevisionFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiappsv1.ControllerRevision]
+
+// ControllerRevisionIndexers is a specialization of [cache.TypedIndexers] for ControllerRevision.
+type ControllerRevisionIndexers = cache.TypedIndexers[*apiappsv1.ControllerRevision]
+
+// DeletedControllerRevision is a specialization of [cache.DeletedObject] for ControllerRevision.
+type DeletedControllerRevision = cache.DeletedObject[*apiappsv1.ControllerRevision]
 
 type controllerRevisionInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type controllerRevisionInformer struct {
 // NewControllerRevisionInformer constructs a new informer for ControllerRevision type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedControllerRevisionInformer]).
 func NewControllerRevisionInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewControllerRevisionInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedControllerRevisionInformer constructs a new informer for ControllerRevision type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedControllerRevisionInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ControllerRevisionIndexers) ControllerRevisionIndexInformer {
+	return NewTypedControllerRevisionInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredControllerRevisionInformer constructs a new informer for ControllerRevision type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredControllerRevisionInformer]).
 func NewFilteredControllerRevisionInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewControllerRevisionInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedControllerRevisionInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredControllerRevisionInformer constructs a new informer for ControllerRevision type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredControllerRevisionInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ControllerRevisionIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ControllerRevisionIndexInformer {
+	return NewTypedControllerRevisionInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewControllerRevisionInformerWithOptions constructs a new informer for ControllerRevision type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedControllerRevisionInformerWithOptions]).
 func NewControllerRevisionInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedControllerRevisionInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedControllerRevisionInformerWithOptions constructs a new informer for ControllerRevision type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedControllerRevisionInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) ControllerRevisionIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "controllerrevisions"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiappsv1.ControllerRevision](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewControllerRevisionInformerWithOptions(client kubernetes.Interface, names
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *controllerRevisionInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewControllerRevisionInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedControllerRevisionInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *controllerRevisionInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiappsv1.ControllerRevision{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *controllerRevisionInformer) TypedInformer() ControllerRevisionIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiappsv1.ControllerRevision](f.factory.InformerFor(&apiappsv1.ControllerRevision{}, f.defaultInformer))
 }
 
 func (f *controllerRevisionInformer) Lister() appsv1.ControllerRevisionLister {
 	return appsv1.NewControllerRevisionLister(f.Informer().GetIndexer())
+}
+
+// ToTypedControllerRevisionInformer converts an untyped informer into a TypedControllerRevisionInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ControllerRevision. If that is not the case, calling type-safe methods of the returned
+// TypedControllerRevisionInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedControllerRevisionInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedControllerRevisionInformer(informer ControllerRevisionInformer) TypedControllerRevisionInformer {
+	if informer, ok := informer.(TypedControllerRevisionInformer); ok {
+		return informer
+	}
+	return &controllerRevisionTypedInformerAdapter{informer}
+}
+
+type controllerRevisionTypedInformerAdapter struct {
+	ControllerRevisionInformer
+}
+
+func (a *controllerRevisionTypedInformerAdapter) TypedInformer() ControllerRevisionIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiappsv1.ControllerRevision](a.Informer())
+}
+
+// ToControllerRevisionIndexInformer converts an untyped informer into a ControllerRevisionIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ControllerRevision. If that is not the case, calling type-safe methods of the returned
+// ControllerRevisionIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ControllerRevisionIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToControllerRevisionIndexInformer(informer cache.SharedIndexInformer) ControllerRevisionIndexInformer {
+	if informer, ok := informer.(ControllerRevisionIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiappsv1.ControllerRevision](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/apps/v1/daemonset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/daemonset.go
@@ -34,11 +34,39 @@ import (
 )
 
 // DaemonSetInformer provides access to a shared informer and lister for
-// DaemonSets.
+// DaemonSets. Prefer using the type-safe variant (see [TypedDaemonSetInformer]).
 type DaemonSetInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() appsv1.DaemonSetLister
 }
+
+// TypedDaemonSetInformer provides access to a shared informer and lister for
+// DaemonSets, including the type-safe TypedInformer variant.
+// It is a superset of DaemonSetInformer.
+type TypedDaemonSetInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() DaemonSetIndexInformer
+	Lister() appsv1.DaemonSetLister
+}
+
+// DaemonSetIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type DaemonSetIndexInformer cache.TypedSharedIndexInformer[*apiappsv1.DaemonSet]
+
+// DaemonSetHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for DaemonSet.
+type DaemonSetHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiappsv1.DaemonSet]
+
+// DaemonSetDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for DaemonSet.
+type DaemonSetDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiappsv1.DaemonSet]
+
+// DaemonSetFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for DaemonSet.
+type DaemonSetFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiappsv1.DaemonSet]
+
+// DaemonSetIndexers is a specialization of [cache.TypedIndexers] for DaemonSet.
+type DaemonSetIndexers = cache.TypedIndexers[*apiappsv1.DaemonSet]
+
+// DeletedDaemonSet is a specialization of [cache.DeletedObject] for DaemonSet.
+type DeletedDaemonSet = cache.DeletedObject[*apiappsv1.DaemonSet]
 
 type daemonSetInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type daemonSetInformer struct {
 // NewDaemonSetInformer constructs a new informer for DaemonSet type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedDaemonSetInformer]).
 func NewDaemonSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewDaemonSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedDaemonSetInformer constructs a new informer for DaemonSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedDaemonSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers DaemonSetIndexers) DaemonSetIndexInformer {
+	return NewTypedDaemonSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredDaemonSetInformer constructs a new informer for DaemonSet type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredDaemonSetInformer]).
 func NewFilteredDaemonSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewDaemonSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedDaemonSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredDaemonSetInformer constructs a new informer for DaemonSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredDaemonSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers DaemonSetIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) DaemonSetIndexInformer {
+	return NewTypedDaemonSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewDaemonSetInformerWithOptions constructs a new informer for DaemonSet type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedDaemonSetInformerWithOptions]).
 func NewDaemonSetInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedDaemonSetInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedDaemonSetInformerWithOptions constructs a new informer for DaemonSet type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedDaemonSetInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) DaemonSetIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "daemonsets"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiappsv1.DaemonSet](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewDaemonSetInformerWithOptions(client kubernetes.Interface, namespace stri
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *daemonSetInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewDaemonSetInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedDaemonSetInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *daemonSetInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiappsv1.DaemonSet{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *daemonSetInformer) TypedInformer() DaemonSetIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiappsv1.DaemonSet](f.factory.InformerFor(&apiappsv1.DaemonSet{}, f.defaultInformer))
 }
 
 func (f *daemonSetInformer) Lister() appsv1.DaemonSetLister {
 	return appsv1.NewDaemonSetLister(f.Informer().GetIndexer())
+}
+
+// ToTypedDaemonSetInformer converts an untyped informer into a TypedDaemonSetInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *DaemonSet. If that is not the case, calling type-safe methods of the returned
+// TypedDaemonSetInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedDaemonSetInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedDaemonSetInformer(informer DaemonSetInformer) TypedDaemonSetInformer {
+	if informer, ok := informer.(TypedDaemonSetInformer); ok {
+		return informer
+	}
+	return &daemonSetTypedInformerAdapter{informer}
+}
+
+type daemonSetTypedInformerAdapter struct {
+	DaemonSetInformer
+}
+
+func (a *daemonSetTypedInformerAdapter) TypedInformer() DaemonSetIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiappsv1.DaemonSet](a.Informer())
+}
+
+// ToDaemonSetIndexInformer converts an untyped informer into a DaemonSetIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *DaemonSet. If that is not the case, calling type-safe methods of the returned
+// DaemonSetIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a DaemonSetIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToDaemonSetIndexInformer(informer cache.SharedIndexInformer) DaemonSetIndexInformer {
+	if informer, ok := informer.(DaemonSetIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiappsv1.DaemonSet](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/apps/v1/deployment.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/deployment.go
@@ -34,11 +34,39 @@ import (
 )
 
 // DeploymentInformer provides access to a shared informer and lister for
-// Deployments.
+// Deployments. Prefer using the type-safe variant (see [TypedDeploymentInformer]).
 type DeploymentInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() appsv1.DeploymentLister
 }
+
+// TypedDeploymentInformer provides access to a shared informer and lister for
+// Deployments, including the type-safe TypedInformer variant.
+// It is a superset of DeploymentInformer.
+type TypedDeploymentInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() DeploymentIndexInformer
+	Lister() appsv1.DeploymentLister
+}
+
+// DeploymentIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type DeploymentIndexInformer cache.TypedSharedIndexInformer[*apiappsv1.Deployment]
+
+// DeploymentHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Deployment.
+type DeploymentHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiappsv1.Deployment]
+
+// DeploymentDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Deployment.
+type DeploymentDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiappsv1.Deployment]
+
+// DeploymentFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Deployment.
+type DeploymentFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiappsv1.Deployment]
+
+// DeploymentIndexers is a specialization of [cache.TypedIndexers] for Deployment.
+type DeploymentIndexers = cache.TypedIndexers[*apiappsv1.Deployment]
+
+// DeletedDeployment is a specialization of [cache.DeletedObject] for Deployment.
+type DeletedDeployment = cache.DeletedObject[*apiappsv1.Deployment]
 
 type deploymentInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type deploymentInformer struct {
 // NewDeploymentInformer constructs a new informer for Deployment type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedDeploymentInformer]).
 func NewDeploymentInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewDeploymentInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedDeploymentInformer constructs a new informer for Deployment type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedDeploymentInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers DeploymentIndexers) DeploymentIndexInformer {
+	return NewTypedDeploymentInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredDeploymentInformer constructs a new informer for Deployment type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredDeploymentInformer]).
 func NewFilteredDeploymentInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewDeploymentInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedDeploymentInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredDeploymentInformer constructs a new informer for Deployment type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredDeploymentInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers DeploymentIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) DeploymentIndexInformer {
+	return NewTypedDeploymentInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewDeploymentInformerWithOptions constructs a new informer for Deployment type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedDeploymentInformerWithOptions]).
 func NewDeploymentInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedDeploymentInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedDeploymentInformerWithOptions constructs a new informer for Deployment type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedDeploymentInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) DeploymentIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiappsv1.Deployment](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewDeploymentInformerWithOptions(client kubernetes.Interface, namespace str
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *deploymentInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewDeploymentInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedDeploymentInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *deploymentInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiappsv1.Deployment{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *deploymentInformer) TypedInformer() DeploymentIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiappsv1.Deployment](f.factory.InformerFor(&apiappsv1.Deployment{}, f.defaultInformer))
 }
 
 func (f *deploymentInformer) Lister() appsv1.DeploymentLister {
 	return appsv1.NewDeploymentLister(f.Informer().GetIndexer())
+}
+
+// ToTypedDeploymentInformer converts an untyped informer into a TypedDeploymentInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Deployment. If that is not the case, calling type-safe methods of the returned
+// TypedDeploymentInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedDeploymentInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedDeploymentInformer(informer DeploymentInformer) TypedDeploymentInformer {
+	if informer, ok := informer.(TypedDeploymentInformer); ok {
+		return informer
+	}
+	return &deploymentTypedInformerAdapter{informer}
+}
+
+type deploymentTypedInformerAdapter struct {
+	DeploymentInformer
+}
+
+func (a *deploymentTypedInformerAdapter) TypedInformer() DeploymentIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiappsv1.Deployment](a.Informer())
+}
+
+// ToDeploymentIndexInformer converts an untyped informer into a DeploymentIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Deployment. If that is not the case, calling type-safe methods of the returned
+// DeploymentIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a DeploymentIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToDeploymentIndexInformer(informer cache.SharedIndexInformer) DeploymentIndexInformer {
+	if informer, ok := informer.(DeploymentIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiappsv1.Deployment](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/apps/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/interface.go
@@ -25,15 +25,15 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// ControllerRevisions returns a ControllerRevisionInformer.
-	ControllerRevisions() ControllerRevisionInformer
+	ControllerRevisions() TypedControllerRevisionInformer
 	// DaemonSets returns a DaemonSetInformer.
-	DaemonSets() DaemonSetInformer
+	DaemonSets() TypedDaemonSetInformer
 	// Deployments returns a DeploymentInformer.
-	Deployments() DeploymentInformer
+	Deployments() TypedDeploymentInformer
 	// ReplicaSets returns a ReplicaSetInformer.
-	ReplicaSets() ReplicaSetInformer
+	ReplicaSets() TypedReplicaSetInformer
 	// StatefulSets returns a StatefulSetInformer.
-	StatefulSets() StatefulSetInformer
+	StatefulSets() TypedStatefulSetInformer
 }
 
 type version struct {
@@ -47,27 +47,27 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// ControllerRevisions returns a ControllerRevisionInformer.
-func (v *version) ControllerRevisions() ControllerRevisionInformer {
+// ControllerRevisions returns a TypedControllerRevisionInformer.
+func (v *version) ControllerRevisions() TypedControllerRevisionInformer {
 	return &controllerRevisionInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// DaemonSets returns a DaemonSetInformer.
-func (v *version) DaemonSets() DaemonSetInformer {
+// DaemonSets returns a TypedDaemonSetInformer.
+func (v *version) DaemonSets() TypedDaemonSetInformer {
 	return &daemonSetInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// Deployments returns a DeploymentInformer.
-func (v *version) Deployments() DeploymentInformer {
+// Deployments returns a TypedDeploymentInformer.
+func (v *version) Deployments() TypedDeploymentInformer {
 	return &deploymentInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// ReplicaSets returns a ReplicaSetInformer.
-func (v *version) ReplicaSets() ReplicaSetInformer {
+// ReplicaSets returns a TypedReplicaSetInformer.
+func (v *version) ReplicaSets() TypedReplicaSetInformer {
 	return &replicaSetInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// StatefulSets returns a StatefulSetInformer.
-func (v *version) StatefulSets() StatefulSetInformer {
+// StatefulSets returns a TypedStatefulSetInformer.
+func (v *version) StatefulSets() TypedStatefulSetInformer {
 	return &statefulSetInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/apps/v1/replicaset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/replicaset.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ReplicaSetInformer provides access to a shared informer and lister for
-// ReplicaSets.
+// ReplicaSets. Prefer using the type-safe variant (see [TypedReplicaSetInformer]).
 type ReplicaSetInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() appsv1.ReplicaSetLister
 }
+
+// TypedReplicaSetInformer provides access to a shared informer and lister for
+// ReplicaSets, including the type-safe TypedInformer variant.
+// It is a superset of ReplicaSetInformer.
+type TypedReplicaSetInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ReplicaSetIndexInformer
+	Lister() appsv1.ReplicaSetLister
+}
+
+// ReplicaSetIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ReplicaSetIndexInformer cache.TypedSharedIndexInformer[*apiappsv1.ReplicaSet]
+
+// ReplicaSetHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ReplicaSet.
+type ReplicaSetHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiappsv1.ReplicaSet]
+
+// ReplicaSetDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ReplicaSet.
+type ReplicaSetDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiappsv1.ReplicaSet]
+
+// ReplicaSetFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ReplicaSet.
+type ReplicaSetFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiappsv1.ReplicaSet]
+
+// ReplicaSetIndexers is a specialization of [cache.TypedIndexers] for ReplicaSet.
+type ReplicaSetIndexers = cache.TypedIndexers[*apiappsv1.ReplicaSet]
+
+// DeletedReplicaSet is a specialization of [cache.DeletedObject] for ReplicaSet.
+type DeletedReplicaSet = cache.DeletedObject[*apiappsv1.ReplicaSet]
 
 type replicaSetInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type replicaSetInformer struct {
 // NewReplicaSetInformer constructs a new informer for ReplicaSet type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedReplicaSetInformer]).
 func NewReplicaSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewReplicaSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedReplicaSetInformer constructs a new informer for ReplicaSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedReplicaSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ReplicaSetIndexers) ReplicaSetIndexInformer {
+	return NewTypedReplicaSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredReplicaSetInformer constructs a new informer for ReplicaSet type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredReplicaSetInformer]).
 func NewFilteredReplicaSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewReplicaSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedReplicaSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredReplicaSetInformer constructs a new informer for ReplicaSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredReplicaSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ReplicaSetIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ReplicaSetIndexInformer {
+	return NewTypedReplicaSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewReplicaSetInformerWithOptions constructs a new informer for ReplicaSet type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedReplicaSetInformerWithOptions]).
 func NewReplicaSetInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedReplicaSetInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedReplicaSetInformerWithOptions constructs a new informer for ReplicaSet type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedReplicaSetInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) ReplicaSetIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "replicasets"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiappsv1.ReplicaSet](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewReplicaSetInformerWithOptions(client kubernetes.Interface, namespace str
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *replicaSetInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewReplicaSetInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedReplicaSetInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *replicaSetInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiappsv1.ReplicaSet{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *replicaSetInformer) TypedInformer() ReplicaSetIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiappsv1.ReplicaSet](f.factory.InformerFor(&apiappsv1.ReplicaSet{}, f.defaultInformer))
 }
 
 func (f *replicaSetInformer) Lister() appsv1.ReplicaSetLister {
 	return appsv1.NewReplicaSetLister(f.Informer().GetIndexer())
+}
+
+// ToTypedReplicaSetInformer converts an untyped informer into a TypedReplicaSetInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ReplicaSet. If that is not the case, calling type-safe methods of the returned
+// TypedReplicaSetInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedReplicaSetInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedReplicaSetInformer(informer ReplicaSetInformer) TypedReplicaSetInformer {
+	if informer, ok := informer.(TypedReplicaSetInformer); ok {
+		return informer
+	}
+	return &replicaSetTypedInformerAdapter{informer}
+}
+
+type replicaSetTypedInformerAdapter struct {
+	ReplicaSetInformer
+}
+
+func (a *replicaSetTypedInformerAdapter) TypedInformer() ReplicaSetIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiappsv1.ReplicaSet](a.Informer())
+}
+
+// ToReplicaSetIndexInformer converts an untyped informer into a ReplicaSetIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ReplicaSet. If that is not the case, calling type-safe methods of the returned
+// ReplicaSetIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ReplicaSetIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToReplicaSetIndexInformer(informer cache.SharedIndexInformer) ReplicaSetIndexInformer {
+	if informer, ok := informer.(ReplicaSetIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiappsv1.ReplicaSet](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/apps/v1/statefulset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/statefulset.go
@@ -34,11 +34,39 @@ import (
 )
 
 // StatefulSetInformer provides access to a shared informer and lister for
-// StatefulSets.
+// StatefulSets. Prefer using the type-safe variant (see [TypedStatefulSetInformer]).
 type StatefulSetInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() appsv1.StatefulSetLister
 }
+
+// TypedStatefulSetInformer provides access to a shared informer and lister for
+// StatefulSets, including the type-safe TypedInformer variant.
+// It is a superset of StatefulSetInformer.
+type TypedStatefulSetInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() StatefulSetIndexInformer
+	Lister() appsv1.StatefulSetLister
+}
+
+// StatefulSetIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type StatefulSetIndexInformer cache.TypedSharedIndexInformer[*apiappsv1.StatefulSet]
+
+// StatefulSetHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for StatefulSet.
+type StatefulSetHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiappsv1.StatefulSet]
+
+// StatefulSetDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for StatefulSet.
+type StatefulSetDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiappsv1.StatefulSet]
+
+// StatefulSetFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for StatefulSet.
+type StatefulSetFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiappsv1.StatefulSet]
+
+// StatefulSetIndexers is a specialization of [cache.TypedIndexers] for StatefulSet.
+type StatefulSetIndexers = cache.TypedIndexers[*apiappsv1.StatefulSet]
+
+// DeletedStatefulSet is a specialization of [cache.DeletedObject] for StatefulSet.
+type DeletedStatefulSet = cache.DeletedObject[*apiappsv1.StatefulSet]
 
 type statefulSetInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type statefulSetInformer struct {
 // NewStatefulSetInformer constructs a new informer for StatefulSet type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedStatefulSetInformer]).
 func NewStatefulSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewStatefulSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedStatefulSetInformer constructs a new informer for StatefulSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedStatefulSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers StatefulSetIndexers) StatefulSetIndexInformer {
+	return NewTypedStatefulSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredStatefulSetInformer constructs a new informer for StatefulSet type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredStatefulSetInformer]).
 func NewFilteredStatefulSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewStatefulSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedStatefulSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredStatefulSetInformer constructs a new informer for StatefulSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredStatefulSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers StatefulSetIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) StatefulSetIndexInformer {
+	return NewTypedStatefulSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewStatefulSetInformerWithOptions constructs a new informer for StatefulSet type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedStatefulSetInformerWithOptions]).
 func NewStatefulSetInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedStatefulSetInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedStatefulSetInformerWithOptions constructs a new informer for StatefulSet type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedStatefulSetInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) StatefulSetIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiappsv1.StatefulSet](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewStatefulSetInformerWithOptions(client kubernetes.Interface, namespace st
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *statefulSetInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewStatefulSetInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedStatefulSetInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *statefulSetInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiappsv1.StatefulSet{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *statefulSetInformer) TypedInformer() StatefulSetIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiappsv1.StatefulSet](f.factory.InformerFor(&apiappsv1.StatefulSet{}, f.defaultInformer))
 }
 
 func (f *statefulSetInformer) Lister() appsv1.StatefulSetLister {
 	return appsv1.NewStatefulSetLister(f.Informer().GetIndexer())
+}
+
+// ToTypedStatefulSetInformer converts an untyped informer into a TypedStatefulSetInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *StatefulSet. If that is not the case, calling type-safe methods of the returned
+// TypedStatefulSetInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedStatefulSetInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedStatefulSetInformer(informer StatefulSetInformer) TypedStatefulSetInformer {
+	if informer, ok := informer.(TypedStatefulSetInformer); ok {
+		return informer
+	}
+	return &statefulSetTypedInformerAdapter{informer}
+}
+
+type statefulSetTypedInformerAdapter struct {
+	StatefulSetInformer
+}
+
+func (a *statefulSetTypedInformerAdapter) TypedInformer() StatefulSetIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiappsv1.StatefulSet](a.Informer())
+}
+
+// ToStatefulSetIndexInformer converts an untyped informer into a StatefulSetIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *StatefulSet. If that is not the case, calling type-safe methods of the returned
+// StatefulSetIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a StatefulSetIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToStatefulSetIndexInformer(informer cache.SharedIndexInformer) StatefulSetIndexInformer {
+	if informer, ok := informer.(StatefulSetIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiappsv1.StatefulSet](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta1/controllerrevision.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ControllerRevisionInformer provides access to a shared informer and lister for
-// ControllerRevisions.
+// ControllerRevisions. Prefer using the type-safe variant (see [TypedControllerRevisionInformer]).
 type ControllerRevisionInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() appsv1beta1.ControllerRevisionLister
 }
+
+// TypedControllerRevisionInformer provides access to a shared informer and lister for
+// ControllerRevisions, including the type-safe TypedInformer variant.
+// It is a superset of ControllerRevisionInformer.
+type TypedControllerRevisionInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ControllerRevisionIndexInformer
+	Lister() appsv1beta1.ControllerRevisionLister
+}
+
+// ControllerRevisionIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ControllerRevisionIndexInformer cache.TypedSharedIndexInformer[*apiappsv1beta1.ControllerRevision]
+
+// ControllerRevisionHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ControllerRevision.
+type ControllerRevisionHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiappsv1beta1.ControllerRevision]
+
+// ControllerRevisionDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ControllerRevision.
+type ControllerRevisionDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiappsv1beta1.ControllerRevision]
+
+// ControllerRevisionFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ControllerRevision.
+type ControllerRevisionFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiappsv1beta1.ControllerRevision]
+
+// ControllerRevisionIndexers is a specialization of [cache.TypedIndexers] for ControllerRevision.
+type ControllerRevisionIndexers = cache.TypedIndexers[*apiappsv1beta1.ControllerRevision]
+
+// DeletedControllerRevision is a specialization of [cache.DeletedObject] for ControllerRevision.
+type DeletedControllerRevision = cache.DeletedObject[*apiappsv1beta1.ControllerRevision]
 
 type controllerRevisionInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type controllerRevisionInformer struct {
 // NewControllerRevisionInformer constructs a new informer for ControllerRevision type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedControllerRevisionInformer]).
 func NewControllerRevisionInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewControllerRevisionInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedControllerRevisionInformer constructs a new informer for ControllerRevision type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedControllerRevisionInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ControllerRevisionIndexers) ControllerRevisionIndexInformer {
+	return NewTypedControllerRevisionInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredControllerRevisionInformer constructs a new informer for ControllerRevision type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredControllerRevisionInformer]).
 func NewFilteredControllerRevisionInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewControllerRevisionInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedControllerRevisionInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredControllerRevisionInformer constructs a new informer for ControllerRevision type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredControllerRevisionInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ControllerRevisionIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ControllerRevisionIndexInformer {
+	return NewTypedControllerRevisionInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewControllerRevisionInformerWithOptions constructs a new informer for ControllerRevision type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedControllerRevisionInformerWithOptions]).
 func NewControllerRevisionInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedControllerRevisionInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedControllerRevisionInformerWithOptions constructs a new informer for ControllerRevision type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedControllerRevisionInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) ControllerRevisionIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1beta1", Resource: "controllerrevisions"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta1.ControllerRevision](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewControllerRevisionInformerWithOptions(client kubernetes.Interface, names
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *controllerRevisionInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewControllerRevisionInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedControllerRevisionInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *controllerRevisionInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiappsv1beta1.ControllerRevision{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *controllerRevisionInformer) TypedInformer() ControllerRevisionIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta1.ControllerRevision](f.factory.InformerFor(&apiappsv1beta1.ControllerRevision{}, f.defaultInformer))
 }
 
 func (f *controllerRevisionInformer) Lister() appsv1beta1.ControllerRevisionLister {
 	return appsv1beta1.NewControllerRevisionLister(f.Informer().GetIndexer())
+}
+
+// ToTypedControllerRevisionInformer converts an untyped informer into a TypedControllerRevisionInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ControllerRevision. If that is not the case, calling type-safe methods of the returned
+// TypedControllerRevisionInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedControllerRevisionInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedControllerRevisionInformer(informer ControllerRevisionInformer) TypedControllerRevisionInformer {
+	if informer, ok := informer.(TypedControllerRevisionInformer); ok {
+		return informer
+	}
+	return &controllerRevisionTypedInformerAdapter{informer}
+}
+
+type controllerRevisionTypedInformerAdapter struct {
+	ControllerRevisionInformer
+}
+
+func (a *controllerRevisionTypedInformerAdapter) TypedInformer() ControllerRevisionIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta1.ControllerRevision](a.Informer())
+}
+
+// ToControllerRevisionIndexInformer converts an untyped informer into a ControllerRevisionIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ControllerRevision. If that is not the case, calling type-safe methods of the returned
+// ControllerRevisionIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ControllerRevisionIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToControllerRevisionIndexInformer(informer cache.SharedIndexInformer) ControllerRevisionIndexInformer {
+	if informer, ok := informer.(ControllerRevisionIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta1.ControllerRevision](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta1/deployment.go
@@ -34,11 +34,39 @@ import (
 )
 
 // DeploymentInformer provides access to a shared informer and lister for
-// Deployments.
+// Deployments. Prefer using the type-safe variant (see [TypedDeploymentInformer]).
 type DeploymentInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() appsv1beta1.DeploymentLister
 }
+
+// TypedDeploymentInformer provides access to a shared informer and lister for
+// Deployments, including the type-safe TypedInformer variant.
+// It is a superset of DeploymentInformer.
+type TypedDeploymentInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() DeploymentIndexInformer
+	Lister() appsv1beta1.DeploymentLister
+}
+
+// DeploymentIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type DeploymentIndexInformer cache.TypedSharedIndexInformer[*apiappsv1beta1.Deployment]
+
+// DeploymentHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Deployment.
+type DeploymentHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiappsv1beta1.Deployment]
+
+// DeploymentDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Deployment.
+type DeploymentDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiappsv1beta1.Deployment]
+
+// DeploymentFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Deployment.
+type DeploymentFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiappsv1beta1.Deployment]
+
+// DeploymentIndexers is a specialization of [cache.TypedIndexers] for Deployment.
+type DeploymentIndexers = cache.TypedIndexers[*apiappsv1beta1.Deployment]
+
+// DeletedDeployment is a specialization of [cache.DeletedObject] for Deployment.
+type DeletedDeployment = cache.DeletedObject[*apiappsv1beta1.Deployment]
 
 type deploymentInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type deploymentInformer struct {
 // NewDeploymentInformer constructs a new informer for Deployment type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedDeploymentInformer]).
 func NewDeploymentInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewDeploymentInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedDeploymentInformer constructs a new informer for Deployment type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedDeploymentInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers DeploymentIndexers) DeploymentIndexInformer {
+	return NewTypedDeploymentInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredDeploymentInformer constructs a new informer for Deployment type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredDeploymentInformer]).
 func NewFilteredDeploymentInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewDeploymentInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedDeploymentInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredDeploymentInformer constructs a new informer for Deployment type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredDeploymentInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers DeploymentIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) DeploymentIndexInformer {
+	return NewTypedDeploymentInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewDeploymentInformerWithOptions constructs a new informer for Deployment type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedDeploymentInformerWithOptions]).
 func NewDeploymentInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedDeploymentInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedDeploymentInformerWithOptions constructs a new informer for Deployment type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedDeploymentInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) DeploymentIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1beta1", Resource: "deployments"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta1.Deployment](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewDeploymentInformerWithOptions(client kubernetes.Interface, namespace str
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *deploymentInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewDeploymentInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedDeploymentInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *deploymentInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiappsv1beta1.Deployment{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *deploymentInformer) TypedInformer() DeploymentIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta1.Deployment](f.factory.InformerFor(&apiappsv1beta1.Deployment{}, f.defaultInformer))
 }
 
 func (f *deploymentInformer) Lister() appsv1beta1.DeploymentLister {
 	return appsv1beta1.NewDeploymentLister(f.Informer().GetIndexer())
+}
+
+// ToTypedDeploymentInformer converts an untyped informer into a TypedDeploymentInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Deployment. If that is not the case, calling type-safe methods of the returned
+// TypedDeploymentInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedDeploymentInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedDeploymentInformer(informer DeploymentInformer) TypedDeploymentInformer {
+	if informer, ok := informer.(TypedDeploymentInformer); ok {
+		return informer
+	}
+	return &deploymentTypedInformerAdapter{informer}
+}
+
+type deploymentTypedInformerAdapter struct {
+	DeploymentInformer
+}
+
+func (a *deploymentTypedInformerAdapter) TypedInformer() DeploymentIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta1.Deployment](a.Informer())
+}
+
+// ToDeploymentIndexInformer converts an untyped informer into a DeploymentIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Deployment. If that is not the case, calling type-safe methods of the returned
+// DeploymentIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a DeploymentIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToDeploymentIndexInformer(informer cache.SharedIndexInformer) DeploymentIndexInformer {
+	if informer, ok := informer.(DeploymentIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta1.Deployment](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta1/interface.go
@@ -25,11 +25,11 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// ControllerRevisions returns a ControllerRevisionInformer.
-	ControllerRevisions() ControllerRevisionInformer
+	ControllerRevisions() TypedControllerRevisionInformer
 	// Deployments returns a DeploymentInformer.
-	Deployments() DeploymentInformer
+	Deployments() TypedDeploymentInformer
 	// StatefulSets returns a StatefulSetInformer.
-	StatefulSets() StatefulSetInformer
+	StatefulSets() TypedStatefulSetInformer
 }
 
 type version struct {
@@ -43,17 +43,17 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// ControllerRevisions returns a ControllerRevisionInformer.
-func (v *version) ControllerRevisions() ControllerRevisionInformer {
+// ControllerRevisions returns a TypedControllerRevisionInformer.
+func (v *version) ControllerRevisions() TypedControllerRevisionInformer {
 	return &controllerRevisionInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// Deployments returns a DeploymentInformer.
-func (v *version) Deployments() DeploymentInformer {
+// Deployments returns a TypedDeploymentInformer.
+func (v *version) Deployments() TypedDeploymentInformer {
 	return &deploymentInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// StatefulSets returns a StatefulSetInformer.
-func (v *version) StatefulSets() StatefulSetInformer {
+// StatefulSets returns a TypedStatefulSetInformer.
+func (v *version) StatefulSets() TypedStatefulSetInformer {
 	return &statefulSetInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta1/statefulset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta1/statefulset.go
@@ -34,11 +34,39 @@ import (
 )
 
 // StatefulSetInformer provides access to a shared informer and lister for
-// StatefulSets.
+// StatefulSets. Prefer using the type-safe variant (see [TypedStatefulSetInformer]).
 type StatefulSetInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() appsv1beta1.StatefulSetLister
 }
+
+// TypedStatefulSetInformer provides access to a shared informer and lister for
+// StatefulSets, including the type-safe TypedInformer variant.
+// It is a superset of StatefulSetInformer.
+type TypedStatefulSetInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() StatefulSetIndexInformer
+	Lister() appsv1beta1.StatefulSetLister
+}
+
+// StatefulSetIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type StatefulSetIndexInformer cache.TypedSharedIndexInformer[*apiappsv1beta1.StatefulSet]
+
+// StatefulSetHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for StatefulSet.
+type StatefulSetHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiappsv1beta1.StatefulSet]
+
+// StatefulSetDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for StatefulSet.
+type StatefulSetDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiappsv1beta1.StatefulSet]
+
+// StatefulSetFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for StatefulSet.
+type StatefulSetFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiappsv1beta1.StatefulSet]
+
+// StatefulSetIndexers is a specialization of [cache.TypedIndexers] for StatefulSet.
+type StatefulSetIndexers = cache.TypedIndexers[*apiappsv1beta1.StatefulSet]
+
+// DeletedStatefulSet is a specialization of [cache.DeletedObject] for StatefulSet.
+type DeletedStatefulSet = cache.DeletedObject[*apiappsv1beta1.StatefulSet]
 
 type statefulSetInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type statefulSetInformer struct {
 // NewStatefulSetInformer constructs a new informer for StatefulSet type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedStatefulSetInformer]).
 func NewStatefulSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewStatefulSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedStatefulSetInformer constructs a new informer for StatefulSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedStatefulSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers StatefulSetIndexers) StatefulSetIndexInformer {
+	return NewTypedStatefulSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredStatefulSetInformer constructs a new informer for StatefulSet type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredStatefulSetInformer]).
 func NewFilteredStatefulSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewStatefulSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedStatefulSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredStatefulSetInformer constructs a new informer for StatefulSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredStatefulSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers StatefulSetIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) StatefulSetIndexInformer {
+	return NewTypedStatefulSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewStatefulSetInformerWithOptions constructs a new informer for StatefulSet type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedStatefulSetInformerWithOptions]).
 func NewStatefulSetInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedStatefulSetInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedStatefulSetInformerWithOptions constructs a new informer for StatefulSet type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedStatefulSetInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) StatefulSetIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1beta1", Resource: "statefulsets"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta1.StatefulSet](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewStatefulSetInformerWithOptions(client kubernetes.Interface, namespace st
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *statefulSetInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewStatefulSetInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedStatefulSetInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *statefulSetInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiappsv1beta1.StatefulSet{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *statefulSetInformer) TypedInformer() StatefulSetIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta1.StatefulSet](f.factory.InformerFor(&apiappsv1beta1.StatefulSet{}, f.defaultInformer))
 }
 
 func (f *statefulSetInformer) Lister() appsv1beta1.StatefulSetLister {
 	return appsv1beta1.NewStatefulSetLister(f.Informer().GetIndexer())
+}
+
+// ToTypedStatefulSetInformer converts an untyped informer into a TypedStatefulSetInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *StatefulSet. If that is not the case, calling type-safe methods of the returned
+// TypedStatefulSetInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedStatefulSetInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedStatefulSetInformer(informer StatefulSetInformer) TypedStatefulSetInformer {
+	if informer, ok := informer.(TypedStatefulSetInformer); ok {
+		return informer
+	}
+	return &statefulSetTypedInformerAdapter{informer}
+}
+
+type statefulSetTypedInformerAdapter struct {
+	StatefulSetInformer
+}
+
+func (a *statefulSetTypedInformerAdapter) TypedInformer() StatefulSetIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta1.StatefulSet](a.Informer())
+}
+
+// ToStatefulSetIndexInformer converts an untyped informer into a StatefulSetIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *StatefulSet. If that is not the case, calling type-safe methods of the returned
+// StatefulSetIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a StatefulSetIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToStatefulSetIndexInformer(informer cache.SharedIndexInformer) StatefulSetIndexInformer {
+	if informer, ok := informer.(StatefulSetIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta1.StatefulSet](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/controllerrevision.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ControllerRevisionInformer provides access to a shared informer and lister for
-// ControllerRevisions.
+// ControllerRevisions. Prefer using the type-safe variant (see [TypedControllerRevisionInformer]).
 type ControllerRevisionInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() appsv1beta2.ControllerRevisionLister
 }
+
+// TypedControllerRevisionInformer provides access to a shared informer and lister for
+// ControllerRevisions, including the type-safe TypedInformer variant.
+// It is a superset of ControllerRevisionInformer.
+type TypedControllerRevisionInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ControllerRevisionIndexInformer
+	Lister() appsv1beta2.ControllerRevisionLister
+}
+
+// ControllerRevisionIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ControllerRevisionIndexInformer cache.TypedSharedIndexInformer[*apiappsv1beta2.ControllerRevision]
+
+// ControllerRevisionHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ControllerRevision.
+type ControllerRevisionHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiappsv1beta2.ControllerRevision]
+
+// ControllerRevisionDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ControllerRevision.
+type ControllerRevisionDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiappsv1beta2.ControllerRevision]
+
+// ControllerRevisionFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ControllerRevision.
+type ControllerRevisionFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiappsv1beta2.ControllerRevision]
+
+// ControllerRevisionIndexers is a specialization of [cache.TypedIndexers] for ControllerRevision.
+type ControllerRevisionIndexers = cache.TypedIndexers[*apiappsv1beta2.ControllerRevision]
+
+// DeletedControllerRevision is a specialization of [cache.DeletedObject] for ControllerRevision.
+type DeletedControllerRevision = cache.DeletedObject[*apiappsv1beta2.ControllerRevision]
 
 type controllerRevisionInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type controllerRevisionInformer struct {
 // NewControllerRevisionInformer constructs a new informer for ControllerRevision type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedControllerRevisionInformer]).
 func NewControllerRevisionInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewControllerRevisionInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedControllerRevisionInformer constructs a new informer for ControllerRevision type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedControllerRevisionInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ControllerRevisionIndexers) ControllerRevisionIndexInformer {
+	return NewTypedControllerRevisionInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredControllerRevisionInformer constructs a new informer for ControllerRevision type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredControllerRevisionInformer]).
 func NewFilteredControllerRevisionInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewControllerRevisionInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedControllerRevisionInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredControllerRevisionInformer constructs a new informer for ControllerRevision type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredControllerRevisionInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ControllerRevisionIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ControllerRevisionIndexInformer {
+	return NewTypedControllerRevisionInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewControllerRevisionInformerWithOptions constructs a new informer for ControllerRevision type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedControllerRevisionInformerWithOptions]).
 func NewControllerRevisionInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedControllerRevisionInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedControllerRevisionInformerWithOptions constructs a new informer for ControllerRevision type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedControllerRevisionInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) ControllerRevisionIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1beta2", Resource: "controllerrevisions"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta2.ControllerRevision](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewControllerRevisionInformerWithOptions(client kubernetes.Interface, names
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *controllerRevisionInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewControllerRevisionInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedControllerRevisionInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *controllerRevisionInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiappsv1beta2.ControllerRevision{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *controllerRevisionInformer) TypedInformer() ControllerRevisionIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta2.ControllerRevision](f.factory.InformerFor(&apiappsv1beta2.ControllerRevision{}, f.defaultInformer))
 }
 
 func (f *controllerRevisionInformer) Lister() appsv1beta2.ControllerRevisionLister {
 	return appsv1beta2.NewControllerRevisionLister(f.Informer().GetIndexer())
+}
+
+// ToTypedControllerRevisionInformer converts an untyped informer into a TypedControllerRevisionInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ControllerRevision. If that is not the case, calling type-safe methods of the returned
+// TypedControllerRevisionInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedControllerRevisionInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedControllerRevisionInformer(informer ControllerRevisionInformer) TypedControllerRevisionInformer {
+	if informer, ok := informer.(TypedControllerRevisionInformer); ok {
+		return informer
+	}
+	return &controllerRevisionTypedInformerAdapter{informer}
+}
+
+type controllerRevisionTypedInformerAdapter struct {
+	ControllerRevisionInformer
+}
+
+func (a *controllerRevisionTypedInformerAdapter) TypedInformer() ControllerRevisionIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta2.ControllerRevision](a.Informer())
+}
+
+// ToControllerRevisionIndexInformer converts an untyped informer into a ControllerRevisionIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ControllerRevision. If that is not the case, calling type-safe methods of the returned
+// ControllerRevisionIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ControllerRevisionIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToControllerRevisionIndexInformer(informer cache.SharedIndexInformer) ControllerRevisionIndexInformer {
+	if informer, ok := informer.(ControllerRevisionIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta2.ControllerRevision](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/daemonset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/daemonset.go
@@ -34,11 +34,39 @@ import (
 )
 
 // DaemonSetInformer provides access to a shared informer and lister for
-// DaemonSets.
+// DaemonSets. Prefer using the type-safe variant (see [TypedDaemonSetInformer]).
 type DaemonSetInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() appsv1beta2.DaemonSetLister
 }
+
+// TypedDaemonSetInformer provides access to a shared informer and lister for
+// DaemonSets, including the type-safe TypedInformer variant.
+// It is a superset of DaemonSetInformer.
+type TypedDaemonSetInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() DaemonSetIndexInformer
+	Lister() appsv1beta2.DaemonSetLister
+}
+
+// DaemonSetIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type DaemonSetIndexInformer cache.TypedSharedIndexInformer[*apiappsv1beta2.DaemonSet]
+
+// DaemonSetHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for DaemonSet.
+type DaemonSetHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiappsv1beta2.DaemonSet]
+
+// DaemonSetDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for DaemonSet.
+type DaemonSetDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiappsv1beta2.DaemonSet]
+
+// DaemonSetFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for DaemonSet.
+type DaemonSetFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiappsv1beta2.DaemonSet]
+
+// DaemonSetIndexers is a specialization of [cache.TypedIndexers] for DaemonSet.
+type DaemonSetIndexers = cache.TypedIndexers[*apiappsv1beta2.DaemonSet]
+
+// DeletedDaemonSet is a specialization of [cache.DeletedObject] for DaemonSet.
+type DeletedDaemonSet = cache.DeletedObject[*apiappsv1beta2.DaemonSet]
 
 type daemonSetInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type daemonSetInformer struct {
 // NewDaemonSetInformer constructs a new informer for DaemonSet type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedDaemonSetInformer]).
 func NewDaemonSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewDaemonSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedDaemonSetInformer constructs a new informer for DaemonSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedDaemonSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers DaemonSetIndexers) DaemonSetIndexInformer {
+	return NewTypedDaemonSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredDaemonSetInformer constructs a new informer for DaemonSet type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredDaemonSetInformer]).
 func NewFilteredDaemonSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewDaemonSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedDaemonSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredDaemonSetInformer constructs a new informer for DaemonSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredDaemonSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers DaemonSetIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) DaemonSetIndexInformer {
+	return NewTypedDaemonSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewDaemonSetInformerWithOptions constructs a new informer for DaemonSet type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedDaemonSetInformerWithOptions]).
 func NewDaemonSetInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedDaemonSetInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedDaemonSetInformerWithOptions constructs a new informer for DaemonSet type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedDaemonSetInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) DaemonSetIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1beta2", Resource: "daemonsets"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta2.DaemonSet](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewDaemonSetInformerWithOptions(client kubernetes.Interface, namespace stri
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *daemonSetInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewDaemonSetInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedDaemonSetInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *daemonSetInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiappsv1beta2.DaemonSet{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *daemonSetInformer) TypedInformer() DaemonSetIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta2.DaemonSet](f.factory.InformerFor(&apiappsv1beta2.DaemonSet{}, f.defaultInformer))
 }
 
 func (f *daemonSetInformer) Lister() appsv1beta2.DaemonSetLister {
 	return appsv1beta2.NewDaemonSetLister(f.Informer().GetIndexer())
+}
+
+// ToTypedDaemonSetInformer converts an untyped informer into a TypedDaemonSetInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *DaemonSet. If that is not the case, calling type-safe methods of the returned
+// TypedDaemonSetInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedDaemonSetInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedDaemonSetInformer(informer DaemonSetInformer) TypedDaemonSetInformer {
+	if informer, ok := informer.(TypedDaemonSetInformer); ok {
+		return informer
+	}
+	return &daemonSetTypedInformerAdapter{informer}
+}
+
+type daemonSetTypedInformerAdapter struct {
+	DaemonSetInformer
+}
+
+func (a *daemonSetTypedInformerAdapter) TypedInformer() DaemonSetIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta2.DaemonSet](a.Informer())
+}
+
+// ToDaemonSetIndexInformer converts an untyped informer into a DaemonSetIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *DaemonSet. If that is not the case, calling type-safe methods of the returned
+// DaemonSetIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a DaemonSetIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToDaemonSetIndexInformer(informer cache.SharedIndexInformer) DaemonSetIndexInformer {
+	if informer, ok := informer.(DaemonSetIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta2.DaemonSet](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/deployment.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/deployment.go
@@ -34,11 +34,39 @@ import (
 )
 
 // DeploymentInformer provides access to a shared informer and lister for
-// Deployments.
+// Deployments. Prefer using the type-safe variant (see [TypedDeploymentInformer]).
 type DeploymentInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() appsv1beta2.DeploymentLister
 }
+
+// TypedDeploymentInformer provides access to a shared informer and lister for
+// Deployments, including the type-safe TypedInformer variant.
+// It is a superset of DeploymentInformer.
+type TypedDeploymentInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() DeploymentIndexInformer
+	Lister() appsv1beta2.DeploymentLister
+}
+
+// DeploymentIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type DeploymentIndexInformer cache.TypedSharedIndexInformer[*apiappsv1beta2.Deployment]
+
+// DeploymentHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Deployment.
+type DeploymentHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiappsv1beta2.Deployment]
+
+// DeploymentDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Deployment.
+type DeploymentDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiappsv1beta2.Deployment]
+
+// DeploymentFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Deployment.
+type DeploymentFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiappsv1beta2.Deployment]
+
+// DeploymentIndexers is a specialization of [cache.TypedIndexers] for Deployment.
+type DeploymentIndexers = cache.TypedIndexers[*apiappsv1beta2.Deployment]
+
+// DeletedDeployment is a specialization of [cache.DeletedObject] for Deployment.
+type DeletedDeployment = cache.DeletedObject[*apiappsv1beta2.Deployment]
 
 type deploymentInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type deploymentInformer struct {
 // NewDeploymentInformer constructs a new informer for Deployment type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedDeploymentInformer]).
 func NewDeploymentInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewDeploymentInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedDeploymentInformer constructs a new informer for Deployment type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedDeploymentInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers DeploymentIndexers) DeploymentIndexInformer {
+	return NewTypedDeploymentInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredDeploymentInformer constructs a new informer for Deployment type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredDeploymentInformer]).
 func NewFilteredDeploymentInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewDeploymentInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedDeploymentInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredDeploymentInformer constructs a new informer for Deployment type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredDeploymentInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers DeploymentIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) DeploymentIndexInformer {
+	return NewTypedDeploymentInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewDeploymentInformerWithOptions constructs a new informer for Deployment type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedDeploymentInformerWithOptions]).
 func NewDeploymentInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedDeploymentInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedDeploymentInformerWithOptions constructs a new informer for Deployment type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedDeploymentInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) DeploymentIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1beta2", Resource: "deployments"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta2.Deployment](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewDeploymentInformerWithOptions(client kubernetes.Interface, namespace str
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *deploymentInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewDeploymentInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedDeploymentInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *deploymentInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiappsv1beta2.Deployment{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *deploymentInformer) TypedInformer() DeploymentIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta2.Deployment](f.factory.InformerFor(&apiappsv1beta2.Deployment{}, f.defaultInformer))
 }
 
 func (f *deploymentInformer) Lister() appsv1beta2.DeploymentLister {
 	return appsv1beta2.NewDeploymentLister(f.Informer().GetIndexer())
+}
+
+// ToTypedDeploymentInformer converts an untyped informer into a TypedDeploymentInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Deployment. If that is not the case, calling type-safe methods of the returned
+// TypedDeploymentInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedDeploymentInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedDeploymentInformer(informer DeploymentInformer) TypedDeploymentInformer {
+	if informer, ok := informer.(TypedDeploymentInformer); ok {
+		return informer
+	}
+	return &deploymentTypedInformerAdapter{informer}
+}
+
+type deploymentTypedInformerAdapter struct {
+	DeploymentInformer
+}
+
+func (a *deploymentTypedInformerAdapter) TypedInformer() DeploymentIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta2.Deployment](a.Informer())
+}
+
+// ToDeploymentIndexInformer converts an untyped informer into a DeploymentIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Deployment. If that is not the case, calling type-safe methods of the returned
+// DeploymentIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a DeploymentIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToDeploymentIndexInformer(informer cache.SharedIndexInformer) DeploymentIndexInformer {
+	if informer, ok := informer.(DeploymentIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta2.Deployment](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/interface.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/interface.go
@@ -25,15 +25,15 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// ControllerRevisions returns a ControllerRevisionInformer.
-	ControllerRevisions() ControllerRevisionInformer
+	ControllerRevisions() TypedControllerRevisionInformer
 	// DaemonSets returns a DaemonSetInformer.
-	DaemonSets() DaemonSetInformer
+	DaemonSets() TypedDaemonSetInformer
 	// Deployments returns a DeploymentInformer.
-	Deployments() DeploymentInformer
+	Deployments() TypedDeploymentInformer
 	// ReplicaSets returns a ReplicaSetInformer.
-	ReplicaSets() ReplicaSetInformer
+	ReplicaSets() TypedReplicaSetInformer
 	// StatefulSets returns a StatefulSetInformer.
-	StatefulSets() StatefulSetInformer
+	StatefulSets() TypedStatefulSetInformer
 }
 
 type version struct {
@@ -47,27 +47,27 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// ControllerRevisions returns a ControllerRevisionInformer.
-func (v *version) ControllerRevisions() ControllerRevisionInformer {
+// ControllerRevisions returns a TypedControllerRevisionInformer.
+func (v *version) ControllerRevisions() TypedControllerRevisionInformer {
 	return &controllerRevisionInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// DaemonSets returns a DaemonSetInformer.
-func (v *version) DaemonSets() DaemonSetInformer {
+// DaemonSets returns a TypedDaemonSetInformer.
+func (v *version) DaemonSets() TypedDaemonSetInformer {
 	return &daemonSetInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// Deployments returns a DeploymentInformer.
-func (v *version) Deployments() DeploymentInformer {
+// Deployments returns a TypedDeploymentInformer.
+func (v *version) Deployments() TypedDeploymentInformer {
 	return &deploymentInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// ReplicaSets returns a ReplicaSetInformer.
-func (v *version) ReplicaSets() ReplicaSetInformer {
+// ReplicaSets returns a TypedReplicaSetInformer.
+func (v *version) ReplicaSets() TypedReplicaSetInformer {
 	return &replicaSetInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// StatefulSets returns a StatefulSetInformer.
-func (v *version) StatefulSets() StatefulSetInformer {
+// StatefulSets returns a TypedStatefulSetInformer.
+func (v *version) StatefulSets() TypedStatefulSetInformer {
 	return &statefulSetInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/replicaset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/replicaset.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ReplicaSetInformer provides access to a shared informer and lister for
-// ReplicaSets.
+// ReplicaSets. Prefer using the type-safe variant (see [TypedReplicaSetInformer]).
 type ReplicaSetInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() appsv1beta2.ReplicaSetLister
 }
+
+// TypedReplicaSetInformer provides access to a shared informer and lister for
+// ReplicaSets, including the type-safe TypedInformer variant.
+// It is a superset of ReplicaSetInformer.
+type TypedReplicaSetInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ReplicaSetIndexInformer
+	Lister() appsv1beta2.ReplicaSetLister
+}
+
+// ReplicaSetIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ReplicaSetIndexInformer cache.TypedSharedIndexInformer[*apiappsv1beta2.ReplicaSet]
+
+// ReplicaSetHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ReplicaSet.
+type ReplicaSetHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiappsv1beta2.ReplicaSet]
+
+// ReplicaSetDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ReplicaSet.
+type ReplicaSetDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiappsv1beta2.ReplicaSet]
+
+// ReplicaSetFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ReplicaSet.
+type ReplicaSetFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiappsv1beta2.ReplicaSet]
+
+// ReplicaSetIndexers is a specialization of [cache.TypedIndexers] for ReplicaSet.
+type ReplicaSetIndexers = cache.TypedIndexers[*apiappsv1beta2.ReplicaSet]
+
+// DeletedReplicaSet is a specialization of [cache.DeletedObject] for ReplicaSet.
+type DeletedReplicaSet = cache.DeletedObject[*apiappsv1beta2.ReplicaSet]
 
 type replicaSetInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type replicaSetInformer struct {
 // NewReplicaSetInformer constructs a new informer for ReplicaSet type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedReplicaSetInformer]).
 func NewReplicaSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewReplicaSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedReplicaSetInformer constructs a new informer for ReplicaSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedReplicaSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ReplicaSetIndexers) ReplicaSetIndexInformer {
+	return NewTypedReplicaSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredReplicaSetInformer constructs a new informer for ReplicaSet type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredReplicaSetInformer]).
 func NewFilteredReplicaSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewReplicaSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedReplicaSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredReplicaSetInformer constructs a new informer for ReplicaSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredReplicaSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ReplicaSetIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ReplicaSetIndexInformer {
+	return NewTypedReplicaSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewReplicaSetInformerWithOptions constructs a new informer for ReplicaSet type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedReplicaSetInformerWithOptions]).
 func NewReplicaSetInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedReplicaSetInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedReplicaSetInformerWithOptions constructs a new informer for ReplicaSet type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedReplicaSetInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) ReplicaSetIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1beta2", Resource: "replicasets"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta2.ReplicaSet](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewReplicaSetInformerWithOptions(client kubernetes.Interface, namespace str
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *replicaSetInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewReplicaSetInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedReplicaSetInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *replicaSetInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiappsv1beta2.ReplicaSet{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *replicaSetInformer) TypedInformer() ReplicaSetIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta2.ReplicaSet](f.factory.InformerFor(&apiappsv1beta2.ReplicaSet{}, f.defaultInformer))
 }
 
 func (f *replicaSetInformer) Lister() appsv1beta2.ReplicaSetLister {
 	return appsv1beta2.NewReplicaSetLister(f.Informer().GetIndexer())
+}
+
+// ToTypedReplicaSetInformer converts an untyped informer into a TypedReplicaSetInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ReplicaSet. If that is not the case, calling type-safe methods of the returned
+// TypedReplicaSetInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedReplicaSetInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedReplicaSetInformer(informer ReplicaSetInformer) TypedReplicaSetInformer {
+	if informer, ok := informer.(TypedReplicaSetInformer); ok {
+		return informer
+	}
+	return &replicaSetTypedInformerAdapter{informer}
+}
+
+type replicaSetTypedInformerAdapter struct {
+	ReplicaSetInformer
+}
+
+func (a *replicaSetTypedInformerAdapter) TypedInformer() ReplicaSetIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta2.ReplicaSet](a.Informer())
+}
+
+// ToReplicaSetIndexInformer converts an untyped informer into a ReplicaSetIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ReplicaSet. If that is not the case, calling type-safe methods of the returned
+// ReplicaSetIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ReplicaSetIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToReplicaSetIndexInformer(informer cache.SharedIndexInformer) ReplicaSetIndexInformer {
+	if informer, ok := informer.(ReplicaSetIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta2.ReplicaSet](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/statefulset.go
@@ -34,11 +34,39 @@ import (
 )
 
 // StatefulSetInformer provides access to a shared informer and lister for
-// StatefulSets.
+// StatefulSets. Prefer using the type-safe variant (see [TypedStatefulSetInformer]).
 type StatefulSetInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() appsv1beta2.StatefulSetLister
 }
+
+// TypedStatefulSetInformer provides access to a shared informer and lister for
+// StatefulSets, including the type-safe TypedInformer variant.
+// It is a superset of StatefulSetInformer.
+type TypedStatefulSetInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() StatefulSetIndexInformer
+	Lister() appsv1beta2.StatefulSetLister
+}
+
+// StatefulSetIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type StatefulSetIndexInformer cache.TypedSharedIndexInformer[*apiappsv1beta2.StatefulSet]
+
+// StatefulSetHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for StatefulSet.
+type StatefulSetHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiappsv1beta2.StatefulSet]
+
+// StatefulSetDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for StatefulSet.
+type StatefulSetDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiappsv1beta2.StatefulSet]
+
+// StatefulSetFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for StatefulSet.
+type StatefulSetFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiappsv1beta2.StatefulSet]
+
+// StatefulSetIndexers is a specialization of [cache.TypedIndexers] for StatefulSet.
+type StatefulSetIndexers = cache.TypedIndexers[*apiappsv1beta2.StatefulSet]
+
+// DeletedStatefulSet is a specialization of [cache.DeletedObject] for StatefulSet.
+type DeletedStatefulSet = cache.DeletedObject[*apiappsv1beta2.StatefulSet]
 
 type statefulSetInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type statefulSetInformer struct {
 // NewStatefulSetInformer constructs a new informer for StatefulSet type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedStatefulSetInformer]).
 func NewStatefulSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewStatefulSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedStatefulSetInformer constructs a new informer for StatefulSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedStatefulSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers StatefulSetIndexers) StatefulSetIndexInformer {
+	return NewTypedStatefulSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredStatefulSetInformer constructs a new informer for StatefulSet type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredStatefulSetInformer]).
 func NewFilteredStatefulSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewStatefulSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedStatefulSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredStatefulSetInformer constructs a new informer for StatefulSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredStatefulSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers StatefulSetIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) StatefulSetIndexInformer {
+	return NewTypedStatefulSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewStatefulSetInformerWithOptions constructs a new informer for StatefulSet type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedStatefulSetInformerWithOptions]).
 func NewStatefulSetInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedStatefulSetInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedStatefulSetInformerWithOptions constructs a new informer for StatefulSet type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedStatefulSetInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) StatefulSetIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1beta2", Resource: "statefulsets"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta2.StatefulSet](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewStatefulSetInformerWithOptions(client kubernetes.Interface, namespace st
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *statefulSetInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewStatefulSetInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedStatefulSetInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *statefulSetInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiappsv1beta2.StatefulSet{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *statefulSetInformer) TypedInformer() StatefulSetIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta2.StatefulSet](f.factory.InformerFor(&apiappsv1beta2.StatefulSet{}, f.defaultInformer))
 }
 
 func (f *statefulSetInformer) Lister() appsv1beta2.StatefulSetLister {
 	return appsv1beta2.NewStatefulSetLister(f.Informer().GetIndexer())
+}
+
+// ToTypedStatefulSetInformer converts an untyped informer into a TypedStatefulSetInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *StatefulSet. If that is not the case, calling type-safe methods of the returned
+// TypedStatefulSetInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedStatefulSetInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedStatefulSetInformer(informer StatefulSetInformer) TypedStatefulSetInformer {
+	if informer, ok := informer.(TypedStatefulSetInformer); ok {
+		return informer
+	}
+	return &statefulSetTypedInformerAdapter{informer}
+}
+
+type statefulSetTypedInformerAdapter struct {
+	StatefulSetInformer
+}
+
+func (a *statefulSetTypedInformerAdapter) TypedInformer() StatefulSetIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta2.StatefulSet](a.Informer())
+}
+
+// ToStatefulSetIndexInformer converts an untyped informer into a StatefulSetIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *StatefulSet. If that is not the case, calling type-safe methods of the returned
+// StatefulSetIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a StatefulSetIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToStatefulSetIndexInformer(informer cache.SharedIndexInformer) StatefulSetIndexInformer {
+	if informer, ok := informer.(StatefulSetIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiappsv1beta2.StatefulSet](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/informers/autoscaling/v1/horizontalpodautoscaler.go
@@ -34,11 +34,39 @@ import (
 )
 
 // HorizontalPodAutoscalerInformer provides access to a shared informer and lister for
-// HorizontalPodAutoscalers.
+// HorizontalPodAutoscalers. Prefer using the type-safe variant (see [TypedHorizontalPodAutoscalerInformer]).
 type HorizontalPodAutoscalerInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() autoscalingv1.HorizontalPodAutoscalerLister
 }
+
+// TypedHorizontalPodAutoscalerInformer provides access to a shared informer and lister for
+// HorizontalPodAutoscalers, including the type-safe TypedInformer variant.
+// It is a superset of HorizontalPodAutoscalerInformer.
+type TypedHorizontalPodAutoscalerInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() HorizontalPodAutoscalerIndexInformer
+	Lister() autoscalingv1.HorizontalPodAutoscalerLister
+}
+
+// HorizontalPodAutoscalerIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type HorizontalPodAutoscalerIndexInformer cache.TypedSharedIndexInformer[*apiautoscalingv1.HorizontalPodAutoscaler]
+
+// HorizontalPodAutoscalerHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for HorizontalPodAutoscaler.
+type HorizontalPodAutoscalerHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiautoscalingv1.HorizontalPodAutoscaler]
+
+// HorizontalPodAutoscalerDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for HorizontalPodAutoscaler.
+type HorizontalPodAutoscalerDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiautoscalingv1.HorizontalPodAutoscaler]
+
+// HorizontalPodAutoscalerFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for HorizontalPodAutoscaler.
+type HorizontalPodAutoscalerFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiautoscalingv1.HorizontalPodAutoscaler]
+
+// HorizontalPodAutoscalerIndexers is a specialization of [cache.TypedIndexers] for HorizontalPodAutoscaler.
+type HorizontalPodAutoscalerIndexers = cache.TypedIndexers[*apiautoscalingv1.HorizontalPodAutoscaler]
+
+// DeletedHorizontalPodAutoscaler is a specialization of [cache.DeletedObject] for HorizontalPodAutoscaler.
+type DeletedHorizontalPodAutoscaler = cache.DeletedObject[*apiautoscalingv1.HorizontalPodAutoscaler]
 
 type horizontalPodAutoscalerInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type horizontalPodAutoscalerInformer struct {
 // NewHorizontalPodAutoscalerInformer constructs a new informer for HorizontalPodAutoscaler type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedHorizontalPodAutoscalerInformer]).
 func NewHorizontalPodAutoscalerInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewHorizontalPodAutoscalerInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedHorizontalPodAutoscalerInformer constructs a new informer for HorizontalPodAutoscaler type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedHorizontalPodAutoscalerInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers HorizontalPodAutoscalerIndexers) HorizontalPodAutoscalerIndexInformer {
+	return NewTypedHorizontalPodAutoscalerInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredHorizontalPodAutoscalerInformer constructs a new informer for HorizontalPodAutoscaler type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredHorizontalPodAutoscalerInformer]).
 func NewFilteredHorizontalPodAutoscalerInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewHorizontalPodAutoscalerInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedHorizontalPodAutoscalerInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredHorizontalPodAutoscalerInformer constructs a new informer for HorizontalPodAutoscaler type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredHorizontalPodAutoscalerInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers HorizontalPodAutoscalerIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) HorizontalPodAutoscalerIndexInformer {
+	return NewTypedHorizontalPodAutoscalerInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewHorizontalPodAutoscalerInformerWithOptions constructs a new informer for HorizontalPodAutoscaler type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedHorizontalPodAutoscalerInformerWithOptions]).
 func NewHorizontalPodAutoscalerInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedHorizontalPodAutoscalerInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedHorizontalPodAutoscalerInformerWithOptions constructs a new informer for HorizontalPodAutoscaler type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedHorizontalPodAutoscalerInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) HorizontalPodAutoscalerIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "autoscaling", Version: "v1", Resource: "horizontalpodautoscalers"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiautoscalingv1.HorizontalPodAutoscaler](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewHorizontalPodAutoscalerInformerWithOptions(client kubernetes.Interface, 
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *horizontalPodAutoscalerInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewHorizontalPodAutoscalerInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedHorizontalPodAutoscalerInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *horizontalPodAutoscalerInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiautoscalingv1.HorizontalPodAutoscaler{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *horizontalPodAutoscalerInformer) TypedInformer() HorizontalPodAutoscalerIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiautoscalingv1.HorizontalPodAutoscaler](f.factory.InformerFor(&apiautoscalingv1.HorizontalPodAutoscaler{}, f.defaultInformer))
 }
 
 func (f *horizontalPodAutoscalerInformer) Lister() autoscalingv1.HorizontalPodAutoscalerLister {
 	return autoscalingv1.NewHorizontalPodAutoscalerLister(f.Informer().GetIndexer())
+}
+
+// ToTypedHorizontalPodAutoscalerInformer converts an untyped informer into a TypedHorizontalPodAutoscalerInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *HorizontalPodAutoscaler. If that is not the case, calling type-safe methods of the returned
+// TypedHorizontalPodAutoscalerInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedHorizontalPodAutoscalerInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedHorizontalPodAutoscalerInformer(informer HorizontalPodAutoscalerInformer) TypedHorizontalPodAutoscalerInformer {
+	if informer, ok := informer.(TypedHorizontalPodAutoscalerInformer); ok {
+		return informer
+	}
+	return &horizontalPodAutoscalerTypedInformerAdapter{informer}
+}
+
+type horizontalPodAutoscalerTypedInformerAdapter struct {
+	HorizontalPodAutoscalerInformer
+}
+
+func (a *horizontalPodAutoscalerTypedInformerAdapter) TypedInformer() HorizontalPodAutoscalerIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiautoscalingv1.HorizontalPodAutoscaler](a.Informer())
+}
+
+// ToHorizontalPodAutoscalerIndexInformer converts an untyped informer into a HorizontalPodAutoscalerIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *HorizontalPodAutoscaler. If that is not the case, calling type-safe methods of the returned
+// HorizontalPodAutoscalerIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a HorizontalPodAutoscalerIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToHorizontalPodAutoscalerIndexInformer(informer cache.SharedIndexInformer) HorizontalPodAutoscalerIndexInformer {
+	if informer, ok := informer.(HorizontalPodAutoscalerIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiautoscalingv1.HorizontalPodAutoscaler](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/autoscaling/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/autoscaling/v1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// HorizontalPodAutoscalers returns a HorizontalPodAutoscalerInformer.
-	HorizontalPodAutoscalers() HorizontalPodAutoscalerInformer
+	HorizontalPodAutoscalers() TypedHorizontalPodAutoscalerInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// HorizontalPodAutoscalers returns a HorizontalPodAutoscalerInformer.
-func (v *version) HorizontalPodAutoscalers() HorizontalPodAutoscalerInformer {
+// HorizontalPodAutoscalers returns a TypedHorizontalPodAutoscalerInformer.
+func (v *version) HorizontalPodAutoscalers() TypedHorizontalPodAutoscalerInformer {
 	return &horizontalPodAutoscalerInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/autoscaling/v2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/informers/autoscaling/v2/horizontalpodautoscaler.go
@@ -34,11 +34,39 @@ import (
 )
 
 // HorizontalPodAutoscalerInformer provides access to a shared informer and lister for
-// HorizontalPodAutoscalers.
+// HorizontalPodAutoscalers. Prefer using the type-safe variant (see [TypedHorizontalPodAutoscalerInformer]).
 type HorizontalPodAutoscalerInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() autoscalingv2.HorizontalPodAutoscalerLister
 }
+
+// TypedHorizontalPodAutoscalerInformer provides access to a shared informer and lister for
+// HorizontalPodAutoscalers, including the type-safe TypedInformer variant.
+// It is a superset of HorizontalPodAutoscalerInformer.
+type TypedHorizontalPodAutoscalerInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() HorizontalPodAutoscalerIndexInformer
+	Lister() autoscalingv2.HorizontalPodAutoscalerLister
+}
+
+// HorizontalPodAutoscalerIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type HorizontalPodAutoscalerIndexInformer cache.TypedSharedIndexInformer[*apiautoscalingv2.HorizontalPodAutoscaler]
+
+// HorizontalPodAutoscalerHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for HorizontalPodAutoscaler.
+type HorizontalPodAutoscalerHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiautoscalingv2.HorizontalPodAutoscaler]
+
+// HorizontalPodAutoscalerDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for HorizontalPodAutoscaler.
+type HorizontalPodAutoscalerDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiautoscalingv2.HorizontalPodAutoscaler]
+
+// HorizontalPodAutoscalerFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for HorizontalPodAutoscaler.
+type HorizontalPodAutoscalerFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiautoscalingv2.HorizontalPodAutoscaler]
+
+// HorizontalPodAutoscalerIndexers is a specialization of [cache.TypedIndexers] for HorizontalPodAutoscaler.
+type HorizontalPodAutoscalerIndexers = cache.TypedIndexers[*apiautoscalingv2.HorizontalPodAutoscaler]
+
+// DeletedHorizontalPodAutoscaler is a specialization of [cache.DeletedObject] for HorizontalPodAutoscaler.
+type DeletedHorizontalPodAutoscaler = cache.DeletedObject[*apiautoscalingv2.HorizontalPodAutoscaler]
 
 type horizontalPodAutoscalerInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type horizontalPodAutoscalerInformer struct {
 // NewHorizontalPodAutoscalerInformer constructs a new informer for HorizontalPodAutoscaler type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedHorizontalPodAutoscalerInformer]).
 func NewHorizontalPodAutoscalerInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewHorizontalPodAutoscalerInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedHorizontalPodAutoscalerInformer constructs a new informer for HorizontalPodAutoscaler type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedHorizontalPodAutoscalerInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers HorizontalPodAutoscalerIndexers) HorizontalPodAutoscalerIndexInformer {
+	return NewTypedHorizontalPodAutoscalerInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredHorizontalPodAutoscalerInformer constructs a new informer for HorizontalPodAutoscaler type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredHorizontalPodAutoscalerInformer]).
 func NewFilteredHorizontalPodAutoscalerInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewHorizontalPodAutoscalerInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedHorizontalPodAutoscalerInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredHorizontalPodAutoscalerInformer constructs a new informer for HorizontalPodAutoscaler type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredHorizontalPodAutoscalerInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers HorizontalPodAutoscalerIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) HorizontalPodAutoscalerIndexInformer {
+	return NewTypedHorizontalPodAutoscalerInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewHorizontalPodAutoscalerInformerWithOptions constructs a new informer for HorizontalPodAutoscaler type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedHorizontalPodAutoscalerInformerWithOptions]).
 func NewHorizontalPodAutoscalerInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedHorizontalPodAutoscalerInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedHorizontalPodAutoscalerInformerWithOptions constructs a new informer for HorizontalPodAutoscaler type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedHorizontalPodAutoscalerInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) HorizontalPodAutoscalerIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "autoscaling", Version: "v2", Resource: "horizontalpodautoscalers"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiautoscalingv2.HorizontalPodAutoscaler](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewHorizontalPodAutoscalerInformerWithOptions(client kubernetes.Interface, 
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *horizontalPodAutoscalerInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewHorizontalPodAutoscalerInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedHorizontalPodAutoscalerInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *horizontalPodAutoscalerInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiautoscalingv2.HorizontalPodAutoscaler{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *horizontalPodAutoscalerInformer) TypedInformer() HorizontalPodAutoscalerIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiautoscalingv2.HorizontalPodAutoscaler](f.factory.InformerFor(&apiautoscalingv2.HorizontalPodAutoscaler{}, f.defaultInformer))
 }
 
 func (f *horizontalPodAutoscalerInformer) Lister() autoscalingv2.HorizontalPodAutoscalerLister {
 	return autoscalingv2.NewHorizontalPodAutoscalerLister(f.Informer().GetIndexer())
+}
+
+// ToTypedHorizontalPodAutoscalerInformer converts an untyped informer into a TypedHorizontalPodAutoscalerInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *HorizontalPodAutoscaler. If that is not the case, calling type-safe methods of the returned
+// TypedHorizontalPodAutoscalerInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedHorizontalPodAutoscalerInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedHorizontalPodAutoscalerInformer(informer HorizontalPodAutoscalerInformer) TypedHorizontalPodAutoscalerInformer {
+	if informer, ok := informer.(TypedHorizontalPodAutoscalerInformer); ok {
+		return informer
+	}
+	return &horizontalPodAutoscalerTypedInformerAdapter{informer}
+}
+
+type horizontalPodAutoscalerTypedInformerAdapter struct {
+	HorizontalPodAutoscalerInformer
+}
+
+func (a *horizontalPodAutoscalerTypedInformerAdapter) TypedInformer() HorizontalPodAutoscalerIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiautoscalingv2.HorizontalPodAutoscaler](a.Informer())
+}
+
+// ToHorizontalPodAutoscalerIndexInformer converts an untyped informer into a HorizontalPodAutoscalerIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *HorizontalPodAutoscaler. If that is not the case, calling type-safe methods of the returned
+// HorizontalPodAutoscalerIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a HorizontalPodAutoscalerIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToHorizontalPodAutoscalerIndexInformer(informer cache.SharedIndexInformer) HorizontalPodAutoscalerIndexInformer {
+	if informer, ok := informer.(HorizontalPodAutoscalerIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiautoscalingv2.HorizontalPodAutoscaler](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/autoscaling/v2/interface.go
+++ b/staging/src/k8s.io/client-go/informers/autoscaling/v2/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// HorizontalPodAutoscalers returns a HorizontalPodAutoscalerInformer.
-	HorizontalPodAutoscalers() HorizontalPodAutoscalerInformer
+	HorizontalPodAutoscalers() TypedHorizontalPodAutoscalerInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// HorizontalPodAutoscalers returns a HorizontalPodAutoscalerInformer.
-func (v *version) HorizontalPodAutoscalers() HorizontalPodAutoscalerInformer {
+// HorizontalPodAutoscalers returns a TypedHorizontalPodAutoscalerInformer.
+func (v *version) HorizontalPodAutoscalers() TypedHorizontalPodAutoscalerInformer {
 	return &horizontalPodAutoscalerInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/batch/v1/cronjob.go
+++ b/staging/src/k8s.io/client-go/informers/batch/v1/cronjob.go
@@ -34,11 +34,39 @@ import (
 )
 
 // CronJobInformer provides access to a shared informer and lister for
-// CronJobs.
+// CronJobs. Prefer using the type-safe variant (see [TypedCronJobInformer]).
 type CronJobInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() batchv1.CronJobLister
 }
+
+// TypedCronJobInformer provides access to a shared informer and lister for
+// CronJobs, including the type-safe TypedInformer variant.
+// It is a superset of CronJobInformer.
+type TypedCronJobInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() CronJobIndexInformer
+	Lister() batchv1.CronJobLister
+}
+
+// CronJobIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type CronJobIndexInformer cache.TypedSharedIndexInformer[*apibatchv1.CronJob]
+
+// CronJobHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for CronJob.
+type CronJobHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apibatchv1.CronJob]
+
+// CronJobDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for CronJob.
+type CronJobDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apibatchv1.CronJob]
+
+// CronJobFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for CronJob.
+type CronJobFilteringHandler = cache.TypedFilteringResourceEventHandler[*apibatchv1.CronJob]
+
+// CronJobIndexers is a specialization of [cache.TypedIndexers] for CronJob.
+type CronJobIndexers = cache.TypedIndexers[*apibatchv1.CronJob]
+
+// DeletedCronJob is a specialization of [cache.DeletedObject] for CronJob.
+type DeletedCronJob = cache.DeletedObject[*apibatchv1.CronJob]
 
 type cronJobInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type cronJobInformer struct {
 // NewCronJobInformer constructs a new informer for CronJob type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCronJobInformer]).
 func NewCronJobInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewCronJobInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedCronJobInformer constructs a new informer for CronJob type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCronJobInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers CronJobIndexers) CronJobIndexInformer {
+	return NewTypedCronJobInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredCronJobInformer constructs a new informer for CronJob type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredCronJobInformer]).
 func NewFilteredCronJobInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewCronJobInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedCronJobInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredCronJobInformer constructs a new informer for CronJob type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredCronJobInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers CronJobIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) CronJobIndexInformer {
+	return NewTypedCronJobInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewCronJobInformerWithOptions constructs a new informer for CronJob type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCronJobInformerWithOptions]).
 func NewCronJobInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedCronJobInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedCronJobInformerWithOptions constructs a new informer for CronJob type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCronJobInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) CronJobIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "cronjobs"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apibatchv1.CronJob](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewCronJobInformerWithOptions(client kubernetes.Interface, namespace string
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *cronJobInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewCronJobInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedCronJobInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *cronJobInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apibatchv1.CronJob{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *cronJobInformer) TypedInformer() CronJobIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apibatchv1.CronJob](f.factory.InformerFor(&apibatchv1.CronJob{}, f.defaultInformer))
 }
 
 func (f *cronJobInformer) Lister() batchv1.CronJobLister {
 	return batchv1.NewCronJobLister(f.Informer().GetIndexer())
+}
+
+// ToTypedCronJobInformer converts an untyped informer into a TypedCronJobInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CronJob. If that is not the case, calling type-safe methods of the returned
+// TypedCronJobInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedCronJobInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedCronJobInformer(informer CronJobInformer) TypedCronJobInformer {
+	if informer, ok := informer.(TypedCronJobInformer); ok {
+		return informer
+	}
+	return &cronJobTypedInformerAdapter{informer}
+}
+
+type cronJobTypedInformerAdapter struct {
+	CronJobInformer
+}
+
+func (a *cronJobTypedInformerAdapter) TypedInformer() CronJobIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apibatchv1.CronJob](a.Informer())
+}
+
+// ToCronJobIndexInformer converts an untyped informer into a CronJobIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CronJob. If that is not the case, calling type-safe methods of the returned
+// CronJobIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a CronJobIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToCronJobIndexInformer(informer cache.SharedIndexInformer) CronJobIndexInformer {
+	if informer, ok := informer.(CronJobIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apibatchv1.CronJob](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/batch/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/batch/v1/interface.go
@@ -25,9 +25,9 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// CronJobs returns a CronJobInformer.
-	CronJobs() CronJobInformer
+	CronJobs() TypedCronJobInformer
 	// Jobs returns a JobInformer.
-	Jobs() JobInformer
+	Jobs() TypedJobInformer
 }
 
 type version struct {
@@ -41,12 +41,12 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// CronJobs returns a CronJobInformer.
-func (v *version) CronJobs() CronJobInformer {
+// CronJobs returns a TypedCronJobInformer.
+func (v *version) CronJobs() TypedCronJobInformer {
 	return &cronJobInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// Jobs returns a JobInformer.
-func (v *version) Jobs() JobInformer {
+// Jobs returns a TypedJobInformer.
+func (v *version) Jobs() TypedJobInformer {
 	return &jobInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/batch/v1/job.go
+++ b/staging/src/k8s.io/client-go/informers/batch/v1/job.go
@@ -34,11 +34,39 @@ import (
 )
 
 // JobInformer provides access to a shared informer and lister for
-// Jobs.
+// Jobs. Prefer using the type-safe variant (see [TypedJobInformer]).
 type JobInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() batchv1.JobLister
 }
+
+// TypedJobInformer provides access to a shared informer and lister for
+// Jobs, including the type-safe TypedInformer variant.
+// It is a superset of JobInformer.
+type TypedJobInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() JobIndexInformer
+	Lister() batchv1.JobLister
+}
+
+// JobIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type JobIndexInformer cache.TypedSharedIndexInformer[*apibatchv1.Job]
+
+// JobHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Job.
+type JobHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apibatchv1.Job]
+
+// JobDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Job.
+type JobDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apibatchv1.Job]
+
+// JobFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Job.
+type JobFilteringHandler = cache.TypedFilteringResourceEventHandler[*apibatchv1.Job]
+
+// JobIndexers is a specialization of [cache.TypedIndexers] for Job.
+type JobIndexers = cache.TypedIndexers[*apibatchv1.Job]
+
+// DeletedJob is a specialization of [cache.DeletedObject] for Job.
+type DeletedJob = cache.DeletedObject[*apibatchv1.Job]
 
 type jobInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type jobInformer struct {
 // NewJobInformer constructs a new informer for Job type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedJobInformer]).
 func NewJobInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewJobInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedJobInformer constructs a new informer for Job type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedJobInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers JobIndexers) JobIndexInformer {
+	return NewTypedJobInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredJobInformer constructs a new informer for Job type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredJobInformer]).
 func NewFilteredJobInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewJobInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedJobInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredJobInformer constructs a new informer for Job type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredJobInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers JobIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) JobIndexInformer {
+	return NewTypedJobInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewJobInformerWithOptions constructs a new informer for Job type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedJobInformerWithOptions]).
 func NewJobInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedJobInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedJobInformerWithOptions constructs a new informer for Job type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedJobInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) JobIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "jobs"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apibatchv1.Job](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewJobInformerWithOptions(client kubernetes.Interface, namespace string, op
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *jobInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewJobInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedJobInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *jobInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apibatchv1.Job{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *jobInformer) TypedInformer() JobIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apibatchv1.Job](f.factory.InformerFor(&apibatchv1.Job{}, f.defaultInformer))
 }
 
 func (f *jobInformer) Lister() batchv1.JobLister {
 	return batchv1.NewJobLister(f.Informer().GetIndexer())
+}
+
+// ToTypedJobInformer converts an untyped informer into a TypedJobInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Job. If that is not the case, calling type-safe methods of the returned
+// TypedJobInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedJobInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedJobInformer(informer JobInformer) TypedJobInformer {
+	if informer, ok := informer.(TypedJobInformer); ok {
+		return informer
+	}
+	return &jobTypedInformerAdapter{informer}
+}
+
+type jobTypedInformerAdapter struct {
+	JobInformer
+}
+
+func (a *jobTypedInformerAdapter) TypedInformer() JobIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apibatchv1.Job](a.Informer())
+}
+
+// ToJobIndexInformer converts an untyped informer into a JobIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Job. If that is not the case, calling type-safe methods of the returned
+// JobIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a JobIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToJobIndexInformer(informer cache.SharedIndexInformer) JobIndexInformer {
+	if informer, ok := informer.(JobIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apibatchv1.Job](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/batch/v1beta1/cronjob.go
+++ b/staging/src/k8s.io/client-go/informers/batch/v1beta1/cronjob.go
@@ -34,11 +34,39 @@ import (
 )
 
 // CronJobInformer provides access to a shared informer and lister for
-// CronJobs.
+// CronJobs. Prefer using the type-safe variant (see [TypedCronJobInformer]).
 type CronJobInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() batchv1beta1.CronJobLister
 }
+
+// TypedCronJobInformer provides access to a shared informer and lister for
+// CronJobs, including the type-safe TypedInformer variant.
+// It is a superset of CronJobInformer.
+type TypedCronJobInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() CronJobIndexInformer
+	Lister() batchv1beta1.CronJobLister
+}
+
+// CronJobIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type CronJobIndexInformer cache.TypedSharedIndexInformer[*apibatchv1beta1.CronJob]
+
+// CronJobHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for CronJob.
+type CronJobHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apibatchv1beta1.CronJob]
+
+// CronJobDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for CronJob.
+type CronJobDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apibatchv1beta1.CronJob]
+
+// CronJobFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for CronJob.
+type CronJobFilteringHandler = cache.TypedFilteringResourceEventHandler[*apibatchv1beta1.CronJob]
+
+// CronJobIndexers is a specialization of [cache.TypedIndexers] for CronJob.
+type CronJobIndexers = cache.TypedIndexers[*apibatchv1beta1.CronJob]
+
+// DeletedCronJob is a specialization of [cache.DeletedObject] for CronJob.
+type DeletedCronJob = cache.DeletedObject[*apibatchv1beta1.CronJob]
 
 type cronJobInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type cronJobInformer struct {
 // NewCronJobInformer constructs a new informer for CronJob type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCronJobInformer]).
 func NewCronJobInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewCronJobInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedCronJobInformer constructs a new informer for CronJob type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCronJobInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers CronJobIndexers) CronJobIndexInformer {
+	return NewTypedCronJobInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredCronJobInformer constructs a new informer for CronJob type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredCronJobInformer]).
 func NewFilteredCronJobInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewCronJobInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedCronJobInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredCronJobInformer constructs a new informer for CronJob type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredCronJobInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers CronJobIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) CronJobIndexInformer {
+	return NewTypedCronJobInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewCronJobInformerWithOptions constructs a new informer for CronJob type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCronJobInformerWithOptions]).
 func NewCronJobInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedCronJobInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedCronJobInformerWithOptions constructs a new informer for CronJob type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCronJobInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) CronJobIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "batch", Version: "v1beta1", Resource: "cronjobs"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apibatchv1beta1.CronJob](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewCronJobInformerWithOptions(client kubernetes.Interface, namespace string
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *cronJobInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewCronJobInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedCronJobInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *cronJobInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apibatchv1beta1.CronJob{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *cronJobInformer) TypedInformer() CronJobIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apibatchv1beta1.CronJob](f.factory.InformerFor(&apibatchv1beta1.CronJob{}, f.defaultInformer))
 }
 
 func (f *cronJobInformer) Lister() batchv1beta1.CronJobLister {
 	return batchv1beta1.NewCronJobLister(f.Informer().GetIndexer())
+}
+
+// ToTypedCronJobInformer converts an untyped informer into a TypedCronJobInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CronJob. If that is not the case, calling type-safe methods of the returned
+// TypedCronJobInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedCronJobInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedCronJobInformer(informer CronJobInformer) TypedCronJobInformer {
+	if informer, ok := informer.(TypedCronJobInformer); ok {
+		return informer
+	}
+	return &cronJobTypedInformerAdapter{informer}
+}
+
+type cronJobTypedInformerAdapter struct {
+	CronJobInformer
+}
+
+func (a *cronJobTypedInformerAdapter) TypedInformer() CronJobIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apibatchv1beta1.CronJob](a.Informer())
+}
+
+// ToCronJobIndexInformer converts an untyped informer into a CronJobIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CronJob. If that is not the case, calling type-safe methods of the returned
+// CronJobIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a CronJobIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToCronJobIndexInformer(informer cache.SharedIndexInformer) CronJobIndexInformer {
+	if informer, ok := informer.(CronJobIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apibatchv1beta1.CronJob](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/batch/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/batch/v1beta1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// CronJobs returns a CronJobInformer.
-	CronJobs() CronJobInformer
+	CronJobs() TypedCronJobInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// CronJobs returns a CronJobInformer.
-func (v *version) CronJobs() CronJobInformer {
+// CronJobs returns a TypedCronJobInformer.
+func (v *version) CronJobs() TypedCronJobInformer {
 	return &cronJobInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/certificates/v1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/informers/certificates/v1/certificatesigningrequest.go
@@ -34,11 +34,39 @@ import (
 )
 
 // CertificateSigningRequestInformer provides access to a shared informer and lister for
-// CertificateSigningRequests.
+// CertificateSigningRequests. Prefer using the type-safe variant (see [TypedCertificateSigningRequestInformer]).
 type CertificateSigningRequestInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() certificatesv1.CertificateSigningRequestLister
 }
+
+// TypedCertificateSigningRequestInformer provides access to a shared informer and lister for
+// CertificateSigningRequests, including the type-safe TypedInformer variant.
+// It is a superset of CertificateSigningRequestInformer.
+type TypedCertificateSigningRequestInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() CertificateSigningRequestIndexInformer
+	Lister() certificatesv1.CertificateSigningRequestLister
+}
+
+// CertificateSigningRequestIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type CertificateSigningRequestIndexInformer cache.TypedSharedIndexInformer[*apicertificatesv1.CertificateSigningRequest]
+
+// CertificateSigningRequestHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for CertificateSigningRequest.
+type CertificateSigningRequestHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apicertificatesv1.CertificateSigningRequest]
+
+// CertificateSigningRequestDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for CertificateSigningRequest.
+type CertificateSigningRequestDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apicertificatesv1.CertificateSigningRequest]
+
+// CertificateSigningRequestFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for CertificateSigningRequest.
+type CertificateSigningRequestFilteringHandler = cache.TypedFilteringResourceEventHandler[*apicertificatesv1.CertificateSigningRequest]
+
+// CertificateSigningRequestIndexers is a specialization of [cache.TypedIndexers] for CertificateSigningRequest.
+type CertificateSigningRequestIndexers = cache.TypedIndexers[*apicertificatesv1.CertificateSigningRequest]
+
+// DeletedCertificateSigningRequest is a specialization of [cache.DeletedObject] for CertificateSigningRequest.
+type DeletedCertificateSigningRequest = cache.DeletedObject[*apicertificatesv1.CertificateSigningRequest]
 
 type certificateSigningRequestInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type certificateSigningRequestInformer struct {
 // NewCertificateSigningRequestInformer constructs a new informer for CertificateSigningRequest type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCertificateSigningRequestInformer]).
 func NewCertificateSigningRequestInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewCertificateSigningRequestInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedCertificateSigningRequestInformer constructs a new informer for CertificateSigningRequest type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCertificateSigningRequestInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers CertificateSigningRequestIndexers) CertificateSigningRequestIndexInformer {
+	return NewTypedCertificateSigningRequestInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredCertificateSigningRequestInformer constructs a new informer for CertificateSigningRequest type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredCertificateSigningRequestInformer]).
 func NewFilteredCertificateSigningRequestInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewCertificateSigningRequestInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedCertificateSigningRequestInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredCertificateSigningRequestInformer constructs a new informer for CertificateSigningRequest type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredCertificateSigningRequestInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers CertificateSigningRequestIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) CertificateSigningRequestIndexInformer {
+	return NewTypedCertificateSigningRequestInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewCertificateSigningRequestInformerWithOptions constructs a new informer for CertificateSigningRequest type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCertificateSigningRequestInformerWithOptions]).
 func NewCertificateSigningRequestInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedCertificateSigningRequestInformerWithOptions(client, options)
+}
+
+// NewTypedCertificateSigningRequestInformerWithOptions constructs a new informer for CertificateSigningRequest type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCertificateSigningRequestInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) CertificateSigningRequestIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "certificates.k8s.io", Version: "v1", Resource: "certificatesigningrequests"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apicertificatesv1.CertificateSigningRequest](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewCertificateSigningRequestInformerWithOptions(client kubernetes.Interface
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *certificateSigningRequestInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewCertificateSigningRequestInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedCertificateSigningRequestInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *certificateSigningRequestInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apicertificatesv1.CertificateSigningRequest{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *certificateSigningRequestInformer) TypedInformer() CertificateSigningRequestIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicertificatesv1.CertificateSigningRequest](f.factory.InformerFor(&apicertificatesv1.CertificateSigningRequest{}, f.defaultInformer))
 }
 
 func (f *certificateSigningRequestInformer) Lister() certificatesv1.CertificateSigningRequestLister {
 	return certificatesv1.NewCertificateSigningRequestLister(f.Informer().GetIndexer())
+}
+
+// ToTypedCertificateSigningRequestInformer converts an untyped informer into a TypedCertificateSigningRequestInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CertificateSigningRequest. If that is not the case, calling type-safe methods of the returned
+// TypedCertificateSigningRequestInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedCertificateSigningRequestInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedCertificateSigningRequestInformer(informer CertificateSigningRequestInformer) TypedCertificateSigningRequestInformer {
+	if informer, ok := informer.(TypedCertificateSigningRequestInformer); ok {
+		return informer
+	}
+	return &certificateSigningRequestTypedInformerAdapter{informer}
+}
+
+type certificateSigningRequestTypedInformerAdapter struct {
+	CertificateSigningRequestInformer
+}
+
+func (a *certificateSigningRequestTypedInformerAdapter) TypedInformer() CertificateSigningRequestIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicertificatesv1.CertificateSigningRequest](a.Informer())
+}
+
+// ToCertificateSigningRequestIndexInformer converts an untyped informer into a CertificateSigningRequestIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CertificateSigningRequest. If that is not the case, calling type-safe methods of the returned
+// CertificateSigningRequestIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a CertificateSigningRequestIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToCertificateSigningRequestIndexInformer(informer cache.SharedIndexInformer) CertificateSigningRequestIndexInformer {
+	if informer, ok := informer.(CertificateSigningRequestIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apicertificatesv1.CertificateSigningRequest](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/certificates/v1/clustertrustbundle.go
+++ b/staging/src/k8s.io/client-go/informers/certificates/v1/clustertrustbundle.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ClusterTrustBundleInformer provides access to a shared informer and lister for
-// ClusterTrustBundles.
+// ClusterTrustBundles. Prefer using the type-safe variant (see [TypedClusterTrustBundleInformer]).
 type ClusterTrustBundleInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() certificatesv1.ClusterTrustBundleLister
 }
+
+// TypedClusterTrustBundleInformer provides access to a shared informer and lister for
+// ClusterTrustBundles, including the type-safe TypedInformer variant.
+// It is a superset of ClusterTrustBundleInformer.
+type TypedClusterTrustBundleInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ClusterTrustBundleIndexInformer
+	Lister() certificatesv1.ClusterTrustBundleLister
+}
+
+// ClusterTrustBundleIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ClusterTrustBundleIndexInformer cache.TypedSharedIndexInformer[*apicertificatesv1.ClusterTrustBundle]
+
+// ClusterTrustBundleHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ClusterTrustBundle.
+type ClusterTrustBundleHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apicertificatesv1.ClusterTrustBundle]
+
+// ClusterTrustBundleDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ClusterTrustBundle.
+type ClusterTrustBundleDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apicertificatesv1.ClusterTrustBundle]
+
+// ClusterTrustBundleFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ClusterTrustBundle.
+type ClusterTrustBundleFilteringHandler = cache.TypedFilteringResourceEventHandler[*apicertificatesv1.ClusterTrustBundle]
+
+// ClusterTrustBundleIndexers is a specialization of [cache.TypedIndexers] for ClusterTrustBundle.
+type ClusterTrustBundleIndexers = cache.TypedIndexers[*apicertificatesv1.ClusterTrustBundle]
+
+// DeletedClusterTrustBundle is a specialization of [cache.DeletedObject] for ClusterTrustBundle.
+type DeletedClusterTrustBundle = cache.DeletedObject[*apicertificatesv1.ClusterTrustBundle]
 
 type clusterTrustBundleInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type clusterTrustBundleInformer struct {
 // NewClusterTrustBundleInformer constructs a new informer for ClusterTrustBundle type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedClusterTrustBundleInformer]).
 func NewClusterTrustBundleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewClusterTrustBundleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedClusterTrustBundleInformer constructs a new informer for ClusterTrustBundle type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedClusterTrustBundleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ClusterTrustBundleIndexers) ClusterTrustBundleIndexInformer {
+	return NewTypedClusterTrustBundleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredClusterTrustBundleInformer constructs a new informer for ClusterTrustBundle type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredClusterTrustBundleInformer]).
 func NewFilteredClusterTrustBundleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewClusterTrustBundleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedClusterTrustBundleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredClusterTrustBundleInformer constructs a new informer for ClusterTrustBundle type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredClusterTrustBundleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ClusterTrustBundleIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ClusterTrustBundleIndexInformer {
+	return NewTypedClusterTrustBundleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewClusterTrustBundleInformerWithOptions constructs a new informer for ClusterTrustBundle type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedClusterTrustBundleInformerWithOptions]).
 func NewClusterTrustBundleInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedClusterTrustBundleInformerWithOptions(client, options)
+}
+
+// NewTypedClusterTrustBundleInformerWithOptions constructs a new informer for ClusterTrustBundle type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedClusterTrustBundleInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ClusterTrustBundleIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "certificates.k8s.io", Version: "v1", Resource: "clustertrustbundles"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apicertificatesv1.ClusterTrustBundle](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewClusterTrustBundleInformerWithOptions(client kubernetes.Interface, optio
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *clusterTrustBundleInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewClusterTrustBundleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedClusterTrustBundleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *clusterTrustBundleInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apicertificatesv1.ClusterTrustBundle{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *clusterTrustBundleInformer) TypedInformer() ClusterTrustBundleIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicertificatesv1.ClusterTrustBundle](f.factory.InformerFor(&apicertificatesv1.ClusterTrustBundle{}, f.defaultInformer))
 }
 
 func (f *clusterTrustBundleInformer) Lister() certificatesv1.ClusterTrustBundleLister {
 	return certificatesv1.NewClusterTrustBundleLister(f.Informer().GetIndexer())
+}
+
+// ToTypedClusterTrustBundleInformer converts an untyped informer into a TypedClusterTrustBundleInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ClusterTrustBundle. If that is not the case, calling type-safe methods of the returned
+// TypedClusterTrustBundleInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedClusterTrustBundleInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedClusterTrustBundleInformer(informer ClusterTrustBundleInformer) TypedClusterTrustBundleInformer {
+	if informer, ok := informer.(TypedClusterTrustBundleInformer); ok {
+		return informer
+	}
+	return &clusterTrustBundleTypedInformerAdapter{informer}
+}
+
+type clusterTrustBundleTypedInformerAdapter struct {
+	ClusterTrustBundleInformer
+}
+
+func (a *clusterTrustBundleTypedInformerAdapter) TypedInformer() ClusterTrustBundleIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicertificatesv1.ClusterTrustBundle](a.Informer())
+}
+
+// ToClusterTrustBundleIndexInformer converts an untyped informer into a ClusterTrustBundleIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ClusterTrustBundle. If that is not the case, calling type-safe methods of the returned
+// ClusterTrustBundleIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ClusterTrustBundleIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToClusterTrustBundleIndexInformer(informer cache.SharedIndexInformer) ClusterTrustBundleIndexInformer {
+	if informer, ok := informer.(ClusterTrustBundleIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apicertificatesv1.ClusterTrustBundle](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/certificates/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/certificates/v1/interface.go
@@ -25,9 +25,9 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// CertificateSigningRequests returns a CertificateSigningRequestInformer.
-	CertificateSigningRequests() CertificateSigningRequestInformer
+	CertificateSigningRequests() TypedCertificateSigningRequestInformer
 	// ClusterTrustBundles returns a ClusterTrustBundleInformer.
-	ClusterTrustBundles() ClusterTrustBundleInformer
+	ClusterTrustBundles() TypedClusterTrustBundleInformer
 }
 
 type version struct {
@@ -41,12 +41,12 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// CertificateSigningRequests returns a CertificateSigningRequestInformer.
-func (v *version) CertificateSigningRequests() CertificateSigningRequestInformer {
+// CertificateSigningRequests returns a TypedCertificateSigningRequestInformer.
+func (v *version) CertificateSigningRequests() TypedCertificateSigningRequestInformer {
 	return &certificateSigningRequestInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// ClusterTrustBundles returns a ClusterTrustBundleInformer.
-func (v *version) ClusterTrustBundles() ClusterTrustBundleInformer {
+// ClusterTrustBundles returns a TypedClusterTrustBundleInformer.
+func (v *version) ClusterTrustBundles() TypedClusterTrustBundleInformer {
 	return &clusterTrustBundleInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/certificates/v1alpha1/clustertrustbundle.go
+++ b/staging/src/k8s.io/client-go/informers/certificates/v1alpha1/clustertrustbundle.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ClusterTrustBundleInformer provides access to a shared informer and lister for
-// ClusterTrustBundles.
+// ClusterTrustBundles. Prefer using the type-safe variant (see [TypedClusterTrustBundleInformer]).
 type ClusterTrustBundleInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() certificatesv1alpha1.ClusterTrustBundleLister
 }
+
+// TypedClusterTrustBundleInformer provides access to a shared informer and lister for
+// ClusterTrustBundles, including the type-safe TypedInformer variant.
+// It is a superset of ClusterTrustBundleInformer.
+type TypedClusterTrustBundleInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ClusterTrustBundleIndexInformer
+	Lister() certificatesv1alpha1.ClusterTrustBundleLister
+}
+
+// ClusterTrustBundleIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ClusterTrustBundleIndexInformer cache.TypedSharedIndexInformer[*apicertificatesv1alpha1.ClusterTrustBundle]
+
+// ClusterTrustBundleHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ClusterTrustBundle.
+type ClusterTrustBundleHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apicertificatesv1alpha1.ClusterTrustBundle]
+
+// ClusterTrustBundleDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ClusterTrustBundle.
+type ClusterTrustBundleDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apicertificatesv1alpha1.ClusterTrustBundle]
+
+// ClusterTrustBundleFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ClusterTrustBundle.
+type ClusterTrustBundleFilteringHandler = cache.TypedFilteringResourceEventHandler[*apicertificatesv1alpha1.ClusterTrustBundle]
+
+// ClusterTrustBundleIndexers is a specialization of [cache.TypedIndexers] for ClusterTrustBundle.
+type ClusterTrustBundleIndexers = cache.TypedIndexers[*apicertificatesv1alpha1.ClusterTrustBundle]
+
+// DeletedClusterTrustBundle is a specialization of [cache.DeletedObject] for ClusterTrustBundle.
+type DeletedClusterTrustBundle = cache.DeletedObject[*apicertificatesv1alpha1.ClusterTrustBundle]
 
 type clusterTrustBundleInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type clusterTrustBundleInformer struct {
 // NewClusterTrustBundleInformer constructs a new informer for ClusterTrustBundle type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedClusterTrustBundleInformer]).
 func NewClusterTrustBundleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewClusterTrustBundleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedClusterTrustBundleInformer constructs a new informer for ClusterTrustBundle type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedClusterTrustBundleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ClusterTrustBundleIndexers) ClusterTrustBundleIndexInformer {
+	return NewTypedClusterTrustBundleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredClusterTrustBundleInformer constructs a new informer for ClusterTrustBundle type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredClusterTrustBundleInformer]).
 func NewFilteredClusterTrustBundleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewClusterTrustBundleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedClusterTrustBundleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredClusterTrustBundleInformer constructs a new informer for ClusterTrustBundle type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredClusterTrustBundleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ClusterTrustBundleIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ClusterTrustBundleIndexInformer {
+	return NewTypedClusterTrustBundleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewClusterTrustBundleInformerWithOptions constructs a new informer for ClusterTrustBundle type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedClusterTrustBundleInformerWithOptions]).
 func NewClusterTrustBundleInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedClusterTrustBundleInformerWithOptions(client, options)
+}
+
+// NewTypedClusterTrustBundleInformerWithOptions constructs a new informer for ClusterTrustBundle type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedClusterTrustBundleInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ClusterTrustBundleIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "certificates.k8s.io", Version: "v1alpha1", Resource: "clustertrustbundles"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apicertificatesv1alpha1.ClusterTrustBundle](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewClusterTrustBundleInformerWithOptions(client kubernetes.Interface, optio
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *clusterTrustBundleInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewClusterTrustBundleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedClusterTrustBundleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *clusterTrustBundleInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apicertificatesv1alpha1.ClusterTrustBundle{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *clusterTrustBundleInformer) TypedInformer() ClusterTrustBundleIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicertificatesv1alpha1.ClusterTrustBundle](f.factory.InformerFor(&apicertificatesv1alpha1.ClusterTrustBundle{}, f.defaultInformer))
 }
 
 func (f *clusterTrustBundleInformer) Lister() certificatesv1alpha1.ClusterTrustBundleLister {
 	return certificatesv1alpha1.NewClusterTrustBundleLister(f.Informer().GetIndexer())
+}
+
+// ToTypedClusterTrustBundleInformer converts an untyped informer into a TypedClusterTrustBundleInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ClusterTrustBundle. If that is not the case, calling type-safe methods of the returned
+// TypedClusterTrustBundleInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedClusterTrustBundleInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedClusterTrustBundleInformer(informer ClusterTrustBundleInformer) TypedClusterTrustBundleInformer {
+	if informer, ok := informer.(TypedClusterTrustBundleInformer); ok {
+		return informer
+	}
+	return &clusterTrustBundleTypedInformerAdapter{informer}
+}
+
+type clusterTrustBundleTypedInformerAdapter struct {
+	ClusterTrustBundleInformer
+}
+
+func (a *clusterTrustBundleTypedInformerAdapter) TypedInformer() ClusterTrustBundleIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicertificatesv1alpha1.ClusterTrustBundle](a.Informer())
+}
+
+// ToClusterTrustBundleIndexInformer converts an untyped informer into a ClusterTrustBundleIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ClusterTrustBundle. If that is not the case, calling type-safe methods of the returned
+// ClusterTrustBundleIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ClusterTrustBundleIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToClusterTrustBundleIndexInformer(informer cache.SharedIndexInformer) ClusterTrustBundleIndexInformer {
+	if informer, ok := informer.(ClusterTrustBundleIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apicertificatesv1alpha1.ClusterTrustBundle](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/certificates/v1alpha1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/certificates/v1alpha1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// ClusterTrustBundles returns a ClusterTrustBundleInformer.
-	ClusterTrustBundles() ClusterTrustBundleInformer
+	ClusterTrustBundles() TypedClusterTrustBundleInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// ClusterTrustBundles returns a ClusterTrustBundleInformer.
-func (v *version) ClusterTrustBundles() ClusterTrustBundleInformer {
+// ClusterTrustBundles returns a TypedClusterTrustBundleInformer.
+func (v *version) ClusterTrustBundles() TypedClusterTrustBundleInformer {
 	return &clusterTrustBundleInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/informers/certificates/v1beta1/certificatesigningrequest.go
@@ -34,11 +34,39 @@ import (
 )
 
 // CertificateSigningRequestInformer provides access to a shared informer and lister for
-// CertificateSigningRequests.
+// CertificateSigningRequests. Prefer using the type-safe variant (see [TypedCertificateSigningRequestInformer]).
 type CertificateSigningRequestInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() certificatesv1beta1.CertificateSigningRequestLister
 }
+
+// TypedCertificateSigningRequestInformer provides access to a shared informer and lister for
+// CertificateSigningRequests, including the type-safe TypedInformer variant.
+// It is a superset of CertificateSigningRequestInformer.
+type TypedCertificateSigningRequestInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() CertificateSigningRequestIndexInformer
+	Lister() certificatesv1beta1.CertificateSigningRequestLister
+}
+
+// CertificateSigningRequestIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type CertificateSigningRequestIndexInformer cache.TypedSharedIndexInformer[*apicertificatesv1beta1.CertificateSigningRequest]
+
+// CertificateSigningRequestHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for CertificateSigningRequest.
+type CertificateSigningRequestHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apicertificatesv1beta1.CertificateSigningRequest]
+
+// CertificateSigningRequestDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for CertificateSigningRequest.
+type CertificateSigningRequestDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apicertificatesv1beta1.CertificateSigningRequest]
+
+// CertificateSigningRequestFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for CertificateSigningRequest.
+type CertificateSigningRequestFilteringHandler = cache.TypedFilteringResourceEventHandler[*apicertificatesv1beta1.CertificateSigningRequest]
+
+// CertificateSigningRequestIndexers is a specialization of [cache.TypedIndexers] for CertificateSigningRequest.
+type CertificateSigningRequestIndexers = cache.TypedIndexers[*apicertificatesv1beta1.CertificateSigningRequest]
+
+// DeletedCertificateSigningRequest is a specialization of [cache.DeletedObject] for CertificateSigningRequest.
+type DeletedCertificateSigningRequest = cache.DeletedObject[*apicertificatesv1beta1.CertificateSigningRequest]
 
 type certificateSigningRequestInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type certificateSigningRequestInformer struct {
 // NewCertificateSigningRequestInformer constructs a new informer for CertificateSigningRequest type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCertificateSigningRequestInformer]).
 func NewCertificateSigningRequestInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewCertificateSigningRequestInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedCertificateSigningRequestInformer constructs a new informer for CertificateSigningRequest type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCertificateSigningRequestInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers CertificateSigningRequestIndexers) CertificateSigningRequestIndexInformer {
+	return NewTypedCertificateSigningRequestInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredCertificateSigningRequestInformer constructs a new informer for CertificateSigningRequest type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredCertificateSigningRequestInformer]).
 func NewFilteredCertificateSigningRequestInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewCertificateSigningRequestInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedCertificateSigningRequestInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredCertificateSigningRequestInformer constructs a new informer for CertificateSigningRequest type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredCertificateSigningRequestInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers CertificateSigningRequestIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) CertificateSigningRequestIndexInformer {
+	return NewTypedCertificateSigningRequestInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewCertificateSigningRequestInformerWithOptions constructs a new informer for CertificateSigningRequest type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCertificateSigningRequestInformerWithOptions]).
 func NewCertificateSigningRequestInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedCertificateSigningRequestInformerWithOptions(client, options)
+}
+
+// NewTypedCertificateSigningRequestInformerWithOptions constructs a new informer for CertificateSigningRequest type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCertificateSigningRequestInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) CertificateSigningRequestIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "certificates.k8s.io", Version: "v1beta1", Resource: "certificatesigningrequests"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apicertificatesv1beta1.CertificateSigningRequest](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewCertificateSigningRequestInformerWithOptions(client kubernetes.Interface
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *certificateSigningRequestInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewCertificateSigningRequestInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedCertificateSigningRequestInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *certificateSigningRequestInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apicertificatesv1beta1.CertificateSigningRequest{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *certificateSigningRequestInformer) TypedInformer() CertificateSigningRequestIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicertificatesv1beta1.CertificateSigningRequest](f.factory.InformerFor(&apicertificatesv1beta1.CertificateSigningRequest{}, f.defaultInformer))
 }
 
 func (f *certificateSigningRequestInformer) Lister() certificatesv1beta1.CertificateSigningRequestLister {
 	return certificatesv1beta1.NewCertificateSigningRequestLister(f.Informer().GetIndexer())
+}
+
+// ToTypedCertificateSigningRequestInformer converts an untyped informer into a TypedCertificateSigningRequestInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CertificateSigningRequest. If that is not the case, calling type-safe methods of the returned
+// TypedCertificateSigningRequestInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedCertificateSigningRequestInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedCertificateSigningRequestInformer(informer CertificateSigningRequestInformer) TypedCertificateSigningRequestInformer {
+	if informer, ok := informer.(TypedCertificateSigningRequestInformer); ok {
+		return informer
+	}
+	return &certificateSigningRequestTypedInformerAdapter{informer}
+}
+
+type certificateSigningRequestTypedInformerAdapter struct {
+	CertificateSigningRequestInformer
+}
+
+func (a *certificateSigningRequestTypedInformerAdapter) TypedInformer() CertificateSigningRequestIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicertificatesv1beta1.CertificateSigningRequest](a.Informer())
+}
+
+// ToCertificateSigningRequestIndexInformer converts an untyped informer into a CertificateSigningRequestIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CertificateSigningRequest. If that is not the case, calling type-safe methods of the returned
+// CertificateSigningRequestIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a CertificateSigningRequestIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToCertificateSigningRequestIndexInformer(informer cache.SharedIndexInformer) CertificateSigningRequestIndexInformer {
+	if informer, ok := informer.(CertificateSigningRequestIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apicertificatesv1beta1.CertificateSigningRequest](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/certificates/v1beta1/clustertrustbundle.go
+++ b/staging/src/k8s.io/client-go/informers/certificates/v1beta1/clustertrustbundle.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ClusterTrustBundleInformer provides access to a shared informer and lister for
-// ClusterTrustBundles.
+// ClusterTrustBundles. Prefer using the type-safe variant (see [TypedClusterTrustBundleInformer]).
 type ClusterTrustBundleInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() certificatesv1beta1.ClusterTrustBundleLister
 }
+
+// TypedClusterTrustBundleInformer provides access to a shared informer and lister for
+// ClusterTrustBundles, including the type-safe TypedInformer variant.
+// It is a superset of ClusterTrustBundleInformer.
+type TypedClusterTrustBundleInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ClusterTrustBundleIndexInformer
+	Lister() certificatesv1beta1.ClusterTrustBundleLister
+}
+
+// ClusterTrustBundleIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ClusterTrustBundleIndexInformer cache.TypedSharedIndexInformer[*apicertificatesv1beta1.ClusterTrustBundle]
+
+// ClusterTrustBundleHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ClusterTrustBundle.
+type ClusterTrustBundleHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apicertificatesv1beta1.ClusterTrustBundle]
+
+// ClusterTrustBundleDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ClusterTrustBundle.
+type ClusterTrustBundleDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apicertificatesv1beta1.ClusterTrustBundle]
+
+// ClusterTrustBundleFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ClusterTrustBundle.
+type ClusterTrustBundleFilteringHandler = cache.TypedFilteringResourceEventHandler[*apicertificatesv1beta1.ClusterTrustBundle]
+
+// ClusterTrustBundleIndexers is a specialization of [cache.TypedIndexers] for ClusterTrustBundle.
+type ClusterTrustBundleIndexers = cache.TypedIndexers[*apicertificatesv1beta1.ClusterTrustBundle]
+
+// DeletedClusterTrustBundle is a specialization of [cache.DeletedObject] for ClusterTrustBundle.
+type DeletedClusterTrustBundle = cache.DeletedObject[*apicertificatesv1beta1.ClusterTrustBundle]
 
 type clusterTrustBundleInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type clusterTrustBundleInformer struct {
 // NewClusterTrustBundleInformer constructs a new informer for ClusterTrustBundle type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedClusterTrustBundleInformer]).
 func NewClusterTrustBundleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewClusterTrustBundleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedClusterTrustBundleInformer constructs a new informer for ClusterTrustBundle type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedClusterTrustBundleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ClusterTrustBundleIndexers) ClusterTrustBundleIndexInformer {
+	return NewTypedClusterTrustBundleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredClusterTrustBundleInformer constructs a new informer for ClusterTrustBundle type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredClusterTrustBundleInformer]).
 func NewFilteredClusterTrustBundleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewClusterTrustBundleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedClusterTrustBundleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredClusterTrustBundleInformer constructs a new informer for ClusterTrustBundle type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredClusterTrustBundleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ClusterTrustBundleIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ClusterTrustBundleIndexInformer {
+	return NewTypedClusterTrustBundleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewClusterTrustBundleInformerWithOptions constructs a new informer for ClusterTrustBundle type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedClusterTrustBundleInformerWithOptions]).
 func NewClusterTrustBundleInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedClusterTrustBundleInformerWithOptions(client, options)
+}
+
+// NewTypedClusterTrustBundleInformerWithOptions constructs a new informer for ClusterTrustBundle type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedClusterTrustBundleInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ClusterTrustBundleIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "certificates.k8s.io", Version: "v1beta1", Resource: "clustertrustbundles"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apicertificatesv1beta1.ClusterTrustBundle](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewClusterTrustBundleInformerWithOptions(client kubernetes.Interface, optio
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *clusterTrustBundleInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewClusterTrustBundleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedClusterTrustBundleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *clusterTrustBundleInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apicertificatesv1beta1.ClusterTrustBundle{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *clusterTrustBundleInformer) TypedInformer() ClusterTrustBundleIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicertificatesv1beta1.ClusterTrustBundle](f.factory.InformerFor(&apicertificatesv1beta1.ClusterTrustBundle{}, f.defaultInformer))
 }
 
 func (f *clusterTrustBundleInformer) Lister() certificatesv1beta1.ClusterTrustBundleLister {
 	return certificatesv1beta1.NewClusterTrustBundleLister(f.Informer().GetIndexer())
+}
+
+// ToTypedClusterTrustBundleInformer converts an untyped informer into a TypedClusterTrustBundleInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ClusterTrustBundle. If that is not the case, calling type-safe methods of the returned
+// TypedClusterTrustBundleInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedClusterTrustBundleInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedClusterTrustBundleInformer(informer ClusterTrustBundleInformer) TypedClusterTrustBundleInformer {
+	if informer, ok := informer.(TypedClusterTrustBundleInformer); ok {
+		return informer
+	}
+	return &clusterTrustBundleTypedInformerAdapter{informer}
+}
+
+type clusterTrustBundleTypedInformerAdapter struct {
+	ClusterTrustBundleInformer
+}
+
+func (a *clusterTrustBundleTypedInformerAdapter) TypedInformer() ClusterTrustBundleIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicertificatesv1beta1.ClusterTrustBundle](a.Informer())
+}
+
+// ToClusterTrustBundleIndexInformer converts an untyped informer into a ClusterTrustBundleIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ClusterTrustBundle. If that is not the case, calling type-safe methods of the returned
+// ClusterTrustBundleIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ClusterTrustBundleIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToClusterTrustBundleIndexInformer(informer cache.SharedIndexInformer) ClusterTrustBundleIndexInformer {
+	if informer, ok := informer.(ClusterTrustBundleIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apicertificatesv1beta1.ClusterTrustBundle](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/certificates/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/certificates/v1beta1/interface.go
@@ -25,11 +25,11 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// CertificateSigningRequests returns a CertificateSigningRequestInformer.
-	CertificateSigningRequests() CertificateSigningRequestInformer
+	CertificateSigningRequests() TypedCertificateSigningRequestInformer
 	// ClusterTrustBundles returns a ClusterTrustBundleInformer.
-	ClusterTrustBundles() ClusterTrustBundleInformer
+	ClusterTrustBundles() TypedClusterTrustBundleInformer
 	// PodCertificateRequests returns a PodCertificateRequestInformer.
-	PodCertificateRequests() PodCertificateRequestInformer
+	PodCertificateRequests() TypedPodCertificateRequestInformer
 }
 
 type version struct {
@@ -43,17 +43,17 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// CertificateSigningRequests returns a CertificateSigningRequestInformer.
-func (v *version) CertificateSigningRequests() CertificateSigningRequestInformer {
+// CertificateSigningRequests returns a TypedCertificateSigningRequestInformer.
+func (v *version) CertificateSigningRequests() TypedCertificateSigningRequestInformer {
 	return &certificateSigningRequestInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// ClusterTrustBundles returns a ClusterTrustBundleInformer.
-func (v *version) ClusterTrustBundles() ClusterTrustBundleInformer {
+// ClusterTrustBundles returns a TypedClusterTrustBundleInformer.
+func (v *version) ClusterTrustBundles() TypedClusterTrustBundleInformer {
 	return &clusterTrustBundleInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// PodCertificateRequests returns a PodCertificateRequestInformer.
-func (v *version) PodCertificateRequests() PodCertificateRequestInformer {
+// PodCertificateRequests returns a TypedPodCertificateRequestInformer.
+func (v *version) PodCertificateRequests() TypedPodCertificateRequestInformer {
 	return &podCertificateRequestInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/certificates/v1beta1/podcertificaterequest.go
+++ b/staging/src/k8s.io/client-go/informers/certificates/v1beta1/podcertificaterequest.go
@@ -34,11 +34,39 @@ import (
 )
 
 // PodCertificateRequestInformer provides access to a shared informer and lister for
-// PodCertificateRequests.
+// PodCertificateRequests. Prefer using the type-safe variant (see [TypedPodCertificateRequestInformer]).
 type PodCertificateRequestInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() certificatesv1beta1.PodCertificateRequestLister
 }
+
+// TypedPodCertificateRequestInformer provides access to a shared informer and lister for
+// PodCertificateRequests, including the type-safe TypedInformer variant.
+// It is a superset of PodCertificateRequestInformer.
+type TypedPodCertificateRequestInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() PodCertificateRequestIndexInformer
+	Lister() certificatesv1beta1.PodCertificateRequestLister
+}
+
+// PodCertificateRequestIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type PodCertificateRequestIndexInformer cache.TypedSharedIndexInformer[*apicertificatesv1beta1.PodCertificateRequest]
+
+// PodCertificateRequestHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for PodCertificateRequest.
+type PodCertificateRequestHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apicertificatesv1beta1.PodCertificateRequest]
+
+// PodCertificateRequestDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for PodCertificateRequest.
+type PodCertificateRequestDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apicertificatesv1beta1.PodCertificateRequest]
+
+// PodCertificateRequestFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for PodCertificateRequest.
+type PodCertificateRequestFilteringHandler = cache.TypedFilteringResourceEventHandler[*apicertificatesv1beta1.PodCertificateRequest]
+
+// PodCertificateRequestIndexers is a specialization of [cache.TypedIndexers] for PodCertificateRequest.
+type PodCertificateRequestIndexers = cache.TypedIndexers[*apicertificatesv1beta1.PodCertificateRequest]
+
+// DeletedPodCertificateRequest is a specialization of [cache.DeletedObject] for PodCertificateRequest.
+type DeletedPodCertificateRequest = cache.DeletedObject[*apicertificatesv1beta1.PodCertificateRequest]
 
 type podCertificateRequestInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type podCertificateRequestInformer struct {
 // NewPodCertificateRequestInformer constructs a new informer for PodCertificateRequest type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPodCertificateRequestInformer]).
 func NewPodCertificateRequestInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewPodCertificateRequestInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedPodCertificateRequestInformer constructs a new informer for PodCertificateRequest type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPodCertificateRequestInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers PodCertificateRequestIndexers) PodCertificateRequestIndexInformer {
+	return NewTypedPodCertificateRequestInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredPodCertificateRequestInformer constructs a new informer for PodCertificateRequest type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredPodCertificateRequestInformer]).
 func NewFilteredPodCertificateRequestInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewPodCertificateRequestInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedPodCertificateRequestInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredPodCertificateRequestInformer constructs a new informer for PodCertificateRequest type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredPodCertificateRequestInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers PodCertificateRequestIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) PodCertificateRequestIndexInformer {
+	return NewTypedPodCertificateRequestInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewPodCertificateRequestInformerWithOptions constructs a new informer for PodCertificateRequest type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPodCertificateRequestInformerWithOptions]).
 func NewPodCertificateRequestInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedPodCertificateRequestInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedPodCertificateRequestInformerWithOptions constructs a new informer for PodCertificateRequest type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPodCertificateRequestInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) PodCertificateRequestIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "certificates.k8s.io", Version: "v1beta1", Resource: "podcertificaterequests"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apicertificatesv1beta1.PodCertificateRequest](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewPodCertificateRequestInformerWithOptions(client kubernetes.Interface, na
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *podCertificateRequestInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewPodCertificateRequestInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedPodCertificateRequestInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *podCertificateRequestInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apicertificatesv1beta1.PodCertificateRequest{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *podCertificateRequestInformer) TypedInformer() PodCertificateRequestIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicertificatesv1beta1.PodCertificateRequest](f.factory.InformerFor(&apicertificatesv1beta1.PodCertificateRequest{}, f.defaultInformer))
 }
 
 func (f *podCertificateRequestInformer) Lister() certificatesv1beta1.PodCertificateRequestLister {
 	return certificatesv1beta1.NewPodCertificateRequestLister(f.Informer().GetIndexer())
+}
+
+// ToTypedPodCertificateRequestInformer converts an untyped informer into a TypedPodCertificateRequestInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *PodCertificateRequest. If that is not the case, calling type-safe methods of the returned
+// TypedPodCertificateRequestInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedPodCertificateRequestInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedPodCertificateRequestInformer(informer PodCertificateRequestInformer) TypedPodCertificateRequestInformer {
+	if informer, ok := informer.(TypedPodCertificateRequestInformer); ok {
+		return informer
+	}
+	return &podCertificateRequestTypedInformerAdapter{informer}
+}
+
+type podCertificateRequestTypedInformerAdapter struct {
+	PodCertificateRequestInformer
+}
+
+func (a *podCertificateRequestTypedInformerAdapter) TypedInformer() PodCertificateRequestIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicertificatesv1beta1.PodCertificateRequest](a.Informer())
+}
+
+// ToPodCertificateRequestIndexInformer converts an untyped informer into a PodCertificateRequestIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *PodCertificateRequest. If that is not the case, calling type-safe methods of the returned
+// PodCertificateRequestIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a PodCertificateRequestIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToPodCertificateRequestIndexInformer(informer cache.SharedIndexInformer) PodCertificateRequestIndexInformer {
+	if informer, ok := informer.(PodCertificateRequestIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apicertificatesv1beta1.PodCertificateRequest](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/coordination/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/coordination/v1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// Leases returns a LeaseInformer.
-	Leases() LeaseInformer
+	Leases() TypedLeaseInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// Leases returns a LeaseInformer.
-func (v *version) Leases() LeaseInformer {
+// Leases returns a TypedLeaseInformer.
+func (v *version) Leases() TypedLeaseInformer {
 	return &leaseInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/coordination/v1/lease.go
+++ b/staging/src/k8s.io/client-go/informers/coordination/v1/lease.go
@@ -34,11 +34,39 @@ import (
 )
 
 // LeaseInformer provides access to a shared informer and lister for
-// Leases.
+// Leases. Prefer using the type-safe variant (see [TypedLeaseInformer]).
 type LeaseInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() coordinationv1.LeaseLister
 }
+
+// TypedLeaseInformer provides access to a shared informer and lister for
+// Leases, including the type-safe TypedInformer variant.
+// It is a superset of LeaseInformer.
+type TypedLeaseInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() LeaseIndexInformer
+	Lister() coordinationv1.LeaseLister
+}
+
+// LeaseIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type LeaseIndexInformer cache.TypedSharedIndexInformer[*apicoordinationv1.Lease]
+
+// LeaseHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Lease.
+type LeaseHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apicoordinationv1.Lease]
+
+// LeaseDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Lease.
+type LeaseDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apicoordinationv1.Lease]
+
+// LeaseFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Lease.
+type LeaseFilteringHandler = cache.TypedFilteringResourceEventHandler[*apicoordinationv1.Lease]
+
+// LeaseIndexers is a specialization of [cache.TypedIndexers] for Lease.
+type LeaseIndexers = cache.TypedIndexers[*apicoordinationv1.Lease]
+
+// DeletedLease is a specialization of [cache.DeletedObject] for Lease.
+type DeletedLease = cache.DeletedObject[*apicoordinationv1.Lease]
 
 type leaseInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type leaseInformer struct {
 // NewLeaseInformer constructs a new informer for Lease type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedLeaseInformer]).
 func NewLeaseInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewLeaseInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedLeaseInformer constructs a new informer for Lease type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedLeaseInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers LeaseIndexers) LeaseIndexInformer {
+	return NewTypedLeaseInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredLeaseInformer constructs a new informer for Lease type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredLeaseInformer]).
 func NewFilteredLeaseInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewLeaseInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedLeaseInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredLeaseInformer constructs a new informer for Lease type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredLeaseInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers LeaseIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) LeaseIndexInformer {
+	return NewTypedLeaseInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewLeaseInformerWithOptions constructs a new informer for Lease type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedLeaseInformerWithOptions]).
 func NewLeaseInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedLeaseInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedLeaseInformerWithOptions constructs a new informer for Lease type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedLeaseInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) LeaseIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "coordination.k8s.io", Version: "v1", Resource: "leases"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apicoordinationv1.Lease](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewLeaseInformerWithOptions(client kubernetes.Interface, namespace string, 
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *leaseInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewLeaseInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedLeaseInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *leaseInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apicoordinationv1.Lease{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *leaseInformer) TypedInformer() LeaseIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicoordinationv1.Lease](f.factory.InformerFor(&apicoordinationv1.Lease{}, f.defaultInformer))
 }
 
 func (f *leaseInformer) Lister() coordinationv1.LeaseLister {
 	return coordinationv1.NewLeaseLister(f.Informer().GetIndexer())
+}
+
+// ToTypedLeaseInformer converts an untyped informer into a TypedLeaseInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Lease. If that is not the case, calling type-safe methods of the returned
+// TypedLeaseInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedLeaseInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedLeaseInformer(informer LeaseInformer) TypedLeaseInformer {
+	if informer, ok := informer.(TypedLeaseInformer); ok {
+		return informer
+	}
+	return &leaseTypedInformerAdapter{informer}
+}
+
+type leaseTypedInformerAdapter struct {
+	LeaseInformer
+}
+
+func (a *leaseTypedInformerAdapter) TypedInformer() LeaseIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicoordinationv1.Lease](a.Informer())
+}
+
+// ToLeaseIndexInformer converts an untyped informer into a LeaseIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Lease. If that is not the case, calling type-safe methods of the returned
+// LeaseIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a LeaseIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToLeaseIndexInformer(informer cache.SharedIndexInformer) LeaseIndexInformer {
+	if informer, ok := informer.(LeaseIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apicoordinationv1.Lease](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/coordination/v1alpha2/interface.go
+++ b/staging/src/k8s.io/client-go/informers/coordination/v1alpha2/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// LeaseCandidates returns a LeaseCandidateInformer.
-	LeaseCandidates() LeaseCandidateInformer
+	LeaseCandidates() TypedLeaseCandidateInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// LeaseCandidates returns a LeaseCandidateInformer.
-func (v *version) LeaseCandidates() LeaseCandidateInformer {
+// LeaseCandidates returns a TypedLeaseCandidateInformer.
+func (v *version) LeaseCandidates() TypedLeaseCandidateInformer {
 	return &leaseCandidateInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/coordination/v1alpha2/leasecandidate.go
+++ b/staging/src/k8s.io/client-go/informers/coordination/v1alpha2/leasecandidate.go
@@ -34,11 +34,39 @@ import (
 )
 
 // LeaseCandidateInformer provides access to a shared informer and lister for
-// LeaseCandidates.
+// LeaseCandidates. Prefer using the type-safe variant (see [TypedLeaseCandidateInformer]).
 type LeaseCandidateInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() coordinationv1alpha2.LeaseCandidateLister
 }
+
+// TypedLeaseCandidateInformer provides access to a shared informer and lister for
+// LeaseCandidates, including the type-safe TypedInformer variant.
+// It is a superset of LeaseCandidateInformer.
+type TypedLeaseCandidateInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() LeaseCandidateIndexInformer
+	Lister() coordinationv1alpha2.LeaseCandidateLister
+}
+
+// LeaseCandidateIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type LeaseCandidateIndexInformer cache.TypedSharedIndexInformer[*apicoordinationv1alpha2.LeaseCandidate]
+
+// LeaseCandidateHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for LeaseCandidate.
+type LeaseCandidateHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apicoordinationv1alpha2.LeaseCandidate]
+
+// LeaseCandidateDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for LeaseCandidate.
+type LeaseCandidateDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apicoordinationv1alpha2.LeaseCandidate]
+
+// LeaseCandidateFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for LeaseCandidate.
+type LeaseCandidateFilteringHandler = cache.TypedFilteringResourceEventHandler[*apicoordinationv1alpha2.LeaseCandidate]
+
+// LeaseCandidateIndexers is a specialization of [cache.TypedIndexers] for LeaseCandidate.
+type LeaseCandidateIndexers = cache.TypedIndexers[*apicoordinationv1alpha2.LeaseCandidate]
+
+// DeletedLeaseCandidate is a specialization of [cache.DeletedObject] for LeaseCandidate.
+type DeletedLeaseCandidate = cache.DeletedObject[*apicoordinationv1alpha2.LeaseCandidate]
 
 type leaseCandidateInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type leaseCandidateInformer struct {
 // NewLeaseCandidateInformer constructs a new informer for LeaseCandidate type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedLeaseCandidateInformer]).
 func NewLeaseCandidateInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewLeaseCandidateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedLeaseCandidateInformer constructs a new informer for LeaseCandidate type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedLeaseCandidateInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers LeaseCandidateIndexers) LeaseCandidateIndexInformer {
+	return NewTypedLeaseCandidateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredLeaseCandidateInformer constructs a new informer for LeaseCandidate type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredLeaseCandidateInformer]).
 func NewFilteredLeaseCandidateInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewLeaseCandidateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedLeaseCandidateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredLeaseCandidateInformer constructs a new informer for LeaseCandidate type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredLeaseCandidateInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers LeaseCandidateIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) LeaseCandidateIndexInformer {
+	return NewTypedLeaseCandidateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewLeaseCandidateInformerWithOptions constructs a new informer for LeaseCandidate type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedLeaseCandidateInformerWithOptions]).
 func NewLeaseCandidateInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedLeaseCandidateInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedLeaseCandidateInformerWithOptions constructs a new informer for LeaseCandidate type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedLeaseCandidateInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) LeaseCandidateIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "coordination.k8s.io", Version: "v1alpha2", Resource: "leasecandidates"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apicoordinationv1alpha2.LeaseCandidate](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewLeaseCandidateInformerWithOptions(client kubernetes.Interface, namespace
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *leaseCandidateInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewLeaseCandidateInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedLeaseCandidateInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *leaseCandidateInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apicoordinationv1alpha2.LeaseCandidate{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *leaseCandidateInformer) TypedInformer() LeaseCandidateIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicoordinationv1alpha2.LeaseCandidate](f.factory.InformerFor(&apicoordinationv1alpha2.LeaseCandidate{}, f.defaultInformer))
 }
 
 func (f *leaseCandidateInformer) Lister() coordinationv1alpha2.LeaseCandidateLister {
 	return coordinationv1alpha2.NewLeaseCandidateLister(f.Informer().GetIndexer())
+}
+
+// ToTypedLeaseCandidateInformer converts an untyped informer into a TypedLeaseCandidateInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *LeaseCandidate. If that is not the case, calling type-safe methods of the returned
+// TypedLeaseCandidateInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedLeaseCandidateInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedLeaseCandidateInformer(informer LeaseCandidateInformer) TypedLeaseCandidateInformer {
+	if informer, ok := informer.(TypedLeaseCandidateInformer); ok {
+		return informer
+	}
+	return &leaseCandidateTypedInformerAdapter{informer}
+}
+
+type leaseCandidateTypedInformerAdapter struct {
+	LeaseCandidateInformer
+}
+
+func (a *leaseCandidateTypedInformerAdapter) TypedInformer() LeaseCandidateIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicoordinationv1alpha2.LeaseCandidate](a.Informer())
+}
+
+// ToLeaseCandidateIndexInformer converts an untyped informer into a LeaseCandidateIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *LeaseCandidate. If that is not the case, calling type-safe methods of the returned
+// LeaseCandidateIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a LeaseCandidateIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToLeaseCandidateIndexInformer(informer cache.SharedIndexInformer) LeaseCandidateIndexInformer {
+	if informer, ok := informer.(LeaseCandidateIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apicoordinationv1alpha2.LeaseCandidate](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/coordination/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/coordination/v1beta1/interface.go
@@ -25,9 +25,9 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// Leases returns a LeaseInformer.
-	Leases() LeaseInformer
+	Leases() TypedLeaseInformer
 	// LeaseCandidates returns a LeaseCandidateInformer.
-	LeaseCandidates() LeaseCandidateInformer
+	LeaseCandidates() TypedLeaseCandidateInformer
 }
 
 type version struct {
@@ -41,12 +41,12 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// Leases returns a LeaseInformer.
-func (v *version) Leases() LeaseInformer {
+// Leases returns a TypedLeaseInformer.
+func (v *version) Leases() TypedLeaseInformer {
 	return &leaseInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// LeaseCandidates returns a LeaseCandidateInformer.
-func (v *version) LeaseCandidates() LeaseCandidateInformer {
+// LeaseCandidates returns a TypedLeaseCandidateInformer.
+func (v *version) LeaseCandidates() TypedLeaseCandidateInformer {
 	return &leaseCandidateInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/coordination/v1beta1/lease.go
+++ b/staging/src/k8s.io/client-go/informers/coordination/v1beta1/lease.go
@@ -34,11 +34,39 @@ import (
 )
 
 // LeaseInformer provides access to a shared informer and lister for
-// Leases.
+// Leases. Prefer using the type-safe variant (see [TypedLeaseInformer]).
 type LeaseInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() coordinationv1beta1.LeaseLister
 }
+
+// TypedLeaseInformer provides access to a shared informer and lister for
+// Leases, including the type-safe TypedInformer variant.
+// It is a superset of LeaseInformer.
+type TypedLeaseInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() LeaseIndexInformer
+	Lister() coordinationv1beta1.LeaseLister
+}
+
+// LeaseIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type LeaseIndexInformer cache.TypedSharedIndexInformer[*apicoordinationv1beta1.Lease]
+
+// LeaseHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Lease.
+type LeaseHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apicoordinationv1beta1.Lease]
+
+// LeaseDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Lease.
+type LeaseDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apicoordinationv1beta1.Lease]
+
+// LeaseFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Lease.
+type LeaseFilteringHandler = cache.TypedFilteringResourceEventHandler[*apicoordinationv1beta1.Lease]
+
+// LeaseIndexers is a specialization of [cache.TypedIndexers] for Lease.
+type LeaseIndexers = cache.TypedIndexers[*apicoordinationv1beta1.Lease]
+
+// DeletedLease is a specialization of [cache.DeletedObject] for Lease.
+type DeletedLease = cache.DeletedObject[*apicoordinationv1beta1.Lease]
 
 type leaseInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type leaseInformer struct {
 // NewLeaseInformer constructs a new informer for Lease type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedLeaseInformer]).
 func NewLeaseInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewLeaseInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedLeaseInformer constructs a new informer for Lease type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedLeaseInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers LeaseIndexers) LeaseIndexInformer {
+	return NewTypedLeaseInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredLeaseInformer constructs a new informer for Lease type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredLeaseInformer]).
 func NewFilteredLeaseInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewLeaseInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedLeaseInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredLeaseInformer constructs a new informer for Lease type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredLeaseInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers LeaseIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) LeaseIndexInformer {
+	return NewTypedLeaseInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewLeaseInformerWithOptions constructs a new informer for Lease type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedLeaseInformerWithOptions]).
 func NewLeaseInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedLeaseInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedLeaseInformerWithOptions constructs a new informer for Lease type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedLeaseInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) LeaseIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "coordination.k8s.io", Version: "v1beta1", Resource: "leases"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apicoordinationv1beta1.Lease](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewLeaseInformerWithOptions(client kubernetes.Interface, namespace string, 
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *leaseInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewLeaseInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedLeaseInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *leaseInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apicoordinationv1beta1.Lease{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *leaseInformer) TypedInformer() LeaseIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicoordinationv1beta1.Lease](f.factory.InformerFor(&apicoordinationv1beta1.Lease{}, f.defaultInformer))
 }
 
 func (f *leaseInformer) Lister() coordinationv1beta1.LeaseLister {
 	return coordinationv1beta1.NewLeaseLister(f.Informer().GetIndexer())
+}
+
+// ToTypedLeaseInformer converts an untyped informer into a TypedLeaseInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Lease. If that is not the case, calling type-safe methods of the returned
+// TypedLeaseInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedLeaseInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedLeaseInformer(informer LeaseInformer) TypedLeaseInformer {
+	if informer, ok := informer.(TypedLeaseInformer); ok {
+		return informer
+	}
+	return &leaseTypedInformerAdapter{informer}
+}
+
+type leaseTypedInformerAdapter struct {
+	LeaseInformer
+}
+
+func (a *leaseTypedInformerAdapter) TypedInformer() LeaseIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicoordinationv1beta1.Lease](a.Informer())
+}
+
+// ToLeaseIndexInformer converts an untyped informer into a LeaseIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Lease. If that is not the case, calling type-safe methods of the returned
+// LeaseIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a LeaseIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToLeaseIndexInformer(informer cache.SharedIndexInformer) LeaseIndexInformer {
+	if informer, ok := informer.(LeaseIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apicoordinationv1beta1.Lease](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/coordination/v1beta1/leasecandidate.go
+++ b/staging/src/k8s.io/client-go/informers/coordination/v1beta1/leasecandidate.go
@@ -34,11 +34,39 @@ import (
 )
 
 // LeaseCandidateInformer provides access to a shared informer and lister for
-// LeaseCandidates.
+// LeaseCandidates. Prefer using the type-safe variant (see [TypedLeaseCandidateInformer]).
 type LeaseCandidateInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() coordinationv1beta1.LeaseCandidateLister
 }
+
+// TypedLeaseCandidateInformer provides access to a shared informer and lister for
+// LeaseCandidates, including the type-safe TypedInformer variant.
+// It is a superset of LeaseCandidateInformer.
+type TypedLeaseCandidateInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() LeaseCandidateIndexInformer
+	Lister() coordinationv1beta1.LeaseCandidateLister
+}
+
+// LeaseCandidateIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type LeaseCandidateIndexInformer cache.TypedSharedIndexInformer[*apicoordinationv1beta1.LeaseCandidate]
+
+// LeaseCandidateHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for LeaseCandidate.
+type LeaseCandidateHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apicoordinationv1beta1.LeaseCandidate]
+
+// LeaseCandidateDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for LeaseCandidate.
+type LeaseCandidateDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apicoordinationv1beta1.LeaseCandidate]
+
+// LeaseCandidateFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for LeaseCandidate.
+type LeaseCandidateFilteringHandler = cache.TypedFilteringResourceEventHandler[*apicoordinationv1beta1.LeaseCandidate]
+
+// LeaseCandidateIndexers is a specialization of [cache.TypedIndexers] for LeaseCandidate.
+type LeaseCandidateIndexers = cache.TypedIndexers[*apicoordinationv1beta1.LeaseCandidate]
+
+// DeletedLeaseCandidate is a specialization of [cache.DeletedObject] for LeaseCandidate.
+type DeletedLeaseCandidate = cache.DeletedObject[*apicoordinationv1beta1.LeaseCandidate]
 
 type leaseCandidateInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type leaseCandidateInformer struct {
 // NewLeaseCandidateInformer constructs a new informer for LeaseCandidate type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedLeaseCandidateInformer]).
 func NewLeaseCandidateInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewLeaseCandidateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedLeaseCandidateInformer constructs a new informer for LeaseCandidate type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedLeaseCandidateInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers LeaseCandidateIndexers) LeaseCandidateIndexInformer {
+	return NewTypedLeaseCandidateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredLeaseCandidateInformer constructs a new informer for LeaseCandidate type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredLeaseCandidateInformer]).
 func NewFilteredLeaseCandidateInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewLeaseCandidateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedLeaseCandidateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredLeaseCandidateInformer constructs a new informer for LeaseCandidate type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredLeaseCandidateInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers LeaseCandidateIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) LeaseCandidateIndexInformer {
+	return NewTypedLeaseCandidateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewLeaseCandidateInformerWithOptions constructs a new informer for LeaseCandidate type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedLeaseCandidateInformerWithOptions]).
 func NewLeaseCandidateInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedLeaseCandidateInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedLeaseCandidateInformerWithOptions constructs a new informer for LeaseCandidate type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedLeaseCandidateInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) LeaseCandidateIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "coordination.k8s.io", Version: "v1beta1", Resource: "leasecandidates"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apicoordinationv1beta1.LeaseCandidate](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewLeaseCandidateInformerWithOptions(client kubernetes.Interface, namespace
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *leaseCandidateInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewLeaseCandidateInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedLeaseCandidateInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *leaseCandidateInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apicoordinationv1beta1.LeaseCandidate{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *leaseCandidateInformer) TypedInformer() LeaseCandidateIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicoordinationv1beta1.LeaseCandidate](f.factory.InformerFor(&apicoordinationv1beta1.LeaseCandidate{}, f.defaultInformer))
 }
 
 func (f *leaseCandidateInformer) Lister() coordinationv1beta1.LeaseCandidateLister {
 	return coordinationv1beta1.NewLeaseCandidateLister(f.Informer().GetIndexer())
+}
+
+// ToTypedLeaseCandidateInformer converts an untyped informer into a TypedLeaseCandidateInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *LeaseCandidate. If that is not the case, calling type-safe methods of the returned
+// TypedLeaseCandidateInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedLeaseCandidateInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedLeaseCandidateInformer(informer LeaseCandidateInformer) TypedLeaseCandidateInformer {
+	if informer, ok := informer.(TypedLeaseCandidateInformer); ok {
+		return informer
+	}
+	return &leaseCandidateTypedInformerAdapter{informer}
+}
+
+type leaseCandidateTypedInformerAdapter struct {
+	LeaseCandidateInformer
+}
+
+func (a *leaseCandidateTypedInformerAdapter) TypedInformer() LeaseCandidateIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicoordinationv1beta1.LeaseCandidate](a.Informer())
+}
+
+// ToLeaseCandidateIndexInformer converts an untyped informer into a LeaseCandidateIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *LeaseCandidate. If that is not the case, calling type-safe methods of the returned
+// LeaseCandidateIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a LeaseCandidateIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToLeaseCandidateIndexInformer(informer cache.SharedIndexInformer) LeaseCandidateIndexInformer {
+	if informer, ok := informer.(LeaseCandidateIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apicoordinationv1beta1.LeaseCandidate](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/core/v1/componentstatus.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/componentstatus.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ComponentStatusInformer provides access to a shared informer and lister for
-// ComponentStatuses.
+// ComponentStatuses. Prefer using the type-safe variant (see [TypedComponentStatusInformer]).
 type ComponentStatusInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() corev1.ComponentStatusLister
 }
+
+// TypedComponentStatusInformer provides access to a shared informer and lister for
+// ComponentStatuses, including the type-safe TypedInformer variant.
+// It is a superset of ComponentStatusInformer.
+type TypedComponentStatusInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ComponentStatusIndexInformer
+	Lister() corev1.ComponentStatusLister
+}
+
+// ComponentStatusIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ComponentStatusIndexInformer cache.TypedSharedIndexInformer[*apicorev1.ComponentStatus]
+
+// ComponentStatusHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ComponentStatus.
+type ComponentStatusHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apicorev1.ComponentStatus]
+
+// ComponentStatusDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ComponentStatus.
+type ComponentStatusDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apicorev1.ComponentStatus]
+
+// ComponentStatusFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ComponentStatus.
+type ComponentStatusFilteringHandler = cache.TypedFilteringResourceEventHandler[*apicorev1.ComponentStatus]
+
+// ComponentStatusIndexers is a specialization of [cache.TypedIndexers] for ComponentStatus.
+type ComponentStatusIndexers = cache.TypedIndexers[*apicorev1.ComponentStatus]
+
+// DeletedComponentStatus is a specialization of [cache.DeletedObject] for ComponentStatus.
+type DeletedComponentStatus = cache.DeletedObject[*apicorev1.ComponentStatus]
 
 type componentStatusInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type componentStatusInformer struct {
 // NewComponentStatusInformer constructs a new informer for ComponentStatus type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedComponentStatusInformer]).
 func NewComponentStatusInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewComponentStatusInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedComponentStatusInformer constructs a new informer for ComponentStatus type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedComponentStatusInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ComponentStatusIndexers) ComponentStatusIndexInformer {
+	return NewTypedComponentStatusInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredComponentStatusInformer constructs a new informer for ComponentStatus type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredComponentStatusInformer]).
 func NewFilteredComponentStatusInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewComponentStatusInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedComponentStatusInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredComponentStatusInformer constructs a new informer for ComponentStatus type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredComponentStatusInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ComponentStatusIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ComponentStatusIndexInformer {
+	return NewTypedComponentStatusInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewComponentStatusInformerWithOptions constructs a new informer for ComponentStatus type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedComponentStatusInformerWithOptions]).
 func NewComponentStatusInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedComponentStatusInformerWithOptions(client, options)
+}
+
+// NewTypedComponentStatusInformerWithOptions constructs a new informer for ComponentStatus type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedComponentStatusInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ComponentStatusIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "componentstatuss"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apicorev1.ComponentStatus](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewComponentStatusInformerWithOptions(client kubernetes.Interface, options 
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *componentStatusInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewComponentStatusInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedComponentStatusInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *componentStatusInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apicorev1.ComponentStatus{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *componentStatusInformer) TypedInformer() ComponentStatusIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.ComponentStatus](f.factory.InformerFor(&apicorev1.ComponentStatus{}, f.defaultInformer))
 }
 
 func (f *componentStatusInformer) Lister() corev1.ComponentStatusLister {
 	return corev1.NewComponentStatusLister(f.Informer().GetIndexer())
+}
+
+// ToTypedComponentStatusInformer converts an untyped informer into a TypedComponentStatusInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ComponentStatus. If that is not the case, calling type-safe methods of the returned
+// TypedComponentStatusInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedComponentStatusInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedComponentStatusInformer(informer ComponentStatusInformer) TypedComponentStatusInformer {
+	if informer, ok := informer.(TypedComponentStatusInformer); ok {
+		return informer
+	}
+	return &componentStatusTypedInformerAdapter{informer}
+}
+
+type componentStatusTypedInformerAdapter struct {
+	ComponentStatusInformer
+}
+
+func (a *componentStatusTypedInformerAdapter) TypedInformer() ComponentStatusIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.ComponentStatus](a.Informer())
+}
+
+// ToComponentStatusIndexInformer converts an untyped informer into a ComponentStatusIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ComponentStatus. If that is not the case, calling type-safe methods of the returned
+// ComponentStatusIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ComponentStatusIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToComponentStatusIndexInformer(informer cache.SharedIndexInformer) ComponentStatusIndexInformer {
+	if informer, ok := informer.(ComponentStatusIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apicorev1.ComponentStatus](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/core/v1/configmap.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/configmap.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ConfigMapInformer provides access to a shared informer and lister for
-// ConfigMaps.
+// ConfigMaps. Prefer using the type-safe variant (see [TypedConfigMapInformer]).
 type ConfigMapInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() corev1.ConfigMapLister
 }
+
+// TypedConfigMapInformer provides access to a shared informer and lister for
+// ConfigMaps, including the type-safe TypedInformer variant.
+// It is a superset of ConfigMapInformer.
+type TypedConfigMapInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ConfigMapIndexInformer
+	Lister() corev1.ConfigMapLister
+}
+
+// ConfigMapIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ConfigMapIndexInformer cache.TypedSharedIndexInformer[*apicorev1.ConfigMap]
+
+// ConfigMapHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ConfigMap.
+type ConfigMapHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apicorev1.ConfigMap]
+
+// ConfigMapDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ConfigMap.
+type ConfigMapDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apicorev1.ConfigMap]
+
+// ConfigMapFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ConfigMap.
+type ConfigMapFilteringHandler = cache.TypedFilteringResourceEventHandler[*apicorev1.ConfigMap]
+
+// ConfigMapIndexers is a specialization of [cache.TypedIndexers] for ConfigMap.
+type ConfigMapIndexers = cache.TypedIndexers[*apicorev1.ConfigMap]
+
+// DeletedConfigMap is a specialization of [cache.DeletedObject] for ConfigMap.
+type DeletedConfigMap = cache.DeletedObject[*apicorev1.ConfigMap]
 
 type configMapInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type configMapInformer struct {
 // NewConfigMapInformer constructs a new informer for ConfigMap type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedConfigMapInformer]).
 func NewConfigMapInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewConfigMapInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedConfigMapInformer constructs a new informer for ConfigMap type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedConfigMapInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ConfigMapIndexers) ConfigMapIndexInformer {
+	return NewTypedConfigMapInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredConfigMapInformer constructs a new informer for ConfigMap type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredConfigMapInformer]).
 func NewFilteredConfigMapInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewConfigMapInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedConfigMapInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredConfigMapInformer constructs a new informer for ConfigMap type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredConfigMapInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ConfigMapIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ConfigMapIndexInformer {
+	return NewTypedConfigMapInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewConfigMapInformerWithOptions constructs a new informer for ConfigMap type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedConfigMapInformerWithOptions]).
 func NewConfigMapInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedConfigMapInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedConfigMapInformerWithOptions constructs a new informer for ConfigMap type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedConfigMapInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) ConfigMapIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apicorev1.ConfigMap](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewConfigMapInformerWithOptions(client kubernetes.Interface, namespace stri
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *configMapInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewConfigMapInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedConfigMapInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *configMapInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apicorev1.ConfigMap{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *configMapInformer) TypedInformer() ConfigMapIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.ConfigMap](f.factory.InformerFor(&apicorev1.ConfigMap{}, f.defaultInformer))
 }
 
 func (f *configMapInformer) Lister() corev1.ConfigMapLister {
 	return corev1.NewConfigMapLister(f.Informer().GetIndexer())
+}
+
+// ToTypedConfigMapInformer converts an untyped informer into a TypedConfigMapInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ConfigMap. If that is not the case, calling type-safe methods of the returned
+// TypedConfigMapInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedConfigMapInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedConfigMapInformer(informer ConfigMapInformer) TypedConfigMapInformer {
+	if informer, ok := informer.(TypedConfigMapInformer); ok {
+		return informer
+	}
+	return &configMapTypedInformerAdapter{informer}
+}
+
+type configMapTypedInformerAdapter struct {
+	ConfigMapInformer
+}
+
+func (a *configMapTypedInformerAdapter) TypedInformer() ConfigMapIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.ConfigMap](a.Informer())
+}
+
+// ToConfigMapIndexInformer converts an untyped informer into a ConfigMapIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ConfigMap. If that is not the case, calling type-safe methods of the returned
+// ConfigMapIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ConfigMapIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToConfigMapIndexInformer(informer cache.SharedIndexInformer) ConfigMapIndexInformer {
+	if informer, ok := informer.(ConfigMapIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apicorev1.ConfigMap](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/core/v1/endpoints.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/endpoints.go
@@ -34,11 +34,39 @@ import (
 )
 
 // EndpointsInformer provides access to a shared informer and lister for
-// Endpoints.
+// Endpoints. Prefer using the type-safe variant (see [TypedEndpointsInformer]).
 type EndpointsInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() corev1.EndpointsLister
 }
+
+// TypedEndpointsInformer provides access to a shared informer and lister for
+// Endpoints, including the type-safe TypedInformer variant.
+// It is a superset of EndpointsInformer.
+type TypedEndpointsInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() EndpointsIndexInformer
+	Lister() corev1.EndpointsLister
+}
+
+// EndpointsIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type EndpointsIndexInformer cache.TypedSharedIndexInformer[*apicorev1.Endpoints]
+
+// EndpointsHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Endpoints.
+type EndpointsHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apicorev1.Endpoints]
+
+// EndpointsDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Endpoints.
+type EndpointsDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apicorev1.Endpoints]
+
+// EndpointsFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Endpoints.
+type EndpointsFilteringHandler = cache.TypedFilteringResourceEventHandler[*apicorev1.Endpoints]
+
+// EndpointsIndexers is a specialization of [cache.TypedIndexers] for Endpoints.
+type EndpointsIndexers = cache.TypedIndexers[*apicorev1.Endpoints]
+
+// DeletedEndpoints is a specialization of [cache.DeletedObject] for Endpoints.
+type DeletedEndpoints = cache.DeletedObject[*apicorev1.Endpoints]
 
 type endpointsInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type endpointsInformer struct {
 // NewEndpointsInformer constructs a new informer for Endpoints type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedEndpointsInformer]).
 func NewEndpointsInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewEndpointsInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedEndpointsInformer constructs a new informer for Endpoints type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedEndpointsInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers EndpointsIndexers) EndpointsIndexInformer {
+	return NewTypedEndpointsInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredEndpointsInformer constructs a new informer for Endpoints type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredEndpointsInformer]).
 func NewFilteredEndpointsInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewEndpointsInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedEndpointsInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredEndpointsInformer constructs a new informer for Endpoints type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredEndpointsInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers EndpointsIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) EndpointsIndexInformer {
+	return NewTypedEndpointsInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewEndpointsInformerWithOptions constructs a new informer for Endpoints type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedEndpointsInformerWithOptions]).
 func NewEndpointsInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedEndpointsInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedEndpointsInformerWithOptions constructs a new informer for Endpoints type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedEndpointsInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) EndpointsIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "endpointss"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Endpoints](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewEndpointsInformerWithOptions(client kubernetes.Interface, namespace stri
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *endpointsInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewEndpointsInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedEndpointsInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *endpointsInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apicorev1.Endpoints{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *endpointsInformer) TypedInformer() EndpointsIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Endpoints](f.factory.InformerFor(&apicorev1.Endpoints{}, f.defaultInformer))
 }
 
 func (f *endpointsInformer) Lister() corev1.EndpointsLister {
 	return corev1.NewEndpointsLister(f.Informer().GetIndexer())
+}
+
+// ToTypedEndpointsInformer converts an untyped informer into a TypedEndpointsInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Endpoints. If that is not the case, calling type-safe methods of the returned
+// TypedEndpointsInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedEndpointsInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedEndpointsInformer(informer EndpointsInformer) TypedEndpointsInformer {
+	if informer, ok := informer.(TypedEndpointsInformer); ok {
+		return informer
+	}
+	return &endpointsTypedInformerAdapter{informer}
+}
+
+type endpointsTypedInformerAdapter struct {
+	EndpointsInformer
+}
+
+func (a *endpointsTypedInformerAdapter) TypedInformer() EndpointsIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Endpoints](a.Informer())
+}
+
+// ToEndpointsIndexInformer converts an untyped informer into a EndpointsIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Endpoints. If that is not the case, calling type-safe methods of the returned
+// EndpointsIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a EndpointsIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToEndpointsIndexInformer(informer cache.SharedIndexInformer) EndpointsIndexInformer {
+	if informer, ok := informer.(EndpointsIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Endpoints](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/core/v1/event.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/event.go
@@ -34,11 +34,39 @@ import (
 )
 
 // EventInformer provides access to a shared informer and lister for
-// Events.
+// Events. Prefer using the type-safe variant (see [TypedEventInformer]).
 type EventInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() corev1.EventLister
 }
+
+// TypedEventInformer provides access to a shared informer and lister for
+// Events, including the type-safe TypedInformer variant.
+// It is a superset of EventInformer.
+type TypedEventInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() EventIndexInformer
+	Lister() corev1.EventLister
+}
+
+// EventIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type EventIndexInformer cache.TypedSharedIndexInformer[*apicorev1.Event]
+
+// EventHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Event.
+type EventHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apicorev1.Event]
+
+// EventDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Event.
+type EventDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apicorev1.Event]
+
+// EventFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Event.
+type EventFilteringHandler = cache.TypedFilteringResourceEventHandler[*apicorev1.Event]
+
+// EventIndexers is a specialization of [cache.TypedIndexers] for Event.
+type EventIndexers = cache.TypedIndexers[*apicorev1.Event]
+
+// DeletedEvent is a specialization of [cache.DeletedObject] for Event.
+type DeletedEvent = cache.DeletedObject[*apicorev1.Event]
 
 type eventInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type eventInformer struct {
 // NewEventInformer constructs a new informer for Event type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedEventInformer]).
 func NewEventInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewEventInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedEventInformer constructs a new informer for Event type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedEventInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers EventIndexers) EventIndexInformer {
+	return NewTypedEventInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredEventInformer constructs a new informer for Event type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredEventInformer]).
 func NewFilteredEventInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewEventInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedEventInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredEventInformer constructs a new informer for Event type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredEventInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers EventIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) EventIndexInformer {
+	return NewTypedEventInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewEventInformerWithOptions constructs a new informer for Event type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedEventInformerWithOptions]).
 func NewEventInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedEventInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedEventInformerWithOptions constructs a new informer for Event type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedEventInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) EventIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "events"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Event](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewEventInformerWithOptions(client kubernetes.Interface, namespace string, 
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *eventInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewEventInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedEventInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *eventInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apicorev1.Event{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *eventInformer) TypedInformer() EventIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Event](f.factory.InformerFor(&apicorev1.Event{}, f.defaultInformer))
 }
 
 func (f *eventInformer) Lister() corev1.EventLister {
 	return corev1.NewEventLister(f.Informer().GetIndexer())
+}
+
+// ToTypedEventInformer converts an untyped informer into a TypedEventInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Event. If that is not the case, calling type-safe methods of the returned
+// TypedEventInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedEventInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedEventInformer(informer EventInformer) TypedEventInformer {
+	if informer, ok := informer.(TypedEventInformer); ok {
+		return informer
+	}
+	return &eventTypedInformerAdapter{informer}
+}
+
+type eventTypedInformerAdapter struct {
+	EventInformer
+}
+
+func (a *eventTypedInformerAdapter) TypedInformer() EventIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Event](a.Informer())
+}
+
+// ToEventIndexInformer converts an untyped informer into a EventIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Event. If that is not the case, calling type-safe methods of the returned
+// EventIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a EventIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToEventIndexInformer(informer cache.SharedIndexInformer) EventIndexInformer {
+	if informer, ok := informer.(EventIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Event](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/core/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/interface.go
@@ -25,37 +25,37 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// ComponentStatuses returns a ComponentStatusInformer.
-	ComponentStatuses() ComponentStatusInformer
+	ComponentStatuses() TypedComponentStatusInformer
 	// ConfigMaps returns a ConfigMapInformer.
-	ConfigMaps() ConfigMapInformer
+	ConfigMaps() TypedConfigMapInformer
 	// Endpoints returns a EndpointsInformer.
-	Endpoints() EndpointsInformer
+	Endpoints() TypedEndpointsInformer
 	// Events returns a EventInformer.
-	Events() EventInformer
+	Events() TypedEventInformer
 	// LimitRanges returns a LimitRangeInformer.
-	LimitRanges() LimitRangeInformer
+	LimitRanges() TypedLimitRangeInformer
 	// Namespaces returns a NamespaceInformer.
-	Namespaces() NamespaceInformer
+	Namespaces() TypedNamespaceInformer
 	// Nodes returns a NodeInformer.
-	Nodes() NodeInformer
+	Nodes() TypedNodeInformer
 	// PersistentVolumes returns a PersistentVolumeInformer.
-	PersistentVolumes() PersistentVolumeInformer
+	PersistentVolumes() TypedPersistentVolumeInformer
 	// PersistentVolumeClaims returns a PersistentVolumeClaimInformer.
-	PersistentVolumeClaims() PersistentVolumeClaimInformer
+	PersistentVolumeClaims() TypedPersistentVolumeClaimInformer
 	// Pods returns a PodInformer.
-	Pods() PodInformer
+	Pods() TypedPodInformer
 	// PodTemplates returns a PodTemplateInformer.
-	PodTemplates() PodTemplateInformer
+	PodTemplates() TypedPodTemplateInformer
 	// ReplicationControllers returns a ReplicationControllerInformer.
-	ReplicationControllers() ReplicationControllerInformer
+	ReplicationControllers() TypedReplicationControllerInformer
 	// ResourceQuotas returns a ResourceQuotaInformer.
-	ResourceQuotas() ResourceQuotaInformer
+	ResourceQuotas() TypedResourceQuotaInformer
 	// Secrets returns a SecretInformer.
-	Secrets() SecretInformer
+	Secrets() TypedSecretInformer
 	// Services returns a ServiceInformer.
-	Services() ServiceInformer
+	Services() TypedServiceInformer
 	// ServiceAccounts returns a ServiceAccountInformer.
-	ServiceAccounts() ServiceAccountInformer
+	ServiceAccounts() TypedServiceAccountInformer
 }
 
 type version struct {
@@ -69,82 +69,82 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// ComponentStatuses returns a ComponentStatusInformer.
-func (v *version) ComponentStatuses() ComponentStatusInformer {
+// ComponentStatuses returns a TypedComponentStatusInformer.
+func (v *version) ComponentStatuses() TypedComponentStatusInformer {
 	return &componentStatusInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// ConfigMaps returns a ConfigMapInformer.
-func (v *version) ConfigMaps() ConfigMapInformer {
+// ConfigMaps returns a TypedConfigMapInformer.
+func (v *version) ConfigMaps() TypedConfigMapInformer {
 	return &configMapInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// Endpoints returns a EndpointsInformer.
-func (v *version) Endpoints() EndpointsInformer {
+// Endpoints returns a TypedEndpointsInformer.
+func (v *version) Endpoints() TypedEndpointsInformer {
 	return &endpointsInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// Events returns a EventInformer.
-func (v *version) Events() EventInformer {
+// Events returns a TypedEventInformer.
+func (v *version) Events() TypedEventInformer {
 	return &eventInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// LimitRanges returns a LimitRangeInformer.
-func (v *version) LimitRanges() LimitRangeInformer {
+// LimitRanges returns a TypedLimitRangeInformer.
+func (v *version) LimitRanges() TypedLimitRangeInformer {
 	return &limitRangeInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// Namespaces returns a NamespaceInformer.
-func (v *version) Namespaces() NamespaceInformer {
+// Namespaces returns a TypedNamespaceInformer.
+func (v *version) Namespaces() TypedNamespaceInformer {
 	return &namespaceInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// Nodes returns a NodeInformer.
-func (v *version) Nodes() NodeInformer {
+// Nodes returns a TypedNodeInformer.
+func (v *version) Nodes() TypedNodeInformer {
 	return &nodeInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// PersistentVolumes returns a PersistentVolumeInformer.
-func (v *version) PersistentVolumes() PersistentVolumeInformer {
+// PersistentVolumes returns a TypedPersistentVolumeInformer.
+func (v *version) PersistentVolumes() TypedPersistentVolumeInformer {
 	return &persistentVolumeInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// PersistentVolumeClaims returns a PersistentVolumeClaimInformer.
-func (v *version) PersistentVolumeClaims() PersistentVolumeClaimInformer {
+// PersistentVolumeClaims returns a TypedPersistentVolumeClaimInformer.
+func (v *version) PersistentVolumeClaims() TypedPersistentVolumeClaimInformer {
 	return &persistentVolumeClaimInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// Pods returns a PodInformer.
-func (v *version) Pods() PodInformer {
+// Pods returns a TypedPodInformer.
+func (v *version) Pods() TypedPodInformer {
 	return &podInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// PodTemplates returns a PodTemplateInformer.
-func (v *version) PodTemplates() PodTemplateInformer {
+// PodTemplates returns a TypedPodTemplateInformer.
+func (v *version) PodTemplates() TypedPodTemplateInformer {
 	return &podTemplateInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// ReplicationControllers returns a ReplicationControllerInformer.
-func (v *version) ReplicationControllers() ReplicationControllerInformer {
+// ReplicationControllers returns a TypedReplicationControllerInformer.
+func (v *version) ReplicationControllers() TypedReplicationControllerInformer {
 	return &replicationControllerInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// ResourceQuotas returns a ResourceQuotaInformer.
-func (v *version) ResourceQuotas() ResourceQuotaInformer {
+// ResourceQuotas returns a TypedResourceQuotaInformer.
+func (v *version) ResourceQuotas() TypedResourceQuotaInformer {
 	return &resourceQuotaInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// Secrets returns a SecretInformer.
-func (v *version) Secrets() SecretInformer {
+// Secrets returns a TypedSecretInformer.
+func (v *version) Secrets() TypedSecretInformer {
 	return &secretInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// Services returns a ServiceInformer.
-func (v *version) Services() ServiceInformer {
+// Services returns a TypedServiceInformer.
+func (v *version) Services() TypedServiceInformer {
 	return &serviceInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// ServiceAccounts returns a ServiceAccountInformer.
-func (v *version) ServiceAccounts() ServiceAccountInformer {
+// ServiceAccounts returns a TypedServiceAccountInformer.
+func (v *version) ServiceAccounts() TypedServiceAccountInformer {
 	return &serviceAccountInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/core/v1/limitrange.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/limitrange.go
@@ -34,11 +34,39 @@ import (
 )
 
 // LimitRangeInformer provides access to a shared informer and lister for
-// LimitRanges.
+// LimitRanges. Prefer using the type-safe variant (see [TypedLimitRangeInformer]).
 type LimitRangeInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() corev1.LimitRangeLister
 }
+
+// TypedLimitRangeInformer provides access to a shared informer and lister for
+// LimitRanges, including the type-safe TypedInformer variant.
+// It is a superset of LimitRangeInformer.
+type TypedLimitRangeInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() LimitRangeIndexInformer
+	Lister() corev1.LimitRangeLister
+}
+
+// LimitRangeIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type LimitRangeIndexInformer cache.TypedSharedIndexInformer[*apicorev1.LimitRange]
+
+// LimitRangeHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for LimitRange.
+type LimitRangeHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apicorev1.LimitRange]
+
+// LimitRangeDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for LimitRange.
+type LimitRangeDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apicorev1.LimitRange]
+
+// LimitRangeFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for LimitRange.
+type LimitRangeFilteringHandler = cache.TypedFilteringResourceEventHandler[*apicorev1.LimitRange]
+
+// LimitRangeIndexers is a specialization of [cache.TypedIndexers] for LimitRange.
+type LimitRangeIndexers = cache.TypedIndexers[*apicorev1.LimitRange]
+
+// DeletedLimitRange is a specialization of [cache.DeletedObject] for LimitRange.
+type DeletedLimitRange = cache.DeletedObject[*apicorev1.LimitRange]
 
 type limitRangeInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type limitRangeInformer struct {
 // NewLimitRangeInformer constructs a new informer for LimitRange type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedLimitRangeInformer]).
 func NewLimitRangeInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewLimitRangeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedLimitRangeInformer constructs a new informer for LimitRange type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedLimitRangeInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers LimitRangeIndexers) LimitRangeIndexInformer {
+	return NewTypedLimitRangeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredLimitRangeInformer constructs a new informer for LimitRange type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredLimitRangeInformer]).
 func NewFilteredLimitRangeInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewLimitRangeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedLimitRangeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredLimitRangeInformer constructs a new informer for LimitRange type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredLimitRangeInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers LimitRangeIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) LimitRangeIndexInformer {
+	return NewTypedLimitRangeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewLimitRangeInformerWithOptions constructs a new informer for LimitRange type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedLimitRangeInformerWithOptions]).
 func NewLimitRangeInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedLimitRangeInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedLimitRangeInformerWithOptions constructs a new informer for LimitRange type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedLimitRangeInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) LimitRangeIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "limitranges"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apicorev1.LimitRange](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewLimitRangeInformerWithOptions(client kubernetes.Interface, namespace str
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *limitRangeInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewLimitRangeInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedLimitRangeInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *limitRangeInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apicorev1.LimitRange{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *limitRangeInformer) TypedInformer() LimitRangeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.LimitRange](f.factory.InformerFor(&apicorev1.LimitRange{}, f.defaultInformer))
 }
 
 func (f *limitRangeInformer) Lister() corev1.LimitRangeLister {
 	return corev1.NewLimitRangeLister(f.Informer().GetIndexer())
+}
+
+// ToTypedLimitRangeInformer converts an untyped informer into a TypedLimitRangeInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *LimitRange. If that is not the case, calling type-safe methods of the returned
+// TypedLimitRangeInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedLimitRangeInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedLimitRangeInformer(informer LimitRangeInformer) TypedLimitRangeInformer {
+	if informer, ok := informer.(TypedLimitRangeInformer); ok {
+		return informer
+	}
+	return &limitRangeTypedInformerAdapter{informer}
+}
+
+type limitRangeTypedInformerAdapter struct {
+	LimitRangeInformer
+}
+
+func (a *limitRangeTypedInformerAdapter) TypedInformer() LimitRangeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.LimitRange](a.Informer())
+}
+
+// ToLimitRangeIndexInformer converts an untyped informer into a LimitRangeIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *LimitRange. If that is not the case, calling type-safe methods of the returned
+// LimitRangeIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a LimitRangeIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToLimitRangeIndexInformer(informer cache.SharedIndexInformer) LimitRangeIndexInformer {
+	if informer, ok := informer.(LimitRangeIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apicorev1.LimitRange](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/core/v1/namespace.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/namespace.go
@@ -34,11 +34,39 @@ import (
 )
 
 // NamespaceInformer provides access to a shared informer and lister for
-// Namespaces.
+// Namespaces. Prefer using the type-safe variant (see [TypedNamespaceInformer]).
 type NamespaceInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() corev1.NamespaceLister
 }
+
+// TypedNamespaceInformer provides access to a shared informer and lister for
+// Namespaces, including the type-safe TypedInformer variant.
+// It is a superset of NamespaceInformer.
+type TypedNamespaceInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() NamespaceIndexInformer
+	Lister() corev1.NamespaceLister
+}
+
+// NamespaceIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type NamespaceIndexInformer cache.TypedSharedIndexInformer[*apicorev1.Namespace]
+
+// NamespaceHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Namespace.
+type NamespaceHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apicorev1.Namespace]
+
+// NamespaceDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Namespace.
+type NamespaceDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apicorev1.Namespace]
+
+// NamespaceFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Namespace.
+type NamespaceFilteringHandler = cache.TypedFilteringResourceEventHandler[*apicorev1.Namespace]
+
+// NamespaceIndexers is a specialization of [cache.TypedIndexers] for Namespace.
+type NamespaceIndexers = cache.TypedIndexers[*apicorev1.Namespace]
+
+// DeletedNamespace is a specialization of [cache.DeletedObject] for Namespace.
+type DeletedNamespace = cache.DeletedObject[*apicorev1.Namespace]
 
 type namespaceInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type namespaceInformer struct {
 // NewNamespaceInformer constructs a new informer for Namespace type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedNamespaceInformer]).
 func NewNamespaceInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewNamespaceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedNamespaceInformer constructs a new informer for Namespace type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedNamespaceInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers NamespaceIndexers) NamespaceIndexInformer {
+	return NewTypedNamespaceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredNamespaceInformer constructs a new informer for Namespace type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredNamespaceInformer]).
 func NewFilteredNamespaceInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewNamespaceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedNamespaceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredNamespaceInformer constructs a new informer for Namespace type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredNamespaceInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers NamespaceIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) NamespaceIndexInformer {
+	return NewTypedNamespaceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewNamespaceInformerWithOptions constructs a new informer for Namespace type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedNamespaceInformerWithOptions]).
 func NewNamespaceInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedNamespaceInformerWithOptions(client, options)
+}
+
+// NewTypedNamespaceInformerWithOptions constructs a new informer for Namespace type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedNamespaceInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) NamespaceIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Namespace](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewNamespaceInformerWithOptions(client kubernetes.Interface, options intern
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *namespaceInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewNamespaceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedNamespaceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *namespaceInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apicorev1.Namespace{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *namespaceInformer) TypedInformer() NamespaceIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Namespace](f.factory.InformerFor(&apicorev1.Namespace{}, f.defaultInformer))
 }
 
 func (f *namespaceInformer) Lister() corev1.NamespaceLister {
 	return corev1.NewNamespaceLister(f.Informer().GetIndexer())
+}
+
+// ToTypedNamespaceInformer converts an untyped informer into a TypedNamespaceInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Namespace. If that is not the case, calling type-safe methods of the returned
+// TypedNamespaceInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedNamespaceInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedNamespaceInformer(informer NamespaceInformer) TypedNamespaceInformer {
+	if informer, ok := informer.(TypedNamespaceInformer); ok {
+		return informer
+	}
+	return &namespaceTypedInformerAdapter{informer}
+}
+
+type namespaceTypedInformerAdapter struct {
+	NamespaceInformer
+}
+
+func (a *namespaceTypedInformerAdapter) TypedInformer() NamespaceIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Namespace](a.Informer())
+}
+
+// ToNamespaceIndexInformer converts an untyped informer into a NamespaceIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Namespace. If that is not the case, calling type-safe methods of the returned
+// NamespaceIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a NamespaceIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToNamespaceIndexInformer(informer cache.SharedIndexInformer) NamespaceIndexInformer {
+	if informer, ok := informer.(NamespaceIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Namespace](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/node.go
@@ -34,11 +34,39 @@ import (
 )
 
 // NodeInformer provides access to a shared informer and lister for
-// Nodes.
+// Nodes. Prefer using the type-safe variant (see [TypedNodeInformer]).
 type NodeInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() corev1.NodeLister
 }
+
+// TypedNodeInformer provides access to a shared informer and lister for
+// Nodes, including the type-safe TypedInformer variant.
+// It is a superset of NodeInformer.
+type TypedNodeInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() NodeIndexInformer
+	Lister() corev1.NodeLister
+}
+
+// NodeIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type NodeIndexInformer cache.TypedSharedIndexInformer[*apicorev1.Node]
+
+// NodeHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Node.
+type NodeHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apicorev1.Node]
+
+// NodeDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Node.
+type NodeDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apicorev1.Node]
+
+// NodeFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Node.
+type NodeFilteringHandler = cache.TypedFilteringResourceEventHandler[*apicorev1.Node]
+
+// NodeIndexers is a specialization of [cache.TypedIndexers] for Node.
+type NodeIndexers = cache.TypedIndexers[*apicorev1.Node]
+
+// DeletedNode is a specialization of [cache.DeletedObject] for Node.
+type DeletedNode = cache.DeletedObject[*apicorev1.Node]
 
 type nodeInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type nodeInformer struct {
 // NewNodeInformer constructs a new informer for Node type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedNodeInformer]).
 func NewNodeInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewNodeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedNodeInformer constructs a new informer for Node type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedNodeInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers NodeIndexers) NodeIndexInformer {
+	return NewTypedNodeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredNodeInformer constructs a new informer for Node type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredNodeInformer]).
 func NewFilteredNodeInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewNodeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedNodeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredNodeInformer constructs a new informer for Node type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredNodeInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers NodeIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) NodeIndexInformer {
+	return NewTypedNodeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewNodeInformerWithOptions constructs a new informer for Node type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedNodeInformerWithOptions]).
 func NewNodeInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedNodeInformerWithOptions(client, options)
+}
+
+// NewTypedNodeInformerWithOptions constructs a new informer for Node type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedNodeInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) NodeIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "nodes"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Node](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewNodeInformerWithOptions(client kubernetes.Interface, options internalint
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *nodeInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewNodeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedNodeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *nodeInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apicorev1.Node{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *nodeInformer) TypedInformer() NodeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Node](f.factory.InformerFor(&apicorev1.Node{}, f.defaultInformer))
 }
 
 func (f *nodeInformer) Lister() corev1.NodeLister {
 	return corev1.NewNodeLister(f.Informer().GetIndexer())
+}
+
+// ToTypedNodeInformer converts an untyped informer into a TypedNodeInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Node. If that is not the case, calling type-safe methods of the returned
+// TypedNodeInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedNodeInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedNodeInformer(informer NodeInformer) TypedNodeInformer {
+	if informer, ok := informer.(TypedNodeInformer); ok {
+		return informer
+	}
+	return &nodeTypedInformerAdapter{informer}
+}
+
+type nodeTypedInformerAdapter struct {
+	NodeInformer
+}
+
+func (a *nodeTypedInformerAdapter) TypedInformer() NodeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Node](a.Informer())
+}
+
+// ToNodeIndexInformer converts an untyped informer into a NodeIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Node. If that is not the case, calling type-safe methods of the returned
+// NodeIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a NodeIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToNodeIndexInformer(informer cache.SharedIndexInformer) NodeIndexInformer {
+	if informer, ok := informer.(NodeIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Node](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/core/v1/persistentvolume.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/persistentvolume.go
@@ -34,11 +34,39 @@ import (
 )
 
 // PersistentVolumeInformer provides access to a shared informer and lister for
-// PersistentVolumes.
+// PersistentVolumes. Prefer using the type-safe variant (see [TypedPersistentVolumeInformer]).
 type PersistentVolumeInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() corev1.PersistentVolumeLister
 }
+
+// TypedPersistentVolumeInformer provides access to a shared informer and lister for
+// PersistentVolumes, including the type-safe TypedInformer variant.
+// It is a superset of PersistentVolumeInformer.
+type TypedPersistentVolumeInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() PersistentVolumeIndexInformer
+	Lister() corev1.PersistentVolumeLister
+}
+
+// PersistentVolumeIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type PersistentVolumeIndexInformer cache.TypedSharedIndexInformer[*apicorev1.PersistentVolume]
+
+// PersistentVolumeHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for PersistentVolume.
+type PersistentVolumeHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apicorev1.PersistentVolume]
+
+// PersistentVolumeDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for PersistentVolume.
+type PersistentVolumeDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apicorev1.PersistentVolume]
+
+// PersistentVolumeFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for PersistentVolume.
+type PersistentVolumeFilteringHandler = cache.TypedFilteringResourceEventHandler[*apicorev1.PersistentVolume]
+
+// PersistentVolumeIndexers is a specialization of [cache.TypedIndexers] for PersistentVolume.
+type PersistentVolumeIndexers = cache.TypedIndexers[*apicorev1.PersistentVolume]
+
+// DeletedPersistentVolume is a specialization of [cache.DeletedObject] for PersistentVolume.
+type DeletedPersistentVolume = cache.DeletedObject[*apicorev1.PersistentVolume]
 
 type persistentVolumeInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type persistentVolumeInformer struct {
 // NewPersistentVolumeInformer constructs a new informer for PersistentVolume type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPersistentVolumeInformer]).
 func NewPersistentVolumeInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewPersistentVolumeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedPersistentVolumeInformer constructs a new informer for PersistentVolume type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPersistentVolumeInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers PersistentVolumeIndexers) PersistentVolumeIndexInformer {
+	return NewTypedPersistentVolumeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredPersistentVolumeInformer constructs a new informer for PersistentVolume type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredPersistentVolumeInformer]).
 func NewFilteredPersistentVolumeInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewPersistentVolumeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedPersistentVolumeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredPersistentVolumeInformer constructs a new informer for PersistentVolume type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredPersistentVolumeInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers PersistentVolumeIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) PersistentVolumeIndexInformer {
+	return NewTypedPersistentVolumeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewPersistentVolumeInformerWithOptions constructs a new informer for PersistentVolume type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPersistentVolumeInformerWithOptions]).
 func NewPersistentVolumeInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedPersistentVolumeInformerWithOptions(client, options)
+}
+
+// NewTypedPersistentVolumeInformerWithOptions constructs a new informer for PersistentVolume type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPersistentVolumeInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) PersistentVolumeIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apicorev1.PersistentVolume](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewPersistentVolumeInformerWithOptions(client kubernetes.Interface, options
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *persistentVolumeInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewPersistentVolumeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedPersistentVolumeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *persistentVolumeInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apicorev1.PersistentVolume{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *persistentVolumeInformer) TypedInformer() PersistentVolumeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.PersistentVolume](f.factory.InformerFor(&apicorev1.PersistentVolume{}, f.defaultInformer))
 }
 
 func (f *persistentVolumeInformer) Lister() corev1.PersistentVolumeLister {
 	return corev1.NewPersistentVolumeLister(f.Informer().GetIndexer())
+}
+
+// ToTypedPersistentVolumeInformer converts an untyped informer into a TypedPersistentVolumeInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *PersistentVolume. If that is not the case, calling type-safe methods of the returned
+// TypedPersistentVolumeInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedPersistentVolumeInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedPersistentVolumeInformer(informer PersistentVolumeInformer) TypedPersistentVolumeInformer {
+	if informer, ok := informer.(TypedPersistentVolumeInformer); ok {
+		return informer
+	}
+	return &persistentVolumeTypedInformerAdapter{informer}
+}
+
+type persistentVolumeTypedInformerAdapter struct {
+	PersistentVolumeInformer
+}
+
+func (a *persistentVolumeTypedInformerAdapter) TypedInformer() PersistentVolumeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.PersistentVolume](a.Informer())
+}
+
+// ToPersistentVolumeIndexInformer converts an untyped informer into a PersistentVolumeIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *PersistentVolume. If that is not the case, calling type-safe methods of the returned
+// PersistentVolumeIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a PersistentVolumeIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToPersistentVolumeIndexInformer(informer cache.SharedIndexInformer) PersistentVolumeIndexInformer {
+	if informer, ok := informer.(PersistentVolumeIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apicorev1.PersistentVolume](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/core/v1/persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/persistentvolumeclaim.go
@@ -34,11 +34,39 @@ import (
 )
 
 // PersistentVolumeClaimInformer provides access to a shared informer and lister for
-// PersistentVolumeClaims.
+// PersistentVolumeClaims. Prefer using the type-safe variant (see [TypedPersistentVolumeClaimInformer]).
 type PersistentVolumeClaimInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() corev1.PersistentVolumeClaimLister
 }
+
+// TypedPersistentVolumeClaimInformer provides access to a shared informer and lister for
+// PersistentVolumeClaims, including the type-safe TypedInformer variant.
+// It is a superset of PersistentVolumeClaimInformer.
+type TypedPersistentVolumeClaimInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() PersistentVolumeClaimIndexInformer
+	Lister() corev1.PersistentVolumeClaimLister
+}
+
+// PersistentVolumeClaimIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type PersistentVolumeClaimIndexInformer cache.TypedSharedIndexInformer[*apicorev1.PersistentVolumeClaim]
+
+// PersistentVolumeClaimHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for PersistentVolumeClaim.
+type PersistentVolumeClaimHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apicorev1.PersistentVolumeClaim]
+
+// PersistentVolumeClaimDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for PersistentVolumeClaim.
+type PersistentVolumeClaimDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apicorev1.PersistentVolumeClaim]
+
+// PersistentVolumeClaimFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for PersistentVolumeClaim.
+type PersistentVolumeClaimFilteringHandler = cache.TypedFilteringResourceEventHandler[*apicorev1.PersistentVolumeClaim]
+
+// PersistentVolumeClaimIndexers is a specialization of [cache.TypedIndexers] for PersistentVolumeClaim.
+type PersistentVolumeClaimIndexers = cache.TypedIndexers[*apicorev1.PersistentVolumeClaim]
+
+// DeletedPersistentVolumeClaim is a specialization of [cache.DeletedObject] for PersistentVolumeClaim.
+type DeletedPersistentVolumeClaim = cache.DeletedObject[*apicorev1.PersistentVolumeClaim]
 
 type persistentVolumeClaimInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type persistentVolumeClaimInformer struct {
 // NewPersistentVolumeClaimInformer constructs a new informer for PersistentVolumeClaim type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPersistentVolumeClaimInformer]).
 func NewPersistentVolumeClaimInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewPersistentVolumeClaimInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedPersistentVolumeClaimInformer constructs a new informer for PersistentVolumeClaim type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPersistentVolumeClaimInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers PersistentVolumeClaimIndexers) PersistentVolumeClaimIndexInformer {
+	return NewTypedPersistentVolumeClaimInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredPersistentVolumeClaimInformer constructs a new informer for PersistentVolumeClaim type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredPersistentVolumeClaimInformer]).
 func NewFilteredPersistentVolumeClaimInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewPersistentVolumeClaimInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedPersistentVolumeClaimInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredPersistentVolumeClaimInformer constructs a new informer for PersistentVolumeClaim type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredPersistentVolumeClaimInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers PersistentVolumeClaimIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) PersistentVolumeClaimIndexInformer {
+	return NewTypedPersistentVolumeClaimInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewPersistentVolumeClaimInformerWithOptions constructs a new informer for PersistentVolumeClaim type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPersistentVolumeClaimInformerWithOptions]).
 func NewPersistentVolumeClaimInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedPersistentVolumeClaimInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedPersistentVolumeClaimInformerWithOptions constructs a new informer for PersistentVolumeClaim type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPersistentVolumeClaimInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) PersistentVolumeClaimIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apicorev1.PersistentVolumeClaim](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewPersistentVolumeClaimInformerWithOptions(client kubernetes.Interface, na
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *persistentVolumeClaimInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewPersistentVolumeClaimInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedPersistentVolumeClaimInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *persistentVolumeClaimInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apicorev1.PersistentVolumeClaim{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *persistentVolumeClaimInformer) TypedInformer() PersistentVolumeClaimIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.PersistentVolumeClaim](f.factory.InformerFor(&apicorev1.PersistentVolumeClaim{}, f.defaultInformer))
 }
 
 func (f *persistentVolumeClaimInformer) Lister() corev1.PersistentVolumeClaimLister {
 	return corev1.NewPersistentVolumeClaimLister(f.Informer().GetIndexer())
+}
+
+// ToTypedPersistentVolumeClaimInformer converts an untyped informer into a TypedPersistentVolumeClaimInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *PersistentVolumeClaim. If that is not the case, calling type-safe methods of the returned
+// TypedPersistentVolumeClaimInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedPersistentVolumeClaimInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedPersistentVolumeClaimInformer(informer PersistentVolumeClaimInformer) TypedPersistentVolumeClaimInformer {
+	if informer, ok := informer.(TypedPersistentVolumeClaimInformer); ok {
+		return informer
+	}
+	return &persistentVolumeClaimTypedInformerAdapter{informer}
+}
+
+type persistentVolumeClaimTypedInformerAdapter struct {
+	PersistentVolumeClaimInformer
+}
+
+func (a *persistentVolumeClaimTypedInformerAdapter) TypedInformer() PersistentVolumeClaimIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.PersistentVolumeClaim](a.Informer())
+}
+
+// ToPersistentVolumeClaimIndexInformer converts an untyped informer into a PersistentVolumeClaimIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *PersistentVolumeClaim. If that is not the case, calling type-safe methods of the returned
+// PersistentVolumeClaimIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a PersistentVolumeClaimIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToPersistentVolumeClaimIndexInformer(informer cache.SharedIndexInformer) PersistentVolumeClaimIndexInformer {
+	if informer, ok := informer.(PersistentVolumeClaimIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apicorev1.PersistentVolumeClaim](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/pod.go
@@ -34,11 +34,39 @@ import (
 )
 
 // PodInformer provides access to a shared informer and lister for
-// Pods.
+// Pods. Prefer using the type-safe variant (see [TypedPodInformer]).
 type PodInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() corev1.PodLister
 }
+
+// TypedPodInformer provides access to a shared informer and lister for
+// Pods, including the type-safe TypedInformer variant.
+// It is a superset of PodInformer.
+type TypedPodInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() PodIndexInformer
+	Lister() corev1.PodLister
+}
+
+// PodIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type PodIndexInformer cache.TypedSharedIndexInformer[*apicorev1.Pod]
+
+// PodHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Pod.
+type PodHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apicorev1.Pod]
+
+// PodDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Pod.
+type PodDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apicorev1.Pod]
+
+// PodFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Pod.
+type PodFilteringHandler = cache.TypedFilteringResourceEventHandler[*apicorev1.Pod]
+
+// PodIndexers is a specialization of [cache.TypedIndexers] for Pod.
+type PodIndexers = cache.TypedIndexers[*apicorev1.Pod]
+
+// DeletedPod is a specialization of [cache.DeletedObject] for Pod.
+type DeletedPod = cache.DeletedObject[*apicorev1.Pod]
 
 type podInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type podInformer struct {
 // NewPodInformer constructs a new informer for Pod type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPodInformer]).
 func NewPodInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewPodInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedPodInformer constructs a new informer for Pod type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPodInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers PodIndexers) PodIndexInformer {
+	return NewTypedPodInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredPodInformer constructs a new informer for Pod type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredPodInformer]).
 func NewFilteredPodInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewPodInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedPodInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredPodInformer constructs a new informer for Pod type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredPodInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers PodIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) PodIndexInformer {
+	return NewTypedPodInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewPodInformerWithOptions constructs a new informer for Pod type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPodInformerWithOptions]).
 func NewPodInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedPodInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedPodInformerWithOptions constructs a new informer for Pod type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPodInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) PodIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Pod](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewPodInformerWithOptions(client kubernetes.Interface, namespace string, op
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *podInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewPodInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedPodInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *podInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apicorev1.Pod{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *podInformer) TypedInformer() PodIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Pod](f.factory.InformerFor(&apicorev1.Pod{}, f.defaultInformer))
 }
 
 func (f *podInformer) Lister() corev1.PodLister {
 	return corev1.NewPodLister(f.Informer().GetIndexer())
+}
+
+// ToTypedPodInformer converts an untyped informer into a TypedPodInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Pod. If that is not the case, calling type-safe methods of the returned
+// TypedPodInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedPodInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedPodInformer(informer PodInformer) TypedPodInformer {
+	if informer, ok := informer.(TypedPodInformer); ok {
+		return informer
+	}
+	return &podTypedInformerAdapter{informer}
+}
+
+type podTypedInformerAdapter struct {
+	PodInformer
+}
+
+func (a *podTypedInformerAdapter) TypedInformer() PodIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Pod](a.Informer())
+}
+
+// ToPodIndexInformer converts an untyped informer into a PodIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Pod. If that is not the case, calling type-safe methods of the returned
+// PodIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a PodIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToPodIndexInformer(informer cache.SharedIndexInformer) PodIndexInformer {
+	if informer, ok := informer.(PodIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Pod](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/core/v1/podtemplate.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/podtemplate.go
@@ -34,11 +34,39 @@ import (
 )
 
 // PodTemplateInformer provides access to a shared informer and lister for
-// PodTemplates.
+// PodTemplates. Prefer using the type-safe variant (see [TypedPodTemplateInformer]).
 type PodTemplateInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() corev1.PodTemplateLister
 }
+
+// TypedPodTemplateInformer provides access to a shared informer and lister for
+// PodTemplates, including the type-safe TypedInformer variant.
+// It is a superset of PodTemplateInformer.
+type TypedPodTemplateInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() PodTemplateIndexInformer
+	Lister() corev1.PodTemplateLister
+}
+
+// PodTemplateIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type PodTemplateIndexInformer cache.TypedSharedIndexInformer[*apicorev1.PodTemplate]
+
+// PodTemplateHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for PodTemplate.
+type PodTemplateHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apicorev1.PodTemplate]
+
+// PodTemplateDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for PodTemplate.
+type PodTemplateDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apicorev1.PodTemplate]
+
+// PodTemplateFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for PodTemplate.
+type PodTemplateFilteringHandler = cache.TypedFilteringResourceEventHandler[*apicorev1.PodTemplate]
+
+// PodTemplateIndexers is a specialization of [cache.TypedIndexers] for PodTemplate.
+type PodTemplateIndexers = cache.TypedIndexers[*apicorev1.PodTemplate]
+
+// DeletedPodTemplate is a specialization of [cache.DeletedObject] for PodTemplate.
+type DeletedPodTemplate = cache.DeletedObject[*apicorev1.PodTemplate]
 
 type podTemplateInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type podTemplateInformer struct {
 // NewPodTemplateInformer constructs a new informer for PodTemplate type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPodTemplateInformer]).
 func NewPodTemplateInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewPodTemplateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedPodTemplateInformer constructs a new informer for PodTemplate type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPodTemplateInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers PodTemplateIndexers) PodTemplateIndexInformer {
+	return NewTypedPodTemplateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredPodTemplateInformer constructs a new informer for PodTemplate type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredPodTemplateInformer]).
 func NewFilteredPodTemplateInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewPodTemplateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedPodTemplateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredPodTemplateInformer constructs a new informer for PodTemplate type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredPodTemplateInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers PodTemplateIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) PodTemplateIndexInformer {
+	return NewTypedPodTemplateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewPodTemplateInformerWithOptions constructs a new informer for PodTemplate type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPodTemplateInformerWithOptions]).
 func NewPodTemplateInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedPodTemplateInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedPodTemplateInformerWithOptions constructs a new informer for PodTemplate type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPodTemplateInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) PodTemplateIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "podtemplates"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apicorev1.PodTemplate](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewPodTemplateInformerWithOptions(client kubernetes.Interface, namespace st
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *podTemplateInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewPodTemplateInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedPodTemplateInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *podTemplateInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apicorev1.PodTemplate{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *podTemplateInformer) TypedInformer() PodTemplateIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.PodTemplate](f.factory.InformerFor(&apicorev1.PodTemplate{}, f.defaultInformer))
 }
 
 func (f *podTemplateInformer) Lister() corev1.PodTemplateLister {
 	return corev1.NewPodTemplateLister(f.Informer().GetIndexer())
+}
+
+// ToTypedPodTemplateInformer converts an untyped informer into a TypedPodTemplateInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *PodTemplate. If that is not the case, calling type-safe methods of the returned
+// TypedPodTemplateInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedPodTemplateInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedPodTemplateInformer(informer PodTemplateInformer) TypedPodTemplateInformer {
+	if informer, ok := informer.(TypedPodTemplateInformer); ok {
+		return informer
+	}
+	return &podTemplateTypedInformerAdapter{informer}
+}
+
+type podTemplateTypedInformerAdapter struct {
+	PodTemplateInformer
+}
+
+func (a *podTemplateTypedInformerAdapter) TypedInformer() PodTemplateIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.PodTemplate](a.Informer())
+}
+
+// ToPodTemplateIndexInformer converts an untyped informer into a PodTemplateIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *PodTemplate. If that is not the case, calling type-safe methods of the returned
+// PodTemplateIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a PodTemplateIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToPodTemplateIndexInformer(informer cache.SharedIndexInformer) PodTemplateIndexInformer {
+	if informer, ok := informer.(PodTemplateIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apicorev1.PodTemplate](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/core/v1/replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/replicationcontroller.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ReplicationControllerInformer provides access to a shared informer and lister for
-// ReplicationControllers.
+// ReplicationControllers. Prefer using the type-safe variant (see [TypedReplicationControllerInformer]).
 type ReplicationControllerInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() corev1.ReplicationControllerLister
 }
+
+// TypedReplicationControllerInformer provides access to a shared informer and lister for
+// ReplicationControllers, including the type-safe TypedInformer variant.
+// It is a superset of ReplicationControllerInformer.
+type TypedReplicationControllerInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ReplicationControllerIndexInformer
+	Lister() corev1.ReplicationControllerLister
+}
+
+// ReplicationControllerIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ReplicationControllerIndexInformer cache.TypedSharedIndexInformer[*apicorev1.ReplicationController]
+
+// ReplicationControllerHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ReplicationController.
+type ReplicationControllerHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apicorev1.ReplicationController]
+
+// ReplicationControllerDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ReplicationController.
+type ReplicationControllerDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apicorev1.ReplicationController]
+
+// ReplicationControllerFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ReplicationController.
+type ReplicationControllerFilteringHandler = cache.TypedFilteringResourceEventHandler[*apicorev1.ReplicationController]
+
+// ReplicationControllerIndexers is a specialization of [cache.TypedIndexers] for ReplicationController.
+type ReplicationControllerIndexers = cache.TypedIndexers[*apicorev1.ReplicationController]
+
+// DeletedReplicationController is a specialization of [cache.DeletedObject] for ReplicationController.
+type DeletedReplicationController = cache.DeletedObject[*apicorev1.ReplicationController]
 
 type replicationControllerInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type replicationControllerInformer struct {
 // NewReplicationControllerInformer constructs a new informer for ReplicationController type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedReplicationControllerInformer]).
 func NewReplicationControllerInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewReplicationControllerInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedReplicationControllerInformer constructs a new informer for ReplicationController type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedReplicationControllerInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ReplicationControllerIndexers) ReplicationControllerIndexInformer {
+	return NewTypedReplicationControllerInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredReplicationControllerInformer constructs a new informer for ReplicationController type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredReplicationControllerInformer]).
 func NewFilteredReplicationControllerInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewReplicationControllerInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedReplicationControllerInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredReplicationControllerInformer constructs a new informer for ReplicationController type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredReplicationControllerInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ReplicationControllerIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ReplicationControllerIndexInformer {
+	return NewTypedReplicationControllerInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewReplicationControllerInformerWithOptions constructs a new informer for ReplicationController type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedReplicationControllerInformerWithOptions]).
 func NewReplicationControllerInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedReplicationControllerInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedReplicationControllerInformerWithOptions constructs a new informer for ReplicationController type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedReplicationControllerInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) ReplicationControllerIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "replicationcontrollers"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apicorev1.ReplicationController](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewReplicationControllerInformerWithOptions(client kubernetes.Interface, na
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *replicationControllerInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewReplicationControllerInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedReplicationControllerInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *replicationControllerInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apicorev1.ReplicationController{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *replicationControllerInformer) TypedInformer() ReplicationControllerIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.ReplicationController](f.factory.InformerFor(&apicorev1.ReplicationController{}, f.defaultInformer))
 }
 
 func (f *replicationControllerInformer) Lister() corev1.ReplicationControllerLister {
 	return corev1.NewReplicationControllerLister(f.Informer().GetIndexer())
+}
+
+// ToTypedReplicationControllerInformer converts an untyped informer into a TypedReplicationControllerInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ReplicationController. If that is not the case, calling type-safe methods of the returned
+// TypedReplicationControllerInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedReplicationControllerInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedReplicationControllerInformer(informer ReplicationControllerInformer) TypedReplicationControllerInformer {
+	if informer, ok := informer.(TypedReplicationControllerInformer); ok {
+		return informer
+	}
+	return &replicationControllerTypedInformerAdapter{informer}
+}
+
+type replicationControllerTypedInformerAdapter struct {
+	ReplicationControllerInformer
+}
+
+func (a *replicationControllerTypedInformerAdapter) TypedInformer() ReplicationControllerIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.ReplicationController](a.Informer())
+}
+
+// ToReplicationControllerIndexInformer converts an untyped informer into a ReplicationControllerIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ReplicationController. If that is not the case, calling type-safe methods of the returned
+// ReplicationControllerIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ReplicationControllerIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToReplicationControllerIndexInformer(informer cache.SharedIndexInformer) ReplicationControllerIndexInformer {
+	if informer, ok := informer.(ReplicationControllerIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apicorev1.ReplicationController](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/core/v1/resourcequota.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/resourcequota.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ResourceQuotaInformer provides access to a shared informer and lister for
-// ResourceQuotas.
+// ResourceQuotas. Prefer using the type-safe variant (see [TypedResourceQuotaInformer]).
 type ResourceQuotaInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() corev1.ResourceQuotaLister
 }
+
+// TypedResourceQuotaInformer provides access to a shared informer and lister for
+// ResourceQuotas, including the type-safe TypedInformer variant.
+// It is a superset of ResourceQuotaInformer.
+type TypedResourceQuotaInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ResourceQuotaIndexInformer
+	Lister() corev1.ResourceQuotaLister
+}
+
+// ResourceQuotaIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ResourceQuotaIndexInformer cache.TypedSharedIndexInformer[*apicorev1.ResourceQuota]
+
+// ResourceQuotaHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ResourceQuota.
+type ResourceQuotaHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apicorev1.ResourceQuota]
+
+// ResourceQuotaDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ResourceQuota.
+type ResourceQuotaDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apicorev1.ResourceQuota]
+
+// ResourceQuotaFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ResourceQuota.
+type ResourceQuotaFilteringHandler = cache.TypedFilteringResourceEventHandler[*apicorev1.ResourceQuota]
+
+// ResourceQuotaIndexers is a specialization of [cache.TypedIndexers] for ResourceQuota.
+type ResourceQuotaIndexers = cache.TypedIndexers[*apicorev1.ResourceQuota]
+
+// DeletedResourceQuota is a specialization of [cache.DeletedObject] for ResourceQuota.
+type DeletedResourceQuota = cache.DeletedObject[*apicorev1.ResourceQuota]
 
 type resourceQuotaInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type resourceQuotaInformer struct {
 // NewResourceQuotaInformer constructs a new informer for ResourceQuota type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedResourceQuotaInformer]).
 func NewResourceQuotaInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewResourceQuotaInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedResourceQuotaInformer constructs a new informer for ResourceQuota type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedResourceQuotaInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ResourceQuotaIndexers) ResourceQuotaIndexInformer {
+	return NewTypedResourceQuotaInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredResourceQuotaInformer constructs a new informer for ResourceQuota type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredResourceQuotaInformer]).
 func NewFilteredResourceQuotaInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewResourceQuotaInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedResourceQuotaInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredResourceQuotaInformer constructs a new informer for ResourceQuota type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredResourceQuotaInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ResourceQuotaIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ResourceQuotaIndexInformer {
+	return NewTypedResourceQuotaInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewResourceQuotaInformerWithOptions constructs a new informer for ResourceQuota type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedResourceQuotaInformerWithOptions]).
 func NewResourceQuotaInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedResourceQuotaInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedResourceQuotaInformerWithOptions constructs a new informer for ResourceQuota type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedResourceQuotaInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) ResourceQuotaIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "resourcequotas"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apicorev1.ResourceQuota](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewResourceQuotaInformerWithOptions(client kubernetes.Interface, namespace 
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *resourceQuotaInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewResourceQuotaInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedResourceQuotaInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *resourceQuotaInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apicorev1.ResourceQuota{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *resourceQuotaInformer) TypedInformer() ResourceQuotaIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.ResourceQuota](f.factory.InformerFor(&apicorev1.ResourceQuota{}, f.defaultInformer))
 }
 
 func (f *resourceQuotaInformer) Lister() corev1.ResourceQuotaLister {
 	return corev1.NewResourceQuotaLister(f.Informer().GetIndexer())
+}
+
+// ToTypedResourceQuotaInformer converts an untyped informer into a TypedResourceQuotaInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ResourceQuota. If that is not the case, calling type-safe methods of the returned
+// TypedResourceQuotaInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedResourceQuotaInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedResourceQuotaInformer(informer ResourceQuotaInformer) TypedResourceQuotaInformer {
+	if informer, ok := informer.(TypedResourceQuotaInformer); ok {
+		return informer
+	}
+	return &resourceQuotaTypedInformerAdapter{informer}
+}
+
+type resourceQuotaTypedInformerAdapter struct {
+	ResourceQuotaInformer
+}
+
+func (a *resourceQuotaTypedInformerAdapter) TypedInformer() ResourceQuotaIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.ResourceQuota](a.Informer())
+}
+
+// ToResourceQuotaIndexInformer converts an untyped informer into a ResourceQuotaIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ResourceQuota. If that is not the case, calling type-safe methods of the returned
+// ResourceQuotaIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ResourceQuotaIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToResourceQuotaIndexInformer(informer cache.SharedIndexInformer) ResourceQuotaIndexInformer {
+	if informer, ok := informer.(ResourceQuotaIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apicorev1.ResourceQuota](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/core/v1/secret.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/secret.go
@@ -34,11 +34,39 @@ import (
 )
 
 // SecretInformer provides access to a shared informer and lister for
-// Secrets.
+// Secrets. Prefer using the type-safe variant (see [TypedSecretInformer]).
 type SecretInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() corev1.SecretLister
 }
+
+// TypedSecretInformer provides access to a shared informer and lister for
+// Secrets, including the type-safe TypedInformer variant.
+// It is a superset of SecretInformer.
+type TypedSecretInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() SecretIndexInformer
+	Lister() corev1.SecretLister
+}
+
+// SecretIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type SecretIndexInformer cache.TypedSharedIndexInformer[*apicorev1.Secret]
+
+// SecretHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Secret.
+type SecretHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apicorev1.Secret]
+
+// SecretDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Secret.
+type SecretDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apicorev1.Secret]
+
+// SecretFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Secret.
+type SecretFilteringHandler = cache.TypedFilteringResourceEventHandler[*apicorev1.Secret]
+
+// SecretIndexers is a specialization of [cache.TypedIndexers] for Secret.
+type SecretIndexers = cache.TypedIndexers[*apicorev1.Secret]
+
+// DeletedSecret is a specialization of [cache.DeletedObject] for Secret.
+type DeletedSecret = cache.DeletedObject[*apicorev1.Secret]
 
 type secretInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type secretInformer struct {
 // NewSecretInformer constructs a new informer for Secret type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedSecretInformer]).
 func NewSecretInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewSecretInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedSecretInformer constructs a new informer for Secret type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedSecretInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers SecretIndexers) SecretIndexInformer {
+	return NewTypedSecretInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredSecretInformer constructs a new informer for Secret type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredSecretInformer]).
 func NewFilteredSecretInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewSecretInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedSecretInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredSecretInformer constructs a new informer for Secret type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredSecretInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers SecretIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) SecretIndexInformer {
+	return NewTypedSecretInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewSecretInformerWithOptions constructs a new informer for Secret type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedSecretInformerWithOptions]).
 func NewSecretInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedSecretInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedSecretInformerWithOptions constructs a new informer for Secret type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedSecretInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) SecretIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Secret](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewSecretInformerWithOptions(client kubernetes.Interface, namespace string,
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *secretInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewSecretInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedSecretInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *secretInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apicorev1.Secret{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *secretInformer) TypedInformer() SecretIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Secret](f.factory.InformerFor(&apicorev1.Secret{}, f.defaultInformer))
 }
 
 func (f *secretInformer) Lister() corev1.SecretLister {
 	return corev1.NewSecretLister(f.Informer().GetIndexer())
+}
+
+// ToTypedSecretInformer converts an untyped informer into a TypedSecretInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Secret. If that is not the case, calling type-safe methods of the returned
+// TypedSecretInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedSecretInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedSecretInformer(informer SecretInformer) TypedSecretInformer {
+	if informer, ok := informer.(TypedSecretInformer); ok {
+		return informer
+	}
+	return &secretTypedInformerAdapter{informer}
+}
+
+type secretTypedInformerAdapter struct {
+	SecretInformer
+}
+
+func (a *secretTypedInformerAdapter) TypedInformer() SecretIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Secret](a.Informer())
+}
+
+// ToSecretIndexInformer converts an untyped informer into a SecretIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Secret. If that is not the case, calling type-safe methods of the returned
+// SecretIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a SecretIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToSecretIndexInformer(informer cache.SharedIndexInformer) SecretIndexInformer {
+	if informer, ok := informer.(SecretIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Secret](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/core/v1/service.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/service.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ServiceInformer provides access to a shared informer and lister for
-// Services.
+// Services. Prefer using the type-safe variant (see [TypedServiceInformer]).
 type ServiceInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() corev1.ServiceLister
 }
+
+// TypedServiceInformer provides access to a shared informer and lister for
+// Services, including the type-safe TypedInformer variant.
+// It is a superset of ServiceInformer.
+type TypedServiceInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ServiceIndexInformer
+	Lister() corev1.ServiceLister
+}
+
+// ServiceIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ServiceIndexInformer cache.TypedSharedIndexInformer[*apicorev1.Service]
+
+// ServiceHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Service.
+type ServiceHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apicorev1.Service]
+
+// ServiceDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Service.
+type ServiceDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apicorev1.Service]
+
+// ServiceFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Service.
+type ServiceFilteringHandler = cache.TypedFilteringResourceEventHandler[*apicorev1.Service]
+
+// ServiceIndexers is a specialization of [cache.TypedIndexers] for Service.
+type ServiceIndexers = cache.TypedIndexers[*apicorev1.Service]
+
+// DeletedService is a specialization of [cache.DeletedObject] for Service.
+type DeletedService = cache.DeletedObject[*apicorev1.Service]
 
 type serviceInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type serviceInformer struct {
 // NewServiceInformer constructs a new informer for Service type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedServiceInformer]).
 func NewServiceInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewServiceInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedServiceInformer constructs a new informer for Service type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedServiceInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ServiceIndexers) ServiceIndexInformer {
+	return NewTypedServiceInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredServiceInformer constructs a new informer for Service type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredServiceInformer]).
 func NewFilteredServiceInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewServiceInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedServiceInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredServiceInformer constructs a new informer for Service type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredServiceInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ServiceIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ServiceIndexInformer {
+	return NewTypedServiceInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewServiceInformerWithOptions constructs a new informer for Service type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedServiceInformerWithOptions]).
 func NewServiceInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedServiceInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedServiceInformerWithOptions constructs a new informer for Service type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedServiceInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) ServiceIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Service](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewServiceInformerWithOptions(client kubernetes.Interface, namespace string
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *serviceInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewServiceInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedServiceInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *serviceInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apicorev1.Service{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *serviceInformer) TypedInformer() ServiceIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Service](f.factory.InformerFor(&apicorev1.Service{}, f.defaultInformer))
 }
 
 func (f *serviceInformer) Lister() corev1.ServiceLister {
 	return corev1.NewServiceLister(f.Informer().GetIndexer())
+}
+
+// ToTypedServiceInformer converts an untyped informer into a TypedServiceInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Service. If that is not the case, calling type-safe methods of the returned
+// TypedServiceInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedServiceInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedServiceInformer(informer ServiceInformer) TypedServiceInformer {
+	if informer, ok := informer.(TypedServiceInformer); ok {
+		return informer
+	}
+	return &serviceTypedInformerAdapter{informer}
+}
+
+type serviceTypedInformerAdapter struct {
+	ServiceInformer
+}
+
+func (a *serviceTypedInformerAdapter) TypedInformer() ServiceIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Service](a.Informer())
+}
+
+// ToServiceIndexInformer converts an untyped informer into a ServiceIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Service. If that is not the case, calling type-safe methods of the returned
+// ServiceIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ServiceIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToServiceIndexInformer(informer cache.SharedIndexInformer) ServiceIndexInformer {
+	if informer, ok := informer.(ServiceIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apicorev1.Service](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/core/v1/serviceaccount.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/serviceaccount.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ServiceAccountInformer provides access to a shared informer and lister for
-// ServiceAccounts.
+// ServiceAccounts. Prefer using the type-safe variant (see [TypedServiceAccountInformer]).
 type ServiceAccountInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() corev1.ServiceAccountLister
 }
+
+// TypedServiceAccountInformer provides access to a shared informer and lister for
+// ServiceAccounts, including the type-safe TypedInformer variant.
+// It is a superset of ServiceAccountInformer.
+type TypedServiceAccountInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ServiceAccountIndexInformer
+	Lister() corev1.ServiceAccountLister
+}
+
+// ServiceAccountIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ServiceAccountIndexInformer cache.TypedSharedIndexInformer[*apicorev1.ServiceAccount]
+
+// ServiceAccountHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ServiceAccount.
+type ServiceAccountHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apicorev1.ServiceAccount]
+
+// ServiceAccountDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ServiceAccount.
+type ServiceAccountDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apicorev1.ServiceAccount]
+
+// ServiceAccountFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ServiceAccount.
+type ServiceAccountFilteringHandler = cache.TypedFilteringResourceEventHandler[*apicorev1.ServiceAccount]
+
+// ServiceAccountIndexers is a specialization of [cache.TypedIndexers] for ServiceAccount.
+type ServiceAccountIndexers = cache.TypedIndexers[*apicorev1.ServiceAccount]
+
+// DeletedServiceAccount is a specialization of [cache.DeletedObject] for ServiceAccount.
+type DeletedServiceAccount = cache.DeletedObject[*apicorev1.ServiceAccount]
 
 type serviceAccountInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type serviceAccountInformer struct {
 // NewServiceAccountInformer constructs a new informer for ServiceAccount type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedServiceAccountInformer]).
 func NewServiceAccountInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewServiceAccountInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedServiceAccountInformer constructs a new informer for ServiceAccount type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedServiceAccountInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ServiceAccountIndexers) ServiceAccountIndexInformer {
+	return NewTypedServiceAccountInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredServiceAccountInformer constructs a new informer for ServiceAccount type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredServiceAccountInformer]).
 func NewFilteredServiceAccountInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewServiceAccountInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedServiceAccountInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredServiceAccountInformer constructs a new informer for ServiceAccount type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredServiceAccountInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ServiceAccountIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ServiceAccountIndexInformer {
+	return NewTypedServiceAccountInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewServiceAccountInformerWithOptions constructs a new informer for ServiceAccount type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedServiceAccountInformerWithOptions]).
 func NewServiceAccountInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedServiceAccountInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedServiceAccountInformerWithOptions constructs a new informer for ServiceAccount type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedServiceAccountInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) ServiceAccountIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "serviceaccounts"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apicorev1.ServiceAccount](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewServiceAccountInformerWithOptions(client kubernetes.Interface, namespace
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *serviceAccountInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewServiceAccountInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedServiceAccountInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *serviceAccountInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apicorev1.ServiceAccount{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *serviceAccountInformer) TypedInformer() ServiceAccountIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.ServiceAccount](f.factory.InformerFor(&apicorev1.ServiceAccount{}, f.defaultInformer))
 }
 
 func (f *serviceAccountInformer) Lister() corev1.ServiceAccountLister {
 	return corev1.NewServiceAccountLister(f.Informer().GetIndexer())
+}
+
+// ToTypedServiceAccountInformer converts an untyped informer into a TypedServiceAccountInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ServiceAccount. If that is not the case, calling type-safe methods of the returned
+// TypedServiceAccountInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedServiceAccountInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedServiceAccountInformer(informer ServiceAccountInformer) TypedServiceAccountInformer {
+	if informer, ok := informer.(TypedServiceAccountInformer); ok {
+		return informer
+	}
+	return &serviceAccountTypedInformerAdapter{informer}
+}
+
+type serviceAccountTypedInformerAdapter struct {
+	ServiceAccountInformer
+}
+
+func (a *serviceAccountTypedInformerAdapter) TypedInformer() ServiceAccountIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apicorev1.ServiceAccount](a.Informer())
+}
+
+// ToServiceAccountIndexInformer converts an untyped informer into a ServiceAccountIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ServiceAccount. If that is not the case, calling type-safe methods of the returned
+// ServiceAccountIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ServiceAccountIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToServiceAccountIndexInformer(informer cache.SharedIndexInformer) ServiceAccountIndexInformer {
+	if informer, ok := informer.(ServiceAccountIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apicorev1.ServiceAccount](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/discovery/v1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/informers/discovery/v1/endpointslice.go
@@ -34,11 +34,39 @@ import (
 )
 
 // EndpointSliceInformer provides access to a shared informer and lister for
-// EndpointSlices.
+// EndpointSlices. Prefer using the type-safe variant (see [TypedEndpointSliceInformer]).
 type EndpointSliceInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() discoveryv1.EndpointSliceLister
 }
+
+// TypedEndpointSliceInformer provides access to a shared informer and lister for
+// EndpointSlices, including the type-safe TypedInformer variant.
+// It is a superset of EndpointSliceInformer.
+type TypedEndpointSliceInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() EndpointSliceIndexInformer
+	Lister() discoveryv1.EndpointSliceLister
+}
+
+// EndpointSliceIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type EndpointSliceIndexInformer cache.TypedSharedIndexInformer[*apidiscoveryv1.EndpointSlice]
+
+// EndpointSliceHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for EndpointSlice.
+type EndpointSliceHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apidiscoveryv1.EndpointSlice]
+
+// EndpointSliceDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for EndpointSlice.
+type EndpointSliceDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apidiscoveryv1.EndpointSlice]
+
+// EndpointSliceFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for EndpointSlice.
+type EndpointSliceFilteringHandler = cache.TypedFilteringResourceEventHandler[*apidiscoveryv1.EndpointSlice]
+
+// EndpointSliceIndexers is a specialization of [cache.TypedIndexers] for EndpointSlice.
+type EndpointSliceIndexers = cache.TypedIndexers[*apidiscoveryv1.EndpointSlice]
+
+// DeletedEndpointSlice is a specialization of [cache.DeletedObject] for EndpointSlice.
+type DeletedEndpointSlice = cache.DeletedObject[*apidiscoveryv1.EndpointSlice]
 
 type endpointSliceInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type endpointSliceInformer struct {
 // NewEndpointSliceInformer constructs a new informer for EndpointSlice type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedEndpointSliceInformer]).
 func NewEndpointSliceInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewEndpointSliceInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedEndpointSliceInformer constructs a new informer for EndpointSlice type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedEndpointSliceInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers EndpointSliceIndexers) EndpointSliceIndexInformer {
+	return NewTypedEndpointSliceInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredEndpointSliceInformer constructs a new informer for EndpointSlice type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredEndpointSliceInformer]).
 func NewFilteredEndpointSliceInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewEndpointSliceInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedEndpointSliceInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredEndpointSliceInformer constructs a new informer for EndpointSlice type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredEndpointSliceInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers EndpointSliceIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) EndpointSliceIndexInformer {
+	return NewTypedEndpointSliceInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewEndpointSliceInformerWithOptions constructs a new informer for EndpointSlice type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedEndpointSliceInformerWithOptions]).
 func NewEndpointSliceInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedEndpointSliceInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedEndpointSliceInformerWithOptions constructs a new informer for EndpointSlice type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedEndpointSliceInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) EndpointSliceIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1", Resource: "endpointslices"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apidiscoveryv1.EndpointSlice](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewEndpointSliceInformerWithOptions(client kubernetes.Interface, namespace 
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *endpointSliceInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewEndpointSliceInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedEndpointSliceInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *endpointSliceInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apidiscoveryv1.EndpointSlice{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *endpointSliceInformer) TypedInformer() EndpointSliceIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apidiscoveryv1.EndpointSlice](f.factory.InformerFor(&apidiscoveryv1.EndpointSlice{}, f.defaultInformer))
 }
 
 func (f *endpointSliceInformer) Lister() discoveryv1.EndpointSliceLister {
 	return discoveryv1.NewEndpointSliceLister(f.Informer().GetIndexer())
+}
+
+// ToTypedEndpointSliceInformer converts an untyped informer into a TypedEndpointSliceInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *EndpointSlice. If that is not the case, calling type-safe methods of the returned
+// TypedEndpointSliceInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedEndpointSliceInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedEndpointSliceInformer(informer EndpointSliceInformer) TypedEndpointSliceInformer {
+	if informer, ok := informer.(TypedEndpointSliceInformer); ok {
+		return informer
+	}
+	return &endpointSliceTypedInformerAdapter{informer}
+}
+
+type endpointSliceTypedInformerAdapter struct {
+	EndpointSliceInformer
+}
+
+func (a *endpointSliceTypedInformerAdapter) TypedInformer() EndpointSliceIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apidiscoveryv1.EndpointSlice](a.Informer())
+}
+
+// ToEndpointSliceIndexInformer converts an untyped informer into a EndpointSliceIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *EndpointSlice. If that is not the case, calling type-safe methods of the returned
+// EndpointSliceIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a EndpointSliceIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToEndpointSliceIndexInformer(informer cache.SharedIndexInformer) EndpointSliceIndexInformer {
+	if informer, ok := informer.(EndpointSliceIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apidiscoveryv1.EndpointSlice](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/discovery/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/discovery/v1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// EndpointSlices returns a EndpointSliceInformer.
-	EndpointSlices() EndpointSliceInformer
+	EndpointSlices() TypedEndpointSliceInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// EndpointSlices returns a EndpointSliceInformer.
-func (v *version) EndpointSlices() EndpointSliceInformer {
+// EndpointSlices returns a TypedEndpointSliceInformer.
+func (v *version) EndpointSlices() TypedEndpointSliceInformer {
 	return &endpointSliceInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/discovery/v1beta1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/informers/discovery/v1beta1/endpointslice.go
@@ -34,11 +34,39 @@ import (
 )
 
 // EndpointSliceInformer provides access to a shared informer and lister for
-// EndpointSlices.
+// EndpointSlices. Prefer using the type-safe variant (see [TypedEndpointSliceInformer]).
 type EndpointSliceInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() discoveryv1beta1.EndpointSliceLister
 }
+
+// TypedEndpointSliceInformer provides access to a shared informer and lister for
+// EndpointSlices, including the type-safe TypedInformer variant.
+// It is a superset of EndpointSliceInformer.
+type TypedEndpointSliceInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() EndpointSliceIndexInformer
+	Lister() discoveryv1beta1.EndpointSliceLister
+}
+
+// EndpointSliceIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type EndpointSliceIndexInformer cache.TypedSharedIndexInformer[*apidiscoveryv1beta1.EndpointSlice]
+
+// EndpointSliceHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for EndpointSlice.
+type EndpointSliceHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apidiscoveryv1beta1.EndpointSlice]
+
+// EndpointSliceDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for EndpointSlice.
+type EndpointSliceDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apidiscoveryv1beta1.EndpointSlice]
+
+// EndpointSliceFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for EndpointSlice.
+type EndpointSliceFilteringHandler = cache.TypedFilteringResourceEventHandler[*apidiscoveryv1beta1.EndpointSlice]
+
+// EndpointSliceIndexers is a specialization of [cache.TypedIndexers] for EndpointSlice.
+type EndpointSliceIndexers = cache.TypedIndexers[*apidiscoveryv1beta1.EndpointSlice]
+
+// DeletedEndpointSlice is a specialization of [cache.DeletedObject] for EndpointSlice.
+type DeletedEndpointSlice = cache.DeletedObject[*apidiscoveryv1beta1.EndpointSlice]
 
 type endpointSliceInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type endpointSliceInformer struct {
 // NewEndpointSliceInformer constructs a new informer for EndpointSlice type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedEndpointSliceInformer]).
 func NewEndpointSliceInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewEndpointSliceInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedEndpointSliceInformer constructs a new informer for EndpointSlice type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedEndpointSliceInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers EndpointSliceIndexers) EndpointSliceIndexInformer {
+	return NewTypedEndpointSliceInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredEndpointSliceInformer constructs a new informer for EndpointSlice type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredEndpointSliceInformer]).
 func NewFilteredEndpointSliceInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewEndpointSliceInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedEndpointSliceInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredEndpointSliceInformer constructs a new informer for EndpointSlice type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredEndpointSliceInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers EndpointSliceIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) EndpointSliceIndexInformer {
+	return NewTypedEndpointSliceInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewEndpointSliceInformerWithOptions constructs a new informer for EndpointSlice type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedEndpointSliceInformerWithOptions]).
 func NewEndpointSliceInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedEndpointSliceInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedEndpointSliceInformerWithOptions constructs a new informer for EndpointSlice type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedEndpointSliceInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) EndpointSliceIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1beta1", Resource: "endpointslices"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apidiscoveryv1beta1.EndpointSlice](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewEndpointSliceInformerWithOptions(client kubernetes.Interface, namespace 
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *endpointSliceInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewEndpointSliceInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedEndpointSliceInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *endpointSliceInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apidiscoveryv1beta1.EndpointSlice{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *endpointSliceInformer) TypedInformer() EndpointSliceIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apidiscoveryv1beta1.EndpointSlice](f.factory.InformerFor(&apidiscoveryv1beta1.EndpointSlice{}, f.defaultInformer))
 }
 
 func (f *endpointSliceInformer) Lister() discoveryv1beta1.EndpointSliceLister {
 	return discoveryv1beta1.NewEndpointSliceLister(f.Informer().GetIndexer())
+}
+
+// ToTypedEndpointSliceInformer converts an untyped informer into a TypedEndpointSliceInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *EndpointSlice. If that is not the case, calling type-safe methods of the returned
+// TypedEndpointSliceInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedEndpointSliceInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedEndpointSliceInformer(informer EndpointSliceInformer) TypedEndpointSliceInformer {
+	if informer, ok := informer.(TypedEndpointSliceInformer); ok {
+		return informer
+	}
+	return &endpointSliceTypedInformerAdapter{informer}
+}
+
+type endpointSliceTypedInformerAdapter struct {
+	EndpointSliceInformer
+}
+
+func (a *endpointSliceTypedInformerAdapter) TypedInformer() EndpointSliceIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apidiscoveryv1beta1.EndpointSlice](a.Informer())
+}
+
+// ToEndpointSliceIndexInformer converts an untyped informer into a EndpointSliceIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *EndpointSlice. If that is not the case, calling type-safe methods of the returned
+// EndpointSliceIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a EndpointSliceIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToEndpointSliceIndexInformer(informer cache.SharedIndexInformer) EndpointSliceIndexInformer {
+	if informer, ok := informer.(EndpointSliceIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apidiscoveryv1beta1.EndpointSlice](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/discovery/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/discovery/v1beta1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// EndpointSlices returns a EndpointSliceInformer.
-	EndpointSlices() EndpointSliceInformer
+	EndpointSlices() TypedEndpointSliceInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// EndpointSlices returns a EndpointSliceInformer.
-func (v *version) EndpointSlices() EndpointSliceInformer {
+// EndpointSlices returns a TypedEndpointSliceInformer.
+func (v *version) EndpointSlices() TypedEndpointSliceInformer {
 	return &endpointSliceInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/events/v1/event.go
+++ b/staging/src/k8s.io/client-go/informers/events/v1/event.go
@@ -34,11 +34,39 @@ import (
 )
 
 // EventInformer provides access to a shared informer and lister for
-// Events.
+// Events. Prefer using the type-safe variant (see [TypedEventInformer]).
 type EventInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() eventsv1.EventLister
 }
+
+// TypedEventInformer provides access to a shared informer and lister for
+// Events, including the type-safe TypedInformer variant.
+// It is a superset of EventInformer.
+type TypedEventInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() EventIndexInformer
+	Lister() eventsv1.EventLister
+}
+
+// EventIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type EventIndexInformer cache.TypedSharedIndexInformer[*apieventsv1.Event]
+
+// EventHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Event.
+type EventHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apieventsv1.Event]
+
+// EventDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Event.
+type EventDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apieventsv1.Event]
+
+// EventFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Event.
+type EventFilteringHandler = cache.TypedFilteringResourceEventHandler[*apieventsv1.Event]
+
+// EventIndexers is a specialization of [cache.TypedIndexers] for Event.
+type EventIndexers = cache.TypedIndexers[*apieventsv1.Event]
+
+// DeletedEvent is a specialization of [cache.DeletedObject] for Event.
+type DeletedEvent = cache.DeletedObject[*apieventsv1.Event]
 
 type eventInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type eventInformer struct {
 // NewEventInformer constructs a new informer for Event type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedEventInformer]).
 func NewEventInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewEventInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedEventInformer constructs a new informer for Event type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedEventInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers EventIndexers) EventIndexInformer {
+	return NewTypedEventInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredEventInformer constructs a new informer for Event type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredEventInformer]).
 func NewFilteredEventInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewEventInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedEventInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredEventInformer constructs a new informer for Event type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredEventInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers EventIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) EventIndexInformer {
+	return NewTypedEventInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewEventInformerWithOptions constructs a new informer for Event type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedEventInformerWithOptions]).
 func NewEventInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedEventInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedEventInformerWithOptions constructs a new informer for Event type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedEventInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) EventIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "events.k8s.io", Version: "v1", Resource: "events"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apieventsv1.Event](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewEventInformerWithOptions(client kubernetes.Interface, namespace string, 
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *eventInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewEventInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedEventInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *eventInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apieventsv1.Event{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *eventInformer) TypedInformer() EventIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apieventsv1.Event](f.factory.InformerFor(&apieventsv1.Event{}, f.defaultInformer))
 }
 
 func (f *eventInformer) Lister() eventsv1.EventLister {
 	return eventsv1.NewEventLister(f.Informer().GetIndexer())
+}
+
+// ToTypedEventInformer converts an untyped informer into a TypedEventInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Event. If that is not the case, calling type-safe methods of the returned
+// TypedEventInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedEventInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedEventInformer(informer EventInformer) TypedEventInformer {
+	if informer, ok := informer.(TypedEventInformer); ok {
+		return informer
+	}
+	return &eventTypedInformerAdapter{informer}
+}
+
+type eventTypedInformerAdapter struct {
+	EventInformer
+}
+
+func (a *eventTypedInformerAdapter) TypedInformer() EventIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apieventsv1.Event](a.Informer())
+}
+
+// ToEventIndexInformer converts an untyped informer into a EventIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Event. If that is not the case, calling type-safe methods of the returned
+// EventIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a EventIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToEventIndexInformer(informer cache.SharedIndexInformer) EventIndexInformer {
+	if informer, ok := informer.(EventIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apieventsv1.Event](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/events/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/events/v1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// Events returns a EventInformer.
-	Events() EventInformer
+	Events() TypedEventInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// Events returns a EventInformer.
-func (v *version) Events() EventInformer {
+// Events returns a TypedEventInformer.
+func (v *version) Events() TypedEventInformer {
 	return &eventInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/events/v1beta1/event.go
+++ b/staging/src/k8s.io/client-go/informers/events/v1beta1/event.go
@@ -34,11 +34,39 @@ import (
 )
 
 // EventInformer provides access to a shared informer and lister for
-// Events.
+// Events. Prefer using the type-safe variant (see [TypedEventInformer]).
 type EventInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() eventsv1beta1.EventLister
 }
+
+// TypedEventInformer provides access to a shared informer and lister for
+// Events, including the type-safe TypedInformer variant.
+// It is a superset of EventInformer.
+type TypedEventInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() EventIndexInformer
+	Lister() eventsv1beta1.EventLister
+}
+
+// EventIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type EventIndexInformer cache.TypedSharedIndexInformer[*apieventsv1beta1.Event]
+
+// EventHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Event.
+type EventHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apieventsv1beta1.Event]
+
+// EventDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Event.
+type EventDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apieventsv1beta1.Event]
+
+// EventFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Event.
+type EventFilteringHandler = cache.TypedFilteringResourceEventHandler[*apieventsv1beta1.Event]
+
+// EventIndexers is a specialization of [cache.TypedIndexers] for Event.
+type EventIndexers = cache.TypedIndexers[*apieventsv1beta1.Event]
+
+// DeletedEvent is a specialization of [cache.DeletedObject] for Event.
+type DeletedEvent = cache.DeletedObject[*apieventsv1beta1.Event]
 
 type eventInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type eventInformer struct {
 // NewEventInformer constructs a new informer for Event type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedEventInformer]).
 func NewEventInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewEventInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedEventInformer constructs a new informer for Event type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedEventInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers EventIndexers) EventIndexInformer {
+	return NewTypedEventInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredEventInformer constructs a new informer for Event type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredEventInformer]).
 func NewFilteredEventInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewEventInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedEventInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredEventInformer constructs a new informer for Event type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredEventInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers EventIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) EventIndexInformer {
+	return NewTypedEventInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewEventInformerWithOptions constructs a new informer for Event type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedEventInformerWithOptions]).
 func NewEventInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedEventInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedEventInformerWithOptions constructs a new informer for Event type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedEventInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) EventIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "events.k8s.io", Version: "v1beta1", Resource: "events"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apieventsv1beta1.Event](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewEventInformerWithOptions(client kubernetes.Interface, namespace string, 
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *eventInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewEventInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedEventInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *eventInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apieventsv1beta1.Event{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *eventInformer) TypedInformer() EventIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apieventsv1beta1.Event](f.factory.InformerFor(&apieventsv1beta1.Event{}, f.defaultInformer))
 }
 
 func (f *eventInformer) Lister() eventsv1beta1.EventLister {
 	return eventsv1beta1.NewEventLister(f.Informer().GetIndexer())
+}
+
+// ToTypedEventInformer converts an untyped informer into a TypedEventInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Event. If that is not the case, calling type-safe methods of the returned
+// TypedEventInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedEventInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedEventInformer(informer EventInformer) TypedEventInformer {
+	if informer, ok := informer.(TypedEventInformer); ok {
+		return informer
+	}
+	return &eventTypedInformerAdapter{informer}
+}
+
+type eventTypedInformerAdapter struct {
+	EventInformer
+}
+
+func (a *eventTypedInformerAdapter) TypedInformer() EventIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apieventsv1beta1.Event](a.Informer())
+}
+
+// ToEventIndexInformer converts an untyped informer into a EventIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Event. If that is not the case, calling type-safe methods of the returned
+// EventIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a EventIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToEventIndexInformer(informer cache.SharedIndexInformer) EventIndexInformer {
+	if informer, ok := informer.(EventIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apieventsv1beta1.Event](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/events/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/events/v1beta1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// Events returns a EventInformer.
-	Events() EventInformer
+	Events() TypedEventInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// Events returns a EventInformer.
-func (v *version) Events() EventInformer {
+// Events returns a TypedEventInformer.
+func (v *version) Events() TypedEventInformer {
 	return &eventInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/daemonset.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/daemonset.go
@@ -34,11 +34,39 @@ import (
 )
 
 // DaemonSetInformer provides access to a shared informer and lister for
-// DaemonSets.
+// DaemonSets. Prefer using the type-safe variant (see [TypedDaemonSetInformer]).
 type DaemonSetInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() extensionsv1beta1.DaemonSetLister
 }
+
+// TypedDaemonSetInformer provides access to a shared informer and lister for
+// DaemonSets, including the type-safe TypedInformer variant.
+// It is a superset of DaemonSetInformer.
+type TypedDaemonSetInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() DaemonSetIndexInformer
+	Lister() extensionsv1beta1.DaemonSetLister
+}
+
+// DaemonSetIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type DaemonSetIndexInformer cache.TypedSharedIndexInformer[*apiextensionsv1beta1.DaemonSet]
+
+// DaemonSetHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for DaemonSet.
+type DaemonSetHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiextensionsv1beta1.DaemonSet]
+
+// DaemonSetDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for DaemonSet.
+type DaemonSetDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiextensionsv1beta1.DaemonSet]
+
+// DaemonSetFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for DaemonSet.
+type DaemonSetFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiextensionsv1beta1.DaemonSet]
+
+// DaemonSetIndexers is a specialization of [cache.TypedIndexers] for DaemonSet.
+type DaemonSetIndexers = cache.TypedIndexers[*apiextensionsv1beta1.DaemonSet]
+
+// DeletedDaemonSet is a specialization of [cache.DeletedObject] for DaemonSet.
+type DeletedDaemonSet = cache.DeletedObject[*apiextensionsv1beta1.DaemonSet]
 
 type daemonSetInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type daemonSetInformer struct {
 // NewDaemonSetInformer constructs a new informer for DaemonSet type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedDaemonSetInformer]).
 func NewDaemonSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewDaemonSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedDaemonSetInformer constructs a new informer for DaemonSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedDaemonSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers DaemonSetIndexers) DaemonSetIndexInformer {
+	return NewTypedDaemonSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredDaemonSetInformer constructs a new informer for DaemonSet type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredDaemonSetInformer]).
 func NewFilteredDaemonSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewDaemonSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedDaemonSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredDaemonSetInformer constructs a new informer for DaemonSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredDaemonSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers DaemonSetIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) DaemonSetIndexInformer {
+	return NewTypedDaemonSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewDaemonSetInformerWithOptions constructs a new informer for DaemonSet type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedDaemonSetInformerWithOptions]).
 func NewDaemonSetInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedDaemonSetInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedDaemonSetInformerWithOptions constructs a new informer for DaemonSet type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedDaemonSetInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) DaemonSetIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "daemonsets"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiextensionsv1beta1.DaemonSet](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewDaemonSetInformerWithOptions(client kubernetes.Interface, namespace stri
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *daemonSetInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewDaemonSetInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedDaemonSetInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *daemonSetInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiextensionsv1beta1.DaemonSet{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *daemonSetInformer) TypedInformer() DaemonSetIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiextensionsv1beta1.DaemonSet](f.factory.InformerFor(&apiextensionsv1beta1.DaemonSet{}, f.defaultInformer))
 }
 
 func (f *daemonSetInformer) Lister() extensionsv1beta1.DaemonSetLister {
 	return extensionsv1beta1.NewDaemonSetLister(f.Informer().GetIndexer())
+}
+
+// ToTypedDaemonSetInformer converts an untyped informer into a TypedDaemonSetInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *DaemonSet. If that is not the case, calling type-safe methods of the returned
+// TypedDaemonSetInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedDaemonSetInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedDaemonSetInformer(informer DaemonSetInformer) TypedDaemonSetInformer {
+	if informer, ok := informer.(TypedDaemonSetInformer); ok {
+		return informer
+	}
+	return &daemonSetTypedInformerAdapter{informer}
+}
+
+type daemonSetTypedInformerAdapter struct {
+	DaemonSetInformer
+}
+
+func (a *daemonSetTypedInformerAdapter) TypedInformer() DaemonSetIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiextensionsv1beta1.DaemonSet](a.Informer())
+}
+
+// ToDaemonSetIndexInformer converts an untyped informer into a DaemonSetIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *DaemonSet. If that is not the case, calling type-safe methods of the returned
+// DaemonSetIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a DaemonSetIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToDaemonSetIndexInformer(informer cache.SharedIndexInformer) DaemonSetIndexInformer {
+	if informer, ok := informer.(DaemonSetIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiextensionsv1beta1.DaemonSet](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/deployment.go
@@ -34,11 +34,39 @@ import (
 )
 
 // DeploymentInformer provides access to a shared informer and lister for
-// Deployments.
+// Deployments. Prefer using the type-safe variant (see [TypedDeploymentInformer]).
 type DeploymentInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() extensionsv1beta1.DeploymentLister
 }
+
+// TypedDeploymentInformer provides access to a shared informer and lister for
+// Deployments, including the type-safe TypedInformer variant.
+// It is a superset of DeploymentInformer.
+type TypedDeploymentInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() DeploymentIndexInformer
+	Lister() extensionsv1beta1.DeploymentLister
+}
+
+// DeploymentIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type DeploymentIndexInformer cache.TypedSharedIndexInformer[*apiextensionsv1beta1.Deployment]
+
+// DeploymentHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Deployment.
+type DeploymentHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiextensionsv1beta1.Deployment]
+
+// DeploymentDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Deployment.
+type DeploymentDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiextensionsv1beta1.Deployment]
+
+// DeploymentFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Deployment.
+type DeploymentFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiextensionsv1beta1.Deployment]
+
+// DeploymentIndexers is a specialization of [cache.TypedIndexers] for Deployment.
+type DeploymentIndexers = cache.TypedIndexers[*apiextensionsv1beta1.Deployment]
+
+// DeletedDeployment is a specialization of [cache.DeletedObject] for Deployment.
+type DeletedDeployment = cache.DeletedObject[*apiextensionsv1beta1.Deployment]
 
 type deploymentInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type deploymentInformer struct {
 // NewDeploymentInformer constructs a new informer for Deployment type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedDeploymentInformer]).
 func NewDeploymentInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewDeploymentInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedDeploymentInformer constructs a new informer for Deployment type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedDeploymentInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers DeploymentIndexers) DeploymentIndexInformer {
+	return NewTypedDeploymentInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredDeploymentInformer constructs a new informer for Deployment type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredDeploymentInformer]).
 func NewFilteredDeploymentInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewDeploymentInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedDeploymentInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredDeploymentInformer constructs a new informer for Deployment type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredDeploymentInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers DeploymentIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) DeploymentIndexInformer {
+	return NewTypedDeploymentInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewDeploymentInformerWithOptions constructs a new informer for Deployment type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedDeploymentInformerWithOptions]).
 func NewDeploymentInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedDeploymentInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedDeploymentInformerWithOptions constructs a new informer for Deployment type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedDeploymentInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) DeploymentIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "deployments"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiextensionsv1beta1.Deployment](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewDeploymentInformerWithOptions(client kubernetes.Interface, namespace str
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *deploymentInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewDeploymentInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedDeploymentInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *deploymentInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiextensionsv1beta1.Deployment{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *deploymentInformer) TypedInformer() DeploymentIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiextensionsv1beta1.Deployment](f.factory.InformerFor(&apiextensionsv1beta1.Deployment{}, f.defaultInformer))
 }
 
 func (f *deploymentInformer) Lister() extensionsv1beta1.DeploymentLister {
 	return extensionsv1beta1.NewDeploymentLister(f.Informer().GetIndexer())
+}
+
+// ToTypedDeploymentInformer converts an untyped informer into a TypedDeploymentInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Deployment. If that is not the case, calling type-safe methods of the returned
+// TypedDeploymentInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedDeploymentInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedDeploymentInformer(informer DeploymentInformer) TypedDeploymentInformer {
+	if informer, ok := informer.(TypedDeploymentInformer); ok {
+		return informer
+	}
+	return &deploymentTypedInformerAdapter{informer}
+}
+
+type deploymentTypedInformerAdapter struct {
+	DeploymentInformer
+}
+
+func (a *deploymentTypedInformerAdapter) TypedInformer() DeploymentIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiextensionsv1beta1.Deployment](a.Informer())
+}
+
+// ToDeploymentIndexInformer converts an untyped informer into a DeploymentIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Deployment. If that is not the case, calling type-safe methods of the returned
+// DeploymentIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a DeploymentIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToDeploymentIndexInformer(informer cache.SharedIndexInformer) DeploymentIndexInformer {
+	if informer, ok := informer.(DeploymentIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiextensionsv1beta1.Deployment](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/ingress.go
@@ -34,11 +34,39 @@ import (
 )
 
 // IngressInformer provides access to a shared informer and lister for
-// Ingresses.
+// Ingresses. Prefer using the type-safe variant (see [TypedIngressInformer]).
 type IngressInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() extensionsv1beta1.IngressLister
 }
+
+// TypedIngressInformer provides access to a shared informer and lister for
+// Ingresses, including the type-safe TypedInformer variant.
+// It is a superset of IngressInformer.
+type TypedIngressInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() IngressIndexInformer
+	Lister() extensionsv1beta1.IngressLister
+}
+
+// IngressIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type IngressIndexInformer cache.TypedSharedIndexInformer[*apiextensionsv1beta1.Ingress]
+
+// IngressHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Ingress.
+type IngressHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiextensionsv1beta1.Ingress]
+
+// IngressDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Ingress.
+type IngressDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiextensionsv1beta1.Ingress]
+
+// IngressFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Ingress.
+type IngressFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiextensionsv1beta1.Ingress]
+
+// IngressIndexers is a specialization of [cache.TypedIndexers] for Ingress.
+type IngressIndexers = cache.TypedIndexers[*apiextensionsv1beta1.Ingress]
+
+// DeletedIngress is a specialization of [cache.DeletedObject] for Ingress.
+type DeletedIngress = cache.DeletedObject[*apiextensionsv1beta1.Ingress]
 
 type ingressInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type ingressInformer struct {
 // NewIngressInformer constructs a new informer for Ingress type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedIngressInformer]).
 func NewIngressInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewIngressInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedIngressInformer constructs a new informer for Ingress type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedIngressInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers IngressIndexers) IngressIndexInformer {
+	return NewTypedIngressInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredIngressInformer constructs a new informer for Ingress type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredIngressInformer]).
 func NewFilteredIngressInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewIngressInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedIngressInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredIngressInformer constructs a new informer for Ingress type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredIngressInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers IngressIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) IngressIndexInformer {
+	return NewTypedIngressInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewIngressInformerWithOptions constructs a new informer for Ingress type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedIngressInformerWithOptions]).
 func NewIngressInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedIngressInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedIngressInformerWithOptions constructs a new informer for Ingress type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedIngressInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) IngressIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "ingresss"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiextensionsv1beta1.Ingress](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewIngressInformerWithOptions(client kubernetes.Interface, namespace string
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *ingressInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewIngressInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedIngressInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *ingressInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiextensionsv1beta1.Ingress{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *ingressInformer) TypedInformer() IngressIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiextensionsv1beta1.Ingress](f.factory.InformerFor(&apiextensionsv1beta1.Ingress{}, f.defaultInformer))
 }
 
 func (f *ingressInformer) Lister() extensionsv1beta1.IngressLister {
 	return extensionsv1beta1.NewIngressLister(f.Informer().GetIndexer())
+}
+
+// ToTypedIngressInformer converts an untyped informer into a TypedIngressInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Ingress. If that is not the case, calling type-safe methods of the returned
+// TypedIngressInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedIngressInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedIngressInformer(informer IngressInformer) TypedIngressInformer {
+	if informer, ok := informer.(TypedIngressInformer); ok {
+		return informer
+	}
+	return &ingressTypedInformerAdapter{informer}
+}
+
+type ingressTypedInformerAdapter struct {
+	IngressInformer
+}
+
+func (a *ingressTypedInformerAdapter) TypedInformer() IngressIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiextensionsv1beta1.Ingress](a.Informer())
+}
+
+// ToIngressIndexInformer converts an untyped informer into a IngressIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Ingress. If that is not the case, calling type-safe methods of the returned
+// IngressIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a IngressIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToIngressIndexInformer(informer cache.SharedIndexInformer) IngressIndexInformer {
+	if informer, ok := informer.(IngressIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiextensionsv1beta1.Ingress](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/interface.go
@@ -25,15 +25,15 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// DaemonSets returns a DaemonSetInformer.
-	DaemonSets() DaemonSetInformer
+	DaemonSets() TypedDaemonSetInformer
 	// Deployments returns a DeploymentInformer.
-	Deployments() DeploymentInformer
+	Deployments() TypedDeploymentInformer
 	// Ingresses returns a IngressInformer.
-	Ingresses() IngressInformer
+	Ingresses() TypedIngressInformer
 	// NetworkPolicies returns a NetworkPolicyInformer.
-	NetworkPolicies() NetworkPolicyInformer
+	NetworkPolicies() TypedNetworkPolicyInformer
 	// ReplicaSets returns a ReplicaSetInformer.
-	ReplicaSets() ReplicaSetInformer
+	ReplicaSets() TypedReplicaSetInformer
 }
 
 type version struct {
@@ -47,27 +47,27 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// DaemonSets returns a DaemonSetInformer.
-func (v *version) DaemonSets() DaemonSetInformer {
+// DaemonSets returns a TypedDaemonSetInformer.
+func (v *version) DaemonSets() TypedDaemonSetInformer {
 	return &daemonSetInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// Deployments returns a DeploymentInformer.
-func (v *version) Deployments() DeploymentInformer {
+// Deployments returns a TypedDeploymentInformer.
+func (v *version) Deployments() TypedDeploymentInformer {
 	return &deploymentInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// Ingresses returns a IngressInformer.
-func (v *version) Ingresses() IngressInformer {
+// Ingresses returns a TypedIngressInformer.
+func (v *version) Ingresses() TypedIngressInformer {
 	return &ingressInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// NetworkPolicies returns a NetworkPolicyInformer.
-func (v *version) NetworkPolicies() NetworkPolicyInformer {
+// NetworkPolicies returns a TypedNetworkPolicyInformer.
+func (v *version) NetworkPolicies() TypedNetworkPolicyInformer {
 	return &networkPolicyInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// ReplicaSets returns a ReplicaSetInformer.
-func (v *version) ReplicaSets() ReplicaSetInformer {
+// ReplicaSets returns a TypedReplicaSetInformer.
+func (v *version) ReplicaSets() TypedReplicaSetInformer {
 	return &replicaSetInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/networkpolicy.go
@@ -34,11 +34,39 @@ import (
 )
 
 // NetworkPolicyInformer provides access to a shared informer and lister for
-// NetworkPolicies.
+// NetworkPolicies. Prefer using the type-safe variant (see [TypedNetworkPolicyInformer]).
 type NetworkPolicyInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() extensionsv1beta1.NetworkPolicyLister
 }
+
+// TypedNetworkPolicyInformer provides access to a shared informer and lister for
+// NetworkPolicies, including the type-safe TypedInformer variant.
+// It is a superset of NetworkPolicyInformer.
+type TypedNetworkPolicyInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() NetworkPolicyIndexInformer
+	Lister() extensionsv1beta1.NetworkPolicyLister
+}
+
+// NetworkPolicyIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type NetworkPolicyIndexInformer cache.TypedSharedIndexInformer[*apiextensionsv1beta1.NetworkPolicy]
+
+// NetworkPolicyHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for NetworkPolicy.
+type NetworkPolicyHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiextensionsv1beta1.NetworkPolicy]
+
+// NetworkPolicyDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for NetworkPolicy.
+type NetworkPolicyDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiextensionsv1beta1.NetworkPolicy]
+
+// NetworkPolicyFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for NetworkPolicy.
+type NetworkPolicyFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiextensionsv1beta1.NetworkPolicy]
+
+// NetworkPolicyIndexers is a specialization of [cache.TypedIndexers] for NetworkPolicy.
+type NetworkPolicyIndexers = cache.TypedIndexers[*apiextensionsv1beta1.NetworkPolicy]
+
+// DeletedNetworkPolicy is a specialization of [cache.DeletedObject] for NetworkPolicy.
+type DeletedNetworkPolicy = cache.DeletedObject[*apiextensionsv1beta1.NetworkPolicy]
 
 type networkPolicyInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type networkPolicyInformer struct {
 // NewNetworkPolicyInformer constructs a new informer for NetworkPolicy type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedNetworkPolicyInformer]).
 func NewNetworkPolicyInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewNetworkPolicyInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedNetworkPolicyInformer constructs a new informer for NetworkPolicy type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedNetworkPolicyInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers NetworkPolicyIndexers) NetworkPolicyIndexInformer {
+	return NewTypedNetworkPolicyInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredNetworkPolicyInformer constructs a new informer for NetworkPolicy type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredNetworkPolicyInformer]).
 func NewFilteredNetworkPolicyInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewNetworkPolicyInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedNetworkPolicyInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredNetworkPolicyInformer constructs a new informer for NetworkPolicy type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredNetworkPolicyInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers NetworkPolicyIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) NetworkPolicyIndexInformer {
+	return NewTypedNetworkPolicyInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewNetworkPolicyInformerWithOptions constructs a new informer for NetworkPolicy type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedNetworkPolicyInformerWithOptions]).
 func NewNetworkPolicyInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedNetworkPolicyInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedNetworkPolicyInformerWithOptions constructs a new informer for NetworkPolicy type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedNetworkPolicyInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) NetworkPolicyIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "networkpolicys"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiextensionsv1beta1.NetworkPolicy](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewNetworkPolicyInformerWithOptions(client kubernetes.Interface, namespace 
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *networkPolicyInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewNetworkPolicyInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedNetworkPolicyInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *networkPolicyInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiextensionsv1beta1.NetworkPolicy{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *networkPolicyInformer) TypedInformer() NetworkPolicyIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiextensionsv1beta1.NetworkPolicy](f.factory.InformerFor(&apiextensionsv1beta1.NetworkPolicy{}, f.defaultInformer))
 }
 
 func (f *networkPolicyInformer) Lister() extensionsv1beta1.NetworkPolicyLister {
 	return extensionsv1beta1.NewNetworkPolicyLister(f.Informer().GetIndexer())
+}
+
+// ToTypedNetworkPolicyInformer converts an untyped informer into a TypedNetworkPolicyInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *NetworkPolicy. If that is not the case, calling type-safe methods of the returned
+// TypedNetworkPolicyInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedNetworkPolicyInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedNetworkPolicyInformer(informer NetworkPolicyInformer) TypedNetworkPolicyInformer {
+	if informer, ok := informer.(TypedNetworkPolicyInformer); ok {
+		return informer
+	}
+	return &networkPolicyTypedInformerAdapter{informer}
+}
+
+type networkPolicyTypedInformerAdapter struct {
+	NetworkPolicyInformer
+}
+
+func (a *networkPolicyTypedInformerAdapter) TypedInformer() NetworkPolicyIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiextensionsv1beta1.NetworkPolicy](a.Informer())
+}
+
+// ToNetworkPolicyIndexInformer converts an untyped informer into a NetworkPolicyIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *NetworkPolicy. If that is not the case, calling type-safe methods of the returned
+// NetworkPolicyIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a NetworkPolicyIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToNetworkPolicyIndexInformer(informer cache.SharedIndexInformer) NetworkPolicyIndexInformer {
+	if informer, ok := informer.(NetworkPolicyIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiextensionsv1beta1.NetworkPolicy](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/replicaset.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ReplicaSetInformer provides access to a shared informer and lister for
-// ReplicaSets.
+// ReplicaSets. Prefer using the type-safe variant (see [TypedReplicaSetInformer]).
 type ReplicaSetInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() extensionsv1beta1.ReplicaSetLister
 }
+
+// TypedReplicaSetInformer provides access to a shared informer and lister for
+// ReplicaSets, including the type-safe TypedInformer variant.
+// It is a superset of ReplicaSetInformer.
+type TypedReplicaSetInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ReplicaSetIndexInformer
+	Lister() extensionsv1beta1.ReplicaSetLister
+}
+
+// ReplicaSetIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ReplicaSetIndexInformer cache.TypedSharedIndexInformer[*apiextensionsv1beta1.ReplicaSet]
+
+// ReplicaSetHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ReplicaSet.
+type ReplicaSetHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiextensionsv1beta1.ReplicaSet]
+
+// ReplicaSetDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ReplicaSet.
+type ReplicaSetDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiextensionsv1beta1.ReplicaSet]
+
+// ReplicaSetFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ReplicaSet.
+type ReplicaSetFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiextensionsv1beta1.ReplicaSet]
+
+// ReplicaSetIndexers is a specialization of [cache.TypedIndexers] for ReplicaSet.
+type ReplicaSetIndexers = cache.TypedIndexers[*apiextensionsv1beta1.ReplicaSet]
+
+// DeletedReplicaSet is a specialization of [cache.DeletedObject] for ReplicaSet.
+type DeletedReplicaSet = cache.DeletedObject[*apiextensionsv1beta1.ReplicaSet]
 
 type replicaSetInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type replicaSetInformer struct {
 // NewReplicaSetInformer constructs a new informer for ReplicaSet type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedReplicaSetInformer]).
 func NewReplicaSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewReplicaSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedReplicaSetInformer constructs a new informer for ReplicaSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedReplicaSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ReplicaSetIndexers) ReplicaSetIndexInformer {
+	return NewTypedReplicaSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredReplicaSetInformer constructs a new informer for ReplicaSet type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredReplicaSetInformer]).
 func NewFilteredReplicaSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewReplicaSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedReplicaSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredReplicaSetInformer constructs a new informer for ReplicaSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredReplicaSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ReplicaSetIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ReplicaSetIndexInformer {
+	return NewTypedReplicaSetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewReplicaSetInformerWithOptions constructs a new informer for ReplicaSet type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedReplicaSetInformerWithOptions]).
 func NewReplicaSetInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedReplicaSetInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedReplicaSetInformerWithOptions constructs a new informer for ReplicaSet type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedReplicaSetInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) ReplicaSetIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "replicasets"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiextensionsv1beta1.ReplicaSet](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewReplicaSetInformerWithOptions(client kubernetes.Interface, namespace str
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *replicaSetInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewReplicaSetInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedReplicaSetInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *replicaSetInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiextensionsv1beta1.ReplicaSet{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *replicaSetInformer) TypedInformer() ReplicaSetIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiextensionsv1beta1.ReplicaSet](f.factory.InformerFor(&apiextensionsv1beta1.ReplicaSet{}, f.defaultInformer))
 }
 
 func (f *replicaSetInformer) Lister() extensionsv1beta1.ReplicaSetLister {
 	return extensionsv1beta1.NewReplicaSetLister(f.Informer().GetIndexer())
+}
+
+// ToTypedReplicaSetInformer converts an untyped informer into a TypedReplicaSetInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ReplicaSet. If that is not the case, calling type-safe methods of the returned
+// TypedReplicaSetInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedReplicaSetInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedReplicaSetInformer(informer ReplicaSetInformer) TypedReplicaSetInformer {
+	if informer, ok := informer.(TypedReplicaSetInformer); ok {
+		return informer
+	}
+	return &replicaSetTypedInformerAdapter{informer}
+}
+
+type replicaSetTypedInformerAdapter struct {
+	ReplicaSetInformer
+}
+
+func (a *replicaSetTypedInformerAdapter) TypedInformer() ReplicaSetIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiextensionsv1beta1.ReplicaSet](a.Informer())
+}
+
+// ToReplicaSetIndexInformer converts an untyped informer into a ReplicaSetIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ReplicaSet. If that is not the case, calling type-safe methods of the returned
+// ReplicaSetIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ReplicaSetIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToReplicaSetIndexInformer(informer cache.SharedIndexInformer) ReplicaSetIndexInformer {
+	if informer, ok := informer.(ReplicaSetIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiextensionsv1beta1.ReplicaSet](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1/flowschema.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1/flowschema.go
@@ -34,11 +34,39 @@ import (
 )
 
 // FlowSchemaInformer provides access to a shared informer and lister for
-// FlowSchemas.
+// FlowSchemas. Prefer using the type-safe variant (see [TypedFlowSchemaInformer]).
 type FlowSchemaInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() flowcontrolv1.FlowSchemaLister
 }
+
+// TypedFlowSchemaInformer provides access to a shared informer and lister for
+// FlowSchemas, including the type-safe TypedInformer variant.
+// It is a superset of FlowSchemaInformer.
+type TypedFlowSchemaInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() FlowSchemaIndexInformer
+	Lister() flowcontrolv1.FlowSchemaLister
+}
+
+// FlowSchemaIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type FlowSchemaIndexInformer cache.TypedSharedIndexInformer[*apiflowcontrolv1.FlowSchema]
+
+// FlowSchemaHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for FlowSchema.
+type FlowSchemaHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiflowcontrolv1.FlowSchema]
+
+// FlowSchemaDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for FlowSchema.
+type FlowSchemaDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiflowcontrolv1.FlowSchema]
+
+// FlowSchemaFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for FlowSchema.
+type FlowSchemaFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiflowcontrolv1.FlowSchema]
+
+// FlowSchemaIndexers is a specialization of [cache.TypedIndexers] for FlowSchema.
+type FlowSchemaIndexers = cache.TypedIndexers[*apiflowcontrolv1.FlowSchema]
+
+// DeletedFlowSchema is a specialization of [cache.DeletedObject] for FlowSchema.
+type DeletedFlowSchema = cache.DeletedObject[*apiflowcontrolv1.FlowSchema]
 
 type flowSchemaInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type flowSchemaInformer struct {
 // NewFlowSchemaInformer constructs a new informer for FlowSchema type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFlowSchemaInformer]).
 func NewFlowSchemaInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedFlowSchemaInformer constructs a new informer for FlowSchema type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFlowSchemaInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers FlowSchemaIndexers) FlowSchemaIndexInformer {
+	return NewTypedFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredFlowSchemaInformer constructs a new informer for FlowSchema type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredFlowSchemaInformer]).
 func NewFilteredFlowSchemaInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredFlowSchemaInformer constructs a new informer for FlowSchema type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredFlowSchemaInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers FlowSchemaIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) FlowSchemaIndexInformer {
+	return NewTypedFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewFlowSchemaInformerWithOptions constructs a new informer for FlowSchema type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFlowSchemaInformerWithOptions]).
 func NewFlowSchemaInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedFlowSchemaInformerWithOptions(client, options)
+}
+
+// NewTypedFlowSchemaInformerWithOptions constructs a new informer for FlowSchema type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFlowSchemaInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) FlowSchemaIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "flowcontrol.apiserver.k8s.io", Version: "v1", Resource: "flowschemas"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1.FlowSchema](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewFlowSchemaInformerWithOptions(client kubernetes.Interface, options inter
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *flowSchemaInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *flowSchemaInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiflowcontrolv1.FlowSchema{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *flowSchemaInformer) TypedInformer() FlowSchemaIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1.FlowSchema](f.factory.InformerFor(&apiflowcontrolv1.FlowSchema{}, f.defaultInformer))
 }
 
 func (f *flowSchemaInformer) Lister() flowcontrolv1.FlowSchemaLister {
 	return flowcontrolv1.NewFlowSchemaLister(f.Informer().GetIndexer())
+}
+
+// ToTypedFlowSchemaInformer converts an untyped informer into a TypedFlowSchemaInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *FlowSchema. If that is not the case, calling type-safe methods of the returned
+// TypedFlowSchemaInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedFlowSchemaInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedFlowSchemaInformer(informer FlowSchemaInformer) TypedFlowSchemaInformer {
+	if informer, ok := informer.(TypedFlowSchemaInformer); ok {
+		return informer
+	}
+	return &flowSchemaTypedInformerAdapter{informer}
+}
+
+type flowSchemaTypedInformerAdapter struct {
+	FlowSchemaInformer
+}
+
+func (a *flowSchemaTypedInformerAdapter) TypedInformer() FlowSchemaIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1.FlowSchema](a.Informer())
+}
+
+// ToFlowSchemaIndexInformer converts an untyped informer into a FlowSchemaIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *FlowSchema. If that is not the case, calling type-safe methods of the returned
+// FlowSchemaIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a FlowSchemaIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToFlowSchemaIndexInformer(informer cache.SharedIndexInformer) FlowSchemaIndexInformer {
+	if informer, ok := informer.(FlowSchemaIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1.FlowSchema](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1/interface.go
@@ -25,9 +25,9 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// FlowSchemas returns a FlowSchemaInformer.
-	FlowSchemas() FlowSchemaInformer
+	FlowSchemas() TypedFlowSchemaInformer
 	// PriorityLevelConfigurations returns a PriorityLevelConfigurationInformer.
-	PriorityLevelConfigurations() PriorityLevelConfigurationInformer
+	PriorityLevelConfigurations() TypedPriorityLevelConfigurationInformer
 }
 
 type version struct {
@@ -41,12 +41,12 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// FlowSchemas returns a FlowSchemaInformer.
-func (v *version) FlowSchemas() FlowSchemaInformer {
+// FlowSchemas returns a TypedFlowSchemaInformer.
+func (v *version) FlowSchemas() TypedFlowSchemaInformer {
 	return &flowSchemaInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// PriorityLevelConfigurations returns a PriorityLevelConfigurationInformer.
-func (v *version) PriorityLevelConfigurations() PriorityLevelConfigurationInformer {
+// PriorityLevelConfigurations returns a TypedPriorityLevelConfigurationInformer.
+func (v *version) PriorityLevelConfigurations() TypedPriorityLevelConfigurationInformer {
 	return &priorityLevelConfigurationInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1/prioritylevelconfiguration.go
@@ -34,11 +34,39 @@ import (
 )
 
 // PriorityLevelConfigurationInformer provides access to a shared informer and lister for
-// PriorityLevelConfigurations.
+// PriorityLevelConfigurations. Prefer using the type-safe variant (see [TypedPriorityLevelConfigurationInformer]).
 type PriorityLevelConfigurationInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() flowcontrolv1.PriorityLevelConfigurationLister
 }
+
+// TypedPriorityLevelConfigurationInformer provides access to a shared informer and lister for
+// PriorityLevelConfigurations, including the type-safe TypedInformer variant.
+// It is a superset of PriorityLevelConfigurationInformer.
+type TypedPriorityLevelConfigurationInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() PriorityLevelConfigurationIndexInformer
+	Lister() flowcontrolv1.PriorityLevelConfigurationLister
+}
+
+// PriorityLevelConfigurationIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type PriorityLevelConfigurationIndexInformer cache.TypedSharedIndexInformer[*apiflowcontrolv1.PriorityLevelConfiguration]
+
+// PriorityLevelConfigurationHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for PriorityLevelConfiguration.
+type PriorityLevelConfigurationHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiflowcontrolv1.PriorityLevelConfiguration]
+
+// PriorityLevelConfigurationDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for PriorityLevelConfiguration.
+type PriorityLevelConfigurationDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiflowcontrolv1.PriorityLevelConfiguration]
+
+// PriorityLevelConfigurationFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for PriorityLevelConfiguration.
+type PriorityLevelConfigurationFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiflowcontrolv1.PriorityLevelConfiguration]
+
+// PriorityLevelConfigurationIndexers is a specialization of [cache.TypedIndexers] for PriorityLevelConfiguration.
+type PriorityLevelConfigurationIndexers = cache.TypedIndexers[*apiflowcontrolv1.PriorityLevelConfiguration]
+
+// DeletedPriorityLevelConfiguration is a specialization of [cache.DeletedObject] for PriorityLevelConfiguration.
+type DeletedPriorityLevelConfiguration = cache.DeletedObject[*apiflowcontrolv1.PriorityLevelConfiguration]
 
 type priorityLevelConfigurationInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type priorityLevelConfigurationInformer struct {
 // NewPriorityLevelConfigurationInformer constructs a new informer for PriorityLevelConfiguration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPriorityLevelConfigurationInformer]).
 func NewPriorityLevelConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedPriorityLevelConfigurationInformer constructs a new informer for PriorityLevelConfiguration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPriorityLevelConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers PriorityLevelConfigurationIndexers) PriorityLevelConfigurationIndexInformer {
+	return NewTypedPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredPriorityLevelConfigurationInformer constructs a new informer for PriorityLevelConfiguration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredPriorityLevelConfigurationInformer]).
 func NewFilteredPriorityLevelConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredPriorityLevelConfigurationInformer constructs a new informer for PriorityLevelConfiguration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredPriorityLevelConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers PriorityLevelConfigurationIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) PriorityLevelConfigurationIndexInformer {
+	return NewTypedPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewPriorityLevelConfigurationInformerWithOptions constructs a new informer for PriorityLevelConfiguration type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPriorityLevelConfigurationInformerWithOptions]).
 func NewPriorityLevelConfigurationInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedPriorityLevelConfigurationInformerWithOptions(client, options)
+}
+
+// NewTypedPriorityLevelConfigurationInformerWithOptions constructs a new informer for PriorityLevelConfiguration type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPriorityLevelConfigurationInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) PriorityLevelConfigurationIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "flowcontrol.apiserver.k8s.io", Version: "v1", Resource: "prioritylevelconfigurations"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1.PriorityLevelConfiguration](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewPriorityLevelConfigurationInformerWithOptions(client kubernetes.Interfac
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *priorityLevelConfigurationInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *priorityLevelConfigurationInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiflowcontrolv1.PriorityLevelConfiguration{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *priorityLevelConfigurationInformer) TypedInformer() PriorityLevelConfigurationIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1.PriorityLevelConfiguration](f.factory.InformerFor(&apiflowcontrolv1.PriorityLevelConfiguration{}, f.defaultInformer))
 }
 
 func (f *priorityLevelConfigurationInformer) Lister() flowcontrolv1.PriorityLevelConfigurationLister {
 	return flowcontrolv1.NewPriorityLevelConfigurationLister(f.Informer().GetIndexer())
+}
+
+// ToTypedPriorityLevelConfigurationInformer converts an untyped informer into a TypedPriorityLevelConfigurationInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *PriorityLevelConfiguration. If that is not the case, calling type-safe methods of the returned
+// TypedPriorityLevelConfigurationInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedPriorityLevelConfigurationInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedPriorityLevelConfigurationInformer(informer PriorityLevelConfigurationInformer) TypedPriorityLevelConfigurationInformer {
+	if informer, ok := informer.(TypedPriorityLevelConfigurationInformer); ok {
+		return informer
+	}
+	return &priorityLevelConfigurationTypedInformerAdapter{informer}
+}
+
+type priorityLevelConfigurationTypedInformerAdapter struct {
+	PriorityLevelConfigurationInformer
+}
+
+func (a *priorityLevelConfigurationTypedInformerAdapter) TypedInformer() PriorityLevelConfigurationIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1.PriorityLevelConfiguration](a.Informer())
+}
+
+// ToPriorityLevelConfigurationIndexInformer converts an untyped informer into a PriorityLevelConfigurationIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *PriorityLevelConfiguration. If that is not the case, calling type-safe methods of the returned
+// PriorityLevelConfigurationIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a PriorityLevelConfigurationIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToPriorityLevelConfigurationIndexInformer(informer cache.SharedIndexInformer) PriorityLevelConfigurationIndexInformer {
+	if informer, ok := informer.(PriorityLevelConfigurationIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1.PriorityLevelConfiguration](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta1/flowschema.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta1/flowschema.go
@@ -34,11 +34,39 @@ import (
 )
 
 // FlowSchemaInformer provides access to a shared informer and lister for
-// FlowSchemas.
+// FlowSchemas. Prefer using the type-safe variant (see [TypedFlowSchemaInformer]).
 type FlowSchemaInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() flowcontrolv1beta1.FlowSchemaLister
 }
+
+// TypedFlowSchemaInformer provides access to a shared informer and lister for
+// FlowSchemas, including the type-safe TypedInformer variant.
+// It is a superset of FlowSchemaInformer.
+type TypedFlowSchemaInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() FlowSchemaIndexInformer
+	Lister() flowcontrolv1beta1.FlowSchemaLister
+}
+
+// FlowSchemaIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type FlowSchemaIndexInformer cache.TypedSharedIndexInformer[*apiflowcontrolv1beta1.FlowSchema]
+
+// FlowSchemaHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for FlowSchema.
+type FlowSchemaHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiflowcontrolv1beta1.FlowSchema]
+
+// FlowSchemaDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for FlowSchema.
+type FlowSchemaDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiflowcontrolv1beta1.FlowSchema]
+
+// FlowSchemaFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for FlowSchema.
+type FlowSchemaFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiflowcontrolv1beta1.FlowSchema]
+
+// FlowSchemaIndexers is a specialization of [cache.TypedIndexers] for FlowSchema.
+type FlowSchemaIndexers = cache.TypedIndexers[*apiflowcontrolv1beta1.FlowSchema]
+
+// DeletedFlowSchema is a specialization of [cache.DeletedObject] for FlowSchema.
+type DeletedFlowSchema = cache.DeletedObject[*apiflowcontrolv1beta1.FlowSchema]
 
 type flowSchemaInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type flowSchemaInformer struct {
 // NewFlowSchemaInformer constructs a new informer for FlowSchema type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFlowSchemaInformer]).
 func NewFlowSchemaInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedFlowSchemaInformer constructs a new informer for FlowSchema type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFlowSchemaInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers FlowSchemaIndexers) FlowSchemaIndexInformer {
+	return NewTypedFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredFlowSchemaInformer constructs a new informer for FlowSchema type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredFlowSchemaInformer]).
 func NewFilteredFlowSchemaInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredFlowSchemaInformer constructs a new informer for FlowSchema type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredFlowSchemaInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers FlowSchemaIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) FlowSchemaIndexInformer {
+	return NewTypedFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewFlowSchemaInformerWithOptions constructs a new informer for FlowSchema type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFlowSchemaInformerWithOptions]).
 func NewFlowSchemaInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedFlowSchemaInformerWithOptions(client, options)
+}
+
+// NewTypedFlowSchemaInformerWithOptions constructs a new informer for FlowSchema type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFlowSchemaInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) FlowSchemaIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta1", Resource: "flowschemas"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1beta1.FlowSchema](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewFlowSchemaInformerWithOptions(client kubernetes.Interface, options inter
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *flowSchemaInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *flowSchemaInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiflowcontrolv1beta1.FlowSchema{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *flowSchemaInformer) TypedInformer() FlowSchemaIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1beta1.FlowSchema](f.factory.InformerFor(&apiflowcontrolv1beta1.FlowSchema{}, f.defaultInformer))
 }
 
 func (f *flowSchemaInformer) Lister() flowcontrolv1beta1.FlowSchemaLister {
 	return flowcontrolv1beta1.NewFlowSchemaLister(f.Informer().GetIndexer())
+}
+
+// ToTypedFlowSchemaInformer converts an untyped informer into a TypedFlowSchemaInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *FlowSchema. If that is not the case, calling type-safe methods of the returned
+// TypedFlowSchemaInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedFlowSchemaInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedFlowSchemaInformer(informer FlowSchemaInformer) TypedFlowSchemaInformer {
+	if informer, ok := informer.(TypedFlowSchemaInformer); ok {
+		return informer
+	}
+	return &flowSchemaTypedInformerAdapter{informer}
+}
+
+type flowSchemaTypedInformerAdapter struct {
+	FlowSchemaInformer
+}
+
+func (a *flowSchemaTypedInformerAdapter) TypedInformer() FlowSchemaIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1beta1.FlowSchema](a.Informer())
+}
+
+// ToFlowSchemaIndexInformer converts an untyped informer into a FlowSchemaIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *FlowSchema. If that is not the case, calling type-safe methods of the returned
+// FlowSchemaIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a FlowSchemaIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToFlowSchemaIndexInformer(informer cache.SharedIndexInformer) FlowSchemaIndexInformer {
+	if informer, ok := informer.(FlowSchemaIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1beta1.FlowSchema](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta1/interface.go
@@ -25,9 +25,9 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// FlowSchemas returns a FlowSchemaInformer.
-	FlowSchemas() FlowSchemaInformer
+	FlowSchemas() TypedFlowSchemaInformer
 	// PriorityLevelConfigurations returns a PriorityLevelConfigurationInformer.
-	PriorityLevelConfigurations() PriorityLevelConfigurationInformer
+	PriorityLevelConfigurations() TypedPriorityLevelConfigurationInformer
 }
 
 type version struct {
@@ -41,12 +41,12 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// FlowSchemas returns a FlowSchemaInformer.
-func (v *version) FlowSchemas() FlowSchemaInformer {
+// FlowSchemas returns a TypedFlowSchemaInformer.
+func (v *version) FlowSchemas() TypedFlowSchemaInformer {
 	return &flowSchemaInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// PriorityLevelConfigurations returns a PriorityLevelConfigurationInformer.
-func (v *version) PriorityLevelConfigurations() PriorityLevelConfigurationInformer {
+// PriorityLevelConfigurations returns a TypedPriorityLevelConfigurationInformer.
+func (v *version) PriorityLevelConfigurations() TypedPriorityLevelConfigurationInformer {
 	return &priorityLevelConfigurationInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta1/prioritylevelconfiguration.go
@@ -34,11 +34,39 @@ import (
 )
 
 // PriorityLevelConfigurationInformer provides access to a shared informer and lister for
-// PriorityLevelConfigurations.
+// PriorityLevelConfigurations. Prefer using the type-safe variant (see [TypedPriorityLevelConfigurationInformer]).
 type PriorityLevelConfigurationInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() flowcontrolv1beta1.PriorityLevelConfigurationLister
 }
+
+// TypedPriorityLevelConfigurationInformer provides access to a shared informer and lister for
+// PriorityLevelConfigurations, including the type-safe TypedInformer variant.
+// It is a superset of PriorityLevelConfigurationInformer.
+type TypedPriorityLevelConfigurationInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() PriorityLevelConfigurationIndexInformer
+	Lister() flowcontrolv1beta1.PriorityLevelConfigurationLister
+}
+
+// PriorityLevelConfigurationIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type PriorityLevelConfigurationIndexInformer cache.TypedSharedIndexInformer[*apiflowcontrolv1beta1.PriorityLevelConfiguration]
+
+// PriorityLevelConfigurationHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for PriorityLevelConfiguration.
+type PriorityLevelConfigurationHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiflowcontrolv1beta1.PriorityLevelConfiguration]
+
+// PriorityLevelConfigurationDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for PriorityLevelConfiguration.
+type PriorityLevelConfigurationDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiflowcontrolv1beta1.PriorityLevelConfiguration]
+
+// PriorityLevelConfigurationFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for PriorityLevelConfiguration.
+type PriorityLevelConfigurationFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiflowcontrolv1beta1.PriorityLevelConfiguration]
+
+// PriorityLevelConfigurationIndexers is a specialization of [cache.TypedIndexers] for PriorityLevelConfiguration.
+type PriorityLevelConfigurationIndexers = cache.TypedIndexers[*apiflowcontrolv1beta1.PriorityLevelConfiguration]
+
+// DeletedPriorityLevelConfiguration is a specialization of [cache.DeletedObject] for PriorityLevelConfiguration.
+type DeletedPriorityLevelConfiguration = cache.DeletedObject[*apiflowcontrolv1beta1.PriorityLevelConfiguration]
 
 type priorityLevelConfigurationInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type priorityLevelConfigurationInformer struct {
 // NewPriorityLevelConfigurationInformer constructs a new informer for PriorityLevelConfiguration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPriorityLevelConfigurationInformer]).
 func NewPriorityLevelConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedPriorityLevelConfigurationInformer constructs a new informer for PriorityLevelConfiguration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPriorityLevelConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers PriorityLevelConfigurationIndexers) PriorityLevelConfigurationIndexInformer {
+	return NewTypedPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredPriorityLevelConfigurationInformer constructs a new informer for PriorityLevelConfiguration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredPriorityLevelConfigurationInformer]).
 func NewFilteredPriorityLevelConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredPriorityLevelConfigurationInformer constructs a new informer for PriorityLevelConfiguration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredPriorityLevelConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers PriorityLevelConfigurationIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) PriorityLevelConfigurationIndexInformer {
+	return NewTypedPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewPriorityLevelConfigurationInformerWithOptions constructs a new informer for PriorityLevelConfiguration type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPriorityLevelConfigurationInformerWithOptions]).
 func NewPriorityLevelConfigurationInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedPriorityLevelConfigurationInformerWithOptions(client, options)
+}
+
+// NewTypedPriorityLevelConfigurationInformerWithOptions constructs a new informer for PriorityLevelConfiguration type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPriorityLevelConfigurationInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) PriorityLevelConfigurationIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta1", Resource: "prioritylevelconfigurations"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1beta1.PriorityLevelConfiguration](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewPriorityLevelConfigurationInformerWithOptions(client kubernetes.Interfac
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *priorityLevelConfigurationInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *priorityLevelConfigurationInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiflowcontrolv1beta1.PriorityLevelConfiguration{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *priorityLevelConfigurationInformer) TypedInformer() PriorityLevelConfigurationIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1beta1.PriorityLevelConfiguration](f.factory.InformerFor(&apiflowcontrolv1beta1.PriorityLevelConfiguration{}, f.defaultInformer))
 }
 
 func (f *priorityLevelConfigurationInformer) Lister() flowcontrolv1beta1.PriorityLevelConfigurationLister {
 	return flowcontrolv1beta1.NewPriorityLevelConfigurationLister(f.Informer().GetIndexer())
+}
+
+// ToTypedPriorityLevelConfigurationInformer converts an untyped informer into a TypedPriorityLevelConfigurationInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *PriorityLevelConfiguration. If that is not the case, calling type-safe methods of the returned
+// TypedPriorityLevelConfigurationInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedPriorityLevelConfigurationInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedPriorityLevelConfigurationInformer(informer PriorityLevelConfigurationInformer) TypedPriorityLevelConfigurationInformer {
+	if informer, ok := informer.(TypedPriorityLevelConfigurationInformer); ok {
+		return informer
+	}
+	return &priorityLevelConfigurationTypedInformerAdapter{informer}
+}
+
+type priorityLevelConfigurationTypedInformerAdapter struct {
+	PriorityLevelConfigurationInformer
+}
+
+func (a *priorityLevelConfigurationTypedInformerAdapter) TypedInformer() PriorityLevelConfigurationIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1beta1.PriorityLevelConfiguration](a.Informer())
+}
+
+// ToPriorityLevelConfigurationIndexInformer converts an untyped informer into a PriorityLevelConfigurationIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *PriorityLevelConfiguration. If that is not the case, calling type-safe methods of the returned
+// PriorityLevelConfigurationIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a PriorityLevelConfigurationIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToPriorityLevelConfigurationIndexInformer(informer cache.SharedIndexInformer) PriorityLevelConfigurationIndexInformer {
+	if informer, ok := informer.(PriorityLevelConfigurationIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1beta1.PriorityLevelConfiguration](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta2/flowschema.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta2/flowschema.go
@@ -34,11 +34,39 @@ import (
 )
 
 // FlowSchemaInformer provides access to a shared informer and lister for
-// FlowSchemas.
+// FlowSchemas. Prefer using the type-safe variant (see [TypedFlowSchemaInformer]).
 type FlowSchemaInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() flowcontrolv1beta2.FlowSchemaLister
 }
+
+// TypedFlowSchemaInformer provides access to a shared informer and lister for
+// FlowSchemas, including the type-safe TypedInformer variant.
+// It is a superset of FlowSchemaInformer.
+type TypedFlowSchemaInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() FlowSchemaIndexInformer
+	Lister() flowcontrolv1beta2.FlowSchemaLister
+}
+
+// FlowSchemaIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type FlowSchemaIndexInformer cache.TypedSharedIndexInformer[*apiflowcontrolv1beta2.FlowSchema]
+
+// FlowSchemaHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for FlowSchema.
+type FlowSchemaHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiflowcontrolv1beta2.FlowSchema]
+
+// FlowSchemaDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for FlowSchema.
+type FlowSchemaDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiflowcontrolv1beta2.FlowSchema]
+
+// FlowSchemaFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for FlowSchema.
+type FlowSchemaFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiflowcontrolv1beta2.FlowSchema]
+
+// FlowSchemaIndexers is a specialization of [cache.TypedIndexers] for FlowSchema.
+type FlowSchemaIndexers = cache.TypedIndexers[*apiflowcontrolv1beta2.FlowSchema]
+
+// DeletedFlowSchema is a specialization of [cache.DeletedObject] for FlowSchema.
+type DeletedFlowSchema = cache.DeletedObject[*apiflowcontrolv1beta2.FlowSchema]
 
 type flowSchemaInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type flowSchemaInformer struct {
 // NewFlowSchemaInformer constructs a new informer for FlowSchema type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFlowSchemaInformer]).
 func NewFlowSchemaInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedFlowSchemaInformer constructs a new informer for FlowSchema type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFlowSchemaInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers FlowSchemaIndexers) FlowSchemaIndexInformer {
+	return NewTypedFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredFlowSchemaInformer constructs a new informer for FlowSchema type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredFlowSchemaInformer]).
 func NewFilteredFlowSchemaInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredFlowSchemaInformer constructs a new informer for FlowSchema type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredFlowSchemaInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers FlowSchemaIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) FlowSchemaIndexInformer {
+	return NewTypedFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewFlowSchemaInformerWithOptions constructs a new informer for FlowSchema type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFlowSchemaInformerWithOptions]).
 func NewFlowSchemaInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedFlowSchemaInformerWithOptions(client, options)
+}
+
+// NewTypedFlowSchemaInformerWithOptions constructs a new informer for FlowSchema type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFlowSchemaInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) FlowSchemaIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta2", Resource: "flowschemas"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1beta2.FlowSchema](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewFlowSchemaInformerWithOptions(client kubernetes.Interface, options inter
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *flowSchemaInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *flowSchemaInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiflowcontrolv1beta2.FlowSchema{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *flowSchemaInformer) TypedInformer() FlowSchemaIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1beta2.FlowSchema](f.factory.InformerFor(&apiflowcontrolv1beta2.FlowSchema{}, f.defaultInformer))
 }
 
 func (f *flowSchemaInformer) Lister() flowcontrolv1beta2.FlowSchemaLister {
 	return flowcontrolv1beta2.NewFlowSchemaLister(f.Informer().GetIndexer())
+}
+
+// ToTypedFlowSchemaInformer converts an untyped informer into a TypedFlowSchemaInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *FlowSchema. If that is not the case, calling type-safe methods of the returned
+// TypedFlowSchemaInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedFlowSchemaInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedFlowSchemaInformer(informer FlowSchemaInformer) TypedFlowSchemaInformer {
+	if informer, ok := informer.(TypedFlowSchemaInformer); ok {
+		return informer
+	}
+	return &flowSchemaTypedInformerAdapter{informer}
+}
+
+type flowSchemaTypedInformerAdapter struct {
+	FlowSchemaInformer
+}
+
+func (a *flowSchemaTypedInformerAdapter) TypedInformer() FlowSchemaIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1beta2.FlowSchema](a.Informer())
+}
+
+// ToFlowSchemaIndexInformer converts an untyped informer into a FlowSchemaIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *FlowSchema. If that is not the case, calling type-safe methods of the returned
+// FlowSchemaIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a FlowSchemaIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToFlowSchemaIndexInformer(informer cache.SharedIndexInformer) FlowSchemaIndexInformer {
+	if informer, ok := informer.(FlowSchemaIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1beta2.FlowSchema](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta2/interface.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta2/interface.go
@@ -25,9 +25,9 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// FlowSchemas returns a FlowSchemaInformer.
-	FlowSchemas() FlowSchemaInformer
+	FlowSchemas() TypedFlowSchemaInformer
 	// PriorityLevelConfigurations returns a PriorityLevelConfigurationInformer.
-	PriorityLevelConfigurations() PriorityLevelConfigurationInformer
+	PriorityLevelConfigurations() TypedPriorityLevelConfigurationInformer
 }
 
 type version struct {
@@ -41,12 +41,12 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// FlowSchemas returns a FlowSchemaInformer.
-func (v *version) FlowSchemas() FlowSchemaInformer {
+// FlowSchemas returns a TypedFlowSchemaInformer.
+func (v *version) FlowSchemas() TypedFlowSchemaInformer {
 	return &flowSchemaInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// PriorityLevelConfigurations returns a PriorityLevelConfigurationInformer.
-func (v *version) PriorityLevelConfigurations() PriorityLevelConfigurationInformer {
+// PriorityLevelConfigurations returns a TypedPriorityLevelConfigurationInformer.
+func (v *version) PriorityLevelConfigurations() TypedPriorityLevelConfigurationInformer {
 	return &priorityLevelConfigurationInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta2/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta2/prioritylevelconfiguration.go
@@ -34,11 +34,39 @@ import (
 )
 
 // PriorityLevelConfigurationInformer provides access to a shared informer and lister for
-// PriorityLevelConfigurations.
+// PriorityLevelConfigurations. Prefer using the type-safe variant (see [TypedPriorityLevelConfigurationInformer]).
 type PriorityLevelConfigurationInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() flowcontrolv1beta2.PriorityLevelConfigurationLister
 }
+
+// TypedPriorityLevelConfigurationInformer provides access to a shared informer and lister for
+// PriorityLevelConfigurations, including the type-safe TypedInformer variant.
+// It is a superset of PriorityLevelConfigurationInformer.
+type TypedPriorityLevelConfigurationInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() PriorityLevelConfigurationIndexInformer
+	Lister() flowcontrolv1beta2.PriorityLevelConfigurationLister
+}
+
+// PriorityLevelConfigurationIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type PriorityLevelConfigurationIndexInformer cache.TypedSharedIndexInformer[*apiflowcontrolv1beta2.PriorityLevelConfiguration]
+
+// PriorityLevelConfigurationHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for PriorityLevelConfiguration.
+type PriorityLevelConfigurationHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiflowcontrolv1beta2.PriorityLevelConfiguration]
+
+// PriorityLevelConfigurationDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for PriorityLevelConfiguration.
+type PriorityLevelConfigurationDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiflowcontrolv1beta2.PriorityLevelConfiguration]
+
+// PriorityLevelConfigurationFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for PriorityLevelConfiguration.
+type PriorityLevelConfigurationFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiflowcontrolv1beta2.PriorityLevelConfiguration]
+
+// PriorityLevelConfigurationIndexers is a specialization of [cache.TypedIndexers] for PriorityLevelConfiguration.
+type PriorityLevelConfigurationIndexers = cache.TypedIndexers[*apiflowcontrolv1beta2.PriorityLevelConfiguration]
+
+// DeletedPriorityLevelConfiguration is a specialization of [cache.DeletedObject] for PriorityLevelConfiguration.
+type DeletedPriorityLevelConfiguration = cache.DeletedObject[*apiflowcontrolv1beta2.PriorityLevelConfiguration]
 
 type priorityLevelConfigurationInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type priorityLevelConfigurationInformer struct {
 // NewPriorityLevelConfigurationInformer constructs a new informer for PriorityLevelConfiguration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPriorityLevelConfigurationInformer]).
 func NewPriorityLevelConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedPriorityLevelConfigurationInformer constructs a new informer for PriorityLevelConfiguration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPriorityLevelConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers PriorityLevelConfigurationIndexers) PriorityLevelConfigurationIndexInformer {
+	return NewTypedPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredPriorityLevelConfigurationInformer constructs a new informer for PriorityLevelConfiguration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredPriorityLevelConfigurationInformer]).
 func NewFilteredPriorityLevelConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredPriorityLevelConfigurationInformer constructs a new informer for PriorityLevelConfiguration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredPriorityLevelConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers PriorityLevelConfigurationIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) PriorityLevelConfigurationIndexInformer {
+	return NewTypedPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewPriorityLevelConfigurationInformerWithOptions constructs a new informer for PriorityLevelConfiguration type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPriorityLevelConfigurationInformerWithOptions]).
 func NewPriorityLevelConfigurationInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedPriorityLevelConfigurationInformerWithOptions(client, options)
+}
+
+// NewTypedPriorityLevelConfigurationInformerWithOptions constructs a new informer for PriorityLevelConfiguration type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPriorityLevelConfigurationInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) PriorityLevelConfigurationIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta2", Resource: "prioritylevelconfigurations"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1beta2.PriorityLevelConfiguration](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewPriorityLevelConfigurationInformerWithOptions(client kubernetes.Interfac
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *priorityLevelConfigurationInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *priorityLevelConfigurationInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiflowcontrolv1beta2.PriorityLevelConfiguration{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *priorityLevelConfigurationInformer) TypedInformer() PriorityLevelConfigurationIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1beta2.PriorityLevelConfiguration](f.factory.InformerFor(&apiflowcontrolv1beta2.PriorityLevelConfiguration{}, f.defaultInformer))
 }
 
 func (f *priorityLevelConfigurationInformer) Lister() flowcontrolv1beta2.PriorityLevelConfigurationLister {
 	return flowcontrolv1beta2.NewPriorityLevelConfigurationLister(f.Informer().GetIndexer())
+}
+
+// ToTypedPriorityLevelConfigurationInformer converts an untyped informer into a TypedPriorityLevelConfigurationInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *PriorityLevelConfiguration. If that is not the case, calling type-safe methods of the returned
+// TypedPriorityLevelConfigurationInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedPriorityLevelConfigurationInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedPriorityLevelConfigurationInformer(informer PriorityLevelConfigurationInformer) TypedPriorityLevelConfigurationInformer {
+	if informer, ok := informer.(TypedPriorityLevelConfigurationInformer); ok {
+		return informer
+	}
+	return &priorityLevelConfigurationTypedInformerAdapter{informer}
+}
+
+type priorityLevelConfigurationTypedInformerAdapter struct {
+	PriorityLevelConfigurationInformer
+}
+
+func (a *priorityLevelConfigurationTypedInformerAdapter) TypedInformer() PriorityLevelConfigurationIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1beta2.PriorityLevelConfiguration](a.Informer())
+}
+
+// ToPriorityLevelConfigurationIndexInformer converts an untyped informer into a PriorityLevelConfigurationIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *PriorityLevelConfiguration. If that is not the case, calling type-safe methods of the returned
+// PriorityLevelConfigurationIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a PriorityLevelConfigurationIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToPriorityLevelConfigurationIndexInformer(informer cache.SharedIndexInformer) PriorityLevelConfigurationIndexInformer {
+	if informer, ok := informer.(PriorityLevelConfigurationIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1beta2.PriorityLevelConfiguration](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta3/flowschema.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta3/flowschema.go
@@ -34,11 +34,39 @@ import (
 )
 
 // FlowSchemaInformer provides access to a shared informer and lister for
-// FlowSchemas.
+// FlowSchemas. Prefer using the type-safe variant (see [TypedFlowSchemaInformer]).
 type FlowSchemaInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() flowcontrolv1beta3.FlowSchemaLister
 }
+
+// TypedFlowSchemaInformer provides access to a shared informer and lister for
+// FlowSchemas, including the type-safe TypedInformer variant.
+// It is a superset of FlowSchemaInformer.
+type TypedFlowSchemaInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() FlowSchemaIndexInformer
+	Lister() flowcontrolv1beta3.FlowSchemaLister
+}
+
+// FlowSchemaIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type FlowSchemaIndexInformer cache.TypedSharedIndexInformer[*apiflowcontrolv1beta3.FlowSchema]
+
+// FlowSchemaHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for FlowSchema.
+type FlowSchemaHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiflowcontrolv1beta3.FlowSchema]
+
+// FlowSchemaDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for FlowSchema.
+type FlowSchemaDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiflowcontrolv1beta3.FlowSchema]
+
+// FlowSchemaFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for FlowSchema.
+type FlowSchemaFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiflowcontrolv1beta3.FlowSchema]
+
+// FlowSchemaIndexers is a specialization of [cache.TypedIndexers] for FlowSchema.
+type FlowSchemaIndexers = cache.TypedIndexers[*apiflowcontrolv1beta3.FlowSchema]
+
+// DeletedFlowSchema is a specialization of [cache.DeletedObject] for FlowSchema.
+type DeletedFlowSchema = cache.DeletedObject[*apiflowcontrolv1beta3.FlowSchema]
 
 type flowSchemaInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type flowSchemaInformer struct {
 // NewFlowSchemaInformer constructs a new informer for FlowSchema type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFlowSchemaInformer]).
 func NewFlowSchemaInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedFlowSchemaInformer constructs a new informer for FlowSchema type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFlowSchemaInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers FlowSchemaIndexers) FlowSchemaIndexInformer {
+	return NewTypedFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredFlowSchemaInformer constructs a new informer for FlowSchema type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredFlowSchemaInformer]).
 func NewFilteredFlowSchemaInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredFlowSchemaInformer constructs a new informer for FlowSchema type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredFlowSchemaInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers FlowSchemaIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) FlowSchemaIndexInformer {
+	return NewTypedFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewFlowSchemaInformerWithOptions constructs a new informer for FlowSchema type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFlowSchemaInformerWithOptions]).
 func NewFlowSchemaInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedFlowSchemaInformerWithOptions(client, options)
+}
+
+// NewTypedFlowSchemaInformerWithOptions constructs a new informer for FlowSchema type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFlowSchemaInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) FlowSchemaIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta3", Resource: "flowschemas"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1beta3.FlowSchema](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewFlowSchemaInformerWithOptions(client kubernetes.Interface, options inter
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *flowSchemaInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedFlowSchemaInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *flowSchemaInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiflowcontrolv1beta3.FlowSchema{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *flowSchemaInformer) TypedInformer() FlowSchemaIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1beta3.FlowSchema](f.factory.InformerFor(&apiflowcontrolv1beta3.FlowSchema{}, f.defaultInformer))
 }
 
 func (f *flowSchemaInformer) Lister() flowcontrolv1beta3.FlowSchemaLister {
 	return flowcontrolv1beta3.NewFlowSchemaLister(f.Informer().GetIndexer())
+}
+
+// ToTypedFlowSchemaInformer converts an untyped informer into a TypedFlowSchemaInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *FlowSchema. If that is not the case, calling type-safe methods of the returned
+// TypedFlowSchemaInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedFlowSchemaInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedFlowSchemaInformer(informer FlowSchemaInformer) TypedFlowSchemaInformer {
+	if informer, ok := informer.(TypedFlowSchemaInformer); ok {
+		return informer
+	}
+	return &flowSchemaTypedInformerAdapter{informer}
+}
+
+type flowSchemaTypedInformerAdapter struct {
+	FlowSchemaInformer
+}
+
+func (a *flowSchemaTypedInformerAdapter) TypedInformer() FlowSchemaIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1beta3.FlowSchema](a.Informer())
+}
+
+// ToFlowSchemaIndexInformer converts an untyped informer into a FlowSchemaIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *FlowSchema. If that is not the case, calling type-safe methods of the returned
+// FlowSchemaIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a FlowSchemaIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToFlowSchemaIndexInformer(informer cache.SharedIndexInformer) FlowSchemaIndexInformer {
+	if informer, ok := informer.(FlowSchemaIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1beta3.FlowSchema](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta3/interface.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta3/interface.go
@@ -25,9 +25,9 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// FlowSchemas returns a FlowSchemaInformer.
-	FlowSchemas() FlowSchemaInformer
+	FlowSchemas() TypedFlowSchemaInformer
 	// PriorityLevelConfigurations returns a PriorityLevelConfigurationInformer.
-	PriorityLevelConfigurations() PriorityLevelConfigurationInformer
+	PriorityLevelConfigurations() TypedPriorityLevelConfigurationInformer
 }
 
 type version struct {
@@ -41,12 +41,12 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// FlowSchemas returns a FlowSchemaInformer.
-func (v *version) FlowSchemas() FlowSchemaInformer {
+// FlowSchemas returns a TypedFlowSchemaInformer.
+func (v *version) FlowSchemas() TypedFlowSchemaInformer {
 	return &flowSchemaInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// PriorityLevelConfigurations returns a PriorityLevelConfigurationInformer.
-func (v *version) PriorityLevelConfigurations() PriorityLevelConfigurationInformer {
+// PriorityLevelConfigurations returns a TypedPriorityLevelConfigurationInformer.
+func (v *version) PriorityLevelConfigurations() TypedPriorityLevelConfigurationInformer {
 	return &priorityLevelConfigurationInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta3/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta3/prioritylevelconfiguration.go
@@ -34,11 +34,39 @@ import (
 )
 
 // PriorityLevelConfigurationInformer provides access to a shared informer and lister for
-// PriorityLevelConfigurations.
+// PriorityLevelConfigurations. Prefer using the type-safe variant (see [TypedPriorityLevelConfigurationInformer]).
 type PriorityLevelConfigurationInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() flowcontrolv1beta3.PriorityLevelConfigurationLister
 }
+
+// TypedPriorityLevelConfigurationInformer provides access to a shared informer and lister for
+// PriorityLevelConfigurations, including the type-safe TypedInformer variant.
+// It is a superset of PriorityLevelConfigurationInformer.
+type TypedPriorityLevelConfigurationInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() PriorityLevelConfigurationIndexInformer
+	Lister() flowcontrolv1beta3.PriorityLevelConfigurationLister
+}
+
+// PriorityLevelConfigurationIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type PriorityLevelConfigurationIndexInformer cache.TypedSharedIndexInformer[*apiflowcontrolv1beta3.PriorityLevelConfiguration]
+
+// PriorityLevelConfigurationHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for PriorityLevelConfiguration.
+type PriorityLevelConfigurationHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiflowcontrolv1beta3.PriorityLevelConfiguration]
+
+// PriorityLevelConfigurationDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for PriorityLevelConfiguration.
+type PriorityLevelConfigurationDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiflowcontrolv1beta3.PriorityLevelConfiguration]
+
+// PriorityLevelConfigurationFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for PriorityLevelConfiguration.
+type PriorityLevelConfigurationFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiflowcontrolv1beta3.PriorityLevelConfiguration]
+
+// PriorityLevelConfigurationIndexers is a specialization of [cache.TypedIndexers] for PriorityLevelConfiguration.
+type PriorityLevelConfigurationIndexers = cache.TypedIndexers[*apiflowcontrolv1beta3.PriorityLevelConfiguration]
+
+// DeletedPriorityLevelConfiguration is a specialization of [cache.DeletedObject] for PriorityLevelConfiguration.
+type DeletedPriorityLevelConfiguration = cache.DeletedObject[*apiflowcontrolv1beta3.PriorityLevelConfiguration]
 
 type priorityLevelConfigurationInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type priorityLevelConfigurationInformer struct {
 // NewPriorityLevelConfigurationInformer constructs a new informer for PriorityLevelConfiguration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPriorityLevelConfigurationInformer]).
 func NewPriorityLevelConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedPriorityLevelConfigurationInformer constructs a new informer for PriorityLevelConfiguration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPriorityLevelConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers PriorityLevelConfigurationIndexers) PriorityLevelConfigurationIndexInformer {
+	return NewTypedPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredPriorityLevelConfigurationInformer constructs a new informer for PriorityLevelConfiguration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredPriorityLevelConfigurationInformer]).
 func NewFilteredPriorityLevelConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredPriorityLevelConfigurationInformer constructs a new informer for PriorityLevelConfiguration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredPriorityLevelConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers PriorityLevelConfigurationIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) PriorityLevelConfigurationIndexInformer {
+	return NewTypedPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewPriorityLevelConfigurationInformerWithOptions constructs a new informer for PriorityLevelConfiguration type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPriorityLevelConfigurationInformerWithOptions]).
 func NewPriorityLevelConfigurationInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedPriorityLevelConfigurationInformerWithOptions(client, options)
+}
+
+// NewTypedPriorityLevelConfigurationInformerWithOptions constructs a new informer for PriorityLevelConfiguration type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPriorityLevelConfigurationInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) PriorityLevelConfigurationIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta3", Resource: "prioritylevelconfigurations"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1beta3.PriorityLevelConfiguration](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewPriorityLevelConfigurationInformerWithOptions(client kubernetes.Interfac
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *priorityLevelConfigurationInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedPriorityLevelConfigurationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *priorityLevelConfigurationInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiflowcontrolv1beta3.PriorityLevelConfiguration{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *priorityLevelConfigurationInformer) TypedInformer() PriorityLevelConfigurationIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1beta3.PriorityLevelConfiguration](f.factory.InformerFor(&apiflowcontrolv1beta3.PriorityLevelConfiguration{}, f.defaultInformer))
 }
 
 func (f *priorityLevelConfigurationInformer) Lister() flowcontrolv1beta3.PriorityLevelConfigurationLister {
 	return flowcontrolv1beta3.NewPriorityLevelConfigurationLister(f.Informer().GetIndexer())
+}
+
+// ToTypedPriorityLevelConfigurationInformer converts an untyped informer into a TypedPriorityLevelConfigurationInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *PriorityLevelConfiguration. If that is not the case, calling type-safe methods of the returned
+// TypedPriorityLevelConfigurationInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedPriorityLevelConfigurationInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedPriorityLevelConfigurationInformer(informer PriorityLevelConfigurationInformer) TypedPriorityLevelConfigurationInformer {
+	if informer, ok := informer.(TypedPriorityLevelConfigurationInformer); ok {
+		return informer
+	}
+	return &priorityLevelConfigurationTypedInformerAdapter{informer}
+}
+
+type priorityLevelConfigurationTypedInformerAdapter struct {
+	PriorityLevelConfigurationInformer
+}
+
+func (a *priorityLevelConfigurationTypedInformerAdapter) TypedInformer() PriorityLevelConfigurationIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1beta3.PriorityLevelConfiguration](a.Informer())
+}
+
+// ToPriorityLevelConfigurationIndexInformer converts an untyped informer into a PriorityLevelConfigurationIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *PriorityLevelConfiguration. If that is not the case, calling type-safe methods of the returned
+// PriorityLevelConfigurationIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a PriorityLevelConfigurationIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToPriorityLevelConfigurationIndexInformer(informer cache.SharedIndexInformer) PriorityLevelConfigurationIndexInformer {
+	if informer, ok := informer.(PriorityLevelConfigurationIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiflowcontrolv1beta3.PriorityLevelConfiguration](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/networking/v1/ingress.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/ingress.go
@@ -34,11 +34,39 @@ import (
 )
 
 // IngressInformer provides access to a shared informer and lister for
-// Ingresses.
+// Ingresses. Prefer using the type-safe variant (see [TypedIngressInformer]).
 type IngressInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() networkingv1.IngressLister
 }
+
+// TypedIngressInformer provides access to a shared informer and lister for
+// Ingresses, including the type-safe TypedInformer variant.
+// It is a superset of IngressInformer.
+type TypedIngressInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() IngressIndexInformer
+	Lister() networkingv1.IngressLister
+}
+
+// IngressIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type IngressIndexInformer cache.TypedSharedIndexInformer[*apinetworkingv1.Ingress]
+
+// IngressHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Ingress.
+type IngressHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apinetworkingv1.Ingress]
+
+// IngressDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Ingress.
+type IngressDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apinetworkingv1.Ingress]
+
+// IngressFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Ingress.
+type IngressFilteringHandler = cache.TypedFilteringResourceEventHandler[*apinetworkingv1.Ingress]
+
+// IngressIndexers is a specialization of [cache.TypedIndexers] for Ingress.
+type IngressIndexers = cache.TypedIndexers[*apinetworkingv1.Ingress]
+
+// DeletedIngress is a specialization of [cache.DeletedObject] for Ingress.
+type DeletedIngress = cache.DeletedObject[*apinetworkingv1.Ingress]
 
 type ingressInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type ingressInformer struct {
 // NewIngressInformer constructs a new informer for Ingress type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedIngressInformer]).
 func NewIngressInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewIngressInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedIngressInformer constructs a new informer for Ingress type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedIngressInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers IngressIndexers) IngressIndexInformer {
+	return NewTypedIngressInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredIngressInformer constructs a new informer for Ingress type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredIngressInformer]).
 func NewFilteredIngressInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewIngressInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedIngressInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredIngressInformer constructs a new informer for Ingress type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredIngressInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers IngressIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) IngressIndexInformer {
+	return NewTypedIngressInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewIngressInformerWithOptions constructs a new informer for Ingress type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedIngressInformerWithOptions]).
 func NewIngressInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedIngressInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedIngressInformerWithOptions constructs a new informer for Ingress type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedIngressInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) IngressIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingresss"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1.Ingress](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewIngressInformerWithOptions(client kubernetes.Interface, namespace string
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *ingressInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewIngressInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedIngressInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *ingressInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apinetworkingv1.Ingress{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *ingressInformer) TypedInformer() IngressIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1.Ingress](f.factory.InformerFor(&apinetworkingv1.Ingress{}, f.defaultInformer))
 }
 
 func (f *ingressInformer) Lister() networkingv1.IngressLister {
 	return networkingv1.NewIngressLister(f.Informer().GetIndexer())
+}
+
+// ToTypedIngressInformer converts an untyped informer into a TypedIngressInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Ingress. If that is not the case, calling type-safe methods of the returned
+// TypedIngressInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedIngressInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedIngressInformer(informer IngressInformer) TypedIngressInformer {
+	if informer, ok := informer.(TypedIngressInformer); ok {
+		return informer
+	}
+	return &ingressTypedInformerAdapter{informer}
+}
+
+type ingressTypedInformerAdapter struct {
+	IngressInformer
+}
+
+func (a *ingressTypedInformerAdapter) TypedInformer() IngressIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1.Ingress](a.Informer())
+}
+
+// ToIngressIndexInformer converts an untyped informer into a IngressIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Ingress. If that is not the case, calling type-safe methods of the returned
+// IngressIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a IngressIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToIngressIndexInformer(informer cache.SharedIndexInformer) IngressIndexInformer {
+	if informer, ok := informer.(IngressIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1.Ingress](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/networking/v1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/ingressclass.go
@@ -34,11 +34,39 @@ import (
 )
 
 // IngressClassInformer provides access to a shared informer and lister for
-// IngressClasses.
+// IngressClasses. Prefer using the type-safe variant (see [TypedIngressClassInformer]).
 type IngressClassInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() networkingv1.IngressClassLister
 }
+
+// TypedIngressClassInformer provides access to a shared informer and lister for
+// IngressClasses, including the type-safe TypedInformer variant.
+// It is a superset of IngressClassInformer.
+type TypedIngressClassInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() IngressClassIndexInformer
+	Lister() networkingv1.IngressClassLister
+}
+
+// IngressClassIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type IngressClassIndexInformer cache.TypedSharedIndexInformer[*apinetworkingv1.IngressClass]
+
+// IngressClassHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for IngressClass.
+type IngressClassHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apinetworkingv1.IngressClass]
+
+// IngressClassDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for IngressClass.
+type IngressClassDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apinetworkingv1.IngressClass]
+
+// IngressClassFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for IngressClass.
+type IngressClassFilteringHandler = cache.TypedFilteringResourceEventHandler[*apinetworkingv1.IngressClass]
+
+// IngressClassIndexers is a specialization of [cache.TypedIndexers] for IngressClass.
+type IngressClassIndexers = cache.TypedIndexers[*apinetworkingv1.IngressClass]
+
+// DeletedIngressClass is a specialization of [cache.DeletedObject] for IngressClass.
+type DeletedIngressClass = cache.DeletedObject[*apinetworkingv1.IngressClass]
 
 type ingressClassInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type ingressClassInformer struct {
 // NewIngressClassInformer constructs a new informer for IngressClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedIngressClassInformer]).
 func NewIngressClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewIngressClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedIngressClassInformer constructs a new informer for IngressClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedIngressClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers IngressClassIndexers) IngressClassIndexInformer {
+	return NewTypedIngressClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredIngressClassInformer constructs a new informer for IngressClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredIngressClassInformer]).
 func NewFilteredIngressClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewIngressClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedIngressClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredIngressClassInformer constructs a new informer for IngressClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredIngressClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers IngressClassIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) IngressClassIndexInformer {
+	return NewTypedIngressClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewIngressClassInformerWithOptions constructs a new informer for IngressClass type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedIngressClassInformerWithOptions]).
 func NewIngressClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedIngressClassInformerWithOptions(client, options)
+}
+
+// NewTypedIngressClassInformerWithOptions constructs a new informer for IngressClass type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedIngressClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) IngressClassIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingressclasss"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1.IngressClass](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewIngressClassInformerWithOptions(client kubernetes.Interface, options int
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *ingressClassInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewIngressClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedIngressClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *ingressClassInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apinetworkingv1.IngressClass{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *ingressClassInformer) TypedInformer() IngressClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1.IngressClass](f.factory.InformerFor(&apinetworkingv1.IngressClass{}, f.defaultInformer))
 }
 
 func (f *ingressClassInformer) Lister() networkingv1.IngressClassLister {
 	return networkingv1.NewIngressClassLister(f.Informer().GetIndexer())
+}
+
+// ToTypedIngressClassInformer converts an untyped informer into a TypedIngressClassInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *IngressClass. If that is not the case, calling type-safe methods of the returned
+// TypedIngressClassInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedIngressClassInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedIngressClassInformer(informer IngressClassInformer) TypedIngressClassInformer {
+	if informer, ok := informer.(TypedIngressClassInformer); ok {
+		return informer
+	}
+	return &ingressClassTypedInformerAdapter{informer}
+}
+
+type ingressClassTypedInformerAdapter struct {
+	IngressClassInformer
+}
+
+func (a *ingressClassTypedInformerAdapter) TypedInformer() IngressClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1.IngressClass](a.Informer())
+}
+
+// ToIngressClassIndexInformer converts an untyped informer into a IngressClassIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *IngressClass. If that is not the case, calling type-safe methods of the returned
+// IngressClassIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a IngressClassIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToIngressClassIndexInformer(informer cache.SharedIndexInformer) IngressClassIndexInformer {
+	if informer, ok := informer.(IngressClassIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1.IngressClass](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/networking/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/interface.go
@@ -25,15 +25,15 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// IPAddresses returns a IPAddressInformer.
-	IPAddresses() IPAddressInformer
+	IPAddresses() TypedIPAddressInformer
 	// Ingresses returns a IngressInformer.
-	Ingresses() IngressInformer
+	Ingresses() TypedIngressInformer
 	// IngressClasses returns a IngressClassInformer.
-	IngressClasses() IngressClassInformer
+	IngressClasses() TypedIngressClassInformer
 	// NetworkPolicies returns a NetworkPolicyInformer.
-	NetworkPolicies() NetworkPolicyInformer
+	NetworkPolicies() TypedNetworkPolicyInformer
 	// ServiceCIDRs returns a ServiceCIDRInformer.
-	ServiceCIDRs() ServiceCIDRInformer
+	ServiceCIDRs() TypedServiceCIDRInformer
 }
 
 type version struct {
@@ -47,27 +47,27 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// IPAddresses returns a IPAddressInformer.
-func (v *version) IPAddresses() IPAddressInformer {
+// IPAddresses returns a TypedIPAddressInformer.
+func (v *version) IPAddresses() TypedIPAddressInformer {
 	return &iPAddressInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// Ingresses returns a IngressInformer.
-func (v *version) Ingresses() IngressInformer {
+// Ingresses returns a TypedIngressInformer.
+func (v *version) Ingresses() TypedIngressInformer {
 	return &ingressInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// IngressClasses returns a IngressClassInformer.
-func (v *version) IngressClasses() IngressClassInformer {
+// IngressClasses returns a TypedIngressClassInformer.
+func (v *version) IngressClasses() TypedIngressClassInformer {
 	return &ingressClassInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// NetworkPolicies returns a NetworkPolicyInformer.
-func (v *version) NetworkPolicies() NetworkPolicyInformer {
+// NetworkPolicies returns a TypedNetworkPolicyInformer.
+func (v *version) NetworkPolicies() TypedNetworkPolicyInformer {
 	return &networkPolicyInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// ServiceCIDRs returns a ServiceCIDRInformer.
-func (v *version) ServiceCIDRs() ServiceCIDRInformer {
+// ServiceCIDRs returns a TypedServiceCIDRInformer.
+func (v *version) ServiceCIDRs() TypedServiceCIDRInformer {
 	return &serviceCIDRInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/networking/v1/ipaddress.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/ipaddress.go
@@ -34,11 +34,39 @@ import (
 )
 
 // IPAddressInformer provides access to a shared informer and lister for
-// IPAddresses.
+// IPAddresses. Prefer using the type-safe variant (see [TypedIPAddressInformer]).
 type IPAddressInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() networkingv1.IPAddressLister
 }
+
+// TypedIPAddressInformer provides access to a shared informer and lister for
+// IPAddresses, including the type-safe TypedInformer variant.
+// It is a superset of IPAddressInformer.
+type TypedIPAddressInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() IPAddressIndexInformer
+	Lister() networkingv1.IPAddressLister
+}
+
+// IPAddressIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type IPAddressIndexInformer cache.TypedSharedIndexInformer[*apinetworkingv1.IPAddress]
+
+// IPAddressHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for IPAddress.
+type IPAddressHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apinetworkingv1.IPAddress]
+
+// IPAddressDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for IPAddress.
+type IPAddressDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apinetworkingv1.IPAddress]
+
+// IPAddressFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for IPAddress.
+type IPAddressFilteringHandler = cache.TypedFilteringResourceEventHandler[*apinetworkingv1.IPAddress]
+
+// IPAddressIndexers is a specialization of [cache.TypedIndexers] for IPAddress.
+type IPAddressIndexers = cache.TypedIndexers[*apinetworkingv1.IPAddress]
+
+// DeletedIPAddress is a specialization of [cache.DeletedObject] for IPAddress.
+type DeletedIPAddress = cache.DeletedObject[*apinetworkingv1.IPAddress]
 
 type iPAddressInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type iPAddressInformer struct {
 // NewIPAddressInformer constructs a new informer for IPAddress type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedIPAddressInformer]).
 func NewIPAddressInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewIPAddressInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedIPAddressInformer constructs a new informer for IPAddress type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedIPAddressInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers IPAddressIndexers) IPAddressIndexInformer {
+	return NewTypedIPAddressInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredIPAddressInformer constructs a new informer for IPAddress type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredIPAddressInformer]).
 func NewFilteredIPAddressInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewIPAddressInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedIPAddressInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredIPAddressInformer constructs a new informer for IPAddress type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredIPAddressInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers IPAddressIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) IPAddressIndexInformer {
+	return NewTypedIPAddressInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewIPAddressInformerWithOptions constructs a new informer for IPAddress type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedIPAddressInformerWithOptions]).
 func NewIPAddressInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedIPAddressInformerWithOptions(client, options)
+}
+
+// NewTypedIPAddressInformerWithOptions constructs a new informer for IPAddress type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedIPAddressInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) IPAddressIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ipaddresss"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1.IPAddress](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewIPAddressInformerWithOptions(client kubernetes.Interface, options intern
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *iPAddressInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewIPAddressInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedIPAddressInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *iPAddressInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apinetworkingv1.IPAddress{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *iPAddressInformer) TypedInformer() IPAddressIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1.IPAddress](f.factory.InformerFor(&apinetworkingv1.IPAddress{}, f.defaultInformer))
 }
 
 func (f *iPAddressInformer) Lister() networkingv1.IPAddressLister {
 	return networkingv1.NewIPAddressLister(f.Informer().GetIndexer())
+}
+
+// ToTypedIPAddressInformer converts an untyped informer into a TypedIPAddressInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *IPAddress. If that is not the case, calling type-safe methods of the returned
+// TypedIPAddressInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedIPAddressInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedIPAddressInformer(informer IPAddressInformer) TypedIPAddressInformer {
+	if informer, ok := informer.(TypedIPAddressInformer); ok {
+		return informer
+	}
+	return &iPAddressTypedInformerAdapter{informer}
+}
+
+type iPAddressTypedInformerAdapter struct {
+	IPAddressInformer
+}
+
+func (a *iPAddressTypedInformerAdapter) TypedInformer() IPAddressIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1.IPAddress](a.Informer())
+}
+
+// ToIPAddressIndexInformer converts an untyped informer into a IPAddressIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *IPAddress. If that is not the case, calling type-safe methods of the returned
+// IPAddressIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a IPAddressIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToIPAddressIndexInformer(informer cache.SharedIndexInformer) IPAddressIndexInformer {
+	if informer, ok := informer.(IPAddressIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1.IPAddress](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/networking/v1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/networkpolicy.go
@@ -34,11 +34,39 @@ import (
 )
 
 // NetworkPolicyInformer provides access to a shared informer and lister for
-// NetworkPolicies.
+// NetworkPolicies. Prefer using the type-safe variant (see [TypedNetworkPolicyInformer]).
 type NetworkPolicyInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() networkingv1.NetworkPolicyLister
 }
+
+// TypedNetworkPolicyInformer provides access to a shared informer and lister for
+// NetworkPolicies, including the type-safe TypedInformer variant.
+// It is a superset of NetworkPolicyInformer.
+type TypedNetworkPolicyInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() NetworkPolicyIndexInformer
+	Lister() networkingv1.NetworkPolicyLister
+}
+
+// NetworkPolicyIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type NetworkPolicyIndexInformer cache.TypedSharedIndexInformer[*apinetworkingv1.NetworkPolicy]
+
+// NetworkPolicyHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for NetworkPolicy.
+type NetworkPolicyHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apinetworkingv1.NetworkPolicy]
+
+// NetworkPolicyDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for NetworkPolicy.
+type NetworkPolicyDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apinetworkingv1.NetworkPolicy]
+
+// NetworkPolicyFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for NetworkPolicy.
+type NetworkPolicyFilteringHandler = cache.TypedFilteringResourceEventHandler[*apinetworkingv1.NetworkPolicy]
+
+// NetworkPolicyIndexers is a specialization of [cache.TypedIndexers] for NetworkPolicy.
+type NetworkPolicyIndexers = cache.TypedIndexers[*apinetworkingv1.NetworkPolicy]
+
+// DeletedNetworkPolicy is a specialization of [cache.DeletedObject] for NetworkPolicy.
+type DeletedNetworkPolicy = cache.DeletedObject[*apinetworkingv1.NetworkPolicy]
 
 type networkPolicyInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type networkPolicyInformer struct {
 // NewNetworkPolicyInformer constructs a new informer for NetworkPolicy type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedNetworkPolicyInformer]).
 func NewNetworkPolicyInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewNetworkPolicyInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedNetworkPolicyInformer constructs a new informer for NetworkPolicy type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedNetworkPolicyInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers NetworkPolicyIndexers) NetworkPolicyIndexInformer {
+	return NewTypedNetworkPolicyInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredNetworkPolicyInformer constructs a new informer for NetworkPolicy type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredNetworkPolicyInformer]).
 func NewFilteredNetworkPolicyInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewNetworkPolicyInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedNetworkPolicyInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredNetworkPolicyInformer constructs a new informer for NetworkPolicy type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredNetworkPolicyInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers NetworkPolicyIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) NetworkPolicyIndexInformer {
+	return NewTypedNetworkPolicyInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewNetworkPolicyInformerWithOptions constructs a new informer for NetworkPolicy type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedNetworkPolicyInformerWithOptions]).
 func NewNetworkPolicyInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedNetworkPolicyInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedNetworkPolicyInformerWithOptions constructs a new informer for NetworkPolicy type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedNetworkPolicyInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) NetworkPolicyIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicys"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1.NetworkPolicy](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewNetworkPolicyInformerWithOptions(client kubernetes.Interface, namespace 
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *networkPolicyInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewNetworkPolicyInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedNetworkPolicyInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *networkPolicyInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apinetworkingv1.NetworkPolicy{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *networkPolicyInformer) TypedInformer() NetworkPolicyIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1.NetworkPolicy](f.factory.InformerFor(&apinetworkingv1.NetworkPolicy{}, f.defaultInformer))
 }
 
 func (f *networkPolicyInformer) Lister() networkingv1.NetworkPolicyLister {
 	return networkingv1.NewNetworkPolicyLister(f.Informer().GetIndexer())
+}
+
+// ToTypedNetworkPolicyInformer converts an untyped informer into a TypedNetworkPolicyInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *NetworkPolicy. If that is not the case, calling type-safe methods of the returned
+// TypedNetworkPolicyInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedNetworkPolicyInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedNetworkPolicyInformer(informer NetworkPolicyInformer) TypedNetworkPolicyInformer {
+	if informer, ok := informer.(TypedNetworkPolicyInformer); ok {
+		return informer
+	}
+	return &networkPolicyTypedInformerAdapter{informer}
+}
+
+type networkPolicyTypedInformerAdapter struct {
+	NetworkPolicyInformer
+}
+
+func (a *networkPolicyTypedInformerAdapter) TypedInformer() NetworkPolicyIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1.NetworkPolicy](a.Informer())
+}
+
+// ToNetworkPolicyIndexInformer converts an untyped informer into a NetworkPolicyIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *NetworkPolicy. If that is not the case, calling type-safe methods of the returned
+// NetworkPolicyIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a NetworkPolicyIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToNetworkPolicyIndexInformer(informer cache.SharedIndexInformer) NetworkPolicyIndexInformer {
+	if informer, ok := informer.(NetworkPolicyIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1.NetworkPolicy](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/networking/v1/servicecidr.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/servicecidr.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ServiceCIDRInformer provides access to a shared informer and lister for
-// ServiceCIDRs.
+// ServiceCIDRs. Prefer using the type-safe variant (see [TypedServiceCIDRInformer]).
 type ServiceCIDRInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() networkingv1.ServiceCIDRLister
 }
+
+// TypedServiceCIDRInformer provides access to a shared informer and lister for
+// ServiceCIDRs, including the type-safe TypedInformer variant.
+// It is a superset of ServiceCIDRInformer.
+type TypedServiceCIDRInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ServiceCIDRIndexInformer
+	Lister() networkingv1.ServiceCIDRLister
+}
+
+// ServiceCIDRIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ServiceCIDRIndexInformer cache.TypedSharedIndexInformer[*apinetworkingv1.ServiceCIDR]
+
+// ServiceCIDRHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ServiceCIDR.
+type ServiceCIDRHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apinetworkingv1.ServiceCIDR]
+
+// ServiceCIDRDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ServiceCIDR.
+type ServiceCIDRDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apinetworkingv1.ServiceCIDR]
+
+// ServiceCIDRFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ServiceCIDR.
+type ServiceCIDRFilteringHandler = cache.TypedFilteringResourceEventHandler[*apinetworkingv1.ServiceCIDR]
+
+// ServiceCIDRIndexers is a specialization of [cache.TypedIndexers] for ServiceCIDR.
+type ServiceCIDRIndexers = cache.TypedIndexers[*apinetworkingv1.ServiceCIDR]
+
+// DeletedServiceCIDR is a specialization of [cache.DeletedObject] for ServiceCIDR.
+type DeletedServiceCIDR = cache.DeletedObject[*apinetworkingv1.ServiceCIDR]
 
 type serviceCIDRInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type serviceCIDRInformer struct {
 // NewServiceCIDRInformer constructs a new informer for ServiceCIDR type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedServiceCIDRInformer]).
 func NewServiceCIDRInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewServiceCIDRInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedServiceCIDRInformer constructs a new informer for ServiceCIDR type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedServiceCIDRInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ServiceCIDRIndexers) ServiceCIDRIndexInformer {
+	return NewTypedServiceCIDRInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredServiceCIDRInformer constructs a new informer for ServiceCIDR type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredServiceCIDRInformer]).
 func NewFilteredServiceCIDRInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewServiceCIDRInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedServiceCIDRInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredServiceCIDRInformer constructs a new informer for ServiceCIDR type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredServiceCIDRInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ServiceCIDRIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ServiceCIDRIndexInformer {
+	return NewTypedServiceCIDRInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewServiceCIDRInformerWithOptions constructs a new informer for ServiceCIDR type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedServiceCIDRInformerWithOptions]).
 func NewServiceCIDRInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedServiceCIDRInformerWithOptions(client, options)
+}
+
+// NewTypedServiceCIDRInformerWithOptions constructs a new informer for ServiceCIDR type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedServiceCIDRInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ServiceCIDRIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "servicecidrs"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1.ServiceCIDR](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewServiceCIDRInformerWithOptions(client kubernetes.Interface, options inte
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *serviceCIDRInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewServiceCIDRInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedServiceCIDRInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *serviceCIDRInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apinetworkingv1.ServiceCIDR{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *serviceCIDRInformer) TypedInformer() ServiceCIDRIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1.ServiceCIDR](f.factory.InformerFor(&apinetworkingv1.ServiceCIDR{}, f.defaultInformer))
 }
 
 func (f *serviceCIDRInformer) Lister() networkingv1.ServiceCIDRLister {
 	return networkingv1.NewServiceCIDRLister(f.Informer().GetIndexer())
+}
+
+// ToTypedServiceCIDRInformer converts an untyped informer into a TypedServiceCIDRInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ServiceCIDR. If that is not the case, calling type-safe methods of the returned
+// TypedServiceCIDRInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedServiceCIDRInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedServiceCIDRInformer(informer ServiceCIDRInformer) TypedServiceCIDRInformer {
+	if informer, ok := informer.(TypedServiceCIDRInformer); ok {
+		return informer
+	}
+	return &serviceCIDRTypedInformerAdapter{informer}
+}
+
+type serviceCIDRTypedInformerAdapter struct {
+	ServiceCIDRInformer
+}
+
+func (a *serviceCIDRTypedInformerAdapter) TypedInformer() ServiceCIDRIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1.ServiceCIDR](a.Informer())
+}
+
+// ToServiceCIDRIndexInformer converts an untyped informer into a ServiceCIDRIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ServiceCIDR. If that is not the case, calling type-safe methods of the returned
+// ServiceCIDRIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ServiceCIDRIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToServiceCIDRIndexInformer(informer cache.SharedIndexInformer) ServiceCIDRIndexInformer {
+	if informer, ok := informer.(ServiceCIDRIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1.ServiceCIDR](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/networking/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1beta1/ingress.go
@@ -34,11 +34,39 @@ import (
 )
 
 // IngressInformer provides access to a shared informer and lister for
-// Ingresses.
+// Ingresses. Prefer using the type-safe variant (see [TypedIngressInformer]).
 type IngressInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() networkingv1beta1.IngressLister
 }
+
+// TypedIngressInformer provides access to a shared informer and lister for
+// Ingresses, including the type-safe TypedInformer variant.
+// It is a superset of IngressInformer.
+type TypedIngressInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() IngressIndexInformer
+	Lister() networkingv1beta1.IngressLister
+}
+
+// IngressIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type IngressIndexInformer cache.TypedSharedIndexInformer[*apinetworkingv1beta1.Ingress]
+
+// IngressHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Ingress.
+type IngressHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apinetworkingv1beta1.Ingress]
+
+// IngressDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Ingress.
+type IngressDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apinetworkingv1beta1.Ingress]
+
+// IngressFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Ingress.
+type IngressFilteringHandler = cache.TypedFilteringResourceEventHandler[*apinetworkingv1beta1.Ingress]
+
+// IngressIndexers is a specialization of [cache.TypedIndexers] for Ingress.
+type IngressIndexers = cache.TypedIndexers[*apinetworkingv1beta1.Ingress]
+
+// DeletedIngress is a specialization of [cache.DeletedObject] for Ingress.
+type DeletedIngress = cache.DeletedObject[*apinetworkingv1beta1.Ingress]
 
 type ingressInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type ingressInformer struct {
 // NewIngressInformer constructs a new informer for Ingress type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedIngressInformer]).
 func NewIngressInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewIngressInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedIngressInformer constructs a new informer for Ingress type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedIngressInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers IngressIndexers) IngressIndexInformer {
+	return NewTypedIngressInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredIngressInformer constructs a new informer for Ingress type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredIngressInformer]).
 func NewFilteredIngressInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewIngressInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedIngressInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredIngressInformer constructs a new informer for Ingress type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredIngressInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers IngressIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) IngressIndexInformer {
+	return NewTypedIngressInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewIngressInformerWithOptions constructs a new informer for Ingress type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedIngressInformerWithOptions]).
 func NewIngressInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedIngressInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedIngressInformerWithOptions constructs a new informer for Ingress type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedIngressInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) IngressIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1beta1", Resource: "ingresss"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1beta1.Ingress](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewIngressInformerWithOptions(client kubernetes.Interface, namespace string
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *ingressInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewIngressInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedIngressInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *ingressInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apinetworkingv1beta1.Ingress{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *ingressInformer) TypedInformer() IngressIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1beta1.Ingress](f.factory.InformerFor(&apinetworkingv1beta1.Ingress{}, f.defaultInformer))
 }
 
 func (f *ingressInformer) Lister() networkingv1beta1.IngressLister {
 	return networkingv1beta1.NewIngressLister(f.Informer().GetIndexer())
+}
+
+// ToTypedIngressInformer converts an untyped informer into a TypedIngressInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Ingress. If that is not the case, calling type-safe methods of the returned
+// TypedIngressInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedIngressInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedIngressInformer(informer IngressInformer) TypedIngressInformer {
+	if informer, ok := informer.(TypedIngressInformer); ok {
+		return informer
+	}
+	return &ingressTypedInformerAdapter{informer}
+}
+
+type ingressTypedInformerAdapter struct {
+	IngressInformer
+}
+
+func (a *ingressTypedInformerAdapter) TypedInformer() IngressIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1beta1.Ingress](a.Informer())
+}
+
+// ToIngressIndexInformer converts an untyped informer into a IngressIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Ingress. If that is not the case, calling type-safe methods of the returned
+// IngressIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a IngressIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToIngressIndexInformer(informer cache.SharedIndexInformer) IngressIndexInformer {
+	if informer, ok := informer.(IngressIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1beta1.Ingress](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/networking/v1beta1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1beta1/ingressclass.go
@@ -34,11 +34,39 @@ import (
 )
 
 // IngressClassInformer provides access to a shared informer and lister for
-// IngressClasses.
+// IngressClasses. Prefer using the type-safe variant (see [TypedIngressClassInformer]).
 type IngressClassInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() networkingv1beta1.IngressClassLister
 }
+
+// TypedIngressClassInformer provides access to a shared informer and lister for
+// IngressClasses, including the type-safe TypedInformer variant.
+// It is a superset of IngressClassInformer.
+type TypedIngressClassInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() IngressClassIndexInformer
+	Lister() networkingv1beta1.IngressClassLister
+}
+
+// IngressClassIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type IngressClassIndexInformer cache.TypedSharedIndexInformer[*apinetworkingv1beta1.IngressClass]
+
+// IngressClassHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for IngressClass.
+type IngressClassHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apinetworkingv1beta1.IngressClass]
+
+// IngressClassDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for IngressClass.
+type IngressClassDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apinetworkingv1beta1.IngressClass]
+
+// IngressClassFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for IngressClass.
+type IngressClassFilteringHandler = cache.TypedFilteringResourceEventHandler[*apinetworkingv1beta1.IngressClass]
+
+// IngressClassIndexers is a specialization of [cache.TypedIndexers] for IngressClass.
+type IngressClassIndexers = cache.TypedIndexers[*apinetworkingv1beta1.IngressClass]
+
+// DeletedIngressClass is a specialization of [cache.DeletedObject] for IngressClass.
+type DeletedIngressClass = cache.DeletedObject[*apinetworkingv1beta1.IngressClass]
 
 type ingressClassInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type ingressClassInformer struct {
 // NewIngressClassInformer constructs a new informer for IngressClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedIngressClassInformer]).
 func NewIngressClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewIngressClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedIngressClassInformer constructs a new informer for IngressClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedIngressClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers IngressClassIndexers) IngressClassIndexInformer {
+	return NewTypedIngressClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredIngressClassInformer constructs a new informer for IngressClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredIngressClassInformer]).
 func NewFilteredIngressClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewIngressClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedIngressClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredIngressClassInformer constructs a new informer for IngressClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredIngressClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers IngressClassIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) IngressClassIndexInformer {
+	return NewTypedIngressClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewIngressClassInformerWithOptions constructs a new informer for IngressClass type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedIngressClassInformerWithOptions]).
 func NewIngressClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedIngressClassInformerWithOptions(client, options)
+}
+
+// NewTypedIngressClassInformerWithOptions constructs a new informer for IngressClass type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedIngressClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) IngressClassIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1beta1", Resource: "ingressclasss"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1beta1.IngressClass](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewIngressClassInformerWithOptions(client kubernetes.Interface, options int
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *ingressClassInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewIngressClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedIngressClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *ingressClassInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apinetworkingv1beta1.IngressClass{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *ingressClassInformer) TypedInformer() IngressClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1beta1.IngressClass](f.factory.InformerFor(&apinetworkingv1beta1.IngressClass{}, f.defaultInformer))
 }
 
 func (f *ingressClassInformer) Lister() networkingv1beta1.IngressClassLister {
 	return networkingv1beta1.NewIngressClassLister(f.Informer().GetIndexer())
+}
+
+// ToTypedIngressClassInformer converts an untyped informer into a TypedIngressClassInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *IngressClass. If that is not the case, calling type-safe methods of the returned
+// TypedIngressClassInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedIngressClassInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedIngressClassInformer(informer IngressClassInformer) TypedIngressClassInformer {
+	if informer, ok := informer.(TypedIngressClassInformer); ok {
+		return informer
+	}
+	return &ingressClassTypedInformerAdapter{informer}
+}
+
+type ingressClassTypedInformerAdapter struct {
+	IngressClassInformer
+}
+
+func (a *ingressClassTypedInformerAdapter) TypedInformer() IngressClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1beta1.IngressClass](a.Informer())
+}
+
+// ToIngressClassIndexInformer converts an untyped informer into a IngressClassIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *IngressClass. If that is not the case, calling type-safe methods of the returned
+// IngressClassIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a IngressClassIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToIngressClassIndexInformer(informer cache.SharedIndexInformer) IngressClassIndexInformer {
+	if informer, ok := informer.(IngressClassIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1beta1.IngressClass](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/networking/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1beta1/interface.go
@@ -25,13 +25,13 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// IPAddresses returns a IPAddressInformer.
-	IPAddresses() IPAddressInformer
+	IPAddresses() TypedIPAddressInformer
 	// Ingresses returns a IngressInformer.
-	Ingresses() IngressInformer
+	Ingresses() TypedIngressInformer
 	// IngressClasses returns a IngressClassInformer.
-	IngressClasses() IngressClassInformer
+	IngressClasses() TypedIngressClassInformer
 	// ServiceCIDRs returns a ServiceCIDRInformer.
-	ServiceCIDRs() ServiceCIDRInformer
+	ServiceCIDRs() TypedServiceCIDRInformer
 }
 
 type version struct {
@@ -45,22 +45,22 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// IPAddresses returns a IPAddressInformer.
-func (v *version) IPAddresses() IPAddressInformer {
+// IPAddresses returns a TypedIPAddressInformer.
+func (v *version) IPAddresses() TypedIPAddressInformer {
 	return &iPAddressInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// Ingresses returns a IngressInformer.
-func (v *version) Ingresses() IngressInformer {
+// Ingresses returns a TypedIngressInformer.
+func (v *version) Ingresses() TypedIngressInformer {
 	return &ingressInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// IngressClasses returns a IngressClassInformer.
-func (v *version) IngressClasses() IngressClassInformer {
+// IngressClasses returns a TypedIngressClassInformer.
+func (v *version) IngressClasses() TypedIngressClassInformer {
 	return &ingressClassInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// ServiceCIDRs returns a ServiceCIDRInformer.
-func (v *version) ServiceCIDRs() ServiceCIDRInformer {
+// ServiceCIDRs returns a TypedServiceCIDRInformer.
+func (v *version) ServiceCIDRs() TypedServiceCIDRInformer {
 	return &serviceCIDRInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/networking/v1beta1/ipaddress.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1beta1/ipaddress.go
@@ -34,11 +34,39 @@ import (
 )
 
 // IPAddressInformer provides access to a shared informer and lister for
-// IPAddresses.
+// IPAddresses. Prefer using the type-safe variant (see [TypedIPAddressInformer]).
 type IPAddressInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() networkingv1beta1.IPAddressLister
 }
+
+// TypedIPAddressInformer provides access to a shared informer and lister for
+// IPAddresses, including the type-safe TypedInformer variant.
+// It is a superset of IPAddressInformer.
+type TypedIPAddressInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() IPAddressIndexInformer
+	Lister() networkingv1beta1.IPAddressLister
+}
+
+// IPAddressIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type IPAddressIndexInformer cache.TypedSharedIndexInformer[*apinetworkingv1beta1.IPAddress]
+
+// IPAddressHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for IPAddress.
+type IPAddressHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apinetworkingv1beta1.IPAddress]
+
+// IPAddressDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for IPAddress.
+type IPAddressDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apinetworkingv1beta1.IPAddress]
+
+// IPAddressFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for IPAddress.
+type IPAddressFilteringHandler = cache.TypedFilteringResourceEventHandler[*apinetworkingv1beta1.IPAddress]
+
+// IPAddressIndexers is a specialization of [cache.TypedIndexers] for IPAddress.
+type IPAddressIndexers = cache.TypedIndexers[*apinetworkingv1beta1.IPAddress]
+
+// DeletedIPAddress is a specialization of [cache.DeletedObject] for IPAddress.
+type DeletedIPAddress = cache.DeletedObject[*apinetworkingv1beta1.IPAddress]
 
 type iPAddressInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type iPAddressInformer struct {
 // NewIPAddressInformer constructs a new informer for IPAddress type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedIPAddressInformer]).
 func NewIPAddressInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewIPAddressInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedIPAddressInformer constructs a new informer for IPAddress type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedIPAddressInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers IPAddressIndexers) IPAddressIndexInformer {
+	return NewTypedIPAddressInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredIPAddressInformer constructs a new informer for IPAddress type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredIPAddressInformer]).
 func NewFilteredIPAddressInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewIPAddressInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedIPAddressInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredIPAddressInformer constructs a new informer for IPAddress type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredIPAddressInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers IPAddressIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) IPAddressIndexInformer {
+	return NewTypedIPAddressInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewIPAddressInformerWithOptions constructs a new informer for IPAddress type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedIPAddressInformerWithOptions]).
 func NewIPAddressInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedIPAddressInformerWithOptions(client, options)
+}
+
+// NewTypedIPAddressInformerWithOptions constructs a new informer for IPAddress type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedIPAddressInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) IPAddressIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1beta1", Resource: "ipaddresss"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1beta1.IPAddress](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewIPAddressInformerWithOptions(client kubernetes.Interface, options intern
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *iPAddressInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewIPAddressInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedIPAddressInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *iPAddressInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apinetworkingv1beta1.IPAddress{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *iPAddressInformer) TypedInformer() IPAddressIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1beta1.IPAddress](f.factory.InformerFor(&apinetworkingv1beta1.IPAddress{}, f.defaultInformer))
 }
 
 func (f *iPAddressInformer) Lister() networkingv1beta1.IPAddressLister {
 	return networkingv1beta1.NewIPAddressLister(f.Informer().GetIndexer())
+}
+
+// ToTypedIPAddressInformer converts an untyped informer into a TypedIPAddressInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *IPAddress. If that is not the case, calling type-safe methods of the returned
+// TypedIPAddressInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedIPAddressInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedIPAddressInformer(informer IPAddressInformer) TypedIPAddressInformer {
+	if informer, ok := informer.(TypedIPAddressInformer); ok {
+		return informer
+	}
+	return &iPAddressTypedInformerAdapter{informer}
+}
+
+type iPAddressTypedInformerAdapter struct {
+	IPAddressInformer
+}
+
+func (a *iPAddressTypedInformerAdapter) TypedInformer() IPAddressIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1beta1.IPAddress](a.Informer())
+}
+
+// ToIPAddressIndexInformer converts an untyped informer into a IPAddressIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *IPAddress. If that is not the case, calling type-safe methods of the returned
+// IPAddressIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a IPAddressIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToIPAddressIndexInformer(informer cache.SharedIndexInformer) IPAddressIndexInformer {
+	if informer, ok := informer.(IPAddressIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1beta1.IPAddress](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/networking/v1beta1/servicecidr.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1beta1/servicecidr.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ServiceCIDRInformer provides access to a shared informer and lister for
-// ServiceCIDRs.
+// ServiceCIDRs. Prefer using the type-safe variant (see [TypedServiceCIDRInformer]).
 type ServiceCIDRInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() networkingv1beta1.ServiceCIDRLister
 }
+
+// TypedServiceCIDRInformer provides access to a shared informer and lister for
+// ServiceCIDRs, including the type-safe TypedInformer variant.
+// It is a superset of ServiceCIDRInformer.
+type TypedServiceCIDRInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ServiceCIDRIndexInformer
+	Lister() networkingv1beta1.ServiceCIDRLister
+}
+
+// ServiceCIDRIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ServiceCIDRIndexInformer cache.TypedSharedIndexInformer[*apinetworkingv1beta1.ServiceCIDR]
+
+// ServiceCIDRHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ServiceCIDR.
+type ServiceCIDRHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apinetworkingv1beta1.ServiceCIDR]
+
+// ServiceCIDRDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ServiceCIDR.
+type ServiceCIDRDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apinetworkingv1beta1.ServiceCIDR]
+
+// ServiceCIDRFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ServiceCIDR.
+type ServiceCIDRFilteringHandler = cache.TypedFilteringResourceEventHandler[*apinetworkingv1beta1.ServiceCIDR]
+
+// ServiceCIDRIndexers is a specialization of [cache.TypedIndexers] for ServiceCIDR.
+type ServiceCIDRIndexers = cache.TypedIndexers[*apinetworkingv1beta1.ServiceCIDR]
+
+// DeletedServiceCIDR is a specialization of [cache.DeletedObject] for ServiceCIDR.
+type DeletedServiceCIDR = cache.DeletedObject[*apinetworkingv1beta1.ServiceCIDR]
 
 type serviceCIDRInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type serviceCIDRInformer struct {
 // NewServiceCIDRInformer constructs a new informer for ServiceCIDR type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedServiceCIDRInformer]).
 func NewServiceCIDRInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewServiceCIDRInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedServiceCIDRInformer constructs a new informer for ServiceCIDR type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedServiceCIDRInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ServiceCIDRIndexers) ServiceCIDRIndexInformer {
+	return NewTypedServiceCIDRInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredServiceCIDRInformer constructs a new informer for ServiceCIDR type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredServiceCIDRInformer]).
 func NewFilteredServiceCIDRInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewServiceCIDRInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedServiceCIDRInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredServiceCIDRInformer constructs a new informer for ServiceCIDR type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredServiceCIDRInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ServiceCIDRIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ServiceCIDRIndexInformer {
+	return NewTypedServiceCIDRInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewServiceCIDRInformerWithOptions constructs a new informer for ServiceCIDR type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedServiceCIDRInformerWithOptions]).
 func NewServiceCIDRInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedServiceCIDRInformerWithOptions(client, options)
+}
+
+// NewTypedServiceCIDRInformerWithOptions constructs a new informer for ServiceCIDR type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedServiceCIDRInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ServiceCIDRIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1beta1", Resource: "servicecidrs"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1beta1.ServiceCIDR](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewServiceCIDRInformerWithOptions(client kubernetes.Interface, options inte
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *serviceCIDRInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewServiceCIDRInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedServiceCIDRInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *serviceCIDRInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apinetworkingv1beta1.ServiceCIDR{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *serviceCIDRInformer) TypedInformer() ServiceCIDRIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1beta1.ServiceCIDR](f.factory.InformerFor(&apinetworkingv1beta1.ServiceCIDR{}, f.defaultInformer))
 }
 
 func (f *serviceCIDRInformer) Lister() networkingv1beta1.ServiceCIDRLister {
 	return networkingv1beta1.NewServiceCIDRLister(f.Informer().GetIndexer())
+}
+
+// ToTypedServiceCIDRInformer converts an untyped informer into a TypedServiceCIDRInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ServiceCIDR. If that is not the case, calling type-safe methods of the returned
+// TypedServiceCIDRInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedServiceCIDRInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedServiceCIDRInformer(informer ServiceCIDRInformer) TypedServiceCIDRInformer {
+	if informer, ok := informer.(TypedServiceCIDRInformer); ok {
+		return informer
+	}
+	return &serviceCIDRTypedInformerAdapter{informer}
+}
+
+type serviceCIDRTypedInformerAdapter struct {
+	ServiceCIDRInformer
+}
+
+func (a *serviceCIDRTypedInformerAdapter) TypedInformer() ServiceCIDRIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1beta1.ServiceCIDR](a.Informer())
+}
+
+// ToServiceCIDRIndexInformer converts an untyped informer into a ServiceCIDRIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ServiceCIDR. If that is not the case, calling type-safe methods of the returned
+// ServiceCIDRIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ServiceCIDRIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToServiceCIDRIndexInformer(informer cache.SharedIndexInformer) ServiceCIDRIndexInformer {
+	if informer, ok := informer.(ServiceCIDRIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apinetworkingv1beta1.ServiceCIDR](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/node/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/node/v1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// RuntimeClasses returns a RuntimeClassInformer.
-	RuntimeClasses() RuntimeClassInformer
+	RuntimeClasses() TypedRuntimeClassInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// RuntimeClasses returns a RuntimeClassInformer.
-func (v *version) RuntimeClasses() RuntimeClassInformer {
+// RuntimeClasses returns a TypedRuntimeClassInformer.
+func (v *version) RuntimeClasses() TypedRuntimeClassInformer {
 	return &runtimeClassInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/node/v1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/informers/node/v1/runtimeclass.go
@@ -34,11 +34,39 @@ import (
 )
 
 // RuntimeClassInformer provides access to a shared informer and lister for
-// RuntimeClasses.
+// RuntimeClasses. Prefer using the type-safe variant (see [TypedRuntimeClassInformer]).
 type RuntimeClassInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() nodev1.RuntimeClassLister
 }
+
+// TypedRuntimeClassInformer provides access to a shared informer and lister for
+// RuntimeClasses, including the type-safe TypedInformer variant.
+// It is a superset of RuntimeClassInformer.
+type TypedRuntimeClassInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() RuntimeClassIndexInformer
+	Lister() nodev1.RuntimeClassLister
+}
+
+// RuntimeClassIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type RuntimeClassIndexInformer cache.TypedSharedIndexInformer[*apinodev1.RuntimeClass]
+
+// RuntimeClassHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for RuntimeClass.
+type RuntimeClassHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apinodev1.RuntimeClass]
+
+// RuntimeClassDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for RuntimeClass.
+type RuntimeClassDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apinodev1.RuntimeClass]
+
+// RuntimeClassFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for RuntimeClass.
+type RuntimeClassFilteringHandler = cache.TypedFilteringResourceEventHandler[*apinodev1.RuntimeClass]
+
+// RuntimeClassIndexers is a specialization of [cache.TypedIndexers] for RuntimeClass.
+type RuntimeClassIndexers = cache.TypedIndexers[*apinodev1.RuntimeClass]
+
+// DeletedRuntimeClass is a specialization of [cache.DeletedObject] for RuntimeClass.
+type DeletedRuntimeClass = cache.DeletedObject[*apinodev1.RuntimeClass]
 
 type runtimeClassInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type runtimeClassInformer struct {
 // NewRuntimeClassInformer constructs a new informer for RuntimeClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedRuntimeClassInformer]).
 func NewRuntimeClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewRuntimeClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedRuntimeClassInformer constructs a new informer for RuntimeClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedRuntimeClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers RuntimeClassIndexers) RuntimeClassIndexInformer {
+	return NewTypedRuntimeClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredRuntimeClassInformer constructs a new informer for RuntimeClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredRuntimeClassInformer]).
 func NewFilteredRuntimeClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewRuntimeClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedRuntimeClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredRuntimeClassInformer constructs a new informer for RuntimeClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredRuntimeClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers RuntimeClassIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) RuntimeClassIndexInformer {
+	return NewTypedRuntimeClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewRuntimeClassInformerWithOptions constructs a new informer for RuntimeClass type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedRuntimeClassInformerWithOptions]).
 func NewRuntimeClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedRuntimeClassInformerWithOptions(client, options)
+}
+
+// NewTypedRuntimeClassInformerWithOptions constructs a new informer for RuntimeClass type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedRuntimeClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) RuntimeClassIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "node.k8s.io", Version: "v1", Resource: "runtimeclasss"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apinodev1.RuntimeClass](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewRuntimeClassInformerWithOptions(client kubernetes.Interface, options int
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *runtimeClassInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewRuntimeClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedRuntimeClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *runtimeClassInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apinodev1.RuntimeClass{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *runtimeClassInformer) TypedInformer() RuntimeClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apinodev1.RuntimeClass](f.factory.InformerFor(&apinodev1.RuntimeClass{}, f.defaultInformer))
 }
 
 func (f *runtimeClassInformer) Lister() nodev1.RuntimeClassLister {
 	return nodev1.NewRuntimeClassLister(f.Informer().GetIndexer())
+}
+
+// ToTypedRuntimeClassInformer converts an untyped informer into a TypedRuntimeClassInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *RuntimeClass. If that is not the case, calling type-safe methods of the returned
+// TypedRuntimeClassInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedRuntimeClassInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedRuntimeClassInformer(informer RuntimeClassInformer) TypedRuntimeClassInformer {
+	if informer, ok := informer.(TypedRuntimeClassInformer); ok {
+		return informer
+	}
+	return &runtimeClassTypedInformerAdapter{informer}
+}
+
+type runtimeClassTypedInformerAdapter struct {
+	RuntimeClassInformer
+}
+
+func (a *runtimeClassTypedInformerAdapter) TypedInformer() RuntimeClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apinodev1.RuntimeClass](a.Informer())
+}
+
+// ToRuntimeClassIndexInformer converts an untyped informer into a RuntimeClassIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *RuntimeClass. If that is not the case, calling type-safe methods of the returned
+// RuntimeClassIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a RuntimeClassIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToRuntimeClassIndexInformer(informer cache.SharedIndexInformer) RuntimeClassIndexInformer {
+	if informer, ok := informer.(RuntimeClassIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apinodev1.RuntimeClass](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/node/v1alpha1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/node/v1alpha1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// RuntimeClasses returns a RuntimeClassInformer.
-	RuntimeClasses() RuntimeClassInformer
+	RuntimeClasses() TypedRuntimeClassInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// RuntimeClasses returns a RuntimeClassInformer.
-func (v *version) RuntimeClasses() RuntimeClassInformer {
+// RuntimeClasses returns a TypedRuntimeClassInformer.
+func (v *version) RuntimeClasses() TypedRuntimeClassInformer {
 	return &runtimeClassInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/node/v1alpha1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/informers/node/v1alpha1/runtimeclass.go
@@ -34,11 +34,39 @@ import (
 )
 
 // RuntimeClassInformer provides access to a shared informer and lister for
-// RuntimeClasses.
+// RuntimeClasses. Prefer using the type-safe variant (see [TypedRuntimeClassInformer]).
 type RuntimeClassInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() nodev1alpha1.RuntimeClassLister
 }
+
+// TypedRuntimeClassInformer provides access to a shared informer and lister for
+// RuntimeClasses, including the type-safe TypedInformer variant.
+// It is a superset of RuntimeClassInformer.
+type TypedRuntimeClassInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() RuntimeClassIndexInformer
+	Lister() nodev1alpha1.RuntimeClassLister
+}
+
+// RuntimeClassIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type RuntimeClassIndexInformer cache.TypedSharedIndexInformer[*apinodev1alpha1.RuntimeClass]
+
+// RuntimeClassHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for RuntimeClass.
+type RuntimeClassHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apinodev1alpha1.RuntimeClass]
+
+// RuntimeClassDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for RuntimeClass.
+type RuntimeClassDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apinodev1alpha1.RuntimeClass]
+
+// RuntimeClassFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for RuntimeClass.
+type RuntimeClassFilteringHandler = cache.TypedFilteringResourceEventHandler[*apinodev1alpha1.RuntimeClass]
+
+// RuntimeClassIndexers is a specialization of [cache.TypedIndexers] for RuntimeClass.
+type RuntimeClassIndexers = cache.TypedIndexers[*apinodev1alpha1.RuntimeClass]
+
+// DeletedRuntimeClass is a specialization of [cache.DeletedObject] for RuntimeClass.
+type DeletedRuntimeClass = cache.DeletedObject[*apinodev1alpha1.RuntimeClass]
 
 type runtimeClassInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type runtimeClassInformer struct {
 // NewRuntimeClassInformer constructs a new informer for RuntimeClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedRuntimeClassInformer]).
 func NewRuntimeClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewRuntimeClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedRuntimeClassInformer constructs a new informer for RuntimeClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedRuntimeClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers RuntimeClassIndexers) RuntimeClassIndexInformer {
+	return NewTypedRuntimeClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredRuntimeClassInformer constructs a new informer for RuntimeClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredRuntimeClassInformer]).
 func NewFilteredRuntimeClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewRuntimeClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedRuntimeClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredRuntimeClassInformer constructs a new informer for RuntimeClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredRuntimeClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers RuntimeClassIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) RuntimeClassIndexInformer {
+	return NewTypedRuntimeClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewRuntimeClassInformerWithOptions constructs a new informer for RuntimeClass type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedRuntimeClassInformerWithOptions]).
 func NewRuntimeClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedRuntimeClassInformerWithOptions(client, options)
+}
+
+// NewTypedRuntimeClassInformerWithOptions constructs a new informer for RuntimeClass type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedRuntimeClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) RuntimeClassIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "node.k8s.io", Version: "v1alpha1", Resource: "runtimeclasss"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apinodev1alpha1.RuntimeClass](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewRuntimeClassInformerWithOptions(client kubernetes.Interface, options int
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *runtimeClassInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewRuntimeClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedRuntimeClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *runtimeClassInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apinodev1alpha1.RuntimeClass{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *runtimeClassInformer) TypedInformer() RuntimeClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apinodev1alpha1.RuntimeClass](f.factory.InformerFor(&apinodev1alpha1.RuntimeClass{}, f.defaultInformer))
 }
 
 func (f *runtimeClassInformer) Lister() nodev1alpha1.RuntimeClassLister {
 	return nodev1alpha1.NewRuntimeClassLister(f.Informer().GetIndexer())
+}
+
+// ToTypedRuntimeClassInformer converts an untyped informer into a TypedRuntimeClassInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *RuntimeClass. If that is not the case, calling type-safe methods of the returned
+// TypedRuntimeClassInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedRuntimeClassInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedRuntimeClassInformer(informer RuntimeClassInformer) TypedRuntimeClassInformer {
+	if informer, ok := informer.(TypedRuntimeClassInformer); ok {
+		return informer
+	}
+	return &runtimeClassTypedInformerAdapter{informer}
+}
+
+type runtimeClassTypedInformerAdapter struct {
+	RuntimeClassInformer
+}
+
+func (a *runtimeClassTypedInformerAdapter) TypedInformer() RuntimeClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apinodev1alpha1.RuntimeClass](a.Informer())
+}
+
+// ToRuntimeClassIndexInformer converts an untyped informer into a RuntimeClassIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *RuntimeClass. If that is not the case, calling type-safe methods of the returned
+// RuntimeClassIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a RuntimeClassIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToRuntimeClassIndexInformer(informer cache.SharedIndexInformer) RuntimeClassIndexInformer {
+	if informer, ok := informer.(RuntimeClassIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apinodev1alpha1.RuntimeClass](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/node/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/node/v1beta1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// RuntimeClasses returns a RuntimeClassInformer.
-	RuntimeClasses() RuntimeClassInformer
+	RuntimeClasses() TypedRuntimeClassInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// RuntimeClasses returns a RuntimeClassInformer.
-func (v *version) RuntimeClasses() RuntimeClassInformer {
+// RuntimeClasses returns a TypedRuntimeClassInformer.
+func (v *version) RuntimeClasses() TypedRuntimeClassInformer {
 	return &runtimeClassInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/node/v1beta1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/informers/node/v1beta1/runtimeclass.go
@@ -34,11 +34,39 @@ import (
 )
 
 // RuntimeClassInformer provides access to a shared informer and lister for
-// RuntimeClasses.
+// RuntimeClasses. Prefer using the type-safe variant (see [TypedRuntimeClassInformer]).
 type RuntimeClassInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() nodev1beta1.RuntimeClassLister
 }
+
+// TypedRuntimeClassInformer provides access to a shared informer and lister for
+// RuntimeClasses, including the type-safe TypedInformer variant.
+// It is a superset of RuntimeClassInformer.
+type TypedRuntimeClassInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() RuntimeClassIndexInformer
+	Lister() nodev1beta1.RuntimeClassLister
+}
+
+// RuntimeClassIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type RuntimeClassIndexInformer cache.TypedSharedIndexInformer[*apinodev1beta1.RuntimeClass]
+
+// RuntimeClassHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for RuntimeClass.
+type RuntimeClassHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apinodev1beta1.RuntimeClass]
+
+// RuntimeClassDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for RuntimeClass.
+type RuntimeClassDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apinodev1beta1.RuntimeClass]
+
+// RuntimeClassFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for RuntimeClass.
+type RuntimeClassFilteringHandler = cache.TypedFilteringResourceEventHandler[*apinodev1beta1.RuntimeClass]
+
+// RuntimeClassIndexers is a specialization of [cache.TypedIndexers] for RuntimeClass.
+type RuntimeClassIndexers = cache.TypedIndexers[*apinodev1beta1.RuntimeClass]
+
+// DeletedRuntimeClass is a specialization of [cache.DeletedObject] for RuntimeClass.
+type DeletedRuntimeClass = cache.DeletedObject[*apinodev1beta1.RuntimeClass]
 
 type runtimeClassInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type runtimeClassInformer struct {
 // NewRuntimeClassInformer constructs a new informer for RuntimeClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedRuntimeClassInformer]).
 func NewRuntimeClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewRuntimeClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedRuntimeClassInformer constructs a new informer for RuntimeClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedRuntimeClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers RuntimeClassIndexers) RuntimeClassIndexInformer {
+	return NewTypedRuntimeClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredRuntimeClassInformer constructs a new informer for RuntimeClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredRuntimeClassInformer]).
 func NewFilteredRuntimeClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewRuntimeClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedRuntimeClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredRuntimeClassInformer constructs a new informer for RuntimeClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredRuntimeClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers RuntimeClassIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) RuntimeClassIndexInformer {
+	return NewTypedRuntimeClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewRuntimeClassInformerWithOptions constructs a new informer for RuntimeClass type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedRuntimeClassInformerWithOptions]).
 func NewRuntimeClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedRuntimeClassInformerWithOptions(client, options)
+}
+
+// NewTypedRuntimeClassInformerWithOptions constructs a new informer for RuntimeClass type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedRuntimeClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) RuntimeClassIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "node.k8s.io", Version: "v1beta1", Resource: "runtimeclasss"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apinodev1beta1.RuntimeClass](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewRuntimeClassInformerWithOptions(client kubernetes.Interface, options int
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *runtimeClassInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewRuntimeClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedRuntimeClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *runtimeClassInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apinodev1beta1.RuntimeClass{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *runtimeClassInformer) TypedInformer() RuntimeClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apinodev1beta1.RuntimeClass](f.factory.InformerFor(&apinodev1beta1.RuntimeClass{}, f.defaultInformer))
 }
 
 func (f *runtimeClassInformer) Lister() nodev1beta1.RuntimeClassLister {
 	return nodev1beta1.NewRuntimeClassLister(f.Informer().GetIndexer())
+}
+
+// ToTypedRuntimeClassInformer converts an untyped informer into a TypedRuntimeClassInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *RuntimeClass. If that is not the case, calling type-safe methods of the returned
+// TypedRuntimeClassInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedRuntimeClassInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedRuntimeClassInformer(informer RuntimeClassInformer) TypedRuntimeClassInformer {
+	if informer, ok := informer.(TypedRuntimeClassInformer); ok {
+		return informer
+	}
+	return &runtimeClassTypedInformerAdapter{informer}
+}
+
+type runtimeClassTypedInformerAdapter struct {
+	RuntimeClassInformer
+}
+
+func (a *runtimeClassTypedInformerAdapter) TypedInformer() RuntimeClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apinodev1beta1.RuntimeClass](a.Informer())
+}
+
+// ToRuntimeClassIndexInformer converts an untyped informer into a RuntimeClassIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *RuntimeClass. If that is not the case, calling type-safe methods of the returned
+// RuntimeClassIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a RuntimeClassIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToRuntimeClassIndexInformer(informer cache.SharedIndexInformer) RuntimeClassIndexInformer {
+	if informer, ok := informer.(RuntimeClassIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apinodev1beta1.RuntimeClass](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/policy/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/policy/v1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// PodDisruptionBudgets returns a PodDisruptionBudgetInformer.
-	PodDisruptionBudgets() PodDisruptionBudgetInformer
+	PodDisruptionBudgets() TypedPodDisruptionBudgetInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// PodDisruptionBudgets returns a PodDisruptionBudgetInformer.
-func (v *version) PodDisruptionBudgets() PodDisruptionBudgetInformer {
+// PodDisruptionBudgets returns a TypedPodDisruptionBudgetInformer.
+func (v *version) PodDisruptionBudgets() TypedPodDisruptionBudgetInformer {
 	return &podDisruptionBudgetInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/policy/v1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/informers/policy/v1/poddisruptionbudget.go
@@ -34,11 +34,39 @@ import (
 )
 
 // PodDisruptionBudgetInformer provides access to a shared informer and lister for
-// PodDisruptionBudgets.
+// PodDisruptionBudgets. Prefer using the type-safe variant (see [TypedPodDisruptionBudgetInformer]).
 type PodDisruptionBudgetInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() policyv1.PodDisruptionBudgetLister
 }
+
+// TypedPodDisruptionBudgetInformer provides access to a shared informer and lister for
+// PodDisruptionBudgets, including the type-safe TypedInformer variant.
+// It is a superset of PodDisruptionBudgetInformer.
+type TypedPodDisruptionBudgetInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() PodDisruptionBudgetIndexInformer
+	Lister() policyv1.PodDisruptionBudgetLister
+}
+
+// PodDisruptionBudgetIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type PodDisruptionBudgetIndexInformer cache.TypedSharedIndexInformer[*apipolicyv1.PodDisruptionBudget]
+
+// PodDisruptionBudgetHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for PodDisruptionBudget.
+type PodDisruptionBudgetHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apipolicyv1.PodDisruptionBudget]
+
+// PodDisruptionBudgetDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for PodDisruptionBudget.
+type PodDisruptionBudgetDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apipolicyv1.PodDisruptionBudget]
+
+// PodDisruptionBudgetFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for PodDisruptionBudget.
+type PodDisruptionBudgetFilteringHandler = cache.TypedFilteringResourceEventHandler[*apipolicyv1.PodDisruptionBudget]
+
+// PodDisruptionBudgetIndexers is a specialization of [cache.TypedIndexers] for PodDisruptionBudget.
+type PodDisruptionBudgetIndexers = cache.TypedIndexers[*apipolicyv1.PodDisruptionBudget]
+
+// DeletedPodDisruptionBudget is a specialization of [cache.DeletedObject] for PodDisruptionBudget.
+type DeletedPodDisruptionBudget = cache.DeletedObject[*apipolicyv1.PodDisruptionBudget]
 
 type podDisruptionBudgetInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type podDisruptionBudgetInformer struct {
 // NewPodDisruptionBudgetInformer constructs a new informer for PodDisruptionBudget type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPodDisruptionBudgetInformer]).
 func NewPodDisruptionBudgetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewPodDisruptionBudgetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedPodDisruptionBudgetInformer constructs a new informer for PodDisruptionBudget type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPodDisruptionBudgetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers PodDisruptionBudgetIndexers) PodDisruptionBudgetIndexInformer {
+	return NewTypedPodDisruptionBudgetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredPodDisruptionBudgetInformer constructs a new informer for PodDisruptionBudget type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredPodDisruptionBudgetInformer]).
 func NewFilteredPodDisruptionBudgetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewPodDisruptionBudgetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedPodDisruptionBudgetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredPodDisruptionBudgetInformer constructs a new informer for PodDisruptionBudget type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredPodDisruptionBudgetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers PodDisruptionBudgetIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) PodDisruptionBudgetIndexInformer {
+	return NewTypedPodDisruptionBudgetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewPodDisruptionBudgetInformerWithOptions constructs a new informer for PodDisruptionBudget type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPodDisruptionBudgetInformerWithOptions]).
 func NewPodDisruptionBudgetInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedPodDisruptionBudgetInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedPodDisruptionBudgetInformerWithOptions constructs a new informer for PodDisruptionBudget type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPodDisruptionBudgetInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) PodDisruptionBudgetIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "policy", Version: "v1", Resource: "poddisruptionbudgets"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apipolicyv1.PodDisruptionBudget](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewPodDisruptionBudgetInformerWithOptions(client kubernetes.Interface, name
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *podDisruptionBudgetInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewPodDisruptionBudgetInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedPodDisruptionBudgetInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *podDisruptionBudgetInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apipolicyv1.PodDisruptionBudget{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *podDisruptionBudgetInformer) TypedInformer() PodDisruptionBudgetIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apipolicyv1.PodDisruptionBudget](f.factory.InformerFor(&apipolicyv1.PodDisruptionBudget{}, f.defaultInformer))
 }
 
 func (f *podDisruptionBudgetInformer) Lister() policyv1.PodDisruptionBudgetLister {
 	return policyv1.NewPodDisruptionBudgetLister(f.Informer().GetIndexer())
+}
+
+// ToTypedPodDisruptionBudgetInformer converts an untyped informer into a TypedPodDisruptionBudgetInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *PodDisruptionBudget. If that is not the case, calling type-safe methods of the returned
+// TypedPodDisruptionBudgetInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedPodDisruptionBudgetInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedPodDisruptionBudgetInformer(informer PodDisruptionBudgetInformer) TypedPodDisruptionBudgetInformer {
+	if informer, ok := informer.(TypedPodDisruptionBudgetInformer); ok {
+		return informer
+	}
+	return &podDisruptionBudgetTypedInformerAdapter{informer}
+}
+
+type podDisruptionBudgetTypedInformerAdapter struct {
+	PodDisruptionBudgetInformer
+}
+
+func (a *podDisruptionBudgetTypedInformerAdapter) TypedInformer() PodDisruptionBudgetIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apipolicyv1.PodDisruptionBudget](a.Informer())
+}
+
+// ToPodDisruptionBudgetIndexInformer converts an untyped informer into a PodDisruptionBudgetIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *PodDisruptionBudget. If that is not the case, calling type-safe methods of the returned
+// PodDisruptionBudgetIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a PodDisruptionBudgetIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToPodDisruptionBudgetIndexInformer(informer cache.SharedIndexInformer) PodDisruptionBudgetIndexInformer {
+	if informer, ok := informer.(PodDisruptionBudgetIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apipolicyv1.PodDisruptionBudget](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/policy/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/policy/v1beta1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// PodDisruptionBudgets returns a PodDisruptionBudgetInformer.
-	PodDisruptionBudgets() PodDisruptionBudgetInformer
+	PodDisruptionBudgets() TypedPodDisruptionBudgetInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// PodDisruptionBudgets returns a PodDisruptionBudgetInformer.
-func (v *version) PodDisruptionBudgets() PodDisruptionBudgetInformer {
+// PodDisruptionBudgets returns a TypedPodDisruptionBudgetInformer.
+func (v *version) PodDisruptionBudgets() TypedPodDisruptionBudgetInformer {
 	return &podDisruptionBudgetInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/informers/policy/v1beta1/poddisruptionbudget.go
@@ -34,11 +34,39 @@ import (
 )
 
 // PodDisruptionBudgetInformer provides access to a shared informer and lister for
-// PodDisruptionBudgets.
+// PodDisruptionBudgets. Prefer using the type-safe variant (see [TypedPodDisruptionBudgetInformer]).
 type PodDisruptionBudgetInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() policyv1beta1.PodDisruptionBudgetLister
 }
+
+// TypedPodDisruptionBudgetInformer provides access to a shared informer and lister for
+// PodDisruptionBudgets, including the type-safe TypedInformer variant.
+// It is a superset of PodDisruptionBudgetInformer.
+type TypedPodDisruptionBudgetInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() PodDisruptionBudgetIndexInformer
+	Lister() policyv1beta1.PodDisruptionBudgetLister
+}
+
+// PodDisruptionBudgetIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type PodDisruptionBudgetIndexInformer cache.TypedSharedIndexInformer[*apipolicyv1beta1.PodDisruptionBudget]
+
+// PodDisruptionBudgetHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for PodDisruptionBudget.
+type PodDisruptionBudgetHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apipolicyv1beta1.PodDisruptionBudget]
+
+// PodDisruptionBudgetDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for PodDisruptionBudget.
+type PodDisruptionBudgetDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apipolicyv1beta1.PodDisruptionBudget]
+
+// PodDisruptionBudgetFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for PodDisruptionBudget.
+type PodDisruptionBudgetFilteringHandler = cache.TypedFilteringResourceEventHandler[*apipolicyv1beta1.PodDisruptionBudget]
+
+// PodDisruptionBudgetIndexers is a specialization of [cache.TypedIndexers] for PodDisruptionBudget.
+type PodDisruptionBudgetIndexers = cache.TypedIndexers[*apipolicyv1beta1.PodDisruptionBudget]
+
+// DeletedPodDisruptionBudget is a specialization of [cache.DeletedObject] for PodDisruptionBudget.
+type DeletedPodDisruptionBudget = cache.DeletedObject[*apipolicyv1beta1.PodDisruptionBudget]
 
 type podDisruptionBudgetInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type podDisruptionBudgetInformer struct {
 // NewPodDisruptionBudgetInformer constructs a new informer for PodDisruptionBudget type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPodDisruptionBudgetInformer]).
 func NewPodDisruptionBudgetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewPodDisruptionBudgetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedPodDisruptionBudgetInformer constructs a new informer for PodDisruptionBudget type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPodDisruptionBudgetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers PodDisruptionBudgetIndexers) PodDisruptionBudgetIndexInformer {
+	return NewTypedPodDisruptionBudgetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredPodDisruptionBudgetInformer constructs a new informer for PodDisruptionBudget type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredPodDisruptionBudgetInformer]).
 func NewFilteredPodDisruptionBudgetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewPodDisruptionBudgetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedPodDisruptionBudgetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredPodDisruptionBudgetInformer constructs a new informer for PodDisruptionBudget type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredPodDisruptionBudgetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers PodDisruptionBudgetIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) PodDisruptionBudgetIndexInformer {
+	return NewTypedPodDisruptionBudgetInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewPodDisruptionBudgetInformerWithOptions constructs a new informer for PodDisruptionBudget type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPodDisruptionBudgetInformerWithOptions]).
 func NewPodDisruptionBudgetInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedPodDisruptionBudgetInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedPodDisruptionBudgetInformerWithOptions constructs a new informer for PodDisruptionBudget type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPodDisruptionBudgetInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) PodDisruptionBudgetIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "policy", Version: "v1beta1", Resource: "poddisruptionbudgets"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apipolicyv1beta1.PodDisruptionBudget](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewPodDisruptionBudgetInformerWithOptions(client kubernetes.Interface, name
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *podDisruptionBudgetInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewPodDisruptionBudgetInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedPodDisruptionBudgetInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *podDisruptionBudgetInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apipolicyv1beta1.PodDisruptionBudget{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *podDisruptionBudgetInformer) TypedInformer() PodDisruptionBudgetIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apipolicyv1beta1.PodDisruptionBudget](f.factory.InformerFor(&apipolicyv1beta1.PodDisruptionBudget{}, f.defaultInformer))
 }
 
 func (f *podDisruptionBudgetInformer) Lister() policyv1beta1.PodDisruptionBudgetLister {
 	return policyv1beta1.NewPodDisruptionBudgetLister(f.Informer().GetIndexer())
+}
+
+// ToTypedPodDisruptionBudgetInformer converts an untyped informer into a TypedPodDisruptionBudgetInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *PodDisruptionBudget. If that is not the case, calling type-safe methods of the returned
+// TypedPodDisruptionBudgetInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedPodDisruptionBudgetInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedPodDisruptionBudgetInformer(informer PodDisruptionBudgetInformer) TypedPodDisruptionBudgetInformer {
+	if informer, ok := informer.(TypedPodDisruptionBudgetInformer); ok {
+		return informer
+	}
+	return &podDisruptionBudgetTypedInformerAdapter{informer}
+}
+
+type podDisruptionBudgetTypedInformerAdapter struct {
+	PodDisruptionBudgetInformer
+}
+
+func (a *podDisruptionBudgetTypedInformerAdapter) TypedInformer() PodDisruptionBudgetIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apipolicyv1beta1.PodDisruptionBudget](a.Informer())
+}
+
+// ToPodDisruptionBudgetIndexInformer converts an untyped informer into a PodDisruptionBudgetIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *PodDisruptionBudget. If that is not the case, calling type-safe methods of the returned
+// PodDisruptionBudgetIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a PodDisruptionBudgetIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToPodDisruptionBudgetIndexInformer(informer cache.SharedIndexInformer) PodDisruptionBudgetIndexInformer {
+	if informer, ok := informer.(PodDisruptionBudgetIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apipolicyv1beta1.PodDisruptionBudget](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/rbac/v1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1/clusterrole.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ClusterRoleInformer provides access to a shared informer and lister for
-// ClusterRoles.
+// ClusterRoles. Prefer using the type-safe variant (see [TypedClusterRoleInformer]).
 type ClusterRoleInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() rbacv1.ClusterRoleLister
 }
+
+// TypedClusterRoleInformer provides access to a shared informer and lister for
+// ClusterRoles, including the type-safe TypedInformer variant.
+// It is a superset of ClusterRoleInformer.
+type TypedClusterRoleInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ClusterRoleIndexInformer
+	Lister() rbacv1.ClusterRoleLister
+}
+
+// ClusterRoleIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ClusterRoleIndexInformer cache.TypedSharedIndexInformer[*apirbacv1.ClusterRole]
+
+// ClusterRoleHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ClusterRole.
+type ClusterRoleHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apirbacv1.ClusterRole]
+
+// ClusterRoleDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ClusterRole.
+type ClusterRoleDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apirbacv1.ClusterRole]
+
+// ClusterRoleFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ClusterRole.
+type ClusterRoleFilteringHandler = cache.TypedFilteringResourceEventHandler[*apirbacv1.ClusterRole]
+
+// ClusterRoleIndexers is a specialization of [cache.TypedIndexers] for ClusterRole.
+type ClusterRoleIndexers = cache.TypedIndexers[*apirbacv1.ClusterRole]
+
+// DeletedClusterRole is a specialization of [cache.DeletedObject] for ClusterRole.
+type DeletedClusterRole = cache.DeletedObject[*apirbacv1.ClusterRole]
 
 type clusterRoleInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type clusterRoleInformer struct {
 // NewClusterRoleInformer constructs a new informer for ClusterRole type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedClusterRoleInformer]).
 func NewClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewClusterRoleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedClusterRoleInformer constructs a new informer for ClusterRole type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ClusterRoleIndexers) ClusterRoleIndexInformer {
+	return NewTypedClusterRoleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredClusterRoleInformer constructs a new informer for ClusterRole type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredClusterRoleInformer]).
 func NewFilteredClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewClusterRoleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedClusterRoleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredClusterRoleInformer constructs a new informer for ClusterRole type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ClusterRoleIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ClusterRoleIndexInformer {
+	return NewTypedClusterRoleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewClusterRoleInformerWithOptions constructs a new informer for ClusterRole type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedClusterRoleInformerWithOptions]).
 func NewClusterRoleInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedClusterRoleInformerWithOptions(client, options)
+}
+
+// NewTypedClusterRoleInformerWithOptions constructs a new informer for ClusterRole type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedClusterRoleInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ClusterRoleIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apirbacv1.ClusterRole](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewClusterRoleInformerWithOptions(client kubernetes.Interface, options inte
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *clusterRoleInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewClusterRoleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedClusterRoleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *clusterRoleInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apirbacv1.ClusterRole{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *clusterRoleInformer) TypedInformer() ClusterRoleIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apirbacv1.ClusterRole](f.factory.InformerFor(&apirbacv1.ClusterRole{}, f.defaultInformer))
 }
 
 func (f *clusterRoleInformer) Lister() rbacv1.ClusterRoleLister {
 	return rbacv1.NewClusterRoleLister(f.Informer().GetIndexer())
+}
+
+// ToTypedClusterRoleInformer converts an untyped informer into a TypedClusterRoleInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ClusterRole. If that is not the case, calling type-safe methods of the returned
+// TypedClusterRoleInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedClusterRoleInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedClusterRoleInformer(informer ClusterRoleInformer) TypedClusterRoleInformer {
+	if informer, ok := informer.(TypedClusterRoleInformer); ok {
+		return informer
+	}
+	return &clusterRoleTypedInformerAdapter{informer}
+}
+
+type clusterRoleTypedInformerAdapter struct {
+	ClusterRoleInformer
+}
+
+func (a *clusterRoleTypedInformerAdapter) TypedInformer() ClusterRoleIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apirbacv1.ClusterRole](a.Informer())
+}
+
+// ToClusterRoleIndexInformer converts an untyped informer into a ClusterRoleIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ClusterRole. If that is not the case, calling type-safe methods of the returned
+// ClusterRoleIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ClusterRoleIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToClusterRoleIndexInformer(informer cache.SharedIndexInformer) ClusterRoleIndexInformer {
+	if informer, ok := informer.(ClusterRoleIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apirbacv1.ClusterRole](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/rbac/v1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1/clusterrolebinding.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ClusterRoleBindingInformer provides access to a shared informer and lister for
-// ClusterRoleBindings.
+// ClusterRoleBindings. Prefer using the type-safe variant (see [TypedClusterRoleBindingInformer]).
 type ClusterRoleBindingInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() rbacv1.ClusterRoleBindingLister
 }
+
+// TypedClusterRoleBindingInformer provides access to a shared informer and lister for
+// ClusterRoleBindings, including the type-safe TypedInformer variant.
+// It is a superset of ClusterRoleBindingInformer.
+type TypedClusterRoleBindingInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ClusterRoleBindingIndexInformer
+	Lister() rbacv1.ClusterRoleBindingLister
+}
+
+// ClusterRoleBindingIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ClusterRoleBindingIndexInformer cache.TypedSharedIndexInformer[*apirbacv1.ClusterRoleBinding]
+
+// ClusterRoleBindingHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ClusterRoleBinding.
+type ClusterRoleBindingHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apirbacv1.ClusterRoleBinding]
+
+// ClusterRoleBindingDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ClusterRoleBinding.
+type ClusterRoleBindingDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apirbacv1.ClusterRoleBinding]
+
+// ClusterRoleBindingFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ClusterRoleBinding.
+type ClusterRoleBindingFilteringHandler = cache.TypedFilteringResourceEventHandler[*apirbacv1.ClusterRoleBinding]
+
+// ClusterRoleBindingIndexers is a specialization of [cache.TypedIndexers] for ClusterRoleBinding.
+type ClusterRoleBindingIndexers = cache.TypedIndexers[*apirbacv1.ClusterRoleBinding]
+
+// DeletedClusterRoleBinding is a specialization of [cache.DeletedObject] for ClusterRoleBinding.
+type DeletedClusterRoleBinding = cache.DeletedObject[*apirbacv1.ClusterRoleBinding]
 
 type clusterRoleBindingInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type clusterRoleBindingInformer struct {
 // NewClusterRoleBindingInformer constructs a new informer for ClusterRoleBinding type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedClusterRoleBindingInformer]).
 func NewClusterRoleBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewClusterRoleBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedClusterRoleBindingInformer constructs a new informer for ClusterRoleBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedClusterRoleBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ClusterRoleBindingIndexers) ClusterRoleBindingIndexInformer {
+	return NewTypedClusterRoleBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredClusterRoleBindingInformer constructs a new informer for ClusterRoleBinding type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredClusterRoleBindingInformer]).
 func NewFilteredClusterRoleBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewClusterRoleBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedClusterRoleBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredClusterRoleBindingInformer constructs a new informer for ClusterRoleBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredClusterRoleBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ClusterRoleBindingIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ClusterRoleBindingIndexInformer {
+	return NewTypedClusterRoleBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewClusterRoleBindingInformerWithOptions constructs a new informer for ClusterRoleBinding type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedClusterRoleBindingInformerWithOptions]).
 func NewClusterRoleBindingInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedClusterRoleBindingInformerWithOptions(client, options)
+}
+
+// NewTypedClusterRoleBindingInformerWithOptions constructs a new informer for ClusterRoleBinding type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedClusterRoleBindingInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ClusterRoleBindingIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apirbacv1.ClusterRoleBinding](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewClusterRoleBindingInformerWithOptions(client kubernetes.Interface, optio
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *clusterRoleBindingInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewClusterRoleBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedClusterRoleBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *clusterRoleBindingInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apirbacv1.ClusterRoleBinding{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *clusterRoleBindingInformer) TypedInformer() ClusterRoleBindingIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apirbacv1.ClusterRoleBinding](f.factory.InformerFor(&apirbacv1.ClusterRoleBinding{}, f.defaultInformer))
 }
 
 func (f *clusterRoleBindingInformer) Lister() rbacv1.ClusterRoleBindingLister {
 	return rbacv1.NewClusterRoleBindingLister(f.Informer().GetIndexer())
+}
+
+// ToTypedClusterRoleBindingInformer converts an untyped informer into a TypedClusterRoleBindingInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ClusterRoleBinding. If that is not the case, calling type-safe methods of the returned
+// TypedClusterRoleBindingInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedClusterRoleBindingInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedClusterRoleBindingInformer(informer ClusterRoleBindingInformer) TypedClusterRoleBindingInformer {
+	if informer, ok := informer.(TypedClusterRoleBindingInformer); ok {
+		return informer
+	}
+	return &clusterRoleBindingTypedInformerAdapter{informer}
+}
+
+type clusterRoleBindingTypedInformerAdapter struct {
+	ClusterRoleBindingInformer
+}
+
+func (a *clusterRoleBindingTypedInformerAdapter) TypedInformer() ClusterRoleBindingIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apirbacv1.ClusterRoleBinding](a.Informer())
+}
+
+// ToClusterRoleBindingIndexInformer converts an untyped informer into a ClusterRoleBindingIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ClusterRoleBinding. If that is not the case, calling type-safe methods of the returned
+// ClusterRoleBindingIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ClusterRoleBindingIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToClusterRoleBindingIndexInformer(informer cache.SharedIndexInformer) ClusterRoleBindingIndexInformer {
+	if informer, ok := informer.(ClusterRoleBindingIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apirbacv1.ClusterRoleBinding](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/rbac/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1/interface.go
@@ -25,13 +25,13 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// ClusterRoles returns a ClusterRoleInformer.
-	ClusterRoles() ClusterRoleInformer
+	ClusterRoles() TypedClusterRoleInformer
 	// ClusterRoleBindings returns a ClusterRoleBindingInformer.
-	ClusterRoleBindings() ClusterRoleBindingInformer
+	ClusterRoleBindings() TypedClusterRoleBindingInformer
 	// Roles returns a RoleInformer.
-	Roles() RoleInformer
+	Roles() TypedRoleInformer
 	// RoleBindings returns a RoleBindingInformer.
-	RoleBindings() RoleBindingInformer
+	RoleBindings() TypedRoleBindingInformer
 }
 
 type version struct {
@@ -45,22 +45,22 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// ClusterRoles returns a ClusterRoleInformer.
-func (v *version) ClusterRoles() ClusterRoleInformer {
+// ClusterRoles returns a TypedClusterRoleInformer.
+func (v *version) ClusterRoles() TypedClusterRoleInformer {
 	return &clusterRoleInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// ClusterRoleBindings returns a ClusterRoleBindingInformer.
-func (v *version) ClusterRoleBindings() ClusterRoleBindingInformer {
+// ClusterRoleBindings returns a TypedClusterRoleBindingInformer.
+func (v *version) ClusterRoleBindings() TypedClusterRoleBindingInformer {
 	return &clusterRoleBindingInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// Roles returns a RoleInformer.
-func (v *version) Roles() RoleInformer {
+// Roles returns a TypedRoleInformer.
+func (v *version) Roles() TypedRoleInformer {
 	return &roleInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// RoleBindings returns a RoleBindingInformer.
-func (v *version) RoleBindings() RoleBindingInformer {
+// RoleBindings returns a TypedRoleBindingInformer.
+func (v *version) RoleBindings() TypedRoleBindingInformer {
 	return &roleBindingInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/rbac/v1/role.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1/role.go
@@ -34,11 +34,39 @@ import (
 )
 
 // RoleInformer provides access to a shared informer and lister for
-// Roles.
+// Roles. Prefer using the type-safe variant (see [TypedRoleInformer]).
 type RoleInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() rbacv1.RoleLister
 }
+
+// TypedRoleInformer provides access to a shared informer and lister for
+// Roles, including the type-safe TypedInformer variant.
+// It is a superset of RoleInformer.
+type TypedRoleInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() RoleIndexInformer
+	Lister() rbacv1.RoleLister
+}
+
+// RoleIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type RoleIndexInformer cache.TypedSharedIndexInformer[*apirbacv1.Role]
+
+// RoleHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Role.
+type RoleHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apirbacv1.Role]
+
+// RoleDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Role.
+type RoleDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apirbacv1.Role]
+
+// RoleFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Role.
+type RoleFilteringHandler = cache.TypedFilteringResourceEventHandler[*apirbacv1.Role]
+
+// RoleIndexers is a specialization of [cache.TypedIndexers] for Role.
+type RoleIndexers = cache.TypedIndexers[*apirbacv1.Role]
+
+// DeletedRole is a specialization of [cache.DeletedObject] for Role.
+type DeletedRole = cache.DeletedObject[*apirbacv1.Role]
 
 type roleInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type roleInformer struct {
 // NewRoleInformer constructs a new informer for Role type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedRoleInformer]).
 func NewRoleInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewRoleInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedRoleInformer constructs a new informer for Role type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedRoleInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers RoleIndexers) RoleIndexInformer {
+	return NewTypedRoleInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredRoleInformer constructs a new informer for Role type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredRoleInformer]).
 func NewFilteredRoleInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewRoleInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedRoleInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredRoleInformer constructs a new informer for Role type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredRoleInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers RoleIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) RoleIndexInformer {
+	return NewTypedRoleInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewRoleInformerWithOptions constructs a new informer for Role type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedRoleInformerWithOptions]).
 func NewRoleInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedRoleInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedRoleInformerWithOptions constructs a new informer for Role type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedRoleInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) RoleIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apirbacv1.Role](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewRoleInformerWithOptions(client kubernetes.Interface, namespace string, o
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *roleInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewRoleInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedRoleInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *roleInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apirbacv1.Role{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *roleInformer) TypedInformer() RoleIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apirbacv1.Role](f.factory.InformerFor(&apirbacv1.Role{}, f.defaultInformer))
 }
 
 func (f *roleInformer) Lister() rbacv1.RoleLister {
 	return rbacv1.NewRoleLister(f.Informer().GetIndexer())
+}
+
+// ToTypedRoleInformer converts an untyped informer into a TypedRoleInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Role. If that is not the case, calling type-safe methods of the returned
+// TypedRoleInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedRoleInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedRoleInformer(informer RoleInformer) TypedRoleInformer {
+	if informer, ok := informer.(TypedRoleInformer); ok {
+		return informer
+	}
+	return &roleTypedInformerAdapter{informer}
+}
+
+type roleTypedInformerAdapter struct {
+	RoleInformer
+}
+
+func (a *roleTypedInformerAdapter) TypedInformer() RoleIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apirbacv1.Role](a.Informer())
+}
+
+// ToRoleIndexInformer converts an untyped informer into a RoleIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Role. If that is not the case, calling type-safe methods of the returned
+// RoleIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a RoleIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToRoleIndexInformer(informer cache.SharedIndexInformer) RoleIndexInformer {
+	if informer, ok := informer.(RoleIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apirbacv1.Role](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/rbac/v1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1/rolebinding.go
@@ -34,11 +34,39 @@ import (
 )
 
 // RoleBindingInformer provides access to a shared informer and lister for
-// RoleBindings.
+// RoleBindings. Prefer using the type-safe variant (see [TypedRoleBindingInformer]).
 type RoleBindingInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() rbacv1.RoleBindingLister
 }
+
+// TypedRoleBindingInformer provides access to a shared informer and lister for
+// RoleBindings, including the type-safe TypedInformer variant.
+// It is a superset of RoleBindingInformer.
+type TypedRoleBindingInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() RoleBindingIndexInformer
+	Lister() rbacv1.RoleBindingLister
+}
+
+// RoleBindingIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type RoleBindingIndexInformer cache.TypedSharedIndexInformer[*apirbacv1.RoleBinding]
+
+// RoleBindingHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for RoleBinding.
+type RoleBindingHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apirbacv1.RoleBinding]
+
+// RoleBindingDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for RoleBinding.
+type RoleBindingDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apirbacv1.RoleBinding]
+
+// RoleBindingFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for RoleBinding.
+type RoleBindingFilteringHandler = cache.TypedFilteringResourceEventHandler[*apirbacv1.RoleBinding]
+
+// RoleBindingIndexers is a specialization of [cache.TypedIndexers] for RoleBinding.
+type RoleBindingIndexers = cache.TypedIndexers[*apirbacv1.RoleBinding]
+
+// DeletedRoleBinding is a specialization of [cache.DeletedObject] for RoleBinding.
+type DeletedRoleBinding = cache.DeletedObject[*apirbacv1.RoleBinding]
 
 type roleBindingInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type roleBindingInformer struct {
 // NewRoleBindingInformer constructs a new informer for RoleBinding type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedRoleBindingInformer]).
 func NewRoleBindingInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewRoleBindingInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedRoleBindingInformer constructs a new informer for RoleBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedRoleBindingInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers RoleBindingIndexers) RoleBindingIndexInformer {
+	return NewTypedRoleBindingInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredRoleBindingInformer constructs a new informer for RoleBinding type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredRoleBindingInformer]).
 func NewFilteredRoleBindingInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewRoleBindingInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedRoleBindingInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredRoleBindingInformer constructs a new informer for RoleBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredRoleBindingInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers RoleBindingIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) RoleBindingIndexInformer {
+	return NewTypedRoleBindingInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewRoleBindingInformerWithOptions constructs a new informer for RoleBinding type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedRoleBindingInformerWithOptions]).
 func NewRoleBindingInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedRoleBindingInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedRoleBindingInformerWithOptions constructs a new informer for RoleBinding type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedRoleBindingInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) RoleBindingIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apirbacv1.RoleBinding](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewRoleBindingInformerWithOptions(client kubernetes.Interface, namespace st
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *roleBindingInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewRoleBindingInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedRoleBindingInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *roleBindingInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apirbacv1.RoleBinding{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *roleBindingInformer) TypedInformer() RoleBindingIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apirbacv1.RoleBinding](f.factory.InformerFor(&apirbacv1.RoleBinding{}, f.defaultInformer))
 }
 
 func (f *roleBindingInformer) Lister() rbacv1.RoleBindingLister {
 	return rbacv1.NewRoleBindingLister(f.Informer().GetIndexer())
+}
+
+// ToTypedRoleBindingInformer converts an untyped informer into a TypedRoleBindingInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *RoleBinding. If that is not the case, calling type-safe methods of the returned
+// TypedRoleBindingInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedRoleBindingInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedRoleBindingInformer(informer RoleBindingInformer) TypedRoleBindingInformer {
+	if informer, ok := informer.(TypedRoleBindingInformer); ok {
+		return informer
+	}
+	return &roleBindingTypedInformerAdapter{informer}
+}
+
+type roleBindingTypedInformerAdapter struct {
+	RoleBindingInformer
+}
+
+func (a *roleBindingTypedInformerAdapter) TypedInformer() RoleBindingIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apirbacv1.RoleBinding](a.Informer())
+}
+
+// ToRoleBindingIndexInformer converts an untyped informer into a RoleBindingIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *RoleBinding. If that is not the case, calling type-safe methods of the returned
+// RoleBindingIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a RoleBindingIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToRoleBindingIndexInformer(informer cache.SharedIndexInformer) RoleBindingIndexInformer {
+	if informer, ok := informer.(RoleBindingIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apirbacv1.RoleBinding](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/clusterrole.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ClusterRoleInformer provides access to a shared informer and lister for
-// ClusterRoles.
+// ClusterRoles. Prefer using the type-safe variant (see [TypedClusterRoleInformer]).
 type ClusterRoleInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() rbacv1alpha1.ClusterRoleLister
 }
+
+// TypedClusterRoleInformer provides access to a shared informer and lister for
+// ClusterRoles, including the type-safe TypedInformer variant.
+// It is a superset of ClusterRoleInformer.
+type TypedClusterRoleInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ClusterRoleIndexInformer
+	Lister() rbacv1alpha1.ClusterRoleLister
+}
+
+// ClusterRoleIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ClusterRoleIndexInformer cache.TypedSharedIndexInformer[*apirbacv1alpha1.ClusterRole]
+
+// ClusterRoleHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ClusterRole.
+type ClusterRoleHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apirbacv1alpha1.ClusterRole]
+
+// ClusterRoleDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ClusterRole.
+type ClusterRoleDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apirbacv1alpha1.ClusterRole]
+
+// ClusterRoleFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ClusterRole.
+type ClusterRoleFilteringHandler = cache.TypedFilteringResourceEventHandler[*apirbacv1alpha1.ClusterRole]
+
+// ClusterRoleIndexers is a specialization of [cache.TypedIndexers] for ClusterRole.
+type ClusterRoleIndexers = cache.TypedIndexers[*apirbacv1alpha1.ClusterRole]
+
+// DeletedClusterRole is a specialization of [cache.DeletedObject] for ClusterRole.
+type DeletedClusterRole = cache.DeletedObject[*apirbacv1alpha1.ClusterRole]
 
 type clusterRoleInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type clusterRoleInformer struct {
 // NewClusterRoleInformer constructs a new informer for ClusterRole type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedClusterRoleInformer]).
 func NewClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewClusterRoleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedClusterRoleInformer constructs a new informer for ClusterRole type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ClusterRoleIndexers) ClusterRoleIndexInformer {
+	return NewTypedClusterRoleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredClusterRoleInformer constructs a new informer for ClusterRole type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredClusterRoleInformer]).
 func NewFilteredClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewClusterRoleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedClusterRoleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredClusterRoleInformer constructs a new informer for ClusterRole type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ClusterRoleIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ClusterRoleIndexInformer {
+	return NewTypedClusterRoleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewClusterRoleInformerWithOptions constructs a new informer for ClusterRole type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedClusterRoleInformerWithOptions]).
 func NewClusterRoleInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedClusterRoleInformerWithOptions(client, options)
+}
+
+// NewTypedClusterRoleInformerWithOptions constructs a new informer for ClusterRole type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedClusterRoleInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ClusterRoleIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1alpha1", Resource: "clusterroles"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apirbacv1alpha1.ClusterRole](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewClusterRoleInformerWithOptions(client kubernetes.Interface, options inte
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *clusterRoleInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewClusterRoleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedClusterRoleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *clusterRoleInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apirbacv1alpha1.ClusterRole{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *clusterRoleInformer) TypedInformer() ClusterRoleIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apirbacv1alpha1.ClusterRole](f.factory.InformerFor(&apirbacv1alpha1.ClusterRole{}, f.defaultInformer))
 }
 
 func (f *clusterRoleInformer) Lister() rbacv1alpha1.ClusterRoleLister {
 	return rbacv1alpha1.NewClusterRoleLister(f.Informer().GetIndexer())
+}
+
+// ToTypedClusterRoleInformer converts an untyped informer into a TypedClusterRoleInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ClusterRole. If that is not the case, calling type-safe methods of the returned
+// TypedClusterRoleInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedClusterRoleInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedClusterRoleInformer(informer ClusterRoleInformer) TypedClusterRoleInformer {
+	if informer, ok := informer.(TypedClusterRoleInformer); ok {
+		return informer
+	}
+	return &clusterRoleTypedInformerAdapter{informer}
+}
+
+type clusterRoleTypedInformerAdapter struct {
+	ClusterRoleInformer
+}
+
+func (a *clusterRoleTypedInformerAdapter) TypedInformer() ClusterRoleIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apirbacv1alpha1.ClusterRole](a.Informer())
+}
+
+// ToClusterRoleIndexInformer converts an untyped informer into a ClusterRoleIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ClusterRole. If that is not the case, calling type-safe methods of the returned
+// ClusterRoleIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ClusterRoleIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToClusterRoleIndexInformer(informer cache.SharedIndexInformer) ClusterRoleIndexInformer {
+	if informer, ok := informer.(ClusterRoleIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apirbacv1alpha1.ClusterRole](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/clusterrolebinding.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ClusterRoleBindingInformer provides access to a shared informer and lister for
-// ClusterRoleBindings.
+// ClusterRoleBindings. Prefer using the type-safe variant (see [TypedClusterRoleBindingInformer]).
 type ClusterRoleBindingInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() rbacv1alpha1.ClusterRoleBindingLister
 }
+
+// TypedClusterRoleBindingInformer provides access to a shared informer and lister for
+// ClusterRoleBindings, including the type-safe TypedInformer variant.
+// It is a superset of ClusterRoleBindingInformer.
+type TypedClusterRoleBindingInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ClusterRoleBindingIndexInformer
+	Lister() rbacv1alpha1.ClusterRoleBindingLister
+}
+
+// ClusterRoleBindingIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ClusterRoleBindingIndexInformer cache.TypedSharedIndexInformer[*apirbacv1alpha1.ClusterRoleBinding]
+
+// ClusterRoleBindingHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ClusterRoleBinding.
+type ClusterRoleBindingHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apirbacv1alpha1.ClusterRoleBinding]
+
+// ClusterRoleBindingDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ClusterRoleBinding.
+type ClusterRoleBindingDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apirbacv1alpha1.ClusterRoleBinding]
+
+// ClusterRoleBindingFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ClusterRoleBinding.
+type ClusterRoleBindingFilteringHandler = cache.TypedFilteringResourceEventHandler[*apirbacv1alpha1.ClusterRoleBinding]
+
+// ClusterRoleBindingIndexers is a specialization of [cache.TypedIndexers] for ClusterRoleBinding.
+type ClusterRoleBindingIndexers = cache.TypedIndexers[*apirbacv1alpha1.ClusterRoleBinding]
+
+// DeletedClusterRoleBinding is a specialization of [cache.DeletedObject] for ClusterRoleBinding.
+type DeletedClusterRoleBinding = cache.DeletedObject[*apirbacv1alpha1.ClusterRoleBinding]
 
 type clusterRoleBindingInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type clusterRoleBindingInformer struct {
 // NewClusterRoleBindingInformer constructs a new informer for ClusterRoleBinding type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedClusterRoleBindingInformer]).
 func NewClusterRoleBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewClusterRoleBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedClusterRoleBindingInformer constructs a new informer for ClusterRoleBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedClusterRoleBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ClusterRoleBindingIndexers) ClusterRoleBindingIndexInformer {
+	return NewTypedClusterRoleBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredClusterRoleBindingInformer constructs a new informer for ClusterRoleBinding type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredClusterRoleBindingInformer]).
 func NewFilteredClusterRoleBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewClusterRoleBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedClusterRoleBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredClusterRoleBindingInformer constructs a new informer for ClusterRoleBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredClusterRoleBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ClusterRoleBindingIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ClusterRoleBindingIndexInformer {
+	return NewTypedClusterRoleBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewClusterRoleBindingInformerWithOptions constructs a new informer for ClusterRoleBinding type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedClusterRoleBindingInformerWithOptions]).
 func NewClusterRoleBindingInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedClusterRoleBindingInformerWithOptions(client, options)
+}
+
+// NewTypedClusterRoleBindingInformerWithOptions constructs a new informer for ClusterRoleBinding type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedClusterRoleBindingInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ClusterRoleBindingIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1alpha1", Resource: "clusterrolebindings"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apirbacv1alpha1.ClusterRoleBinding](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewClusterRoleBindingInformerWithOptions(client kubernetes.Interface, optio
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *clusterRoleBindingInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewClusterRoleBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedClusterRoleBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *clusterRoleBindingInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apirbacv1alpha1.ClusterRoleBinding{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *clusterRoleBindingInformer) TypedInformer() ClusterRoleBindingIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apirbacv1alpha1.ClusterRoleBinding](f.factory.InformerFor(&apirbacv1alpha1.ClusterRoleBinding{}, f.defaultInformer))
 }
 
 func (f *clusterRoleBindingInformer) Lister() rbacv1alpha1.ClusterRoleBindingLister {
 	return rbacv1alpha1.NewClusterRoleBindingLister(f.Informer().GetIndexer())
+}
+
+// ToTypedClusterRoleBindingInformer converts an untyped informer into a TypedClusterRoleBindingInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ClusterRoleBinding. If that is not the case, calling type-safe methods of the returned
+// TypedClusterRoleBindingInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedClusterRoleBindingInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedClusterRoleBindingInformer(informer ClusterRoleBindingInformer) TypedClusterRoleBindingInformer {
+	if informer, ok := informer.(TypedClusterRoleBindingInformer); ok {
+		return informer
+	}
+	return &clusterRoleBindingTypedInformerAdapter{informer}
+}
+
+type clusterRoleBindingTypedInformerAdapter struct {
+	ClusterRoleBindingInformer
+}
+
+func (a *clusterRoleBindingTypedInformerAdapter) TypedInformer() ClusterRoleBindingIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apirbacv1alpha1.ClusterRoleBinding](a.Informer())
+}
+
+// ToClusterRoleBindingIndexInformer converts an untyped informer into a ClusterRoleBindingIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ClusterRoleBinding. If that is not the case, calling type-safe methods of the returned
+// ClusterRoleBindingIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ClusterRoleBindingIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToClusterRoleBindingIndexInformer(informer cache.SharedIndexInformer) ClusterRoleBindingIndexInformer {
+	if informer, ok := informer.(ClusterRoleBindingIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apirbacv1alpha1.ClusterRoleBinding](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/interface.go
@@ -25,13 +25,13 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// ClusterRoles returns a ClusterRoleInformer.
-	ClusterRoles() ClusterRoleInformer
+	ClusterRoles() TypedClusterRoleInformer
 	// ClusterRoleBindings returns a ClusterRoleBindingInformer.
-	ClusterRoleBindings() ClusterRoleBindingInformer
+	ClusterRoleBindings() TypedClusterRoleBindingInformer
 	// Roles returns a RoleInformer.
-	Roles() RoleInformer
+	Roles() TypedRoleInformer
 	// RoleBindings returns a RoleBindingInformer.
-	RoleBindings() RoleBindingInformer
+	RoleBindings() TypedRoleBindingInformer
 }
 
 type version struct {
@@ -45,22 +45,22 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// ClusterRoles returns a ClusterRoleInformer.
-func (v *version) ClusterRoles() ClusterRoleInformer {
+// ClusterRoles returns a TypedClusterRoleInformer.
+func (v *version) ClusterRoles() TypedClusterRoleInformer {
 	return &clusterRoleInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// ClusterRoleBindings returns a ClusterRoleBindingInformer.
-func (v *version) ClusterRoleBindings() ClusterRoleBindingInformer {
+// ClusterRoleBindings returns a TypedClusterRoleBindingInformer.
+func (v *version) ClusterRoleBindings() TypedClusterRoleBindingInformer {
 	return &clusterRoleBindingInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// Roles returns a RoleInformer.
-func (v *version) Roles() RoleInformer {
+// Roles returns a TypedRoleInformer.
+func (v *version) Roles() TypedRoleInformer {
 	return &roleInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// RoleBindings returns a RoleBindingInformer.
-func (v *version) RoleBindings() RoleBindingInformer {
+// RoleBindings returns a TypedRoleBindingInformer.
+func (v *version) RoleBindings() TypedRoleBindingInformer {
 	return &roleBindingInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/role.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/role.go
@@ -34,11 +34,39 @@ import (
 )
 
 // RoleInformer provides access to a shared informer and lister for
-// Roles.
+// Roles. Prefer using the type-safe variant (see [TypedRoleInformer]).
 type RoleInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() rbacv1alpha1.RoleLister
 }
+
+// TypedRoleInformer provides access to a shared informer and lister for
+// Roles, including the type-safe TypedInformer variant.
+// It is a superset of RoleInformer.
+type TypedRoleInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() RoleIndexInformer
+	Lister() rbacv1alpha1.RoleLister
+}
+
+// RoleIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type RoleIndexInformer cache.TypedSharedIndexInformer[*apirbacv1alpha1.Role]
+
+// RoleHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Role.
+type RoleHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apirbacv1alpha1.Role]
+
+// RoleDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Role.
+type RoleDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apirbacv1alpha1.Role]
+
+// RoleFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Role.
+type RoleFilteringHandler = cache.TypedFilteringResourceEventHandler[*apirbacv1alpha1.Role]
+
+// RoleIndexers is a specialization of [cache.TypedIndexers] for Role.
+type RoleIndexers = cache.TypedIndexers[*apirbacv1alpha1.Role]
+
+// DeletedRole is a specialization of [cache.DeletedObject] for Role.
+type DeletedRole = cache.DeletedObject[*apirbacv1alpha1.Role]
 
 type roleInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type roleInformer struct {
 // NewRoleInformer constructs a new informer for Role type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedRoleInformer]).
 func NewRoleInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewRoleInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedRoleInformer constructs a new informer for Role type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedRoleInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers RoleIndexers) RoleIndexInformer {
+	return NewTypedRoleInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredRoleInformer constructs a new informer for Role type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredRoleInformer]).
 func NewFilteredRoleInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewRoleInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedRoleInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredRoleInformer constructs a new informer for Role type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredRoleInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers RoleIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) RoleIndexInformer {
+	return NewTypedRoleInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewRoleInformerWithOptions constructs a new informer for Role type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedRoleInformerWithOptions]).
 func NewRoleInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedRoleInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedRoleInformerWithOptions constructs a new informer for Role type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedRoleInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) RoleIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1alpha1", Resource: "roles"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apirbacv1alpha1.Role](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewRoleInformerWithOptions(client kubernetes.Interface, namespace string, o
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *roleInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewRoleInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedRoleInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *roleInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apirbacv1alpha1.Role{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *roleInformer) TypedInformer() RoleIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apirbacv1alpha1.Role](f.factory.InformerFor(&apirbacv1alpha1.Role{}, f.defaultInformer))
 }
 
 func (f *roleInformer) Lister() rbacv1alpha1.RoleLister {
 	return rbacv1alpha1.NewRoleLister(f.Informer().GetIndexer())
+}
+
+// ToTypedRoleInformer converts an untyped informer into a TypedRoleInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Role. If that is not the case, calling type-safe methods of the returned
+// TypedRoleInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedRoleInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedRoleInformer(informer RoleInformer) TypedRoleInformer {
+	if informer, ok := informer.(TypedRoleInformer); ok {
+		return informer
+	}
+	return &roleTypedInformerAdapter{informer}
+}
+
+type roleTypedInformerAdapter struct {
+	RoleInformer
+}
+
+func (a *roleTypedInformerAdapter) TypedInformer() RoleIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apirbacv1alpha1.Role](a.Informer())
+}
+
+// ToRoleIndexInformer converts an untyped informer into a RoleIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Role. If that is not the case, calling type-safe methods of the returned
+// RoleIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a RoleIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToRoleIndexInformer(informer cache.SharedIndexInformer) RoleIndexInformer {
+	if informer, ok := informer.(RoleIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apirbacv1alpha1.Role](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/rolebinding.go
@@ -34,11 +34,39 @@ import (
 )
 
 // RoleBindingInformer provides access to a shared informer and lister for
-// RoleBindings.
+// RoleBindings. Prefer using the type-safe variant (see [TypedRoleBindingInformer]).
 type RoleBindingInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() rbacv1alpha1.RoleBindingLister
 }
+
+// TypedRoleBindingInformer provides access to a shared informer and lister for
+// RoleBindings, including the type-safe TypedInformer variant.
+// It is a superset of RoleBindingInformer.
+type TypedRoleBindingInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() RoleBindingIndexInformer
+	Lister() rbacv1alpha1.RoleBindingLister
+}
+
+// RoleBindingIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type RoleBindingIndexInformer cache.TypedSharedIndexInformer[*apirbacv1alpha1.RoleBinding]
+
+// RoleBindingHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for RoleBinding.
+type RoleBindingHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apirbacv1alpha1.RoleBinding]
+
+// RoleBindingDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for RoleBinding.
+type RoleBindingDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apirbacv1alpha1.RoleBinding]
+
+// RoleBindingFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for RoleBinding.
+type RoleBindingFilteringHandler = cache.TypedFilteringResourceEventHandler[*apirbacv1alpha1.RoleBinding]
+
+// RoleBindingIndexers is a specialization of [cache.TypedIndexers] for RoleBinding.
+type RoleBindingIndexers = cache.TypedIndexers[*apirbacv1alpha1.RoleBinding]
+
+// DeletedRoleBinding is a specialization of [cache.DeletedObject] for RoleBinding.
+type DeletedRoleBinding = cache.DeletedObject[*apirbacv1alpha1.RoleBinding]
 
 type roleBindingInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type roleBindingInformer struct {
 // NewRoleBindingInformer constructs a new informer for RoleBinding type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedRoleBindingInformer]).
 func NewRoleBindingInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewRoleBindingInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedRoleBindingInformer constructs a new informer for RoleBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedRoleBindingInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers RoleBindingIndexers) RoleBindingIndexInformer {
+	return NewTypedRoleBindingInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredRoleBindingInformer constructs a new informer for RoleBinding type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredRoleBindingInformer]).
 func NewFilteredRoleBindingInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewRoleBindingInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedRoleBindingInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredRoleBindingInformer constructs a new informer for RoleBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredRoleBindingInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers RoleBindingIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) RoleBindingIndexInformer {
+	return NewTypedRoleBindingInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewRoleBindingInformerWithOptions constructs a new informer for RoleBinding type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedRoleBindingInformerWithOptions]).
 func NewRoleBindingInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedRoleBindingInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedRoleBindingInformerWithOptions constructs a new informer for RoleBinding type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedRoleBindingInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) RoleBindingIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1alpha1", Resource: "rolebindings"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apirbacv1alpha1.RoleBinding](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewRoleBindingInformerWithOptions(client kubernetes.Interface, namespace st
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *roleBindingInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewRoleBindingInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedRoleBindingInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *roleBindingInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apirbacv1alpha1.RoleBinding{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *roleBindingInformer) TypedInformer() RoleBindingIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apirbacv1alpha1.RoleBinding](f.factory.InformerFor(&apirbacv1alpha1.RoleBinding{}, f.defaultInformer))
 }
 
 func (f *roleBindingInformer) Lister() rbacv1alpha1.RoleBindingLister {
 	return rbacv1alpha1.NewRoleBindingLister(f.Informer().GetIndexer())
+}
+
+// ToTypedRoleBindingInformer converts an untyped informer into a TypedRoleBindingInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *RoleBinding. If that is not the case, calling type-safe methods of the returned
+// TypedRoleBindingInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedRoleBindingInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedRoleBindingInformer(informer RoleBindingInformer) TypedRoleBindingInformer {
+	if informer, ok := informer.(TypedRoleBindingInformer); ok {
+		return informer
+	}
+	return &roleBindingTypedInformerAdapter{informer}
+}
+
+type roleBindingTypedInformerAdapter struct {
+	RoleBindingInformer
+}
+
+func (a *roleBindingTypedInformerAdapter) TypedInformer() RoleBindingIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apirbacv1alpha1.RoleBinding](a.Informer())
+}
+
+// ToRoleBindingIndexInformer converts an untyped informer into a RoleBindingIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *RoleBinding. If that is not the case, calling type-safe methods of the returned
+// RoleBindingIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a RoleBindingIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToRoleBindingIndexInformer(informer cache.SharedIndexInformer) RoleBindingIndexInformer {
+	if informer, ok := informer.(RoleBindingIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apirbacv1alpha1.RoleBinding](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/clusterrole.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ClusterRoleInformer provides access to a shared informer and lister for
-// ClusterRoles.
+// ClusterRoles. Prefer using the type-safe variant (see [TypedClusterRoleInformer]).
 type ClusterRoleInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() rbacv1beta1.ClusterRoleLister
 }
+
+// TypedClusterRoleInformer provides access to a shared informer and lister for
+// ClusterRoles, including the type-safe TypedInformer variant.
+// It is a superset of ClusterRoleInformer.
+type TypedClusterRoleInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ClusterRoleIndexInformer
+	Lister() rbacv1beta1.ClusterRoleLister
+}
+
+// ClusterRoleIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ClusterRoleIndexInformer cache.TypedSharedIndexInformer[*apirbacv1beta1.ClusterRole]
+
+// ClusterRoleHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ClusterRole.
+type ClusterRoleHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apirbacv1beta1.ClusterRole]
+
+// ClusterRoleDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ClusterRole.
+type ClusterRoleDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apirbacv1beta1.ClusterRole]
+
+// ClusterRoleFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ClusterRole.
+type ClusterRoleFilteringHandler = cache.TypedFilteringResourceEventHandler[*apirbacv1beta1.ClusterRole]
+
+// ClusterRoleIndexers is a specialization of [cache.TypedIndexers] for ClusterRole.
+type ClusterRoleIndexers = cache.TypedIndexers[*apirbacv1beta1.ClusterRole]
+
+// DeletedClusterRole is a specialization of [cache.DeletedObject] for ClusterRole.
+type DeletedClusterRole = cache.DeletedObject[*apirbacv1beta1.ClusterRole]
 
 type clusterRoleInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type clusterRoleInformer struct {
 // NewClusterRoleInformer constructs a new informer for ClusterRole type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedClusterRoleInformer]).
 func NewClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewClusterRoleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedClusterRoleInformer constructs a new informer for ClusterRole type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ClusterRoleIndexers) ClusterRoleIndexInformer {
+	return NewTypedClusterRoleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredClusterRoleInformer constructs a new informer for ClusterRole type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredClusterRoleInformer]).
 func NewFilteredClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewClusterRoleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedClusterRoleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredClusterRoleInformer constructs a new informer for ClusterRole type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ClusterRoleIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ClusterRoleIndexInformer {
+	return NewTypedClusterRoleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewClusterRoleInformerWithOptions constructs a new informer for ClusterRole type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedClusterRoleInformerWithOptions]).
 func NewClusterRoleInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedClusterRoleInformerWithOptions(client, options)
+}
+
+// NewTypedClusterRoleInformerWithOptions constructs a new informer for ClusterRole type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedClusterRoleInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ClusterRoleIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Resource: "clusterroles"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apirbacv1beta1.ClusterRole](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewClusterRoleInformerWithOptions(client kubernetes.Interface, options inte
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *clusterRoleInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewClusterRoleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedClusterRoleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *clusterRoleInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apirbacv1beta1.ClusterRole{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *clusterRoleInformer) TypedInformer() ClusterRoleIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apirbacv1beta1.ClusterRole](f.factory.InformerFor(&apirbacv1beta1.ClusterRole{}, f.defaultInformer))
 }
 
 func (f *clusterRoleInformer) Lister() rbacv1beta1.ClusterRoleLister {
 	return rbacv1beta1.NewClusterRoleLister(f.Informer().GetIndexer())
+}
+
+// ToTypedClusterRoleInformer converts an untyped informer into a TypedClusterRoleInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ClusterRole. If that is not the case, calling type-safe methods of the returned
+// TypedClusterRoleInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedClusterRoleInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedClusterRoleInformer(informer ClusterRoleInformer) TypedClusterRoleInformer {
+	if informer, ok := informer.(TypedClusterRoleInformer); ok {
+		return informer
+	}
+	return &clusterRoleTypedInformerAdapter{informer}
+}
+
+type clusterRoleTypedInformerAdapter struct {
+	ClusterRoleInformer
+}
+
+func (a *clusterRoleTypedInformerAdapter) TypedInformer() ClusterRoleIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apirbacv1beta1.ClusterRole](a.Informer())
+}
+
+// ToClusterRoleIndexInformer converts an untyped informer into a ClusterRoleIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ClusterRole. If that is not the case, calling type-safe methods of the returned
+// ClusterRoleIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ClusterRoleIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToClusterRoleIndexInformer(informer cache.SharedIndexInformer) ClusterRoleIndexInformer {
+	if informer, ok := informer.(ClusterRoleIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apirbacv1beta1.ClusterRole](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/clusterrolebinding.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ClusterRoleBindingInformer provides access to a shared informer and lister for
-// ClusterRoleBindings.
+// ClusterRoleBindings. Prefer using the type-safe variant (see [TypedClusterRoleBindingInformer]).
 type ClusterRoleBindingInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() rbacv1beta1.ClusterRoleBindingLister
 }
+
+// TypedClusterRoleBindingInformer provides access to a shared informer and lister for
+// ClusterRoleBindings, including the type-safe TypedInformer variant.
+// It is a superset of ClusterRoleBindingInformer.
+type TypedClusterRoleBindingInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ClusterRoleBindingIndexInformer
+	Lister() rbacv1beta1.ClusterRoleBindingLister
+}
+
+// ClusterRoleBindingIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ClusterRoleBindingIndexInformer cache.TypedSharedIndexInformer[*apirbacv1beta1.ClusterRoleBinding]
+
+// ClusterRoleBindingHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ClusterRoleBinding.
+type ClusterRoleBindingHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apirbacv1beta1.ClusterRoleBinding]
+
+// ClusterRoleBindingDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ClusterRoleBinding.
+type ClusterRoleBindingDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apirbacv1beta1.ClusterRoleBinding]
+
+// ClusterRoleBindingFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ClusterRoleBinding.
+type ClusterRoleBindingFilteringHandler = cache.TypedFilteringResourceEventHandler[*apirbacv1beta1.ClusterRoleBinding]
+
+// ClusterRoleBindingIndexers is a specialization of [cache.TypedIndexers] for ClusterRoleBinding.
+type ClusterRoleBindingIndexers = cache.TypedIndexers[*apirbacv1beta1.ClusterRoleBinding]
+
+// DeletedClusterRoleBinding is a specialization of [cache.DeletedObject] for ClusterRoleBinding.
+type DeletedClusterRoleBinding = cache.DeletedObject[*apirbacv1beta1.ClusterRoleBinding]
 
 type clusterRoleBindingInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type clusterRoleBindingInformer struct {
 // NewClusterRoleBindingInformer constructs a new informer for ClusterRoleBinding type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedClusterRoleBindingInformer]).
 func NewClusterRoleBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewClusterRoleBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedClusterRoleBindingInformer constructs a new informer for ClusterRoleBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedClusterRoleBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ClusterRoleBindingIndexers) ClusterRoleBindingIndexInformer {
+	return NewTypedClusterRoleBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredClusterRoleBindingInformer constructs a new informer for ClusterRoleBinding type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredClusterRoleBindingInformer]).
 func NewFilteredClusterRoleBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewClusterRoleBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedClusterRoleBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredClusterRoleBindingInformer constructs a new informer for ClusterRoleBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredClusterRoleBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ClusterRoleBindingIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ClusterRoleBindingIndexInformer {
+	return NewTypedClusterRoleBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewClusterRoleBindingInformerWithOptions constructs a new informer for ClusterRoleBinding type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedClusterRoleBindingInformerWithOptions]).
 func NewClusterRoleBindingInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedClusterRoleBindingInformerWithOptions(client, options)
+}
+
+// NewTypedClusterRoleBindingInformerWithOptions constructs a new informer for ClusterRoleBinding type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedClusterRoleBindingInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ClusterRoleBindingIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Resource: "clusterrolebindings"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apirbacv1beta1.ClusterRoleBinding](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewClusterRoleBindingInformerWithOptions(client kubernetes.Interface, optio
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *clusterRoleBindingInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewClusterRoleBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedClusterRoleBindingInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *clusterRoleBindingInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apirbacv1beta1.ClusterRoleBinding{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *clusterRoleBindingInformer) TypedInformer() ClusterRoleBindingIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apirbacv1beta1.ClusterRoleBinding](f.factory.InformerFor(&apirbacv1beta1.ClusterRoleBinding{}, f.defaultInformer))
 }
 
 func (f *clusterRoleBindingInformer) Lister() rbacv1beta1.ClusterRoleBindingLister {
 	return rbacv1beta1.NewClusterRoleBindingLister(f.Informer().GetIndexer())
+}
+
+// ToTypedClusterRoleBindingInformer converts an untyped informer into a TypedClusterRoleBindingInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ClusterRoleBinding. If that is not the case, calling type-safe methods of the returned
+// TypedClusterRoleBindingInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedClusterRoleBindingInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedClusterRoleBindingInformer(informer ClusterRoleBindingInformer) TypedClusterRoleBindingInformer {
+	if informer, ok := informer.(TypedClusterRoleBindingInformer); ok {
+		return informer
+	}
+	return &clusterRoleBindingTypedInformerAdapter{informer}
+}
+
+type clusterRoleBindingTypedInformerAdapter struct {
+	ClusterRoleBindingInformer
+}
+
+func (a *clusterRoleBindingTypedInformerAdapter) TypedInformer() ClusterRoleBindingIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apirbacv1beta1.ClusterRoleBinding](a.Informer())
+}
+
+// ToClusterRoleBindingIndexInformer converts an untyped informer into a ClusterRoleBindingIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ClusterRoleBinding. If that is not the case, calling type-safe methods of the returned
+// ClusterRoleBindingIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ClusterRoleBindingIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToClusterRoleBindingIndexInformer(informer cache.SharedIndexInformer) ClusterRoleBindingIndexInformer {
+	if informer, ok := informer.(ClusterRoleBindingIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apirbacv1beta1.ClusterRoleBinding](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/interface.go
@@ -25,13 +25,13 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// ClusterRoles returns a ClusterRoleInformer.
-	ClusterRoles() ClusterRoleInformer
+	ClusterRoles() TypedClusterRoleInformer
 	// ClusterRoleBindings returns a ClusterRoleBindingInformer.
-	ClusterRoleBindings() ClusterRoleBindingInformer
+	ClusterRoleBindings() TypedClusterRoleBindingInformer
 	// Roles returns a RoleInformer.
-	Roles() RoleInformer
+	Roles() TypedRoleInformer
 	// RoleBindings returns a RoleBindingInformer.
-	RoleBindings() RoleBindingInformer
+	RoleBindings() TypedRoleBindingInformer
 }
 
 type version struct {
@@ -45,22 +45,22 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// ClusterRoles returns a ClusterRoleInformer.
-func (v *version) ClusterRoles() ClusterRoleInformer {
+// ClusterRoles returns a TypedClusterRoleInformer.
+func (v *version) ClusterRoles() TypedClusterRoleInformer {
 	return &clusterRoleInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// ClusterRoleBindings returns a ClusterRoleBindingInformer.
-func (v *version) ClusterRoleBindings() ClusterRoleBindingInformer {
+// ClusterRoleBindings returns a TypedClusterRoleBindingInformer.
+func (v *version) ClusterRoleBindings() TypedClusterRoleBindingInformer {
 	return &clusterRoleBindingInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// Roles returns a RoleInformer.
-func (v *version) Roles() RoleInformer {
+// Roles returns a TypedRoleInformer.
+func (v *version) Roles() TypedRoleInformer {
 	return &roleInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// RoleBindings returns a RoleBindingInformer.
-func (v *version) RoleBindings() RoleBindingInformer {
+// RoleBindings returns a TypedRoleBindingInformer.
+func (v *version) RoleBindings() TypedRoleBindingInformer {
 	return &roleBindingInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/role.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/role.go
@@ -34,11 +34,39 @@ import (
 )
 
 // RoleInformer provides access to a shared informer and lister for
-// Roles.
+// Roles. Prefer using the type-safe variant (see [TypedRoleInformer]).
 type RoleInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() rbacv1beta1.RoleLister
 }
+
+// TypedRoleInformer provides access to a shared informer and lister for
+// Roles, including the type-safe TypedInformer variant.
+// It is a superset of RoleInformer.
+type TypedRoleInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() RoleIndexInformer
+	Lister() rbacv1beta1.RoleLister
+}
+
+// RoleIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type RoleIndexInformer cache.TypedSharedIndexInformer[*apirbacv1beta1.Role]
+
+// RoleHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Role.
+type RoleHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apirbacv1beta1.Role]
+
+// RoleDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Role.
+type RoleDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apirbacv1beta1.Role]
+
+// RoleFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Role.
+type RoleFilteringHandler = cache.TypedFilteringResourceEventHandler[*apirbacv1beta1.Role]
+
+// RoleIndexers is a specialization of [cache.TypedIndexers] for Role.
+type RoleIndexers = cache.TypedIndexers[*apirbacv1beta1.Role]
+
+// DeletedRole is a specialization of [cache.DeletedObject] for Role.
+type DeletedRole = cache.DeletedObject[*apirbacv1beta1.Role]
 
 type roleInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type roleInformer struct {
 // NewRoleInformer constructs a new informer for Role type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedRoleInformer]).
 func NewRoleInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewRoleInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedRoleInformer constructs a new informer for Role type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedRoleInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers RoleIndexers) RoleIndexInformer {
+	return NewTypedRoleInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredRoleInformer constructs a new informer for Role type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredRoleInformer]).
 func NewFilteredRoleInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewRoleInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedRoleInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredRoleInformer constructs a new informer for Role type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredRoleInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers RoleIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) RoleIndexInformer {
+	return NewTypedRoleInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewRoleInformerWithOptions constructs a new informer for Role type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedRoleInformerWithOptions]).
 func NewRoleInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedRoleInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedRoleInformerWithOptions constructs a new informer for Role type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedRoleInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) RoleIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Resource: "roles"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apirbacv1beta1.Role](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewRoleInformerWithOptions(client kubernetes.Interface, namespace string, o
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *roleInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewRoleInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedRoleInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *roleInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apirbacv1beta1.Role{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *roleInformer) TypedInformer() RoleIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apirbacv1beta1.Role](f.factory.InformerFor(&apirbacv1beta1.Role{}, f.defaultInformer))
 }
 
 func (f *roleInformer) Lister() rbacv1beta1.RoleLister {
 	return rbacv1beta1.NewRoleLister(f.Informer().GetIndexer())
+}
+
+// ToTypedRoleInformer converts an untyped informer into a TypedRoleInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Role. If that is not the case, calling type-safe methods of the returned
+// TypedRoleInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedRoleInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedRoleInformer(informer RoleInformer) TypedRoleInformer {
+	if informer, ok := informer.(TypedRoleInformer); ok {
+		return informer
+	}
+	return &roleTypedInformerAdapter{informer}
+}
+
+type roleTypedInformerAdapter struct {
+	RoleInformer
+}
+
+func (a *roleTypedInformerAdapter) TypedInformer() RoleIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apirbacv1beta1.Role](a.Informer())
+}
+
+// ToRoleIndexInformer converts an untyped informer into a RoleIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Role. If that is not the case, calling type-safe methods of the returned
+// RoleIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a RoleIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToRoleIndexInformer(informer cache.SharedIndexInformer) RoleIndexInformer {
+	if informer, ok := informer.(RoleIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apirbacv1beta1.Role](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/rolebinding.go
@@ -34,11 +34,39 @@ import (
 )
 
 // RoleBindingInformer provides access to a shared informer and lister for
-// RoleBindings.
+// RoleBindings. Prefer using the type-safe variant (see [TypedRoleBindingInformer]).
 type RoleBindingInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() rbacv1beta1.RoleBindingLister
 }
+
+// TypedRoleBindingInformer provides access to a shared informer and lister for
+// RoleBindings, including the type-safe TypedInformer variant.
+// It is a superset of RoleBindingInformer.
+type TypedRoleBindingInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() RoleBindingIndexInformer
+	Lister() rbacv1beta1.RoleBindingLister
+}
+
+// RoleBindingIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type RoleBindingIndexInformer cache.TypedSharedIndexInformer[*apirbacv1beta1.RoleBinding]
+
+// RoleBindingHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for RoleBinding.
+type RoleBindingHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apirbacv1beta1.RoleBinding]
+
+// RoleBindingDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for RoleBinding.
+type RoleBindingDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apirbacv1beta1.RoleBinding]
+
+// RoleBindingFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for RoleBinding.
+type RoleBindingFilteringHandler = cache.TypedFilteringResourceEventHandler[*apirbacv1beta1.RoleBinding]
+
+// RoleBindingIndexers is a specialization of [cache.TypedIndexers] for RoleBinding.
+type RoleBindingIndexers = cache.TypedIndexers[*apirbacv1beta1.RoleBinding]
+
+// DeletedRoleBinding is a specialization of [cache.DeletedObject] for RoleBinding.
+type DeletedRoleBinding = cache.DeletedObject[*apirbacv1beta1.RoleBinding]
 
 type roleBindingInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type roleBindingInformer struct {
 // NewRoleBindingInformer constructs a new informer for RoleBinding type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedRoleBindingInformer]).
 func NewRoleBindingInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewRoleBindingInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedRoleBindingInformer constructs a new informer for RoleBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedRoleBindingInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers RoleBindingIndexers) RoleBindingIndexInformer {
+	return NewTypedRoleBindingInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredRoleBindingInformer constructs a new informer for RoleBinding type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredRoleBindingInformer]).
 func NewFilteredRoleBindingInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewRoleBindingInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedRoleBindingInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredRoleBindingInformer constructs a new informer for RoleBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredRoleBindingInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers RoleBindingIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) RoleBindingIndexInformer {
+	return NewTypedRoleBindingInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewRoleBindingInformerWithOptions constructs a new informer for RoleBinding type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedRoleBindingInformerWithOptions]).
 func NewRoleBindingInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedRoleBindingInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedRoleBindingInformerWithOptions constructs a new informer for RoleBinding type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedRoleBindingInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) RoleBindingIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Resource: "rolebindings"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apirbacv1beta1.RoleBinding](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewRoleBindingInformerWithOptions(client kubernetes.Interface, namespace st
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *roleBindingInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewRoleBindingInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedRoleBindingInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *roleBindingInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apirbacv1beta1.RoleBinding{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *roleBindingInformer) TypedInformer() RoleBindingIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apirbacv1beta1.RoleBinding](f.factory.InformerFor(&apirbacv1beta1.RoleBinding{}, f.defaultInformer))
 }
 
 func (f *roleBindingInformer) Lister() rbacv1beta1.RoleBindingLister {
 	return rbacv1beta1.NewRoleBindingLister(f.Informer().GetIndexer())
+}
+
+// ToTypedRoleBindingInformer converts an untyped informer into a TypedRoleBindingInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *RoleBinding. If that is not the case, calling type-safe methods of the returned
+// TypedRoleBindingInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedRoleBindingInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedRoleBindingInformer(informer RoleBindingInformer) TypedRoleBindingInformer {
+	if informer, ok := informer.(TypedRoleBindingInformer); ok {
+		return informer
+	}
+	return &roleBindingTypedInformerAdapter{informer}
+}
+
+type roleBindingTypedInformerAdapter struct {
+	RoleBindingInformer
+}
+
+func (a *roleBindingTypedInformerAdapter) TypedInformer() RoleBindingIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apirbacv1beta1.RoleBinding](a.Informer())
+}
+
+// ToRoleBindingIndexInformer converts an untyped informer into a RoleBindingIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *RoleBinding. If that is not the case, calling type-safe methods of the returned
+// RoleBindingIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a RoleBindingIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToRoleBindingIndexInformer(informer cache.SharedIndexInformer) RoleBindingIndexInformer {
+	if informer, ok := informer.(RoleBindingIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apirbacv1beta1.RoleBinding](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/resource/v1/deviceclass.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1/deviceclass.go
@@ -34,11 +34,39 @@ import (
 )
 
 // DeviceClassInformer provides access to a shared informer and lister for
-// DeviceClasses.
+// DeviceClasses. Prefer using the type-safe variant (see [TypedDeviceClassInformer]).
 type DeviceClassInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() resourcev1.DeviceClassLister
 }
+
+// TypedDeviceClassInformer provides access to a shared informer and lister for
+// DeviceClasses, including the type-safe TypedInformer variant.
+// It is a superset of DeviceClassInformer.
+type TypedDeviceClassInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() DeviceClassIndexInformer
+	Lister() resourcev1.DeviceClassLister
+}
+
+// DeviceClassIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type DeviceClassIndexInformer cache.TypedSharedIndexInformer[*apiresourcev1.DeviceClass]
+
+// DeviceClassHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for DeviceClass.
+type DeviceClassHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiresourcev1.DeviceClass]
+
+// DeviceClassDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for DeviceClass.
+type DeviceClassDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiresourcev1.DeviceClass]
+
+// DeviceClassFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for DeviceClass.
+type DeviceClassFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiresourcev1.DeviceClass]
+
+// DeviceClassIndexers is a specialization of [cache.TypedIndexers] for DeviceClass.
+type DeviceClassIndexers = cache.TypedIndexers[*apiresourcev1.DeviceClass]
+
+// DeletedDeviceClass is a specialization of [cache.DeletedObject] for DeviceClass.
+type DeletedDeviceClass = cache.DeletedObject[*apiresourcev1.DeviceClass]
 
 type deviceClassInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type deviceClassInformer struct {
 // NewDeviceClassInformer constructs a new informer for DeviceClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedDeviceClassInformer]).
 func NewDeviceClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewDeviceClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedDeviceClassInformer constructs a new informer for DeviceClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedDeviceClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers DeviceClassIndexers) DeviceClassIndexInformer {
+	return NewTypedDeviceClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredDeviceClassInformer constructs a new informer for DeviceClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredDeviceClassInformer]).
 func NewFilteredDeviceClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewDeviceClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedDeviceClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredDeviceClassInformer constructs a new informer for DeviceClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredDeviceClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers DeviceClassIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) DeviceClassIndexInformer {
+	return NewTypedDeviceClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewDeviceClassInformerWithOptions constructs a new informer for DeviceClass type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedDeviceClassInformerWithOptions]).
 func NewDeviceClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedDeviceClassInformerWithOptions(client, options)
+}
+
+// NewTypedDeviceClassInformerWithOptions constructs a new informer for DeviceClass type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedDeviceClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) DeviceClassIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "resource.k8s.io", Version: "v1", Resource: "deviceclasss"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1.DeviceClass](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewDeviceClassInformerWithOptions(client kubernetes.Interface, options inte
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *deviceClassInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewDeviceClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedDeviceClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *deviceClassInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiresourcev1.DeviceClass{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *deviceClassInformer) TypedInformer() DeviceClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1.DeviceClass](f.factory.InformerFor(&apiresourcev1.DeviceClass{}, f.defaultInformer))
 }
 
 func (f *deviceClassInformer) Lister() resourcev1.DeviceClassLister {
 	return resourcev1.NewDeviceClassLister(f.Informer().GetIndexer())
+}
+
+// ToTypedDeviceClassInformer converts an untyped informer into a TypedDeviceClassInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *DeviceClass. If that is not the case, calling type-safe methods of the returned
+// TypedDeviceClassInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedDeviceClassInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedDeviceClassInformer(informer DeviceClassInformer) TypedDeviceClassInformer {
+	if informer, ok := informer.(TypedDeviceClassInformer); ok {
+		return informer
+	}
+	return &deviceClassTypedInformerAdapter{informer}
+}
+
+type deviceClassTypedInformerAdapter struct {
+	DeviceClassInformer
+}
+
+func (a *deviceClassTypedInformerAdapter) TypedInformer() DeviceClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1.DeviceClass](a.Informer())
+}
+
+// ToDeviceClassIndexInformer converts an untyped informer into a DeviceClassIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *DeviceClass. If that is not the case, calling type-safe methods of the returned
+// DeviceClassIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a DeviceClassIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToDeviceClassIndexInformer(informer cache.SharedIndexInformer) DeviceClassIndexInformer {
+	if informer, ok := informer.(DeviceClassIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1.DeviceClass](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/resource/v1/devicetaintrule.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1/devicetaintrule.go
@@ -34,11 +34,39 @@ import (
 )
 
 // DeviceTaintRuleInformer provides access to a shared informer and lister for
-// DeviceTaintRules.
+// DeviceTaintRules. Prefer using the type-safe variant (see [TypedDeviceTaintRuleInformer]).
 type DeviceTaintRuleInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() resourcev1.DeviceTaintRuleLister
 }
+
+// TypedDeviceTaintRuleInformer provides access to a shared informer and lister for
+// DeviceTaintRules, including the type-safe TypedInformer variant.
+// It is a superset of DeviceTaintRuleInformer.
+type TypedDeviceTaintRuleInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() DeviceTaintRuleIndexInformer
+	Lister() resourcev1.DeviceTaintRuleLister
+}
+
+// DeviceTaintRuleIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type DeviceTaintRuleIndexInformer cache.TypedSharedIndexInformer[*apiresourcev1.DeviceTaintRule]
+
+// DeviceTaintRuleHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for DeviceTaintRule.
+type DeviceTaintRuleHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiresourcev1.DeviceTaintRule]
+
+// DeviceTaintRuleDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for DeviceTaintRule.
+type DeviceTaintRuleDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiresourcev1.DeviceTaintRule]
+
+// DeviceTaintRuleFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for DeviceTaintRule.
+type DeviceTaintRuleFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiresourcev1.DeviceTaintRule]
+
+// DeviceTaintRuleIndexers is a specialization of [cache.TypedIndexers] for DeviceTaintRule.
+type DeviceTaintRuleIndexers = cache.TypedIndexers[*apiresourcev1.DeviceTaintRule]
+
+// DeletedDeviceTaintRule is a specialization of [cache.DeletedObject] for DeviceTaintRule.
+type DeletedDeviceTaintRule = cache.DeletedObject[*apiresourcev1.DeviceTaintRule]
 
 type deviceTaintRuleInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type deviceTaintRuleInformer struct {
 // NewDeviceTaintRuleInformer constructs a new informer for DeviceTaintRule type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedDeviceTaintRuleInformer]).
 func NewDeviceTaintRuleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewDeviceTaintRuleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedDeviceTaintRuleInformer constructs a new informer for DeviceTaintRule type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedDeviceTaintRuleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers DeviceTaintRuleIndexers) DeviceTaintRuleIndexInformer {
+	return NewTypedDeviceTaintRuleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredDeviceTaintRuleInformer constructs a new informer for DeviceTaintRule type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredDeviceTaintRuleInformer]).
 func NewFilteredDeviceTaintRuleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewDeviceTaintRuleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedDeviceTaintRuleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredDeviceTaintRuleInformer constructs a new informer for DeviceTaintRule type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredDeviceTaintRuleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers DeviceTaintRuleIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) DeviceTaintRuleIndexInformer {
+	return NewTypedDeviceTaintRuleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewDeviceTaintRuleInformerWithOptions constructs a new informer for DeviceTaintRule type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedDeviceTaintRuleInformerWithOptions]).
 func NewDeviceTaintRuleInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedDeviceTaintRuleInformerWithOptions(client, options)
+}
+
+// NewTypedDeviceTaintRuleInformerWithOptions constructs a new informer for DeviceTaintRule type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedDeviceTaintRuleInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) DeviceTaintRuleIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "resource.k8s.io", Version: "v1", Resource: "devicetaintrules"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1.DeviceTaintRule](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewDeviceTaintRuleInformerWithOptions(client kubernetes.Interface, options 
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *deviceTaintRuleInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewDeviceTaintRuleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedDeviceTaintRuleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *deviceTaintRuleInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiresourcev1.DeviceTaintRule{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *deviceTaintRuleInformer) TypedInformer() DeviceTaintRuleIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1.DeviceTaintRule](f.factory.InformerFor(&apiresourcev1.DeviceTaintRule{}, f.defaultInformer))
 }
 
 func (f *deviceTaintRuleInformer) Lister() resourcev1.DeviceTaintRuleLister {
 	return resourcev1.NewDeviceTaintRuleLister(f.Informer().GetIndexer())
+}
+
+// ToTypedDeviceTaintRuleInformer converts an untyped informer into a TypedDeviceTaintRuleInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *DeviceTaintRule. If that is not the case, calling type-safe methods of the returned
+// TypedDeviceTaintRuleInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedDeviceTaintRuleInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedDeviceTaintRuleInformer(informer DeviceTaintRuleInformer) TypedDeviceTaintRuleInformer {
+	if informer, ok := informer.(TypedDeviceTaintRuleInformer); ok {
+		return informer
+	}
+	return &deviceTaintRuleTypedInformerAdapter{informer}
+}
+
+type deviceTaintRuleTypedInformerAdapter struct {
+	DeviceTaintRuleInformer
+}
+
+func (a *deviceTaintRuleTypedInformerAdapter) TypedInformer() DeviceTaintRuleIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1.DeviceTaintRule](a.Informer())
+}
+
+// ToDeviceTaintRuleIndexInformer converts an untyped informer into a DeviceTaintRuleIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *DeviceTaintRule. If that is not the case, calling type-safe methods of the returned
+// DeviceTaintRuleIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a DeviceTaintRuleIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToDeviceTaintRuleIndexInformer(informer cache.SharedIndexInformer) DeviceTaintRuleIndexInformer {
+	if informer, ok := informer.(DeviceTaintRuleIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1.DeviceTaintRule](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/resource/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1/interface.go
@@ -25,15 +25,15 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// DeviceClasses returns a DeviceClassInformer.
-	DeviceClasses() DeviceClassInformer
+	DeviceClasses() TypedDeviceClassInformer
 	// DeviceTaintRules returns a DeviceTaintRuleInformer.
-	DeviceTaintRules() DeviceTaintRuleInformer
+	DeviceTaintRules() TypedDeviceTaintRuleInformer
 	// ResourceClaims returns a ResourceClaimInformer.
-	ResourceClaims() ResourceClaimInformer
+	ResourceClaims() TypedResourceClaimInformer
 	// ResourceClaimTemplates returns a ResourceClaimTemplateInformer.
-	ResourceClaimTemplates() ResourceClaimTemplateInformer
+	ResourceClaimTemplates() TypedResourceClaimTemplateInformer
 	// ResourceSlices returns a ResourceSliceInformer.
-	ResourceSlices() ResourceSliceInformer
+	ResourceSlices() TypedResourceSliceInformer
 }
 
 type version struct {
@@ -47,27 +47,27 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// DeviceClasses returns a DeviceClassInformer.
-func (v *version) DeviceClasses() DeviceClassInformer {
+// DeviceClasses returns a TypedDeviceClassInformer.
+func (v *version) DeviceClasses() TypedDeviceClassInformer {
 	return &deviceClassInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// DeviceTaintRules returns a DeviceTaintRuleInformer.
-func (v *version) DeviceTaintRules() DeviceTaintRuleInformer {
+// DeviceTaintRules returns a TypedDeviceTaintRuleInformer.
+func (v *version) DeviceTaintRules() TypedDeviceTaintRuleInformer {
 	return &deviceTaintRuleInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// ResourceClaims returns a ResourceClaimInformer.
-func (v *version) ResourceClaims() ResourceClaimInformer {
+// ResourceClaims returns a TypedResourceClaimInformer.
+func (v *version) ResourceClaims() TypedResourceClaimInformer {
 	return &resourceClaimInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// ResourceClaimTemplates returns a ResourceClaimTemplateInformer.
-func (v *version) ResourceClaimTemplates() ResourceClaimTemplateInformer {
+// ResourceClaimTemplates returns a TypedResourceClaimTemplateInformer.
+func (v *version) ResourceClaimTemplates() TypedResourceClaimTemplateInformer {
 	return &resourceClaimTemplateInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// ResourceSlices returns a ResourceSliceInformer.
-func (v *version) ResourceSlices() ResourceSliceInformer {
+// ResourceSlices returns a TypedResourceSliceInformer.
+func (v *version) ResourceSlices() TypedResourceSliceInformer {
 	return &resourceSliceInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/resource/v1/resourceclaim.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1/resourceclaim.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ResourceClaimInformer provides access to a shared informer and lister for
-// ResourceClaims.
+// ResourceClaims. Prefer using the type-safe variant (see [TypedResourceClaimInformer]).
 type ResourceClaimInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() resourcev1.ResourceClaimLister
 }
+
+// TypedResourceClaimInformer provides access to a shared informer and lister for
+// ResourceClaims, including the type-safe TypedInformer variant.
+// It is a superset of ResourceClaimInformer.
+type TypedResourceClaimInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ResourceClaimIndexInformer
+	Lister() resourcev1.ResourceClaimLister
+}
+
+// ResourceClaimIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ResourceClaimIndexInformer cache.TypedSharedIndexInformer[*apiresourcev1.ResourceClaim]
+
+// ResourceClaimHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ResourceClaim.
+type ResourceClaimHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiresourcev1.ResourceClaim]
+
+// ResourceClaimDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ResourceClaim.
+type ResourceClaimDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiresourcev1.ResourceClaim]
+
+// ResourceClaimFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ResourceClaim.
+type ResourceClaimFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiresourcev1.ResourceClaim]
+
+// ResourceClaimIndexers is a specialization of [cache.TypedIndexers] for ResourceClaim.
+type ResourceClaimIndexers = cache.TypedIndexers[*apiresourcev1.ResourceClaim]
+
+// DeletedResourceClaim is a specialization of [cache.DeletedObject] for ResourceClaim.
+type DeletedResourceClaim = cache.DeletedObject[*apiresourcev1.ResourceClaim]
 
 type resourceClaimInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type resourceClaimInformer struct {
 // NewResourceClaimInformer constructs a new informer for ResourceClaim type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedResourceClaimInformer]).
 func NewResourceClaimInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewResourceClaimInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedResourceClaimInformer constructs a new informer for ResourceClaim type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedResourceClaimInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ResourceClaimIndexers) ResourceClaimIndexInformer {
+	return NewTypedResourceClaimInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredResourceClaimInformer constructs a new informer for ResourceClaim type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredResourceClaimInformer]).
 func NewFilteredResourceClaimInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewResourceClaimInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedResourceClaimInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredResourceClaimInformer constructs a new informer for ResourceClaim type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredResourceClaimInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ResourceClaimIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ResourceClaimIndexInformer {
+	return NewTypedResourceClaimInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewResourceClaimInformerWithOptions constructs a new informer for ResourceClaim type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedResourceClaimInformerWithOptions]).
 func NewResourceClaimInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedResourceClaimInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedResourceClaimInformerWithOptions constructs a new informer for ResourceClaim type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedResourceClaimInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) ResourceClaimIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "resource.k8s.io", Version: "v1", Resource: "resourceclaims"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1.ResourceClaim](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewResourceClaimInformerWithOptions(client kubernetes.Interface, namespace 
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *resourceClaimInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewResourceClaimInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedResourceClaimInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *resourceClaimInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiresourcev1.ResourceClaim{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *resourceClaimInformer) TypedInformer() ResourceClaimIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1.ResourceClaim](f.factory.InformerFor(&apiresourcev1.ResourceClaim{}, f.defaultInformer))
 }
 
 func (f *resourceClaimInformer) Lister() resourcev1.ResourceClaimLister {
 	return resourcev1.NewResourceClaimLister(f.Informer().GetIndexer())
+}
+
+// ToTypedResourceClaimInformer converts an untyped informer into a TypedResourceClaimInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ResourceClaim. If that is not the case, calling type-safe methods of the returned
+// TypedResourceClaimInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedResourceClaimInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedResourceClaimInformer(informer ResourceClaimInformer) TypedResourceClaimInformer {
+	if informer, ok := informer.(TypedResourceClaimInformer); ok {
+		return informer
+	}
+	return &resourceClaimTypedInformerAdapter{informer}
+}
+
+type resourceClaimTypedInformerAdapter struct {
+	ResourceClaimInformer
+}
+
+func (a *resourceClaimTypedInformerAdapter) TypedInformer() ResourceClaimIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1.ResourceClaim](a.Informer())
+}
+
+// ToResourceClaimIndexInformer converts an untyped informer into a ResourceClaimIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ResourceClaim. If that is not the case, calling type-safe methods of the returned
+// ResourceClaimIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ResourceClaimIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToResourceClaimIndexInformer(informer cache.SharedIndexInformer) ResourceClaimIndexInformer {
+	if informer, ok := informer.(ResourceClaimIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1.ResourceClaim](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/resource/v1/resourceclaimtemplate.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1/resourceclaimtemplate.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ResourceClaimTemplateInformer provides access to a shared informer and lister for
-// ResourceClaimTemplates.
+// ResourceClaimTemplates. Prefer using the type-safe variant (see [TypedResourceClaimTemplateInformer]).
 type ResourceClaimTemplateInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() resourcev1.ResourceClaimTemplateLister
 }
+
+// TypedResourceClaimTemplateInformer provides access to a shared informer and lister for
+// ResourceClaimTemplates, including the type-safe TypedInformer variant.
+// It is a superset of ResourceClaimTemplateInformer.
+type TypedResourceClaimTemplateInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ResourceClaimTemplateIndexInformer
+	Lister() resourcev1.ResourceClaimTemplateLister
+}
+
+// ResourceClaimTemplateIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ResourceClaimTemplateIndexInformer cache.TypedSharedIndexInformer[*apiresourcev1.ResourceClaimTemplate]
+
+// ResourceClaimTemplateHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ResourceClaimTemplate.
+type ResourceClaimTemplateHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiresourcev1.ResourceClaimTemplate]
+
+// ResourceClaimTemplateDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ResourceClaimTemplate.
+type ResourceClaimTemplateDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiresourcev1.ResourceClaimTemplate]
+
+// ResourceClaimTemplateFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ResourceClaimTemplate.
+type ResourceClaimTemplateFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiresourcev1.ResourceClaimTemplate]
+
+// ResourceClaimTemplateIndexers is a specialization of [cache.TypedIndexers] for ResourceClaimTemplate.
+type ResourceClaimTemplateIndexers = cache.TypedIndexers[*apiresourcev1.ResourceClaimTemplate]
+
+// DeletedResourceClaimTemplate is a specialization of [cache.DeletedObject] for ResourceClaimTemplate.
+type DeletedResourceClaimTemplate = cache.DeletedObject[*apiresourcev1.ResourceClaimTemplate]
 
 type resourceClaimTemplateInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type resourceClaimTemplateInformer struct {
 // NewResourceClaimTemplateInformer constructs a new informer for ResourceClaimTemplate type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedResourceClaimTemplateInformer]).
 func NewResourceClaimTemplateInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewResourceClaimTemplateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedResourceClaimTemplateInformer constructs a new informer for ResourceClaimTemplate type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedResourceClaimTemplateInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ResourceClaimTemplateIndexers) ResourceClaimTemplateIndexInformer {
+	return NewTypedResourceClaimTemplateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredResourceClaimTemplateInformer constructs a new informer for ResourceClaimTemplate type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredResourceClaimTemplateInformer]).
 func NewFilteredResourceClaimTemplateInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewResourceClaimTemplateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedResourceClaimTemplateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredResourceClaimTemplateInformer constructs a new informer for ResourceClaimTemplate type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredResourceClaimTemplateInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ResourceClaimTemplateIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ResourceClaimTemplateIndexInformer {
+	return NewTypedResourceClaimTemplateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewResourceClaimTemplateInformerWithOptions constructs a new informer for ResourceClaimTemplate type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedResourceClaimTemplateInformerWithOptions]).
 func NewResourceClaimTemplateInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedResourceClaimTemplateInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedResourceClaimTemplateInformerWithOptions constructs a new informer for ResourceClaimTemplate type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedResourceClaimTemplateInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) ResourceClaimTemplateIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "resource.k8s.io", Version: "v1", Resource: "resourceclaimtemplates"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1.ResourceClaimTemplate](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewResourceClaimTemplateInformerWithOptions(client kubernetes.Interface, na
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *resourceClaimTemplateInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewResourceClaimTemplateInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedResourceClaimTemplateInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *resourceClaimTemplateInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiresourcev1.ResourceClaimTemplate{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *resourceClaimTemplateInformer) TypedInformer() ResourceClaimTemplateIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1.ResourceClaimTemplate](f.factory.InformerFor(&apiresourcev1.ResourceClaimTemplate{}, f.defaultInformer))
 }
 
 func (f *resourceClaimTemplateInformer) Lister() resourcev1.ResourceClaimTemplateLister {
 	return resourcev1.NewResourceClaimTemplateLister(f.Informer().GetIndexer())
+}
+
+// ToTypedResourceClaimTemplateInformer converts an untyped informer into a TypedResourceClaimTemplateInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ResourceClaimTemplate. If that is not the case, calling type-safe methods of the returned
+// TypedResourceClaimTemplateInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedResourceClaimTemplateInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedResourceClaimTemplateInformer(informer ResourceClaimTemplateInformer) TypedResourceClaimTemplateInformer {
+	if informer, ok := informer.(TypedResourceClaimTemplateInformer); ok {
+		return informer
+	}
+	return &resourceClaimTemplateTypedInformerAdapter{informer}
+}
+
+type resourceClaimTemplateTypedInformerAdapter struct {
+	ResourceClaimTemplateInformer
+}
+
+func (a *resourceClaimTemplateTypedInformerAdapter) TypedInformer() ResourceClaimTemplateIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1.ResourceClaimTemplate](a.Informer())
+}
+
+// ToResourceClaimTemplateIndexInformer converts an untyped informer into a ResourceClaimTemplateIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ResourceClaimTemplate. If that is not the case, calling type-safe methods of the returned
+// ResourceClaimTemplateIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ResourceClaimTemplateIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToResourceClaimTemplateIndexInformer(informer cache.SharedIndexInformer) ResourceClaimTemplateIndexInformer {
+	if informer, ok := informer.(ResourceClaimTemplateIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1.ResourceClaimTemplate](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/resource/v1/resourceslice.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1/resourceslice.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ResourceSliceInformer provides access to a shared informer and lister for
-// ResourceSlices.
+// ResourceSlices. Prefer using the type-safe variant (see [TypedResourceSliceInformer]).
 type ResourceSliceInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() resourcev1.ResourceSliceLister
 }
+
+// TypedResourceSliceInformer provides access to a shared informer and lister for
+// ResourceSlices, including the type-safe TypedInformer variant.
+// It is a superset of ResourceSliceInformer.
+type TypedResourceSliceInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ResourceSliceIndexInformer
+	Lister() resourcev1.ResourceSliceLister
+}
+
+// ResourceSliceIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ResourceSliceIndexInformer cache.TypedSharedIndexInformer[*apiresourcev1.ResourceSlice]
+
+// ResourceSliceHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ResourceSlice.
+type ResourceSliceHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiresourcev1.ResourceSlice]
+
+// ResourceSliceDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ResourceSlice.
+type ResourceSliceDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiresourcev1.ResourceSlice]
+
+// ResourceSliceFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ResourceSlice.
+type ResourceSliceFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiresourcev1.ResourceSlice]
+
+// ResourceSliceIndexers is a specialization of [cache.TypedIndexers] for ResourceSlice.
+type ResourceSliceIndexers = cache.TypedIndexers[*apiresourcev1.ResourceSlice]
+
+// DeletedResourceSlice is a specialization of [cache.DeletedObject] for ResourceSlice.
+type DeletedResourceSlice = cache.DeletedObject[*apiresourcev1.ResourceSlice]
 
 type resourceSliceInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type resourceSliceInformer struct {
 // NewResourceSliceInformer constructs a new informer for ResourceSlice type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedResourceSliceInformer]).
 func NewResourceSliceInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewResourceSliceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedResourceSliceInformer constructs a new informer for ResourceSlice type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedResourceSliceInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ResourceSliceIndexers) ResourceSliceIndexInformer {
+	return NewTypedResourceSliceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredResourceSliceInformer constructs a new informer for ResourceSlice type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredResourceSliceInformer]).
 func NewFilteredResourceSliceInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewResourceSliceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedResourceSliceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredResourceSliceInformer constructs a new informer for ResourceSlice type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredResourceSliceInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ResourceSliceIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ResourceSliceIndexInformer {
+	return NewTypedResourceSliceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewResourceSliceInformerWithOptions constructs a new informer for ResourceSlice type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedResourceSliceInformerWithOptions]).
 func NewResourceSliceInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedResourceSliceInformerWithOptions(client, options)
+}
+
+// NewTypedResourceSliceInformerWithOptions constructs a new informer for ResourceSlice type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedResourceSliceInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ResourceSliceIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "resource.k8s.io", Version: "v1", Resource: "resourceslices"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1.ResourceSlice](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewResourceSliceInformerWithOptions(client kubernetes.Interface, options in
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *resourceSliceInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewResourceSliceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedResourceSliceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *resourceSliceInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiresourcev1.ResourceSlice{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *resourceSliceInformer) TypedInformer() ResourceSliceIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1.ResourceSlice](f.factory.InformerFor(&apiresourcev1.ResourceSlice{}, f.defaultInformer))
 }
 
 func (f *resourceSliceInformer) Lister() resourcev1.ResourceSliceLister {
 	return resourcev1.NewResourceSliceLister(f.Informer().GetIndexer())
+}
+
+// ToTypedResourceSliceInformer converts an untyped informer into a TypedResourceSliceInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ResourceSlice. If that is not the case, calling type-safe methods of the returned
+// TypedResourceSliceInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedResourceSliceInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedResourceSliceInformer(informer ResourceSliceInformer) TypedResourceSliceInformer {
+	if informer, ok := informer.(TypedResourceSliceInformer); ok {
+		return informer
+	}
+	return &resourceSliceTypedInformerAdapter{informer}
+}
+
+type resourceSliceTypedInformerAdapter struct {
+	ResourceSliceInformer
+}
+
+func (a *resourceSliceTypedInformerAdapter) TypedInformer() ResourceSliceIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1.ResourceSlice](a.Informer())
+}
+
+// ToResourceSliceIndexInformer converts an untyped informer into a ResourceSliceIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ResourceSlice. If that is not the case, calling type-safe methods of the returned
+// ResourceSliceIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ResourceSliceIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToResourceSliceIndexInformer(informer cache.SharedIndexInformer) ResourceSliceIndexInformer {
+	if informer, ok := informer.(ResourceSliceIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1.ResourceSlice](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/resource/v1alpha3/devicetaintrule.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1alpha3/devicetaintrule.go
@@ -34,11 +34,39 @@ import (
 )
 
 // DeviceTaintRuleInformer provides access to a shared informer and lister for
-// DeviceTaintRules.
+// DeviceTaintRules. Prefer using the type-safe variant (see [TypedDeviceTaintRuleInformer]).
 type DeviceTaintRuleInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() resourcev1alpha3.DeviceTaintRuleLister
 }
+
+// TypedDeviceTaintRuleInformer provides access to a shared informer and lister for
+// DeviceTaintRules, including the type-safe TypedInformer variant.
+// It is a superset of DeviceTaintRuleInformer.
+type TypedDeviceTaintRuleInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() DeviceTaintRuleIndexInformer
+	Lister() resourcev1alpha3.DeviceTaintRuleLister
+}
+
+// DeviceTaintRuleIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type DeviceTaintRuleIndexInformer cache.TypedSharedIndexInformer[*apiresourcev1alpha3.DeviceTaintRule]
+
+// DeviceTaintRuleHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for DeviceTaintRule.
+type DeviceTaintRuleHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiresourcev1alpha3.DeviceTaintRule]
+
+// DeviceTaintRuleDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for DeviceTaintRule.
+type DeviceTaintRuleDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiresourcev1alpha3.DeviceTaintRule]
+
+// DeviceTaintRuleFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for DeviceTaintRule.
+type DeviceTaintRuleFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiresourcev1alpha3.DeviceTaintRule]
+
+// DeviceTaintRuleIndexers is a specialization of [cache.TypedIndexers] for DeviceTaintRule.
+type DeviceTaintRuleIndexers = cache.TypedIndexers[*apiresourcev1alpha3.DeviceTaintRule]
+
+// DeletedDeviceTaintRule is a specialization of [cache.DeletedObject] for DeviceTaintRule.
+type DeletedDeviceTaintRule = cache.DeletedObject[*apiresourcev1alpha3.DeviceTaintRule]
 
 type deviceTaintRuleInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type deviceTaintRuleInformer struct {
 // NewDeviceTaintRuleInformer constructs a new informer for DeviceTaintRule type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedDeviceTaintRuleInformer]).
 func NewDeviceTaintRuleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewDeviceTaintRuleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedDeviceTaintRuleInformer constructs a new informer for DeviceTaintRule type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedDeviceTaintRuleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers DeviceTaintRuleIndexers) DeviceTaintRuleIndexInformer {
+	return NewTypedDeviceTaintRuleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredDeviceTaintRuleInformer constructs a new informer for DeviceTaintRule type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredDeviceTaintRuleInformer]).
 func NewFilteredDeviceTaintRuleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewDeviceTaintRuleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedDeviceTaintRuleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredDeviceTaintRuleInformer constructs a new informer for DeviceTaintRule type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredDeviceTaintRuleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers DeviceTaintRuleIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) DeviceTaintRuleIndexInformer {
+	return NewTypedDeviceTaintRuleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewDeviceTaintRuleInformerWithOptions constructs a new informer for DeviceTaintRule type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedDeviceTaintRuleInformerWithOptions]).
 func NewDeviceTaintRuleInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedDeviceTaintRuleInformerWithOptions(client, options)
+}
+
+// NewTypedDeviceTaintRuleInformerWithOptions constructs a new informer for DeviceTaintRule type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedDeviceTaintRuleInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) DeviceTaintRuleIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "resource.k8s.io", Version: "v1alpha3", Resource: "devicetaintrules"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1alpha3.DeviceTaintRule](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewDeviceTaintRuleInformerWithOptions(client kubernetes.Interface, options 
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *deviceTaintRuleInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewDeviceTaintRuleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedDeviceTaintRuleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *deviceTaintRuleInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiresourcev1alpha3.DeviceTaintRule{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *deviceTaintRuleInformer) TypedInformer() DeviceTaintRuleIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1alpha3.DeviceTaintRule](f.factory.InformerFor(&apiresourcev1alpha3.DeviceTaintRule{}, f.defaultInformer))
 }
 
 func (f *deviceTaintRuleInformer) Lister() resourcev1alpha3.DeviceTaintRuleLister {
 	return resourcev1alpha3.NewDeviceTaintRuleLister(f.Informer().GetIndexer())
+}
+
+// ToTypedDeviceTaintRuleInformer converts an untyped informer into a TypedDeviceTaintRuleInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *DeviceTaintRule. If that is not the case, calling type-safe methods of the returned
+// TypedDeviceTaintRuleInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedDeviceTaintRuleInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedDeviceTaintRuleInformer(informer DeviceTaintRuleInformer) TypedDeviceTaintRuleInformer {
+	if informer, ok := informer.(TypedDeviceTaintRuleInformer); ok {
+		return informer
+	}
+	return &deviceTaintRuleTypedInformerAdapter{informer}
+}
+
+type deviceTaintRuleTypedInformerAdapter struct {
+	DeviceTaintRuleInformer
+}
+
+func (a *deviceTaintRuleTypedInformerAdapter) TypedInformer() DeviceTaintRuleIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1alpha3.DeviceTaintRule](a.Informer())
+}
+
+// ToDeviceTaintRuleIndexInformer converts an untyped informer into a DeviceTaintRuleIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *DeviceTaintRule. If that is not the case, calling type-safe methods of the returned
+// DeviceTaintRuleIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a DeviceTaintRuleIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToDeviceTaintRuleIndexInformer(informer cache.SharedIndexInformer) DeviceTaintRuleIndexInformer {
+	if informer, ok := informer.(DeviceTaintRuleIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1alpha3.DeviceTaintRule](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/resource/v1alpha3/interface.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1alpha3/interface.go
@@ -25,9 +25,9 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// DeviceTaintRules returns a DeviceTaintRuleInformer.
-	DeviceTaintRules() DeviceTaintRuleInformer
+	DeviceTaintRules() TypedDeviceTaintRuleInformer
 	// ResourcePoolStatusRequests returns a ResourcePoolStatusRequestInformer.
-	ResourcePoolStatusRequests() ResourcePoolStatusRequestInformer
+	ResourcePoolStatusRequests() TypedResourcePoolStatusRequestInformer
 }
 
 type version struct {
@@ -41,12 +41,12 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// DeviceTaintRules returns a DeviceTaintRuleInformer.
-func (v *version) DeviceTaintRules() DeviceTaintRuleInformer {
+// DeviceTaintRules returns a TypedDeviceTaintRuleInformer.
+func (v *version) DeviceTaintRules() TypedDeviceTaintRuleInformer {
 	return &deviceTaintRuleInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// ResourcePoolStatusRequests returns a ResourcePoolStatusRequestInformer.
-func (v *version) ResourcePoolStatusRequests() ResourcePoolStatusRequestInformer {
+// ResourcePoolStatusRequests returns a TypedResourcePoolStatusRequestInformer.
+func (v *version) ResourcePoolStatusRequests() TypedResourcePoolStatusRequestInformer {
 	return &resourcePoolStatusRequestInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/resource/v1alpha3/resourcepoolstatusrequest.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1alpha3/resourcepoolstatusrequest.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ResourcePoolStatusRequestInformer provides access to a shared informer and lister for
-// ResourcePoolStatusRequests.
+// ResourcePoolStatusRequests. Prefer using the type-safe variant (see [TypedResourcePoolStatusRequestInformer]).
 type ResourcePoolStatusRequestInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() resourcev1alpha3.ResourcePoolStatusRequestLister
 }
+
+// TypedResourcePoolStatusRequestInformer provides access to a shared informer and lister for
+// ResourcePoolStatusRequests, including the type-safe TypedInformer variant.
+// It is a superset of ResourcePoolStatusRequestInformer.
+type TypedResourcePoolStatusRequestInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ResourcePoolStatusRequestIndexInformer
+	Lister() resourcev1alpha3.ResourcePoolStatusRequestLister
+}
+
+// ResourcePoolStatusRequestIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ResourcePoolStatusRequestIndexInformer cache.TypedSharedIndexInformer[*apiresourcev1alpha3.ResourcePoolStatusRequest]
+
+// ResourcePoolStatusRequestHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ResourcePoolStatusRequest.
+type ResourcePoolStatusRequestHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiresourcev1alpha3.ResourcePoolStatusRequest]
+
+// ResourcePoolStatusRequestDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ResourcePoolStatusRequest.
+type ResourcePoolStatusRequestDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiresourcev1alpha3.ResourcePoolStatusRequest]
+
+// ResourcePoolStatusRequestFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ResourcePoolStatusRequest.
+type ResourcePoolStatusRequestFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiresourcev1alpha3.ResourcePoolStatusRequest]
+
+// ResourcePoolStatusRequestIndexers is a specialization of [cache.TypedIndexers] for ResourcePoolStatusRequest.
+type ResourcePoolStatusRequestIndexers = cache.TypedIndexers[*apiresourcev1alpha3.ResourcePoolStatusRequest]
+
+// DeletedResourcePoolStatusRequest is a specialization of [cache.DeletedObject] for ResourcePoolStatusRequest.
+type DeletedResourcePoolStatusRequest = cache.DeletedObject[*apiresourcev1alpha3.ResourcePoolStatusRequest]
 
 type resourcePoolStatusRequestInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type resourcePoolStatusRequestInformer struct {
 // NewResourcePoolStatusRequestInformer constructs a new informer for ResourcePoolStatusRequest type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedResourcePoolStatusRequestInformer]).
 func NewResourcePoolStatusRequestInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewResourcePoolStatusRequestInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedResourcePoolStatusRequestInformer constructs a new informer for ResourcePoolStatusRequest type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedResourcePoolStatusRequestInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ResourcePoolStatusRequestIndexers) ResourcePoolStatusRequestIndexInformer {
+	return NewTypedResourcePoolStatusRequestInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredResourcePoolStatusRequestInformer constructs a new informer for ResourcePoolStatusRequest type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredResourcePoolStatusRequestInformer]).
 func NewFilteredResourcePoolStatusRequestInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewResourcePoolStatusRequestInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedResourcePoolStatusRequestInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredResourcePoolStatusRequestInformer constructs a new informer for ResourcePoolStatusRequest type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredResourcePoolStatusRequestInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ResourcePoolStatusRequestIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ResourcePoolStatusRequestIndexInformer {
+	return NewTypedResourcePoolStatusRequestInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewResourcePoolStatusRequestInformerWithOptions constructs a new informer for ResourcePoolStatusRequest type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedResourcePoolStatusRequestInformerWithOptions]).
 func NewResourcePoolStatusRequestInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedResourcePoolStatusRequestInformerWithOptions(client, options)
+}
+
+// NewTypedResourcePoolStatusRequestInformerWithOptions constructs a new informer for ResourcePoolStatusRequest type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedResourcePoolStatusRequestInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ResourcePoolStatusRequestIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "resource.k8s.io", Version: "v1alpha3", Resource: "resourcepoolstatusrequests"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1alpha3.ResourcePoolStatusRequest](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewResourcePoolStatusRequestInformerWithOptions(client kubernetes.Interface
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *resourcePoolStatusRequestInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewResourcePoolStatusRequestInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedResourcePoolStatusRequestInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *resourcePoolStatusRequestInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiresourcev1alpha3.ResourcePoolStatusRequest{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *resourcePoolStatusRequestInformer) TypedInformer() ResourcePoolStatusRequestIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1alpha3.ResourcePoolStatusRequest](f.factory.InformerFor(&apiresourcev1alpha3.ResourcePoolStatusRequest{}, f.defaultInformer))
 }
 
 func (f *resourcePoolStatusRequestInformer) Lister() resourcev1alpha3.ResourcePoolStatusRequestLister {
 	return resourcev1alpha3.NewResourcePoolStatusRequestLister(f.Informer().GetIndexer())
+}
+
+// ToTypedResourcePoolStatusRequestInformer converts an untyped informer into a TypedResourcePoolStatusRequestInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ResourcePoolStatusRequest. If that is not the case, calling type-safe methods of the returned
+// TypedResourcePoolStatusRequestInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedResourcePoolStatusRequestInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedResourcePoolStatusRequestInformer(informer ResourcePoolStatusRequestInformer) TypedResourcePoolStatusRequestInformer {
+	if informer, ok := informer.(TypedResourcePoolStatusRequestInformer); ok {
+		return informer
+	}
+	return &resourcePoolStatusRequestTypedInformerAdapter{informer}
+}
+
+type resourcePoolStatusRequestTypedInformerAdapter struct {
+	ResourcePoolStatusRequestInformer
+}
+
+func (a *resourcePoolStatusRequestTypedInformerAdapter) TypedInformer() ResourcePoolStatusRequestIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1alpha3.ResourcePoolStatusRequest](a.Informer())
+}
+
+// ToResourcePoolStatusRequestIndexInformer converts an untyped informer into a ResourcePoolStatusRequestIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ResourcePoolStatusRequest. If that is not the case, calling type-safe methods of the returned
+// ResourcePoolStatusRequestIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ResourcePoolStatusRequestIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToResourcePoolStatusRequestIndexInformer(informer cache.SharedIndexInformer) ResourcePoolStatusRequestIndexInformer {
+	if informer, ok := informer.(ResourcePoolStatusRequestIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1alpha3.ResourcePoolStatusRequest](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta1/deviceclass.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta1/deviceclass.go
@@ -34,11 +34,39 @@ import (
 )
 
 // DeviceClassInformer provides access to a shared informer and lister for
-// DeviceClasses.
+// DeviceClasses. Prefer using the type-safe variant (see [TypedDeviceClassInformer]).
 type DeviceClassInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() resourcev1beta1.DeviceClassLister
 }
+
+// TypedDeviceClassInformer provides access to a shared informer and lister for
+// DeviceClasses, including the type-safe TypedInformer variant.
+// It is a superset of DeviceClassInformer.
+type TypedDeviceClassInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() DeviceClassIndexInformer
+	Lister() resourcev1beta1.DeviceClassLister
+}
+
+// DeviceClassIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type DeviceClassIndexInformer cache.TypedSharedIndexInformer[*apiresourcev1beta1.DeviceClass]
+
+// DeviceClassHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for DeviceClass.
+type DeviceClassHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiresourcev1beta1.DeviceClass]
+
+// DeviceClassDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for DeviceClass.
+type DeviceClassDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiresourcev1beta1.DeviceClass]
+
+// DeviceClassFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for DeviceClass.
+type DeviceClassFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiresourcev1beta1.DeviceClass]
+
+// DeviceClassIndexers is a specialization of [cache.TypedIndexers] for DeviceClass.
+type DeviceClassIndexers = cache.TypedIndexers[*apiresourcev1beta1.DeviceClass]
+
+// DeletedDeviceClass is a specialization of [cache.DeletedObject] for DeviceClass.
+type DeletedDeviceClass = cache.DeletedObject[*apiresourcev1beta1.DeviceClass]
 
 type deviceClassInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type deviceClassInformer struct {
 // NewDeviceClassInformer constructs a new informer for DeviceClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedDeviceClassInformer]).
 func NewDeviceClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewDeviceClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedDeviceClassInformer constructs a new informer for DeviceClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedDeviceClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers DeviceClassIndexers) DeviceClassIndexInformer {
+	return NewTypedDeviceClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredDeviceClassInformer constructs a new informer for DeviceClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredDeviceClassInformer]).
 func NewFilteredDeviceClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewDeviceClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedDeviceClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredDeviceClassInformer constructs a new informer for DeviceClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredDeviceClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers DeviceClassIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) DeviceClassIndexInformer {
+	return NewTypedDeviceClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewDeviceClassInformerWithOptions constructs a new informer for DeviceClass type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedDeviceClassInformerWithOptions]).
 func NewDeviceClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedDeviceClassInformerWithOptions(client, options)
+}
+
+// NewTypedDeviceClassInformerWithOptions constructs a new informer for DeviceClass type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedDeviceClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) DeviceClassIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "resource.k8s.io", Version: "v1beta1", Resource: "deviceclasss"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta1.DeviceClass](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewDeviceClassInformerWithOptions(client kubernetes.Interface, options inte
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *deviceClassInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewDeviceClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedDeviceClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *deviceClassInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiresourcev1beta1.DeviceClass{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *deviceClassInformer) TypedInformer() DeviceClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta1.DeviceClass](f.factory.InformerFor(&apiresourcev1beta1.DeviceClass{}, f.defaultInformer))
 }
 
 func (f *deviceClassInformer) Lister() resourcev1beta1.DeviceClassLister {
 	return resourcev1beta1.NewDeviceClassLister(f.Informer().GetIndexer())
+}
+
+// ToTypedDeviceClassInformer converts an untyped informer into a TypedDeviceClassInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *DeviceClass. If that is not the case, calling type-safe methods of the returned
+// TypedDeviceClassInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedDeviceClassInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedDeviceClassInformer(informer DeviceClassInformer) TypedDeviceClassInformer {
+	if informer, ok := informer.(TypedDeviceClassInformer); ok {
+		return informer
+	}
+	return &deviceClassTypedInformerAdapter{informer}
+}
+
+type deviceClassTypedInformerAdapter struct {
+	DeviceClassInformer
+}
+
+func (a *deviceClassTypedInformerAdapter) TypedInformer() DeviceClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta1.DeviceClass](a.Informer())
+}
+
+// ToDeviceClassIndexInformer converts an untyped informer into a DeviceClassIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *DeviceClass. If that is not the case, calling type-safe methods of the returned
+// DeviceClassIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a DeviceClassIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToDeviceClassIndexInformer(informer cache.SharedIndexInformer) DeviceClassIndexInformer {
+	if informer, ok := informer.(DeviceClassIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta1.DeviceClass](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta1/interface.go
@@ -25,13 +25,13 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// DeviceClasses returns a DeviceClassInformer.
-	DeviceClasses() DeviceClassInformer
+	DeviceClasses() TypedDeviceClassInformer
 	// ResourceClaims returns a ResourceClaimInformer.
-	ResourceClaims() ResourceClaimInformer
+	ResourceClaims() TypedResourceClaimInformer
 	// ResourceClaimTemplates returns a ResourceClaimTemplateInformer.
-	ResourceClaimTemplates() ResourceClaimTemplateInformer
+	ResourceClaimTemplates() TypedResourceClaimTemplateInformer
 	// ResourceSlices returns a ResourceSliceInformer.
-	ResourceSlices() ResourceSliceInformer
+	ResourceSlices() TypedResourceSliceInformer
 }
 
 type version struct {
@@ -45,22 +45,22 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// DeviceClasses returns a DeviceClassInformer.
-func (v *version) DeviceClasses() DeviceClassInformer {
+// DeviceClasses returns a TypedDeviceClassInformer.
+func (v *version) DeviceClasses() TypedDeviceClassInformer {
 	return &deviceClassInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// ResourceClaims returns a ResourceClaimInformer.
-func (v *version) ResourceClaims() ResourceClaimInformer {
+// ResourceClaims returns a TypedResourceClaimInformer.
+func (v *version) ResourceClaims() TypedResourceClaimInformer {
 	return &resourceClaimInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// ResourceClaimTemplates returns a ResourceClaimTemplateInformer.
-func (v *version) ResourceClaimTemplates() ResourceClaimTemplateInformer {
+// ResourceClaimTemplates returns a TypedResourceClaimTemplateInformer.
+func (v *version) ResourceClaimTemplates() TypedResourceClaimTemplateInformer {
 	return &resourceClaimTemplateInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// ResourceSlices returns a ResourceSliceInformer.
-func (v *version) ResourceSlices() ResourceSliceInformer {
+// ResourceSlices returns a TypedResourceSliceInformer.
+func (v *version) ResourceSlices() TypedResourceSliceInformer {
 	return &resourceSliceInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta1/resourceclaim.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta1/resourceclaim.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ResourceClaimInformer provides access to a shared informer and lister for
-// ResourceClaims.
+// ResourceClaims. Prefer using the type-safe variant (see [TypedResourceClaimInformer]).
 type ResourceClaimInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() resourcev1beta1.ResourceClaimLister
 }
+
+// TypedResourceClaimInformer provides access to a shared informer and lister for
+// ResourceClaims, including the type-safe TypedInformer variant.
+// It is a superset of ResourceClaimInformer.
+type TypedResourceClaimInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ResourceClaimIndexInformer
+	Lister() resourcev1beta1.ResourceClaimLister
+}
+
+// ResourceClaimIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ResourceClaimIndexInformer cache.TypedSharedIndexInformer[*apiresourcev1beta1.ResourceClaim]
+
+// ResourceClaimHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ResourceClaim.
+type ResourceClaimHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiresourcev1beta1.ResourceClaim]
+
+// ResourceClaimDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ResourceClaim.
+type ResourceClaimDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiresourcev1beta1.ResourceClaim]
+
+// ResourceClaimFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ResourceClaim.
+type ResourceClaimFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiresourcev1beta1.ResourceClaim]
+
+// ResourceClaimIndexers is a specialization of [cache.TypedIndexers] for ResourceClaim.
+type ResourceClaimIndexers = cache.TypedIndexers[*apiresourcev1beta1.ResourceClaim]
+
+// DeletedResourceClaim is a specialization of [cache.DeletedObject] for ResourceClaim.
+type DeletedResourceClaim = cache.DeletedObject[*apiresourcev1beta1.ResourceClaim]
 
 type resourceClaimInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type resourceClaimInformer struct {
 // NewResourceClaimInformer constructs a new informer for ResourceClaim type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedResourceClaimInformer]).
 func NewResourceClaimInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewResourceClaimInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedResourceClaimInformer constructs a new informer for ResourceClaim type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedResourceClaimInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ResourceClaimIndexers) ResourceClaimIndexInformer {
+	return NewTypedResourceClaimInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredResourceClaimInformer constructs a new informer for ResourceClaim type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredResourceClaimInformer]).
 func NewFilteredResourceClaimInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewResourceClaimInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedResourceClaimInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredResourceClaimInformer constructs a new informer for ResourceClaim type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredResourceClaimInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ResourceClaimIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ResourceClaimIndexInformer {
+	return NewTypedResourceClaimInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewResourceClaimInformerWithOptions constructs a new informer for ResourceClaim type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedResourceClaimInformerWithOptions]).
 func NewResourceClaimInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedResourceClaimInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedResourceClaimInformerWithOptions constructs a new informer for ResourceClaim type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedResourceClaimInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) ResourceClaimIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "resource.k8s.io", Version: "v1beta1", Resource: "resourceclaims"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta1.ResourceClaim](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewResourceClaimInformerWithOptions(client kubernetes.Interface, namespace 
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *resourceClaimInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewResourceClaimInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedResourceClaimInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *resourceClaimInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiresourcev1beta1.ResourceClaim{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *resourceClaimInformer) TypedInformer() ResourceClaimIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta1.ResourceClaim](f.factory.InformerFor(&apiresourcev1beta1.ResourceClaim{}, f.defaultInformer))
 }
 
 func (f *resourceClaimInformer) Lister() resourcev1beta1.ResourceClaimLister {
 	return resourcev1beta1.NewResourceClaimLister(f.Informer().GetIndexer())
+}
+
+// ToTypedResourceClaimInformer converts an untyped informer into a TypedResourceClaimInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ResourceClaim. If that is not the case, calling type-safe methods of the returned
+// TypedResourceClaimInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedResourceClaimInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedResourceClaimInformer(informer ResourceClaimInformer) TypedResourceClaimInformer {
+	if informer, ok := informer.(TypedResourceClaimInformer); ok {
+		return informer
+	}
+	return &resourceClaimTypedInformerAdapter{informer}
+}
+
+type resourceClaimTypedInformerAdapter struct {
+	ResourceClaimInformer
+}
+
+func (a *resourceClaimTypedInformerAdapter) TypedInformer() ResourceClaimIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta1.ResourceClaim](a.Informer())
+}
+
+// ToResourceClaimIndexInformer converts an untyped informer into a ResourceClaimIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ResourceClaim. If that is not the case, calling type-safe methods of the returned
+// ResourceClaimIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ResourceClaimIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToResourceClaimIndexInformer(informer cache.SharedIndexInformer) ResourceClaimIndexInformer {
+	if informer, ok := informer.(ResourceClaimIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta1.ResourceClaim](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta1/resourceclaimtemplate.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta1/resourceclaimtemplate.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ResourceClaimTemplateInformer provides access to a shared informer and lister for
-// ResourceClaimTemplates.
+// ResourceClaimTemplates. Prefer using the type-safe variant (see [TypedResourceClaimTemplateInformer]).
 type ResourceClaimTemplateInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() resourcev1beta1.ResourceClaimTemplateLister
 }
+
+// TypedResourceClaimTemplateInformer provides access to a shared informer and lister for
+// ResourceClaimTemplates, including the type-safe TypedInformer variant.
+// It is a superset of ResourceClaimTemplateInformer.
+type TypedResourceClaimTemplateInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ResourceClaimTemplateIndexInformer
+	Lister() resourcev1beta1.ResourceClaimTemplateLister
+}
+
+// ResourceClaimTemplateIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ResourceClaimTemplateIndexInformer cache.TypedSharedIndexInformer[*apiresourcev1beta1.ResourceClaimTemplate]
+
+// ResourceClaimTemplateHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ResourceClaimTemplate.
+type ResourceClaimTemplateHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiresourcev1beta1.ResourceClaimTemplate]
+
+// ResourceClaimTemplateDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ResourceClaimTemplate.
+type ResourceClaimTemplateDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiresourcev1beta1.ResourceClaimTemplate]
+
+// ResourceClaimTemplateFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ResourceClaimTemplate.
+type ResourceClaimTemplateFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiresourcev1beta1.ResourceClaimTemplate]
+
+// ResourceClaimTemplateIndexers is a specialization of [cache.TypedIndexers] for ResourceClaimTemplate.
+type ResourceClaimTemplateIndexers = cache.TypedIndexers[*apiresourcev1beta1.ResourceClaimTemplate]
+
+// DeletedResourceClaimTemplate is a specialization of [cache.DeletedObject] for ResourceClaimTemplate.
+type DeletedResourceClaimTemplate = cache.DeletedObject[*apiresourcev1beta1.ResourceClaimTemplate]
 
 type resourceClaimTemplateInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type resourceClaimTemplateInformer struct {
 // NewResourceClaimTemplateInformer constructs a new informer for ResourceClaimTemplate type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedResourceClaimTemplateInformer]).
 func NewResourceClaimTemplateInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewResourceClaimTemplateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedResourceClaimTemplateInformer constructs a new informer for ResourceClaimTemplate type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedResourceClaimTemplateInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ResourceClaimTemplateIndexers) ResourceClaimTemplateIndexInformer {
+	return NewTypedResourceClaimTemplateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredResourceClaimTemplateInformer constructs a new informer for ResourceClaimTemplate type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredResourceClaimTemplateInformer]).
 func NewFilteredResourceClaimTemplateInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewResourceClaimTemplateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedResourceClaimTemplateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredResourceClaimTemplateInformer constructs a new informer for ResourceClaimTemplate type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredResourceClaimTemplateInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ResourceClaimTemplateIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ResourceClaimTemplateIndexInformer {
+	return NewTypedResourceClaimTemplateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewResourceClaimTemplateInformerWithOptions constructs a new informer for ResourceClaimTemplate type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedResourceClaimTemplateInformerWithOptions]).
 func NewResourceClaimTemplateInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedResourceClaimTemplateInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedResourceClaimTemplateInformerWithOptions constructs a new informer for ResourceClaimTemplate type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedResourceClaimTemplateInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) ResourceClaimTemplateIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "resource.k8s.io", Version: "v1beta1", Resource: "resourceclaimtemplates"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta1.ResourceClaimTemplate](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewResourceClaimTemplateInformerWithOptions(client kubernetes.Interface, na
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *resourceClaimTemplateInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewResourceClaimTemplateInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedResourceClaimTemplateInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *resourceClaimTemplateInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiresourcev1beta1.ResourceClaimTemplate{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *resourceClaimTemplateInformer) TypedInformer() ResourceClaimTemplateIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta1.ResourceClaimTemplate](f.factory.InformerFor(&apiresourcev1beta1.ResourceClaimTemplate{}, f.defaultInformer))
 }
 
 func (f *resourceClaimTemplateInformer) Lister() resourcev1beta1.ResourceClaimTemplateLister {
 	return resourcev1beta1.NewResourceClaimTemplateLister(f.Informer().GetIndexer())
+}
+
+// ToTypedResourceClaimTemplateInformer converts an untyped informer into a TypedResourceClaimTemplateInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ResourceClaimTemplate. If that is not the case, calling type-safe methods of the returned
+// TypedResourceClaimTemplateInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedResourceClaimTemplateInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedResourceClaimTemplateInformer(informer ResourceClaimTemplateInformer) TypedResourceClaimTemplateInformer {
+	if informer, ok := informer.(TypedResourceClaimTemplateInformer); ok {
+		return informer
+	}
+	return &resourceClaimTemplateTypedInformerAdapter{informer}
+}
+
+type resourceClaimTemplateTypedInformerAdapter struct {
+	ResourceClaimTemplateInformer
+}
+
+func (a *resourceClaimTemplateTypedInformerAdapter) TypedInformer() ResourceClaimTemplateIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta1.ResourceClaimTemplate](a.Informer())
+}
+
+// ToResourceClaimTemplateIndexInformer converts an untyped informer into a ResourceClaimTemplateIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ResourceClaimTemplate. If that is not the case, calling type-safe methods of the returned
+// ResourceClaimTemplateIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ResourceClaimTemplateIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToResourceClaimTemplateIndexInformer(informer cache.SharedIndexInformer) ResourceClaimTemplateIndexInformer {
+	if informer, ok := informer.(ResourceClaimTemplateIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta1.ResourceClaimTemplate](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta1/resourceslice.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta1/resourceslice.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ResourceSliceInformer provides access to a shared informer and lister for
-// ResourceSlices.
+// ResourceSlices. Prefer using the type-safe variant (see [TypedResourceSliceInformer]).
 type ResourceSliceInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() resourcev1beta1.ResourceSliceLister
 }
+
+// TypedResourceSliceInformer provides access to a shared informer and lister for
+// ResourceSlices, including the type-safe TypedInformer variant.
+// It is a superset of ResourceSliceInformer.
+type TypedResourceSliceInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ResourceSliceIndexInformer
+	Lister() resourcev1beta1.ResourceSliceLister
+}
+
+// ResourceSliceIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ResourceSliceIndexInformer cache.TypedSharedIndexInformer[*apiresourcev1beta1.ResourceSlice]
+
+// ResourceSliceHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ResourceSlice.
+type ResourceSliceHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiresourcev1beta1.ResourceSlice]
+
+// ResourceSliceDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ResourceSlice.
+type ResourceSliceDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiresourcev1beta1.ResourceSlice]
+
+// ResourceSliceFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ResourceSlice.
+type ResourceSliceFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiresourcev1beta1.ResourceSlice]
+
+// ResourceSliceIndexers is a specialization of [cache.TypedIndexers] for ResourceSlice.
+type ResourceSliceIndexers = cache.TypedIndexers[*apiresourcev1beta1.ResourceSlice]
+
+// DeletedResourceSlice is a specialization of [cache.DeletedObject] for ResourceSlice.
+type DeletedResourceSlice = cache.DeletedObject[*apiresourcev1beta1.ResourceSlice]
 
 type resourceSliceInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type resourceSliceInformer struct {
 // NewResourceSliceInformer constructs a new informer for ResourceSlice type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedResourceSliceInformer]).
 func NewResourceSliceInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewResourceSliceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedResourceSliceInformer constructs a new informer for ResourceSlice type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedResourceSliceInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ResourceSliceIndexers) ResourceSliceIndexInformer {
+	return NewTypedResourceSliceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredResourceSliceInformer constructs a new informer for ResourceSlice type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredResourceSliceInformer]).
 func NewFilteredResourceSliceInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewResourceSliceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedResourceSliceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredResourceSliceInformer constructs a new informer for ResourceSlice type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredResourceSliceInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ResourceSliceIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ResourceSliceIndexInformer {
+	return NewTypedResourceSliceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewResourceSliceInformerWithOptions constructs a new informer for ResourceSlice type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedResourceSliceInformerWithOptions]).
 func NewResourceSliceInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedResourceSliceInformerWithOptions(client, options)
+}
+
+// NewTypedResourceSliceInformerWithOptions constructs a new informer for ResourceSlice type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedResourceSliceInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ResourceSliceIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "resource.k8s.io", Version: "v1beta1", Resource: "resourceslices"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta1.ResourceSlice](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewResourceSliceInformerWithOptions(client kubernetes.Interface, options in
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *resourceSliceInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewResourceSliceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedResourceSliceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *resourceSliceInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiresourcev1beta1.ResourceSlice{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *resourceSliceInformer) TypedInformer() ResourceSliceIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta1.ResourceSlice](f.factory.InformerFor(&apiresourcev1beta1.ResourceSlice{}, f.defaultInformer))
 }
 
 func (f *resourceSliceInformer) Lister() resourcev1beta1.ResourceSliceLister {
 	return resourcev1beta1.NewResourceSliceLister(f.Informer().GetIndexer())
+}
+
+// ToTypedResourceSliceInformer converts an untyped informer into a TypedResourceSliceInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ResourceSlice. If that is not the case, calling type-safe methods of the returned
+// TypedResourceSliceInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedResourceSliceInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedResourceSliceInformer(informer ResourceSliceInformer) TypedResourceSliceInformer {
+	if informer, ok := informer.(TypedResourceSliceInformer); ok {
+		return informer
+	}
+	return &resourceSliceTypedInformerAdapter{informer}
+}
+
+type resourceSliceTypedInformerAdapter struct {
+	ResourceSliceInformer
+}
+
+func (a *resourceSliceTypedInformerAdapter) TypedInformer() ResourceSliceIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta1.ResourceSlice](a.Informer())
+}
+
+// ToResourceSliceIndexInformer converts an untyped informer into a ResourceSliceIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ResourceSlice. If that is not the case, calling type-safe methods of the returned
+// ResourceSliceIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ResourceSliceIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToResourceSliceIndexInformer(informer cache.SharedIndexInformer) ResourceSliceIndexInformer {
+	if informer, ok := informer.(ResourceSliceIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta1.ResourceSlice](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta2/deviceclass.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta2/deviceclass.go
@@ -34,11 +34,39 @@ import (
 )
 
 // DeviceClassInformer provides access to a shared informer and lister for
-// DeviceClasses.
+// DeviceClasses. Prefer using the type-safe variant (see [TypedDeviceClassInformer]).
 type DeviceClassInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() resourcev1beta2.DeviceClassLister
 }
+
+// TypedDeviceClassInformer provides access to a shared informer and lister for
+// DeviceClasses, including the type-safe TypedInformer variant.
+// It is a superset of DeviceClassInformer.
+type TypedDeviceClassInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() DeviceClassIndexInformer
+	Lister() resourcev1beta2.DeviceClassLister
+}
+
+// DeviceClassIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type DeviceClassIndexInformer cache.TypedSharedIndexInformer[*apiresourcev1beta2.DeviceClass]
+
+// DeviceClassHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for DeviceClass.
+type DeviceClassHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiresourcev1beta2.DeviceClass]
+
+// DeviceClassDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for DeviceClass.
+type DeviceClassDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiresourcev1beta2.DeviceClass]
+
+// DeviceClassFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for DeviceClass.
+type DeviceClassFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiresourcev1beta2.DeviceClass]
+
+// DeviceClassIndexers is a specialization of [cache.TypedIndexers] for DeviceClass.
+type DeviceClassIndexers = cache.TypedIndexers[*apiresourcev1beta2.DeviceClass]
+
+// DeletedDeviceClass is a specialization of [cache.DeletedObject] for DeviceClass.
+type DeletedDeviceClass = cache.DeletedObject[*apiresourcev1beta2.DeviceClass]
 
 type deviceClassInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type deviceClassInformer struct {
 // NewDeviceClassInformer constructs a new informer for DeviceClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedDeviceClassInformer]).
 func NewDeviceClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewDeviceClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedDeviceClassInformer constructs a new informer for DeviceClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedDeviceClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers DeviceClassIndexers) DeviceClassIndexInformer {
+	return NewTypedDeviceClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredDeviceClassInformer constructs a new informer for DeviceClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredDeviceClassInformer]).
 func NewFilteredDeviceClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewDeviceClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedDeviceClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredDeviceClassInformer constructs a new informer for DeviceClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredDeviceClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers DeviceClassIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) DeviceClassIndexInformer {
+	return NewTypedDeviceClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewDeviceClassInformerWithOptions constructs a new informer for DeviceClass type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedDeviceClassInformerWithOptions]).
 func NewDeviceClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedDeviceClassInformerWithOptions(client, options)
+}
+
+// NewTypedDeviceClassInformerWithOptions constructs a new informer for DeviceClass type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedDeviceClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) DeviceClassIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "resource.k8s.io", Version: "v1beta2", Resource: "deviceclasss"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta2.DeviceClass](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewDeviceClassInformerWithOptions(client kubernetes.Interface, options inte
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *deviceClassInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewDeviceClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedDeviceClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *deviceClassInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiresourcev1beta2.DeviceClass{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *deviceClassInformer) TypedInformer() DeviceClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta2.DeviceClass](f.factory.InformerFor(&apiresourcev1beta2.DeviceClass{}, f.defaultInformer))
 }
 
 func (f *deviceClassInformer) Lister() resourcev1beta2.DeviceClassLister {
 	return resourcev1beta2.NewDeviceClassLister(f.Informer().GetIndexer())
+}
+
+// ToTypedDeviceClassInformer converts an untyped informer into a TypedDeviceClassInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *DeviceClass. If that is not the case, calling type-safe methods of the returned
+// TypedDeviceClassInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedDeviceClassInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedDeviceClassInformer(informer DeviceClassInformer) TypedDeviceClassInformer {
+	if informer, ok := informer.(TypedDeviceClassInformer); ok {
+		return informer
+	}
+	return &deviceClassTypedInformerAdapter{informer}
+}
+
+type deviceClassTypedInformerAdapter struct {
+	DeviceClassInformer
+}
+
+func (a *deviceClassTypedInformerAdapter) TypedInformer() DeviceClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta2.DeviceClass](a.Informer())
+}
+
+// ToDeviceClassIndexInformer converts an untyped informer into a DeviceClassIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *DeviceClass. If that is not the case, calling type-safe methods of the returned
+// DeviceClassIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a DeviceClassIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToDeviceClassIndexInformer(informer cache.SharedIndexInformer) DeviceClassIndexInformer {
+	if informer, ok := informer.(DeviceClassIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta2.DeviceClass](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta2/devicetaintrule.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta2/devicetaintrule.go
@@ -34,11 +34,39 @@ import (
 )
 
 // DeviceTaintRuleInformer provides access to a shared informer and lister for
-// DeviceTaintRules.
+// DeviceTaintRules. Prefer using the type-safe variant (see [TypedDeviceTaintRuleInformer]).
 type DeviceTaintRuleInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() resourcev1beta2.DeviceTaintRuleLister
 }
+
+// TypedDeviceTaintRuleInformer provides access to a shared informer and lister for
+// DeviceTaintRules, including the type-safe TypedInformer variant.
+// It is a superset of DeviceTaintRuleInformer.
+type TypedDeviceTaintRuleInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() DeviceTaintRuleIndexInformer
+	Lister() resourcev1beta2.DeviceTaintRuleLister
+}
+
+// DeviceTaintRuleIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type DeviceTaintRuleIndexInformer cache.TypedSharedIndexInformer[*apiresourcev1beta2.DeviceTaintRule]
+
+// DeviceTaintRuleHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for DeviceTaintRule.
+type DeviceTaintRuleHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiresourcev1beta2.DeviceTaintRule]
+
+// DeviceTaintRuleDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for DeviceTaintRule.
+type DeviceTaintRuleDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiresourcev1beta2.DeviceTaintRule]
+
+// DeviceTaintRuleFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for DeviceTaintRule.
+type DeviceTaintRuleFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiresourcev1beta2.DeviceTaintRule]
+
+// DeviceTaintRuleIndexers is a specialization of [cache.TypedIndexers] for DeviceTaintRule.
+type DeviceTaintRuleIndexers = cache.TypedIndexers[*apiresourcev1beta2.DeviceTaintRule]
+
+// DeletedDeviceTaintRule is a specialization of [cache.DeletedObject] for DeviceTaintRule.
+type DeletedDeviceTaintRule = cache.DeletedObject[*apiresourcev1beta2.DeviceTaintRule]
 
 type deviceTaintRuleInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type deviceTaintRuleInformer struct {
 // NewDeviceTaintRuleInformer constructs a new informer for DeviceTaintRule type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedDeviceTaintRuleInformer]).
 func NewDeviceTaintRuleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewDeviceTaintRuleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedDeviceTaintRuleInformer constructs a new informer for DeviceTaintRule type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedDeviceTaintRuleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers DeviceTaintRuleIndexers) DeviceTaintRuleIndexInformer {
+	return NewTypedDeviceTaintRuleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredDeviceTaintRuleInformer constructs a new informer for DeviceTaintRule type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredDeviceTaintRuleInformer]).
 func NewFilteredDeviceTaintRuleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewDeviceTaintRuleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedDeviceTaintRuleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredDeviceTaintRuleInformer constructs a new informer for DeviceTaintRule type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredDeviceTaintRuleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers DeviceTaintRuleIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) DeviceTaintRuleIndexInformer {
+	return NewTypedDeviceTaintRuleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewDeviceTaintRuleInformerWithOptions constructs a new informer for DeviceTaintRule type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedDeviceTaintRuleInformerWithOptions]).
 func NewDeviceTaintRuleInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedDeviceTaintRuleInformerWithOptions(client, options)
+}
+
+// NewTypedDeviceTaintRuleInformerWithOptions constructs a new informer for DeviceTaintRule type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedDeviceTaintRuleInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) DeviceTaintRuleIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "resource.k8s.io", Version: "v1beta2", Resource: "devicetaintrules"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta2.DeviceTaintRule](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewDeviceTaintRuleInformerWithOptions(client kubernetes.Interface, options 
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *deviceTaintRuleInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewDeviceTaintRuleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedDeviceTaintRuleInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *deviceTaintRuleInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiresourcev1beta2.DeviceTaintRule{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *deviceTaintRuleInformer) TypedInformer() DeviceTaintRuleIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta2.DeviceTaintRule](f.factory.InformerFor(&apiresourcev1beta2.DeviceTaintRule{}, f.defaultInformer))
 }
 
 func (f *deviceTaintRuleInformer) Lister() resourcev1beta2.DeviceTaintRuleLister {
 	return resourcev1beta2.NewDeviceTaintRuleLister(f.Informer().GetIndexer())
+}
+
+// ToTypedDeviceTaintRuleInformer converts an untyped informer into a TypedDeviceTaintRuleInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *DeviceTaintRule. If that is not the case, calling type-safe methods of the returned
+// TypedDeviceTaintRuleInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedDeviceTaintRuleInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedDeviceTaintRuleInformer(informer DeviceTaintRuleInformer) TypedDeviceTaintRuleInformer {
+	if informer, ok := informer.(TypedDeviceTaintRuleInformer); ok {
+		return informer
+	}
+	return &deviceTaintRuleTypedInformerAdapter{informer}
+}
+
+type deviceTaintRuleTypedInformerAdapter struct {
+	DeviceTaintRuleInformer
+}
+
+func (a *deviceTaintRuleTypedInformerAdapter) TypedInformer() DeviceTaintRuleIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta2.DeviceTaintRule](a.Informer())
+}
+
+// ToDeviceTaintRuleIndexInformer converts an untyped informer into a DeviceTaintRuleIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *DeviceTaintRule. If that is not the case, calling type-safe methods of the returned
+// DeviceTaintRuleIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a DeviceTaintRuleIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToDeviceTaintRuleIndexInformer(informer cache.SharedIndexInformer) DeviceTaintRuleIndexInformer {
+	if informer, ok := informer.(DeviceTaintRuleIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta2.DeviceTaintRule](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta2/interface.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta2/interface.go
@@ -25,15 +25,15 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// DeviceClasses returns a DeviceClassInformer.
-	DeviceClasses() DeviceClassInformer
+	DeviceClasses() TypedDeviceClassInformer
 	// DeviceTaintRules returns a DeviceTaintRuleInformer.
-	DeviceTaintRules() DeviceTaintRuleInformer
+	DeviceTaintRules() TypedDeviceTaintRuleInformer
 	// ResourceClaims returns a ResourceClaimInformer.
-	ResourceClaims() ResourceClaimInformer
+	ResourceClaims() TypedResourceClaimInformer
 	// ResourceClaimTemplates returns a ResourceClaimTemplateInformer.
-	ResourceClaimTemplates() ResourceClaimTemplateInformer
+	ResourceClaimTemplates() TypedResourceClaimTemplateInformer
 	// ResourceSlices returns a ResourceSliceInformer.
-	ResourceSlices() ResourceSliceInformer
+	ResourceSlices() TypedResourceSliceInformer
 }
 
 type version struct {
@@ -47,27 +47,27 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// DeviceClasses returns a DeviceClassInformer.
-func (v *version) DeviceClasses() DeviceClassInformer {
+// DeviceClasses returns a TypedDeviceClassInformer.
+func (v *version) DeviceClasses() TypedDeviceClassInformer {
 	return &deviceClassInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// DeviceTaintRules returns a DeviceTaintRuleInformer.
-func (v *version) DeviceTaintRules() DeviceTaintRuleInformer {
+// DeviceTaintRules returns a TypedDeviceTaintRuleInformer.
+func (v *version) DeviceTaintRules() TypedDeviceTaintRuleInformer {
 	return &deviceTaintRuleInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// ResourceClaims returns a ResourceClaimInformer.
-func (v *version) ResourceClaims() ResourceClaimInformer {
+// ResourceClaims returns a TypedResourceClaimInformer.
+func (v *version) ResourceClaims() TypedResourceClaimInformer {
 	return &resourceClaimInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// ResourceClaimTemplates returns a ResourceClaimTemplateInformer.
-func (v *version) ResourceClaimTemplates() ResourceClaimTemplateInformer {
+// ResourceClaimTemplates returns a TypedResourceClaimTemplateInformer.
+func (v *version) ResourceClaimTemplates() TypedResourceClaimTemplateInformer {
 	return &resourceClaimTemplateInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// ResourceSlices returns a ResourceSliceInformer.
-func (v *version) ResourceSlices() ResourceSliceInformer {
+// ResourceSlices returns a TypedResourceSliceInformer.
+func (v *version) ResourceSlices() TypedResourceSliceInformer {
 	return &resourceSliceInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta2/resourceclaim.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta2/resourceclaim.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ResourceClaimInformer provides access to a shared informer and lister for
-// ResourceClaims.
+// ResourceClaims. Prefer using the type-safe variant (see [TypedResourceClaimInformer]).
 type ResourceClaimInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() resourcev1beta2.ResourceClaimLister
 }
+
+// TypedResourceClaimInformer provides access to a shared informer and lister for
+// ResourceClaims, including the type-safe TypedInformer variant.
+// It is a superset of ResourceClaimInformer.
+type TypedResourceClaimInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ResourceClaimIndexInformer
+	Lister() resourcev1beta2.ResourceClaimLister
+}
+
+// ResourceClaimIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ResourceClaimIndexInformer cache.TypedSharedIndexInformer[*apiresourcev1beta2.ResourceClaim]
+
+// ResourceClaimHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ResourceClaim.
+type ResourceClaimHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiresourcev1beta2.ResourceClaim]
+
+// ResourceClaimDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ResourceClaim.
+type ResourceClaimDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiresourcev1beta2.ResourceClaim]
+
+// ResourceClaimFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ResourceClaim.
+type ResourceClaimFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiresourcev1beta2.ResourceClaim]
+
+// ResourceClaimIndexers is a specialization of [cache.TypedIndexers] for ResourceClaim.
+type ResourceClaimIndexers = cache.TypedIndexers[*apiresourcev1beta2.ResourceClaim]
+
+// DeletedResourceClaim is a specialization of [cache.DeletedObject] for ResourceClaim.
+type DeletedResourceClaim = cache.DeletedObject[*apiresourcev1beta2.ResourceClaim]
 
 type resourceClaimInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type resourceClaimInformer struct {
 // NewResourceClaimInformer constructs a new informer for ResourceClaim type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedResourceClaimInformer]).
 func NewResourceClaimInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewResourceClaimInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedResourceClaimInformer constructs a new informer for ResourceClaim type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedResourceClaimInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ResourceClaimIndexers) ResourceClaimIndexInformer {
+	return NewTypedResourceClaimInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredResourceClaimInformer constructs a new informer for ResourceClaim type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredResourceClaimInformer]).
 func NewFilteredResourceClaimInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewResourceClaimInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedResourceClaimInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredResourceClaimInformer constructs a new informer for ResourceClaim type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredResourceClaimInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ResourceClaimIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ResourceClaimIndexInformer {
+	return NewTypedResourceClaimInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewResourceClaimInformerWithOptions constructs a new informer for ResourceClaim type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedResourceClaimInformerWithOptions]).
 func NewResourceClaimInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedResourceClaimInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedResourceClaimInformerWithOptions constructs a new informer for ResourceClaim type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedResourceClaimInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) ResourceClaimIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "resource.k8s.io", Version: "v1beta2", Resource: "resourceclaims"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta2.ResourceClaim](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewResourceClaimInformerWithOptions(client kubernetes.Interface, namespace 
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *resourceClaimInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewResourceClaimInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedResourceClaimInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *resourceClaimInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiresourcev1beta2.ResourceClaim{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *resourceClaimInformer) TypedInformer() ResourceClaimIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta2.ResourceClaim](f.factory.InformerFor(&apiresourcev1beta2.ResourceClaim{}, f.defaultInformer))
 }
 
 func (f *resourceClaimInformer) Lister() resourcev1beta2.ResourceClaimLister {
 	return resourcev1beta2.NewResourceClaimLister(f.Informer().GetIndexer())
+}
+
+// ToTypedResourceClaimInformer converts an untyped informer into a TypedResourceClaimInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ResourceClaim. If that is not the case, calling type-safe methods of the returned
+// TypedResourceClaimInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedResourceClaimInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedResourceClaimInformer(informer ResourceClaimInformer) TypedResourceClaimInformer {
+	if informer, ok := informer.(TypedResourceClaimInformer); ok {
+		return informer
+	}
+	return &resourceClaimTypedInformerAdapter{informer}
+}
+
+type resourceClaimTypedInformerAdapter struct {
+	ResourceClaimInformer
+}
+
+func (a *resourceClaimTypedInformerAdapter) TypedInformer() ResourceClaimIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta2.ResourceClaim](a.Informer())
+}
+
+// ToResourceClaimIndexInformer converts an untyped informer into a ResourceClaimIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ResourceClaim. If that is not the case, calling type-safe methods of the returned
+// ResourceClaimIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ResourceClaimIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToResourceClaimIndexInformer(informer cache.SharedIndexInformer) ResourceClaimIndexInformer {
+	if informer, ok := informer.(ResourceClaimIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta2.ResourceClaim](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta2/resourceclaimtemplate.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta2/resourceclaimtemplate.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ResourceClaimTemplateInformer provides access to a shared informer and lister for
-// ResourceClaimTemplates.
+// ResourceClaimTemplates. Prefer using the type-safe variant (see [TypedResourceClaimTemplateInformer]).
 type ResourceClaimTemplateInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() resourcev1beta2.ResourceClaimTemplateLister
 }
+
+// TypedResourceClaimTemplateInformer provides access to a shared informer and lister for
+// ResourceClaimTemplates, including the type-safe TypedInformer variant.
+// It is a superset of ResourceClaimTemplateInformer.
+type TypedResourceClaimTemplateInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ResourceClaimTemplateIndexInformer
+	Lister() resourcev1beta2.ResourceClaimTemplateLister
+}
+
+// ResourceClaimTemplateIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ResourceClaimTemplateIndexInformer cache.TypedSharedIndexInformer[*apiresourcev1beta2.ResourceClaimTemplate]
+
+// ResourceClaimTemplateHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ResourceClaimTemplate.
+type ResourceClaimTemplateHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiresourcev1beta2.ResourceClaimTemplate]
+
+// ResourceClaimTemplateDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ResourceClaimTemplate.
+type ResourceClaimTemplateDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiresourcev1beta2.ResourceClaimTemplate]
+
+// ResourceClaimTemplateFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ResourceClaimTemplate.
+type ResourceClaimTemplateFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiresourcev1beta2.ResourceClaimTemplate]
+
+// ResourceClaimTemplateIndexers is a specialization of [cache.TypedIndexers] for ResourceClaimTemplate.
+type ResourceClaimTemplateIndexers = cache.TypedIndexers[*apiresourcev1beta2.ResourceClaimTemplate]
+
+// DeletedResourceClaimTemplate is a specialization of [cache.DeletedObject] for ResourceClaimTemplate.
+type DeletedResourceClaimTemplate = cache.DeletedObject[*apiresourcev1beta2.ResourceClaimTemplate]
 
 type resourceClaimTemplateInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type resourceClaimTemplateInformer struct {
 // NewResourceClaimTemplateInformer constructs a new informer for ResourceClaimTemplate type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedResourceClaimTemplateInformer]).
 func NewResourceClaimTemplateInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewResourceClaimTemplateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedResourceClaimTemplateInformer constructs a new informer for ResourceClaimTemplate type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedResourceClaimTemplateInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ResourceClaimTemplateIndexers) ResourceClaimTemplateIndexInformer {
+	return NewTypedResourceClaimTemplateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredResourceClaimTemplateInformer constructs a new informer for ResourceClaimTemplate type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredResourceClaimTemplateInformer]).
 func NewFilteredResourceClaimTemplateInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewResourceClaimTemplateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedResourceClaimTemplateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredResourceClaimTemplateInformer constructs a new informer for ResourceClaimTemplate type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredResourceClaimTemplateInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers ResourceClaimTemplateIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ResourceClaimTemplateIndexInformer {
+	return NewTypedResourceClaimTemplateInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewResourceClaimTemplateInformerWithOptions constructs a new informer for ResourceClaimTemplate type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedResourceClaimTemplateInformerWithOptions]).
 func NewResourceClaimTemplateInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedResourceClaimTemplateInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedResourceClaimTemplateInformerWithOptions constructs a new informer for ResourceClaimTemplate type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedResourceClaimTemplateInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) ResourceClaimTemplateIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "resource.k8s.io", Version: "v1beta2", Resource: "resourceclaimtemplates"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta2.ResourceClaimTemplate](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewResourceClaimTemplateInformerWithOptions(client kubernetes.Interface, na
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *resourceClaimTemplateInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewResourceClaimTemplateInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedResourceClaimTemplateInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *resourceClaimTemplateInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiresourcev1beta2.ResourceClaimTemplate{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *resourceClaimTemplateInformer) TypedInformer() ResourceClaimTemplateIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta2.ResourceClaimTemplate](f.factory.InformerFor(&apiresourcev1beta2.ResourceClaimTemplate{}, f.defaultInformer))
 }
 
 func (f *resourceClaimTemplateInformer) Lister() resourcev1beta2.ResourceClaimTemplateLister {
 	return resourcev1beta2.NewResourceClaimTemplateLister(f.Informer().GetIndexer())
+}
+
+// ToTypedResourceClaimTemplateInformer converts an untyped informer into a TypedResourceClaimTemplateInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ResourceClaimTemplate. If that is not the case, calling type-safe methods of the returned
+// TypedResourceClaimTemplateInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedResourceClaimTemplateInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedResourceClaimTemplateInformer(informer ResourceClaimTemplateInformer) TypedResourceClaimTemplateInformer {
+	if informer, ok := informer.(TypedResourceClaimTemplateInformer); ok {
+		return informer
+	}
+	return &resourceClaimTemplateTypedInformerAdapter{informer}
+}
+
+type resourceClaimTemplateTypedInformerAdapter struct {
+	ResourceClaimTemplateInformer
+}
+
+func (a *resourceClaimTemplateTypedInformerAdapter) TypedInformer() ResourceClaimTemplateIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta2.ResourceClaimTemplate](a.Informer())
+}
+
+// ToResourceClaimTemplateIndexInformer converts an untyped informer into a ResourceClaimTemplateIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ResourceClaimTemplate. If that is not the case, calling type-safe methods of the returned
+// ResourceClaimTemplateIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ResourceClaimTemplateIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToResourceClaimTemplateIndexInformer(informer cache.SharedIndexInformer) ResourceClaimTemplateIndexInformer {
+	if informer, ok := informer.(ResourceClaimTemplateIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta2.ResourceClaimTemplate](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta2/resourceslice.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta2/resourceslice.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ResourceSliceInformer provides access to a shared informer and lister for
-// ResourceSlices.
+// ResourceSlices. Prefer using the type-safe variant (see [TypedResourceSliceInformer]).
 type ResourceSliceInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() resourcev1beta2.ResourceSliceLister
 }
+
+// TypedResourceSliceInformer provides access to a shared informer and lister for
+// ResourceSlices, including the type-safe TypedInformer variant.
+// It is a superset of ResourceSliceInformer.
+type TypedResourceSliceInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ResourceSliceIndexInformer
+	Lister() resourcev1beta2.ResourceSliceLister
+}
+
+// ResourceSliceIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ResourceSliceIndexInformer cache.TypedSharedIndexInformer[*apiresourcev1beta2.ResourceSlice]
+
+// ResourceSliceHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ResourceSlice.
+type ResourceSliceHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiresourcev1beta2.ResourceSlice]
+
+// ResourceSliceDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ResourceSlice.
+type ResourceSliceDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiresourcev1beta2.ResourceSlice]
+
+// ResourceSliceFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ResourceSlice.
+type ResourceSliceFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiresourcev1beta2.ResourceSlice]
+
+// ResourceSliceIndexers is a specialization of [cache.TypedIndexers] for ResourceSlice.
+type ResourceSliceIndexers = cache.TypedIndexers[*apiresourcev1beta2.ResourceSlice]
+
+// DeletedResourceSlice is a specialization of [cache.DeletedObject] for ResourceSlice.
+type DeletedResourceSlice = cache.DeletedObject[*apiresourcev1beta2.ResourceSlice]
 
 type resourceSliceInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type resourceSliceInformer struct {
 // NewResourceSliceInformer constructs a new informer for ResourceSlice type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedResourceSliceInformer]).
 func NewResourceSliceInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewResourceSliceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedResourceSliceInformer constructs a new informer for ResourceSlice type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedResourceSliceInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ResourceSliceIndexers) ResourceSliceIndexInformer {
+	return NewTypedResourceSliceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredResourceSliceInformer constructs a new informer for ResourceSlice type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredResourceSliceInformer]).
 func NewFilteredResourceSliceInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewResourceSliceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedResourceSliceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredResourceSliceInformer constructs a new informer for ResourceSlice type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredResourceSliceInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers ResourceSliceIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ResourceSliceIndexInformer {
+	return NewTypedResourceSliceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewResourceSliceInformerWithOptions constructs a new informer for ResourceSlice type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedResourceSliceInformerWithOptions]).
 func NewResourceSliceInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedResourceSliceInformerWithOptions(client, options)
+}
+
+// NewTypedResourceSliceInformerWithOptions constructs a new informer for ResourceSlice type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedResourceSliceInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ResourceSliceIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "resource.k8s.io", Version: "v1beta2", Resource: "resourceslices"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta2.ResourceSlice](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewResourceSliceInformerWithOptions(client kubernetes.Interface, options in
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *resourceSliceInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewResourceSliceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedResourceSliceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *resourceSliceInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiresourcev1beta2.ResourceSlice{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *resourceSliceInformer) TypedInformer() ResourceSliceIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta2.ResourceSlice](f.factory.InformerFor(&apiresourcev1beta2.ResourceSlice{}, f.defaultInformer))
 }
 
 func (f *resourceSliceInformer) Lister() resourcev1beta2.ResourceSliceLister {
 	return resourcev1beta2.NewResourceSliceLister(f.Informer().GetIndexer())
+}
+
+// ToTypedResourceSliceInformer converts an untyped informer into a TypedResourceSliceInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ResourceSlice. If that is not the case, calling type-safe methods of the returned
+// TypedResourceSliceInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedResourceSliceInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedResourceSliceInformer(informer ResourceSliceInformer) TypedResourceSliceInformer {
+	if informer, ok := informer.(TypedResourceSliceInformer); ok {
+		return informer
+	}
+	return &resourceSliceTypedInformerAdapter{informer}
+}
+
+type resourceSliceTypedInformerAdapter struct {
+	ResourceSliceInformer
+}
+
+func (a *resourceSliceTypedInformerAdapter) TypedInformer() ResourceSliceIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta2.ResourceSlice](a.Informer())
+}
+
+// ToResourceSliceIndexInformer converts an untyped informer into a ResourceSliceIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ResourceSlice. If that is not the case, calling type-safe methods of the returned
+// ResourceSliceIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ResourceSliceIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToResourceSliceIndexInformer(informer cache.SharedIndexInformer) ResourceSliceIndexInformer {
+	if informer, ok := informer.(ResourceSliceIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta2.ResourceSlice](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/scheduling/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/scheduling/v1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// PriorityClasses returns a PriorityClassInformer.
-	PriorityClasses() PriorityClassInformer
+	PriorityClasses() TypedPriorityClassInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// PriorityClasses returns a PriorityClassInformer.
-func (v *version) PriorityClasses() PriorityClassInformer {
+// PriorityClasses returns a TypedPriorityClassInformer.
+func (v *version) PriorityClasses() TypedPriorityClassInformer {
 	return &priorityClassInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/scheduling/v1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/informers/scheduling/v1/priorityclass.go
@@ -34,11 +34,39 @@ import (
 )
 
 // PriorityClassInformer provides access to a shared informer and lister for
-// PriorityClasses.
+// PriorityClasses. Prefer using the type-safe variant (see [TypedPriorityClassInformer]).
 type PriorityClassInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() schedulingv1.PriorityClassLister
 }
+
+// TypedPriorityClassInformer provides access to a shared informer and lister for
+// PriorityClasses, including the type-safe TypedInformer variant.
+// It is a superset of PriorityClassInformer.
+type TypedPriorityClassInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() PriorityClassIndexInformer
+	Lister() schedulingv1.PriorityClassLister
+}
+
+// PriorityClassIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type PriorityClassIndexInformer cache.TypedSharedIndexInformer[*apischedulingv1.PriorityClass]
+
+// PriorityClassHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for PriorityClass.
+type PriorityClassHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apischedulingv1.PriorityClass]
+
+// PriorityClassDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for PriorityClass.
+type PriorityClassDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apischedulingv1.PriorityClass]
+
+// PriorityClassFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for PriorityClass.
+type PriorityClassFilteringHandler = cache.TypedFilteringResourceEventHandler[*apischedulingv1.PriorityClass]
+
+// PriorityClassIndexers is a specialization of [cache.TypedIndexers] for PriorityClass.
+type PriorityClassIndexers = cache.TypedIndexers[*apischedulingv1.PriorityClass]
+
+// DeletedPriorityClass is a specialization of [cache.DeletedObject] for PriorityClass.
+type DeletedPriorityClass = cache.DeletedObject[*apischedulingv1.PriorityClass]
 
 type priorityClassInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type priorityClassInformer struct {
 // NewPriorityClassInformer constructs a new informer for PriorityClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPriorityClassInformer]).
 func NewPriorityClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewPriorityClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedPriorityClassInformer constructs a new informer for PriorityClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPriorityClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers PriorityClassIndexers) PriorityClassIndexInformer {
+	return NewTypedPriorityClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredPriorityClassInformer constructs a new informer for PriorityClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredPriorityClassInformer]).
 func NewFilteredPriorityClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewPriorityClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedPriorityClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredPriorityClassInformer constructs a new informer for PriorityClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredPriorityClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers PriorityClassIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) PriorityClassIndexInformer {
+	return NewTypedPriorityClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewPriorityClassInformerWithOptions constructs a new informer for PriorityClass type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPriorityClassInformerWithOptions]).
 func NewPriorityClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedPriorityClassInformerWithOptions(client, options)
+}
+
+// NewTypedPriorityClassInformerWithOptions constructs a new informer for PriorityClass type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPriorityClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) PriorityClassIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "scheduling.k8s.io", Version: "v1", Resource: "priorityclasss"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apischedulingv1.PriorityClass](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewPriorityClassInformerWithOptions(client kubernetes.Interface, options in
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *priorityClassInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewPriorityClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedPriorityClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *priorityClassInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apischedulingv1.PriorityClass{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *priorityClassInformer) TypedInformer() PriorityClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apischedulingv1.PriorityClass](f.factory.InformerFor(&apischedulingv1.PriorityClass{}, f.defaultInformer))
 }
 
 func (f *priorityClassInformer) Lister() schedulingv1.PriorityClassLister {
 	return schedulingv1.NewPriorityClassLister(f.Informer().GetIndexer())
+}
+
+// ToTypedPriorityClassInformer converts an untyped informer into a TypedPriorityClassInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *PriorityClass. If that is not the case, calling type-safe methods of the returned
+// TypedPriorityClassInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedPriorityClassInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedPriorityClassInformer(informer PriorityClassInformer) TypedPriorityClassInformer {
+	if informer, ok := informer.(TypedPriorityClassInformer); ok {
+		return informer
+	}
+	return &priorityClassTypedInformerAdapter{informer}
+}
+
+type priorityClassTypedInformerAdapter struct {
+	PriorityClassInformer
+}
+
+func (a *priorityClassTypedInformerAdapter) TypedInformer() PriorityClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apischedulingv1.PriorityClass](a.Informer())
+}
+
+// ToPriorityClassIndexInformer converts an untyped informer into a PriorityClassIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *PriorityClass. If that is not the case, calling type-safe methods of the returned
+// PriorityClassIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a PriorityClassIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToPriorityClassIndexInformer(informer cache.SharedIndexInformer) PriorityClassIndexInformer {
+	if informer, ok := informer.(PriorityClassIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apischedulingv1.PriorityClass](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/scheduling/v1alpha3/compositepodgroup.go
+++ b/staging/src/k8s.io/client-go/informers/scheduling/v1alpha3/compositepodgroup.go
@@ -34,11 +34,39 @@ import (
 )
 
 // CompositePodGroupInformer provides access to a shared informer and lister for
-// CompositePodGroups.
+// CompositePodGroups. Prefer using the type-safe variant (see [TypedCompositePodGroupInformer]).
 type CompositePodGroupInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() schedulingv1alpha3.CompositePodGroupLister
 }
+
+// TypedCompositePodGroupInformer provides access to a shared informer and lister for
+// CompositePodGroups, including the type-safe TypedInformer variant.
+// It is a superset of CompositePodGroupInformer.
+type TypedCompositePodGroupInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() CompositePodGroupIndexInformer
+	Lister() schedulingv1alpha3.CompositePodGroupLister
+}
+
+// CompositePodGroupIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type CompositePodGroupIndexInformer cache.TypedSharedIndexInformer[*apischedulingv1alpha3.CompositePodGroup]
+
+// CompositePodGroupHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for CompositePodGroup.
+type CompositePodGroupHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apischedulingv1alpha3.CompositePodGroup]
+
+// CompositePodGroupDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for CompositePodGroup.
+type CompositePodGroupDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apischedulingv1alpha3.CompositePodGroup]
+
+// CompositePodGroupFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for CompositePodGroup.
+type CompositePodGroupFilteringHandler = cache.TypedFilteringResourceEventHandler[*apischedulingv1alpha3.CompositePodGroup]
+
+// CompositePodGroupIndexers is a specialization of [cache.TypedIndexers] for CompositePodGroup.
+type CompositePodGroupIndexers = cache.TypedIndexers[*apischedulingv1alpha3.CompositePodGroup]
+
+// DeletedCompositePodGroup is a specialization of [cache.DeletedObject] for CompositePodGroup.
+type DeletedCompositePodGroup = cache.DeletedObject[*apischedulingv1alpha3.CompositePodGroup]
 
 type compositePodGroupInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type compositePodGroupInformer struct {
 // NewCompositePodGroupInformer constructs a new informer for CompositePodGroup type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCompositePodGroupInformer]).
 func NewCompositePodGroupInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewCompositePodGroupInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedCompositePodGroupInformer constructs a new informer for CompositePodGroup type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCompositePodGroupInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers CompositePodGroupIndexers) CompositePodGroupIndexInformer {
+	return NewTypedCompositePodGroupInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredCompositePodGroupInformer constructs a new informer for CompositePodGroup type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredCompositePodGroupInformer]).
 func NewFilteredCompositePodGroupInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewCompositePodGroupInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedCompositePodGroupInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredCompositePodGroupInformer constructs a new informer for CompositePodGroup type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredCompositePodGroupInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers CompositePodGroupIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) CompositePodGroupIndexInformer {
+	return NewTypedCompositePodGroupInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewCompositePodGroupInformerWithOptions constructs a new informer for CompositePodGroup type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCompositePodGroupInformerWithOptions]).
 func NewCompositePodGroupInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedCompositePodGroupInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedCompositePodGroupInformerWithOptions constructs a new informer for CompositePodGroup type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCompositePodGroupInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) CompositePodGroupIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "scheduling.k8s.io", Version: "v1alpha3", Resource: "compositepodgroups"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apischedulingv1alpha3.CompositePodGroup](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewCompositePodGroupInformerWithOptions(client kubernetes.Interface, namesp
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *compositePodGroupInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewCompositePodGroupInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedCompositePodGroupInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *compositePodGroupInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apischedulingv1alpha3.CompositePodGroup{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *compositePodGroupInformer) TypedInformer() CompositePodGroupIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apischedulingv1alpha3.CompositePodGroup](f.factory.InformerFor(&apischedulingv1alpha3.CompositePodGroup{}, f.defaultInformer))
 }
 
 func (f *compositePodGroupInformer) Lister() schedulingv1alpha3.CompositePodGroupLister {
 	return schedulingv1alpha3.NewCompositePodGroupLister(f.Informer().GetIndexer())
+}
+
+// ToTypedCompositePodGroupInformer converts an untyped informer into a TypedCompositePodGroupInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CompositePodGroup. If that is not the case, calling type-safe methods of the returned
+// TypedCompositePodGroupInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedCompositePodGroupInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedCompositePodGroupInformer(informer CompositePodGroupInformer) TypedCompositePodGroupInformer {
+	if informer, ok := informer.(TypedCompositePodGroupInformer); ok {
+		return informer
+	}
+	return &compositePodGroupTypedInformerAdapter{informer}
+}
+
+type compositePodGroupTypedInformerAdapter struct {
+	CompositePodGroupInformer
+}
+
+func (a *compositePodGroupTypedInformerAdapter) TypedInformer() CompositePodGroupIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apischedulingv1alpha3.CompositePodGroup](a.Informer())
+}
+
+// ToCompositePodGroupIndexInformer converts an untyped informer into a CompositePodGroupIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CompositePodGroup. If that is not the case, calling type-safe methods of the returned
+// CompositePodGroupIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a CompositePodGroupIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToCompositePodGroupIndexInformer(informer cache.SharedIndexInformer) CompositePodGroupIndexInformer {
+	if informer, ok := informer.(CompositePodGroupIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apischedulingv1alpha3.CompositePodGroup](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/scheduling/v1alpha3/interface.go
+++ b/staging/src/k8s.io/client-go/informers/scheduling/v1alpha3/interface.go
@@ -25,11 +25,11 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// CompositePodGroups returns a CompositePodGroupInformer.
-	CompositePodGroups() CompositePodGroupInformer
+	CompositePodGroups() TypedCompositePodGroupInformer
 	// PodGroups returns a PodGroupInformer.
-	PodGroups() PodGroupInformer
+	PodGroups() TypedPodGroupInformer
 	// Workloads returns a WorkloadInformer.
-	Workloads() WorkloadInformer
+	Workloads() TypedWorkloadInformer
 }
 
 type version struct {
@@ -43,17 +43,17 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// CompositePodGroups returns a CompositePodGroupInformer.
-func (v *version) CompositePodGroups() CompositePodGroupInformer {
+// CompositePodGroups returns a TypedCompositePodGroupInformer.
+func (v *version) CompositePodGroups() TypedCompositePodGroupInformer {
 	return &compositePodGroupInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// PodGroups returns a PodGroupInformer.
-func (v *version) PodGroups() PodGroupInformer {
+// PodGroups returns a TypedPodGroupInformer.
+func (v *version) PodGroups() TypedPodGroupInformer {
 	return &podGroupInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// Workloads returns a WorkloadInformer.
-func (v *version) Workloads() WorkloadInformer {
+// Workloads returns a TypedWorkloadInformer.
+func (v *version) Workloads() TypedWorkloadInformer {
 	return &workloadInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/scheduling/v1alpha3/podgroup.go
+++ b/staging/src/k8s.io/client-go/informers/scheduling/v1alpha3/podgroup.go
@@ -34,11 +34,39 @@ import (
 )
 
 // PodGroupInformer provides access to a shared informer and lister for
-// PodGroups.
+// PodGroups. Prefer using the type-safe variant (see [TypedPodGroupInformer]).
 type PodGroupInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() schedulingv1alpha3.PodGroupLister
 }
+
+// TypedPodGroupInformer provides access to a shared informer and lister for
+// PodGroups, including the type-safe TypedInformer variant.
+// It is a superset of PodGroupInformer.
+type TypedPodGroupInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() PodGroupIndexInformer
+	Lister() schedulingv1alpha3.PodGroupLister
+}
+
+// PodGroupIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type PodGroupIndexInformer cache.TypedSharedIndexInformer[*apischedulingv1alpha3.PodGroup]
+
+// PodGroupHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for PodGroup.
+type PodGroupHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apischedulingv1alpha3.PodGroup]
+
+// PodGroupDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for PodGroup.
+type PodGroupDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apischedulingv1alpha3.PodGroup]
+
+// PodGroupFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for PodGroup.
+type PodGroupFilteringHandler = cache.TypedFilteringResourceEventHandler[*apischedulingv1alpha3.PodGroup]
+
+// PodGroupIndexers is a specialization of [cache.TypedIndexers] for PodGroup.
+type PodGroupIndexers = cache.TypedIndexers[*apischedulingv1alpha3.PodGroup]
+
+// DeletedPodGroup is a specialization of [cache.DeletedObject] for PodGroup.
+type DeletedPodGroup = cache.DeletedObject[*apischedulingv1alpha3.PodGroup]
 
 type podGroupInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type podGroupInformer struct {
 // NewPodGroupInformer constructs a new informer for PodGroup type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPodGroupInformer]).
 func NewPodGroupInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewPodGroupInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedPodGroupInformer constructs a new informer for PodGroup type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPodGroupInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers PodGroupIndexers) PodGroupIndexInformer {
+	return NewTypedPodGroupInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredPodGroupInformer constructs a new informer for PodGroup type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredPodGroupInformer]).
 func NewFilteredPodGroupInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewPodGroupInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedPodGroupInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredPodGroupInformer constructs a new informer for PodGroup type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredPodGroupInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers PodGroupIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) PodGroupIndexInformer {
+	return NewTypedPodGroupInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewPodGroupInformerWithOptions constructs a new informer for PodGroup type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPodGroupInformerWithOptions]).
 func NewPodGroupInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedPodGroupInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedPodGroupInformerWithOptions constructs a new informer for PodGroup type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPodGroupInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) PodGroupIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "scheduling.k8s.io", Version: "v1alpha3", Resource: "podgroups"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apischedulingv1alpha3.PodGroup](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewPodGroupInformerWithOptions(client kubernetes.Interface, namespace strin
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *podGroupInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewPodGroupInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedPodGroupInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *podGroupInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apischedulingv1alpha3.PodGroup{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *podGroupInformer) TypedInformer() PodGroupIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apischedulingv1alpha3.PodGroup](f.factory.InformerFor(&apischedulingv1alpha3.PodGroup{}, f.defaultInformer))
 }
 
 func (f *podGroupInformer) Lister() schedulingv1alpha3.PodGroupLister {
 	return schedulingv1alpha3.NewPodGroupLister(f.Informer().GetIndexer())
+}
+
+// ToTypedPodGroupInformer converts an untyped informer into a TypedPodGroupInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *PodGroup. If that is not the case, calling type-safe methods of the returned
+// TypedPodGroupInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedPodGroupInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedPodGroupInformer(informer PodGroupInformer) TypedPodGroupInformer {
+	if informer, ok := informer.(TypedPodGroupInformer); ok {
+		return informer
+	}
+	return &podGroupTypedInformerAdapter{informer}
+}
+
+type podGroupTypedInformerAdapter struct {
+	PodGroupInformer
+}
+
+func (a *podGroupTypedInformerAdapter) TypedInformer() PodGroupIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apischedulingv1alpha3.PodGroup](a.Informer())
+}
+
+// ToPodGroupIndexInformer converts an untyped informer into a PodGroupIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *PodGroup. If that is not the case, calling type-safe methods of the returned
+// PodGroupIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a PodGroupIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToPodGroupIndexInformer(informer cache.SharedIndexInformer) PodGroupIndexInformer {
+	if informer, ok := informer.(PodGroupIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apischedulingv1alpha3.PodGroup](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/scheduling/v1alpha3/workload.go
+++ b/staging/src/k8s.io/client-go/informers/scheduling/v1alpha3/workload.go
@@ -34,11 +34,39 @@ import (
 )
 
 // WorkloadInformer provides access to a shared informer and lister for
-// Workloads.
+// Workloads. Prefer using the type-safe variant (see [TypedWorkloadInformer]).
 type WorkloadInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() schedulingv1alpha3.WorkloadLister
 }
+
+// TypedWorkloadInformer provides access to a shared informer and lister for
+// Workloads, including the type-safe TypedInformer variant.
+// It is a superset of WorkloadInformer.
+type TypedWorkloadInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() WorkloadIndexInformer
+	Lister() schedulingv1alpha3.WorkloadLister
+}
+
+// WorkloadIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type WorkloadIndexInformer cache.TypedSharedIndexInformer[*apischedulingv1alpha3.Workload]
+
+// WorkloadHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Workload.
+type WorkloadHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apischedulingv1alpha3.Workload]
+
+// WorkloadDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Workload.
+type WorkloadDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apischedulingv1alpha3.Workload]
+
+// WorkloadFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Workload.
+type WorkloadFilteringHandler = cache.TypedFilteringResourceEventHandler[*apischedulingv1alpha3.Workload]
+
+// WorkloadIndexers is a specialization of [cache.TypedIndexers] for Workload.
+type WorkloadIndexers = cache.TypedIndexers[*apischedulingv1alpha3.Workload]
+
+// DeletedWorkload is a specialization of [cache.DeletedObject] for Workload.
+type DeletedWorkload = cache.DeletedObject[*apischedulingv1alpha3.Workload]
 
 type workloadInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type workloadInformer struct {
 // NewWorkloadInformer constructs a new informer for Workload type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedWorkloadInformer]).
 func NewWorkloadInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewWorkloadInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedWorkloadInformer constructs a new informer for Workload type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedWorkloadInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers WorkloadIndexers) WorkloadIndexInformer {
+	return NewTypedWorkloadInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredWorkloadInformer constructs a new informer for Workload type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredWorkloadInformer]).
 func NewFilteredWorkloadInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewWorkloadInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedWorkloadInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredWorkloadInformer constructs a new informer for Workload type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredWorkloadInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers WorkloadIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) WorkloadIndexInformer {
+	return NewTypedWorkloadInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewWorkloadInformerWithOptions constructs a new informer for Workload type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedWorkloadInformerWithOptions]).
 func NewWorkloadInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedWorkloadInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedWorkloadInformerWithOptions constructs a new informer for Workload type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedWorkloadInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) WorkloadIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "scheduling.k8s.io", Version: "v1alpha3", Resource: "workloads"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apischedulingv1alpha3.Workload](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewWorkloadInformerWithOptions(client kubernetes.Interface, namespace strin
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *workloadInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewWorkloadInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedWorkloadInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *workloadInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apischedulingv1alpha3.Workload{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *workloadInformer) TypedInformer() WorkloadIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apischedulingv1alpha3.Workload](f.factory.InformerFor(&apischedulingv1alpha3.Workload{}, f.defaultInformer))
 }
 
 func (f *workloadInformer) Lister() schedulingv1alpha3.WorkloadLister {
 	return schedulingv1alpha3.NewWorkloadLister(f.Informer().GetIndexer())
+}
+
+// ToTypedWorkloadInformer converts an untyped informer into a TypedWorkloadInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Workload. If that is not the case, calling type-safe methods of the returned
+// TypedWorkloadInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedWorkloadInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedWorkloadInformer(informer WorkloadInformer) TypedWorkloadInformer {
+	if informer, ok := informer.(TypedWorkloadInformer); ok {
+		return informer
+	}
+	return &workloadTypedInformerAdapter{informer}
+}
+
+type workloadTypedInformerAdapter struct {
+	WorkloadInformer
+}
+
+func (a *workloadTypedInformerAdapter) TypedInformer() WorkloadIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apischedulingv1alpha3.Workload](a.Informer())
+}
+
+// ToWorkloadIndexInformer converts an untyped informer into a WorkloadIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Workload. If that is not the case, calling type-safe methods of the returned
+// WorkloadIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a WorkloadIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToWorkloadIndexInformer(informer cache.SharedIndexInformer) WorkloadIndexInformer {
+	if informer, ok := informer.(WorkloadIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apischedulingv1alpha3.Workload](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/scheduling/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/scheduling/v1beta1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// PriorityClasses returns a PriorityClassInformer.
-	PriorityClasses() PriorityClassInformer
+	PriorityClasses() TypedPriorityClassInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// PriorityClasses returns a PriorityClassInformer.
-func (v *version) PriorityClasses() PriorityClassInformer {
+// PriorityClasses returns a TypedPriorityClassInformer.
+func (v *version) PriorityClasses() TypedPriorityClassInformer {
 	return &priorityClassInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/scheduling/v1beta1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/informers/scheduling/v1beta1/priorityclass.go
@@ -34,11 +34,39 @@ import (
 )
 
 // PriorityClassInformer provides access to a shared informer and lister for
-// PriorityClasses.
+// PriorityClasses. Prefer using the type-safe variant (see [TypedPriorityClassInformer]).
 type PriorityClassInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() schedulingv1beta1.PriorityClassLister
 }
+
+// TypedPriorityClassInformer provides access to a shared informer and lister for
+// PriorityClasses, including the type-safe TypedInformer variant.
+// It is a superset of PriorityClassInformer.
+type TypedPriorityClassInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() PriorityClassIndexInformer
+	Lister() schedulingv1beta1.PriorityClassLister
+}
+
+// PriorityClassIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type PriorityClassIndexInformer cache.TypedSharedIndexInformer[*apischedulingv1beta1.PriorityClass]
+
+// PriorityClassHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for PriorityClass.
+type PriorityClassHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apischedulingv1beta1.PriorityClass]
+
+// PriorityClassDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for PriorityClass.
+type PriorityClassDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apischedulingv1beta1.PriorityClass]
+
+// PriorityClassFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for PriorityClass.
+type PriorityClassFilteringHandler = cache.TypedFilteringResourceEventHandler[*apischedulingv1beta1.PriorityClass]
+
+// PriorityClassIndexers is a specialization of [cache.TypedIndexers] for PriorityClass.
+type PriorityClassIndexers = cache.TypedIndexers[*apischedulingv1beta1.PriorityClass]
+
+// DeletedPriorityClass is a specialization of [cache.DeletedObject] for PriorityClass.
+type DeletedPriorityClass = cache.DeletedObject[*apischedulingv1beta1.PriorityClass]
 
 type priorityClassInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type priorityClassInformer struct {
 // NewPriorityClassInformer constructs a new informer for PriorityClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPriorityClassInformer]).
 func NewPriorityClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewPriorityClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedPriorityClassInformer constructs a new informer for PriorityClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPriorityClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers PriorityClassIndexers) PriorityClassIndexInformer {
+	return NewTypedPriorityClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredPriorityClassInformer constructs a new informer for PriorityClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredPriorityClassInformer]).
 func NewFilteredPriorityClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewPriorityClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedPriorityClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredPriorityClassInformer constructs a new informer for PriorityClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredPriorityClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers PriorityClassIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) PriorityClassIndexInformer {
+	return NewTypedPriorityClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewPriorityClassInformerWithOptions constructs a new informer for PriorityClass type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedPriorityClassInformerWithOptions]).
 func NewPriorityClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedPriorityClassInformerWithOptions(client, options)
+}
+
+// NewTypedPriorityClassInformerWithOptions constructs a new informer for PriorityClass type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedPriorityClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) PriorityClassIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "scheduling.k8s.io", Version: "v1beta1", Resource: "priorityclasss"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apischedulingv1beta1.PriorityClass](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewPriorityClassInformerWithOptions(client kubernetes.Interface, options in
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *priorityClassInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewPriorityClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedPriorityClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *priorityClassInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apischedulingv1beta1.PriorityClass{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *priorityClassInformer) TypedInformer() PriorityClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apischedulingv1beta1.PriorityClass](f.factory.InformerFor(&apischedulingv1beta1.PriorityClass{}, f.defaultInformer))
 }
 
 func (f *priorityClassInformer) Lister() schedulingv1beta1.PriorityClassLister {
 	return schedulingv1beta1.NewPriorityClassLister(f.Informer().GetIndexer())
+}
+
+// ToTypedPriorityClassInformer converts an untyped informer into a TypedPriorityClassInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *PriorityClass. If that is not the case, calling type-safe methods of the returned
+// TypedPriorityClassInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedPriorityClassInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedPriorityClassInformer(informer PriorityClassInformer) TypedPriorityClassInformer {
+	if informer, ok := informer.(TypedPriorityClassInformer); ok {
+		return informer
+	}
+	return &priorityClassTypedInformerAdapter{informer}
+}
+
+type priorityClassTypedInformerAdapter struct {
+	PriorityClassInformer
+}
+
+func (a *priorityClassTypedInformerAdapter) TypedInformer() PriorityClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apischedulingv1beta1.PriorityClass](a.Informer())
+}
+
+// ToPriorityClassIndexInformer converts an untyped informer into a PriorityClassIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *PriorityClass. If that is not the case, calling type-safe methods of the returned
+// PriorityClassIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a PriorityClassIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToPriorityClassIndexInformer(informer cache.SharedIndexInformer) PriorityClassIndexInformer {
+	if informer, ok := informer.(PriorityClassIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apischedulingv1beta1.PriorityClass](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/storage/v1/csidriver.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/csidriver.go
@@ -34,11 +34,39 @@ import (
 )
 
 // CSIDriverInformer provides access to a shared informer and lister for
-// CSIDrivers.
+// CSIDrivers. Prefer using the type-safe variant (see [TypedCSIDriverInformer]).
 type CSIDriverInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() storagev1.CSIDriverLister
 }
+
+// TypedCSIDriverInformer provides access to a shared informer and lister for
+// CSIDrivers, including the type-safe TypedInformer variant.
+// It is a superset of CSIDriverInformer.
+type TypedCSIDriverInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() CSIDriverIndexInformer
+	Lister() storagev1.CSIDriverLister
+}
+
+// CSIDriverIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type CSIDriverIndexInformer cache.TypedSharedIndexInformer[*apistoragev1.CSIDriver]
+
+// CSIDriverHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for CSIDriver.
+type CSIDriverHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apistoragev1.CSIDriver]
+
+// CSIDriverDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for CSIDriver.
+type CSIDriverDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apistoragev1.CSIDriver]
+
+// CSIDriverFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for CSIDriver.
+type CSIDriverFilteringHandler = cache.TypedFilteringResourceEventHandler[*apistoragev1.CSIDriver]
+
+// CSIDriverIndexers is a specialization of [cache.TypedIndexers] for CSIDriver.
+type CSIDriverIndexers = cache.TypedIndexers[*apistoragev1.CSIDriver]
+
+// DeletedCSIDriver is a specialization of [cache.DeletedObject] for CSIDriver.
+type DeletedCSIDriver = cache.DeletedObject[*apistoragev1.CSIDriver]
 
 type cSIDriverInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type cSIDriverInformer struct {
 // NewCSIDriverInformer constructs a new informer for CSIDriver type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCSIDriverInformer]).
 func NewCSIDriverInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewCSIDriverInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedCSIDriverInformer constructs a new informer for CSIDriver type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCSIDriverInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers CSIDriverIndexers) CSIDriverIndexInformer {
+	return NewTypedCSIDriverInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredCSIDriverInformer constructs a new informer for CSIDriver type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredCSIDriverInformer]).
 func NewFilteredCSIDriverInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewCSIDriverInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedCSIDriverInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredCSIDriverInformer constructs a new informer for CSIDriver type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredCSIDriverInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers CSIDriverIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) CSIDriverIndexInformer {
+	return NewTypedCSIDriverInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewCSIDriverInformerWithOptions constructs a new informer for CSIDriver type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCSIDriverInformerWithOptions]).
 func NewCSIDriverInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedCSIDriverInformerWithOptions(client, options)
+}
+
+// NewTypedCSIDriverInformerWithOptions constructs a new informer for CSIDriver type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCSIDriverInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) CSIDriverIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "csidrivers"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apistoragev1.CSIDriver](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewCSIDriverInformerWithOptions(client kubernetes.Interface, options intern
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *cSIDriverInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewCSIDriverInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedCSIDriverInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *cSIDriverInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apistoragev1.CSIDriver{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *cSIDriverInformer) TypedInformer() CSIDriverIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1.CSIDriver](f.factory.InformerFor(&apistoragev1.CSIDriver{}, f.defaultInformer))
 }
 
 func (f *cSIDriverInformer) Lister() storagev1.CSIDriverLister {
 	return storagev1.NewCSIDriverLister(f.Informer().GetIndexer())
+}
+
+// ToTypedCSIDriverInformer converts an untyped informer into a TypedCSIDriverInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CSIDriver. If that is not the case, calling type-safe methods of the returned
+// TypedCSIDriverInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedCSIDriverInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedCSIDriverInformer(informer CSIDriverInformer) TypedCSIDriverInformer {
+	if informer, ok := informer.(TypedCSIDriverInformer); ok {
+		return informer
+	}
+	return &cSIDriverTypedInformerAdapter{informer}
+}
+
+type cSIDriverTypedInformerAdapter struct {
+	CSIDriverInformer
+}
+
+func (a *cSIDriverTypedInformerAdapter) TypedInformer() CSIDriverIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1.CSIDriver](a.Informer())
+}
+
+// ToCSIDriverIndexInformer converts an untyped informer into a CSIDriverIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CSIDriver. If that is not the case, calling type-safe methods of the returned
+// CSIDriverIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a CSIDriverIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToCSIDriverIndexInformer(informer cache.SharedIndexInformer) CSIDriverIndexInformer {
+	if informer, ok := informer.(CSIDriverIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apistoragev1.CSIDriver](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/storage/v1/csinode.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/csinode.go
@@ -34,11 +34,39 @@ import (
 )
 
 // CSINodeInformer provides access to a shared informer and lister for
-// CSINodes.
+// CSINodes. Prefer using the type-safe variant (see [TypedCSINodeInformer]).
 type CSINodeInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() storagev1.CSINodeLister
 }
+
+// TypedCSINodeInformer provides access to a shared informer and lister for
+// CSINodes, including the type-safe TypedInformer variant.
+// It is a superset of CSINodeInformer.
+type TypedCSINodeInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() CSINodeIndexInformer
+	Lister() storagev1.CSINodeLister
+}
+
+// CSINodeIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type CSINodeIndexInformer cache.TypedSharedIndexInformer[*apistoragev1.CSINode]
+
+// CSINodeHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for CSINode.
+type CSINodeHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apistoragev1.CSINode]
+
+// CSINodeDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for CSINode.
+type CSINodeDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apistoragev1.CSINode]
+
+// CSINodeFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for CSINode.
+type CSINodeFilteringHandler = cache.TypedFilteringResourceEventHandler[*apistoragev1.CSINode]
+
+// CSINodeIndexers is a specialization of [cache.TypedIndexers] for CSINode.
+type CSINodeIndexers = cache.TypedIndexers[*apistoragev1.CSINode]
+
+// DeletedCSINode is a specialization of [cache.DeletedObject] for CSINode.
+type DeletedCSINode = cache.DeletedObject[*apistoragev1.CSINode]
 
 type cSINodeInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type cSINodeInformer struct {
 // NewCSINodeInformer constructs a new informer for CSINode type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCSINodeInformer]).
 func NewCSINodeInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewCSINodeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedCSINodeInformer constructs a new informer for CSINode type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCSINodeInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers CSINodeIndexers) CSINodeIndexInformer {
+	return NewTypedCSINodeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredCSINodeInformer constructs a new informer for CSINode type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredCSINodeInformer]).
 func NewFilteredCSINodeInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewCSINodeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedCSINodeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredCSINodeInformer constructs a new informer for CSINode type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredCSINodeInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers CSINodeIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) CSINodeIndexInformer {
+	return NewTypedCSINodeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewCSINodeInformerWithOptions constructs a new informer for CSINode type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCSINodeInformerWithOptions]).
 func NewCSINodeInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedCSINodeInformerWithOptions(client, options)
+}
+
+// NewTypedCSINodeInformerWithOptions constructs a new informer for CSINode type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCSINodeInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) CSINodeIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "csinodes"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apistoragev1.CSINode](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewCSINodeInformerWithOptions(client kubernetes.Interface, options internal
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *cSINodeInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewCSINodeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedCSINodeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *cSINodeInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apistoragev1.CSINode{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *cSINodeInformer) TypedInformer() CSINodeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1.CSINode](f.factory.InformerFor(&apistoragev1.CSINode{}, f.defaultInformer))
 }
 
 func (f *cSINodeInformer) Lister() storagev1.CSINodeLister {
 	return storagev1.NewCSINodeLister(f.Informer().GetIndexer())
+}
+
+// ToTypedCSINodeInformer converts an untyped informer into a TypedCSINodeInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CSINode. If that is not the case, calling type-safe methods of the returned
+// TypedCSINodeInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedCSINodeInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedCSINodeInformer(informer CSINodeInformer) TypedCSINodeInformer {
+	if informer, ok := informer.(TypedCSINodeInformer); ok {
+		return informer
+	}
+	return &cSINodeTypedInformerAdapter{informer}
+}
+
+type cSINodeTypedInformerAdapter struct {
+	CSINodeInformer
+}
+
+func (a *cSINodeTypedInformerAdapter) TypedInformer() CSINodeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1.CSINode](a.Informer())
+}
+
+// ToCSINodeIndexInformer converts an untyped informer into a CSINodeIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CSINode. If that is not the case, calling type-safe methods of the returned
+// CSINodeIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a CSINodeIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToCSINodeIndexInformer(informer cache.SharedIndexInformer) CSINodeIndexInformer {
+	if informer, ok := informer.(CSINodeIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apistoragev1.CSINode](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/storage/v1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/csistoragecapacity.go
@@ -34,11 +34,39 @@ import (
 )
 
 // CSIStorageCapacityInformer provides access to a shared informer and lister for
-// CSIStorageCapacities.
+// CSIStorageCapacities. Prefer using the type-safe variant (see [TypedCSIStorageCapacityInformer]).
 type CSIStorageCapacityInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() storagev1.CSIStorageCapacityLister
 }
+
+// TypedCSIStorageCapacityInformer provides access to a shared informer and lister for
+// CSIStorageCapacities, including the type-safe TypedInformer variant.
+// It is a superset of CSIStorageCapacityInformer.
+type TypedCSIStorageCapacityInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() CSIStorageCapacityIndexInformer
+	Lister() storagev1.CSIStorageCapacityLister
+}
+
+// CSIStorageCapacityIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type CSIStorageCapacityIndexInformer cache.TypedSharedIndexInformer[*apistoragev1.CSIStorageCapacity]
+
+// CSIStorageCapacityHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for CSIStorageCapacity.
+type CSIStorageCapacityHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apistoragev1.CSIStorageCapacity]
+
+// CSIStorageCapacityDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for CSIStorageCapacity.
+type CSIStorageCapacityDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apistoragev1.CSIStorageCapacity]
+
+// CSIStorageCapacityFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for CSIStorageCapacity.
+type CSIStorageCapacityFilteringHandler = cache.TypedFilteringResourceEventHandler[*apistoragev1.CSIStorageCapacity]
+
+// CSIStorageCapacityIndexers is a specialization of [cache.TypedIndexers] for CSIStorageCapacity.
+type CSIStorageCapacityIndexers = cache.TypedIndexers[*apistoragev1.CSIStorageCapacity]
+
+// DeletedCSIStorageCapacity is a specialization of [cache.DeletedObject] for CSIStorageCapacity.
+type DeletedCSIStorageCapacity = cache.DeletedObject[*apistoragev1.CSIStorageCapacity]
 
 type cSIStorageCapacityInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type cSIStorageCapacityInformer struct {
 // NewCSIStorageCapacityInformer constructs a new informer for CSIStorageCapacity type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCSIStorageCapacityInformer]).
 func NewCSIStorageCapacityInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewCSIStorageCapacityInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedCSIStorageCapacityInformer constructs a new informer for CSIStorageCapacity type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCSIStorageCapacityInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers CSIStorageCapacityIndexers) CSIStorageCapacityIndexInformer {
+	return NewTypedCSIStorageCapacityInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredCSIStorageCapacityInformer constructs a new informer for CSIStorageCapacity type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredCSIStorageCapacityInformer]).
 func NewFilteredCSIStorageCapacityInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewCSIStorageCapacityInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedCSIStorageCapacityInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredCSIStorageCapacityInformer constructs a new informer for CSIStorageCapacity type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredCSIStorageCapacityInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers CSIStorageCapacityIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) CSIStorageCapacityIndexInformer {
+	return NewTypedCSIStorageCapacityInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewCSIStorageCapacityInformerWithOptions constructs a new informer for CSIStorageCapacity type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCSIStorageCapacityInformerWithOptions]).
 func NewCSIStorageCapacityInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedCSIStorageCapacityInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedCSIStorageCapacityInformerWithOptions constructs a new informer for CSIStorageCapacity type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCSIStorageCapacityInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) CSIStorageCapacityIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "csistoragecapacitys"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apistoragev1.CSIStorageCapacity](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewCSIStorageCapacityInformerWithOptions(client kubernetes.Interface, names
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *cSIStorageCapacityInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewCSIStorageCapacityInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedCSIStorageCapacityInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *cSIStorageCapacityInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apistoragev1.CSIStorageCapacity{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *cSIStorageCapacityInformer) TypedInformer() CSIStorageCapacityIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1.CSIStorageCapacity](f.factory.InformerFor(&apistoragev1.CSIStorageCapacity{}, f.defaultInformer))
 }
 
 func (f *cSIStorageCapacityInformer) Lister() storagev1.CSIStorageCapacityLister {
 	return storagev1.NewCSIStorageCapacityLister(f.Informer().GetIndexer())
+}
+
+// ToTypedCSIStorageCapacityInformer converts an untyped informer into a TypedCSIStorageCapacityInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CSIStorageCapacity. If that is not the case, calling type-safe methods of the returned
+// TypedCSIStorageCapacityInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedCSIStorageCapacityInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedCSIStorageCapacityInformer(informer CSIStorageCapacityInformer) TypedCSIStorageCapacityInformer {
+	if informer, ok := informer.(TypedCSIStorageCapacityInformer); ok {
+		return informer
+	}
+	return &cSIStorageCapacityTypedInformerAdapter{informer}
+}
+
+type cSIStorageCapacityTypedInformerAdapter struct {
+	CSIStorageCapacityInformer
+}
+
+func (a *cSIStorageCapacityTypedInformerAdapter) TypedInformer() CSIStorageCapacityIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1.CSIStorageCapacity](a.Informer())
+}
+
+// ToCSIStorageCapacityIndexInformer converts an untyped informer into a CSIStorageCapacityIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CSIStorageCapacity. If that is not the case, calling type-safe methods of the returned
+// CSIStorageCapacityIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a CSIStorageCapacityIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToCSIStorageCapacityIndexInformer(informer cache.SharedIndexInformer) CSIStorageCapacityIndexInformer {
+	if informer, ok := informer.(CSIStorageCapacityIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apistoragev1.CSIStorageCapacity](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/storage/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/interface.go
@@ -25,17 +25,17 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// CSIDrivers returns a CSIDriverInformer.
-	CSIDrivers() CSIDriverInformer
+	CSIDrivers() TypedCSIDriverInformer
 	// CSINodes returns a CSINodeInformer.
-	CSINodes() CSINodeInformer
+	CSINodes() TypedCSINodeInformer
 	// CSIStorageCapacities returns a CSIStorageCapacityInformer.
-	CSIStorageCapacities() CSIStorageCapacityInformer
+	CSIStorageCapacities() TypedCSIStorageCapacityInformer
 	// StorageClasses returns a StorageClassInformer.
-	StorageClasses() StorageClassInformer
+	StorageClasses() TypedStorageClassInformer
 	// VolumeAttachments returns a VolumeAttachmentInformer.
-	VolumeAttachments() VolumeAttachmentInformer
+	VolumeAttachments() TypedVolumeAttachmentInformer
 	// VolumeAttributesClasses returns a VolumeAttributesClassInformer.
-	VolumeAttributesClasses() VolumeAttributesClassInformer
+	VolumeAttributesClasses() TypedVolumeAttributesClassInformer
 }
 
 type version struct {
@@ -49,32 +49,32 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// CSIDrivers returns a CSIDriverInformer.
-func (v *version) CSIDrivers() CSIDriverInformer {
+// CSIDrivers returns a TypedCSIDriverInformer.
+func (v *version) CSIDrivers() TypedCSIDriverInformer {
 	return &cSIDriverInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// CSINodes returns a CSINodeInformer.
-func (v *version) CSINodes() CSINodeInformer {
+// CSINodes returns a TypedCSINodeInformer.
+func (v *version) CSINodes() TypedCSINodeInformer {
 	return &cSINodeInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// CSIStorageCapacities returns a CSIStorageCapacityInformer.
-func (v *version) CSIStorageCapacities() CSIStorageCapacityInformer {
+// CSIStorageCapacities returns a TypedCSIStorageCapacityInformer.
+func (v *version) CSIStorageCapacities() TypedCSIStorageCapacityInformer {
 	return &cSIStorageCapacityInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// StorageClasses returns a StorageClassInformer.
-func (v *version) StorageClasses() StorageClassInformer {
+// StorageClasses returns a TypedStorageClassInformer.
+func (v *version) StorageClasses() TypedStorageClassInformer {
 	return &storageClassInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// VolumeAttachments returns a VolumeAttachmentInformer.
-func (v *version) VolumeAttachments() VolumeAttachmentInformer {
+// VolumeAttachments returns a TypedVolumeAttachmentInformer.
+func (v *version) VolumeAttachments() TypedVolumeAttachmentInformer {
 	return &volumeAttachmentInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// VolumeAttributesClasses returns a VolumeAttributesClassInformer.
-func (v *version) VolumeAttributesClasses() VolumeAttributesClassInformer {
+// VolumeAttributesClasses returns a TypedVolumeAttributesClassInformer.
+func (v *version) VolumeAttributesClasses() TypedVolumeAttributesClassInformer {
 	return &volumeAttributesClassInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/storage/v1/storageclass.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/storageclass.go
@@ -34,11 +34,39 @@ import (
 )
 
 // StorageClassInformer provides access to a shared informer and lister for
-// StorageClasses.
+// StorageClasses. Prefer using the type-safe variant (see [TypedStorageClassInformer]).
 type StorageClassInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() storagev1.StorageClassLister
 }
+
+// TypedStorageClassInformer provides access to a shared informer and lister for
+// StorageClasses, including the type-safe TypedInformer variant.
+// It is a superset of StorageClassInformer.
+type TypedStorageClassInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() StorageClassIndexInformer
+	Lister() storagev1.StorageClassLister
+}
+
+// StorageClassIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type StorageClassIndexInformer cache.TypedSharedIndexInformer[*apistoragev1.StorageClass]
+
+// StorageClassHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for StorageClass.
+type StorageClassHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apistoragev1.StorageClass]
+
+// StorageClassDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for StorageClass.
+type StorageClassDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apistoragev1.StorageClass]
+
+// StorageClassFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for StorageClass.
+type StorageClassFilteringHandler = cache.TypedFilteringResourceEventHandler[*apistoragev1.StorageClass]
+
+// StorageClassIndexers is a specialization of [cache.TypedIndexers] for StorageClass.
+type StorageClassIndexers = cache.TypedIndexers[*apistoragev1.StorageClass]
+
+// DeletedStorageClass is a specialization of [cache.DeletedObject] for StorageClass.
+type DeletedStorageClass = cache.DeletedObject[*apistoragev1.StorageClass]
 
 type storageClassInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type storageClassInformer struct {
 // NewStorageClassInformer constructs a new informer for StorageClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedStorageClassInformer]).
 func NewStorageClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewStorageClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedStorageClassInformer constructs a new informer for StorageClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedStorageClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers StorageClassIndexers) StorageClassIndexInformer {
+	return NewTypedStorageClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredStorageClassInformer constructs a new informer for StorageClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredStorageClassInformer]).
 func NewFilteredStorageClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewStorageClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedStorageClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredStorageClassInformer constructs a new informer for StorageClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredStorageClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers StorageClassIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) StorageClassIndexInformer {
+	return NewTypedStorageClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewStorageClassInformerWithOptions constructs a new informer for StorageClass type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedStorageClassInformerWithOptions]).
 func NewStorageClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedStorageClassInformerWithOptions(client, options)
+}
+
+// NewTypedStorageClassInformerWithOptions constructs a new informer for StorageClass type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedStorageClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) StorageClassIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "storageclasss"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apistoragev1.StorageClass](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewStorageClassInformerWithOptions(client kubernetes.Interface, options int
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *storageClassInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewStorageClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedStorageClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *storageClassInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apistoragev1.StorageClass{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *storageClassInformer) TypedInformer() StorageClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1.StorageClass](f.factory.InformerFor(&apistoragev1.StorageClass{}, f.defaultInformer))
 }
 
 func (f *storageClassInformer) Lister() storagev1.StorageClassLister {
 	return storagev1.NewStorageClassLister(f.Informer().GetIndexer())
+}
+
+// ToTypedStorageClassInformer converts an untyped informer into a TypedStorageClassInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *StorageClass. If that is not the case, calling type-safe methods of the returned
+// TypedStorageClassInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedStorageClassInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedStorageClassInformer(informer StorageClassInformer) TypedStorageClassInformer {
+	if informer, ok := informer.(TypedStorageClassInformer); ok {
+		return informer
+	}
+	return &storageClassTypedInformerAdapter{informer}
+}
+
+type storageClassTypedInformerAdapter struct {
+	StorageClassInformer
+}
+
+func (a *storageClassTypedInformerAdapter) TypedInformer() StorageClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1.StorageClass](a.Informer())
+}
+
+// ToStorageClassIndexInformer converts an untyped informer into a StorageClassIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *StorageClass. If that is not the case, calling type-safe methods of the returned
+// StorageClassIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a StorageClassIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToStorageClassIndexInformer(informer cache.SharedIndexInformer) StorageClassIndexInformer {
+	if informer, ok := informer.(StorageClassIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apistoragev1.StorageClass](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/storage/v1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/volumeattachment.go
@@ -34,11 +34,39 @@ import (
 )
 
 // VolumeAttachmentInformer provides access to a shared informer and lister for
-// VolumeAttachments.
+// VolumeAttachments. Prefer using the type-safe variant (see [TypedVolumeAttachmentInformer]).
 type VolumeAttachmentInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() storagev1.VolumeAttachmentLister
 }
+
+// TypedVolumeAttachmentInformer provides access to a shared informer and lister for
+// VolumeAttachments, including the type-safe TypedInformer variant.
+// It is a superset of VolumeAttachmentInformer.
+type TypedVolumeAttachmentInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() VolumeAttachmentIndexInformer
+	Lister() storagev1.VolumeAttachmentLister
+}
+
+// VolumeAttachmentIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type VolumeAttachmentIndexInformer cache.TypedSharedIndexInformer[*apistoragev1.VolumeAttachment]
+
+// VolumeAttachmentHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for VolumeAttachment.
+type VolumeAttachmentHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apistoragev1.VolumeAttachment]
+
+// VolumeAttachmentDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for VolumeAttachment.
+type VolumeAttachmentDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apistoragev1.VolumeAttachment]
+
+// VolumeAttachmentFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for VolumeAttachment.
+type VolumeAttachmentFilteringHandler = cache.TypedFilteringResourceEventHandler[*apistoragev1.VolumeAttachment]
+
+// VolumeAttachmentIndexers is a specialization of [cache.TypedIndexers] for VolumeAttachment.
+type VolumeAttachmentIndexers = cache.TypedIndexers[*apistoragev1.VolumeAttachment]
+
+// DeletedVolumeAttachment is a specialization of [cache.DeletedObject] for VolumeAttachment.
+type DeletedVolumeAttachment = cache.DeletedObject[*apistoragev1.VolumeAttachment]
 
 type volumeAttachmentInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type volumeAttachmentInformer struct {
 // NewVolumeAttachmentInformer constructs a new informer for VolumeAttachment type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedVolumeAttachmentInformer]).
 func NewVolumeAttachmentInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewVolumeAttachmentInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedVolumeAttachmentInformer constructs a new informer for VolumeAttachment type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedVolumeAttachmentInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers VolumeAttachmentIndexers) VolumeAttachmentIndexInformer {
+	return NewTypedVolumeAttachmentInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredVolumeAttachmentInformer constructs a new informer for VolumeAttachment type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredVolumeAttachmentInformer]).
 func NewFilteredVolumeAttachmentInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewVolumeAttachmentInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedVolumeAttachmentInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredVolumeAttachmentInformer constructs a new informer for VolumeAttachment type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredVolumeAttachmentInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers VolumeAttachmentIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) VolumeAttachmentIndexInformer {
+	return NewTypedVolumeAttachmentInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewVolumeAttachmentInformerWithOptions constructs a new informer for VolumeAttachment type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedVolumeAttachmentInformerWithOptions]).
 func NewVolumeAttachmentInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedVolumeAttachmentInformerWithOptions(client, options)
+}
+
+// NewTypedVolumeAttachmentInformerWithOptions constructs a new informer for VolumeAttachment type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedVolumeAttachmentInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) VolumeAttachmentIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "volumeattachments"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apistoragev1.VolumeAttachment](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewVolumeAttachmentInformerWithOptions(client kubernetes.Interface, options
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *volumeAttachmentInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewVolumeAttachmentInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedVolumeAttachmentInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *volumeAttachmentInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apistoragev1.VolumeAttachment{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *volumeAttachmentInformer) TypedInformer() VolumeAttachmentIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1.VolumeAttachment](f.factory.InformerFor(&apistoragev1.VolumeAttachment{}, f.defaultInformer))
 }
 
 func (f *volumeAttachmentInformer) Lister() storagev1.VolumeAttachmentLister {
 	return storagev1.NewVolumeAttachmentLister(f.Informer().GetIndexer())
+}
+
+// ToTypedVolumeAttachmentInformer converts an untyped informer into a TypedVolumeAttachmentInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *VolumeAttachment. If that is not the case, calling type-safe methods of the returned
+// TypedVolumeAttachmentInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedVolumeAttachmentInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedVolumeAttachmentInformer(informer VolumeAttachmentInformer) TypedVolumeAttachmentInformer {
+	if informer, ok := informer.(TypedVolumeAttachmentInformer); ok {
+		return informer
+	}
+	return &volumeAttachmentTypedInformerAdapter{informer}
+}
+
+type volumeAttachmentTypedInformerAdapter struct {
+	VolumeAttachmentInformer
+}
+
+func (a *volumeAttachmentTypedInformerAdapter) TypedInformer() VolumeAttachmentIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1.VolumeAttachment](a.Informer())
+}
+
+// ToVolumeAttachmentIndexInformer converts an untyped informer into a VolumeAttachmentIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *VolumeAttachment. If that is not the case, calling type-safe methods of the returned
+// VolumeAttachmentIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a VolumeAttachmentIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToVolumeAttachmentIndexInformer(informer cache.SharedIndexInformer) VolumeAttachmentIndexInformer {
+	if informer, ok := informer.(VolumeAttachmentIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apistoragev1.VolumeAttachment](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/storage/v1/volumeattributesclass.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/volumeattributesclass.go
@@ -34,11 +34,39 @@ import (
 )
 
 // VolumeAttributesClassInformer provides access to a shared informer and lister for
-// VolumeAttributesClasses.
+// VolumeAttributesClasses. Prefer using the type-safe variant (see [TypedVolumeAttributesClassInformer]).
 type VolumeAttributesClassInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() storagev1.VolumeAttributesClassLister
 }
+
+// TypedVolumeAttributesClassInformer provides access to a shared informer and lister for
+// VolumeAttributesClasses, including the type-safe TypedInformer variant.
+// It is a superset of VolumeAttributesClassInformer.
+type TypedVolumeAttributesClassInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() VolumeAttributesClassIndexInformer
+	Lister() storagev1.VolumeAttributesClassLister
+}
+
+// VolumeAttributesClassIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type VolumeAttributesClassIndexInformer cache.TypedSharedIndexInformer[*apistoragev1.VolumeAttributesClass]
+
+// VolumeAttributesClassHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for VolumeAttributesClass.
+type VolumeAttributesClassHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apistoragev1.VolumeAttributesClass]
+
+// VolumeAttributesClassDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for VolumeAttributesClass.
+type VolumeAttributesClassDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apistoragev1.VolumeAttributesClass]
+
+// VolumeAttributesClassFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for VolumeAttributesClass.
+type VolumeAttributesClassFilteringHandler = cache.TypedFilteringResourceEventHandler[*apistoragev1.VolumeAttributesClass]
+
+// VolumeAttributesClassIndexers is a specialization of [cache.TypedIndexers] for VolumeAttributesClass.
+type VolumeAttributesClassIndexers = cache.TypedIndexers[*apistoragev1.VolumeAttributesClass]
+
+// DeletedVolumeAttributesClass is a specialization of [cache.DeletedObject] for VolumeAttributesClass.
+type DeletedVolumeAttributesClass = cache.DeletedObject[*apistoragev1.VolumeAttributesClass]
 
 type volumeAttributesClassInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type volumeAttributesClassInformer struct {
 // NewVolumeAttributesClassInformer constructs a new informer for VolumeAttributesClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedVolumeAttributesClassInformer]).
 func NewVolumeAttributesClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewVolumeAttributesClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedVolumeAttributesClassInformer constructs a new informer for VolumeAttributesClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedVolumeAttributesClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers VolumeAttributesClassIndexers) VolumeAttributesClassIndexInformer {
+	return NewTypedVolumeAttributesClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredVolumeAttributesClassInformer constructs a new informer for VolumeAttributesClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredVolumeAttributesClassInformer]).
 func NewFilteredVolumeAttributesClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewVolumeAttributesClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedVolumeAttributesClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredVolumeAttributesClassInformer constructs a new informer for VolumeAttributesClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredVolumeAttributesClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers VolumeAttributesClassIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) VolumeAttributesClassIndexInformer {
+	return NewTypedVolumeAttributesClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewVolumeAttributesClassInformerWithOptions constructs a new informer for VolumeAttributesClass type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedVolumeAttributesClassInformerWithOptions]).
 func NewVolumeAttributesClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedVolumeAttributesClassInformerWithOptions(client, options)
+}
+
+// NewTypedVolumeAttributesClassInformerWithOptions constructs a new informer for VolumeAttributesClass type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedVolumeAttributesClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) VolumeAttributesClassIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "volumeattributesclasss"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apistoragev1.VolumeAttributesClass](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewVolumeAttributesClassInformerWithOptions(client kubernetes.Interface, op
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *volumeAttributesClassInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewVolumeAttributesClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedVolumeAttributesClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *volumeAttributesClassInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apistoragev1.VolumeAttributesClass{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *volumeAttributesClassInformer) TypedInformer() VolumeAttributesClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1.VolumeAttributesClass](f.factory.InformerFor(&apistoragev1.VolumeAttributesClass{}, f.defaultInformer))
 }
 
 func (f *volumeAttributesClassInformer) Lister() storagev1.VolumeAttributesClassLister {
 	return storagev1.NewVolumeAttributesClassLister(f.Informer().GetIndexer())
+}
+
+// ToTypedVolumeAttributesClassInformer converts an untyped informer into a TypedVolumeAttributesClassInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *VolumeAttributesClass. If that is not the case, calling type-safe methods of the returned
+// TypedVolumeAttributesClassInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedVolumeAttributesClassInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedVolumeAttributesClassInformer(informer VolumeAttributesClassInformer) TypedVolumeAttributesClassInformer {
+	if informer, ok := informer.(TypedVolumeAttributesClassInformer); ok {
+		return informer
+	}
+	return &volumeAttributesClassTypedInformerAdapter{informer}
+}
+
+type volumeAttributesClassTypedInformerAdapter struct {
+	VolumeAttributesClassInformer
+}
+
+func (a *volumeAttributesClassTypedInformerAdapter) TypedInformer() VolumeAttributesClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1.VolumeAttributesClass](a.Informer())
+}
+
+// ToVolumeAttributesClassIndexInformer converts an untyped informer into a VolumeAttributesClassIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *VolumeAttributesClass. If that is not the case, calling type-safe methods of the returned
+// VolumeAttributesClassIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a VolumeAttributesClassIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToVolumeAttributesClassIndexInformer(informer cache.SharedIndexInformer) VolumeAttributesClassIndexInformer {
+	if informer, ok := informer.(VolumeAttributesClassIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apistoragev1.VolumeAttributesClass](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/storage/v1alpha1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1alpha1/csistoragecapacity.go
@@ -34,11 +34,39 @@ import (
 )
 
 // CSIStorageCapacityInformer provides access to a shared informer and lister for
-// CSIStorageCapacities.
+// CSIStorageCapacities. Prefer using the type-safe variant (see [TypedCSIStorageCapacityInformer]).
 type CSIStorageCapacityInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() storagev1alpha1.CSIStorageCapacityLister
 }
+
+// TypedCSIStorageCapacityInformer provides access to a shared informer and lister for
+// CSIStorageCapacities, including the type-safe TypedInformer variant.
+// It is a superset of CSIStorageCapacityInformer.
+type TypedCSIStorageCapacityInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() CSIStorageCapacityIndexInformer
+	Lister() storagev1alpha1.CSIStorageCapacityLister
+}
+
+// CSIStorageCapacityIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type CSIStorageCapacityIndexInformer cache.TypedSharedIndexInformer[*apistoragev1alpha1.CSIStorageCapacity]
+
+// CSIStorageCapacityHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for CSIStorageCapacity.
+type CSIStorageCapacityHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apistoragev1alpha1.CSIStorageCapacity]
+
+// CSIStorageCapacityDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for CSIStorageCapacity.
+type CSIStorageCapacityDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apistoragev1alpha1.CSIStorageCapacity]
+
+// CSIStorageCapacityFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for CSIStorageCapacity.
+type CSIStorageCapacityFilteringHandler = cache.TypedFilteringResourceEventHandler[*apistoragev1alpha1.CSIStorageCapacity]
+
+// CSIStorageCapacityIndexers is a specialization of [cache.TypedIndexers] for CSIStorageCapacity.
+type CSIStorageCapacityIndexers = cache.TypedIndexers[*apistoragev1alpha1.CSIStorageCapacity]
+
+// DeletedCSIStorageCapacity is a specialization of [cache.DeletedObject] for CSIStorageCapacity.
+type DeletedCSIStorageCapacity = cache.DeletedObject[*apistoragev1alpha1.CSIStorageCapacity]
 
 type cSIStorageCapacityInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type cSIStorageCapacityInformer struct {
 // NewCSIStorageCapacityInformer constructs a new informer for CSIStorageCapacity type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCSIStorageCapacityInformer]).
 func NewCSIStorageCapacityInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewCSIStorageCapacityInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedCSIStorageCapacityInformer constructs a new informer for CSIStorageCapacity type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCSIStorageCapacityInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers CSIStorageCapacityIndexers) CSIStorageCapacityIndexInformer {
+	return NewTypedCSIStorageCapacityInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredCSIStorageCapacityInformer constructs a new informer for CSIStorageCapacity type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredCSIStorageCapacityInformer]).
 func NewFilteredCSIStorageCapacityInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewCSIStorageCapacityInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedCSIStorageCapacityInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredCSIStorageCapacityInformer constructs a new informer for CSIStorageCapacity type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredCSIStorageCapacityInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers CSIStorageCapacityIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) CSIStorageCapacityIndexInformer {
+	return NewTypedCSIStorageCapacityInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewCSIStorageCapacityInformerWithOptions constructs a new informer for CSIStorageCapacity type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCSIStorageCapacityInformerWithOptions]).
 func NewCSIStorageCapacityInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedCSIStorageCapacityInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedCSIStorageCapacityInformerWithOptions constructs a new informer for CSIStorageCapacity type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCSIStorageCapacityInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) CSIStorageCapacityIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1alpha1", Resource: "csistoragecapacitys"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apistoragev1alpha1.CSIStorageCapacity](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewCSIStorageCapacityInformerWithOptions(client kubernetes.Interface, names
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *cSIStorageCapacityInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewCSIStorageCapacityInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedCSIStorageCapacityInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *cSIStorageCapacityInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apistoragev1alpha1.CSIStorageCapacity{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *cSIStorageCapacityInformer) TypedInformer() CSIStorageCapacityIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1alpha1.CSIStorageCapacity](f.factory.InformerFor(&apistoragev1alpha1.CSIStorageCapacity{}, f.defaultInformer))
 }
 
 func (f *cSIStorageCapacityInformer) Lister() storagev1alpha1.CSIStorageCapacityLister {
 	return storagev1alpha1.NewCSIStorageCapacityLister(f.Informer().GetIndexer())
+}
+
+// ToTypedCSIStorageCapacityInformer converts an untyped informer into a TypedCSIStorageCapacityInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CSIStorageCapacity. If that is not the case, calling type-safe methods of the returned
+// TypedCSIStorageCapacityInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedCSIStorageCapacityInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedCSIStorageCapacityInformer(informer CSIStorageCapacityInformer) TypedCSIStorageCapacityInformer {
+	if informer, ok := informer.(TypedCSIStorageCapacityInformer); ok {
+		return informer
+	}
+	return &cSIStorageCapacityTypedInformerAdapter{informer}
+}
+
+type cSIStorageCapacityTypedInformerAdapter struct {
+	CSIStorageCapacityInformer
+}
+
+func (a *cSIStorageCapacityTypedInformerAdapter) TypedInformer() CSIStorageCapacityIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1alpha1.CSIStorageCapacity](a.Informer())
+}
+
+// ToCSIStorageCapacityIndexInformer converts an untyped informer into a CSIStorageCapacityIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CSIStorageCapacity. If that is not the case, calling type-safe methods of the returned
+// CSIStorageCapacityIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a CSIStorageCapacityIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToCSIStorageCapacityIndexInformer(informer cache.SharedIndexInformer) CSIStorageCapacityIndexInformer {
+	if informer, ok := informer.(CSIStorageCapacityIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apistoragev1alpha1.CSIStorageCapacity](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/storage/v1alpha1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1alpha1/interface.go
@@ -25,11 +25,11 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// CSIStorageCapacities returns a CSIStorageCapacityInformer.
-	CSIStorageCapacities() CSIStorageCapacityInformer
+	CSIStorageCapacities() TypedCSIStorageCapacityInformer
 	// VolumeAttachments returns a VolumeAttachmentInformer.
-	VolumeAttachments() VolumeAttachmentInformer
+	VolumeAttachments() TypedVolumeAttachmentInformer
 	// VolumeAttributesClasses returns a VolumeAttributesClassInformer.
-	VolumeAttributesClasses() VolumeAttributesClassInformer
+	VolumeAttributesClasses() TypedVolumeAttributesClassInformer
 }
 
 type version struct {
@@ -43,17 +43,17 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// CSIStorageCapacities returns a CSIStorageCapacityInformer.
-func (v *version) CSIStorageCapacities() CSIStorageCapacityInformer {
+// CSIStorageCapacities returns a TypedCSIStorageCapacityInformer.
+func (v *version) CSIStorageCapacities() TypedCSIStorageCapacityInformer {
 	return &cSIStorageCapacityInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// VolumeAttachments returns a VolumeAttachmentInformer.
-func (v *version) VolumeAttachments() VolumeAttachmentInformer {
+// VolumeAttachments returns a TypedVolumeAttachmentInformer.
+func (v *version) VolumeAttachments() TypedVolumeAttachmentInformer {
 	return &volumeAttachmentInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// VolumeAttributesClasses returns a VolumeAttributesClassInformer.
-func (v *version) VolumeAttributesClasses() VolumeAttributesClassInformer {
+// VolumeAttributesClasses returns a TypedVolumeAttributesClassInformer.
+func (v *version) VolumeAttributesClasses() TypedVolumeAttributesClassInformer {
 	return &volumeAttributesClassInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/storage/v1alpha1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1alpha1/volumeattachment.go
@@ -34,11 +34,39 @@ import (
 )
 
 // VolumeAttachmentInformer provides access to a shared informer and lister for
-// VolumeAttachments.
+// VolumeAttachments. Prefer using the type-safe variant (see [TypedVolumeAttachmentInformer]).
 type VolumeAttachmentInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() storagev1alpha1.VolumeAttachmentLister
 }
+
+// TypedVolumeAttachmentInformer provides access to a shared informer and lister for
+// VolumeAttachments, including the type-safe TypedInformer variant.
+// It is a superset of VolumeAttachmentInformer.
+type TypedVolumeAttachmentInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() VolumeAttachmentIndexInformer
+	Lister() storagev1alpha1.VolumeAttachmentLister
+}
+
+// VolumeAttachmentIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type VolumeAttachmentIndexInformer cache.TypedSharedIndexInformer[*apistoragev1alpha1.VolumeAttachment]
+
+// VolumeAttachmentHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for VolumeAttachment.
+type VolumeAttachmentHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apistoragev1alpha1.VolumeAttachment]
+
+// VolumeAttachmentDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for VolumeAttachment.
+type VolumeAttachmentDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apistoragev1alpha1.VolumeAttachment]
+
+// VolumeAttachmentFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for VolumeAttachment.
+type VolumeAttachmentFilteringHandler = cache.TypedFilteringResourceEventHandler[*apistoragev1alpha1.VolumeAttachment]
+
+// VolumeAttachmentIndexers is a specialization of [cache.TypedIndexers] for VolumeAttachment.
+type VolumeAttachmentIndexers = cache.TypedIndexers[*apistoragev1alpha1.VolumeAttachment]
+
+// DeletedVolumeAttachment is a specialization of [cache.DeletedObject] for VolumeAttachment.
+type DeletedVolumeAttachment = cache.DeletedObject[*apistoragev1alpha1.VolumeAttachment]
 
 type volumeAttachmentInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type volumeAttachmentInformer struct {
 // NewVolumeAttachmentInformer constructs a new informer for VolumeAttachment type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedVolumeAttachmentInformer]).
 func NewVolumeAttachmentInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewVolumeAttachmentInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedVolumeAttachmentInformer constructs a new informer for VolumeAttachment type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedVolumeAttachmentInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers VolumeAttachmentIndexers) VolumeAttachmentIndexInformer {
+	return NewTypedVolumeAttachmentInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredVolumeAttachmentInformer constructs a new informer for VolumeAttachment type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredVolumeAttachmentInformer]).
 func NewFilteredVolumeAttachmentInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewVolumeAttachmentInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedVolumeAttachmentInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredVolumeAttachmentInformer constructs a new informer for VolumeAttachment type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredVolumeAttachmentInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers VolumeAttachmentIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) VolumeAttachmentIndexInformer {
+	return NewTypedVolumeAttachmentInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewVolumeAttachmentInformerWithOptions constructs a new informer for VolumeAttachment type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedVolumeAttachmentInformerWithOptions]).
 func NewVolumeAttachmentInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedVolumeAttachmentInformerWithOptions(client, options)
+}
+
+// NewTypedVolumeAttachmentInformerWithOptions constructs a new informer for VolumeAttachment type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedVolumeAttachmentInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) VolumeAttachmentIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1alpha1", Resource: "volumeattachments"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apistoragev1alpha1.VolumeAttachment](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewVolumeAttachmentInformerWithOptions(client kubernetes.Interface, options
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *volumeAttachmentInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewVolumeAttachmentInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedVolumeAttachmentInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *volumeAttachmentInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apistoragev1alpha1.VolumeAttachment{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *volumeAttachmentInformer) TypedInformer() VolumeAttachmentIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1alpha1.VolumeAttachment](f.factory.InformerFor(&apistoragev1alpha1.VolumeAttachment{}, f.defaultInformer))
 }
 
 func (f *volumeAttachmentInformer) Lister() storagev1alpha1.VolumeAttachmentLister {
 	return storagev1alpha1.NewVolumeAttachmentLister(f.Informer().GetIndexer())
+}
+
+// ToTypedVolumeAttachmentInformer converts an untyped informer into a TypedVolumeAttachmentInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *VolumeAttachment. If that is not the case, calling type-safe methods of the returned
+// TypedVolumeAttachmentInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedVolumeAttachmentInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedVolumeAttachmentInformer(informer VolumeAttachmentInformer) TypedVolumeAttachmentInformer {
+	if informer, ok := informer.(TypedVolumeAttachmentInformer); ok {
+		return informer
+	}
+	return &volumeAttachmentTypedInformerAdapter{informer}
+}
+
+type volumeAttachmentTypedInformerAdapter struct {
+	VolumeAttachmentInformer
+}
+
+func (a *volumeAttachmentTypedInformerAdapter) TypedInformer() VolumeAttachmentIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1alpha1.VolumeAttachment](a.Informer())
+}
+
+// ToVolumeAttachmentIndexInformer converts an untyped informer into a VolumeAttachmentIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *VolumeAttachment. If that is not the case, calling type-safe methods of the returned
+// VolumeAttachmentIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a VolumeAttachmentIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToVolumeAttachmentIndexInformer(informer cache.SharedIndexInformer) VolumeAttachmentIndexInformer {
+	if informer, ok := informer.(VolumeAttachmentIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apistoragev1alpha1.VolumeAttachment](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/storage/v1alpha1/volumeattributesclass.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1alpha1/volumeattributesclass.go
@@ -34,11 +34,39 @@ import (
 )
 
 // VolumeAttributesClassInformer provides access to a shared informer and lister for
-// VolumeAttributesClasses.
+// VolumeAttributesClasses. Prefer using the type-safe variant (see [TypedVolumeAttributesClassInformer]).
 type VolumeAttributesClassInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() storagev1alpha1.VolumeAttributesClassLister
 }
+
+// TypedVolumeAttributesClassInformer provides access to a shared informer and lister for
+// VolumeAttributesClasses, including the type-safe TypedInformer variant.
+// It is a superset of VolumeAttributesClassInformer.
+type TypedVolumeAttributesClassInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() VolumeAttributesClassIndexInformer
+	Lister() storagev1alpha1.VolumeAttributesClassLister
+}
+
+// VolumeAttributesClassIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type VolumeAttributesClassIndexInformer cache.TypedSharedIndexInformer[*apistoragev1alpha1.VolumeAttributesClass]
+
+// VolumeAttributesClassHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for VolumeAttributesClass.
+type VolumeAttributesClassHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apistoragev1alpha1.VolumeAttributesClass]
+
+// VolumeAttributesClassDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for VolumeAttributesClass.
+type VolumeAttributesClassDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apistoragev1alpha1.VolumeAttributesClass]
+
+// VolumeAttributesClassFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for VolumeAttributesClass.
+type VolumeAttributesClassFilteringHandler = cache.TypedFilteringResourceEventHandler[*apistoragev1alpha1.VolumeAttributesClass]
+
+// VolumeAttributesClassIndexers is a specialization of [cache.TypedIndexers] for VolumeAttributesClass.
+type VolumeAttributesClassIndexers = cache.TypedIndexers[*apistoragev1alpha1.VolumeAttributesClass]
+
+// DeletedVolumeAttributesClass is a specialization of [cache.DeletedObject] for VolumeAttributesClass.
+type DeletedVolumeAttributesClass = cache.DeletedObject[*apistoragev1alpha1.VolumeAttributesClass]
 
 type volumeAttributesClassInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type volumeAttributesClassInformer struct {
 // NewVolumeAttributesClassInformer constructs a new informer for VolumeAttributesClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedVolumeAttributesClassInformer]).
 func NewVolumeAttributesClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewVolumeAttributesClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedVolumeAttributesClassInformer constructs a new informer for VolumeAttributesClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedVolumeAttributesClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers VolumeAttributesClassIndexers) VolumeAttributesClassIndexInformer {
+	return NewTypedVolumeAttributesClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredVolumeAttributesClassInformer constructs a new informer for VolumeAttributesClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredVolumeAttributesClassInformer]).
 func NewFilteredVolumeAttributesClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewVolumeAttributesClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedVolumeAttributesClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredVolumeAttributesClassInformer constructs a new informer for VolumeAttributesClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredVolumeAttributesClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers VolumeAttributesClassIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) VolumeAttributesClassIndexInformer {
+	return NewTypedVolumeAttributesClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewVolumeAttributesClassInformerWithOptions constructs a new informer for VolumeAttributesClass type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedVolumeAttributesClassInformerWithOptions]).
 func NewVolumeAttributesClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedVolumeAttributesClassInformerWithOptions(client, options)
+}
+
+// NewTypedVolumeAttributesClassInformerWithOptions constructs a new informer for VolumeAttributesClass type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedVolumeAttributesClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) VolumeAttributesClassIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1alpha1", Resource: "volumeattributesclasss"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apistoragev1alpha1.VolumeAttributesClass](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewVolumeAttributesClassInformerWithOptions(client kubernetes.Interface, op
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *volumeAttributesClassInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewVolumeAttributesClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedVolumeAttributesClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *volumeAttributesClassInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apistoragev1alpha1.VolumeAttributesClass{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *volumeAttributesClassInformer) TypedInformer() VolumeAttributesClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1alpha1.VolumeAttributesClass](f.factory.InformerFor(&apistoragev1alpha1.VolumeAttributesClass{}, f.defaultInformer))
 }
 
 func (f *volumeAttributesClassInformer) Lister() storagev1alpha1.VolumeAttributesClassLister {
 	return storagev1alpha1.NewVolumeAttributesClassLister(f.Informer().GetIndexer())
+}
+
+// ToTypedVolumeAttributesClassInformer converts an untyped informer into a TypedVolumeAttributesClassInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *VolumeAttributesClass. If that is not the case, calling type-safe methods of the returned
+// TypedVolumeAttributesClassInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedVolumeAttributesClassInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedVolumeAttributesClassInformer(informer VolumeAttributesClassInformer) TypedVolumeAttributesClassInformer {
+	if informer, ok := informer.(TypedVolumeAttributesClassInformer); ok {
+		return informer
+	}
+	return &volumeAttributesClassTypedInformerAdapter{informer}
+}
+
+type volumeAttributesClassTypedInformerAdapter struct {
+	VolumeAttributesClassInformer
+}
+
+func (a *volumeAttributesClassTypedInformerAdapter) TypedInformer() VolumeAttributesClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1alpha1.VolumeAttributesClass](a.Informer())
+}
+
+// ToVolumeAttributesClassIndexInformer converts an untyped informer into a VolumeAttributesClassIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *VolumeAttributesClass. If that is not the case, calling type-safe methods of the returned
+// VolumeAttributesClassIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a VolumeAttributesClassIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToVolumeAttributesClassIndexInformer(informer cache.SharedIndexInformer) VolumeAttributesClassIndexInformer {
+	if informer, ok := informer.(VolumeAttributesClassIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apistoragev1alpha1.VolumeAttributesClass](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/csidriver.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/csidriver.go
@@ -34,11 +34,39 @@ import (
 )
 
 // CSIDriverInformer provides access to a shared informer and lister for
-// CSIDrivers.
+// CSIDrivers. Prefer using the type-safe variant (see [TypedCSIDriverInformer]).
 type CSIDriverInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() storagev1beta1.CSIDriverLister
 }
+
+// TypedCSIDriverInformer provides access to a shared informer and lister for
+// CSIDrivers, including the type-safe TypedInformer variant.
+// It is a superset of CSIDriverInformer.
+type TypedCSIDriverInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() CSIDriverIndexInformer
+	Lister() storagev1beta1.CSIDriverLister
+}
+
+// CSIDriverIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type CSIDriverIndexInformer cache.TypedSharedIndexInformer[*apistoragev1beta1.CSIDriver]
+
+// CSIDriverHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for CSIDriver.
+type CSIDriverHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apistoragev1beta1.CSIDriver]
+
+// CSIDriverDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for CSIDriver.
+type CSIDriverDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apistoragev1beta1.CSIDriver]
+
+// CSIDriverFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for CSIDriver.
+type CSIDriverFilteringHandler = cache.TypedFilteringResourceEventHandler[*apistoragev1beta1.CSIDriver]
+
+// CSIDriverIndexers is a specialization of [cache.TypedIndexers] for CSIDriver.
+type CSIDriverIndexers = cache.TypedIndexers[*apistoragev1beta1.CSIDriver]
+
+// DeletedCSIDriver is a specialization of [cache.DeletedObject] for CSIDriver.
+type DeletedCSIDriver = cache.DeletedObject[*apistoragev1beta1.CSIDriver]
 
 type cSIDriverInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type cSIDriverInformer struct {
 // NewCSIDriverInformer constructs a new informer for CSIDriver type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCSIDriverInformer]).
 func NewCSIDriverInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewCSIDriverInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedCSIDriverInformer constructs a new informer for CSIDriver type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCSIDriverInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers CSIDriverIndexers) CSIDriverIndexInformer {
+	return NewTypedCSIDriverInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredCSIDriverInformer constructs a new informer for CSIDriver type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredCSIDriverInformer]).
 func NewFilteredCSIDriverInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewCSIDriverInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedCSIDriverInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredCSIDriverInformer constructs a new informer for CSIDriver type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredCSIDriverInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers CSIDriverIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) CSIDriverIndexInformer {
+	return NewTypedCSIDriverInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewCSIDriverInformerWithOptions constructs a new informer for CSIDriver type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCSIDriverInformerWithOptions]).
 func NewCSIDriverInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedCSIDriverInformerWithOptions(client, options)
+}
+
+// NewTypedCSIDriverInformerWithOptions constructs a new informer for CSIDriver type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCSIDriverInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) CSIDriverIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1beta1", Resource: "csidrivers"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.CSIDriver](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewCSIDriverInformerWithOptions(client kubernetes.Interface, options intern
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *cSIDriverInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewCSIDriverInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedCSIDriverInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *cSIDriverInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apistoragev1beta1.CSIDriver{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *cSIDriverInformer) TypedInformer() CSIDriverIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.CSIDriver](f.factory.InformerFor(&apistoragev1beta1.CSIDriver{}, f.defaultInformer))
 }
 
 func (f *cSIDriverInformer) Lister() storagev1beta1.CSIDriverLister {
 	return storagev1beta1.NewCSIDriverLister(f.Informer().GetIndexer())
+}
+
+// ToTypedCSIDriverInformer converts an untyped informer into a TypedCSIDriverInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CSIDriver. If that is not the case, calling type-safe methods of the returned
+// TypedCSIDriverInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedCSIDriverInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedCSIDriverInformer(informer CSIDriverInformer) TypedCSIDriverInformer {
+	if informer, ok := informer.(TypedCSIDriverInformer); ok {
+		return informer
+	}
+	return &cSIDriverTypedInformerAdapter{informer}
+}
+
+type cSIDriverTypedInformerAdapter struct {
+	CSIDriverInformer
+}
+
+func (a *cSIDriverTypedInformerAdapter) TypedInformer() CSIDriverIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.CSIDriver](a.Informer())
+}
+
+// ToCSIDriverIndexInformer converts an untyped informer into a CSIDriverIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CSIDriver. If that is not the case, calling type-safe methods of the returned
+// CSIDriverIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a CSIDriverIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToCSIDriverIndexInformer(informer cache.SharedIndexInformer) CSIDriverIndexInformer {
+	if informer, ok := informer.(CSIDriverIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.CSIDriver](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/csinode.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/csinode.go
@@ -34,11 +34,39 @@ import (
 )
 
 // CSINodeInformer provides access to a shared informer and lister for
-// CSINodes.
+// CSINodes. Prefer using the type-safe variant (see [TypedCSINodeInformer]).
 type CSINodeInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() storagev1beta1.CSINodeLister
 }
+
+// TypedCSINodeInformer provides access to a shared informer and lister for
+// CSINodes, including the type-safe TypedInformer variant.
+// It is a superset of CSINodeInformer.
+type TypedCSINodeInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() CSINodeIndexInformer
+	Lister() storagev1beta1.CSINodeLister
+}
+
+// CSINodeIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type CSINodeIndexInformer cache.TypedSharedIndexInformer[*apistoragev1beta1.CSINode]
+
+// CSINodeHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for CSINode.
+type CSINodeHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apistoragev1beta1.CSINode]
+
+// CSINodeDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for CSINode.
+type CSINodeDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apistoragev1beta1.CSINode]
+
+// CSINodeFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for CSINode.
+type CSINodeFilteringHandler = cache.TypedFilteringResourceEventHandler[*apistoragev1beta1.CSINode]
+
+// CSINodeIndexers is a specialization of [cache.TypedIndexers] for CSINode.
+type CSINodeIndexers = cache.TypedIndexers[*apistoragev1beta1.CSINode]
+
+// DeletedCSINode is a specialization of [cache.DeletedObject] for CSINode.
+type DeletedCSINode = cache.DeletedObject[*apistoragev1beta1.CSINode]
 
 type cSINodeInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type cSINodeInformer struct {
 // NewCSINodeInformer constructs a new informer for CSINode type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCSINodeInformer]).
 func NewCSINodeInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewCSINodeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedCSINodeInformer constructs a new informer for CSINode type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCSINodeInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers CSINodeIndexers) CSINodeIndexInformer {
+	return NewTypedCSINodeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredCSINodeInformer constructs a new informer for CSINode type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredCSINodeInformer]).
 func NewFilteredCSINodeInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewCSINodeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedCSINodeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredCSINodeInformer constructs a new informer for CSINode type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredCSINodeInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers CSINodeIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) CSINodeIndexInformer {
+	return NewTypedCSINodeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewCSINodeInformerWithOptions constructs a new informer for CSINode type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCSINodeInformerWithOptions]).
 func NewCSINodeInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedCSINodeInformerWithOptions(client, options)
+}
+
+// NewTypedCSINodeInformerWithOptions constructs a new informer for CSINode type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCSINodeInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) CSINodeIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1beta1", Resource: "csinodes"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.CSINode](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewCSINodeInformerWithOptions(client kubernetes.Interface, options internal
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *cSINodeInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewCSINodeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedCSINodeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *cSINodeInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apistoragev1beta1.CSINode{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *cSINodeInformer) TypedInformer() CSINodeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.CSINode](f.factory.InformerFor(&apistoragev1beta1.CSINode{}, f.defaultInformer))
 }
 
 func (f *cSINodeInformer) Lister() storagev1beta1.CSINodeLister {
 	return storagev1beta1.NewCSINodeLister(f.Informer().GetIndexer())
+}
+
+// ToTypedCSINodeInformer converts an untyped informer into a TypedCSINodeInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CSINode. If that is not the case, calling type-safe methods of the returned
+// TypedCSINodeInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedCSINodeInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedCSINodeInformer(informer CSINodeInformer) TypedCSINodeInformer {
+	if informer, ok := informer.(TypedCSINodeInformer); ok {
+		return informer
+	}
+	return &cSINodeTypedInformerAdapter{informer}
+}
+
+type cSINodeTypedInformerAdapter struct {
+	CSINodeInformer
+}
+
+func (a *cSINodeTypedInformerAdapter) TypedInformer() CSINodeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.CSINode](a.Informer())
+}
+
+// ToCSINodeIndexInformer converts an untyped informer into a CSINodeIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CSINode. If that is not the case, calling type-safe methods of the returned
+// CSINodeIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a CSINodeIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToCSINodeIndexInformer(informer cache.SharedIndexInformer) CSINodeIndexInformer {
+	if informer, ok := informer.(CSINodeIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.CSINode](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/csistoragecapacity.go
@@ -34,11 +34,39 @@ import (
 )
 
 // CSIStorageCapacityInformer provides access to a shared informer and lister for
-// CSIStorageCapacities.
+// CSIStorageCapacities. Prefer using the type-safe variant (see [TypedCSIStorageCapacityInformer]).
 type CSIStorageCapacityInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() storagev1beta1.CSIStorageCapacityLister
 }
+
+// TypedCSIStorageCapacityInformer provides access to a shared informer and lister for
+// CSIStorageCapacities, including the type-safe TypedInformer variant.
+// It is a superset of CSIStorageCapacityInformer.
+type TypedCSIStorageCapacityInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() CSIStorageCapacityIndexInformer
+	Lister() storagev1beta1.CSIStorageCapacityLister
+}
+
+// CSIStorageCapacityIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type CSIStorageCapacityIndexInformer cache.TypedSharedIndexInformer[*apistoragev1beta1.CSIStorageCapacity]
+
+// CSIStorageCapacityHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for CSIStorageCapacity.
+type CSIStorageCapacityHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apistoragev1beta1.CSIStorageCapacity]
+
+// CSIStorageCapacityDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for CSIStorageCapacity.
+type CSIStorageCapacityDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apistoragev1beta1.CSIStorageCapacity]
+
+// CSIStorageCapacityFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for CSIStorageCapacity.
+type CSIStorageCapacityFilteringHandler = cache.TypedFilteringResourceEventHandler[*apistoragev1beta1.CSIStorageCapacity]
+
+// CSIStorageCapacityIndexers is a specialization of [cache.TypedIndexers] for CSIStorageCapacity.
+type CSIStorageCapacityIndexers = cache.TypedIndexers[*apistoragev1beta1.CSIStorageCapacity]
+
+// DeletedCSIStorageCapacity is a specialization of [cache.DeletedObject] for CSIStorageCapacity.
+type DeletedCSIStorageCapacity = cache.DeletedObject[*apistoragev1beta1.CSIStorageCapacity]
 
 type cSIStorageCapacityInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type cSIStorageCapacityInformer struct {
 // NewCSIStorageCapacityInformer constructs a new informer for CSIStorageCapacity type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCSIStorageCapacityInformer]).
 func NewCSIStorageCapacityInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewCSIStorageCapacityInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedCSIStorageCapacityInformer constructs a new informer for CSIStorageCapacity type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCSIStorageCapacityInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers CSIStorageCapacityIndexers) CSIStorageCapacityIndexInformer {
+	return NewTypedCSIStorageCapacityInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredCSIStorageCapacityInformer constructs a new informer for CSIStorageCapacity type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredCSIStorageCapacityInformer]).
 func NewFilteredCSIStorageCapacityInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewCSIStorageCapacityInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedCSIStorageCapacityInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredCSIStorageCapacityInformer constructs a new informer for CSIStorageCapacity type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredCSIStorageCapacityInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers CSIStorageCapacityIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) CSIStorageCapacityIndexInformer {
+	return NewTypedCSIStorageCapacityInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewCSIStorageCapacityInformerWithOptions constructs a new informer for CSIStorageCapacity type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedCSIStorageCapacityInformerWithOptions]).
 func NewCSIStorageCapacityInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedCSIStorageCapacityInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedCSIStorageCapacityInformerWithOptions constructs a new informer for CSIStorageCapacity type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedCSIStorageCapacityInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) CSIStorageCapacityIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1beta1", Resource: "csistoragecapacitys"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.CSIStorageCapacity](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewCSIStorageCapacityInformerWithOptions(client kubernetes.Interface, names
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *cSIStorageCapacityInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewCSIStorageCapacityInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedCSIStorageCapacityInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *cSIStorageCapacityInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apistoragev1beta1.CSIStorageCapacity{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *cSIStorageCapacityInformer) TypedInformer() CSIStorageCapacityIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.CSIStorageCapacity](f.factory.InformerFor(&apistoragev1beta1.CSIStorageCapacity{}, f.defaultInformer))
 }
 
 func (f *cSIStorageCapacityInformer) Lister() storagev1beta1.CSIStorageCapacityLister {
 	return storagev1beta1.NewCSIStorageCapacityLister(f.Informer().GetIndexer())
+}
+
+// ToTypedCSIStorageCapacityInformer converts an untyped informer into a TypedCSIStorageCapacityInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CSIStorageCapacity. If that is not the case, calling type-safe methods of the returned
+// TypedCSIStorageCapacityInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedCSIStorageCapacityInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedCSIStorageCapacityInformer(informer CSIStorageCapacityInformer) TypedCSIStorageCapacityInformer {
+	if informer, ok := informer.(TypedCSIStorageCapacityInformer); ok {
+		return informer
+	}
+	return &cSIStorageCapacityTypedInformerAdapter{informer}
+}
+
+type cSIStorageCapacityTypedInformerAdapter struct {
+	CSIStorageCapacityInformer
+}
+
+func (a *cSIStorageCapacityTypedInformerAdapter) TypedInformer() CSIStorageCapacityIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.CSIStorageCapacity](a.Informer())
+}
+
+// ToCSIStorageCapacityIndexInformer converts an untyped informer into a CSIStorageCapacityIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *CSIStorageCapacity. If that is not the case, calling type-safe methods of the returned
+// CSIStorageCapacityIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a CSIStorageCapacityIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToCSIStorageCapacityIndexInformer(informer cache.SharedIndexInformer) CSIStorageCapacityIndexInformer {
+	if informer, ok := informer.(CSIStorageCapacityIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.CSIStorageCapacity](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/interface.go
@@ -25,17 +25,17 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// CSIDrivers returns a CSIDriverInformer.
-	CSIDrivers() CSIDriverInformer
+	CSIDrivers() TypedCSIDriverInformer
 	// CSINodes returns a CSINodeInformer.
-	CSINodes() CSINodeInformer
+	CSINodes() TypedCSINodeInformer
 	// CSIStorageCapacities returns a CSIStorageCapacityInformer.
-	CSIStorageCapacities() CSIStorageCapacityInformer
+	CSIStorageCapacities() TypedCSIStorageCapacityInformer
 	// StorageClasses returns a StorageClassInformer.
-	StorageClasses() StorageClassInformer
+	StorageClasses() TypedStorageClassInformer
 	// VolumeAttachments returns a VolumeAttachmentInformer.
-	VolumeAttachments() VolumeAttachmentInformer
+	VolumeAttachments() TypedVolumeAttachmentInformer
 	// VolumeAttributesClasses returns a VolumeAttributesClassInformer.
-	VolumeAttributesClasses() VolumeAttributesClassInformer
+	VolumeAttributesClasses() TypedVolumeAttributesClassInformer
 }
 
 type version struct {
@@ -49,32 +49,32 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// CSIDrivers returns a CSIDriverInformer.
-func (v *version) CSIDrivers() CSIDriverInformer {
+// CSIDrivers returns a TypedCSIDriverInformer.
+func (v *version) CSIDrivers() TypedCSIDriverInformer {
 	return &cSIDriverInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// CSINodes returns a CSINodeInformer.
-func (v *version) CSINodes() CSINodeInformer {
+// CSINodes returns a TypedCSINodeInformer.
+func (v *version) CSINodes() TypedCSINodeInformer {
 	return &cSINodeInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// CSIStorageCapacities returns a CSIStorageCapacityInformer.
-func (v *version) CSIStorageCapacities() CSIStorageCapacityInformer {
+// CSIStorageCapacities returns a TypedCSIStorageCapacityInformer.
+func (v *version) CSIStorageCapacities() TypedCSIStorageCapacityInformer {
 	return &cSIStorageCapacityInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// StorageClasses returns a StorageClassInformer.
-func (v *version) StorageClasses() StorageClassInformer {
+// StorageClasses returns a TypedStorageClassInformer.
+func (v *version) StorageClasses() TypedStorageClassInformer {
 	return &storageClassInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// VolumeAttachments returns a VolumeAttachmentInformer.
-func (v *version) VolumeAttachments() VolumeAttachmentInformer {
+// VolumeAttachments returns a TypedVolumeAttachmentInformer.
+func (v *version) VolumeAttachments() TypedVolumeAttachmentInformer {
 	return &volumeAttachmentInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// VolumeAttributesClasses returns a VolumeAttributesClassInformer.
-func (v *version) VolumeAttributesClasses() VolumeAttributesClassInformer {
+// VolumeAttributesClasses returns a TypedVolumeAttributesClassInformer.
+func (v *version) VolumeAttributesClasses() TypedVolumeAttributesClassInformer {
 	return &volumeAttributesClassInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/storageclass.go
@@ -34,11 +34,39 @@ import (
 )
 
 // StorageClassInformer provides access to a shared informer and lister for
-// StorageClasses.
+// StorageClasses. Prefer using the type-safe variant (see [TypedStorageClassInformer]).
 type StorageClassInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() storagev1beta1.StorageClassLister
 }
+
+// TypedStorageClassInformer provides access to a shared informer and lister for
+// StorageClasses, including the type-safe TypedInformer variant.
+// It is a superset of StorageClassInformer.
+type TypedStorageClassInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() StorageClassIndexInformer
+	Lister() storagev1beta1.StorageClassLister
+}
+
+// StorageClassIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type StorageClassIndexInformer cache.TypedSharedIndexInformer[*apistoragev1beta1.StorageClass]
+
+// StorageClassHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for StorageClass.
+type StorageClassHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apistoragev1beta1.StorageClass]
+
+// StorageClassDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for StorageClass.
+type StorageClassDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apistoragev1beta1.StorageClass]
+
+// StorageClassFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for StorageClass.
+type StorageClassFilteringHandler = cache.TypedFilteringResourceEventHandler[*apistoragev1beta1.StorageClass]
+
+// StorageClassIndexers is a specialization of [cache.TypedIndexers] for StorageClass.
+type StorageClassIndexers = cache.TypedIndexers[*apistoragev1beta1.StorageClass]
+
+// DeletedStorageClass is a specialization of [cache.DeletedObject] for StorageClass.
+type DeletedStorageClass = cache.DeletedObject[*apistoragev1beta1.StorageClass]
 
 type storageClassInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type storageClassInformer struct {
 // NewStorageClassInformer constructs a new informer for StorageClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedStorageClassInformer]).
 func NewStorageClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewStorageClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedStorageClassInformer constructs a new informer for StorageClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedStorageClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers StorageClassIndexers) StorageClassIndexInformer {
+	return NewTypedStorageClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredStorageClassInformer constructs a new informer for StorageClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredStorageClassInformer]).
 func NewFilteredStorageClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewStorageClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedStorageClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredStorageClassInformer constructs a new informer for StorageClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredStorageClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers StorageClassIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) StorageClassIndexInformer {
+	return NewTypedStorageClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewStorageClassInformerWithOptions constructs a new informer for StorageClass type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedStorageClassInformerWithOptions]).
 func NewStorageClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedStorageClassInformerWithOptions(client, options)
+}
+
+// NewTypedStorageClassInformerWithOptions constructs a new informer for StorageClass type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedStorageClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) StorageClassIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1beta1", Resource: "storageclasss"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.StorageClass](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewStorageClassInformerWithOptions(client kubernetes.Interface, options int
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *storageClassInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewStorageClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedStorageClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *storageClassInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apistoragev1beta1.StorageClass{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *storageClassInformer) TypedInformer() StorageClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.StorageClass](f.factory.InformerFor(&apistoragev1beta1.StorageClass{}, f.defaultInformer))
 }
 
 func (f *storageClassInformer) Lister() storagev1beta1.StorageClassLister {
 	return storagev1beta1.NewStorageClassLister(f.Informer().GetIndexer())
+}
+
+// ToTypedStorageClassInformer converts an untyped informer into a TypedStorageClassInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *StorageClass. If that is not the case, calling type-safe methods of the returned
+// TypedStorageClassInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedStorageClassInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedStorageClassInformer(informer StorageClassInformer) TypedStorageClassInformer {
+	if informer, ok := informer.(TypedStorageClassInformer); ok {
+		return informer
+	}
+	return &storageClassTypedInformerAdapter{informer}
+}
+
+type storageClassTypedInformerAdapter struct {
+	StorageClassInformer
+}
+
+func (a *storageClassTypedInformerAdapter) TypedInformer() StorageClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.StorageClass](a.Informer())
+}
+
+// ToStorageClassIndexInformer converts an untyped informer into a StorageClassIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *StorageClass. If that is not the case, calling type-safe methods of the returned
+// StorageClassIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a StorageClassIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToStorageClassIndexInformer(informer cache.SharedIndexInformer) StorageClassIndexInformer {
+	if informer, ok := informer.(StorageClassIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.StorageClass](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/volumeattachment.go
@@ -34,11 +34,39 @@ import (
 )
 
 // VolumeAttachmentInformer provides access to a shared informer and lister for
-// VolumeAttachments.
+// VolumeAttachments. Prefer using the type-safe variant (see [TypedVolumeAttachmentInformer]).
 type VolumeAttachmentInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() storagev1beta1.VolumeAttachmentLister
 }
+
+// TypedVolumeAttachmentInformer provides access to a shared informer and lister for
+// VolumeAttachments, including the type-safe TypedInformer variant.
+// It is a superset of VolumeAttachmentInformer.
+type TypedVolumeAttachmentInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() VolumeAttachmentIndexInformer
+	Lister() storagev1beta1.VolumeAttachmentLister
+}
+
+// VolumeAttachmentIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type VolumeAttachmentIndexInformer cache.TypedSharedIndexInformer[*apistoragev1beta1.VolumeAttachment]
+
+// VolumeAttachmentHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for VolumeAttachment.
+type VolumeAttachmentHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apistoragev1beta1.VolumeAttachment]
+
+// VolumeAttachmentDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for VolumeAttachment.
+type VolumeAttachmentDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apistoragev1beta1.VolumeAttachment]
+
+// VolumeAttachmentFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for VolumeAttachment.
+type VolumeAttachmentFilteringHandler = cache.TypedFilteringResourceEventHandler[*apistoragev1beta1.VolumeAttachment]
+
+// VolumeAttachmentIndexers is a specialization of [cache.TypedIndexers] for VolumeAttachment.
+type VolumeAttachmentIndexers = cache.TypedIndexers[*apistoragev1beta1.VolumeAttachment]
+
+// DeletedVolumeAttachment is a specialization of [cache.DeletedObject] for VolumeAttachment.
+type DeletedVolumeAttachment = cache.DeletedObject[*apistoragev1beta1.VolumeAttachment]
 
 type volumeAttachmentInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type volumeAttachmentInformer struct {
 // NewVolumeAttachmentInformer constructs a new informer for VolumeAttachment type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedVolumeAttachmentInformer]).
 func NewVolumeAttachmentInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewVolumeAttachmentInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedVolumeAttachmentInformer constructs a new informer for VolumeAttachment type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedVolumeAttachmentInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers VolumeAttachmentIndexers) VolumeAttachmentIndexInformer {
+	return NewTypedVolumeAttachmentInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredVolumeAttachmentInformer constructs a new informer for VolumeAttachment type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredVolumeAttachmentInformer]).
 func NewFilteredVolumeAttachmentInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewVolumeAttachmentInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedVolumeAttachmentInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredVolumeAttachmentInformer constructs a new informer for VolumeAttachment type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredVolumeAttachmentInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers VolumeAttachmentIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) VolumeAttachmentIndexInformer {
+	return NewTypedVolumeAttachmentInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewVolumeAttachmentInformerWithOptions constructs a new informer for VolumeAttachment type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedVolumeAttachmentInformerWithOptions]).
 func NewVolumeAttachmentInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedVolumeAttachmentInformerWithOptions(client, options)
+}
+
+// NewTypedVolumeAttachmentInformerWithOptions constructs a new informer for VolumeAttachment type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedVolumeAttachmentInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) VolumeAttachmentIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1beta1", Resource: "volumeattachments"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.VolumeAttachment](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewVolumeAttachmentInformerWithOptions(client kubernetes.Interface, options
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *volumeAttachmentInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewVolumeAttachmentInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedVolumeAttachmentInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *volumeAttachmentInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apistoragev1beta1.VolumeAttachment{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *volumeAttachmentInformer) TypedInformer() VolumeAttachmentIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.VolumeAttachment](f.factory.InformerFor(&apistoragev1beta1.VolumeAttachment{}, f.defaultInformer))
 }
 
 func (f *volumeAttachmentInformer) Lister() storagev1beta1.VolumeAttachmentLister {
 	return storagev1beta1.NewVolumeAttachmentLister(f.Informer().GetIndexer())
+}
+
+// ToTypedVolumeAttachmentInformer converts an untyped informer into a TypedVolumeAttachmentInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *VolumeAttachment. If that is not the case, calling type-safe methods of the returned
+// TypedVolumeAttachmentInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedVolumeAttachmentInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedVolumeAttachmentInformer(informer VolumeAttachmentInformer) TypedVolumeAttachmentInformer {
+	if informer, ok := informer.(TypedVolumeAttachmentInformer); ok {
+		return informer
+	}
+	return &volumeAttachmentTypedInformerAdapter{informer}
+}
+
+type volumeAttachmentTypedInformerAdapter struct {
+	VolumeAttachmentInformer
+}
+
+func (a *volumeAttachmentTypedInformerAdapter) TypedInformer() VolumeAttachmentIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.VolumeAttachment](a.Informer())
+}
+
+// ToVolumeAttachmentIndexInformer converts an untyped informer into a VolumeAttachmentIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *VolumeAttachment. If that is not the case, calling type-safe methods of the returned
+// VolumeAttachmentIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a VolumeAttachmentIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToVolumeAttachmentIndexInformer(informer cache.SharedIndexInformer) VolumeAttachmentIndexInformer {
+	if informer, ok := informer.(VolumeAttachmentIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.VolumeAttachment](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/volumeattributesclass.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/volumeattributesclass.go
@@ -34,11 +34,39 @@ import (
 )
 
 // VolumeAttributesClassInformer provides access to a shared informer and lister for
-// VolumeAttributesClasses.
+// VolumeAttributesClasses. Prefer using the type-safe variant (see [TypedVolumeAttributesClassInformer]).
 type VolumeAttributesClassInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() storagev1beta1.VolumeAttributesClassLister
 }
+
+// TypedVolumeAttributesClassInformer provides access to a shared informer and lister for
+// VolumeAttributesClasses, including the type-safe TypedInformer variant.
+// It is a superset of VolumeAttributesClassInformer.
+type TypedVolumeAttributesClassInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() VolumeAttributesClassIndexInformer
+	Lister() storagev1beta1.VolumeAttributesClassLister
+}
+
+// VolumeAttributesClassIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type VolumeAttributesClassIndexInformer cache.TypedSharedIndexInformer[*apistoragev1beta1.VolumeAttributesClass]
+
+// VolumeAttributesClassHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for VolumeAttributesClass.
+type VolumeAttributesClassHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apistoragev1beta1.VolumeAttributesClass]
+
+// VolumeAttributesClassDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for VolumeAttributesClass.
+type VolumeAttributesClassDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apistoragev1beta1.VolumeAttributesClass]
+
+// VolumeAttributesClassFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for VolumeAttributesClass.
+type VolumeAttributesClassFilteringHandler = cache.TypedFilteringResourceEventHandler[*apistoragev1beta1.VolumeAttributesClass]
+
+// VolumeAttributesClassIndexers is a specialization of [cache.TypedIndexers] for VolumeAttributesClass.
+type VolumeAttributesClassIndexers = cache.TypedIndexers[*apistoragev1beta1.VolumeAttributesClass]
+
+// DeletedVolumeAttributesClass is a specialization of [cache.DeletedObject] for VolumeAttributesClass.
+type DeletedVolumeAttributesClass = cache.DeletedObject[*apistoragev1beta1.VolumeAttributesClass]
 
 type volumeAttributesClassInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type volumeAttributesClassInformer struct {
 // NewVolumeAttributesClassInformer constructs a new informer for VolumeAttributesClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedVolumeAttributesClassInformer]).
 func NewVolumeAttributesClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewVolumeAttributesClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedVolumeAttributesClassInformer constructs a new informer for VolumeAttributesClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedVolumeAttributesClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers VolumeAttributesClassIndexers) VolumeAttributesClassIndexInformer {
+	return NewTypedVolumeAttributesClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredVolumeAttributesClassInformer constructs a new informer for VolumeAttributesClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredVolumeAttributesClassInformer]).
 func NewFilteredVolumeAttributesClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewVolumeAttributesClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedVolumeAttributesClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredVolumeAttributesClassInformer constructs a new informer for VolumeAttributesClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredVolumeAttributesClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers VolumeAttributesClassIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) VolumeAttributesClassIndexInformer {
+	return NewTypedVolumeAttributesClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewVolumeAttributesClassInformerWithOptions constructs a new informer for VolumeAttributesClass type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedVolumeAttributesClassInformerWithOptions]).
 func NewVolumeAttributesClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedVolumeAttributesClassInformerWithOptions(client, options)
+}
+
+// NewTypedVolumeAttributesClassInformerWithOptions constructs a new informer for VolumeAttributesClass type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedVolumeAttributesClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) VolumeAttributesClassIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1beta1", Resource: "volumeattributesclasss"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.VolumeAttributesClass](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewVolumeAttributesClassInformerWithOptions(client kubernetes.Interface, op
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *volumeAttributesClassInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewVolumeAttributesClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedVolumeAttributesClassInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *volumeAttributesClassInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apistoragev1beta1.VolumeAttributesClass{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *volumeAttributesClassInformer) TypedInformer() VolumeAttributesClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.VolumeAttributesClass](f.factory.InformerFor(&apistoragev1beta1.VolumeAttributesClass{}, f.defaultInformer))
 }
 
 func (f *volumeAttributesClassInformer) Lister() storagev1beta1.VolumeAttributesClassLister {
 	return storagev1beta1.NewVolumeAttributesClassLister(f.Informer().GetIndexer())
+}
+
+// ToTypedVolumeAttributesClassInformer converts an untyped informer into a TypedVolumeAttributesClassInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *VolumeAttributesClass. If that is not the case, calling type-safe methods of the returned
+// TypedVolumeAttributesClassInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedVolumeAttributesClassInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedVolumeAttributesClassInformer(informer VolumeAttributesClassInformer) TypedVolumeAttributesClassInformer {
+	if informer, ok := informer.(TypedVolumeAttributesClassInformer); ok {
+		return informer
+	}
+	return &volumeAttributesClassTypedInformerAdapter{informer}
+}
+
+type volumeAttributesClassTypedInformerAdapter struct {
+	VolumeAttributesClassInformer
+}
+
+func (a *volumeAttributesClassTypedInformerAdapter) TypedInformer() VolumeAttributesClassIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.VolumeAttributesClass](a.Informer())
+}
+
+// ToVolumeAttributesClassIndexInformer converts an untyped informer into a VolumeAttributesClassIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *VolumeAttributesClass. If that is not the case, calling type-safe methods of the returned
+// VolumeAttributesClassIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a VolumeAttributesClassIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToVolumeAttributesClassIndexInformer(informer cache.SharedIndexInformer) VolumeAttributesClassIndexInformer {
+	if informer, ok := informer.(VolumeAttributesClassIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.VolumeAttributesClass](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/storagemigration/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/storagemigration/v1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// StorageVersionMigrations returns a StorageVersionMigrationInformer.
-	StorageVersionMigrations() StorageVersionMigrationInformer
+	StorageVersionMigrations() TypedStorageVersionMigrationInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// StorageVersionMigrations returns a StorageVersionMigrationInformer.
-func (v *version) StorageVersionMigrations() StorageVersionMigrationInformer {
+// StorageVersionMigrations returns a TypedStorageVersionMigrationInformer.
+func (v *version) StorageVersionMigrations() TypedStorageVersionMigrationInformer {
 	return &storageVersionMigrationInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/storagemigration/v1/storageversionmigration.go
+++ b/staging/src/k8s.io/client-go/informers/storagemigration/v1/storageversionmigration.go
@@ -34,11 +34,39 @@ import (
 )
 
 // StorageVersionMigrationInformer provides access to a shared informer and lister for
-// StorageVersionMigrations.
+// StorageVersionMigrations. Prefer using the type-safe variant (see [TypedStorageVersionMigrationInformer]).
 type StorageVersionMigrationInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() storagemigrationv1.StorageVersionMigrationLister
 }
+
+// TypedStorageVersionMigrationInformer provides access to a shared informer and lister for
+// StorageVersionMigrations, including the type-safe TypedInformer variant.
+// It is a superset of StorageVersionMigrationInformer.
+type TypedStorageVersionMigrationInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() StorageVersionMigrationIndexInformer
+	Lister() storagemigrationv1.StorageVersionMigrationLister
+}
+
+// StorageVersionMigrationIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type StorageVersionMigrationIndexInformer cache.TypedSharedIndexInformer[*apistoragemigrationv1.StorageVersionMigration]
+
+// StorageVersionMigrationHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for StorageVersionMigration.
+type StorageVersionMigrationHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apistoragemigrationv1.StorageVersionMigration]
+
+// StorageVersionMigrationDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for StorageVersionMigration.
+type StorageVersionMigrationDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apistoragemigrationv1.StorageVersionMigration]
+
+// StorageVersionMigrationFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for StorageVersionMigration.
+type StorageVersionMigrationFilteringHandler = cache.TypedFilteringResourceEventHandler[*apistoragemigrationv1.StorageVersionMigration]
+
+// StorageVersionMigrationIndexers is a specialization of [cache.TypedIndexers] for StorageVersionMigration.
+type StorageVersionMigrationIndexers = cache.TypedIndexers[*apistoragemigrationv1.StorageVersionMigration]
+
+// DeletedStorageVersionMigration is a specialization of [cache.DeletedObject] for StorageVersionMigration.
+type DeletedStorageVersionMigration = cache.DeletedObject[*apistoragemigrationv1.StorageVersionMigration]
 
 type storageVersionMigrationInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type storageVersionMigrationInformer struct {
 // NewStorageVersionMigrationInformer constructs a new informer for StorageVersionMigration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedStorageVersionMigrationInformer]).
 func NewStorageVersionMigrationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewStorageVersionMigrationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedStorageVersionMigrationInformer constructs a new informer for StorageVersionMigration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedStorageVersionMigrationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers StorageVersionMigrationIndexers) StorageVersionMigrationIndexInformer {
+	return NewTypedStorageVersionMigrationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredStorageVersionMigrationInformer constructs a new informer for StorageVersionMigration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredStorageVersionMigrationInformer]).
 func NewFilteredStorageVersionMigrationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewStorageVersionMigrationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedStorageVersionMigrationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredStorageVersionMigrationInformer constructs a new informer for StorageVersionMigration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredStorageVersionMigrationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers StorageVersionMigrationIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) StorageVersionMigrationIndexInformer {
+	return NewTypedStorageVersionMigrationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewStorageVersionMigrationInformerWithOptions constructs a new informer for StorageVersionMigration type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedStorageVersionMigrationInformerWithOptions]).
 func NewStorageVersionMigrationInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedStorageVersionMigrationInformerWithOptions(client, options)
+}
+
+// NewTypedStorageVersionMigrationInformerWithOptions constructs a new informer for StorageVersionMigration type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedStorageVersionMigrationInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) StorageVersionMigrationIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "storagemigration.k8s.io", Version: "v1", Resource: "storageversionmigrations"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apistoragemigrationv1.StorageVersionMigration](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewStorageVersionMigrationInformerWithOptions(client kubernetes.Interface, 
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *storageVersionMigrationInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewStorageVersionMigrationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedStorageVersionMigrationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *storageVersionMigrationInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apistoragemigrationv1.StorageVersionMigration{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *storageVersionMigrationInformer) TypedInformer() StorageVersionMigrationIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragemigrationv1.StorageVersionMigration](f.factory.InformerFor(&apistoragemigrationv1.StorageVersionMigration{}, f.defaultInformer))
 }
 
 func (f *storageVersionMigrationInformer) Lister() storagemigrationv1.StorageVersionMigrationLister {
 	return storagemigrationv1.NewStorageVersionMigrationLister(f.Informer().GetIndexer())
+}
+
+// ToTypedStorageVersionMigrationInformer converts an untyped informer into a TypedStorageVersionMigrationInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *StorageVersionMigration. If that is not the case, calling type-safe methods of the returned
+// TypedStorageVersionMigrationInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedStorageVersionMigrationInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedStorageVersionMigrationInformer(informer StorageVersionMigrationInformer) TypedStorageVersionMigrationInformer {
+	if informer, ok := informer.(TypedStorageVersionMigrationInformer); ok {
+		return informer
+	}
+	return &storageVersionMigrationTypedInformerAdapter{informer}
+}
+
+type storageVersionMigrationTypedInformerAdapter struct {
+	StorageVersionMigrationInformer
+}
+
+func (a *storageVersionMigrationTypedInformerAdapter) TypedInformer() StorageVersionMigrationIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragemigrationv1.StorageVersionMigration](a.Informer())
+}
+
+// ToStorageVersionMigrationIndexInformer converts an untyped informer into a StorageVersionMigrationIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *StorageVersionMigration. If that is not the case, calling type-safe methods of the returned
+// StorageVersionMigrationIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a StorageVersionMigrationIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToStorageVersionMigrationIndexInformer(informer cache.SharedIndexInformer) StorageVersionMigrationIndexInformer {
+	if informer, ok := informer.(StorageVersionMigrationIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apistoragemigrationv1.StorageVersionMigration](informer)
 }

--- a/staging/src/k8s.io/client-go/informers/storagemigration/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/storagemigration/v1beta1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// StorageVersionMigrations returns a StorageVersionMigrationInformer.
-	StorageVersionMigrations() StorageVersionMigrationInformer
+	StorageVersionMigrations() TypedStorageVersionMigrationInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// StorageVersionMigrations returns a StorageVersionMigrationInformer.
-func (v *version) StorageVersionMigrations() StorageVersionMigrationInformer {
+// StorageVersionMigrations returns a TypedStorageVersionMigrationInformer.
+func (v *version) StorageVersionMigrations() TypedStorageVersionMigrationInformer {
 	return &storageVersionMigrationInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/client-go/informers/storagemigration/v1beta1/storageversionmigration.go
+++ b/staging/src/k8s.io/client-go/informers/storagemigration/v1beta1/storageversionmigration.go
@@ -34,11 +34,39 @@ import (
 )
 
 // StorageVersionMigrationInformer provides access to a shared informer and lister for
-// StorageVersionMigrations.
+// StorageVersionMigrations. Prefer using the type-safe variant (see [TypedStorageVersionMigrationInformer]).
 type StorageVersionMigrationInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() storagemigrationv1beta1.StorageVersionMigrationLister
 }
+
+// TypedStorageVersionMigrationInformer provides access to a shared informer and lister for
+// StorageVersionMigrations, including the type-safe TypedInformer variant.
+// It is a superset of StorageVersionMigrationInformer.
+type TypedStorageVersionMigrationInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() StorageVersionMigrationIndexInformer
+	Lister() storagemigrationv1beta1.StorageVersionMigrationLister
+}
+
+// StorageVersionMigrationIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type StorageVersionMigrationIndexInformer cache.TypedSharedIndexInformer[*apistoragemigrationv1beta1.StorageVersionMigration]
+
+// StorageVersionMigrationHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for StorageVersionMigration.
+type StorageVersionMigrationHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apistoragemigrationv1beta1.StorageVersionMigration]
+
+// StorageVersionMigrationDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for StorageVersionMigration.
+type StorageVersionMigrationDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apistoragemigrationv1beta1.StorageVersionMigration]
+
+// StorageVersionMigrationFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for StorageVersionMigration.
+type StorageVersionMigrationFilteringHandler = cache.TypedFilteringResourceEventHandler[*apistoragemigrationv1beta1.StorageVersionMigration]
+
+// StorageVersionMigrationIndexers is a specialization of [cache.TypedIndexers] for StorageVersionMigration.
+type StorageVersionMigrationIndexers = cache.TypedIndexers[*apistoragemigrationv1beta1.StorageVersionMigration]
+
+// DeletedStorageVersionMigration is a specialization of [cache.DeletedObject] for StorageVersionMigration.
+type DeletedStorageVersionMigration = cache.DeletedObject[*apistoragemigrationv1beta1.StorageVersionMigration]
 
 type storageVersionMigrationInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type storageVersionMigrationInformer struct {
 // NewStorageVersionMigrationInformer constructs a new informer for StorageVersionMigration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedStorageVersionMigrationInformer]).
 func NewStorageVersionMigrationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewStorageVersionMigrationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedStorageVersionMigrationInformer constructs a new informer for StorageVersionMigration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedStorageVersionMigrationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers StorageVersionMigrationIndexers) StorageVersionMigrationIndexInformer {
+	return NewTypedStorageVersionMigrationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredStorageVersionMigrationInformer constructs a new informer for StorageVersionMigration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredStorageVersionMigrationInformer]).
 func NewFilteredStorageVersionMigrationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewStorageVersionMigrationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedStorageVersionMigrationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredStorageVersionMigrationInformer constructs a new informer for StorageVersionMigration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredStorageVersionMigrationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers StorageVersionMigrationIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) StorageVersionMigrationIndexInformer {
+	return NewTypedStorageVersionMigrationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewStorageVersionMigrationInformerWithOptions constructs a new informer for StorageVersionMigration type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedStorageVersionMigrationInformerWithOptions]).
 func NewStorageVersionMigrationInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedStorageVersionMigrationInformerWithOptions(client, options)
+}
+
+// NewTypedStorageVersionMigrationInformerWithOptions constructs a new informer for StorageVersionMigration type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedStorageVersionMigrationInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) StorageVersionMigrationIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "storagemigration.k8s.io", Version: "v1beta1", Resource: "storageversionmigrations"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apistoragemigrationv1beta1.StorageVersionMigration](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewStorageVersionMigrationInformerWithOptions(client kubernetes.Interface, 
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *storageVersionMigrationInformer) defaultInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewStorageVersionMigrationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedStorageVersionMigrationInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *storageVersionMigrationInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apistoragemigrationv1beta1.StorageVersionMigration{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *storageVersionMigrationInformer) TypedInformer() StorageVersionMigrationIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragemigrationv1beta1.StorageVersionMigration](f.factory.InformerFor(&apistoragemigrationv1beta1.StorageVersionMigration{}, f.defaultInformer))
 }
 
 func (f *storageVersionMigrationInformer) Lister() storagemigrationv1beta1.StorageVersionMigrationLister {
 	return storagemigrationv1beta1.NewStorageVersionMigrationLister(f.Informer().GetIndexer())
+}
+
+// ToTypedStorageVersionMigrationInformer converts an untyped informer into a TypedStorageVersionMigrationInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *StorageVersionMigration. If that is not the case, calling type-safe methods of the returned
+// TypedStorageVersionMigrationInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedStorageVersionMigrationInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedStorageVersionMigrationInformer(informer StorageVersionMigrationInformer) TypedStorageVersionMigrationInformer {
+	if informer, ok := informer.(TypedStorageVersionMigrationInformer); ok {
+		return informer
+	}
+	return &storageVersionMigrationTypedInformerAdapter{informer}
+}
+
+type storageVersionMigrationTypedInformerAdapter struct {
+	StorageVersionMigrationInformer
+}
+
+func (a *storageVersionMigrationTypedInformerAdapter) TypedInformer() StorageVersionMigrationIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apistoragemigrationv1beta1.StorageVersionMigration](a.Informer())
+}
+
+// ToStorageVersionMigrationIndexInformer converts an untyped informer into a StorageVersionMigrationIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *StorageVersionMigration. If that is not the case, calling type-safe methods of the returned
+// StorageVersionMigrationIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a StorageVersionMigrationIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToStorageVersionMigrationIndexInformer(informer cache.SharedIndexInformer) StorageVersionMigrationIndexInformer {
+	if informer, ok := informer.(StorageVersionMigrationIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apistoragemigrationv1beta1.StorageVersionMigration](informer)
 }

--- a/staging/src/k8s.io/client-go/tools/cache/controller.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller.go
@@ -20,9 +20,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -282,6 +284,126 @@ type ResourceEventHandler interface {
 	OnDelete(obj interface{})
 }
 
+// Object is the subset of metav1.Object that is needed to determine the
+// name and, if applicable, namespace of an object. All standard Kubernetes
+// API types satisfy this interface through their embedded ObjectMeta.
+//
+// comparable is required so that a zero T can be compared against
+// OptionalObj to detect a missing object (e.g. a nil pointer).
+type Object interface {
+	comparable
+
+	GetName() string
+	GetNamespace() string
+}
+
+// TypedResourceEventHandler is a type-safe variant of ResourceEventHandler.
+type TypedResourceEventHandler[T Object] interface {
+	OnAdd(obj T, isInInitialList bool)
+	OnUpdate(oldObj, newObj T)
+	OnDelete(obj DeletedObject[T])
+}
+
+// DeletedObject provides information about a deleted object.
+//
+// It implements GetObjectName and GetKey, which replace
+// [DeletionHandlingObjectToName] and [DeletionHandlingMetaNamespaceKeyFunc]
+//
+// It implements the GetName and GetNamespace methods for use
+// with klog.KObj: an OnDelete event handler can log
+// it's parameter directly and is guaranteed to produce the same
+// log output as with klog.KObj applied to the actual object.
+//
+// All of these methods work regardless whether DeletedObject actually has
+// the deleted object.
+type DeletedObject[T Object] struct {
+	// OptionalObj is the deleted object.
+	//
+	// It can be:
+	// - stale: it is some *older* revision, not the one which got deleted
+	// - nil: the informer noticed a deletion without finding *any* copy of the deleted object
+	//
+	// The only guaranteed information is the key under which the deleted
+	// object was stored in the informer cache. Use [DeletedObject.GetObjectName]
+	// and [DeletedObject.GetKey] to extract the namespace and name resp.
+	// the key under which the deleted object was stored. They work in
+	// all cases.
+	OptionalObj T
+
+	// FinalStateUnknown is nil if the deleted object is available and up-to-date.
+	// Otherwise FinalStateUnknown is non-nil to provide the key.
+	// The untyped object inside it matches OptionalObj.
+	FinalStateUnknown *DeletedFinalStateUnknown
+}
+
+// GetObjectName returns the object name (= namespace if available and name)
+// for the deleted object. Note that this is slightly different from
+// GetName which returns just that name without the namespace.
+//
+// This is a type-safe variant of [DeletionHandlingObjectToName] which
+// cannot fail because T is guaranteed to have a name and namespace and
+// the key of FinalStateUnknown, if invalid, is simply treated as a
+// name without a namespace.
+func (d DeletedObject[T]) GetObjectName() ObjectName {
+	if d.FinalStateUnknown != nil {
+		// Same splitting as SplitMetaNamespaceKey and ParseObjectName,
+		// except that a key with more than one "/" is not treated as an error:
+		// the extra "/" become part of the name.
+		namespace, name, found := strings.Cut(d.FinalStateUnknown.Key, "/")
+		if !found {
+			return ObjectName{Name: namespace}
+		}
+		return ObjectName{Namespace: namespace, Name: name}
+	}
+	var null T
+	if d.OptionalObj == null {
+		// Avoid calling GetName/GetNamespace on a zero OptionalObj (e.g. a
+		// nil pointer), which could panic. A nil pointer boxed behind a
+		// further layer of indirection is not detected here and is not
+		// handled.
+		return ObjectName{}
+	}
+	// Same logic as MetaObjectToName, adapted to use T's own
+	// GetNamespace and GetName methods instead of going through
+	// meta.Accessor as ObjectToName does.
+	if namespace := d.OptionalObj.GetNamespace(); len(namespace) > 0 {
+		return ObjectName{Namespace: namespace, Name: d.OptionalObj.GetName()}
+	}
+	return ObjectName{Name: d.OptionalObj.GetName()}
+}
+
+// GetName returns the name without the namespace. Note that this is slightly
+// different from GetObjectName which returns the combination of namespace and name in a
+// struct.
+func (d DeletedObject[T]) GetName() string {
+	return d.GetObjectName().Name
+}
+
+// GetNamespace returns the namespace if there is one, otherwise the empty string.
+func (d DeletedObject[T]) GetNamespace() string {
+	return d.GetObjectName().Namespace
+}
+
+// GetKey returns the key under which the deleted object was stored.
+//
+// This is a type-safe variant of [DeletionHandlingMetaNamespaceKeyFunc]
+// which cannot fail because T is guaranteed to have a name and namespace.
+func (d DeletedObject[T]) GetKey() string {
+	if d.FinalStateUnknown != nil {
+		return d.FinalStateUnknown.Key
+	}
+	var null T
+	if d.OptionalObj == null {
+		return ""
+	}
+	// Same encoding as MetaNamespaceKeyFunc via ObjectName.String,
+	// adapted to use T's own GetNamespace and GetName methods.
+	if namespace := d.OptionalObj.GetNamespace(); len(namespace) > 0 {
+		return namespace + "/" + d.OptionalObj.GetName()
+	}
+	return d.OptionalObj.GetName()
+}
+
 // ResourceEventHandlerFuncs is an adaptor to let you easily specify as many or
 // as few of the notification functions as you want while still implementing
 // ResourceEventHandler.  This adapter does not remove the prohibition against
@@ -316,6 +438,32 @@ func (r ResourceEventHandlerFuncs) OnDelete(obj interface{}) {
 	}
 }
 
+type TypedResourceEventHandlerFuncs[T Object] struct {
+	AddFunc    func(obj T)
+	UpdateFunc func(oldObj, newObj T)
+	DeleteFunc func(obj DeletedObject[T])
+}
+
+var _ TypedResourceEventHandler[*metav1.ObjectMeta] = TypedResourceEventHandlerFuncs[*metav1.ObjectMeta]{}
+
+func (r TypedResourceEventHandlerFuncs[T]) OnAdd(obj T, isInInitialList bool) {
+	if r.AddFunc != nil {
+		r.AddFunc(obj)
+	}
+}
+
+func (r TypedResourceEventHandlerFuncs[T]) OnUpdate(oldObj, newObj T) {
+	if r.UpdateFunc != nil {
+		r.UpdateFunc(oldObj, newObj)
+	}
+}
+
+func (r TypedResourceEventHandlerFuncs[T]) OnDelete(obj DeletedObject[T]) {
+	if r.DeleteFunc != nil {
+		r.DeleteFunc(obj)
+	}
+}
+
 // ResourceEventHandlerDetailedFuncs is exactly like ResourceEventHandlerFuncs
 // except its AddFunc accepts the isInInitialList parameter, for propagating
 // HasSynced.
@@ -341,6 +489,32 @@ func (r ResourceEventHandlerDetailedFuncs) OnUpdate(oldObj, newObj interface{}) 
 
 // OnDelete calls DeleteFunc if it's not nil.
 func (r ResourceEventHandlerDetailedFuncs) OnDelete(obj interface{}) {
+	if r.DeleteFunc != nil {
+		r.DeleteFunc(obj)
+	}
+}
+
+type TypedResourceEventHandlerDetailedFuncs[T Object] struct {
+	AddFunc    func(obj T, isInInitialList bool)
+	UpdateFunc func(oldObj, newObj T)
+	DeleteFunc func(obj DeletedObject[T])
+}
+
+var _ TypedResourceEventHandler[*metav1.ObjectMeta] = TypedResourceEventHandlerDetailedFuncs[*metav1.ObjectMeta]{}
+
+func (r TypedResourceEventHandlerDetailedFuncs[T]) OnAdd(obj T, isInInitialList bool) {
+	if r.AddFunc != nil {
+		r.AddFunc(obj, isInInitialList)
+	}
+}
+
+func (r TypedResourceEventHandlerDetailedFuncs[T]) OnUpdate(oldObj, newObj T) {
+	if r.UpdateFunc != nil {
+		r.UpdateFunc(oldObj, newObj)
+	}
+}
+
+func (r TypedResourceEventHandlerDetailedFuncs[T]) OnDelete(obj DeletedObject[T]) {
 	if r.DeleteFunc != nil {
 		r.DeleteFunc(obj)
 	}
@@ -383,6 +557,48 @@ func (r FilteringResourceEventHandler) OnUpdate(oldObj, newObj interface{}) {
 // OnDelete calls the nested handler only if the filter succeeds
 func (r FilteringResourceEventHandler) OnDelete(obj interface{}) {
 	if !r.FilterFunc(obj) {
+		return
+	}
+	r.Handler.OnDelete(obj)
+}
+
+// TypedFilteringResourceEventHandler is a type-safe variant of
+// [FilteringResourceEventHandler].
+type TypedFilteringResourceEventHandler[T Object] struct {
+	FilterFunc func(obj T) bool
+	Handler    TypedResourceEventHandler[T]
+}
+
+// OnAdd calls the nested handler only if the filter succeeds
+func (r TypedFilteringResourceEventHandler[T]) OnAdd(obj T, isInInitialList bool) {
+	if !r.FilterFunc(obj) {
+		return
+	}
+	r.Handler.OnAdd(obj, isInInitialList)
+}
+
+// OnUpdate ensures the proper handler is called depending on whether the filter matches
+func (r TypedFilteringResourceEventHandler[T]) OnUpdate(oldObj, newObj T) {
+	newer := r.FilterFunc(newObj)
+	older := r.FilterFunc(oldObj)
+	switch {
+	case newer && older:
+		r.Handler.OnUpdate(oldObj, newObj)
+	case newer && !older:
+		r.Handler.OnAdd(newObj, false)
+	case !newer && older:
+		r.Handler.OnDelete(DeletedObject[T]{OptionalObj: oldObj})
+	default:
+		// do nothing
+	}
+}
+
+// OnDelete calls the nested handler only if the filter succeeds. The filter
+// is applied to [DeletedObject.OptionalObj], which may be the zero value of T
+// if the deleted object could not be recovered; a FilterFunc that relies on T
+// having a valid state must handle that case itself.
+func (r TypedFilteringResourceEventHandler[T]) OnDelete(obj DeletedObject[T]) {
+	if !r.FilterFunc(obj.OptionalObj) {
 		return
 	}
 	r.Handler.OnDelete(obj)

--- a/staging/src/k8s.io/client-go/tools/cache/controller_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller_test.go
@@ -741,6 +741,110 @@ func TestDeletionHandlingObjectToName(t *testing.T) {
 	}
 }
 
+func TestDeletedObjectGetObjectName(t *testing.T) {
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testname",
+			Namespace: "testnamespace",
+		},
+	}
+	expected, err := ObjectToName(cm)
+	if err != nil {
+		t.Error(err)
+	}
+
+	deleted := DeletedObject[*v1.ConfigMap]{OptionalObj: cm}
+	actual := deleted.GetObjectName()
+	if expected != actual {
+		t.Errorf("Expected %#v, got %#v", expected, actual)
+	}
+
+	stringKey, err := MetaNamespaceKeyFunc(cm)
+	if err != nil {
+		t.Error(err)
+	}
+	deletedUnknown := DeletedObject[*v1.ConfigMap]{
+		FinalStateUnknown: &DeletedFinalStateUnknown{
+			Key: stringKey,
+			Obj: cm,
+		},
+	}
+	actual = deletedUnknown.GetObjectName()
+	if expected != actual {
+		t.Errorf("Expected %#v, got %#v", expected, actual)
+	}
+
+	// FinalStateUnknown may have a nil Obj if the informer never saw the
+	// object; the key is still authoritative.
+	deletedUnknownNoObj := DeletedObject[*v1.ConfigMap]{
+		FinalStateUnknown: &DeletedFinalStateUnknown{
+			Key: stringKey,
+			Obj: nil,
+		},
+	}
+	actual = deletedUnknownNoObj.GetObjectName()
+	if expected != actual {
+		t.Errorf("Expected %#v, got %#v", expected, actual)
+	}
+
+	// A completely empty DeletedObject (no FinalStateUnknown, nil
+	// OptionalObj) must not panic and returns the zero ObjectName.
+	var empty DeletedObject[*v1.ConfigMap]
+	if actual := empty.GetObjectName(); actual != (ObjectName{}) {
+		t.Errorf("Expected empty ObjectName, got %#v", actual)
+	}
+}
+
+func TestDeletedObjectGetKey(t *testing.T) {
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testname",
+			Namespace: "testnamespace",
+		},
+	}
+	expected, err := MetaNamespaceKeyFunc(cm)
+	if err != nil {
+		t.Error(err)
+	}
+
+	deleted := DeletedObject[*v1.ConfigMap]{OptionalObj: cm}
+	actual := deleted.GetKey()
+	if expected != actual {
+		t.Errorf("Expected %#v, got %#v", expected, actual)
+	}
+
+	deletedUnknown := DeletedObject[*v1.ConfigMap]{
+		FinalStateUnknown: &DeletedFinalStateUnknown{
+			Key: expected,
+			Obj: cm,
+		},
+	}
+	actual = deletedUnknown.GetKey()
+	if expected != actual {
+		t.Errorf("Expected %#v, got %#v", expected, actual)
+	}
+
+	// FinalStateUnknown may have a nil Obj if the informer never saw the
+	// object; the key is still authoritative.
+	deletedUnknownNoObj := DeletedObject[*v1.ConfigMap]{
+		FinalStateUnknown: &DeletedFinalStateUnknown{
+			Key: expected,
+			Obj: nil,
+		},
+	}
+	actual = deletedUnknownNoObj.GetKey()
+	if expected != actual {
+		t.Errorf("Expected %#v, got %#v", expected, actual)
+	}
+
+	// A completely empty DeletedObject (no FinalStateUnknown, nil
+	// OptionalObj) must not panic and returns the empty string.
+	var empty DeletedObject[*v1.ConfigMap]
+	if actual := empty.GetKey(); actual != "" {
+		t.Errorf("Expected empty key, got %#v", actual)
+	}
+}
+
 type listWatchWithUnSupportedWatchListSemanticsWrapper struct {
 	*ListWatch
 }

--- a/staging/src/k8s.io/client-go/tools/cache/index.go
+++ b/staging/src/k8s.io/client-go/tools/cache/index.go
@@ -98,3 +98,37 @@ type Indexers map[string]IndexFunc
 
 // Indices maps a name to an Index
 type Indices map[string]index
+
+type TypedIndexers[T any] map[string]TypedIndexFunc[T]
+type TypedIndexFunc[T any] func(obj T) ([]string, error)
+type TypedIndexer[T any] interface {
+	Indexer
+
+	TypedIndex(indexName string, obj T) ([]T, error)
+	ByTypedIndex(indexName, indexedValue string) ([]T, error)
+	AddTypedIndexers(newIndexers TypedIndexers[T]) error
+}
+
+// TypedIndexersToIndexers wraps several indexer functions which expect objects
+// of a certain type so that they can be used in an [Indexer].
+// This is needed primarily for setting up [SharedIndexInformerOptions.Indexers].
+// When using one of the typed APIs for installing an indexer function
+// the conversion is done automatically.
+func TypedIndexersToIndexers[T any](indexers TypedIndexers[T]) Indexers {
+	untyped := make(Indexers, len(indexers))
+	for i, indexer := range indexers {
+		untyped[i] = TypedIndexerFuncToIndexerFunc(indexer)
+	}
+	return untyped
+}
+
+// TypedIndexersFuncToIndexerFunc wraps one indexer function which expect objects
+// of a certain type so that they can be used in an [Indexer].
+// This is needed primarily for setting up [SharedIndexInformerOptions.Indexers].
+// When using one of the typed APIs for installing an indexer function
+// the conversion is done automatically.
+func TypedIndexerFuncToIndexerFunc[T any](indexer TypedIndexFunc[T]) IndexFunc {
+	return func(obj any) ([]string, error) {
+		return indexer(obj.(T))
+	}
+}

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -294,6 +295,118 @@ type SharedIndexInformer interface {
 	SharedInformer
 	AddIndexers(indexers Indexers) error
 	GetIndexer() Indexer
+}
+
+// TypedSharedIndexInformer adds type-safe variants for non-type-safe methods
+// in SharedIndexInformer. No type casts are needed when using those variants.
+type TypedSharedIndexInformer[T Object] interface {
+	SharedIndexInformer
+
+	// AddTypedEventHandler is a type-safe replacement for
+	// SharedIndexInformer.AddEventHandlerWithOptions
+	// and SharedIndexInformer.AddEventHandler.
+	//
+	// Without options, it uses the same defaults as AddEventHandler
+	// or AddEventHandlerWithOptions with empty HandlerOptions.
+	// Passing one instance corresponds to AddEventHandlerWithOptions.
+	// Passing more than one is invalid and returns an error.
+	AddTypedEventHandler(handler TypedResourceEventHandler[T], options ...HandlerOptions) (ResourceEventHandlerRegistration, error)
+	AddTypedIndexers(indexers TypedIndexers[T]) error
+	GetTypedIndexer() TypedIndexer[T]
+}
+
+func NewTypedSharedIndexInformer[T Object](informer SharedIndexInformer) TypedSharedIndexInformer[T] {
+	return &typedSharedIndexInformer[T]{SharedIndexInformer: informer}
+}
+
+type typedSharedIndexInformer[T Object] struct {
+	SharedIndexInformer
+}
+
+func (s typedSharedIndexInformer[T]) AddTypedEventHandler(handler TypedResourceEventHandler[T], options ...HandlerOptions) (ResourceEventHandlerRegistration, error) {
+	var o HandlerOptions
+	switch len(options) {
+	case 0:
+	case 1:
+		o = options[0]
+	default:
+		return nil, fmt.Errorf("at most one HandlerOptions may be passed, got %d", len(options))
+	}
+	return s.AddEventHandlerWithOptions(&typedResourceEventHandler[T]{handler}, o)
+}
+
+func (s typedSharedIndexInformer[T]) AddTypedIndexers(indexers TypedIndexers[T]) error {
+	return s.AddIndexers(TypedIndexersToIndexers(indexers))
+}
+
+func (s typedSharedIndexInformer[T]) GetTypedIndexer() TypedIndexer[T] {
+	return &typedIndexer[T]{s.GetIndexer()}
+}
+
+// typedResourceEventHandler implements the untyped ResourceEventHandler interface
+// by invoking the methods of a TypedResourceEventHandler instance.
+type typedResourceEventHandler[T Object] struct {
+	handler TypedResourceEventHandler[T]
+}
+
+var _ ResourceEventHandler = &typedResourceEventHandler[*metav1.ObjectMeta]{}
+
+func (h *typedResourceEventHandler[T]) OnAdd(obj any, isInitialList bool) {
+	h.handler.OnAdd(obj.(T), isInitialList)
+}
+
+func (h *typedResourceEventHandler[T]) OnUpdate(oldObj, newObj any) {
+	h.handler.OnUpdate(oldObj.(T), newObj.(T))
+}
+
+func (h *typedResourceEventHandler[T]) OnDelete(obj any) {
+	if tomb, ok := obj.(DeletedFinalStateUnknown); ok {
+		if tomb.Obj == nil {
+			h.handler.OnDelete(DeletedObject[T]{FinalStateUnknown: &tomb})
+			return
+		}
+		h.handler.OnDelete(DeletedObject[T]{OptionalObj: tomb.Obj.(T), FinalStateUnknown: &tomb})
+		return
+	}
+	h.handler.OnDelete(DeletedObject[T]{OptionalObj: obj.(T)})
+}
+
+type typedIndexer[T any] struct {
+	Indexer
+}
+
+func (i typedIndexer[T]) TypedIndex(indexName string, obj T) ([]T, error) {
+	untyped, err := i.Index(indexName, obj)
+	if err != nil {
+		return nil, err
+	}
+	typed := make([]T, len(untyped))
+	for i, obj := range untyped {
+		typed[i] = obj.(T)
+	}
+	return typed, nil
+}
+
+func (i typedIndexer[T]) ByTypedIndex(indexName, indexedValue string) ([]T, error) {
+	untyped, err := i.ByIndex(indexName, indexedValue)
+	if err != nil {
+		return nil, err
+	}
+	typed := make([]T, len(untyped))
+	for i, obj := range untyped {
+		typed[i] = obj.(T)
+	}
+	return typed, nil
+}
+
+func (i typedIndexer[T]) AddTypedIndexers(newIndexers TypedIndexers[T]) error {
+	untyped := make(Indexers, len(newIndexers))
+	for i, indexer := range newIndexers {
+		untyped[i] = func(obj any) ([]string, error) {
+			return indexer(obj.(T))
+		}
+	}
+	return i.AddIndexers(untyped)
 }
 
 // NewSharedInformer creates a new instance for the ListerWatcher. See NewSharedIndexInformerWithOptions for full details.

--- a/staging/src/k8s.io/client-go/tools/cache/typed_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/typed_test.go
@@ -1,0 +1,499 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// recordingTypedHandler implements TypedResourceEventHandler[*v1.Pod] and
+// records all invocations for later inspection.
+type recordingTypedHandler struct {
+	added        []*v1.Pod
+	addedInitial []bool
+	updatedOld   []*v1.Pod
+	updatedNew   []*v1.Pod
+	deleted      []DeletedObject[*v1.Pod]
+}
+
+func (r *recordingTypedHandler) OnAdd(obj *v1.Pod, isInInitialList bool) {
+	r.added = append(r.added, obj)
+	r.addedInitial = append(r.addedInitial, isInInitialList)
+}
+
+func (r *recordingTypedHandler) OnUpdate(oldObj, newObj *v1.Pod) {
+	r.updatedOld = append(r.updatedOld, oldObj)
+	r.updatedNew = append(r.updatedNew, newObj)
+}
+
+func (r *recordingTypedHandler) OnDelete(obj DeletedObject[*v1.Pod]) {
+	r.deleted = append(r.deleted, obj)
+}
+
+func TestTypedResourceEventHandlerFuncs(t *testing.T) {
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod"}}
+	oldPod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "old-pod"}}
+
+	t.Run("callbacks-are-invoked", func(t *testing.T) {
+		var added []*v1.Pod
+		var addedInitial bool
+		var updatedOld, updatedNew *v1.Pod
+		var deleted DeletedObject[*v1.Pod]
+
+		funcs := TypedResourceEventHandlerFuncs[*v1.Pod]{
+			AddFunc: func(obj *v1.Pod) {
+				added = append(added, obj)
+			},
+			UpdateFunc: func(o, n *v1.Pod) {
+				updatedOld, updatedNew = o, n
+			},
+			DeleteFunc: func(obj DeletedObject[*v1.Pod]) {
+				deleted = obj
+			},
+		}
+
+		funcs.OnAdd(pod, true)
+		assert.Equal(t, []*v1.Pod{pod}, added)
+		addedInitial = true // AddFunc doesn't get isInInitialList, only presence is checked above
+		_ = addedInitial
+
+		funcs.OnUpdate(oldPod, pod)
+		assert.Equal(t, oldPod, updatedOld)
+		assert.Equal(t, pod, updatedNew)
+
+		funcs.OnDelete(DeletedObject[*v1.Pod]{OptionalObj: pod})
+		assert.Equal(t, pod, deleted.OptionalObj)
+	})
+
+	t.Run("nil-callbacks-do-not-panic", func(t *testing.T) {
+		var funcs TypedResourceEventHandlerFuncs[*v1.Pod]
+		assert.NotPanics(t, func() {
+			funcs.OnAdd(pod, false)
+			funcs.OnUpdate(oldPod, pod)
+			funcs.OnDelete(DeletedObject[*v1.Pod]{OptionalObj: pod})
+		})
+	})
+
+	// Compile-time and runtime check that the type implements the interface.
+	var _ TypedResourceEventHandler[*v1.Pod] = TypedResourceEventHandlerFuncs[*v1.Pod]{}
+}
+
+func TestTypedResourceEventHandlerDetailedFuncs(t *testing.T) {
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod"}}
+	oldPod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "old-pod"}}
+
+	t.Run("callbacks-are-invoked-including-isInInitialList", func(t *testing.T) {
+		var added *v1.Pod
+		var addedInitial bool
+		var updatedOld, updatedNew *v1.Pod
+		var deleted DeletedObject[*v1.Pod]
+
+		funcs := TypedResourceEventHandlerDetailedFuncs[*v1.Pod]{
+			AddFunc: func(obj *v1.Pod, isInInitialList bool) {
+				added = obj
+				addedInitial = isInInitialList
+			},
+			UpdateFunc: func(o, n *v1.Pod) {
+				updatedOld, updatedNew = o, n
+			},
+			DeleteFunc: func(obj DeletedObject[*v1.Pod]) {
+				deleted = obj
+			},
+		}
+
+		funcs.OnAdd(pod, true)
+		assert.Equal(t, pod, added)
+		assert.True(t, addedInitial)
+
+		funcs.OnAdd(pod, false)
+		assert.False(t, addedInitial)
+
+		funcs.OnUpdate(oldPod, pod)
+		assert.Equal(t, oldPod, updatedOld)
+		assert.Equal(t, pod, updatedNew)
+
+		funcs.OnDelete(DeletedObject[*v1.Pod]{OptionalObj: pod})
+		assert.Equal(t, pod, deleted.OptionalObj)
+	})
+
+	t.Run("nil-callbacks-do-not-panic", func(t *testing.T) {
+		var funcs TypedResourceEventHandlerDetailedFuncs[*v1.Pod]
+		assert.NotPanics(t, func() {
+			funcs.OnAdd(pod, true)
+			funcs.OnUpdate(oldPod, pod)
+			funcs.OnDelete(DeletedObject[*v1.Pod]{OptionalObj: pod})
+		})
+	})
+
+	var _ TypedResourceEventHandler[*v1.Pod] = TypedResourceEventHandlerDetailedFuncs[*v1.Pod]{}
+}
+
+func TestTypedFilteringResourceEventHandler(t *testing.T) {
+	oldPod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "old"}}
+	newPod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "new"}}
+
+	t.Run("OnAdd", func(t *testing.T) {
+		for _, tc := range []struct {
+			name   string
+			passes bool
+		}{
+			{name: "filter-passes", passes: true},
+			{name: "filter-fails", passes: false},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				handler := &recordingTypedHandler{}
+				r := TypedFilteringResourceEventHandler[*v1.Pod]{
+					FilterFunc: func(obj *v1.Pod) bool { return tc.passes },
+					Handler:    handler,
+				}
+				r.OnAdd(newPod, true)
+				if tc.passes {
+					require.Len(t, handler.added, 1)
+					assert.Equal(t, newPod, handler.added[0])
+					assert.Equal(t, []bool{true}, handler.addedInitial)
+				} else {
+					assert.Empty(t, handler.added)
+				}
+			})
+		}
+	})
+
+	t.Run("OnDelete", func(t *testing.T) {
+		for _, tc := range []struct {
+			name   string
+			passes bool
+		}{
+			{name: "filter-passes", passes: true},
+			{name: "filter-fails", passes: false},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				handler := &recordingTypedHandler{}
+				r := TypedFilteringResourceEventHandler[*v1.Pod]{
+					FilterFunc: func(obj *v1.Pod) bool { return tc.passes },
+					Handler:    handler,
+				}
+				deleted := DeletedObject[*v1.Pod]{OptionalObj: oldPod}
+				r.OnDelete(deleted)
+				if tc.passes {
+					require.Len(t, handler.deleted, 1)
+					assert.Equal(t, deleted, handler.deleted[0])
+				} else {
+					assert.Empty(t, handler.deleted)
+				}
+			})
+		}
+	})
+
+	t.Run("OnUpdate", func(t *testing.T) {
+		for _, tc := range []struct {
+			name         string
+			older, newer bool
+			wantAdd      bool
+			wantUpdate   bool
+			wantDelete   bool
+		}{
+			{name: "still-passing-to-update", older: true, newer: true, wantUpdate: true},
+			{name: "starts-passing-to-add", older: false, newer: true, wantAdd: true},
+			{name: "stops-passing-to-delete", older: true, newer: false, wantDelete: true},
+			{name: "still-failing-to-nothing", older: false, newer: false},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				handler := &recordingTypedHandler{}
+				r := TypedFilteringResourceEventHandler[*v1.Pod]{
+					FilterFunc: func(obj *v1.Pod) bool {
+						switch obj {
+						case oldPod:
+							return tc.older
+						case newPod:
+							return tc.newer
+						}
+						t.Fatalf("unexpected object %v", obj)
+						return false
+					},
+					Handler: handler,
+				}
+				r.OnUpdate(oldPod, newPod)
+
+				if tc.wantAdd {
+					require.Len(t, handler.added, 1)
+					assert.Equal(t, newPod, handler.added[0])
+					assert.Equal(t, []bool{false}, handler.addedInitial)
+				} else {
+					assert.Empty(t, handler.added)
+				}
+
+				if tc.wantUpdate {
+					require.Len(t, handler.updatedNew, 1)
+					assert.Equal(t, oldPod, handler.updatedOld[0])
+					assert.Equal(t, newPod, handler.updatedNew[0])
+				} else {
+					assert.Empty(t, handler.updatedNew)
+				}
+
+				if tc.wantDelete {
+					require.Len(t, handler.deleted, 1)
+					assert.Equal(t, oldPod, handler.deleted[0].OptionalObj)
+				} else {
+					assert.Empty(t, handler.deleted)
+				}
+			})
+		}
+	})
+
+	// Compile-time and runtime check that the type implements the interface.
+	var _ TypedResourceEventHandler[*v1.Pod] = TypedFilteringResourceEventHandler[*v1.Pod]{}
+}
+
+func TestTypedResourceEventHandlerAdapter(t *testing.T) {
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod"}}
+	oldPod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "old-pod"}}
+
+	t.Run("OnAdd", func(t *testing.T) {
+		handler := &recordingTypedHandler{}
+		adapter := &typedResourceEventHandler[*v1.Pod]{handler: handler}
+		adapter.OnAdd(pod, true)
+		require.Len(t, handler.added, 1)
+		assert.Equal(t, pod, handler.added[0])
+		assert.Equal(t, []bool{true}, handler.addedInitial)
+	})
+
+	t.Run("OnUpdate", func(t *testing.T) {
+		handler := &recordingTypedHandler{}
+		adapter := &typedResourceEventHandler[*v1.Pod]{handler: handler}
+		adapter.OnUpdate(oldPod, pod)
+		require.Len(t, handler.updatedNew, 1)
+		assert.Equal(t, oldPod, handler.updatedOld[0])
+		assert.Equal(t, pod, handler.updatedNew[0])
+	})
+
+	t.Run("OnDelete-with-a-plain-object", func(t *testing.T) {
+		handler := &recordingTypedHandler{}
+		adapter := &typedResourceEventHandler[*v1.Pod]{handler: handler}
+		adapter.OnDelete(pod)
+		require.Len(t, handler.deleted, 1)
+		assert.Equal(t, pod, handler.deleted[0].OptionalObj)
+		assert.Nil(t, handler.deleted[0].FinalStateUnknown)
+	})
+
+	t.Run("OnDelete-with-DeletedFinalStateUnknown-carrying-an-object", func(t *testing.T) {
+		handler := &recordingTypedHandler{}
+		adapter := &typedResourceEventHandler[*v1.Pod]{handler: handler}
+		tomb := DeletedFinalStateUnknown{Key: "default/pod", Obj: pod}
+		adapter.OnDelete(tomb)
+		require.Len(t, handler.deleted, 1)
+		assert.Equal(t, pod, handler.deleted[0].OptionalObj)
+		require.NotNil(t, handler.deleted[0].FinalStateUnknown)
+		assert.Equal(t, "default/pod", handler.deleted[0].FinalStateUnknown.Key)
+	})
+
+	t.Run("OnDelete-with-DeletedFinalStateUnknown-without-an-object", func(t *testing.T) {
+		handler := &recordingTypedHandler{}
+		adapter := &typedResourceEventHandler[*v1.Pod]{handler: handler}
+		tomb := DeletedFinalStateUnknown{Key: "default/pod", Obj: nil}
+		adapter.OnDelete(tomb)
+		require.Len(t, handler.deleted, 1)
+		var zero *v1.Pod
+		assert.Equal(t, zero, handler.deleted[0].OptionalObj)
+		require.NotNil(t, handler.deleted[0].FinalStateUnknown)
+		assert.Equal(t, "default/pod", handler.deleted[0].FinalStateUnknown.Key)
+	})
+
+	var _ ResourceEventHandler = &typedResourceEventHandler[*v1.Pod]{}
+}
+
+func TestTypedIndexer(t *testing.T) {
+	pod1 := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "pod1", Labels: map[string]string{"foo": "bar"}}}
+	pod2 := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "pod2", Labels: map[string]string{"foo": "bar"}}}
+
+	raw := NewIndexer(MetaNamespaceKeyFunc, Indexers{
+		"foo": func(obj interface{}) ([]string, error) {
+			return []string{obj.(*v1.Pod).Labels["foo"]}, nil
+		},
+	})
+	require.NoError(t, raw.Add(pod1))
+	require.NoError(t, raw.Add(pod2))
+
+	typed := typedIndexer[*v1.Pod]{Indexer: raw}
+
+	t.Run("TypedIndex", func(t *testing.T) {
+		res, err := typed.TypedIndex("foo", pod1)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []*v1.Pod{pod1, pod2}, res)
+	})
+
+	t.Run("ByTypedIndex", func(t *testing.T) {
+		res, err := typed.ByTypedIndex("foo", "bar")
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []*v1.Pod{pod1, pod2}, res)
+	})
+
+	t.Run("ByTypedIndex-propagates-errors", func(t *testing.T) {
+		_, err := typed.ByTypedIndex("does-not-exist", "bar")
+		require.Error(t, err)
+	})
+
+	t.Run("AddTypedIndexers", func(t *testing.T) {
+		err := typed.AddTypedIndexers(TypedIndexers[*v1.Pod]{
+			"name": func(obj *v1.Pod) ([]string, error) {
+				return []string{obj.Name}, nil
+			},
+		})
+		require.NoError(t, err)
+
+		res, err := raw.ByIndex("name", "pod1")
+		require.NoError(t, err)
+		assert.Equal(t, []interface{}{pod1}, res)
+	})
+
+	var _ TypedIndexer[*v1.Pod] = typedIndexer[*v1.Pod]{}
+}
+
+// fakeSharedIndexInformer is a minimal SharedIndexInformer stand-in that
+// records calls made to it by typedSharedIndexInformer, without needing a
+// fully functional informer.
+type fakeSharedIndexInformer struct {
+	SharedIndexInformer // nil: only the methods overridden below may be called.
+
+	handlerOptions []HandlerOptions
+
+	addedIndexers  Indexers
+	addIndexersErr error
+
+	indexer Indexer
+}
+
+func (f *fakeSharedIndexInformer) AddEventHandlerWithOptions(handler ResourceEventHandler, options HandlerOptions) (ResourceEventHandlerRegistration, error) {
+	f.handlerOptions = append(f.handlerOptions, options)
+	return nil, nil
+}
+
+func (f *fakeSharedIndexInformer) AddIndexers(indexers Indexers) error {
+	f.addedIndexers = indexers
+	return f.addIndexersErr
+}
+
+func (f *fakeSharedIndexInformer) GetIndexer() Indexer {
+	return f.indexer
+}
+
+func TestTypedSharedIndexInformerAddTypedEventHandler(t *testing.T) {
+	period := time.Minute
+
+	for _, tc := range []struct {
+		name    string
+		options []HandlerOptions
+		want    HandlerOptions
+		wantErr bool
+	}{
+		{
+			name: "no-options-uses-the-default",
+			want: HandlerOptions{},
+		},
+		{
+			name:    "one-option-is-passed-through",
+			options: []HandlerOptions{{ResyncPeriod: &period}},
+			want:    HandlerOptions{ResyncPeriod: &period},
+		},
+		{
+			name:    "two-options-are-rejected",
+			options: []HandlerOptions{{}, {}},
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeSharedIndexInformer{}
+			typed := NewTypedSharedIndexInformer[*v1.Pod](fake)
+
+			_, err := typed.AddTypedEventHandler(TypedResourceEventHandlerFuncs[*v1.Pod]{}, tc.options...)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Empty(t, fake.handlerOptions)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, fake.handlerOptions, 1)
+			assert.Equal(t, tc.want, fake.handlerOptions[0])
+		})
+	}
+}
+
+func TestTypedSharedIndexInformerAddTypedIndexers(t *testing.T) {
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod"}}
+
+	fake := &fakeSharedIndexInformer{}
+	typed := NewTypedSharedIndexInformer[*v1.Pod](fake)
+
+	err := typed.AddTypedIndexers(TypedIndexers[*v1.Pod]{
+		"name": func(obj *v1.Pod) ([]string, error) {
+			return []string{obj.Name}, nil
+		},
+	})
+	require.NoError(t, err)
+	require.Contains(t, fake.addedIndexers, "name")
+
+	values, err := fake.addedIndexers["name"](pod)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"pod"}, values)
+
+	fake.addIndexersErr = fmt.Errorf("boom")
+	err = typed.AddTypedIndexers(TypedIndexers[*v1.Pod]{})
+	assert.EqualError(t, err, "boom")
+}
+
+func TestTypedSharedIndexInformerGetTypedIndexer(t *testing.T) {
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "pod"}}
+	raw := NewIndexer(MetaNamespaceKeyFunc, Indexers{
+		"name": func(obj interface{}) ([]string, error) {
+			return []string{obj.(*v1.Pod).Name}, nil
+		},
+	})
+	require.NoError(t, raw.Add(pod))
+
+	fake := &fakeSharedIndexInformer{indexer: raw}
+	typed := NewTypedSharedIndexInformer[*v1.Pod](fake)
+
+	typedIndexer := typed.GetTypedIndexer()
+	res, err := typedIndexer.TypedIndex("name", pod)
+	require.NoError(t, err)
+	assert.Equal(t, []*v1.Pod{pod}, res)
+
+	res, err = typedIndexer.ByTypedIndex("name", "pod")
+	require.NoError(t, err)
+	assert.Equal(t, []*v1.Pod{pod}, res)
+}
+
+func TestTypedIndexersToIndexers(t *testing.T) {
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod"}}
+
+	untyped := TypedIndexersToIndexers(TypedIndexers[*v1.Pod]{
+		"name": func(obj *v1.Pod) ([]string, error) {
+			return []string{obj.Name}, nil
+		},
+	})
+	require.Contains(t, untyped, "name")
+	values, err := untyped["name"](pod)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"pod"}, values)
+}

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/informer.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/informer.go
@@ -78,40 +78,48 @@ func (g *informerGenerator) GenerateType(c *generator.Context, t *types.Type, w 
 	}
 
 	m := map[string]interface{}{
-		"apiScheme":                                c.Universe.Type(apiScheme),
-		"cacheIndexers":                            c.Universe.Type(cacheIndexers),
-		"cacheListWatch":                           c.Universe.Type(cacheListWatch),
-		"cacheMetaNamespaceIndexFunc":              c.Universe.Function(cacheMetaNamespaceIndexFunc),
-		"cacheNamespaceIndex":                      c.Universe.Variable(cacheNamespaceIndex),
-		"cacheNewSharedIndexInformer":              c.Universe.Function(cacheNewSharedIndexInformer),
-		"cacheNewSharedIndexInformerWithOptions":   c.Universe.Function(cacheNewSharedIndexInformerWithOptions),
-		"cacheSharedIndexInformer":                 c.Universe.Type(cacheSharedIndexInformer),
-		"cacheSharedIndexInformerOptions":          c.Universe.Type(cacheSharedIndexInformerOptions),
-		"cacheToListWatcherWithWatchListSemantics": c.Universe.Function(cacheToListWatcherWithWatchListSemanticsFunc),
-		"cacheInformerName":                        c.Universe.Type(cacheInformerName),
-		"clientSetInterface":                       clientSetInterface,
-		"contextContext":                           c.Universe.Type(contextContext),
-		"contextBackground":                        c.Universe.Function(contextBackgroundFunc),
-		"group":                                    namer.IC(g.groupGoName),
-		"groupName":                                g.groupVersion.Group.String(),
-		"informerFor":                              informerFor,
-		"interfacesInformerOptions":                c.Universe.Type(types.Name{Package: g.internalInterfacesPackage, Name: "InformerOptions"}),
-		"interfacesTweakListOptionsFunc":           c.Universe.Type(types.Name{Package: g.internalInterfacesPackage, Name: "TweakListOptionsFunc"}),
-		"interfacesSharedInformerFactory":          c.Universe.Type(types.Name{Package: g.internalInterfacesPackage, Name: "SharedInformerFactory"}),
-		"listOptions":                              c.Universe.Type(listOptions),
-		"lister":                                   c.Universe.Type(types.Name{Package: listerPackage, Name: t.Name.Name + "Lister"}),
-		"namespaceAll":                             c.Universe.Type(metav1NamespaceAll),
-		"namespaced":                               !tags.NonNamespaced,
-		"newLister":                                c.Universe.Function(types.Name{Package: listerPackage, Name: "New" + t.Name.Name + "Lister"}),
-		"resourceName":                             strings.ToLower(t.Name.Name) + "s",
-		"runtimeObject":                            c.Universe.Type(runtimeObject),
-		"schemaGroupVersionResource":               c.Universe.Type(schemaGroupVersionResource),
-		"timeDuration":                             c.Universe.Type(timeDuration),
-		"type":                                     t,
-		"v1ListOptions":                            c.Universe.Type(v1ListOptions),
-		"version":                                  namer.IC(g.groupVersion.Version.String()),
-		"versionName":                              g.groupVersion.Version.String(),
-		"watchInterface":                           c.Universe.Type(watchInterface),
+		"apiScheme":                                   c.Universe.Type(apiScheme),
+		"cacheDeletedObject":                          c.Universe.Type(cacheDeletedObject),
+		"cacheIndexers":                               c.Universe.Type(cacheIndexers),
+		"cacheListWatch":                              c.Universe.Type(cacheListWatch),
+		"cacheMetaNamespaceIndexFunc":                 c.Universe.Function(cacheMetaNamespaceIndexFunc),
+		"cacheNamespaceIndex":                         c.Universe.Variable(cacheNamespaceIndex),
+		"cacheNewSharedIndexInformer":                 c.Universe.Function(cacheNewSharedIndexInformer),
+		"cacheNewTypedSharedIndexInformer":            c.Universe.Function(cacheNewTypedSharedIndexInformer),
+		"cacheNewSharedIndexInformerWithOptions":      c.Universe.Function(cacheNewSharedIndexInformerWithOptions),
+		"cacheSharedIndexInformer":                    c.Universe.Type(cacheSharedIndexInformer),
+		"cacheTypedFilteringResourceEventHandler":     c.Universe.Type(cacheTypedFilteringResourceEventHandler),
+		"cacheTypedResourceEventHandlerDetailedFuncs": c.Universe.Type(cacheTypedResourceEventHandlerDetailedFuncs),
+		"cacheTypedResourceEventHandlerFuncs":         c.Universe.Type(cacheTypedResourceEventHandlerFuncs),
+		"cacheTypedIndexers":                          c.Universe.Type(cacheTypedIndexers),
+		"cacheTypedIndexersToIndexers":                c.Universe.Type(cacheTypedIndexersToIndexers),
+		"cacheTypedSharedIndexInformer":               c.Universe.Type(cacheTypedSharedIndexInformer),
+		"cacheSharedIndexInformerOptions":             c.Universe.Type(cacheSharedIndexInformerOptions),
+		"cacheToListWatcherWithWatchListSemantics":    c.Universe.Function(cacheToListWatcherWithWatchListSemanticsFunc),
+		"cacheInformerName":                           c.Universe.Type(cacheInformerName),
+		"clientSetInterface":                          clientSetInterface,
+		"contextContext":                              c.Universe.Type(contextContext),
+		"contextBackground":                           c.Universe.Function(contextBackgroundFunc),
+		"group":                                       namer.IC(g.groupGoName),
+		"groupName":                                   g.groupVersion.Group.String(),
+		"informerFor":                                 informerFor,
+		"interfacesInformerOptions":                   c.Universe.Type(types.Name{Package: g.internalInterfacesPackage, Name: "InformerOptions"}),
+		"interfacesTweakListOptionsFunc":              c.Universe.Type(types.Name{Package: g.internalInterfacesPackage, Name: "TweakListOptionsFunc"}),
+		"interfacesSharedInformerFactory":             c.Universe.Type(types.Name{Package: g.internalInterfacesPackage, Name: "SharedInformerFactory"}),
+		"listOptions":                                 c.Universe.Type(listOptions),
+		"lister":                                      c.Universe.Type(types.Name{Package: listerPackage, Name: t.Name.Name + "Lister"}),
+		"namespaceAll":                                c.Universe.Type(metav1NamespaceAll),
+		"namespaced":                                  !tags.NonNamespaced,
+		"newLister":                                   c.Universe.Function(types.Name{Package: listerPackage, Name: "New" + t.Name.Name + "Lister"}),
+		"resourceName":                                strings.ToLower(t.Name.Name) + "s",
+		"runtimeObject":                               c.Universe.Type(runtimeObject),
+		"schemaGroupVersionResource":                  c.Universe.Type(schemaGroupVersionResource),
+		"timeDuration":                                c.Universe.Type(timeDuration),
+		"type":                                        t,
+		"v1ListOptions":                               c.Universe.Type(v1ListOptions),
+		"version":                                     namer.IC(g.groupVersion.Version.String()),
+		"versionName":                                 g.groupVersion.Version.String(),
+		"watchInterface":                              c.Universe.Type(watchInterface),
 	}
 
 	sw.Do(typeInformerInterface, m)
@@ -122,17 +130,47 @@ func (g *informerGenerator) GenerateType(c *generator.Context, t *types.Type, w 
 	sw.Do(typeInformerConstructor, m)
 	sw.Do(typeInformerInformer, m)
 	sw.Do(typeInformerLister, m)
+	sw.Do(typeInformerToTypedInformer, m)
+	sw.Do(typeInformerToIndexInformer, m)
 
 	return sw.Error()
 }
 
 var typeInformerInterface = `
 // $.type|public$Informer provides access to a shared informer and lister for
-// $.type|publicPlural$.
+// $.type|publicPlural$. Prefer using the type-safe variant (see [Typed$.type|public$Informer]).
 type $.type|public$Informer interface {
 	Informer() $.cacheSharedIndexInformer|raw$
 	Lister() $.lister|raw$
 }
+
+// Typed$.type|public$Informer provides access to a shared informer and lister for
+// $.type|publicPlural$, including the type-safe TypedInformer variant.
+// It is a superset of $.type|public$Informer.
+type Typed$.type|public$Informer interface {
+	Informer() $.cacheSharedIndexInformer|raw$
+	TypedInformer() $.type|public$IndexInformer
+	Lister() $.lister|raw$
+}
+
+// $.type|public$IndexInformer is a wrapper around the underlying [$.cacheSharedIndexInformer|raw$]
+// with type-safe variants of several methods.
+type $.type|public$IndexInformer $.cacheTypedSharedIndexInformer|raw$[*$.type|raw$]
+
+// $.type|public$HandlerFuncs is a specialization of [$.cacheTypedResourceEventHandlerFuncs|raw$] for $.type|public$.
+type $.type|public$HandlerFuncs = $.cacheTypedResourceEventHandlerFuncs|raw$[*$.type|raw$]
+
+// $.type|public$DetailedHandlerFuncs is a specialization of [$.cacheTypedResourceEventHandlerDetailedFuncs|raw$] for $.type|public$.
+type $.type|public$DetailedHandlerFuncs = $.cacheTypedResourceEventHandlerDetailedFuncs|raw$[*$.type|raw$]
+
+// $.type|public$FilteringHandler is a specialization of [$.cacheTypedFilteringResourceEventHandler|raw$] for $.type|public$.
+type $.type|public$FilteringHandler = $.cacheTypedFilteringResourceEventHandler|raw$[*$.type|raw$]
+
+// $.type|public$Indexers is a specialization of [$.cacheTypedIndexers|raw$] for $.type|public$.
+type $.type|public$Indexers = $.cacheTypedIndexers|raw$[*$.type|raw$]
+
+// Deleted$.type|public$ is a specialization of [$.cacheDeletedObject|raw$] for $.type|public$.
+type Deleted$.type|public$ = $.cacheDeletedObject|raw$[*$.type|raw$]
 `
 
 var typeInformerStruct = `
@@ -147,8 +185,16 @@ var typeInformerPublicConstructor = `
 // New$.type|public$Informer constructs a new informer for $.type|public$ type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTyped$.type|public$Informer]).
 func New$.type|public$Informer(client $.clientSetInterface|raw$$if .namespaced$, namespace string$end$, resyncPeriod $.timeDuration|raw$, indexers $.cacheIndexers|raw$) $.cacheSharedIndexInformer|raw$ {
 	return New$.type|public$InformerWithOptions(client$if .namespaced$, namespace$end$, $.interfacesInformerOptions|raw${ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTyped$.type|public$Informer constructs a new informer for $.type|public$ type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTyped$.type|public$Informer(client $.clientSetInterface|raw$$if .namespaced$, namespace string$end$, resyncPeriod $.timeDuration|raw$, indexers $.type|public$Indexers) $.type|public$IndexInformer {
+	return NewTyped$.type|public$InformerWithOptions(client$if .namespaced$, namespace$end$, $.interfacesInformerOptions|raw${ResyncPeriod: resyncPeriod, Indexers: $.cacheTypedIndexersToIndexers|raw$(indexers)})
 }
 `
 
@@ -156,8 +202,16 @@ var typeFilteredInformerPublicConstructor = `
 // NewFiltered$.type|public$Informer constructs a new informer for $.type|public$ type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFiltered$.type|public$Informer]).
 func NewFiltered$.type|public$Informer(client $.clientSetInterface|raw$$if .namespaced$, namespace string$end$, resyncPeriod $.timeDuration|raw$, indexers $.cacheIndexers|raw$, tweakListOptions $.interfacesTweakListOptionsFunc|raw$) $.cacheSharedIndexInformer|raw$ {
-	return New$.type|public$InformerWithOptions(client$if .namespaced$, namespace$end$, $.interfacesInformerOptions|raw${ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTyped$.type|public$InformerWithOptions(client$if .namespaced$, namespace$end$, $.interfacesInformerOptions|raw${ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFiltered$.type|public$Informer constructs a new informer for $.type|public$ type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFiltered$.type|public$Informer(client $.clientSetInterface|raw$$if .namespaced$, namespace string$end$, resyncPeriod $.timeDuration|raw$, indexers $.type|public$Indexers, tweakListOptions $.interfacesTweakListOptionsFunc|raw$) $.type|public$IndexInformer {
+	return NewTyped$.type|public$InformerWithOptions(client$if .namespaced$, namespace$end$, $.interfacesInformerOptions|raw${ResyncPeriod: resyncPeriod, Indexers: $.cacheTypedIndexersToIndexers|raw$(indexers), TweakListOptions: tweakListOptions})
 }
 `
 
@@ -165,11 +219,19 @@ var typeInformerPublicConstructorWithOptions = `
 // New$.type|public$InformerWithOptions constructs a new informer for $.type|public$ type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTyped$.type|public$InformerWithOptions]).
 func New$.type|public$InformerWithOptions(client $.clientSetInterface|raw$$if .namespaced$, namespace string$end$, options $.interfacesInformerOptions|raw$) $.cacheSharedIndexInformer|raw$ {
+	return NewTyped$.type|public$InformerWithOptions(client$if .namespaced$, namespace$end$, options)
+}
+
+// NewTyped$.type|public$InformerWithOptions constructs a new informer for $.type|public$ type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTyped$.type|public$InformerWithOptions(client $.clientSetInterface|raw$$if .namespaced$, namespace string$end$, options $.interfacesInformerOptions|raw$) $.type|public$IndexInformer {
 	gvr := $.schemaGroupVersionResource|raw${Group: "$.groupName$", Version: "$.versionName$", Resource: "$.resourceName$"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return $.cacheNewSharedIndexInformerWithOptions|raw$(
+	return $.cacheNewTypedSharedIndexInformer|raw$[*$.type|raw$]($.cacheNewSharedIndexInformerWithOptions|raw$(
 		$.cacheToListWatcherWithWatchListSemantics|raw$(&$.cacheListWatch|raw${
 			ListFunc: func(opts $.v1ListOptions|raw$) ($.runtimeObject|raw$, error) {
 				if tweakListOptions != nil {
@@ -202,24 +264,68 @@ func New$.type|public$InformerWithOptions(client $.clientSetInterface|raw$$if .n
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 `
 
 var typeInformerConstructor = `
 func (f *$.type|private$Informer) defaultInformer(client $.clientSetInterface|raw$, resyncPeriod $.timeDuration|raw$) $.cacheSharedIndexInformer|raw$ {
-	return New$.type|public$InformerWithOptions(client$if .namespaced$, f.namespace$end$, $.interfacesInformerOptions|raw${ResyncPeriod: resyncPeriod, Indexers: $.cacheIndexers|raw${$.cacheNamespaceIndex|raw$: $.cacheMetaNamespaceIndexFunc|raw$}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTyped$.type|public$InformerWithOptions(client$if .namespaced$, f.namespace$end$, $.interfacesInformerOptions|raw${ResyncPeriod: resyncPeriod, Indexers: $.cacheIndexers|raw${$.cacheNamespaceIndex|raw$: $.cacheMetaNamespaceIndexFunc|raw$}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 `
 
 var typeInformerInformer = `
 func (f *$.type|private$Informer) Informer() $.cacheSharedIndexInformer|raw$ {
-	return f.factory.$.informerFor$(&$.type|raw${}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *$.type|private$Informer) TypedInformer() $.type|public$IndexInformer {
+	return $.cacheNewTypedSharedIndexInformer|raw$[*$.type|raw$](f.factory.$.informerFor$(&$.type|raw${}, f.defaultInformer))
 }
 `
 
 var typeInformerLister = `
 func (f *$.type|private$Informer) Lister() $.lister|raw$ {
 	return $.newLister|raw$(f.Informer().GetIndexer())
+}
+`
+
+var typeInformerToTypedInformer = `
+// ToTyped$.type|public$Informer converts an untyped informer into a Typed$.type|public$Informer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *$.type|public$. If that is not the case, calling type-safe methods of the returned
+// Typed$.type|public$Informer leads to runtime panics. A safer alternative is to pass
+// around a Typed$.type|public$Informer instances that was obtained from a
+// SharedInformerFactory.
+func ToTyped$.type|public$Informer(informer $.type|public$Informer) Typed$.type|public$Informer {
+	if informer, ok := informer.(Typed$.type|public$Informer); ok {
+		return informer
+	}
+	return &$.type|private$TypedInformerAdapter{informer}
+}
+
+type $.type|private$TypedInformerAdapter struct {
+	$.type|public$Informer
+}
+
+func (a *$.type|private$TypedInformerAdapter) TypedInformer() $.type|public$IndexInformer {
+	return $.cacheNewTypedSharedIndexInformer|raw$[*$.type|raw$](a.Informer())
+}
+`
+
+var typeInformerToIndexInformer = `
+// To$.type|public$IndexInformer converts an untyped informer into a $.type|public$IndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *$.type|public$. If that is not the case, calling type-safe methods of the returned
+// $.type|public$IndexInformer leads to runtime panics. A safer alternative is to pass
+// around a $.type|public$IndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func To$.type|public$IndexInformer(informer $.cacheSharedIndexInformer|raw$) $.type|public$IndexInformer {
+	if informer, ok := informer.($.type|public$IndexInformer); ok {
+		return informer
+	}
+	return $.cacheNewTypedSharedIndexInformer|raw$[*$.type|raw$](informer)
 }
 `

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/types.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/types.go
@@ -20,6 +20,7 @@ import "k8s.io/gengo/v2/types"
 
 var (
 	apiScheme                                    = types.Name{Package: "k8s.io/kubernetes/pkg/api/legacyscheme", Name: "Scheme"}
+	cacheDeletedObject                           = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "DeletedObject"}
 	cacheDoneChecker                             = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "DoneChecker"}
 	cacheGenericLister                           = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "GenericLister"}
 	cacheIndexers                                = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "Indexers"}
@@ -30,7 +31,14 @@ var (
 	cacheNewGenericLister                        = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "NewGenericLister"}
 	cacheNewSharedIndexInformer                  = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "NewSharedIndexInformer"}
 	cacheNewSharedIndexInformerWithOptions       = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "NewSharedIndexInformerWithOptions"}
+	cacheNewTypedSharedIndexInformer             = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "NewTypedSharedIndexInformer"}
 	cacheSharedIndexInformer                     = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "SharedIndexInformer"}
+	cacheTypedFilteringResourceEventHandler      = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "TypedFilteringResourceEventHandler"}
+	cacheTypedResourceEventHandlerDetailedFuncs  = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "TypedResourceEventHandlerDetailedFuncs"}
+	cacheTypedResourceEventHandlerFuncs          = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "TypedResourceEventHandlerFuncs"}
+	cacheTypedIndexers                           = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "TypedIndexers"}
+	cacheTypedIndexersToIndexers                 = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "TypedIndexersToIndexers"}
+	cacheTypedSharedIndexInformer                = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "TypedSharedIndexInformer"}
 	cacheSharedIndexInformerOptions              = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "SharedIndexInformerOptions"}
 	cacheSyncResult                              = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "SyncResult"}
 	cacheTransformFunc                           = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "TransformFunc"}

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/versioninterface.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/versioninterface.go
@@ -85,7 +85,7 @@ var versionTemplate = `
 type Interface interface {
 	$range .types -$
 		// $.|publicPlural$ returns a $.|public$Informer.
-		$.|publicPlural$() $.|public$Informer
+		$.|publicPlural$() Typed$.|public$Informer
 	$end$
 }
 
@@ -102,8 +102,8 @@ func New(f $.interfacesSharedInformerFactory|raw$, namespace string, tweakListOp
 `
 
 var versionFuncTemplate = `
-// $.type|publicPlural$ returns a $.type|public$Informer.
-func (v *version) $.type|publicPlural$() $.type|public$Informer {
+// $.type|publicPlural$ returns a Typed$.type|public$Informer.
+func (v *version) $.type|publicPlural$() Typed$.type|public$Informer {
 	return &$.type|private$Informer{factory: v.factory$if .namespaced$, namespace: v.namespace$end$, tweakListOptions: v.tweakListOptions}
 }
 `

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/example/v1/clustertesttype.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ClusterTestTypeInformer provides access to a shared informer and lister for
-// ClusterTestTypes.
+// ClusterTestTypes. Prefer using the type-safe variant (see [TypedClusterTestTypeInformer]).
 type ClusterTestTypeInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() examplev1.ClusterTestTypeLister
 }
+
+// TypedClusterTestTypeInformer provides access to a shared informer and lister for
+// ClusterTestTypes, including the type-safe TypedInformer variant.
+// It is a superset of ClusterTestTypeInformer.
+type TypedClusterTestTypeInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ClusterTestTypeIndexInformer
+	Lister() examplev1.ClusterTestTypeLister
+}
+
+// ClusterTestTypeIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ClusterTestTypeIndexInformer cache.TypedSharedIndexInformer[*apisexamplev1.ClusterTestType]
+
+// ClusterTestTypeHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ClusterTestType.
+type ClusterTestTypeHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apisexamplev1.ClusterTestType]
+
+// ClusterTestTypeDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ClusterTestType.
+type ClusterTestTypeDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apisexamplev1.ClusterTestType]
+
+// ClusterTestTypeFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ClusterTestType.
+type ClusterTestTypeFilteringHandler = cache.TypedFilteringResourceEventHandler[*apisexamplev1.ClusterTestType]
+
+// ClusterTestTypeIndexers is a specialization of [cache.TypedIndexers] for ClusterTestType.
+type ClusterTestTypeIndexers = cache.TypedIndexers[*apisexamplev1.ClusterTestType]
+
+// DeletedClusterTestType is a specialization of [cache.DeletedObject] for ClusterTestType.
+type DeletedClusterTestType = cache.DeletedObject[*apisexamplev1.ClusterTestType]
 
 type clusterTestTypeInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type clusterTestTypeInformer struct {
 // NewClusterTestTypeInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedClusterTestTypeInformer]).
 func NewClusterTestTypeInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedClusterTestTypeInformer constructs a new informer for ClusterTestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedClusterTestTypeInformer(client versioned.Interface, resyncPeriod time.Duration, indexers ClusterTestTypeIndexers) ClusterTestTypeIndexInformer {
+	return NewTypedClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredClusterTestTypeInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredClusterTestTypeInformer]).
 func NewFilteredClusterTestTypeInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredClusterTestTypeInformer constructs a new informer for ClusterTestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredClusterTestTypeInformer(client versioned.Interface, resyncPeriod time.Duration, indexers ClusterTestTypeIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ClusterTestTypeIndexInformer {
+	return NewTypedClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewClusterTestTypeInformerWithOptions constructs a new informer for ClusterTestType type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedClusterTestTypeInformerWithOptions]).
 func NewClusterTestTypeInformerWithOptions(client versioned.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedClusterTestTypeInformerWithOptions(client, options)
+}
+
+// NewTypedClusterTestTypeInformerWithOptions constructs a new informer for ClusterTestType type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedClusterTestTypeInformerWithOptions(client versioned.Interface, options internalinterfaces.InformerOptions) ClusterTestTypeIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "example-group.hyphens.code-generator.k8s.io", Version: "v1", Resource: "clustertesttypes"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.ClusterTestType](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewClusterTestTypeInformerWithOptions(client versioned.Interface, options i
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *clusterTestTypeInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *clusterTestTypeInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apisexamplev1.ClusterTestType{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *clusterTestTypeInformer) TypedInformer() ClusterTestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.ClusterTestType](f.factory.InformerFor(&apisexamplev1.ClusterTestType{}, f.defaultInformer))
 }
 
 func (f *clusterTestTypeInformer) Lister() examplev1.ClusterTestTypeLister {
 	return examplev1.NewClusterTestTypeLister(f.Informer().GetIndexer())
+}
+
+// ToTypedClusterTestTypeInformer converts an untyped informer into a TypedClusterTestTypeInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ClusterTestType. If that is not the case, calling type-safe methods of the returned
+// TypedClusterTestTypeInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedClusterTestTypeInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedClusterTestTypeInformer(informer ClusterTestTypeInformer) TypedClusterTestTypeInformer {
+	if informer, ok := informer.(TypedClusterTestTypeInformer); ok {
+		return informer
+	}
+	return &clusterTestTypeTypedInformerAdapter{informer}
+}
+
+type clusterTestTypeTypedInformerAdapter struct {
+	ClusterTestTypeInformer
+}
+
+func (a *clusterTestTypeTypedInformerAdapter) TypedInformer() ClusterTestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.ClusterTestType](a.Informer())
+}
+
+// ToClusterTestTypeIndexInformer converts an untyped informer into a ClusterTestTypeIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ClusterTestType. If that is not the case, calling type-safe methods of the returned
+// ClusterTestTypeIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ClusterTestTypeIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToClusterTestTypeIndexInformer(informer cache.SharedIndexInformer) ClusterTestTypeIndexInformer {
+	if informer, ok := informer.(ClusterTestTypeIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.ClusterTestType](informer)
 }

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/example/v1/interface.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/example/v1/interface.go
@@ -25,9 +25,9 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// ClusterTestTypes returns a ClusterTestTypeInformer.
-	ClusterTestTypes() ClusterTestTypeInformer
+	ClusterTestTypes() TypedClusterTestTypeInformer
 	// TestTypes returns a TestTypeInformer.
-	TestTypes() TestTypeInformer
+	TestTypes() TypedTestTypeInformer
 }
 
 type version struct {
@@ -41,12 +41,12 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// ClusterTestTypes returns a ClusterTestTypeInformer.
-func (v *version) ClusterTestTypes() ClusterTestTypeInformer {
+// ClusterTestTypes returns a TypedClusterTestTypeInformer.
+func (v *version) ClusterTestTypes() TypedClusterTestTypeInformer {
 	return &clusterTestTypeInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// TestTypes returns a TestTypeInformer.
-func (v *version) TestTypes() TestTypeInformer {
+// TestTypes returns a TypedTestTypeInformer.
+func (v *version) TestTypes() TypedTestTypeInformer {
 	return &testTypeInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/example/v1/testtype.go
@@ -34,11 +34,39 @@ import (
 )
 
 // TestTypeInformer provides access to a shared informer and lister for
-// TestTypes.
+// TestTypes. Prefer using the type-safe variant (see [TypedTestTypeInformer]).
 type TestTypeInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() examplev1.TestTypeLister
 }
+
+// TypedTestTypeInformer provides access to a shared informer and lister for
+// TestTypes, including the type-safe TypedInformer variant.
+// It is a superset of TestTypeInformer.
+type TypedTestTypeInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() TestTypeIndexInformer
+	Lister() examplev1.TestTypeLister
+}
+
+// TestTypeIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type TestTypeIndexInformer cache.TypedSharedIndexInformer[*apisexamplev1.TestType]
+
+// TestTypeHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for TestType.
+type TestTypeHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apisexamplev1.TestType]
+
+// TestTypeDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for TestType.
+type TestTypeDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apisexamplev1.TestType]
+
+// TestTypeFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for TestType.
+type TestTypeFilteringHandler = cache.TypedFilteringResourceEventHandler[*apisexamplev1.TestType]
+
+// TestTypeIndexers is a specialization of [cache.TypedIndexers] for TestType.
+type TestTypeIndexers = cache.TypedIndexers[*apisexamplev1.TestType]
+
+// DeletedTestType is a specialization of [cache.DeletedObject] for TestType.
+type DeletedTestType = cache.DeletedObject[*apisexamplev1.TestType]
 
 type testTypeInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type testTypeInformer struct {
 // NewTestTypeInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedTestTypeInformer]).
 func NewTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedTestTypeInformer constructs a new informer for TestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers TestTypeIndexers) TestTypeIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredTestTypeInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredTestTypeInformer]).
 func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredTestTypeInformer constructs a new informer for TestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers TestTypeIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) TestTypeIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewTestTypeInformerWithOptions constructs a new informer for TestType type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedTestTypeInformerWithOptions]).
 func NewTestTypeInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedTestTypeInformerWithOptions constructs a new informer for TestType type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedTestTypeInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) TestTypeIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "example-group.hyphens.code-generator.k8s.io", Version: "v1", Resource: "testtypes"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.TestType](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewTestTypeInformerWithOptions(client versioned.Interface, namespace string
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *testTypeInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewTestTypeInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedTestTypeInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *testTypeInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apisexamplev1.TestType{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *testTypeInformer) TypedInformer() TestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.TestType](f.factory.InformerFor(&apisexamplev1.TestType{}, f.defaultInformer))
 }
 
 func (f *testTypeInformer) Lister() examplev1.TestTypeLister {
 	return examplev1.NewTestTypeLister(f.Informer().GetIndexer())
+}
+
+// ToTypedTestTypeInformer converts an untyped informer into a TypedTestTypeInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *TestType. If that is not the case, calling type-safe methods of the returned
+// TypedTestTypeInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedTestTypeInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedTestTypeInformer(informer TestTypeInformer) TypedTestTypeInformer {
+	if informer, ok := informer.(TypedTestTypeInformer); ok {
+		return informer
+	}
+	return &testTypeTypedInformerAdapter{informer}
+}
+
+type testTypeTypedInformerAdapter struct {
+	TestTypeInformer
+}
+
+func (a *testTypeTypedInformerAdapter) TypedInformer() TestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.TestType](a.Informer())
+}
+
+// ToTestTypeIndexInformer converts an untyped informer into a TestTypeIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *TestType. If that is not the case, calling type-safe methods of the returned
+// TestTypeIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a TestTypeIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTestTypeIndexInformer(informer cache.SharedIndexInformer) TestTypeIndexInformer {
+	if informer, ok := informer.(TestTypeIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.TestType](informer)
 }

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/example/v1/clustertesttype.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ClusterTestTypeInformer provides access to a shared informer and lister for
-// ClusterTestTypes.
+// ClusterTestTypes. Prefer using the type-safe variant (see [TypedClusterTestTypeInformer]).
 type ClusterTestTypeInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() examplev1.ClusterTestTypeLister
 }
+
+// TypedClusterTestTypeInformer provides access to a shared informer and lister for
+// ClusterTestTypes, including the type-safe TypedInformer variant.
+// It is a superset of ClusterTestTypeInformer.
+type TypedClusterTestTypeInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ClusterTestTypeIndexInformer
+	Lister() examplev1.ClusterTestTypeLister
+}
+
+// ClusterTestTypeIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ClusterTestTypeIndexInformer cache.TypedSharedIndexInformer[*apisexamplev1.ClusterTestType]
+
+// ClusterTestTypeHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ClusterTestType.
+type ClusterTestTypeHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apisexamplev1.ClusterTestType]
+
+// ClusterTestTypeDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ClusterTestType.
+type ClusterTestTypeDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apisexamplev1.ClusterTestType]
+
+// ClusterTestTypeFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ClusterTestType.
+type ClusterTestTypeFilteringHandler = cache.TypedFilteringResourceEventHandler[*apisexamplev1.ClusterTestType]
+
+// ClusterTestTypeIndexers is a specialization of [cache.TypedIndexers] for ClusterTestType.
+type ClusterTestTypeIndexers = cache.TypedIndexers[*apisexamplev1.ClusterTestType]
+
+// DeletedClusterTestType is a specialization of [cache.DeletedObject] for ClusterTestType.
+type DeletedClusterTestType = cache.DeletedObject[*apisexamplev1.ClusterTestType]
 
 type clusterTestTypeInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type clusterTestTypeInformer struct {
 // NewClusterTestTypeInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedClusterTestTypeInformer]).
 func NewClusterTestTypeInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedClusterTestTypeInformer constructs a new informer for ClusterTestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedClusterTestTypeInformer(client versioned.Interface, resyncPeriod time.Duration, indexers ClusterTestTypeIndexers) ClusterTestTypeIndexInformer {
+	return NewTypedClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredClusterTestTypeInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredClusterTestTypeInformer]).
 func NewFilteredClusterTestTypeInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredClusterTestTypeInformer constructs a new informer for ClusterTestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredClusterTestTypeInformer(client versioned.Interface, resyncPeriod time.Duration, indexers ClusterTestTypeIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ClusterTestTypeIndexInformer {
+	return NewTypedClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewClusterTestTypeInformerWithOptions constructs a new informer for ClusterTestType type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedClusterTestTypeInformerWithOptions]).
 func NewClusterTestTypeInformerWithOptions(client versioned.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedClusterTestTypeInformerWithOptions(client, options)
+}
+
+// NewTypedClusterTestTypeInformerWithOptions constructs a new informer for ClusterTestType type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedClusterTestTypeInformerWithOptions(client versioned.Interface, options internalinterfaces.InformerOptions) ClusterTestTypeIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "example.crd.code-generator.k8s.io", Version: "v1", Resource: "clustertesttypes"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.ClusterTestType](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewClusterTestTypeInformerWithOptions(client versioned.Interface, options i
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *clusterTestTypeInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *clusterTestTypeInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apisexamplev1.ClusterTestType{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *clusterTestTypeInformer) TypedInformer() ClusterTestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.ClusterTestType](f.factory.InformerFor(&apisexamplev1.ClusterTestType{}, f.defaultInformer))
 }
 
 func (f *clusterTestTypeInformer) Lister() examplev1.ClusterTestTypeLister {
 	return examplev1.NewClusterTestTypeLister(f.Informer().GetIndexer())
+}
+
+// ToTypedClusterTestTypeInformer converts an untyped informer into a TypedClusterTestTypeInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ClusterTestType. If that is not the case, calling type-safe methods of the returned
+// TypedClusterTestTypeInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedClusterTestTypeInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedClusterTestTypeInformer(informer ClusterTestTypeInformer) TypedClusterTestTypeInformer {
+	if informer, ok := informer.(TypedClusterTestTypeInformer); ok {
+		return informer
+	}
+	return &clusterTestTypeTypedInformerAdapter{informer}
+}
+
+type clusterTestTypeTypedInformerAdapter struct {
+	ClusterTestTypeInformer
+}
+
+func (a *clusterTestTypeTypedInformerAdapter) TypedInformer() ClusterTestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.ClusterTestType](a.Informer())
+}
+
+// ToClusterTestTypeIndexInformer converts an untyped informer into a ClusterTestTypeIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ClusterTestType. If that is not the case, calling type-safe methods of the returned
+// ClusterTestTypeIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ClusterTestTypeIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToClusterTestTypeIndexInformer(informer cache.SharedIndexInformer) ClusterTestTypeIndexInformer {
+	if informer, ok := informer.(ClusterTestTypeIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.ClusterTestType](informer)
 }

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/example/v1/interface.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/example/v1/interface.go
@@ -25,9 +25,9 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// ClusterTestTypes returns a ClusterTestTypeInformer.
-	ClusterTestTypes() ClusterTestTypeInformer
+	ClusterTestTypes() TypedClusterTestTypeInformer
 	// TestTypes returns a TestTypeInformer.
-	TestTypes() TestTypeInformer
+	TestTypes() TypedTestTypeInformer
 }
 
 type version struct {
@@ -41,12 +41,12 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// ClusterTestTypes returns a ClusterTestTypeInformer.
-func (v *version) ClusterTestTypes() ClusterTestTypeInformer {
+// ClusterTestTypes returns a TypedClusterTestTypeInformer.
+func (v *version) ClusterTestTypes() TypedClusterTestTypeInformer {
 	return &clusterTestTypeInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// TestTypes returns a TestTypeInformer.
-func (v *version) TestTypes() TestTypeInformer {
+// TestTypes returns a TypedTestTypeInformer.
+func (v *version) TestTypes() TypedTestTypeInformer {
 	return &testTypeInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/example/v1/testtype.go
@@ -34,11 +34,39 @@ import (
 )
 
 // TestTypeInformer provides access to a shared informer and lister for
-// TestTypes.
+// TestTypes. Prefer using the type-safe variant (see [TypedTestTypeInformer]).
 type TestTypeInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() examplev1.TestTypeLister
 }
+
+// TypedTestTypeInformer provides access to a shared informer and lister for
+// TestTypes, including the type-safe TypedInformer variant.
+// It is a superset of TestTypeInformer.
+type TypedTestTypeInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() TestTypeIndexInformer
+	Lister() examplev1.TestTypeLister
+}
+
+// TestTypeIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type TestTypeIndexInformer cache.TypedSharedIndexInformer[*apisexamplev1.TestType]
+
+// TestTypeHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for TestType.
+type TestTypeHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apisexamplev1.TestType]
+
+// TestTypeDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for TestType.
+type TestTypeDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apisexamplev1.TestType]
+
+// TestTypeFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for TestType.
+type TestTypeFilteringHandler = cache.TypedFilteringResourceEventHandler[*apisexamplev1.TestType]
+
+// TestTypeIndexers is a specialization of [cache.TypedIndexers] for TestType.
+type TestTypeIndexers = cache.TypedIndexers[*apisexamplev1.TestType]
+
+// DeletedTestType is a specialization of [cache.DeletedObject] for TestType.
+type DeletedTestType = cache.DeletedObject[*apisexamplev1.TestType]
 
 type testTypeInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type testTypeInformer struct {
 // NewTestTypeInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedTestTypeInformer]).
 func NewTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedTestTypeInformer constructs a new informer for TestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers TestTypeIndexers) TestTypeIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredTestTypeInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredTestTypeInformer]).
 func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredTestTypeInformer constructs a new informer for TestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers TestTypeIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) TestTypeIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewTestTypeInformerWithOptions constructs a new informer for TestType type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedTestTypeInformerWithOptions]).
 func NewTestTypeInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedTestTypeInformerWithOptions constructs a new informer for TestType type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedTestTypeInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) TestTypeIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "example.crd.code-generator.k8s.io", Version: "v1", Resource: "testtypes"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.TestType](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewTestTypeInformerWithOptions(client versioned.Interface, namespace string
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *testTypeInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewTestTypeInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedTestTypeInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *testTypeInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apisexamplev1.TestType{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *testTypeInformer) TypedInformer() TestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.TestType](f.factory.InformerFor(&apisexamplev1.TestType{}, f.defaultInformer))
 }
 
 func (f *testTypeInformer) Lister() examplev1.TestTypeLister {
 	return examplev1.NewTestTypeLister(f.Informer().GetIndexer())
+}
+
+// ToTypedTestTypeInformer converts an untyped informer into a TypedTestTypeInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *TestType. If that is not the case, calling type-safe methods of the returned
+// TypedTestTypeInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedTestTypeInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedTestTypeInformer(informer TestTypeInformer) TypedTestTypeInformer {
+	if informer, ok := informer.(TypedTestTypeInformer); ok {
+		return informer
+	}
+	return &testTypeTypedInformerAdapter{informer}
+}
+
+type testTypeTypedInformerAdapter struct {
+	TestTypeInformer
+}
+
+func (a *testTypeTypedInformerAdapter) TypedInformer() TestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.TestType](a.Informer())
+}
+
+// ToTestTypeIndexInformer converts an untyped informer into a TestTypeIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *TestType. If that is not the case, calling type-safe methods of the returned
+// TestTypeIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a TestTypeIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTestTypeIndexInformer(informer cache.SharedIndexInformer) TestTypeIndexInformer {
+	if informer, ok := informer.(TestTypeIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.TestType](informer)
 }

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/core/v1/interface.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/core/v1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// TestTypes returns a TestTypeInformer.
-	TestTypes() TestTypeInformer
+	TestTypes() TypedTestTypeInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// TestTypes returns a TestTypeInformer.
-func (v *version) TestTypes() TestTypeInformer {
+// TestTypes returns a TypedTestTypeInformer.
+func (v *version) TestTypes() TypedTestTypeInformer {
 	return &testTypeInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/core/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/core/v1/testtype.go
@@ -34,11 +34,39 @@ import (
 )
 
 // TestTypeInformer provides access to a shared informer and lister for
-// TestTypes.
+// TestTypes. Prefer using the type-safe variant (see [TypedTestTypeInformer]).
 type TestTypeInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() corev1.TestTypeLister
 }
+
+// TypedTestTypeInformer provides access to a shared informer and lister for
+// TestTypes, including the type-safe TypedInformer variant.
+// It is a superset of TestTypeInformer.
+type TypedTestTypeInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() TestTypeIndexInformer
+	Lister() corev1.TestTypeLister
+}
+
+// TestTypeIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type TestTypeIndexInformer cache.TypedSharedIndexInformer[*apiscorev1.TestType]
+
+// TestTypeHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for TestType.
+type TestTypeHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiscorev1.TestType]
+
+// TestTypeDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for TestType.
+type TestTypeDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiscorev1.TestType]
+
+// TestTypeFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for TestType.
+type TestTypeFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiscorev1.TestType]
+
+// TestTypeIndexers is a specialization of [cache.TypedIndexers] for TestType.
+type TestTypeIndexers = cache.TypedIndexers[*apiscorev1.TestType]
+
+// DeletedTestType is a specialization of [cache.DeletedObject] for TestType.
+type DeletedTestType = cache.DeletedObject[*apiscorev1.TestType]
 
 type testTypeInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type testTypeInformer struct {
 // NewTestTypeInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedTestTypeInformer]).
 func NewTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedTestTypeInformer constructs a new informer for TestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers TestTypeIndexers) TestTypeIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredTestTypeInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredTestTypeInformer]).
 func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredTestTypeInformer constructs a new informer for TestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers TestTypeIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) TestTypeIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewTestTypeInformerWithOptions constructs a new informer for TestType type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedTestTypeInformerWithOptions]).
 func NewTestTypeInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedTestTypeInformerWithOptions constructs a new informer for TestType type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedTestTypeInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) TestTypeIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "testtypes"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiscorev1.TestType](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewTestTypeInformerWithOptions(client versioned.Interface, namespace string
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *testTypeInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewTestTypeInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedTestTypeInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *testTypeInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiscorev1.TestType{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *testTypeInformer) TypedInformer() TestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiscorev1.TestType](f.factory.InformerFor(&apiscorev1.TestType{}, f.defaultInformer))
 }
 
 func (f *testTypeInformer) Lister() corev1.TestTypeLister {
 	return corev1.NewTestTypeLister(f.Informer().GetIndexer())
+}
+
+// ToTypedTestTypeInformer converts an untyped informer into a TypedTestTypeInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *TestType. If that is not the case, calling type-safe methods of the returned
+// TypedTestTypeInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedTestTypeInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedTestTypeInformer(informer TestTypeInformer) TypedTestTypeInformer {
+	if informer, ok := informer.(TypedTestTypeInformer); ok {
+		return informer
+	}
+	return &testTypeTypedInformerAdapter{informer}
+}
+
+type testTypeTypedInformerAdapter struct {
+	TestTypeInformer
+}
+
+func (a *testTypeTypedInformerAdapter) TypedInformer() TestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiscorev1.TestType](a.Informer())
+}
+
+// ToTestTypeIndexInformer converts an untyped informer into a TestTypeIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *TestType. If that is not the case, calling type-safe methods of the returned
+// TestTypeIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a TestTypeIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTestTypeIndexInformer(informer cache.SharedIndexInformer) TestTypeIndexInformer {
+	if informer, ok := informer.(TestTypeIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiscorev1.TestType](informer)
 }

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example/v1/interface.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example/v1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// TestTypes returns a TestTypeInformer.
-	TestTypes() TestTypeInformer
+	TestTypes() TypedTestTypeInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// TestTypes returns a TestTypeInformer.
-func (v *version) TestTypes() TestTypeInformer {
+// TestTypes returns a TypedTestTypeInformer.
+func (v *version) TestTypes() TypedTestTypeInformer {
 	return &testTypeInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example/v1/testtype.go
@@ -34,11 +34,39 @@ import (
 )
 
 // TestTypeInformer provides access to a shared informer and lister for
-// TestTypes.
+// TestTypes. Prefer using the type-safe variant (see [TypedTestTypeInformer]).
 type TestTypeInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() examplev1.TestTypeLister
 }
+
+// TypedTestTypeInformer provides access to a shared informer and lister for
+// TestTypes, including the type-safe TypedInformer variant.
+// It is a superset of TestTypeInformer.
+type TypedTestTypeInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() TestTypeIndexInformer
+	Lister() examplev1.TestTypeLister
+}
+
+// TestTypeIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type TestTypeIndexInformer cache.TypedSharedIndexInformer[*apisexamplev1.TestType]
+
+// TestTypeHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for TestType.
+type TestTypeHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apisexamplev1.TestType]
+
+// TestTypeDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for TestType.
+type TestTypeDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apisexamplev1.TestType]
+
+// TestTypeFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for TestType.
+type TestTypeFilteringHandler = cache.TypedFilteringResourceEventHandler[*apisexamplev1.TestType]
+
+// TestTypeIndexers is a specialization of [cache.TypedIndexers] for TestType.
+type TestTypeIndexers = cache.TypedIndexers[*apisexamplev1.TestType]
+
+// DeletedTestType is a specialization of [cache.DeletedObject] for TestType.
+type DeletedTestType = cache.DeletedObject[*apisexamplev1.TestType]
 
 type testTypeInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type testTypeInformer struct {
 // NewTestTypeInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedTestTypeInformer]).
 func NewTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedTestTypeInformer constructs a new informer for TestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers TestTypeIndexers) TestTypeIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredTestTypeInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredTestTypeInformer]).
 func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredTestTypeInformer constructs a new informer for TestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers TestTypeIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) TestTypeIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewTestTypeInformerWithOptions constructs a new informer for TestType type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedTestTypeInformerWithOptions]).
 func NewTestTypeInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedTestTypeInformerWithOptions constructs a new informer for TestType type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedTestTypeInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) TestTypeIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "example.apiserver.code-generator.k8s.io", Version: "v1", Resource: "testtypes"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.TestType](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewTestTypeInformerWithOptions(client versioned.Interface, namespace string
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *testTypeInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewTestTypeInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedTestTypeInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *testTypeInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apisexamplev1.TestType{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *testTypeInformer) TypedInformer() TestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.TestType](f.factory.InformerFor(&apisexamplev1.TestType{}, f.defaultInformer))
 }
 
 func (f *testTypeInformer) Lister() examplev1.TestTypeLister {
 	return examplev1.NewTestTypeLister(f.Informer().GetIndexer())
+}
+
+// ToTypedTestTypeInformer converts an untyped informer into a TypedTestTypeInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *TestType. If that is not the case, calling type-safe methods of the returned
+// TypedTestTypeInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedTestTypeInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedTestTypeInformer(informer TestTypeInformer) TypedTestTypeInformer {
+	if informer, ok := informer.(TypedTestTypeInformer); ok {
+		return informer
+	}
+	return &testTypeTypedInformerAdapter{informer}
+}
+
+type testTypeTypedInformerAdapter struct {
+	TestTypeInformer
+}
+
+func (a *testTypeTypedInformerAdapter) TypedInformer() TestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.TestType](a.Informer())
+}
+
+// ToTestTypeIndexInformer converts an untyped informer into a TestTypeIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *TestType. If that is not the case, calling type-safe methods of the returned
+// TestTypeIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a TestTypeIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTestTypeIndexInformer(informer cache.SharedIndexInformer) TestTypeIndexInformer {
+	if informer, ok := informer.(TestTypeIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.TestType](informer)
 }

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example2/v1/interface.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example2/v1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// TestTypes returns a TestTypeInformer.
-	TestTypes() TestTypeInformer
+	TestTypes() TypedTestTypeInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// TestTypes returns a TestTypeInformer.
-func (v *version) TestTypes() TestTypeInformer {
+// TestTypes returns a TypedTestTypeInformer.
+func (v *version) TestTypes() TypedTestTypeInformer {
 	return &testTypeInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example2/v1/testtype.go
@@ -34,11 +34,39 @@ import (
 )
 
 // TestTypeInformer provides access to a shared informer and lister for
-// TestTypes.
+// TestTypes. Prefer using the type-safe variant (see [TypedTestTypeInformer]).
 type TestTypeInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() example2v1.TestTypeLister
 }
+
+// TypedTestTypeInformer provides access to a shared informer and lister for
+// TestTypes, including the type-safe TypedInformer variant.
+// It is a superset of TestTypeInformer.
+type TypedTestTypeInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() TestTypeIndexInformer
+	Lister() example2v1.TestTypeLister
+}
+
+// TestTypeIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type TestTypeIndexInformer cache.TypedSharedIndexInformer[*apisexample2v1.TestType]
+
+// TestTypeHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for TestType.
+type TestTypeHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apisexample2v1.TestType]
+
+// TestTypeDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for TestType.
+type TestTypeDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apisexample2v1.TestType]
+
+// TestTypeFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for TestType.
+type TestTypeFilteringHandler = cache.TypedFilteringResourceEventHandler[*apisexample2v1.TestType]
+
+// TestTypeIndexers is a specialization of [cache.TypedIndexers] for TestType.
+type TestTypeIndexers = cache.TypedIndexers[*apisexample2v1.TestType]
+
+// DeletedTestType is a specialization of [cache.DeletedObject] for TestType.
+type DeletedTestType = cache.DeletedObject[*apisexample2v1.TestType]
 
 type testTypeInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type testTypeInformer struct {
 // NewTestTypeInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedTestTypeInformer]).
 func NewTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedTestTypeInformer constructs a new informer for TestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers TestTypeIndexers) TestTypeIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredTestTypeInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredTestTypeInformer]).
 func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredTestTypeInformer constructs a new informer for TestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers TestTypeIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) TestTypeIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewTestTypeInformerWithOptions constructs a new informer for TestType type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedTestTypeInformerWithOptions]).
 func NewTestTypeInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedTestTypeInformerWithOptions constructs a new informer for TestType type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedTestTypeInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) TestTypeIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "example.test.apiserver.code-generator.k8s.io", Version: "v1", Resource: "testtypes"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apisexample2v1.TestType](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewTestTypeInformerWithOptions(client versioned.Interface, namespace string
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *testTypeInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewTestTypeInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedTestTypeInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *testTypeInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apisexample2v1.TestType{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *testTypeInformer) TypedInformer() TestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisexample2v1.TestType](f.factory.InformerFor(&apisexample2v1.TestType{}, f.defaultInformer))
 }
 
 func (f *testTypeInformer) Lister() example2v1.TestTypeLister {
 	return example2v1.NewTestTypeLister(f.Informer().GetIndexer())
+}
+
+// ToTypedTestTypeInformer converts an untyped informer into a TypedTestTypeInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *TestType. If that is not the case, calling type-safe methods of the returned
+// TypedTestTypeInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedTestTypeInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedTestTypeInformer(informer TestTypeInformer) TypedTestTypeInformer {
+	if informer, ok := informer.(TypedTestTypeInformer); ok {
+		return informer
+	}
+	return &testTypeTypedInformerAdapter{informer}
+}
+
+type testTypeTypedInformerAdapter struct {
+	TestTypeInformer
+}
+
+func (a *testTypeTypedInformerAdapter) TypedInformer() TestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisexample2v1.TestType](a.Informer())
+}
+
+// ToTestTypeIndexInformer converts an untyped informer into a TestTypeIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *TestType. If that is not the case, calling type-safe methods of the returned
+// TestTypeIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a TestTypeIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTestTypeIndexInformer(informer cache.SharedIndexInformer) TestTypeIndexInformer {
+	if informer, ok := informer.(TestTypeIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apisexample2v1.TestType](informer)
 }

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example3.io/v1/interface.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example3.io/v1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// TestTypes returns a TestTypeInformer.
-	TestTypes() TestTypeInformer
+	TestTypes() TypedTestTypeInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// TestTypes returns a TestTypeInformer.
-func (v *version) TestTypes() TestTypeInformer {
+// TestTypes returns a TypedTestTypeInformer.
+func (v *version) TestTypes() TypedTestTypeInformer {
 	return &testTypeInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example3.io/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example3.io/v1/testtype.go
@@ -34,11 +34,39 @@ import (
 )
 
 // TestTypeInformer provides access to a shared informer and lister for
-// TestTypes.
+// TestTypes. Prefer using the type-safe variant (see [TypedTestTypeInformer]).
 type TestTypeInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() example3iov1.TestTypeLister
 }
+
+// TypedTestTypeInformer provides access to a shared informer and lister for
+// TestTypes, including the type-safe TypedInformer variant.
+// It is a superset of TestTypeInformer.
+type TypedTestTypeInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() TestTypeIndexInformer
+	Lister() example3iov1.TestTypeLister
+}
+
+// TestTypeIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type TestTypeIndexInformer cache.TypedSharedIndexInformer[*apisexample3iov1.TestType]
+
+// TestTypeHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for TestType.
+type TestTypeHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apisexample3iov1.TestType]
+
+// TestTypeDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for TestType.
+type TestTypeDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apisexample3iov1.TestType]
+
+// TestTypeFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for TestType.
+type TestTypeFilteringHandler = cache.TypedFilteringResourceEventHandler[*apisexample3iov1.TestType]
+
+// TestTypeIndexers is a specialization of [cache.TypedIndexers] for TestType.
+type TestTypeIndexers = cache.TypedIndexers[*apisexample3iov1.TestType]
+
+// DeletedTestType is a specialization of [cache.DeletedObject] for TestType.
+type DeletedTestType = cache.DeletedObject[*apisexample3iov1.TestType]
 
 type testTypeInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type testTypeInformer struct {
 // NewTestTypeInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedTestTypeInformer]).
 func NewTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedTestTypeInformer constructs a new informer for TestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers TestTypeIndexers) TestTypeIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredTestTypeInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredTestTypeInformer]).
 func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredTestTypeInformer constructs a new informer for TestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers TestTypeIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) TestTypeIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewTestTypeInformerWithOptions constructs a new informer for TestType type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedTestTypeInformerWithOptions]).
 func NewTestTypeInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedTestTypeInformerWithOptions constructs a new informer for TestType type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedTestTypeInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) TestTypeIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "example.dots.apiserver.code-generator.k8s.io", Version: "v1", Resource: "testtypes"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apisexample3iov1.TestType](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewTestTypeInformerWithOptions(client versioned.Interface, namespace string
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *testTypeInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewTestTypeInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedTestTypeInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *testTypeInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apisexample3iov1.TestType{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *testTypeInformer) TypedInformer() TestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisexample3iov1.TestType](f.factory.InformerFor(&apisexample3iov1.TestType{}, f.defaultInformer))
 }
 
 func (f *testTypeInformer) Lister() example3iov1.TestTypeLister {
 	return example3iov1.NewTestTypeLister(f.Informer().GetIndexer())
+}
+
+// ToTypedTestTypeInformer converts an untyped informer into a TypedTestTypeInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *TestType. If that is not the case, calling type-safe methods of the returned
+// TypedTestTypeInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedTestTypeInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedTestTypeInformer(informer TestTypeInformer) TypedTestTypeInformer {
+	if informer, ok := informer.(TypedTestTypeInformer); ok {
+		return informer
+	}
+	return &testTypeTypedInformerAdapter{informer}
+}
+
+type testTypeTypedInformerAdapter struct {
+	TestTypeInformer
+}
+
+func (a *testTypeTypedInformerAdapter) TypedInformer() TestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisexample3iov1.TestType](a.Informer())
+}
+
+// ToTestTypeIndexInformer converts an untyped informer into a TestTypeIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *TestType. If that is not the case, calling type-safe methods of the returned
+// TestTypeIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a TestTypeIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTestTypeIndexInformer(informer cache.SharedIndexInformer) TestTypeIndexInformer {
+	if informer, ok := informer.(TestTypeIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apisexample3iov1.TestType](informer)
 }

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/conflicting/v1/interface.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/conflicting/v1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// TestTypes returns a TestTypeInformer.
-	TestTypes() TestTypeInformer
+	TestTypes() TypedTestTypeInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// TestTypes returns a TestTypeInformer.
-func (v *version) TestTypes() TestTypeInformer {
+// TestTypes returns a TypedTestTypeInformer.
+func (v *version) TestTypes() TypedTestTypeInformer {
 	return &testTypeInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/conflicting/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/conflicting/v1/testtype.go
@@ -34,11 +34,39 @@ import (
 )
 
 // TestTypeInformer provides access to a shared informer and lister for
-// TestTypes.
+// TestTypes. Prefer using the type-safe variant (see [TypedTestTypeInformer]).
 type TestTypeInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() conflictingv1.TestTypeLister
 }
+
+// TypedTestTypeInformer provides access to a shared informer and lister for
+// TestTypes, including the type-safe TypedInformer variant.
+// It is a superset of TestTypeInformer.
+type TypedTestTypeInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() TestTypeIndexInformer
+	Lister() conflictingv1.TestTypeLister
+}
+
+// TestTypeIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type TestTypeIndexInformer cache.TypedSharedIndexInformer[*apisconflictingv1.TestType]
+
+// TestTypeHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for TestType.
+type TestTypeHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apisconflictingv1.TestType]
+
+// TestTypeDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for TestType.
+type TestTypeDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apisconflictingv1.TestType]
+
+// TestTypeFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for TestType.
+type TestTypeFilteringHandler = cache.TypedFilteringResourceEventHandler[*apisconflictingv1.TestType]
+
+// TestTypeIndexers is a specialization of [cache.TypedIndexers] for TestType.
+type TestTypeIndexers = cache.TypedIndexers[*apisconflictingv1.TestType]
+
+// DeletedTestType is a specialization of [cache.DeletedObject] for TestType.
+type DeletedTestType = cache.DeletedObject[*apisconflictingv1.TestType]
 
 type testTypeInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type testTypeInformer struct {
 // NewTestTypeInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedTestTypeInformer]).
 func NewTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedTestTypeInformer constructs a new informer for TestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers TestTypeIndexers) TestTypeIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredTestTypeInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredTestTypeInformer]).
 func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredTestTypeInformer constructs a new informer for TestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers TestTypeIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) TestTypeIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewTestTypeInformerWithOptions constructs a new informer for TestType type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedTestTypeInformerWithOptions]).
 func NewTestTypeInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedTestTypeInformerWithOptions constructs a new informer for TestType type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedTestTypeInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) TestTypeIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "conflicting.test.crd.code-generator.k8s.io", Version: "v1", Resource: "testtypes"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apisconflictingv1.TestType](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewTestTypeInformerWithOptions(client versioned.Interface, namespace string
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *testTypeInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewTestTypeInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedTestTypeInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *testTypeInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apisconflictingv1.TestType{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *testTypeInformer) TypedInformer() TestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisconflictingv1.TestType](f.factory.InformerFor(&apisconflictingv1.TestType{}, f.defaultInformer))
 }
 
 func (f *testTypeInformer) Lister() conflictingv1.TestTypeLister {
 	return conflictingv1.NewTestTypeLister(f.Informer().GetIndexer())
+}
+
+// ToTypedTestTypeInformer converts an untyped informer into a TypedTestTypeInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *TestType. If that is not the case, calling type-safe methods of the returned
+// TypedTestTypeInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedTestTypeInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedTestTypeInformer(informer TestTypeInformer) TypedTestTypeInformer {
+	if informer, ok := informer.(TypedTestTypeInformer); ok {
+		return informer
+	}
+	return &testTypeTypedInformerAdapter{informer}
+}
+
+type testTypeTypedInformerAdapter struct {
+	TestTypeInformer
+}
+
+func (a *testTypeTypedInformerAdapter) TypedInformer() TestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisconflictingv1.TestType](a.Informer())
+}
+
+// ToTestTypeIndexInformer converts an untyped informer into a TestTypeIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *TestType. If that is not the case, calling type-safe methods of the returned
+// TestTypeIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a TestTypeIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTestTypeIndexInformer(informer cache.SharedIndexInformer) TestTypeIndexInformer {
+	if informer, ok := informer.(TestTypeIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apisconflictingv1.TestType](informer)
 }

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example/v1/clustertesttype.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ClusterTestTypeInformer provides access to a shared informer and lister for
-// ClusterTestTypes.
+// ClusterTestTypes. Prefer using the type-safe variant (see [TypedClusterTestTypeInformer]).
 type ClusterTestTypeInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() examplev1.ClusterTestTypeLister
 }
+
+// TypedClusterTestTypeInformer provides access to a shared informer and lister for
+// ClusterTestTypes, including the type-safe TypedInformer variant.
+// It is a superset of ClusterTestTypeInformer.
+type TypedClusterTestTypeInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ClusterTestTypeIndexInformer
+	Lister() examplev1.ClusterTestTypeLister
+}
+
+// ClusterTestTypeIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ClusterTestTypeIndexInformer cache.TypedSharedIndexInformer[*apisexamplev1.ClusterTestType]
+
+// ClusterTestTypeHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ClusterTestType.
+type ClusterTestTypeHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apisexamplev1.ClusterTestType]
+
+// ClusterTestTypeDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ClusterTestType.
+type ClusterTestTypeDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apisexamplev1.ClusterTestType]
+
+// ClusterTestTypeFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ClusterTestType.
+type ClusterTestTypeFilteringHandler = cache.TypedFilteringResourceEventHandler[*apisexamplev1.ClusterTestType]
+
+// ClusterTestTypeIndexers is a specialization of [cache.TypedIndexers] for ClusterTestType.
+type ClusterTestTypeIndexers = cache.TypedIndexers[*apisexamplev1.ClusterTestType]
+
+// DeletedClusterTestType is a specialization of [cache.DeletedObject] for ClusterTestType.
+type DeletedClusterTestType = cache.DeletedObject[*apisexamplev1.ClusterTestType]
 
 type clusterTestTypeInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type clusterTestTypeInformer struct {
 // NewClusterTestTypeInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedClusterTestTypeInformer]).
 func NewClusterTestTypeInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedClusterTestTypeInformer constructs a new informer for ClusterTestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedClusterTestTypeInformer(client versioned.Interface, resyncPeriod time.Duration, indexers ClusterTestTypeIndexers) ClusterTestTypeIndexInformer {
+	return NewTypedClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredClusterTestTypeInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredClusterTestTypeInformer]).
 func NewFilteredClusterTestTypeInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredClusterTestTypeInformer constructs a new informer for ClusterTestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredClusterTestTypeInformer(client versioned.Interface, resyncPeriod time.Duration, indexers ClusterTestTypeIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ClusterTestTypeIndexInformer {
+	return NewTypedClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewClusterTestTypeInformerWithOptions constructs a new informer for ClusterTestType type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedClusterTestTypeInformerWithOptions]).
 func NewClusterTestTypeInformerWithOptions(client versioned.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedClusterTestTypeInformerWithOptions(client, options)
+}
+
+// NewTypedClusterTestTypeInformerWithOptions constructs a new informer for ClusterTestType type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedClusterTestTypeInformerWithOptions(client versioned.Interface, options internalinterfaces.InformerOptions) ClusterTestTypeIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "example.crd.code-generator.k8s.io", Version: "v1", Resource: "clustertesttypes"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.ClusterTestType](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewClusterTestTypeInformerWithOptions(client versioned.Interface, options i
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *clusterTestTypeInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *clusterTestTypeInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apisexamplev1.ClusterTestType{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *clusterTestTypeInformer) TypedInformer() ClusterTestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.ClusterTestType](f.factory.InformerFor(&apisexamplev1.ClusterTestType{}, f.defaultInformer))
 }
 
 func (f *clusterTestTypeInformer) Lister() examplev1.ClusterTestTypeLister {
 	return examplev1.NewClusterTestTypeLister(f.Informer().GetIndexer())
+}
+
+// ToTypedClusterTestTypeInformer converts an untyped informer into a TypedClusterTestTypeInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ClusterTestType. If that is not the case, calling type-safe methods of the returned
+// TypedClusterTestTypeInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedClusterTestTypeInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedClusterTestTypeInformer(informer ClusterTestTypeInformer) TypedClusterTestTypeInformer {
+	if informer, ok := informer.(TypedClusterTestTypeInformer); ok {
+		return informer
+	}
+	return &clusterTestTypeTypedInformerAdapter{informer}
+}
+
+type clusterTestTypeTypedInformerAdapter struct {
+	ClusterTestTypeInformer
+}
+
+func (a *clusterTestTypeTypedInformerAdapter) TypedInformer() ClusterTestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.ClusterTestType](a.Informer())
+}
+
+// ToClusterTestTypeIndexInformer converts an untyped informer into a ClusterTestTypeIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ClusterTestType. If that is not the case, calling type-safe methods of the returned
+// ClusterTestTypeIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ClusterTestTypeIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToClusterTestTypeIndexInformer(informer cache.SharedIndexInformer) ClusterTestTypeIndexInformer {
+	if informer, ok := informer.(ClusterTestTypeIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.ClusterTestType](informer)
 }

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example/v1/interface.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example/v1/interface.go
@@ -25,9 +25,9 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// ClusterTestTypes returns a ClusterTestTypeInformer.
-	ClusterTestTypes() ClusterTestTypeInformer
+	ClusterTestTypes() TypedClusterTestTypeInformer
 	// TestTypes returns a TestTypeInformer.
-	TestTypes() TestTypeInformer
+	TestTypes() TypedTestTypeInformer
 }
 
 type version struct {
@@ -41,12 +41,12 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// ClusterTestTypes returns a ClusterTestTypeInformer.
-func (v *version) ClusterTestTypes() ClusterTestTypeInformer {
+// ClusterTestTypes returns a TypedClusterTestTypeInformer.
+func (v *version) ClusterTestTypes() TypedClusterTestTypeInformer {
 	return &clusterTestTypeInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// TestTypes returns a TestTypeInformer.
-func (v *version) TestTypes() TestTypeInformer {
+// TestTypes returns a TypedTestTypeInformer.
+func (v *version) TestTypes() TypedTestTypeInformer {
 	return &testTypeInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example/v1/testtype.go
@@ -34,11 +34,39 @@ import (
 )
 
 // TestTypeInformer provides access to a shared informer and lister for
-// TestTypes.
+// TestTypes. Prefer using the type-safe variant (see [TypedTestTypeInformer]).
 type TestTypeInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() examplev1.TestTypeLister
 }
+
+// TypedTestTypeInformer provides access to a shared informer and lister for
+// TestTypes, including the type-safe TypedInformer variant.
+// It is a superset of TestTypeInformer.
+type TypedTestTypeInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() TestTypeIndexInformer
+	Lister() examplev1.TestTypeLister
+}
+
+// TestTypeIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type TestTypeIndexInformer cache.TypedSharedIndexInformer[*apisexamplev1.TestType]
+
+// TestTypeHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for TestType.
+type TestTypeHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apisexamplev1.TestType]
+
+// TestTypeDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for TestType.
+type TestTypeDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apisexamplev1.TestType]
+
+// TestTypeFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for TestType.
+type TestTypeFilteringHandler = cache.TypedFilteringResourceEventHandler[*apisexamplev1.TestType]
+
+// TestTypeIndexers is a specialization of [cache.TypedIndexers] for TestType.
+type TestTypeIndexers = cache.TypedIndexers[*apisexamplev1.TestType]
+
+// DeletedTestType is a specialization of [cache.DeletedObject] for TestType.
+type DeletedTestType = cache.DeletedObject[*apisexamplev1.TestType]
 
 type testTypeInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type testTypeInformer struct {
 // NewTestTypeInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedTestTypeInformer]).
 func NewTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedTestTypeInformer constructs a new informer for TestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers TestTypeIndexers) TestTypeIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredTestTypeInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredTestTypeInformer]).
 func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredTestTypeInformer constructs a new informer for TestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers TestTypeIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) TestTypeIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewTestTypeInformerWithOptions constructs a new informer for TestType type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedTestTypeInformerWithOptions]).
 func NewTestTypeInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedTestTypeInformerWithOptions constructs a new informer for TestType type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedTestTypeInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) TestTypeIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "example.crd.code-generator.k8s.io", Version: "v1", Resource: "testtypes"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.TestType](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewTestTypeInformerWithOptions(client versioned.Interface, namespace string
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *testTypeInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewTestTypeInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedTestTypeInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *testTypeInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apisexamplev1.TestType{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *testTypeInformer) TypedInformer() TestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.TestType](f.factory.InformerFor(&apisexamplev1.TestType{}, f.defaultInformer))
 }
 
 func (f *testTypeInformer) Lister() examplev1.TestTypeLister {
 	return examplev1.NewTestTypeLister(f.Informer().GetIndexer())
+}
+
+// ToTypedTestTypeInformer converts an untyped informer into a TypedTestTypeInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *TestType. If that is not the case, calling type-safe methods of the returned
+// TypedTestTypeInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedTestTypeInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedTestTypeInformer(informer TestTypeInformer) TypedTestTypeInformer {
+	if informer, ok := informer.(TypedTestTypeInformer); ok {
+		return informer
+	}
+	return &testTypeTypedInformerAdapter{informer}
+}
+
+type testTypeTypedInformerAdapter struct {
+	TestTypeInformer
+}
+
+func (a *testTypeTypedInformerAdapter) TypedInformer() TestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.TestType](a.Informer())
+}
+
+// ToTestTypeIndexInformer converts an untyped informer into a TestTypeIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *TestType. If that is not the case, calling type-safe methods of the returned
+// TestTypeIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a TestTypeIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTestTypeIndexInformer(informer cache.SharedIndexInformer) TestTypeIndexInformer {
+	if informer, ok := informer.(TestTypeIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apisexamplev1.TestType](informer)
 }

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example2/v1/interface.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example2/v1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// TestTypes returns a TestTypeInformer.
-	TestTypes() TestTypeInformer
+	TestTypes() TypedTestTypeInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// TestTypes returns a TestTypeInformer.
-func (v *version) TestTypes() TestTypeInformer {
+// TestTypes returns a TypedTestTypeInformer.
+func (v *version) TestTypes() TypedTestTypeInformer {
 	return &testTypeInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example2/v1/testtype.go
@@ -34,11 +34,39 @@ import (
 )
 
 // TestTypeInformer provides access to a shared informer and lister for
-// TestTypes.
+// TestTypes. Prefer using the type-safe variant (see [TypedTestTypeInformer]).
 type TestTypeInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() example2v1.TestTypeLister
 }
+
+// TypedTestTypeInformer provides access to a shared informer and lister for
+// TestTypes, including the type-safe TypedInformer variant.
+// It is a superset of TestTypeInformer.
+type TypedTestTypeInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() TestTypeIndexInformer
+	Lister() example2v1.TestTypeLister
+}
+
+// TestTypeIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type TestTypeIndexInformer cache.TypedSharedIndexInformer[*apisexample2v1.TestType]
+
+// TestTypeHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for TestType.
+type TestTypeHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apisexample2v1.TestType]
+
+// TestTypeDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for TestType.
+type TestTypeDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apisexample2v1.TestType]
+
+// TestTypeFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for TestType.
+type TestTypeFilteringHandler = cache.TypedFilteringResourceEventHandler[*apisexample2v1.TestType]
+
+// TestTypeIndexers is a specialization of [cache.TypedIndexers] for TestType.
+type TestTypeIndexers = cache.TypedIndexers[*apisexample2v1.TestType]
+
+// DeletedTestType is a specialization of [cache.DeletedObject] for TestType.
+type DeletedTestType = cache.DeletedObject[*apisexample2v1.TestType]
 
 type testTypeInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type testTypeInformer struct {
 // NewTestTypeInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedTestTypeInformer]).
 func NewTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedTestTypeInformer constructs a new informer for TestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers TestTypeIndexers) TestTypeIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredTestTypeInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredTestTypeInformer]).
 func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredTestTypeInformer constructs a new informer for TestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers TestTypeIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) TestTypeIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewTestTypeInformerWithOptions constructs a new informer for TestType type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedTestTypeInformerWithOptions]).
 func NewTestTypeInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedTestTypeInformerWithOptions constructs a new informer for TestType type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedTestTypeInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) TestTypeIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "example.test.crd.code-generator.k8s.io", Version: "v1", Resource: "testtypes"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apisexample2v1.TestType](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewTestTypeInformerWithOptions(client versioned.Interface, namespace string
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *testTypeInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewTestTypeInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedTestTypeInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *testTypeInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apisexample2v1.TestType{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *testTypeInformer) TypedInformer() TestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisexample2v1.TestType](f.factory.InformerFor(&apisexample2v1.TestType{}, f.defaultInformer))
 }
 
 func (f *testTypeInformer) Lister() example2v1.TestTypeLister {
 	return example2v1.NewTestTypeLister(f.Informer().GetIndexer())
+}
+
+// ToTypedTestTypeInformer converts an untyped informer into a TypedTestTypeInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *TestType. If that is not the case, calling type-safe methods of the returned
+// TypedTestTypeInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedTestTypeInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedTestTypeInformer(informer TestTypeInformer) TypedTestTypeInformer {
+	if informer, ok := informer.(TypedTestTypeInformer); ok {
+		return informer
+	}
+	return &testTypeTypedInformerAdapter{informer}
+}
+
+type testTypeTypedInformerAdapter struct {
+	TestTypeInformer
+}
+
+func (a *testTypeTypedInformerAdapter) TypedInformer() TestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisexample2v1.TestType](a.Informer())
+}
+
+// ToTestTypeIndexInformer converts an untyped informer into a TestTypeIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *TestType. If that is not the case, calling type-safe methods of the returned
+// TestTypeIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a TestTypeIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTestTypeIndexInformer(informer cache.SharedIndexInformer) TestTypeIndexInformer {
+	if informer, ok := informer.(TestTypeIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apisexample2v1.TestType](informer)
 }

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/extensions/v1/interface.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/extensions/v1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// TestTypes returns a TestTypeInformer.
-	TestTypes() TestTypeInformer
+	TestTypes() TypedTestTypeInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// TestTypes returns a TestTypeInformer.
-func (v *version) TestTypes() TestTypeInformer {
+// TestTypes returns a TypedTestTypeInformer.
+func (v *version) TestTypes() TypedTestTypeInformer {
 	return &testTypeInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/extensions/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/extensions/v1/testtype.go
@@ -34,11 +34,39 @@ import (
 )
 
 // TestTypeInformer provides access to a shared informer and lister for
-// TestTypes.
+// TestTypes. Prefer using the type-safe variant (see [TypedTestTypeInformer]).
 type TestTypeInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() extensionsv1.TestTypeLister
 }
+
+// TypedTestTypeInformer provides access to a shared informer and lister for
+// TestTypes, including the type-safe TypedInformer variant.
+// It is a superset of TestTypeInformer.
+type TypedTestTypeInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() TestTypeIndexInformer
+	Lister() extensionsv1.TestTypeLister
+}
+
+// TestTypeIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type TestTypeIndexInformer cache.TypedSharedIndexInformer[*apisextensionsv1.TestType]
+
+// TestTypeHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for TestType.
+type TestTypeHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apisextensionsv1.TestType]
+
+// TestTypeDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for TestType.
+type TestTypeDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apisextensionsv1.TestType]
+
+// TestTypeFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for TestType.
+type TestTypeFilteringHandler = cache.TypedFilteringResourceEventHandler[*apisextensionsv1.TestType]
+
+// TestTypeIndexers is a specialization of [cache.TypedIndexers] for TestType.
+type TestTypeIndexers = cache.TypedIndexers[*apisextensionsv1.TestType]
+
+// DeletedTestType is a specialization of [cache.DeletedObject] for TestType.
+type DeletedTestType = cache.DeletedObject[*apisextensionsv1.TestType]
 
 type testTypeInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type testTypeInformer struct {
 // NewTestTypeInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedTestTypeInformer]).
 func NewTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedTestTypeInformer constructs a new informer for TestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers TestTypeIndexers) TestTypeIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredTestTypeInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredTestTypeInformer]).
 func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredTestTypeInformer constructs a new informer for TestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers TestTypeIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) TestTypeIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewTestTypeInformerWithOptions constructs a new informer for TestType type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedTestTypeInformerWithOptions]).
 func NewTestTypeInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedTestTypeInformerWithOptions constructs a new informer for TestType type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedTestTypeInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) TestTypeIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "extensions.test.crd.code-generator.k8s.io", Version: "v1", Resource: "testtypes"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apisextensionsv1.TestType](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewTestTypeInformerWithOptions(client versioned.Interface, namespace string
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *testTypeInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewTestTypeInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedTestTypeInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *testTypeInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apisextensionsv1.TestType{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *testTypeInformer) TypedInformer() TestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisextensionsv1.TestType](f.factory.InformerFor(&apisextensionsv1.TestType{}, f.defaultInformer))
 }
 
 func (f *testTypeInformer) Lister() extensionsv1.TestTypeLister {
 	return extensionsv1.NewTestTypeLister(f.Informer().GetIndexer())
+}
+
+// ToTypedTestTypeInformer converts an untyped informer into a TypedTestTypeInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *TestType. If that is not the case, calling type-safe methods of the returned
+// TypedTestTypeInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedTestTypeInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedTestTypeInformer(informer TestTypeInformer) TypedTestTypeInformer {
+	if informer, ok := informer.(TypedTestTypeInformer); ok {
+		return informer
+	}
+	return &testTypeTypedInformerAdapter{informer}
+}
+
+type testTypeTypedInformerAdapter struct {
+	TestTypeInformer
+}
+
+func (a *testTypeTypedInformerAdapter) TypedInformer() TestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisextensionsv1.TestType](a.Informer())
+}
+
+// ToTestTypeIndexInformer converts an untyped informer into a TestTypeIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *TestType. If that is not the case, calling type-safe methods of the returned
+// TestTypeIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a TestTypeIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTestTypeIndexInformer(informer cache.SharedIndexInformer) TestTypeIndexInformer {
+	if informer, ok := informer.(TestTypeIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apisextensionsv1.TestType](informer)
 }

--- a/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/api/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/api/v1/clustertesttype.go
@@ -34,11 +34,39 @@ import (
 )
 
 // ClusterTestTypeInformer provides access to a shared informer and lister for
-// ClusterTestTypes.
+// ClusterTestTypes. Prefer using the type-safe variant (see [TypedClusterTestTypeInformer]).
 type ClusterTestTypeInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() apiv1.ClusterTestTypeLister
 }
+
+// TypedClusterTestTypeInformer provides access to a shared informer and lister for
+// ClusterTestTypes, including the type-safe TypedInformer variant.
+// It is a superset of ClusterTestTypeInformer.
+type TypedClusterTestTypeInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() ClusterTestTypeIndexInformer
+	Lister() apiv1.ClusterTestTypeLister
+}
+
+// ClusterTestTypeIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type ClusterTestTypeIndexInformer cache.TypedSharedIndexInformer[*singleapiv1.ClusterTestType]
+
+// ClusterTestTypeHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for ClusterTestType.
+type ClusterTestTypeHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*singleapiv1.ClusterTestType]
+
+// ClusterTestTypeDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for ClusterTestType.
+type ClusterTestTypeDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*singleapiv1.ClusterTestType]
+
+// ClusterTestTypeFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for ClusterTestType.
+type ClusterTestTypeFilteringHandler = cache.TypedFilteringResourceEventHandler[*singleapiv1.ClusterTestType]
+
+// ClusterTestTypeIndexers is a specialization of [cache.TypedIndexers] for ClusterTestType.
+type ClusterTestTypeIndexers = cache.TypedIndexers[*singleapiv1.ClusterTestType]
+
+// DeletedClusterTestType is a specialization of [cache.DeletedObject] for ClusterTestType.
+type DeletedClusterTestType = cache.DeletedObject[*singleapiv1.ClusterTestType]
 
 type clusterTestTypeInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type clusterTestTypeInformer struct {
 // NewClusterTestTypeInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedClusterTestTypeInformer]).
 func NewClusterTestTypeInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedClusterTestTypeInformer constructs a new informer for ClusterTestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedClusterTestTypeInformer(client versioned.Interface, resyncPeriod time.Duration, indexers ClusterTestTypeIndexers) ClusterTestTypeIndexInformer {
+	return NewTypedClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredClusterTestTypeInformer constructs a new informer for ClusterTestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredClusterTestTypeInformer]).
 func NewFilteredClusterTestTypeInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredClusterTestTypeInformer constructs a new informer for ClusterTestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredClusterTestTypeInformer(client versioned.Interface, resyncPeriod time.Duration, indexers ClusterTestTypeIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) ClusterTestTypeIndexInformer {
+	return NewTypedClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewClusterTestTypeInformerWithOptions constructs a new informer for ClusterTestType type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedClusterTestTypeInformerWithOptions]).
 func NewClusterTestTypeInformerWithOptions(client versioned.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedClusterTestTypeInformerWithOptions(client, options)
+}
+
+// NewTypedClusterTestTypeInformerWithOptions constructs a new informer for ClusterTestType type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedClusterTestTypeInformerWithOptions(client versioned.Interface, options internalinterfaces.InformerOptions) ClusterTestTypeIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "example.crd.code-generator.k8s.io", Version: "v1", Resource: "clustertesttypes"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*singleapiv1.ClusterTestType](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewClusterTestTypeInformerWithOptions(client versioned.Interface, options i
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *clusterTestTypeInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedClusterTestTypeInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *clusterTestTypeInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&singleapiv1.ClusterTestType{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *clusterTestTypeInformer) TypedInformer() ClusterTestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*singleapiv1.ClusterTestType](f.factory.InformerFor(&singleapiv1.ClusterTestType{}, f.defaultInformer))
 }
 
 func (f *clusterTestTypeInformer) Lister() apiv1.ClusterTestTypeLister {
 	return apiv1.NewClusterTestTypeLister(f.Informer().GetIndexer())
+}
+
+// ToTypedClusterTestTypeInformer converts an untyped informer into a TypedClusterTestTypeInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ClusterTestType. If that is not the case, calling type-safe methods of the returned
+// TypedClusterTestTypeInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedClusterTestTypeInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedClusterTestTypeInformer(informer ClusterTestTypeInformer) TypedClusterTestTypeInformer {
+	if informer, ok := informer.(TypedClusterTestTypeInformer); ok {
+		return informer
+	}
+	return &clusterTestTypeTypedInformerAdapter{informer}
+}
+
+type clusterTestTypeTypedInformerAdapter struct {
+	ClusterTestTypeInformer
+}
+
+func (a *clusterTestTypeTypedInformerAdapter) TypedInformer() ClusterTestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*singleapiv1.ClusterTestType](a.Informer())
+}
+
+// ToClusterTestTypeIndexInformer converts an untyped informer into a ClusterTestTypeIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *ClusterTestType. If that is not the case, calling type-safe methods of the returned
+// ClusterTestTypeIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a ClusterTestTypeIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToClusterTestTypeIndexInformer(informer cache.SharedIndexInformer) ClusterTestTypeIndexInformer {
+	if informer, ok := informer.(ClusterTestTypeIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*singleapiv1.ClusterTestType](informer)
 }

--- a/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/api/v1/interface.go
+++ b/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/api/v1/interface.go
@@ -25,9 +25,9 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// ClusterTestTypes returns a ClusterTestTypeInformer.
-	ClusterTestTypes() ClusterTestTypeInformer
+	ClusterTestTypes() TypedClusterTestTypeInformer
 	// TestTypes returns a TestTypeInformer.
-	TestTypes() TestTypeInformer
+	TestTypes() TypedTestTypeInformer
 }
 
 type version struct {
@@ -41,12 +41,12 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// ClusterTestTypes returns a ClusterTestTypeInformer.
-func (v *version) ClusterTestTypes() ClusterTestTypeInformer {
+// ClusterTestTypes returns a TypedClusterTestTypeInformer.
+func (v *version) ClusterTestTypes() TypedClusterTestTypeInformer {
 	return &clusterTestTypeInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// TestTypes returns a TestTypeInformer.
-func (v *version) TestTypes() TestTypeInformer {
+// TestTypes returns a TypedTestTypeInformer.
+func (v *version) TestTypes() TypedTestTypeInformer {
 	return &testTypeInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/api/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/api/v1/testtype.go
@@ -34,11 +34,39 @@ import (
 )
 
 // TestTypeInformer provides access to a shared informer and lister for
-// TestTypes.
+// TestTypes. Prefer using the type-safe variant (see [TypedTestTypeInformer]).
 type TestTypeInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() apiv1.TestTypeLister
 }
+
+// TypedTestTypeInformer provides access to a shared informer and lister for
+// TestTypes, including the type-safe TypedInformer variant.
+// It is a superset of TestTypeInformer.
+type TypedTestTypeInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() TestTypeIndexInformer
+	Lister() apiv1.TestTypeLister
+}
+
+// TestTypeIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type TestTypeIndexInformer cache.TypedSharedIndexInformer[*singleapiv1.TestType]
+
+// TestTypeHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for TestType.
+type TestTypeHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*singleapiv1.TestType]
+
+// TestTypeDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for TestType.
+type TestTypeDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*singleapiv1.TestType]
+
+// TestTypeFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for TestType.
+type TestTypeFilteringHandler = cache.TypedFilteringResourceEventHandler[*singleapiv1.TestType]
+
+// TestTypeIndexers is a specialization of [cache.TypedIndexers] for TestType.
+type TestTypeIndexers = cache.TypedIndexers[*singleapiv1.TestType]
+
+// DeletedTestType is a specialization of [cache.DeletedObject] for TestType.
+type DeletedTestType = cache.DeletedObject[*singleapiv1.TestType]
 
 type testTypeInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type testTypeInformer struct {
 // NewTestTypeInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedTestTypeInformer]).
 func NewTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedTestTypeInformer constructs a new informer for TestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers TestTypeIndexers) TestTypeIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredTestTypeInformer constructs a new informer for TestType type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredTestTypeInformer]).
 func NewFilteredTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredTestTypeInformer constructs a new informer for TestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredTestTypeInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers TestTypeIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) TestTypeIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewTestTypeInformerWithOptions constructs a new informer for TestType type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedTestTypeInformerWithOptions]).
 func NewTestTypeInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedTestTypeInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedTestTypeInformerWithOptions constructs a new informer for TestType type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedTestTypeInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) TestTypeIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "example.crd.code-generator.k8s.io", Version: "v1", Resource: "testtypes"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*singleapiv1.TestType](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewTestTypeInformerWithOptions(client versioned.Interface, namespace string
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *testTypeInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewTestTypeInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedTestTypeInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *testTypeInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&singleapiv1.TestType{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *testTypeInformer) TypedInformer() TestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*singleapiv1.TestType](f.factory.InformerFor(&singleapiv1.TestType{}, f.defaultInformer))
 }
 
 func (f *testTypeInformer) Lister() apiv1.TestTypeLister {
 	return apiv1.NewTestTypeLister(f.Informer().GetIndexer())
+}
+
+// ToTypedTestTypeInformer converts an untyped informer into a TypedTestTypeInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *TestType. If that is not the case, calling type-safe methods of the returned
+// TypedTestTypeInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedTestTypeInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedTestTypeInformer(informer TestTypeInformer) TypedTestTypeInformer {
+	if informer, ok := informer.(TypedTestTypeInformer); ok {
+		return informer
+	}
+	return &testTypeTypedInformerAdapter{informer}
+}
+
+type testTypeTypedInformerAdapter struct {
+	TestTypeInformer
+}
+
+func (a *testTypeTypedInformerAdapter) TypedInformer() TestTypeIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*singleapiv1.TestType](a.Informer())
+}
+
+// ToTestTypeIndexInformer converts an untyped informer into a TestTypeIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *TestType. If that is not the case, calling type-safe methods of the returned
+// TestTypeIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a TestTypeIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTestTypeIndexInformer(informer cache.SharedIndexInformer) TestTypeIndexInformer {
+	if informer, ok := informer.(TestTypeIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*singleapiv1.TestType](informer)
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1/apiservice.go
@@ -34,11 +34,39 @@ import (
 )
 
 // APIServiceInformer provides access to a shared informer and lister for
-// APIServices.
+// APIServices. Prefer using the type-safe variant (see [TypedAPIServiceInformer]).
 type APIServiceInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() apiregistrationv1.APIServiceLister
 }
+
+// TypedAPIServiceInformer provides access to a shared informer and lister for
+// APIServices, including the type-safe TypedInformer variant.
+// It is a superset of APIServiceInformer.
+type TypedAPIServiceInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() APIServiceIndexInformer
+	Lister() apiregistrationv1.APIServiceLister
+}
+
+// APIServiceIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type APIServiceIndexInformer cache.TypedSharedIndexInformer[*apisapiregistrationv1.APIService]
+
+// APIServiceHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for APIService.
+type APIServiceHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apisapiregistrationv1.APIService]
+
+// APIServiceDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for APIService.
+type APIServiceDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apisapiregistrationv1.APIService]
+
+// APIServiceFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for APIService.
+type APIServiceFilteringHandler = cache.TypedFilteringResourceEventHandler[*apisapiregistrationv1.APIService]
+
+// APIServiceIndexers is a specialization of [cache.TypedIndexers] for APIService.
+type APIServiceIndexers = cache.TypedIndexers[*apisapiregistrationv1.APIService]
+
+// DeletedAPIService is a specialization of [cache.DeletedObject] for APIService.
+type DeletedAPIService = cache.DeletedObject[*apisapiregistrationv1.APIService]
 
 type aPIServiceInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type aPIServiceInformer struct {
 // NewAPIServiceInformer constructs a new informer for APIService type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedAPIServiceInformer]).
 func NewAPIServiceInformer(client clientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewAPIServiceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedAPIServiceInformer constructs a new informer for APIService type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedAPIServiceInformer(client clientset.Interface, resyncPeriod time.Duration, indexers APIServiceIndexers) APIServiceIndexInformer {
+	return NewTypedAPIServiceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredAPIServiceInformer constructs a new informer for APIService type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredAPIServiceInformer]).
 func NewFilteredAPIServiceInformer(client clientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewAPIServiceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedAPIServiceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredAPIServiceInformer constructs a new informer for APIService type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredAPIServiceInformer(client clientset.Interface, resyncPeriod time.Duration, indexers APIServiceIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) APIServiceIndexInformer {
+	return NewTypedAPIServiceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewAPIServiceInformerWithOptions constructs a new informer for APIService type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedAPIServiceInformerWithOptions]).
 func NewAPIServiceInformerWithOptions(client clientset.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedAPIServiceInformerWithOptions(client, options)
+}
+
+// NewTypedAPIServiceInformerWithOptions constructs a new informer for APIService type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedAPIServiceInformerWithOptions(client clientset.Interface, options internalinterfaces.InformerOptions) APIServiceIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "apiregistration.k8s.io", Version: "v1", Resource: "apiservices"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apisapiregistrationv1.APIService](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewAPIServiceInformerWithOptions(client clientset.Interface, options intern
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *aPIServiceInformer) defaultInformer(client clientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewAPIServiceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedAPIServiceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *aPIServiceInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apisapiregistrationv1.APIService{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *aPIServiceInformer) TypedInformer() APIServiceIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisapiregistrationv1.APIService](f.factory.InformerFor(&apisapiregistrationv1.APIService{}, f.defaultInformer))
 }
 
 func (f *aPIServiceInformer) Lister() apiregistrationv1.APIServiceLister {
 	return apiregistrationv1.NewAPIServiceLister(f.Informer().GetIndexer())
+}
+
+// ToTypedAPIServiceInformer converts an untyped informer into a TypedAPIServiceInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *APIService. If that is not the case, calling type-safe methods of the returned
+// TypedAPIServiceInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedAPIServiceInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedAPIServiceInformer(informer APIServiceInformer) TypedAPIServiceInformer {
+	if informer, ok := informer.(TypedAPIServiceInformer); ok {
+		return informer
+	}
+	return &aPIServiceTypedInformerAdapter{informer}
+}
+
+type aPIServiceTypedInformerAdapter struct {
+	APIServiceInformer
+}
+
+func (a *aPIServiceTypedInformerAdapter) TypedInformer() APIServiceIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisapiregistrationv1.APIService](a.Informer())
+}
+
+// ToAPIServiceIndexInformer converts an untyped informer into a APIServiceIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *APIService. If that is not the case, calling type-safe methods of the returned
+// APIServiceIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a APIServiceIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToAPIServiceIndexInformer(informer cache.SharedIndexInformer) APIServiceIndexInformer {
+	if informer, ok := informer.(APIServiceIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apisapiregistrationv1.APIService](informer)
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1/interface.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// APIServices returns a APIServiceInformer.
-	APIServices() APIServiceInformer
+	APIServices() TypedAPIServiceInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// APIServices returns a APIServiceInformer.
-func (v *version) APIServices() APIServiceInformer {
+// APIServices returns a TypedAPIServiceInformer.
+func (v *version) APIServices() TypedAPIServiceInformer {
 	return &aPIServiceInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1beta1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1beta1/apiservice.go
@@ -34,11 +34,39 @@ import (
 )
 
 // APIServiceInformer provides access to a shared informer and lister for
-// APIServices.
+// APIServices. Prefer using the type-safe variant (see [TypedAPIServiceInformer]).
 type APIServiceInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() apiregistrationv1beta1.APIServiceLister
 }
+
+// TypedAPIServiceInformer provides access to a shared informer and lister for
+// APIServices, including the type-safe TypedInformer variant.
+// It is a superset of APIServiceInformer.
+type TypedAPIServiceInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() APIServiceIndexInformer
+	Lister() apiregistrationv1beta1.APIServiceLister
+}
+
+// APIServiceIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type APIServiceIndexInformer cache.TypedSharedIndexInformer[*apisapiregistrationv1beta1.APIService]
+
+// APIServiceHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for APIService.
+type APIServiceHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apisapiregistrationv1beta1.APIService]
+
+// APIServiceDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for APIService.
+type APIServiceDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apisapiregistrationv1beta1.APIService]
+
+// APIServiceFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for APIService.
+type APIServiceFilteringHandler = cache.TypedFilteringResourceEventHandler[*apisapiregistrationv1beta1.APIService]
+
+// APIServiceIndexers is a specialization of [cache.TypedIndexers] for APIService.
+type APIServiceIndexers = cache.TypedIndexers[*apisapiregistrationv1beta1.APIService]
+
+// DeletedAPIService is a specialization of [cache.DeletedObject] for APIService.
+type DeletedAPIService = cache.DeletedObject[*apisapiregistrationv1beta1.APIService]
 
 type aPIServiceInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type aPIServiceInformer struct {
 // NewAPIServiceInformer constructs a new informer for APIService type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedAPIServiceInformer]).
 func NewAPIServiceInformer(client clientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewAPIServiceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedAPIServiceInformer constructs a new informer for APIService type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedAPIServiceInformer(client clientset.Interface, resyncPeriod time.Duration, indexers APIServiceIndexers) APIServiceIndexInformer {
+	return NewTypedAPIServiceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredAPIServiceInformer constructs a new informer for APIService type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredAPIServiceInformer]).
 func NewFilteredAPIServiceInformer(client clientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewAPIServiceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedAPIServiceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredAPIServiceInformer constructs a new informer for APIService type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredAPIServiceInformer(client clientset.Interface, resyncPeriod time.Duration, indexers APIServiceIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) APIServiceIndexInformer {
+	return NewTypedAPIServiceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewAPIServiceInformerWithOptions constructs a new informer for APIService type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedAPIServiceInformerWithOptions]).
 func NewAPIServiceInformerWithOptions(client clientset.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedAPIServiceInformerWithOptions(client, options)
+}
+
+// NewTypedAPIServiceInformerWithOptions constructs a new informer for APIService type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedAPIServiceInformerWithOptions(client clientset.Interface, options internalinterfaces.InformerOptions) APIServiceIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "apiregistration.k8s.io", Version: "v1beta1", Resource: "apiservices"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apisapiregistrationv1beta1.APIService](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewAPIServiceInformerWithOptions(client clientset.Interface, options intern
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *aPIServiceInformer) defaultInformer(client clientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewAPIServiceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedAPIServiceInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *aPIServiceInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apisapiregistrationv1beta1.APIService{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *aPIServiceInformer) TypedInformer() APIServiceIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisapiregistrationv1beta1.APIService](f.factory.InformerFor(&apisapiregistrationv1beta1.APIService{}, f.defaultInformer))
 }
 
 func (f *aPIServiceInformer) Lister() apiregistrationv1beta1.APIServiceLister {
 	return apiregistrationv1beta1.NewAPIServiceLister(f.Informer().GetIndexer())
+}
+
+// ToTypedAPIServiceInformer converts an untyped informer into a TypedAPIServiceInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *APIService. If that is not the case, calling type-safe methods of the returned
+// TypedAPIServiceInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedAPIServiceInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedAPIServiceInformer(informer APIServiceInformer) TypedAPIServiceInformer {
+	if informer, ok := informer.(TypedAPIServiceInformer); ok {
+		return informer
+	}
+	return &aPIServiceTypedInformerAdapter{informer}
+}
+
+type aPIServiceTypedInformerAdapter struct {
+	APIServiceInformer
+}
+
+func (a *aPIServiceTypedInformerAdapter) TypedInformer() APIServiceIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apisapiregistrationv1beta1.APIService](a.Informer())
+}
+
+// ToAPIServiceIndexInformer converts an untyped informer into a APIServiceIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *APIService. If that is not the case, calling type-safe methods of the returned
+// APIServiceIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a APIServiceIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToAPIServiceIndexInformer(informer cache.SharedIndexInformer) APIServiceIndexInformer {
+	if informer, ok := informer.(APIServiceIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apisapiregistrationv1beta1.APIService](informer)
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1beta1/interface.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1beta1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// APIServices returns a APIServiceInformer.
-	APIServices() APIServiceInformer
+	APIServices() TypedAPIServiceInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// APIServices returns a APIServiceInformer.
-func (v *version) APIServices() APIServiceInformer {
+// APIServices returns a TypedAPIServiceInformer.
+func (v *version) APIServices() TypedAPIServiceInformer {
 	return &aPIServiceInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1alpha1/fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1alpha1/fischer.go
@@ -34,11 +34,39 @@ import (
 )
 
 // FischerInformer provides access to a shared informer and lister for
-// Fischers.
+// Fischers. Prefer using the type-safe variant (see [TypedFischerInformer]).
 type FischerInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() wardlev1alpha1.FischerLister
 }
+
+// TypedFischerInformer provides access to a shared informer and lister for
+// Fischers, including the type-safe TypedInformer variant.
+// It is a superset of FischerInformer.
+type TypedFischerInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() FischerIndexInformer
+	Lister() wardlev1alpha1.FischerLister
+}
+
+// FischerIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type FischerIndexInformer cache.TypedSharedIndexInformer[*apiswardlev1alpha1.Fischer]
+
+// FischerHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Fischer.
+type FischerHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiswardlev1alpha1.Fischer]
+
+// FischerDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Fischer.
+type FischerDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiswardlev1alpha1.Fischer]
+
+// FischerFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Fischer.
+type FischerFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiswardlev1alpha1.Fischer]
+
+// FischerIndexers is a specialization of [cache.TypedIndexers] for Fischer.
+type FischerIndexers = cache.TypedIndexers[*apiswardlev1alpha1.Fischer]
+
+// DeletedFischer is a specialization of [cache.DeletedObject] for Fischer.
+type DeletedFischer = cache.DeletedObject[*apiswardlev1alpha1.Fischer]
 
 type fischerInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -48,25 +76,49 @@ type fischerInformer struct {
 // NewFischerInformer constructs a new informer for Fischer type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFischerInformer]).
 func NewFischerInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewFischerInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedFischerInformer constructs a new informer for Fischer type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFischerInformer(client versioned.Interface, resyncPeriod time.Duration, indexers FischerIndexers) FischerIndexInformer {
+	return NewTypedFischerInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredFischerInformer constructs a new informer for Fischer type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredFischerInformer]).
 func NewFilteredFischerInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewFischerInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedFischerInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredFischerInformer constructs a new informer for Fischer type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredFischerInformer(client versioned.Interface, resyncPeriod time.Duration, indexers FischerIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) FischerIndexInformer {
+	return NewTypedFischerInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewFischerInformerWithOptions constructs a new informer for Fischer type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFischerInformerWithOptions]).
 func NewFischerInformerWithOptions(client versioned.Interface, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedFischerInformerWithOptions(client, options)
+}
+
+// NewTypedFischerInformerWithOptions constructs a new informer for Fischer type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFischerInformerWithOptions(client versioned.Interface, options internalinterfaces.InformerOptions) FischerIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "wardle.example.com", Version: "v1alpha1", Resource: "fischers"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiswardlev1alpha1.Fischer](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -99,17 +151,57 @@ func NewFischerInformerWithOptions(client versioned.Interface, options internali
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *fischerInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFischerInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedFischerInformerWithOptions(client, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *fischerInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiswardlev1alpha1.Fischer{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *fischerInformer) TypedInformer() FischerIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiswardlev1alpha1.Fischer](f.factory.InformerFor(&apiswardlev1alpha1.Fischer{}, f.defaultInformer))
 }
 
 func (f *fischerInformer) Lister() wardlev1alpha1.FischerLister {
 	return wardlev1alpha1.NewFischerLister(f.Informer().GetIndexer())
+}
+
+// ToTypedFischerInformer converts an untyped informer into a TypedFischerInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Fischer. If that is not the case, calling type-safe methods of the returned
+// TypedFischerInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedFischerInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedFischerInformer(informer FischerInformer) TypedFischerInformer {
+	if informer, ok := informer.(TypedFischerInformer); ok {
+		return informer
+	}
+	return &fischerTypedInformerAdapter{informer}
+}
+
+type fischerTypedInformerAdapter struct {
+	FischerInformer
+}
+
+func (a *fischerTypedInformerAdapter) TypedInformer() FischerIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiswardlev1alpha1.Fischer](a.Informer())
+}
+
+// ToFischerIndexInformer converts an untyped informer into a FischerIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Fischer. If that is not the case, calling type-safe methods of the returned
+// FischerIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a FischerIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToFischerIndexInformer(informer cache.SharedIndexInformer) FischerIndexInformer {
+	if informer, ok := informer.(FischerIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiswardlev1alpha1.Fischer](informer)
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1alpha1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1alpha1/flunder.go
@@ -34,11 +34,39 @@ import (
 )
 
 // FlunderInformer provides access to a shared informer and lister for
-// Flunders.
+// Flunders. Prefer using the type-safe variant (see [TypedFlunderInformer]).
 type FlunderInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() wardlev1alpha1.FlunderLister
 }
+
+// TypedFlunderInformer provides access to a shared informer and lister for
+// Flunders, including the type-safe TypedInformer variant.
+// It is a superset of FlunderInformer.
+type TypedFlunderInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() FlunderIndexInformer
+	Lister() wardlev1alpha1.FlunderLister
+}
+
+// FlunderIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type FlunderIndexInformer cache.TypedSharedIndexInformer[*apiswardlev1alpha1.Flunder]
+
+// FlunderHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Flunder.
+type FlunderHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiswardlev1alpha1.Flunder]
+
+// FlunderDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Flunder.
+type FlunderDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiswardlev1alpha1.Flunder]
+
+// FlunderFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Flunder.
+type FlunderFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiswardlev1alpha1.Flunder]
+
+// FlunderIndexers is a specialization of [cache.TypedIndexers] for Flunder.
+type FlunderIndexers = cache.TypedIndexers[*apiswardlev1alpha1.Flunder]
+
+// DeletedFlunder is a specialization of [cache.DeletedObject] for Flunder.
+type DeletedFlunder = cache.DeletedObject[*apiswardlev1alpha1.Flunder]
 
 type flunderInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type flunderInformer struct {
 // NewFlunderInformer constructs a new informer for Flunder type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFlunderInformer]).
 func NewFlunderInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewFlunderInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedFlunderInformer constructs a new informer for Flunder type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFlunderInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers FlunderIndexers) FlunderIndexInformer {
+	return NewTypedFlunderInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredFlunderInformer constructs a new informer for Flunder type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredFlunderInformer]).
 func NewFilteredFlunderInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewFlunderInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedFlunderInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredFlunderInformer constructs a new informer for Flunder type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredFlunderInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers FlunderIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) FlunderIndexInformer {
+	return NewTypedFlunderInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewFlunderInformerWithOptions constructs a new informer for Flunder type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFlunderInformerWithOptions]).
 func NewFlunderInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedFlunderInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedFlunderInformerWithOptions constructs a new informer for Flunder type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFlunderInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) FlunderIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "wardle.example.com", Version: "v1alpha1", Resource: "flunders"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiswardlev1alpha1.Flunder](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewFlunderInformerWithOptions(client versioned.Interface, namespace string,
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *flunderInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFlunderInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedFlunderInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *flunderInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiswardlev1alpha1.Flunder{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *flunderInformer) TypedInformer() FlunderIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiswardlev1alpha1.Flunder](f.factory.InformerFor(&apiswardlev1alpha1.Flunder{}, f.defaultInformer))
 }
 
 func (f *flunderInformer) Lister() wardlev1alpha1.FlunderLister {
 	return wardlev1alpha1.NewFlunderLister(f.Informer().GetIndexer())
+}
+
+// ToTypedFlunderInformer converts an untyped informer into a TypedFlunderInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Flunder. If that is not the case, calling type-safe methods of the returned
+// TypedFlunderInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedFlunderInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedFlunderInformer(informer FlunderInformer) TypedFlunderInformer {
+	if informer, ok := informer.(TypedFlunderInformer); ok {
+		return informer
+	}
+	return &flunderTypedInformerAdapter{informer}
+}
+
+type flunderTypedInformerAdapter struct {
+	FlunderInformer
+}
+
+func (a *flunderTypedInformerAdapter) TypedInformer() FlunderIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiswardlev1alpha1.Flunder](a.Informer())
+}
+
+// ToFlunderIndexInformer converts an untyped informer into a FlunderIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Flunder. If that is not the case, calling type-safe methods of the returned
+// FlunderIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a FlunderIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToFlunderIndexInformer(informer cache.SharedIndexInformer) FlunderIndexInformer {
+	if informer, ok := informer.(FlunderIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiswardlev1alpha1.Flunder](informer)
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1alpha1/interface.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1alpha1/interface.go
@@ -25,9 +25,9 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// Fischers returns a FischerInformer.
-	Fischers() FischerInformer
+	Fischers() TypedFischerInformer
 	// Flunders returns a FlunderInformer.
-	Flunders() FlunderInformer
+	Flunders() TypedFlunderInformer
 }
 
 type version struct {
@@ -41,12 +41,12 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// Fischers returns a FischerInformer.
-func (v *version) Fischers() FischerInformer {
+// Fischers returns a TypedFischerInformer.
+func (v *version) Fischers() TypedFischerInformer {
 	return &fischerInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// Flunders returns a FlunderInformer.
-func (v *version) Flunders() FlunderInformer {
+// Flunders returns a TypedFlunderInformer.
+func (v *version) Flunders() TypedFlunderInformer {
 	return &flunderInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1beta1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1beta1/flunder.go
@@ -34,11 +34,39 @@ import (
 )
 
 // FlunderInformer provides access to a shared informer and lister for
-// Flunders.
+// Flunders. Prefer using the type-safe variant (see [TypedFlunderInformer]).
 type FlunderInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() wardlev1beta1.FlunderLister
 }
+
+// TypedFlunderInformer provides access to a shared informer and lister for
+// Flunders, including the type-safe TypedInformer variant.
+// It is a superset of FlunderInformer.
+type TypedFlunderInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() FlunderIndexInformer
+	Lister() wardlev1beta1.FlunderLister
+}
+
+// FlunderIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type FlunderIndexInformer cache.TypedSharedIndexInformer[*apiswardlev1beta1.Flunder]
+
+// FlunderHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Flunder.
+type FlunderHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apiswardlev1beta1.Flunder]
+
+// FlunderDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Flunder.
+type FlunderDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apiswardlev1beta1.Flunder]
+
+// FlunderFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Flunder.
+type FlunderFilteringHandler = cache.TypedFilteringResourceEventHandler[*apiswardlev1beta1.Flunder]
+
+// FlunderIndexers is a specialization of [cache.TypedIndexers] for Flunder.
+type FlunderIndexers = cache.TypedIndexers[*apiswardlev1beta1.Flunder]
+
+// DeletedFlunder is a specialization of [cache.DeletedObject] for Flunder.
+type DeletedFlunder = cache.DeletedObject[*apiswardlev1beta1.Flunder]
 
 type flunderInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type flunderInformer struct {
 // NewFlunderInformer constructs a new informer for Flunder type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFlunderInformer]).
 func NewFlunderInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewFlunderInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedFlunderInformer constructs a new informer for Flunder type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFlunderInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers FlunderIndexers) FlunderIndexInformer {
+	return NewTypedFlunderInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredFlunderInformer constructs a new informer for Flunder type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredFlunderInformer]).
 func NewFilteredFlunderInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewFlunderInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedFlunderInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredFlunderInformer constructs a new informer for Flunder type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredFlunderInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers FlunderIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) FlunderIndexInformer {
+	return NewTypedFlunderInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewFlunderInformerWithOptions constructs a new informer for Flunder type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFlunderInformerWithOptions]).
 func NewFlunderInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedFlunderInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedFlunderInformerWithOptions constructs a new informer for Flunder type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFlunderInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) FlunderIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "wardle.example.com", Version: "v1beta1", Resource: "flunders"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apiswardlev1beta1.Flunder](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewFlunderInformerWithOptions(client versioned.Interface, namespace string,
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *flunderInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFlunderInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedFlunderInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *flunderInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiswardlev1beta1.Flunder{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *flunderInformer) TypedInformer() FlunderIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiswardlev1beta1.Flunder](f.factory.InformerFor(&apiswardlev1beta1.Flunder{}, f.defaultInformer))
 }
 
 func (f *flunderInformer) Lister() wardlev1beta1.FlunderLister {
 	return wardlev1beta1.NewFlunderLister(f.Informer().GetIndexer())
+}
+
+// ToTypedFlunderInformer converts an untyped informer into a TypedFlunderInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Flunder. If that is not the case, calling type-safe methods of the returned
+// TypedFlunderInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedFlunderInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedFlunderInformer(informer FlunderInformer) TypedFlunderInformer {
+	if informer, ok := informer.(TypedFlunderInformer); ok {
+		return informer
+	}
+	return &flunderTypedInformerAdapter{informer}
+}
+
+type flunderTypedInformerAdapter struct {
+	FlunderInformer
+}
+
+func (a *flunderTypedInformerAdapter) TypedInformer() FlunderIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apiswardlev1beta1.Flunder](a.Informer())
+}
+
+// ToFlunderIndexInformer converts an untyped informer into a FlunderIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Flunder. If that is not the case, calling type-safe methods of the returned
+// FlunderIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a FlunderIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToFlunderIndexInformer(informer cache.SharedIndexInformer) FlunderIndexInformer {
+	if informer, ok := informer.(FlunderIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apiswardlev1beta1.Flunder](informer)
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1beta1/interface.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1beta1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// Flunders returns a FlunderInformer.
-	Flunders() FlunderInformer
+	Flunders() TypedFlunderInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// Flunders returns a FlunderInformer.
-func (v *version) Flunders() FlunderInformer {
+// Flunders returns a TypedFlunderInformer.
+func (v *version) Flunders() TypedFlunderInformer {
 	return &flunderInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/samplecontroller/v1alpha1/foo.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/samplecontroller/v1alpha1/foo.go
@@ -34,11 +34,39 @@ import (
 )
 
 // FooInformer provides access to a shared informer and lister for
-// Foos.
+// Foos. Prefer using the type-safe variant (see [TypedFooInformer]).
 type FooInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() samplecontrollerv1alpha1.FooLister
 }
+
+// TypedFooInformer provides access to a shared informer and lister for
+// Foos, including the type-safe TypedInformer variant.
+// It is a superset of FooInformer.
+type TypedFooInformer interface {
+	Informer() cache.SharedIndexInformer
+	TypedInformer() FooIndexInformer
+	Lister() samplecontrollerv1alpha1.FooLister
+}
+
+// FooIndexInformer is a wrapper around the underlying [cache.SharedIndexInformer]
+// with type-safe variants of several methods.
+type FooIndexInformer cache.TypedSharedIndexInformer[*apissamplecontrollerv1alpha1.Foo]
+
+// FooHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerFuncs] for Foo.
+type FooHandlerFuncs = cache.TypedResourceEventHandlerFuncs[*apissamplecontrollerv1alpha1.Foo]
+
+// FooDetailedHandlerFuncs is a specialization of [cache.TypedResourceEventHandlerDetailedFuncs] for Foo.
+type FooDetailedHandlerFuncs = cache.TypedResourceEventHandlerDetailedFuncs[*apissamplecontrollerv1alpha1.Foo]
+
+// FooFilteringHandler is a specialization of [cache.TypedFilteringResourceEventHandler] for Foo.
+type FooFilteringHandler = cache.TypedFilteringResourceEventHandler[*apissamplecontrollerv1alpha1.Foo]
+
+// FooIndexers is a specialization of [cache.TypedIndexers] for Foo.
+type FooIndexers = cache.TypedIndexers[*apissamplecontrollerv1alpha1.Foo]
+
+// DeletedFoo is a specialization of [cache.DeletedObject] for Foo.
+type DeletedFoo = cache.DeletedObject[*apissamplecontrollerv1alpha1.Foo]
 
 type fooInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
@@ -49,25 +77,49 @@ type fooInformer struct {
 // NewFooInformer constructs a new informer for Foo type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFooInformer]).
 func NewFooInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewFooInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers})
+}
+
+// NewTypedFooInformer constructs a new informer for Foo type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFooInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers FooIndexers) FooIndexInformer {
+	return NewTypedFooInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers)})
 }
 
 // NewFilteredFooInformer constructs a new informer for Foo type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFilteredFooInformer]).
 func NewFilteredFooInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
-	return NewFooInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+	return NewTypedFooInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: indexers, TweakListOptions: tweakListOptions})
+}
+
+// NewTypedFilteredFooInformer constructs a new informer for Foo type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFilteredFooInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers FooIndexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) FooIndexInformer {
+	return NewTypedFooInformerWithOptions(client, namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.TypedIndexersToIndexers(indexers), TweakListOptions: tweakListOptions})
 }
 
 // NewFooInformerWithOptions constructs a new informer for Foo type with additional options.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
+// If you really need an independent one, prefer using the type-safe variant (see [NewTypedFooInformerWithOptions]).
 func NewFooInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) cache.SharedIndexInformer {
+	return NewTypedFooInformerWithOptions(client, namespace, options)
+}
+
+// NewTypedFooInformerWithOptions constructs a new informer for Foo type with additional options.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTypedFooInformerWithOptions(client versioned.Interface, namespace string, options internalinterfaces.InformerOptions) FooIndexInformer {
 	gvr := schema.GroupVersionResource{Group: "samplecontroller.k8s.io", Version: "v1alpha1", Resource: "foos"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
-	return cache.NewSharedIndexInformerWithOptions(
+	return cache.NewTypedSharedIndexInformer[*apissamplecontrollerv1alpha1.Foo](cache.NewSharedIndexInformerWithOptions(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListFunc: func(opts v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
@@ -100,17 +152,57 @@ func NewFooInformerWithOptions(client versioned.Interface, namespace string, opt
 			Indexers:     options.Indexers,
 			Identifier:   identifier,
 		},
-	)
+	))
 }
 
 func (f *fooInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFooInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
+	return NewTypedFooInformerWithOptions(client, f.namespace, internalinterfaces.InformerOptions{ResyncPeriod: resyncPeriod, Indexers: cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, InformerName: f.factory.InformerName(), TweakListOptions: f.tweakListOptions})
 }
 
 func (f *fooInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apissamplecontrollerv1alpha1.Foo{}, f.defaultInformer)
+	return f.TypedInformer()
+}
+
+func (f *fooInformer) TypedInformer() FooIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apissamplecontrollerv1alpha1.Foo](f.factory.InformerFor(&apissamplecontrollerv1alpha1.Foo{}, f.defaultInformer))
 }
 
 func (f *fooInformer) Lister() samplecontrollerv1alpha1.FooLister {
 	return samplecontrollerv1alpha1.NewFooLister(f.Informer().GetIndexer())
+}
+
+// ToTypedFooInformer converts an untyped informer into a TypedFooInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Foo. If that is not the case, calling type-safe methods of the returned
+// TypedFooInformer leads to runtime panics. A safer alternative is to pass
+// around a TypedFooInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToTypedFooInformer(informer FooInformer) TypedFooInformer {
+	if informer, ok := informer.(TypedFooInformer); ok {
+		return informer
+	}
+	return &fooTypedInformerAdapter{informer}
+}
+
+type fooTypedInformerAdapter struct {
+	FooInformer
+}
+
+func (a *fooTypedInformerAdapter) TypedInformer() FooIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apissamplecontrollerv1alpha1.Foo](a.Informer())
+}
+
+// ToFooIndexInformer converts an untyped informer into a FooIndexInformer.
+//
+// WARNING: this conversion is only safe if the informer handles objects of type
+// *Foo. If that is not the case, calling type-safe methods of the returned
+// FooIndexInformer leads to runtime panics. A safer alternative is to pass
+// around a FooIndexInformer instances that was obtained from a
+// SharedInformerFactory.
+func ToFooIndexInformer(informer cache.SharedIndexInformer) FooIndexInformer {
+	if informer, ok := informer.(FooIndexInformer); ok {
+		return informer
+	}
+	return cache.NewTypedSharedIndexInformer[*apissamplecontrollerv1alpha1.Foo](informer)
 }

--- a/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/samplecontroller/v1alpha1/interface.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/samplecontroller/v1alpha1/interface.go
@@ -25,7 +25,7 @@ import (
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	// Foos returns a FooInformer.
-	Foos() FooInformer
+	Foos() TypedFooInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// Foos returns a FooInformer.
-func (v *version) Foos() FooInformer {
+// Foos returns a TypedFooInformer.
+func (v *version) Foos() TypedFooInformer {
 	return &fooInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

All code using the result of the generated client-go Informer() methods (a cache.SharedIndexInformer) constantly has to do type casts from "any" to the actual type of the objects managed by the informer.

This is:
- annoying at best
- often done inconsistently (should failed type assertions panic or be logged and if so, how?)
- a source of bugs (not handling DeletedFinalStateUnknown, type in event handler not matching the type in the informer)

In contrast, the Lister() result *is* typed. It converts without a type check in e.g. ResourceIndexer[T].List:

	err = cache.ListAllByNamespace(l.indexer, l.namespace, selector, func(m interface{}) {
		ret = append(ret, m.(T))
	})

This change here does the same wrapping for SharedIndexInformer, Indexer and index functions.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This is a Go API break because all generated interfaces change. See client-go CHANGELOG.md for details.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @aojea @skitt @neolit123 