### PR TITLE
Dump full config on kubelet startup instead of command line arguments

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -129,6 +129,7 @@ import (
 	"k8s.io/utils/cpuset"
 	"k8s.io/utils/exec"
 	netutils "k8s.io/utils/net"
+	"sigs.k8s.io/yaml"
 )
 
 func init() {
@@ -249,10 +250,19 @@ is checked every 20 seconds (also configurable with a flag).`,
 			if err := logsapi.ValidateAndApplyAsField(&kubeletConfig.Logging, utilfeature.DefaultFeatureGate, field.NewPath("logging")); err != nil {
 				return fmt.Errorf("initialize logging: %v", err)
 			}
+			// Dump the full effective KubeletConfiguration.
+			if cfgStr, err := marshalKubeletConfigForLog(kubeletConfig); err != nil {
+				// Logging must never block startup; log the error and continue.
+				logger.Error(err, "Failed to marshal effective KubeletConfiguration for logging")
+			} else {
+				logger.Info("Effective KubeletConfiguration", "config", cfgStr)
+			}
+			// Node-specific flags that are not part of KubeletConfiguration (e.g.
+			// --hostname-override, --kubeconfig, --node-ip, --cert-dir) come straight from the
+			// command line and remain accurate, so they stay available for debugging.
 			cliflag.PrintFlags(cleanFlagSet)
 
 			// We always validate the local configuration (command line + config file).
-			// This is the default "last-known-good" config for dynamic config, and must always remain valid.
 			if err := kubeletconfigvalidation.ValidateKubeletConfiguration(kubeletConfig, utilfeature.DefaultFeatureGate); err != nil {
 				return fmt.Errorf("failed to validate kubelet configuration, error: %w, path: %s", err, kubeletConfig)
 			}
@@ -284,21 +294,12 @@ is checked every 20 seconds (also configurable with a flag).`,
 				logger.Error(err, "Kubelet running with insufficient permissions")
 			}
 
-			// make the kubelet's config safe for logging
-			config := kubeletServer.KubeletConfiguration.DeepCopy()
-			for k := range config.StaticPodURLHeader {
-				config.StaticPodURLHeader[k] = []string{"<masked>"}
-			}
-
 			// Log skipped drop-in files if any were encountered during configuration merge
 			if len(skippedDropinFiles) > 0 {
 				for _, skippedFile := range skippedDropinFiles {
 					logger.V(4).Info("Skipped file in drop-in directory (does not have .conf extension)", "file", skippedFile)
 				}
 			}
-
-			// log the kubelet's config for inspection
-			logger.V(5).Info("KubeletConfiguration", "configuration", klog.Format(config))
 
 			// set up signal context for kubelet shutdown
 			ctx := genericapiserver.SetupSignalContext()
@@ -555,17 +556,49 @@ func Run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Depend
 	return nil
 }
 
-func setConfigz(cz *configz.Config, kc *kubeletconfiginternal.KubeletConfiguration) error {
+// convertToVersionedKubeletConfig converts the internal KubeletConfiguration to the
+// external kubelet.config.k8s.io/v1beta1 representation and stamps the GroupVersionKind.
+// This is the same conversion that /configz performs, so callers that want to surface the
+// effective configuration in the exact form served by /configz can share this single path.
+func convertToVersionedKubeletConfig(kc *kubeletconfiginternal.KubeletConfiguration) (*kubeletconfigv1beta1.KubeletConfiguration, error) {
 	scheme, _, err := kubeletscheme.NewSchemeAndCodecs()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	versioned := &kubeletconfigv1beta1.KubeletConfiguration{}
 	if err := scheme.Convert(kc, versioned, nil); err != nil {
-		return err
+		return nil, err
 	}
 	versioned.GetObjectKind().SetGroupVersionKind(kubeletconfigv1beta1.SchemeGroupVersion.WithKind("KubeletConfiguration"))
+	return versioned, nil
+}
+
+func setConfigz(cz *configz.Config, kc *kubeletconfiginternal.KubeletConfiguration) error {
+	versioned, err := convertToVersionedKubeletConfig(kc)
+	if err != nil {
+		return err
+	}
 	return cz.Set(versioned)
+}
+
+// marshalKubeletConfigForLog renders the effective KubeletConfiguration as a human-readable
+// YAML string for startup logging. The output mirrors what /configz serves except the
+// sensitive field StaticPodURLHeader is masked while /configz outputs it.
+func marshalKubeletConfigForLog(kc *kubeletconfiginternal.KubeletConfiguration) (string, error) {
+	// Make the config safe for logging without mutating the caller's copy.
+	safe := kc.DeepCopy()
+	for k := range safe.StaticPodURLHeader {
+		safe.StaticPodURLHeader[k] = []string{"<masked>"}
+	}
+	versioned, err := convertToVersionedKubeletConfig(safe)
+	if err != nil {
+		return "", err
+	}
+	data, err := yaml.Marshal(versioned)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
 }
 
 func initConfigz(ctx context.Context, kc *kubeletconfiginternal.KubeletConfiguration) error {

--- a/cmd/kubelet/app/server_test.go
+++ b/cmd/kubelet/app/server_test.go
@@ -553,3 +553,37 @@ readOnlyPort: 9999
 		})
 	}
 }
+
+func TestMarshalKubeletConfigForLog(t *testing.T) {
+	kc := &kubeletconfiginternal.KubeletConfiguration{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KubeletConfiguration",
+			APIVersion: "kubelet.config.k8s.io/v1beta1",
+		},
+		// Non-default values that must round-trip into the marshaled output.
+		FailSwapOn:   false,
+		EvictionHard: map[string]string{"memory.available": "200Mi"},
+		// Sensitive field that must be masked.
+		StaticPodURLHeader: map[string][]string{
+			"Authorization": {"Bearer super-secret-token"},
+		},
+	}
+
+	out, err := marshalKubeletConfigForLog(kc)
+	require.NoError(t, err)
+
+	// (2) The output carries the external GroupVersionKind, mirroring /configz.
+	require.Contains(t, out, "apiVersion: kubelet.config.k8s.io/v1beta1")
+	require.Contains(t, out, "kind: KubeletConfiguration")
+
+	// (1) Non-default effective values are present.
+	require.Contains(t, out, "failSwapOn: false")
+	require.Contains(t, out, "memory.available: 200Mi")
+
+	// (3) Sensitive StaticPodURLHeader values are masked, never leaked.
+	require.Contains(t, out, "<masked>")
+	require.NotContains(t, out, "super-secret-token")
+
+	// The helper must not mutate the caller's config when masking.
+	require.Equal(t, []string{"Bearer super-secret-token"}, kc.StaticPodURLHeader["Authorization"])
+}

--- a/test/e2e_node/kubelet_config_dir_test.go
+++ b/test/e2e_node/kubelet_config_dir_test.go
@@ -186,6 +186,41 @@ featureGates:
 			// Compare the expected config with the merged config
 			gomega.Expect(initialConfig).To(gomega.BeComparableTo(mergedConfig), "Merged kubelet config does not match the expected configuration.")
 		})
+		ginkgo.It("should dump the effective KubeletConfiguration to the kubelet log at startup", func(ctx context.Context) {
+			configDir := framework.TestContext.KubeletConfigDropinDir
+
+			// Set a distinctive, non-default value via a drop-in config. The startup log
+			// dumps the *effective* (post-merge) KubeletConfiguration, so this value must
+			// appear in the log.
+			contents := []byte(`apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+eventBurst: 101`)
+
+			dropinConfigPath := filepath.Join(configDir, "10-kubelet.conf")
+			framework.ExpectNoError(os.WriteFile(dropinConfigPath, contents, 0755))
+
+			ginkgo.By("Restarting the kubelet")
+			restartKubelet := mustStopKubelet(ctx, f)
+			restartKubelet(ctx)
+
+			ginkgo.By("Verifying the effective KubeletConfiguration is dumped to the kubelet log")
+			// The startup dump is logged once shortly after the kubelet starts. Poll the
+			// kubelet log to avoid flaking on the log not being flushed yet.
+			gomega.Eventually(ctx, func() (string, error) {
+				kubeletLog, err := os.ReadFile(framework.TestContext.ReportDir + "/kubelet.log")
+				if err != nil {
+					return "", err
+				}
+				return string(kubeletLog), nil
+			}).WithPolling(5*time.Second).WithTimeout(time.Minute).Should(gomega.And(
+				// Greppable startup header emitted by the effective-config dump.
+				gomega.ContainSubstring("Effective KubeletConfiguration"),
+				// Marker that the dumped value is the serialized KubeletConfiguration.
+				gomega.ContainSubstring("kind: KubeletConfiguration"),
+				// The effective, post-merge value set via the drop-in config above.
+				gomega.ContainSubstring("eventBurst: 101"),
+			), "kubelet log should contain the effective KubeletConfiguration with merged values")
+		})
 	})
 
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

/sig node

Dump the full effective KubeletConfiguration at startup. Printing the raw command-line flags (cliflag.PrintFlags, below) is misleading: flags that mirror KubeletConfiguration fields are parsed before --config / --config-dir are merged and flag precedence is re-enforced, so they can show stale values that do not match what the kubelet actually runs with. The effective configuration logged here reflects all overrides (defaults, the --config file, drop-in --config-dir files, and command-line flag precedence) and is serialized exactly like /configz.

#### Which issue(s) this PR is related to:

See kubernetes/kubernetes#122736.

#### Special notes for your reviewer:

Some AI was used

#### Does this PR introduce a user-facing change?

```release-note
Kubelet logs effective configuration on start.

ACTION REQUIRED: cluster admin should review permissions to only allow trusted users to nodes/logs cluster role. This is mostly the reminder as it was the best practice anyways and almost all of the effective configuration values can be already Inferred from other log messages or the kubelet behavior.
```

