### PR TITLE
Improve same-version fast return for SSA

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/typeconverter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/typeconverter.go
@@ -109,6 +109,24 @@ func valueToObject(val value.Value) (runtime.Object, error) {
 	}
 }
 
+// GroupVersionOfTypedValue returns the extracted GroupVersion from the TypeMeta
+// fields of a TypedValue, or return false if no TypeMeta fields are found.
+func GroupVersionOfTypedValue(object *typed.TypedValue) (schema.GroupVersion, bool) {
+	val := object.AsValue()
+	if val == nil || !val.IsMap() {
+		return schema.GroupVersion{}, false
+	}
+	apiVersion, ok := val.AsMap().Get("apiVersion")
+	if !ok || !apiVersion.IsString() {
+		return schema.GroupVersion{}, false
+	}
+	groupVersion, err := schema.ParseGroupVersion(apiVersion.AsString())
+	if err != nil {
+		return schema.GroupVersion{}, false
+	}
+	return groupVersion, true
+}
+
 func indexModels(
 	typeParser *typed.Parser,
 	openAPISchemas map[string]*spec.Schema,

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/versionconverter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/versionconverter.go
@@ -63,23 +63,22 @@ func newCRDVersionConverter(t TypeConverter, o runtime.ObjectConvertor, h schema
 
 // Convert implements sigs.k8s.io/structured-merge-diff/merge.Converter
 func (v *versionConverter) Convert(object *typed.TypedValue, version fieldpath.APIVersion) (*typed.TypedValue, error) {
-	// Convert the smd typed value to a kubernetes object.
-	objectToConvert, err := v.typeConverter.TypedToObject(object)
-	if err != nil {
-		return object, err
-	}
-
-	// Parse the target groupVersion.
 	groupVersion, err := schema.ParseGroupVersion(string(version))
 	if err != nil {
 		return object, err
 	}
 
 	// If attempting to convert to the same version as we already have, just return it.
-	fromVersion := objectToConvert.GetObjectKind().GroupVersionKind().GroupVersion()
-	if fromVersion == groupVersion {
+	if typedVersion, ok := GroupVersionOfTypedValue(object); ok && typedVersion == groupVersion {
 		return object, nil
 	}
+
+	// Convert the smd typed value to a kubernetes object.
+	objectToConvert, err := v.typeConverter.TypedToObject(object)
+	if err != nil {
+		return object, err
+	}
+	fromVersion := objectToConvert.GetObjectKind().GroupVersionKind().GroupVersion()
 
 	// Convert to internal
 	internalObject, err := v.objectConvertor.ConvertToVersion(objectToConvert, v.hubGetter(fromVersion))

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/versionconverter_bench_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/versionconverter_bench_test.go
@@ -1,0 +1,197 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v6/merge"
+)
+
+// benchDeployment is a structured (reflect-backed) object whose JSON shape is a
+// subset of the apps Deployment schema. Built-in types reach the version
+// converter as reflect-backed typed values, so the pre-fast-path Convert had to
+// deep-copy the whole object via TypedToObject just to read its apiVersion;
+// this type reproduces that cost.
+type benchDeployment struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+}
+
+func (d *benchDeployment) DeepCopyObject() runtime.Object {
+	out := &benchDeployment{TypeMeta: d.TypeMeta}
+	d.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	return out
+}
+
+// structuredDeployment returns a reflect-backed Deployment with n labels and n
+// annotations, exercising the built-in-type code path.
+func structuredDeployment(apiVersion string, n int) runtime.Object {
+	labels, annotations := metaMaps(n)
+	return &benchDeployment{
+		TypeMeta: metav1.TypeMeta{APIVersion: apiVersion, Kind: "Deployment"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "nginx-deployment",
+			Namespace:   "default",
+			Labels:      labels,
+			Annotations: annotations,
+		},
+	}
+}
+
+// unstructuredDeployment returns a value-backed Deployment, exercising the CRD
+// code path (the typed value already holds a map, so TypedToObject is cheap).
+func unstructuredDeployment(apiVersion string, n int) runtime.Object {
+	labels, annotations := metaMaps(n)
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": apiVersion,
+		"kind":       "Deployment",
+		"metadata": map[string]interface{}{
+			"name":        "nginx-deployment",
+			"namespace":   "default",
+			"labels":      toInterfaceMap(labels),
+			"annotations": toInterfaceMap(annotations),
+		},
+	}}
+}
+
+func metaMaps(n int) (labels, annotations map[string]string) {
+	labels = make(map[string]string, n)
+	annotations = make(map[string]string, n)
+	for i := range n {
+		labels[fmt.Sprintf("k8s.io/label-%d", i)] = fmt.Sprintf("value-%d", i)
+		annotations[fmt.Sprintf("k8s.io/annotation-%d", i)] = fmt.Sprintf("value-%d", i)
+	}
+	return labels, annotations
+}
+
+func toInterfaceMap(m map[string]string) map[string]interface{} {
+	out := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+func benchVersionConverter() merge.Converter {
+	oc := fakeObjectConvertorForTestSchema{
+		gvkForVersion("v1beta1"): objForGroupVersion("apps/v1beta1"),
+		gvkForVersion("v1"):      objForGroupVersion("apps/v1"),
+	}
+	return newVersionConverter(testTypeConverter, oc, schema.GroupVersion{Group: "apps", Version: runtime.APIVersionInternal})
+}
+
+var benchBackings = []struct {
+	name  string
+	build func(apiVersion string, n int) runtime.Object
+}{
+	{"structured", structuredDeployment},
+	{"unstructured", unstructuredDeployment},
+}
+
+var benchConversions = []struct {
+	name    string
+	version fieldpath.APIVersion
+}{
+	{"same-version", "apps/v1beta1"},
+	{"cross-version", "apps/v1"},
+}
+
+var benchSizes = []int{0, 10, 100, 1000}
+
+// BenchmarkVersionConverter measures versionConverter.Convert across reflect-backed
+// (built-in) and value-backed (CRD) inputs, for the same-version (fast path) and
+// cross-version (fallback) cases, over a range of object sizes.
+func BenchmarkVersionConverter(b *testing.B) {
+	vc := benchVersionConverter()
+	for _, backing := range benchBackings {
+		for _, conv := range benchConversions {
+			for _, n := range benchSizes {
+				input, err := testTypeConverter.ObjectToTyped(backing.build("apps/v1beta1", n))
+				if err != nil {
+					b.Fatalf("ObjectToTyped(%s, fields=%d): %v", backing.name, n, err)
+				}
+				b.Run(fmt.Sprintf("%s/%s/fields=%d", backing.name, conv.name, n), func(b *testing.B) {
+					b.ReportAllocs()
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						if _, err := vc.Convert(input, conv.version); err != nil {
+							b.Fatalf("Convert: %v", err)
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+// TestBenchmarkFastPathEngages guards the benchmark: it confirms the same-version
+// case takes the fast path (no TypedToObject / ConvertToVersion) for both
+// reflect-backed and value-backed inputs, and that the cross-version case does
+// not, so the before/after comparison measures the intended code paths.
+func TestBenchmarkFastPathEngages(t *testing.T) {
+	for _, backing := range benchBackings {
+		t.Run(backing.name, func(t *testing.T) {
+			input, err := testTypeConverter.ObjectToTyped(backing.build("apps/v1beta1", 10))
+			if err != nil {
+				t.Fatalf("ObjectToTyped: %v", err)
+			}
+
+			// Same version: fast path, no materialization or conversion.
+			tc := &countingTypeConverter{TypeConverter: testTypeConverter}
+			oc := &countingObjectConvertor{ObjectConvertor: benchObjectConvertor()}
+			vc := newVersionConverter(tc, oc, schema.GroupVersion{Group: "apps", Version: runtime.APIVersionInternal})
+			out, err := vc.Convert(input, fieldpath.APIVersion("apps/v1beta1"))
+			if err != nil {
+				t.Fatalf("Convert same-version: %v", err)
+			}
+			if out != input {
+				t.Errorf("same-version Convert should return input unchanged")
+			}
+			if tc.typedToObjectCalls != 0 {
+				t.Errorf("same-version Convert called TypedToObject %d times, want 0", tc.typedToObjectCalls)
+			}
+			if oc.convertToVersionCalls != 0 {
+				t.Errorf("same-version Convert called ConvertToVersion %d times, want 0", oc.convertToVersionCalls)
+			}
+
+			// Cross version: fallback path materializes the object.
+			tc = &countingTypeConverter{TypeConverter: testTypeConverter}
+			oc = &countingObjectConvertor{ObjectConvertor: benchObjectConvertor()}
+			vc = newVersionConverter(tc, oc, schema.GroupVersion{Group: "apps", Version: runtime.APIVersionInternal})
+			if _, err := vc.Convert(input, fieldpath.APIVersion("apps/v1")); err != nil {
+				t.Fatalf("Convert cross-version: %v", err)
+			}
+			if tc.typedToObjectCalls == 0 {
+				t.Errorf("cross-version Convert should call TypedToObject")
+			}
+		})
+	}
+}
+
+func benchObjectConvertor() fakeObjectConvertorForTestSchema {
+	return fakeObjectConvertorForTestSchema{
+		gvkForVersion("v1beta1"): objForGroupVersion("apps/v1beta1"),
+		gvkForVersion("v1"):      objForGroupVersion("apps/v1"),
+	}
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/versionconverter_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/versionconverter_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
 )
 
 var testTypeConverter = func() TypeConverter {
@@ -78,6 +79,50 @@ func TestVersionConverter(t *testing.T) {
 	if !reflect.DeepEqual(expected, actual) {
 		t.Fatalf("expected to get %v but got %v", expected, actual)
 	}
+}
+
+func TestVersionConverterSameVersion(t *testing.T) {
+	tc := &countingTypeConverter{TypeConverter: testTypeConverter}
+	oc := &countingObjectConvertor{ObjectConvertor: fakeObjectConvertorForTestSchema{}}
+	vc := newVersionConverter(tc, oc, schema.GroupVersion{Group: "apps", Version: runtime.APIVersionInternal})
+
+	input, err := testTypeConverter.ObjectToTyped(objForGroupVersion("apps/v1beta1"))
+	if err != nil {
+		t.Fatalf("error converting input object to a typed value: %v", err)
+	}
+	output, err := vc.Convert(input, fieldpath.APIVersion("apps/v1beta1"))
+	if err != nil {
+		t.Fatalf("expected err to be nil but got %v", err)
+	}
+	if output != input {
+		t.Errorf("expected same-version conversion to return the input unchanged")
+	}
+	if tc.typedToObjectCalls != 0 {
+		t.Errorf("expected no TypedToObject calls for same-version conversion, got %d", tc.typedToObjectCalls)
+	}
+	if oc.convertToVersionCalls != 0 {
+		t.Errorf("expected no ConvertToVersion calls for same-version conversion, got %d", oc.convertToVersionCalls)
+	}
+}
+
+type countingTypeConverter struct {
+	TypeConverter
+	typedToObjectCalls int
+}
+
+func (c *countingTypeConverter) TypedToObject(value *typed.TypedValue) (runtime.Object, error) {
+	c.typedToObjectCalls++
+	return c.TypeConverter.TypedToObject(value)
+}
+
+type countingObjectConvertor struct {
+	runtime.ObjectConvertor
+	convertToVersionCalls int
+}
+
+func (c *countingObjectConvertor) ConvertToVersion(in runtime.Object, gv runtime.GroupVersioner) (runtime.Object, error) {
+	c.convertToVersionCalls++
+	return c.ObjectConvertor.ConvertToVersion(in, gv)
 }
 
 func gvkForVersion(v string) schema.GroupVersionKind {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

`versionConverter.Convert` has always returned the input object when the target version is the same as the input version. But only *after* a conversion from a `TypedObject` to Kubernetes object, which is quite expensive.

This optimization avoid this conversion, making same-version writes significantly cheaper for SSA to process.

```
goos: linux  goarch: amd64  cpu: 13th Gen Intel(R) Core(TM) i9-13900K
  pkg: k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager

                                     │   sec/op (before → after)         │
  NewObject/Pod/Update-32              121.4µ → 120.1µ        ~ (p=0.315)
  NewObject/Pod/UpdateTwice-32         279.7µ → 250.0µ   -10.62% (p=0.000)
  NewObject/Pod/Apply-32               151.7µ → 152.8µ        ~ (p=0.684)
  NewObject/Pod/UpdateApply-32         698.2µ → 614.2µ   -12.03% (p=0.000)
  NewObject/Node/Update-32             201.5µ → 194.8µ    -3.31% (p=0.000)
  NewObject/Node/UpdateTwice-32        454.4µ → 407.6µ   -10.30% (p=0.000)
  NewObject/Node/Apply-32              256.7µ → 256.2µ        ~ (p=0.971)
  NewObject/Node/UpdateApply-32       1051.5µ → 937.5µ   -10.84% (p=0.000)
  NewObject/Endpoints/Update-32        749.2µ → 764.7µ    +2.06% (p=0.002)
  NewObject/Endpoints/UpdateTwice-32   2.994m → 2.293m   -23.43% (p=0.000)
  NewObject/Endpoints/Apply-32         600.7µ → 597.3µ        ~ (p=0.796)
  NewObject/Endpoints/UpdateApply-32   4.981m → 4.158m   -16.53% (p=0.000)
  RepeatedUpdate-32                    118.0µ → 117.8µ        ~ (p=0.684)
  geomean                              479.3µ → 445.9µ    -6.97%

                                     │   B/op (before → after)            │
  NewObject/Pod/UpdateTwice-32         157.4Ki → 135.0Ki  -14.22% (p=0.000)
  NewObject/Pod/UpdateApply-32         416.7Ki → 344.8Ki  -17.25% (p=0.000)
  NewObject/Node/UpdateTwice-32        282.0Ki → 243.9Ki  -13.53% (p=0.000)
  NewObject/Node/UpdateApply-32        657.2Ki → 550.8Ki  -16.19% (p=0.000)
  NewObject/Endpoints/UpdateTwice-32  1550.8Ki → 619.2Ki  -60.08% (p=0.000)
  NewObject/Endpoints/UpdateApply-32   2.199Mi → 1.277Mi  -41.95% (p=0.000)
    (single Update/Apply rows: ~0%)
  geomean                              256.6Ki → 217.9Ki  -15.09%

                                     │   allocs/op (before → after)       │
  NewObject/Pod/UpdateTwice-32          3.106k → 2.826k    -9.01% (p=0.000)
  NewObject/Pod/UpdateApply-32          8.151k → 7.000k   -14.13% (p=0.000)
  NewObject/Node/UpdateTwice-32         6.061k → 5.327k   -12.11% (p=0.000)
  NewObject/Node/UpdateApply-32         14.03k → 11.91k   -15.13% (p=0.000)
  NewObject/Endpoints/UpdateTwice-32    31.86k → 18.49k   -41.96% (p=0.000)
  NewObject/Endpoints/UpdateApply-32    45.96k → 32.34k   -29.64% (p=0.000)
    (single Update/Apply rows: ~0%)
  geomean                                5.403k → 4.839k  -10.45%
```

```
  goos: linux
  goarch: amd64
  pkg: k8s.io/apimachinery/pkg/util/managedfields/internal
  cpu: 13th Gen Intel(R) Core(TM) i9-13900K
                                                             │ before │          after          │
                                                             │ sec/op │   sec/op     vs base     │
  VersionConverter/structured/same-version/fields=0-32          984.5n ± 2%   117.7n ± 2%  -88.04% (p=0.000 n=10)
  VersionConverter/structured/same-version/fields=10-32        3851.0n ± 2%   119.4n ± 2%  -96.90% (p=0.000 n=10)
  VersionConverter/structured/same-version/fields=100-32      23559.0n ± 2%   118.8n ± 2%  -99.50% (p=0.000 n=10)
  VersionConverter/structured/same-version/fields=1000-32    226264.0n ± 2%   116.6n ± 2%  -99.95% (p=0.000 n=10)
  VersionConverter/structured/cross-version/fields=0-32         1.798µ ± 2%   1.911µ ± 3%   +6.26% (p=0.000 n=10)
  VersionConverter/structured/cross-version/fields=10-32        4.731µ ± 2%   4.683µ ± 4%        ~ (p=0.165 n=10)
  VersionConverter/structured/cross-version/fields=100-32       24.10µ ± 3%   23.96µ ± 3%        ~ (p=0.436 n=10)
  VersionConverter/structured/cross-version/fields=1000-32      228.7µ ± 2%   232.9µ ± 1%   +1.83% (p=0.019 n=10)
  VersionConverter/unstructured/same-version/fields=0-32        43.77n ± 2%   41.09n ± 2%   -6.11% (p=0.000 n=10)
  VersionConverter/unstructured/same-version/fields=10-32       43.71n ± 3%   40.68n ± 1%   -6.94% (p=0.000 n=10)
  VersionConverter/unstructured/same-version/fields=100-32      43.33n ± 1%   40.42n ± 2%   -6.72% (p=0.000 n=10)
  VersionConverter/unstructured/same-version/fields=1000-32     43.11n ± 2%   40.27n ± 1%   -6.60% (p=0.000 n=10)
  VersionConverter/unstructured/cross-version/fields=0-32       704.5n ± 3%   740.2n ± 1%   +5.07% (p=0.000 n=10)
  VersionConverter/unstructured/cross-version/fields=10-32      701.0n ± 1%   736.0n ± 1%   +4.99% (p=0.000 n=10)
  VersionConverter/unstructured/cross-version/fields=100-32     696.4n ± 2%   735.4n ± 1%   +5.60% (p=0.000 n=10)
  VersionConverter/unstructured/cross-version/fields=1000-32    702.1n ± 3%   722.2n ± 1%   +2.87% (p=0.000 n=10)

                                                             │ before  │           after            │
                                                             │  B/op   │     B/op      vs base       │
  VersionConverter/structured/same-version/fields=0-32         1744.00 ± 0%     96.00 ± 0%   -94.50% (p=0.000 n=10)
  VersionConverter/structured/same-version/fields=10-32        4704.00 ± 0%     96.00 ± 0%   -97.96% (p=0.000 n=10)
  VersionConverter/structured/same-version/fields=100-32      26240.00 ± 0%     96.00 ± 0%   -99.63% (p=0.000 n=10)
  VersionConverter/structured/same-version/fields=1000-32    310032.00 ± 0%     96.00 ± 0%   -99.97% (p=0.000 n=10)
  VersionConverter/structured/cross-version/fields=0-32        2.186Ki ± 0%   2.279Ki ± 0%    +4.29% (p=0.000 n=10)
  VersionConverter/structured/cross-version/fields=1000-32     303.9Ki ± 0%   304.0Ki ± 0%    +0.03% (p=0.000 n=10)
  VersionConverter/unstructured/same-version/fields=0-32          8.000 ± 0%    16.000 ± 0%  +100.00% (p=0.000 n=10)
  VersionConverter/unstructured/cross-version/fields=0-32         497.0 ± 0%     513.0 ± 0%    +3.22% (p=0.000 n=10)

                                                             │ before   │           after           │
                                                             │allocs/op │  allocs/op   vs base       │
  VersionConverter/structured/same-version/fields=0-32          13.000 ± 0%    2.000 ± 0%  -84.62% (p=0.000 n=10)
  VersionConverter/structured/same-version/fields=10-32        105.000 ± 0%    2.000 ± 0%  -98.10% (p=0.000 n=10)
  VersionConverter/structured/same-version/fields=100-32       825.000 ± 0%    2.000 ± 0%  -99.76% (p=0.000 n=10)
  VersionConverter/structured/same-version/fields=1000-32     8029.000 ± 0%    2.000 ± 0%  -99.98% (p=0.000 n=10)
  VersionConverter/structured/cross-version/fields=0-32          23.00 ± 0%    25.00 ± 0%   +8.70% (p=0.000 n=10)
  VersionConverter/unstructured/same-version/fields=0-32          1.000 ± 0%    1.000 ± 0%        ~ (p=1.000 n=10)
  VersionConverter/unstructured/cross-version/fields=0-32        11.00 ± 0%    12.00 ± 0%   +9.09% (p=0.000 n=10)
```

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

While a modest boost to write performance, I don't think this one needs a release note.

```release-note
NONE
```
