### PR TITLE
Skip encoding FieldsV1 on writes if unchanged

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -119,7 +119,7 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730
 	sigs.k8s.io/knftables v0.0.21
 	sigs.k8s.io/randfill v1.0.0
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -260,4 +260,5 @@ replace (
 	k8s.io/sample-cli-plugin => ./staging/src/k8s.io/sample-cli-plugin
 	k8s.io/sample-controller => ./staging/src/k8s.io/sample-controller
 	k8s.io/streaming => ./staging/src/k8s.io/streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/go.sum
+++ b/go.sum
@@ -217,6 +217,8 @@ github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7X
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/joshdk/go-junit v1.0.0 h1:S86cUKIdwBHWwA6xCmFlf3RTLfVXYQfvanM5Uh+K6GE=
 github.com/joshdk/go-junit v1.0.0/go.mod h1:TiiV0PqkaNfFXjEiyjWM3XXrhVyCa1K4Zfga6W52ung=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -529,7 +531,5 @@ sigs.k8s.io/kustomize/kyaml v0.21.1 h1:IVlbmhC076nf6foyL6Taw4BkrLuEsXUXNpsE+ScX7
 sigs.k8s.io/kustomize/kyaml v0.21.1/go.mod h1:hmxADesM3yUN2vbA5z1/YTBnzLJ1dajdqpQonwBL1FQ=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/api/go.mod
+++ b/staging/src/k8s.io/api/go.mod
@@ -29,11 +29,12 @@ require (
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
 replace (
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/streaming => ../streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/staging/src/k8s.io/api/go.sum
+++ b/staging/src/k8s.io/api/go.sum
@@ -27,6 +27,8 @@ github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
@@ -86,7 +88,5 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/apiextensions-apiserver/go.mod
+++ b/staging/src/k8s.io/apiextensions-apiserver/go.mod
@@ -36,7 +36,7 @@ require (
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730
 	sigs.k8s.io/randfill v1.0.0
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -141,4 +141,5 @@ replace (
 	k8s.io/component-base => ../component-base
 	k8s.io/kms => ../kms
 	k8s.io/streaming => ../streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/staging/src/k8s.io/apiextensions-apiserver/go.sum
+++ b/staging/src/k8s.io/apiextensions-apiserver/go.sum
@@ -123,6 +123,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -326,7 +328,5 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/apimachinery/go.mod
+++ b/staging/src/k8s.io/apimachinery/go.mod
@@ -25,7 +25,7 @@ require (
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730
 	sigs.k8s.io/randfill v1.0.0
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -60,4 +60,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace k8s.io/streaming => ../streaming
+replace (
+	k8s.io/streaming => ../streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
+)

--- a/staging/src/k8s.io/apimachinery/go.sum
+++ b/staging/src/k8s.io/apimachinery/go.sum
@@ -53,6 +53,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -129,7 +131,5 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/managedfields.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/managedfields.go
@@ -158,6 +158,13 @@ func BuildManagerIdentifier(encodedManager *metav1.ManagedFieldsEntry) (manager 
 	return string(b), nil
 }
 
+// frozenVersionedSet is a frozen fieldpath.VersionedSet that retains the
+// FieldsV1 it was decoded from.
+type frozenVersionedSet struct {
+	fieldpath.VersionedSet
+	encoded *metav1.FieldsV1
+}
+
 func decodeVersionedSet(encodedVersionedSet *metav1.ManagedFieldsEntry) (versionedSet fieldpath.VersionedSet, err error) {
 	fields := EmptyFields
 	if encodedVersionedSet.FieldsV1 != nil {
@@ -167,7 +174,11 @@ func decodeVersionedSet(encodedVersionedSet *metav1.ManagedFieldsEntry) (version
 	if err != nil {
 		return nil, fmt.Errorf("error decoding set: %v", err)
 	}
-	return fieldpath.NewVersionedSet(&set, fieldpath.APIVersion(encodedVersionedSet.APIVersion), encodedVersionedSet.Operation == metav1.ManagedFieldsOperationApply), nil
+	set.Freeze() // Guard against accidental in-place mutations to the set. Copy-on-write operations are allowed.
+	return &frozenVersionedSet{
+		VersionedSet: fieldpath.NewVersionedSet(&set, fieldpath.APIVersion(encodedVersionedSet.APIVersion), encodedVersionedSet.Operation == metav1.ManagedFieldsOperationApply),
+		encoded:      encodedVersionedSet.FieldsV1,
+	}, nil
 }
 
 // encodeManagedFields converts ManagedFields from the format used by
@@ -238,11 +249,16 @@ func encodeManagerVersionedSet(manager string, versionedSet fieldpath.VersionedS
 		encodedVersionedSet.Operation = metav1.ManagedFieldsOperationApply
 	}
 	encodedVersionedSet.FieldsType = "FieldsV1"
-	fields, err := SetToFields(*versionedSet.Set())
-	if err != nil {
-		return nil, fmt.Errorf("error encoding set: %v", err)
+	if frozenSet, ok := versionedSet.(*frozenVersionedSet); ok && frozenSet.encoded != nil {
+		// Go back the frozenVersionedSet that was originally decoded, just reuse it.
+		encodedVersionedSet.FieldsV1 = frozenSet.encoded
+	} else {
+		fields, err := SetToFields(*versionedSet.Set())
+		if err != nil {
+			return nil, fmt.Errorf("error encoding set: %v", err)
+		}
+		encodedVersionedSet.FieldsV1 = &fields
 	}
-	encodedVersionedSet.FieldsV1 = &fields
 
 	return encodedVersionedSet, nil
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/managedfields_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/managedfields_test.go
@@ -24,6 +24,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
 	"sigs.k8s.io/yaml"
 )
 
@@ -292,6 +293,113 @@ func TestRoundTripManagedFields(t *testing.T) {
 				t.Fatalf("expected:\n%v\nbut got:\n%v", test, string(marshaled))
 			}
 		})
+	}
+}
+
+// TestEncodeReusesRawFieldsOfUnchangedManagers verifies that encoding reuses
+// the decoded FieldsV1 raw bytes for managers whose VersionedSet was not
+// replaced, and re-encodes the set for managers whose VersionedSet was.
+func TestEncodeReusesRawFieldsOfUnchangedManagers(t *testing.T) {
+	var unmarshaled []metav1.ManagedFieldsEntry
+	if err := yaml.Unmarshal([]byte(`- apiVersion: v1
+  fieldsType: FieldsV1
+  fieldsV1:
+    f:spec:
+      f:replicas: {}
+  manager: foo
+  operation: Update
+`), &unmarshaled); err != nil {
+		t.Fatalf("did not expect yaml unmarshalling error but got: %v", err)
+	}
+	decoded, err := DecodeManagedFields(unmarshaled)
+	if err != nil {
+		t.Fatalf("did not expect decoding error but got: %v", err)
+	}
+
+	encoded, err := encodeManagedFields(decoded)
+	if err != nil {
+		t.Fatalf("did not expect encoding error but got: %v", err)
+	}
+	if encoded[0].FieldsV1 != unmarshaled[0].FieldsV1 {
+		t.Errorf("expected unchanged manager to reuse the decoded FieldsV1, got: %s", encoded[0].FieldsV1)
+	}
+
+	for manager, vs := range decoded.Fields() {
+		added := fieldpath.NewSet(fieldpath.MakePathOrDie("spec", "paused"))
+		decoded.Fields()[manager] = fieldpath.NewVersionedSet(vs.Set().Union(added), vs.APIVersion(), vs.Applied())
+	}
+	encoded, err = encodeManagedFields(decoded)
+	if err != nil {
+		t.Fatalf("did not expect encoding error but got: %v", err)
+	}
+	set, err := FieldsToSet(*encoded[0].FieldsV1)
+	if err != nil {
+		t.Fatalf("did not expect decoding error but got: %v", err)
+	}
+	want := fieldpath.NewSet(
+		fieldpath.MakePathOrDie("spec", "paused"),
+		fieldpath.MakePathOrDie("spec", "replicas"),
+	)
+	if !set.Equals(want) {
+		t.Errorf("expected re-encoded set:\n%v\nbut got:\n%v", want, &set)
+	}
+}
+
+func BenchmarkEncodeManagedFields(b *testing.B) {
+	var unmarshaled []metav1.ManagedFieldsEntry
+	if err := yaml.Unmarshal([]byte(`- apiVersion: v1
+  fieldsType: FieldsV1
+  fieldsV1:
+    f:metadata:
+      f:labels:
+        f:app: {}
+      f:name: {}
+    f:spec:
+      f:replicas: {}
+      f:selector:
+        f:matchLabels:
+          f:app: {}
+      f:template:
+        f:metadata:
+          f:labels:
+            f:app: {}
+        f:spec:
+          f:containers:
+            k:{"name":"nginx"}:
+              .: {}
+              f:image: {}
+              f:name: {}
+              f:ports:
+                i:0:
+                  f:containerPort: {}
+  manager: foo
+  operation: Apply
+- apiVersion: v1
+  fieldsType: FieldsV1
+  fieldsV1:
+    f:status:
+      f:availableReplicas: {}
+      f:observedGeneration: {}
+      f:readyReplicas: {}
+      f:replicas: {}
+      f:updatedReplicas: {}
+  manager: bar
+  operation: Update
+  subresource: status
+  time: "2011-12-13T14:15:16Z"
+`), &unmarshaled); err != nil {
+		b.Fatalf("did not expect yaml unmarshalling error but got: %v", err)
+	}
+	decoded, err := DecodeManagedFields(unmarshaled)
+	if err != nil {
+		b.Fatalf("did not expect decoding error but got: %v", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := encodeManagedFields(decoded); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/go.mod
+++ b/staging/src/k8s.io/apiserver/go.mod
@@ -60,7 +60,7 @@ require (
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730
 	sigs.k8s.io/randfill v1.0.0
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -137,4 +137,5 @@ replace (
 	k8s.io/component-base => ../component-base
 	k8s.io/kms => ../kms
 	k8s.io/streaming => ../streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/staging/src/k8s.io/apiserver/go.sum
+++ b/staging/src/k8s.io/apiserver/go.sum
@@ -123,6 +123,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -322,7 +324,5 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/cli-runtime/go.mod
+++ b/staging/src/k8s.io/cli-runtime/go.mod
@@ -74,7 +74,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 // indirect
 )
 
 replace (
@@ -82,4 +82,5 @@ replace (
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/client-go => ../client-go
 	k8s.io/streaming => ../streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/staging/src/k8s.io/cli-runtime/go.sum
+++ b/staging/src/k8s.io/cli-runtime/go.sum
@@ -67,6 +67,8 @@ github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w7
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -169,7 +171,5 @@ sigs.k8s.io/kustomize/kyaml v0.21.1 h1:IVlbmhC076nf6foyL6Taw4BkrLuEsXUXNpsE+ScX7
 sigs.k8s.io/kustomize/kyaml v0.21.1/go.mod h1:hmxADesM3yUN2vbA5z1/YTBnzLJ1dajdqpQonwBL1FQ=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/client-go/go.mod
+++ b/staging/src/k8s.io/client-go/go.mod
@@ -31,7 +31,7 @@ require (
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730
 	sigs.k8s.io/randfill v1.0.0
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -74,4 +74,5 @@ replace (
 	k8s.io/api => ../api
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/streaming => ../streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/staging/src/k8s.io/client-go/go.sum
+++ b/staging/src/k8s.io/client-go/go.sum
@@ -59,6 +59,8 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -139,7 +141,5 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/cloud-provider/go.mod
+++ b/staging/src/k8s.io/cloud-provider/go.mod
@@ -115,7 +115,7 @@ require (
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
@@ -129,4 +129,5 @@ replace (
 	k8s.io/controller-manager => ../controller-manager
 	k8s.io/kms => ../kms
 	k8s.io/streaming => ../streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/staging/src/k8s.io/cloud-provider/go.sum
+++ b/staging/src/k8s.io/cloud-provider/go.sum
@@ -119,6 +119,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -292,7 +294,5 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/cluster-bootstrap/go.mod
+++ b/staging/src/k8s.io/cluster-bootstrap/go.mod
@@ -34,11 +34,12 @@ require (
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 // indirect
 )
 
 replace (
 	k8s.io/api => ../api
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/streaming => ../streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/staging/src/k8s.io/cluster-bootstrap/go.sum
+++ b/staging/src/k8s.io/cluster-bootstrap/go.sum
@@ -28,6 +28,8 @@ github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -96,7 +98,5 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/code-generator/examples/go.mod
+++ b/staging/src/k8s.io/code-generator/examples/go.mod
@@ -64,3 +64,5 @@ replace (
 	k8s.io/apimachinery => ../../apimachinery
 	k8s.io/client-go => ../../client-go
 )
+
+replace sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7

--- a/staging/src/k8s.io/code-generator/examples/go.sum
+++ b/staging/src/k8s.io/code-generator/examples/go.sum
@@ -49,6 +49,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -117,7 +119,5 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/code-generator/go.mod
+++ b/staging/src/k8s.io/code-generator/go.mod
@@ -55,10 +55,11 @@ require (
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 // indirect
 )
 
 replace (
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/streaming => ../streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/staging/src/k8s.io/code-generator/go.sum
+++ b/staging/src/k8s.io/code-generator/go.sum
@@ -53,6 +53,8 @@ github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -156,7 +158,5 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/component-base/go.mod
+++ b/staging/src/k8s.io/component-base/go.mod
@@ -90,7 +90,7 @@ require (
 	k8s.io/api v0.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260519202549-bbf5c5577288 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
@@ -99,4 +99,5 @@ replace (
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/client-go => ../client-go
 	k8s.io/streaming => ../streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/staging/src/k8s.io/component-base/go.sum
+++ b/staging/src/k8s.io/component-base/go.sum
@@ -92,6 +92,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF2
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -229,7 +231,5 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/component-helpers/go.mod
+++ b/staging/src/k8s.io/component-helpers/go.mod
@@ -55,7 +55,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20260519202549-bbf5c5577288 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
@@ -64,4 +64,5 @@ replace (
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/client-go => ../client-go
 	k8s.io/streaming => ../streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/staging/src/k8s.io/component-helpers/go.sum
+++ b/staging/src/k8s.io/component-helpers/go.sum
@@ -54,6 +54,8 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -132,7 +134,5 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/controller-manager/go.mod
+++ b/staging/src/k8s.io/controller-manager/go.mod
@@ -107,7 +107,7 @@ require (
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
@@ -119,4 +119,5 @@ replace (
 	k8s.io/component-base => ../component-base
 	k8s.io/kms => ../kms
 	k8s.io/streaming => ../streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/staging/src/k8s.io/controller-manager/go.sum
+++ b/staging/src/k8s.io/controller-manager/go.sum
@@ -116,6 +116,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -287,7 +289,5 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/cri-client/go.mod
+++ b/staging/src/k8s.io/cri-client/go.mod
@@ -44,4 +44,5 @@ replace (
 	k8s.io/client-go => ../client-go
 	k8s.io/component-base => ../component-base
 	k8s.io/cri-api => ../cri-api
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/staging/src/k8s.io/cri-client/go.sum
+++ b/staging/src/k8s.io/cri-client/go.sum
@@ -52,6 +52,7 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
@@ -140,5 +141,4 @@ k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 h1:AZYQSJemyQB5eRxqcPky+/7EdBj0x
 k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/csi-translation-lib/go.mod
+++ b/staging/src/k8s.io/csi-translation-lib/go.mod
@@ -33,11 +33,12 @@ require (
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 // indirect
 )
 
 replace (
 	k8s.io/api => ../api
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/streaming => ../streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/staging/src/k8s.io/csi-translation-lib/go.sum
+++ b/staging/src/k8s.io/csi-translation-lib/go.sum
@@ -29,6 +29,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -94,7 +96,5 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/dynamic-resource-allocation/go.mod
+++ b/staging/src/k8s.io/dynamic-resource-allocation/go.mod
@@ -86,7 +86,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20260519202549-bbf5c5577288 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
@@ -100,4 +100,5 @@ replace (
 	k8s.io/kms => ../kms
 	k8s.io/kubelet => ../kubelet
 	k8s.io/streaming => ../streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/staging/src/k8s.io/dynamic-resource-allocation/go.sum
+++ b/staging/src/k8s.io/dynamic-resource-allocation/go.sum
@@ -96,6 +96,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDe
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -248,7 +250,5 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/endpointslice/go.mod
+++ b/staging/src/k8s.io/endpointslice/go.mod
@@ -70,7 +70,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20260519202549-bbf5c5577288 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
@@ -80,4 +80,5 @@ replace (
 	k8s.io/client-go => ../client-go
 	k8s.io/component-base => ../component-base
 	k8s.io/streaming => ../streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/staging/src/k8s.io/endpointslice/go.sum
+++ b/staging/src/k8s.io/endpointslice/go.sum
@@ -70,6 +70,8 @@ github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -182,7 +184,5 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/kms/internal/plugins/_mock/go.mod
+++ b/staging/src/k8s.io/kms/internal/plugins/_mock/go.mod
@@ -22,3 +22,5 @@ require (
 )
 
 replace k8s.io/kms => ../../../../kms
+
+replace sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7

--- a/staging/src/k8s.io/kube-aggregator/go.mod
+++ b/staging/src/k8s.io/kube-aggregator/go.mod
@@ -27,7 +27,7 @@ require (
 	k8s.io/streaming v0.0.0
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/randfill v1.0.0
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )
 
 require (
@@ -130,4 +130,5 @@ replace (
 	k8s.io/component-base => ../component-base
 	k8s.io/kms => ../kms
 	k8s.io/streaming => ../streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/staging/src/k8s.io/kube-aggregator/go.sum
+++ b/staging/src/k8s.io/kube-aggregator/go.sum
@@ -118,6 +118,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -298,7 +300,5 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/kube-controller-manager/go.mod
+++ b/staging/src/k8s.io/kube-controller-manager/go.mod
@@ -29,7 +29,7 @@ require (
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 // indirect
 )
 
 replace (
@@ -43,4 +43,5 @@ replace (
 	k8s.io/controller-manager => ../controller-manager
 	k8s.io/kms => ../kms
 	k8s.io/streaming => ../streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/staging/src/k8s.io/kube-controller-manager/go.sum
+++ b/staging/src/k8s.io/kube-controller-manager/go.sum
@@ -46,6 +46,8 @@ github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0/go.mod 
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3/go.mod h1:NbCUVmiS4foBGBHOYlCT25+YmGpJ32dZPi75pGEUpj4=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
@@ -133,7 +135,5 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/kube-proxy/go.mod
+++ b/staging/src/k8s.io/kube-proxy/go.mod
@@ -45,7 +45,7 @@ require (
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
@@ -55,4 +55,5 @@ replace (
 	k8s.io/client-go => ../client-go
 	k8s.io/component-base => ../component-base
 	k8s.io/streaming => ../streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/staging/src/k8s.io/kube-proxy/go.sum
+++ b/staging/src/k8s.io/kube-proxy/go.sum
@@ -46,6 +46,8 @@ github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -150,7 +152,5 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/kube-scheduler/go.mod
+++ b/staging/src/k8s.io/kube-scheduler/go.mod
@@ -80,7 +80,7 @@ require (
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 // indirect
 )
 
 replace (
@@ -94,4 +94,5 @@ replace (
 	k8s.io/kms => ../kms
 	k8s.io/kubelet => ../kubelet
 	k8s.io/streaming => ../streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/staging/src/k8s.io/kube-scheduler/go.sum
+++ b/staging/src/k8s.io/kube-scheduler/go.sum
@@ -86,6 +86,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDe
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -224,7 +226,5 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/kubectl/go.mod
+++ b/staging/src/k8s.io/kubectl/go.mod
@@ -45,7 +45,7 @@ require (
 	sigs.k8s.io/kustomize/kustomize/v5 v5.8.1
 	sigs.k8s.io/kustomize/kyaml v0.21.1
 	sigs.k8s.io/randfill v1.0.0
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -113,4 +113,5 @@ replace (
 	k8s.io/component-helpers => ../component-helpers
 	k8s.io/metrics => ../metrics
 	k8s.io/streaming => ../streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/staging/src/k8s.io/kubectl/go.sum
+++ b/staging/src/k8s.io/kubectl/go.sum
@@ -107,6 +107,8 @@ github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7X
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/joshdk/go-junit v1.0.0 h1:S86cUKIdwBHWwA6xCmFlf3RTLfVXYQfvanM5Uh+K6GE=
 github.com/joshdk/go-junit v1.0.0/go.mod h1:TiiV0PqkaNfFXjEiyjWM3XXrhVyCa1K4Zfga6W52ung=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -261,7 +263,5 @@ sigs.k8s.io/kustomize/kyaml v0.21.1 h1:IVlbmhC076nf6foyL6Taw4BkrLuEsXUXNpsE+ScX7
 sigs.k8s.io/kustomize/kyaml v0.21.1/go.mod h1:hmxADesM3yUN2vbA5z1/YTBnzLJ1dajdqpQonwBL1FQ=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/kubelet/go.mod
+++ b/staging/src/k8s.io/kubelet/go.mod
@@ -51,7 +51,7 @@ require (
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
@@ -61,4 +61,5 @@ replace (
 	k8s.io/client-go => ../client-go
 	k8s.io/component-base => ../component-base
 	k8s.io/streaming => ../streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/staging/src/k8s.io/kubelet/go.sum
+++ b/staging/src/k8s.io/kubelet/go.sum
@@ -59,6 +59,8 @@ github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -181,7 +183,5 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/metrics/go.mod
+++ b/staging/src/k8s.io/metrics/go.mod
@@ -64,7 +64,7 @@ require (
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
@@ -74,4 +74,5 @@ replace (
 	k8s.io/client-go => ../client-go
 	k8s.io/code-generator => ../code-generator
 	k8s.io/streaming => ../streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/staging/src/k8s.io/metrics/go.sum
+++ b/staging/src/k8s.io/metrics/go.sum
@@ -55,6 +55,8 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -140,7 +142,5 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/pod-security-admission/go.mod
+++ b/staging/src/k8s.io/pod-security-admission/go.mod
@@ -112,7 +112,7 @@ require (
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 // indirect
 )
 
 replace (
@@ -123,4 +123,5 @@ replace (
 	k8s.io/component-base => ../component-base
 	k8s.io/kms => ../kms
 	k8s.io/streaming => ../streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/staging/src/k8s.io/pod-security-admission/go.sum
+++ b/staging/src/k8s.io/pod-security-admission/go.sum
@@ -116,6 +116,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -287,7 +289,5 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/sample-apiserver/go.mod
+++ b/staging/src/k8s.io/sample-apiserver/go.mod
@@ -17,7 +17,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20260519202549-bbf5c5577288
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/randfill v1.0.0
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )
 
 require (
@@ -127,4 +127,5 @@ replace (
 	k8s.io/component-base => ../component-base
 	k8s.io/kms => ../kms
 	k8s.io/streaming => ../streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/staging/src/k8s.io/sample-apiserver/go.sum
+++ b/staging/src/k8s.io/sample-apiserver/go.sum
@@ -117,6 +117,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -295,7 +297,5 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/sample-cli-plugin/go.mod
+++ b/staging/src/k8s.io/sample-cli-plugin/go.mod
@@ -70,7 +70,7 @@ require (
 	sigs.k8s.io/kustomize/api v0.21.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.21.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
@@ -80,4 +80,5 @@ replace (
 	k8s.io/cli-runtime => ../cli-runtime
 	k8s.io/client-go => ../client-go
 	k8s.io/streaming => ../streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/staging/src/k8s.io/sample-cli-plugin/go.sum
+++ b/staging/src/k8s.io/sample-cli-plugin/go.sum
@@ -67,6 +67,8 @@ github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w7
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -169,7 +171,5 @@ sigs.k8s.io/kustomize/kyaml v0.21.1 h1:IVlbmhC076nf6foyL6Taw4BkrLuEsXUXNpsE+ScX7
 sigs.k8s.io/kustomize/kyaml v0.21.1/go.mod h1:hmxADesM3yUN2vbA5z1/YTBnzLJ1dajdqpQonwBL1FQ=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/staging/src/k8s.io/sample-controller/go.mod
+++ b/staging/src/k8s.io/sample-controller/go.mod
@@ -15,7 +15,7 @@ require (
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/kube-openapi v0.0.0-20260519202549-bbf5c5577288
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )
 
 require (
@@ -71,4 +71,5 @@ replace (
 	k8s.io/client-go => ../client-go
 	k8s.io/code-generator => ../code-generator
 	k8s.io/streaming => ../streaming
+	sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 )

--- a/staging/src/k8s.io/sample-controller/go.sum
+++ b/staging/src/k8s.io/sample-controller/go.sum
@@ -55,6 +55,8 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 h1:4UH3S+zEiPQiJbYHuocxQmuBI/IVMrQtUMG20fC5u9A=
+github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -141,7 +143,5 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
-sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1334,7 +1334,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 ## explicit; go 1.18
 sigs.k8s.io/randfill
 sigs.k8s.io/randfill/bytesource
-# sigs.k8s.io/structured-merge-diff/v6 v6.4.0
+# sigs.k8s.io/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7
 ## explicit; go 1.23
 sigs.k8s.io/structured-merge-diff/v6/fieldpath
 sigs.k8s.io/structured-merge-diff/v6/merge
@@ -1345,3 +1345,4 @@ sigs.k8s.io/structured-merge-diff/v6/value
 ## explicit; go 1.22
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/kyaml
+# sigs.k8s.io/structured-merge-diff/v6 => github.com/jpbetz/structured-merge-diff/v6 v6.3.3-0.20260618013952-2dbe2afc5ae7

--- a/vendor/sigs.k8s.io/structured-merge-diff/v6/fieldpath/element.go
+++ b/vendor/sigs.k8s.io/structured-merge-diff/v6/fieldpath/element.go
@@ -227,6 +227,14 @@ func KeyByFields(nameValues ...interface{}) *value.FieldList {
 // TODO: serialize as a list.
 type PathElementSet struct {
 	members sortedPathElements
+
+	// frozen marks the PathElementSet as read-only.
+	frozen bool
+}
+
+// freeze marks the set read-only.
+func (s *PathElementSet) freeze() {
+	s.frozen = true
 }
 
 func MakePathElementSet(size int) PathElementSet {
@@ -254,7 +262,11 @@ func (s PathElementSet) Copy() PathElementSet {
 }
 
 // Insert adds pe to the set.
+// Insert panics if the set has been frozen.
 func (s *PathElementSet) Insert(pe PathElement) {
+	if s.frozen {
+		panic("fieldpath: Insert called on a frozen Set")
+	}
 	loc, found := slices.BinarySearchFunc(s.members, pe, func(a, b PathElement) int {
 		return a.Compare(b)
 	})

--- a/vendor/sigs.k8s.io/structured-merge-diff/v6/fieldpath/serialize-pe.go
+++ b/vendor/sigs.k8s.io/structured-merge-diff/v6/fieldpath/serialize-pe.go
@@ -97,6 +97,14 @@ func DeserializePathElement(s string) (PathElement, error) {
 		if err != nil {
 			return PathElement{}, err
 		}
+		// Lookahead validates that there is no unexpected trailing data.
+		// io.EOF is a successful termination indicator; all other errors or trailing data fail.
+		if iter.WhatIsNext(); iter.Error != io.EOF {
+			if iter.Error == nil {
+				iter.ReportError("managedFields parsing", "unexpected trailing data after JSON object")
+			}
+			return PathElement{}, iter.Error
+		}
 		return PathElement{Value: &v}, nil
 	case peKeySepBytes[0]:
 		iter := readPool.BorrowIterator(b)
@@ -112,8 +120,16 @@ func DeserializePathElement(s string) (PathElement, error) {
 			fields = append(fields, value.Field{Name: key, Value: v})
 			return true
 		})
+		// Lookahead validates that there is no unexpected trailing data.
+		// io.EOF is a successful termination indicator; all other errors or trailing data fail.
+		if iter.WhatIsNext(); iter.Error != io.EOF {
+			if iter.Error == nil {
+				iter.ReportError("managedFields parsing", "unexpected trailing data after JSON object")
+			}
+			return PathElement{}, iter.Error
+		}
 		fields.Sort()
-		return PathElement{Key: &fields}, iter.Error
+		return PathElement{Key: &fields}, nil
 	case peIndexSepBytes[0]:
 		i, err := strconv.Atoi(s[2:])
 		if err != nil {

--- a/vendor/sigs.k8s.io/structured-merge-diff/v6/fieldpath/serialize.go
+++ b/vendor/sigs.k8s.io/structured-merge-diff/v6/fieldpath/serialize.go
@@ -165,7 +165,11 @@ func (s *Set) emitContentsV1(includeSelf bool, stream *jsoniter.Stream, r *reusa
 }
 
 // FromJSON clears s and reads a JSON formatted set structure.
+// FromJSON panics if the Set has been frozen.
 func (s *Set) FromJSON(r io.Reader) error {
+	if s.frozen {
+		panic("fieldpath: FromJSON called on a frozen Set")
+	}
 	// The iterator pool is completely useless for memory management, grrr.
 	iter := jsoniter.Parse(jsoniter.ConfigCompatibleWithStandardLibrary, r, 4096)
 
@@ -174,6 +178,17 @@ func (s *Set) FromJSON(r io.Reader) error {
 		*s = Set{}
 	} else {
 		*s = *found
+	}
+	if iter.Error != nil {
+		return iter.Error
+	}
+	if iter.WhatIsNext(); iter.Error == nil {
+		// Piggy back on scanner aware error reporting here.
+		iter.ReportError("managedFields parsing", "unexpected trailing data after JSON object")
+		return iter.Error
+	}
+	if iter.Error == io.EOF {
+		return nil
 	}
 	return iter.Error
 }

--- a/vendor/sigs.k8s.io/structured-merge-diff/v6/fieldpath/set.go
+++ b/vendor/sigs.k8s.io/structured-merge-diff/v6/fieldpath/set.go
@@ -38,6 +38,9 @@ type Set struct {
 	// members of the set. Appearance in this list does not imply membership.
 	// Note: this is a tree, not an arbitrary graph.
 	Children SetNodeMap
+
+	// frozen marks this Set as read-only.
+	frozen bool
 }
 
 // NewSet makes a set from a list of paths.
@@ -51,6 +54,7 @@ func NewSet(paths ...Path) *Set {
 
 // Copy returns a copy of the Set.
 // This is not a full deep copy as any contained value.Value is not copied.
+// The returned Set is not frozen.
 func (s *Set) Copy() *Set {
 	return &Set{
 		Members:  s.Members.Copy(),
@@ -58,9 +62,30 @@ func (s *Set) Copy() *Set {
 	}
 }
 
+// Freeze marks the Set as read-only. Calling functions that mutate state
+// results in a panic. The Members and Children are also frozen.
+//
+// Freeze only guards the set's structure. It does not deep-copy the contained
+// PathElements and Values as these types are expected to be treated as
+// immutable across structured-merge-diff.
+//
+// Freeze is not airtight. It is designed to ensure well-behaved consumers of
+// this API do not accidentally mutate Sets that are intended to be read-only
+// but it does not prevent all possible forms of mutation.
+func (s *Set) Freeze() *Set {
+	s.frozen = true
+	s.Members.freeze()
+	s.Children.freeze()
+	return s
+}
+
 // Insert adds the field identified by `p` to the set. Important: parent fields
 // are NOT added to the set; if that is desired, they must be added separately.
+// Insert panics if the Set has been frozen.
 func (s *Set) Insert(p Path) {
+	if s.frozen {
+		panic("fieldpath: Insert called on a frozen Set")
+	}
 	if len(p) == 0 {
 		// Zero-length path identifies the entire object; we don't
 		// track top-level ownership.
@@ -465,6 +490,17 @@ type setNode struct {
 // SetNodeMap is a map of PathElement to subset.
 type SetNodeMap struct {
 	members sortedSetNode
+
+	// frozen marks the SetNodeMap as read-ohnly.
+	frozen bool
+}
+
+// freeze marks the map read-only and freezes every child Set.
+func (s *SetNodeMap) freeze() {
+	s.frozen = true
+	for i := range s.members {
+		s.members[i].set.Freeze()
+	}
 }
 
 type sortedSetNode []setNode
@@ -486,7 +522,11 @@ func (s *SetNodeMap) Copy() SetNodeMap {
 }
 
 // Descend adds pe to the set if necessary, returning the associated subset.
+// Descend panics if the set has been frozen.
 func (s *SetNodeMap) Descend(pe PathElement) *Set {
+	if s.frozen {
+		panic("fieldpath: Descend called on a frozen Set")
+	}
 	loc, found := slices.BinarySearchFunc(s.members, pe, func(a setNode, b PathElement) int {
 		return a.pathElement.Compare(b)
 	})

--- a/vendor/sigs.k8s.io/structured-merge-diff/v6/value/reflectcache.go
+++ b/vendor/sigs.k8s.io/structured-merge-diff/v6/value/reflectcache.go
@@ -39,14 +39,28 @@ type UnstructuredConverter interface {
 	ToUnstructured() interface{}
 }
 
+// UnstructuredConverterWithError is implemented instead of UnstructuredConverter by types for which
+// some, but not all, values can be converted directly to unstructured. If a type implements both
+// UnstructuredConverter and UnstructuredConverterWithError, its UnstructuredConverterWithError
+// implementation takes precedence during conversion.
+type UnstructuredConverterWithError interface {
+	json.Marshaler // require that json.Marshaler is implemented
+
+	// ToUnstructured returns the unstructured representation, or a non-nil error if the value
+	// cannot be converted to unstructured.
+	ToUnstructuredWithError() (any, error)
+}
+
 // TypeReflectCacheEntry keeps data gathered using reflection about how a type is converted to/from unstructured.
 type TypeReflectCacheEntry struct {
-	isJsonMarshaler        bool
-	ptrIsJsonMarshaler     bool
-	isJsonUnmarshaler      bool
-	ptrIsJsonUnmarshaler   bool
-	isStringConvertable    bool
-	ptrIsStringConvertable bool
+	isJsonMarshaler                     bool
+	ptrIsJsonMarshaler                  bool
+	isJsonUnmarshaler                   bool
+	ptrIsJsonUnmarshaler                bool
+	isUnstructuredConverter             bool
+	ptrIsUnstructuredConverter          bool
+	isUnstructuredConverterWithError    bool
+	ptrIsUnstructuredConverterWithError bool
 
 	structFields        map[string]*FieldCacheEntry
 	orderedStructFields []*FieldCacheEntry
@@ -93,9 +107,10 @@ func (f *FieldCacheEntry) GetFrom(structVal reflect.Value) reflect.Value {
 	return structVal
 }
 
-var marshalerType = reflect.TypeOf(new(json.Marshaler)).Elem()
-var unmarshalerType = reflect.TypeOf(new(json.Unmarshaler)).Elem()
-var unstructuredConvertableType = reflect.TypeOf(new(UnstructuredConverter)).Elem()
+var marshalerType = reflect.TypeFor[json.Marshaler]()
+var unmarshalerType = reflect.TypeFor[json.Unmarshaler]()
+var unstructuredConverterType = reflect.TypeFor[UnstructuredConverter]()
+var unstructuredConverterWithErrorType = reflect.TypeFor[UnstructuredConverterWithError]()
 var defaultReflectCache = newReflectCache()
 
 // TypeReflectEntryOf returns the TypeReflectCacheEntry of the provided reflect.Type.
@@ -122,11 +137,13 @@ func typeReflectEntryOf(cm reflectCacheMap, t reflect.Type, updates reflectCache
 		return record
 	}
 	typeEntry := &TypeReflectCacheEntry{
-		isJsonMarshaler:        t.Implements(marshalerType),
-		ptrIsJsonMarshaler:     reflect.PtrTo(t).Implements(marshalerType),
-		isJsonUnmarshaler:      reflect.PtrTo(t).Implements(unmarshalerType),
-		isStringConvertable:    t.Implements(unstructuredConvertableType),
-		ptrIsStringConvertable: reflect.PtrTo(t).Implements(unstructuredConvertableType),
+		isJsonMarshaler:                     t.Implements(marshalerType),
+		ptrIsJsonMarshaler:                  reflect.PointerTo(t).Implements(marshalerType),
+		isJsonUnmarshaler:                   reflect.PointerTo(t).Implements(unmarshalerType),
+		isUnstructuredConverter:             t.Implements(unstructuredConverterType),
+		ptrIsUnstructuredConverter:          reflect.PointerTo(t).Implements(unstructuredConverterType),
+		isUnstructuredConverterWithError:    t.Implements(unstructuredConverterWithErrorType),
+		ptrIsUnstructuredConverterWithError: reflect.PointerTo(t).Implements(unstructuredConverterWithErrorType),
 	}
 	if t.Kind() == reflect.Struct {
 		fieldEntries := map[string]*FieldCacheEntry{}
@@ -190,7 +207,7 @@ func (e TypeReflectCacheEntry) OrderedFields() []*FieldCacheEntry {
 
 // CanConvertToUnstructured returns true if this TypeReflectCacheEntry can convert values of its type to unstructured.
 func (e TypeReflectCacheEntry) CanConvertToUnstructured() bool {
-	return e.isJsonMarshaler || e.ptrIsJsonMarshaler || e.isStringConvertable || e.ptrIsStringConvertable
+	return e.isJsonMarshaler || e.ptrIsJsonMarshaler || e.isUnstructuredConverter || e.ptrIsUnstructuredConverter || e.isUnstructuredConverterWithError || e.ptrIsUnstructuredConverterWithError
 }
 
 // ToUnstructured converts the provided value to unstructured and returns it.
@@ -206,7 +223,7 @@ func (e TypeReflectCacheEntry) ToUnstructured(sv reflect.Value) (interface{}, er
 	// Check if the object has a custom string converter and use it if available, since it is much more efficient
 	// than round tripping through json.
 	if converter, ok := e.getUnstructuredConverter(sv); ok {
-		return converter.ToUnstructured(), nil
+		return converter.ToUnstructuredWithError()
 	}
 	// Check if the object has a custom JSON marshaller/unmarshaller.
 	if marshaler, ok := e.getJsonMarshaler(sv); ok {
@@ -318,16 +335,26 @@ func (e TypeReflectCacheEntry) getJsonUnmarshaler(v reflect.Value) (json.Unmarsh
 	return v.Addr().Interface().(json.Unmarshaler), true
 }
 
-func (e TypeReflectCacheEntry) getUnstructuredConverter(v reflect.Value) (UnstructuredConverter, bool) {
-	if e.isStringConvertable {
-		return v.Interface().(UnstructuredConverter), true
-	}
-	if e.ptrIsStringConvertable {
+type unstructuredConverterWithNilError struct {
+	UnstructuredConverter
+}
+
+func (c unstructuredConverterWithNilError) ToUnstructuredWithError() (any, error) {
+	return c.UnstructuredConverter.ToUnstructured(), nil
+}
+
+func (e TypeReflectCacheEntry) getUnstructuredConverter(v reflect.Value) (UnstructuredConverterWithError, bool) {
+	switch {
+	case e.isUnstructuredConverterWithError:
+		return v.Interface().(UnstructuredConverterWithError), true
+	case e.ptrIsUnstructuredConverterWithError && v.CanAddr():
 		// Check pointer receivers if v is not a pointer
-		if v.CanAddr() {
-			v = v.Addr()
-			return v.Interface().(UnstructuredConverter), true
-		}
+		return v.Addr().Interface().(UnstructuredConverterWithError), true
+	case e.isUnstructuredConverter:
+		return unstructuredConverterWithNilError{v.Interface().(UnstructuredConverter)}, true
+	case e.ptrIsUnstructuredConverter && v.CanAddr():
+		// Check pointer receivers if v is not a pointer
+		return unstructuredConverterWithNilError{v.Addr().Interface().(UnstructuredConverter)}, true
 	}
 	return nil, false
 }

--- a/vendor/sigs.k8s.io/structured-merge-diff/v6/value/value.go
+++ b/vendor/sigs.k8s.io/structured-merge-diff/v6/value/value.go
@@ -118,6 +118,11 @@ func readJSONIter(iter *jsoniter.Iterator) (Value, error) {
 	if iter.Error != nil && iter.Error != io.EOF {
 		return nil, iter.Error
 	}
+	if iter.WhatIsNext(); iter.Error == nil {
+		// Piggy back on scanner aware error reporting here.
+		iter.ReportError("managedFields parsing", "unexpected trailing data after JSON object")
+		return nil, iter.Error
+	}
 	return NewValueInterface(v), nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

Many writes do not require changes to the field ownership tracked by FieldsV1. 

#### Which issue(s) this PR is related to:

While the micro-benchmark looks OK:

```
goos: linux
goarch: amd64
pkg: k8s.io/apimachinery/pkg/util/managedfields/internal
cpu: 13th Gen Intel(R) Core(TM) i9-13900K
                           │ /tmp/freeze-bench/encscale_old.txt │ /tmp/freeze-bench/encscale_new.txt  │
                           │               sec/op               │   sec/op     vs base                │
EncodeScale/managers=1-32                          1550.5n ± 4%   879.0n ± 4%  -43.31% (p=0.000 n=10)
EncodeScale/managers=2-32                           3.150µ ± 2%   1.811µ ± 3%  -42.52% (p=0.000 n=10)
EncodeScale/managers=5-32                           7.856µ ± 2%   4.667µ ± 6%  -40.60% (p=0.000 n=10)
EncodeScale/managers=10-32                         16.242µ ± 5%   9.598µ ± 7%  -40.91% (p=0.000 n=10)
EncodeScale/managers=20-32                          33.21µ ± 4%   20.23µ ± 6%  -39.10% (p=0.000 n=10)
EncodeScale/managers=50-32                          83.29µ ± 5%   49.44µ ± 6%  -40.64% (p=0.000 n=10)
geomean                                             10.95µ        6.439µ       -41.20%

                           │ /tmp/freeze-bench/encscale_old.txt │  /tmp/freeze-bench/encscale_new.txt  │
                           │                B/op                │     B/op      vs base                │
EncodeScale/managers=1-32                           1021.0 ± 0%     520.0 ± 0%  -49.07% (p=0.000 n=10)
EncodeScale/managers=2-32                          2.206Ki ± 0%   1.227Ki ± 0%  -44.40% (p=0.000 n=10)
EncodeScale/managers=5-32                          6.100Ki ± 0%   3.648Ki ± 0%  -40.19% (p=0.000 n=10)
EncodeScale/managers=10-32                        12.255Ki ± 0%   7.352Ki ± 0%  -40.01% (p=0.000 n=10)
EncodeScale/managers=20-32                         25.22Ki ± 0%   15.26Ki ± 0%  -39.49% (p=0.000 n=10)
EncodeScale/managers=50-32                         60.09Ki ± 0%   34.98Ki ± 0%  -41.79% (p=0.000 n=10)
geomean                                            7.932Ki        4.554Ki       -42.59%

                           │ /tmp/freeze-bench/encscale_old.txt │ /tmp/freeze-bench/encscale_new.txt │
                           │             allocs/op              │ allocs/op   vs base                │
EncodeScale/managers=1-32                            18.00 ± 0%   11.00 ± 0%  -38.89% (p=0.000 n=10)
EncodeScale/managers=2-32                            37.00 ± 0%   23.00 ± 0%  -37.84% (p=0.000 n=10)
EncodeScale/managers=5-32                            88.00 ± 0%   52.00 ± 0%  -40.91% (p=0.000 n=10)
EncodeScale/managers=10-32                          171.00 ± 0%   98.00 ± 0%  -42.69% (p=0.000 n=10)
EncodeScale/managers=20-32                           334.0 ± 0%   189.0 ± 0%  -43.41% (p=0.000 n=10)
EncodeScale/managers=50-32                           822.0 ± 0%   460.0 ± 0%  -44.04% (p=0.000 n=10)
geomean                                              118.4        69.44       -41.34%
```

The cost of freezing the set makes this slightly negative for broader benchmarks:

```
goos: linux
goarch: amd64
pkg: k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager
cpu: 13th Gen Intel(R) Core(TM) i9-13900K
                                   │ /tmp/freeze-bench/fm2_old.txt │   /tmp/freeze-bench/fm2_new.txt    │
                                   │            sec/op             │   sec/op     vs base               │
NewObject/Pod/Update-32                                117.3µ ± 2%   125.8µ ± 2%  +7.25% (p=0.000 n=10)
NewObject/Pod/UpdateTwice-32                           272.1µ ± 1%   274.5µ ± 2%       ~ (p=0.190 n=10)
NewObject/Pod/Apply-32                                 153.4µ ± 2%   151.9µ ± 3%       ~ (p=0.796 n=10)
NewObject/Pod/UpdateApply-32                           684.4µ ± 2%   683.5µ ± 3%       ~ (p=0.739 n=10)
NewObject/Node/Update-32                               200.0µ ± 2%   201.8µ ± 3%       ~ (p=0.684 n=10)
NewObject/Node/UpdateTwice-32                          457.9µ ± 2%   449.5µ ± 3%       ~ (p=0.123 n=10)
NewObject/Node/Apply-32                                256.0µ ± 3%   263.4µ ± 6%       ~ (p=0.052 n=10)
NewObject/Node/UpdateApply-32                          1.058m ± 2%   1.053m ± 2%       ~ (p=0.353 n=10)
NewObject/Endpoints/Update-32                          745.4µ ± 3%   748.1µ ± 4%       ~ (p=0.353 n=10)
NewObject/Endpoints/UpdateTwice-32                     2.927m ± 4%   3.038m ± 4%       ~ (p=0.089 n=10)
NewObject/Endpoints/Apply-32                           593.4µ ± 2%   590.6µ ± 4%       ~ (p=0.739 n=10)
NewObject/Endpoints/UpdateApply-32                     4.882m ± 2%   4.922m ± 3%       ~ (p=0.912 n=10)
RepeatedUpdate-32                                      117.6µ ± 3%   121.2µ ± 3%  +3.05% (p=0.015 n=10)
geomean                                                474.5µ        480.2µ       +1.21%

                                   │ /tmp/freeze-bench/fm2_old.txt │    /tmp/freeze-bench/fm2_new.txt     │
                                   │             B/op              │     B/op       vs base               │
NewObject/Pod/Update-32                               74.31Ki ± 0%    79.39Ki ± 0%  +6.84% (p=0.000 n=10)
NewObject/Pod/UpdateTwice-32                          157.3Ki ± 0%    154.7Ki ± 0%  -1.67% (p=0.000 n=10)
NewObject/Pod/Apply-32                                98.24Ki ± 0%   100.44Ki ± 0%  +2.24% (p=0.000 n=10)
NewObject/Pod/UpdateApply-32                          416.7Ki ± 0%    415.0Ki ± 0%  -0.40% (p=0.000 n=10)
NewObject/Node/Update-32                              128.8Ki ± 0%    135.0Ki ± 0%  +4.82% (p=0.000 n=10)
NewObject/Node/UpdateTwice-32                         282.1Ki ± 0%    277.7Ki ± 0%  -1.56% (p=0.000 n=10)
NewObject/Node/Apply-32                               155.9Ki ± 0%    158.2Ki ± 0%  +1.50% (p=0.000 n=10)
NewObject/Node/UpdateApply-32                         657.4Ki ± 0%    653.9Ki ± 0%  -0.54% (p=0.000 n=10)
NewObject/Endpoints/Update-32                         211.7Ki ± 0%    212.5Ki ± 0%  +0.35% (p=0.000 n=10)
NewObject/Endpoints/UpdateTwice-32                    1.514Mi ± 0%    1.516Mi ± 0%  +0.15% (p=0.001 n=10)
NewObject/Endpoints/Apply-32                          214.3Ki ± 0%    215.0Ki ± 0%  +0.35% (p=0.000 n=10)
NewObject/Endpoints/UpdateApply-32                    2.198Mi ± 0%    2.199Mi ± 0%       ~ (p=0.436 n=10)
RepeatedUpdate-32                                     74.46Ki ± 0%    79.56Ki ± 0%  +6.85% (p=0.000 n=10)
geomean                                               256.7Ki         260.3Ki       +1.42%

                                   │ /tmp/freeze-bench/fm2_old.txt │   /tmp/freeze-bench/fm2_new.txt    │
                                   │           allocs/op           │  allocs/op   vs base               │
NewObject/Pod/Update-32                                1.458k ± 0%   1.482k ± 0%  +1.65% (p=0.000 n=10)
NewObject/Pod/UpdateTwice-32                           3.105k ± 0%   3.179k ± 0%  +2.38% (p=0.000 n=10)
NewObject/Pod/Apply-32                                 1.805k ± 0%   1.807k ± 0%  +0.11% (p=0.000 n=10)
NewObject/Pod/UpdateApply-32                           8.151k ± 0%   8.233k ± 0%  +1.01% (p=0.000 n=10)
NewObject/Node/Update-32                               2.480k ± 0%   2.556k ± 0%  +3.06% (p=0.000 n=10)
NewObject/Node/UpdateTwice-32                          6.061k ± 0%   6.312k ± 0%  +4.13% (p=0.000 n=10)
NewObject/Node/Apply-32                                2.809k ± 0%   2.811k ± 0%  +0.07% (p=0.000 n=10)
NewObject/Node/UpdateApply-32                          14.03k ± 0%   14.29k ± 0%  +1.82% (p=0.000 n=10)
NewObject/Endpoints/Update-32                          6.252k ± 0%   6.250k ± 0%       ~ (p=0.637 n=10)
NewObject/Endpoints/UpdateTwice-32                     31.85k ± 0%   31.87k ± 0%       ~ (p=0.055 n=10)
NewObject/Endpoints/Apply-32                           6.354k ± 0%   6.357k ± 0%       ~ (p=0.082 n=10)
NewObject/Endpoints/UpdateApply-32                     45.94k ± 0%   45.93k ± 0%       ~ (p=0.342 n=10)
RepeatedUpdate-32                                      1.460k ± 0%   1.485k ± 0%  +1.71% (p=0.000 n=10)
geomean                                                5.404k        5.470k       +1.22%
```

Even an ideal case pod with multiple managers only shows minimal gain:

```
goos: linux
goarch: amd64
pkg: k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager
cpu: 13th Gen Intel(R) Core(TM) i9-13900K
                               │ /tmp/freeze-bench/exemplar_old.txt │ /tmp/freeze-bench/exemplar_new.txt │
                               │               sec/op               │   sec/op     vs base               │
ApplyExemplarPod/managers=1-32                          1.940m ± 6%   1.932m ± 6%       ~ (p=0.684 n=10)
ApplyExemplarPod/managers=2-32                          2.437m ± 2%   2.368m ± 3%  -2.83% (p=0.007 n=10)
ApplyExemplarPod/managers=4-32                          3.279m ± 4%   3.335m ± 2%       ~ (p=0.190 n=10)
ApplyExemplarPod/managers=8-32                          5.225m ± 5%   5.087m ± 4%  -2.63% (p=0.043 n=10)
geomean                                                 3.000m        2.968m       -1.05%

                               │ /tmp/freeze-bench/exemplar_old.txt │ /tmp/freeze-bench/exemplar_new.txt  │
                               │                B/op                │     B/op      vs base               │
ApplyExemplarPod/managers=1-32                         1.395Mi ± 0%   1.449Mi ± 0%  +3.87% (p=0.000 n=10)
ApplyExemplarPod/managers=2-32                         1.824Mi ± 0%   1.854Mi ± 0%  +1.69% (p=0.000 n=10)
ApplyExemplarPod/managers=4-32                         2.677Mi ± 0%   2.663Mi ± 0%  -0.55% (p=0.000 n=10)
ApplyExemplarPod/managers=8-32                         4.377Mi ± 0%   4.273Mi ± 0%  -2.37% (p=0.000 n=10)
geomean                                                2.337Mi        2.352Mi       +0.63%

                               │ /tmp/freeze-bench/exemplar_old.txt │ /tmp/freeze-bench/exemplar_new.txt │
                               │             allocs/op              │  allocs/op   vs base               │
ApplyExemplarPod/managers=1-32                          22.00k ± 0%   22.00k ± 0%  +0.02% (p=0.044 n=10)
ApplyExemplarPod/managers=2-32                          28.75k ± 0%   28.73k ± 0%  -0.08% (p=0.000 n=10)
ApplyExemplarPod/managers=4-32                          42.24k ± 0%   42.17k ± 0%  -0.16% (p=0.000 n=10)
ApplyExemplarPod/managers=8-32                          69.20k ± 0%   69.04k ± 0%  -0.23% (p=0.000 n=10)
geomean                                                 36.87k        36.83k       -0.11%
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
