### PR TITLE
Add missing CONTRIBUTING.md to mount-utils staging repo

### DIFF
--- a/staging/src/k8s.io/mount-utils/CONTRIBUTING.md
+++ b/staging/src/k8s.io/mount-utils/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing guidelines
+
+Do not open pull requests directly against this repository, they will be ignored. Instead, please open pull requests against [kubernetes/kubernetes](https://git.k8s.io/kubernetes/).  Please follow the same [contributing guide](https://git.k8s.io/kubernetes/CONTRIBUTING.md) you would follow for any other pull request made to kubernetes/kubernetes.
+
+This repository is published from [kubernetes/kubernetes/staging/src/k8s.io/mount-utils](https://git.k8s.io/kubernetes/staging/src/k8s.io/mount-utils) by the [kubernetes publishing-bot](https://git.k8s.io/publishing-bot).
+
+Please see [Staging Directory and Publishing](https://git.k8s.io/community/contributors/devel/sig-architecture/staging.md) for more information

--- a/staging/src/k8s.io/mount-utils/README.md
+++ b/staging/src/k8s.io/mount-utils/README.md
@@ -30,7 +30,7 @@ You can reach the maintainers of this repository at:
 Participation in the Kubernetes community is governed by the [Kubernetes
 Code of Conduct](code-of-conduct.md).
 
-### Contibution Guidelines
+### Contribution Guidelines
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for more information.
 


### PR DESCRIPTION
The mount-utils README links to ./CONTRIBUTING.md in two places, but the file is missing (it 404s on the published github.com/kubernetes/mount-utils repo). mount-utils is the only staged repo under staging/src/k8s.io that references CONTRIBUTING.md without shipping it; all 32 siblings carry the standard publishing-bot template. Added the same template (path adjusted for mount-utils) and fixed the "Contibution" typo in the README heading.
