### PR TITLE
Add podgroup level metrics

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -6540,6 +6540,36 @@
   componentEndpoints:
   - component: kube-scheduler
     endpoint: /metrics
+- name: queue_incoming_entities_total
+  subsystem: scheduler
+  help: Number of scheduling entities added to scheduling queues by event, queue type,
+    and entity type. Entity types are either 'pod' (for individual pods that are not
+    members of any podgroup) or 'podgroup'.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - event
+  - queue
+  - type
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
+- name: queued_entities
+  subsystem: scheduler
+  help: Number of queued scheduling entities ('pod' or 'podgroup'; 'pod' stands for
+    individual pods that are not members of any podgroup) by the queue type. 'active'
+    means number of entities in activeQ; 'backoff' means number of entities in backoffQ;
+    'unschedulable' means number of entities in unschedulableEntities that the scheduler
+    attempted to schedule and failed; 'gated' is the number of unschedulable entities
+    that the scheduler never attempted to schedule because they are gated.
+  type: Gauge
+  stabilityLevel: ALPHA
+  labels:
+  - queue
+  - type
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: queueing_hint_execution_duration_seconds
   subsystem: scheduler
   help: Duration for running a queueing hint function of a plugin.
@@ -8603,7 +8633,8 @@
     activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number
     of pods in unschedulableEntities that the scheduler attempted to schedule and
     failed; 'gated' is the number of unschedulable pods that the scheduler never attempted
-    to schedule because they are gated.
+    to schedule because they are gated; 'incomplete' means number of pods in incompletePodGroupPods;
+    'pending' means number of pods in pendingPodGroupPods.
   type: Gauge
   stabilityLevel: STABLE
   labels:

--- a/hack/tools/instrumentation/testdata/stable-metrics-list.yaml
+++ b/hack/tools/instrumentation/testdata/stable-metrics-list.yaml
@@ -1142,7 +1142,8 @@
     activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number
     of pods in unschedulableEntities that the scheduler attempted to schedule and
     failed; 'gated' is the number of unschedulable pods that the scheduler never attempted
-    to schedule because they are gated.
+    to schedule because they are gated; 'incomplete' means number of pods in incompletePodGroupPods;
+    'pending' means number of pods in pendingPodGroupPods.
   type: Gauge
   stabilityLevel: STABLE
   labels:

--- a/pkg/scheduler/backend/heap/heap.go
+++ b/pkg/scheduler/backend/heap/heap.go
@@ -23,6 +23,7 @@ import (
 	"container/heap"
 	"fmt"
 
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 )
 
@@ -30,6 +31,8 @@ import (
 type Item interface {
 	// Size returns the size of the item, used for metrics.
 	Size() int
+	// Type returns the type of the item, used for metrics. Refers to the scheduling entity, which is either 'pod' or 'podgroup'.
+	Type() fwk.EntityKeyType
 }
 
 // KeyFunc is a function type to get the key from an object.
@@ -124,14 +127,14 @@ func (h *Heap[T]) AddOrUpdate(obj T) {
 	if idx, exists := h.data.keyIndex[key]; exists {
 		if h.metricRecorder != nil {
 			// The new object might have a different size than the stored one.
-			h.metricRecorder.Add(obj.Size() - h.data.queue[idx].obj.Size())
+			h.metricRecorder.Update(h.data.queue[idx].obj, obj)
 		}
 		h.data.queue[idx].obj = obj
 		heap.Fix(h.data, idx)
 	} else {
 		heap.Push(h.data, &heapItem[T]{obj: obj, key: key})
 		if h.metricRecorder != nil {
-			h.metricRecorder.Add(obj.Size())
+			h.metricRecorder.Add(obj)
 		}
 	}
 }
@@ -142,9 +145,9 @@ func (h *Heap[T]) Delete(obj T) T {
 	if idx, ok := h.data.keyIndex[key]; ok {
 		removed := heap.Remove(h.data, idx).(T)
 		if h.metricRecorder != nil {
-			// Use the size of the removed object, because the passed obj might be
+			// Use the removed object, because the passed obj might be
 			// a lookup object whose size doesn't match the stored one.
-			h.metricRecorder.Add(-removed.Size())
+			h.metricRecorder.Remove(removed)
 		}
 		return removed
 	}
@@ -165,7 +168,7 @@ func (h *Heap[T]) Pop() (T, error) {
 	obj := heap.Pop(h.data)
 	typedObj := obj.(T)
 	if h.metricRecorder != nil {
-		h.metricRecorder.Add(-typedObj.Size())
+		h.metricRecorder.Remove(typedObj)
 	}
 	return typedObj, nil
 }

--- a/pkg/scheduler/backend/heap/heap_test.go
+++ b/pkg/scheduler/backend/heap/heap_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/metrics"
 )
 
 func testHeapObjectKeyFunc(obj testHeapObject) string {
@@ -39,23 +41,27 @@ func (obj testHeapObject) Size() int {
 	return obj.size
 }
 
+func (obj testHeapObject) Type() fwk.EntityKeyType {
+	return fwk.EntityKeyType("test")
+}
+
 type testMetricRecorder int
 
-func (tmr *testMetricRecorder) Add(val int) {
+func (tmr *testMetricRecorder) Add(entity metrics.Entity) {
 	if tmr != nil {
-		*tmr += testMetricRecorder(val)
+		*tmr += testMetricRecorder(entity.Size())
 	}
 }
 
-func (tmr *testMetricRecorder) Inc() {
+func (tmr *testMetricRecorder) Remove(entity metrics.Entity) {
 	if tmr != nil {
-		*tmr++
+		*tmr -= testMetricRecorder(entity.Size())
 	}
 }
 
-func (tmr *testMetricRecorder) Dec() {
+func (tmr *testMetricRecorder) Update(oldEntity, newEntity metrics.Entity) {
 	if tmr != nil {
-		*tmr--
+		*tmr += testMetricRecorder(newEntity.Size() - oldEntity.Size())
 	}
 }
 

--- a/pkg/scheduler/backend/queue/active_queue.go
+++ b/pkg/scheduler/backend/queue/active_queue.go
@@ -48,7 +48,9 @@ type activeQueuer interface {
 	// The event should show which event triggered this addition and is used for the metric recording.
 	// Note: it does not signal the pop() method to wake up,
 	// so the caller is responsible for calling broadcast() after executing this method.
-	add(logger klog.Logger, entity framework.QueuedEntityInfo, event string)
+	// 'strategy' is the previous queuing strategy, helps determine if the entity moved into a different
+	// queue or newly added to correctly maintain incoming entities metrics.
+	add(logger klog.Logger, entity framework.QueuedEntityInfo, event string, strategy *queueingStrategy)
 	// get returns the entity matching entity inside the activeQ.
 	get(entityLookup framework.QueuedEntityInfo) (framework.QueuedEntityInfo, bool)
 
@@ -344,7 +346,7 @@ func (aq *activeQueue) unlockedPop(logger klog.Logger) (framework.QueuedEntityIn
 		if err != nil {
 			return nil, err
 		}
-		metrics.SchedulerQueueIncomingPods.WithLabelValues("active", framework.PopFromBackoffQ).Add(float64(entity.Size()))
+		recordIncomingEntitiesMetrics("active", entity, framework.PopFromBackoffQ, nil)
 	}
 	err = aq.unlockedMoveEntityToInFlight(logger, entity)
 	if err != nil {
@@ -403,12 +405,12 @@ func (aq *activeQueue) has(entityLookup framework.QueuedEntityInfo) bool {
 // The event should show which event triggered this addition and is used for the metric recording.
 // Note: it does not signal the pop() method to wake up,
 // so the caller is responsible for calling broadcast() after executing this method.
-func (aq *activeQueue) add(logger klog.Logger, entity framework.QueuedEntityInfo, event string) {
+func (aq *activeQueue) add(logger klog.Logger, entity framework.QueuedEntityInfo, event string, strategy *queueingStrategy) {
 	aq.lock.Lock()
 	defer aq.lock.Unlock()
 
 	aq.queue.AddOrUpdate(entity)
-	metrics.SchedulerQueueIncomingPods.WithLabelValues("active", event).Add(float64(entity.Size()))
+	recordIncomingEntitiesMetrics("active", entity, event, strategy)
 	logger.V(5).Info("Entity moved to an internal scheduling queue", "type", entity.Type(), "entity", klog.KObj(entity), "event", event, "queue", activeQ)
 }
 

--- a/pkg/scheduler/backend/queue/active_queue_test.go
+++ b/pkg/scheduler/backend/queue/active_queue_test.go
@@ -30,10 +30,10 @@ import (
 func TestClose(t *testing.T) {
 	logger, ctx := ktesting.NewTestContext(t)
 	rr := metrics.NewMetricsAsyncRecorder(10, time.Second, ctx.Done())
-	aq := newActiveQueue(heap.NewWithRecorder(queuedEntityKeyFunc, heap.LessFunc[framework.QueuedEntityInfo](convertLessFn(newDefaultQueueSort())), metrics.NewActivePodsRecorder()), rr, nil)
+	aq := newActiveQueue(heap.NewWithRecorder(queuedEntityKeyFunc, heap.LessFunc[framework.QueuedEntityInfo](convertLessFn(newDefaultQueueSort())), metrics.NewActiveEntitiesRecorder()), rr, nil)
 
-	aq.add(logger, &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: st.MakePod().Namespace("foo").Name("p1").UID("p1").Obj()}}, framework.EventUnscheduledPodAdd.Label())
-	aq.add(logger, &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: st.MakePod().Namespace("bar").Name("p2").UID("p2").Obj()}}, framework.EventUnscheduledPodAdd.Label())
+	aq.add(logger, &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: st.MakePod().Namespace("foo").Name("p1").UID("p1").Obj()}}, framework.EventUnscheduledPodAdd.Label(), nil)
+	aq.add(logger, &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: st.MakePod().Namespace("bar").Name("p2").UID("p2").Obj()}}, framework.EventUnscheduledPodAdd.Label(), nil)
 
 	_, err := aq.pop(logger)
 	if err != nil {

--- a/pkg/scheduler/backend/queue/backoff_queue.go
+++ b/pkg/scheduler/backend/queue/backoff_queue.go
@@ -60,7 +60,9 @@ type backoffQueuer interface {
 	// add adds the entity to backoffQueue.
 	// The event should show which event triggered this addition and is used for the metric recording.
 	// It also ensures that entity is not in both queues.
-	add(logger klog.Logger, entity framework.QueuedEntityInfo, event string)
+	// 'strategy' is the previous queuing strategy, helps determine if the entity moved into a different
+	// queue or newly added to correctly maintain incoming entities metrics.
+	add(logger klog.Logger, entity framework.QueuedEntityInfo, event string, strategy *queueingStrategy)
 	// update updates the pod in backoffQueue if oldEntity is already in the queue and the pod is present there.
 	// It returns new pod info if updated, nil otherwise.
 	update(newPod *v1.Pod, oldEntity framework.QueuedEntityInfo) *framework.QueuedPodInfo
@@ -119,8 +121,8 @@ func newBackoffQueue(clock clock.WithTicker, podInitialBackoffDuration time.Dura
 	if popFromBackoffQEnabled {
 		entityBackoffQLessFn = bq.lessBackoffCompletedWithPriority
 	}
-	bq.entityBackoffQ = heap.NewWithRecorder(queuedEntityKeyFunc, entityBackoffQLessFn, metrics.NewBackoffPodsRecorder())
-	bq.entityErrorBackoffQ = heap.NewWithRecorder(queuedEntityKeyFunc, bq.lessBackoffCompleted, metrics.NewBackoffPodsRecorder())
+	bq.entityBackoffQ = heap.NewWithRecorder(queuedEntityKeyFunc, entityBackoffQLessFn, metrics.NewBackoffEntitiesRecorder())
+	bq.entityErrorBackoffQ = heap.NewWithRecorder(queuedEntityKeyFunc, bq.lessBackoffCompleted, metrics.NewBackoffEntitiesRecorder())
 
 	return bq
 }
@@ -295,7 +297,7 @@ func (bq *backoffQueue) popAllBackoffCompleted(logger klog.Logger) []framework.Q
 // add adds the entity to backoffQueue.
 // The event should show which event triggered this addition and is used for the metric recording.
 // It also ensures that entity is not in both queues.
-func (bq *backoffQueue) add(logger klog.Logger, entity framework.QueuedEntityInfo, event string) {
+func (bq *backoffQueue) add(logger klog.Logger, entity framework.QueuedEntityInfo, event string, strategy *queueingStrategy) {
 	bq.lock.Lock()
 	defer bq.lock.Unlock()
 
@@ -308,7 +310,7 @@ func (bq *backoffQueue) add(logger klog.Logger, entity framework.QueuedEntityInf
 			logger.Error(nil, "BackoffQueue add() was called with an entity that was already in the entityBackoffQ", "type", entity.Type(), "entity", klog.KObj(entity))
 			return
 		}
-		metrics.SchedulerQueueIncomingPods.WithLabelValues("backoff", event).Add(float64(entity.Size()))
+		recordIncomingEntitiesMetrics("backoff", entity, event, strategy)
 		logger.V(5).Info("Entity moved to an internal scheduling queue", "type", entity.Type(), "entity", klog.KObj(entity), "event", event, "queue", backoffQ)
 		return
 	}
@@ -318,7 +320,7 @@ func (bq *backoffQueue) add(logger klog.Logger, entity framework.QueuedEntityInf
 		logger.Error(nil, "BackoffQueue add() was called with an entity that was already in the entityErrorBackoffQ", "type", entity.Type(), "entity", klog.KObj(entity))
 		return
 	}
-	metrics.SchedulerQueueIncomingPods.WithLabelValues("backoff", event).Add(float64(entity.Size()))
+	recordIncomingEntitiesMetrics("backoff", entity, event, strategy)
 	logger.V(5).Info("Entity moved to an internal scheduling queue", "type", entity.Type(), "entity", klog.KObj(entity), "event", event, "queue", backoffQ)
 }
 

--- a/pkg/scheduler/backend/queue/backoff_queue_test.go
+++ b/pkg/scheduler/backend/queue/backoff_queue_test.go
@@ -272,7 +272,7 @@ func TestBackoffQueue_popAllBackoffCompleted(t *testing.T) {
 				logger, _ := ktesting.NewTestContext(t)
 				bq := newBackoffQueue(fakeClock, DefaultPodInitialBackoffDuration, DefaultPodMaxBackoffDuration, convertLessFn(newDefaultQueueSort()), popFromBackoffQEnabled)
 				for _, podName := range tt.podsInBackoff {
-					bq.add(logger, podInfos[podName], framework.EventUnscheduledPodAdd.Label())
+					bq.add(logger, podInfos[podName], framework.EventUnscheduledPodAdd.Label(), nil)
 				}
 				gotPodInfos := bq.popAllBackoffCompleted(logger)
 				var gotPods []string
@@ -383,7 +383,7 @@ func TestBackoffQueueOrdering(t *testing.T) {
 			logger, _ := ktesting.NewTestContext(t)
 			bq := newBackoffQueue(fakeClock, DefaultPodInitialBackoffDuration, DefaultPodMaxBackoffDuration, convertLessFn(newDefaultQueueSort()), tt.popFromBackoffQEnabled)
 			for _, podInfo := range podInfos {
-				bq.add(logger, podInfo, framework.EventUnscheduledPodAdd.Label())
+				bq.add(logger, podInfo, framework.EventUnscheduledPodAdd.Label(), nil)
 			}
 			gotPodInfos := bq.popAllBackoffCompleted(logger)
 			var gotPods []string

--- a/pkg/scheduler/backend/queue/pod_group_member_pods.go
+++ b/pkg/scheduler/backend/queue/pod_group_member_pods.go
@@ -18,6 +18,7 @@ package queue
 
 import (
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/component-base/metrics"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
@@ -28,21 +29,25 @@ type podGroupMemberPods struct {
 	// podGroupToPodInfos stores QueuedPodInfos keyed by their pod group key (pg-type/namespace/pg-name),
 	// and then by pod key (namespace/pg-name).
 	podGroupToPodInfos map[fwk.EntityKey]map[fwk.EntityKey]*framework.QueuedPodInfo
+	podsRecorder       metrics.GaugeMetric
 }
 
-func newPodGroupMemberPods() *podGroupMemberPods {
+func newPodGroupMemberPods(podsRecorder metrics.GaugeMetric) *podGroupMemberPods {
 	return &podGroupMemberPods{
 		podGroupToPodInfos: make(map[fwk.EntityKey]map[fwk.EntityKey]*framework.QueuedPodInfo),
+		podsRecorder:       podsRecorder,
 	}
 }
 
 // add adds a pod info.
+// It also increments the metric counter.
 func (p *podGroupMemberPods) add(pInfo *framework.QueuedPodInfo) {
 	pgKey, pKey := podGroupKeyForPod(pInfo.Pod), podKey(pInfo.Pod)
 	if p.podGroupToPodInfos[pgKey] == nil {
 		p.podGroupToPodInfos[pgKey] = make(map[fwk.EntityKey]*framework.QueuedPodInfo)
 	}
 	p.podGroupToPodInfos[pgKey][pKey] = pInfo
+	p.podsRecorder.Inc()
 }
 
 // has checks if the pod is tracked.
@@ -77,6 +82,7 @@ func (p *podGroupMemberPods) update(newPod *v1.Pod) *framework.QueuedPodInfo {
 }
 
 // delete removes a specific pod and returns its pod info if found.
+// It also decrements the metric counter.
 func (p *podGroupMemberPods) delete(podLookup *v1.Pod) *framework.QueuedPodInfo {
 	pgKey, pKey := podGroupKeyForPod(podLookup), podKey(podLookup)
 	if pInfo, ok := p.podGroupToPodInfos[pgKey][pKey]; ok {
@@ -84,6 +90,7 @@ func (p *podGroupMemberPods) delete(podLookup *v1.Pod) *framework.QueuedPodInfo 
 		if len(p.podGroupToPodInfos[pgKey]) == 0 {
 			delete(p.podGroupToPodInfos, pgKey)
 		}
+		p.podsRecorder.Dec()
 		return pInfo
 	}
 	return nil
@@ -100,7 +107,8 @@ func (p *podGroupMemberPods) list() []*v1.Pod {
 	return pods
 }
 
-// clearGroup removes and returns all pod infos for a specific pod group namespace and name.
+// clear removes and returns all pod infos for a specific pod group namespace and name.
+// It also decrements the metric counter for all cleared pods.
 func (p *podGroupMemberPods) clear(namespace, name string) []*framework.QueuedPodInfo {
 	pgKey := fwk.PodGroupKey(namespace, name)
 	if pInfos, ok := p.podGroupToPodInfos[pgKey]; ok {
@@ -108,6 +116,7 @@ func (p *podGroupMemberPods) clear(namespace, name string) []*framework.QueuedPo
 		var pInfoList []*framework.QueuedPodInfo
 		for _, pInfo := range pInfos {
 			pInfoList = append(pInfoList, pInfo)
+			p.podsRecorder.Dec()
 		}
 		return pInfoList
 	}

--- a/pkg/scheduler/backend/queue/pod_group_member_pods_test.go
+++ b/pkg/scheduler/backend/queue/pod_group_member_pods_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/metrics"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 )
 
@@ -69,7 +70,7 @@ func TestPodGroupMemberPods_Add(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ppm := newPodGroupMemberPods()
+			ppm := newPodGroupMemberPods(metrics.IncompletePodGroupPods())
 			for _, pInfo := range tt.podsToAdd {
 				ppm.add(pInfo)
 			}
@@ -124,7 +125,7 @@ func TestPodGroupMemberPods_Get(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ppm := newPodGroupMemberPods()
+			ppm := newPodGroupMemberPods(metrics.IncompletePodGroupPods())
 			for _, pInfo := range tt.podsToAdd {
 				ppm.add(pInfo)
 			}
@@ -172,7 +173,7 @@ func TestPodGroupMemberPods_Has(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ppm := newPodGroupMemberPods()
+			ppm := newPodGroupMemberPods(metrics.IncompletePodGroupPods())
 			for _, pInfo := range tt.podsToAdd {
 				ppm.add(pInfo)
 			}
@@ -215,7 +216,7 @@ func TestPodGroupMemberPods_Update(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ppm := newPodGroupMemberPods()
+			ppm := newPodGroupMemberPods(metrics.IncompletePodGroupPods())
 			for _, pInfo := range tt.podsToAdd {
 				ppm.add(pInfo.DeepCopy())
 			}
@@ -279,7 +280,7 @@ func TestPodGroupMemberPods_Delete(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ppm := newPodGroupMemberPods()
+			ppm := newPodGroupMemberPods(metrics.IncompletePodGroupPods())
 			for _, pInfo := range tt.podsToAdd {
 				ppm.add(pInfo.DeepCopy())
 			}
@@ -342,7 +343,7 @@ func TestPodGroupMemberPods_Clear(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ppm := newPodGroupMemberPods()
+			ppm := newPodGroupMemberPods(metrics.IncompletePodGroupPods())
 			for _, pInfo := range tt.podsToAdd {
 				ppm.add(pInfo)
 			}
@@ -385,7 +386,7 @@ func TestPodGroupMemberPods_Len(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ppm := newPodGroupMemberPods()
+			ppm := newPodGroupMemberPods(metrics.IncompletePodGroupPods())
 			for _, pInfo := range tt.podsToAdd {
 				ppm.add(pInfo)
 			}

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -445,9 +445,9 @@ func NewPriorityQueue(
 		stop:                              make(chan struct{}),
 		podMaxInUnschedulablePodsDuration: options.podMaxInUnschedulablePodsDuration,
 		backoffQ:                          backoffQ,
-		unschedulableEntities:             newUnschedulableEntities(metrics.NewUnschedulablePodsRecorder(), metrics.NewGatedPodsRecorder()),
-		pendingPodGroupPods:               newPodGroupMemberPods(),
-		incompletePodGroupPods:            newPodGroupMemberPods(),
+		unschedulableEntities:             newUnschedulableEntities(metrics.NewUnschedulableEntitiesRecorder(), metrics.NewGatedEntitiesRecorder()),
+		pendingPodGroupPods:               newPodGroupMemberPods(metrics.PendingPodGroupPods()),
+		incompletePodGroupPods:            newPodGroupMemberPods(metrics.IncompletePodGroupPods()),
 		workloadForest:                    newWorkloadForest(isCompositePodGroupEnabled),
 		preEnqueuePluginMap:               options.preEnqueuePluginMap,
 		queueingHintMap:                   options.queueingHintMap,
@@ -465,7 +465,7 @@ func NewPriorityQueue(
 	if isPopFromBackoffQEnabled {
 		backoffQPopper = backoffQ
 	}
-	pq.activeQ = newActiveQueue(heap.NewWithRecorder(queuedEntityKeyFunc, heap.LessFunc[framework.QueuedEntityInfo](lessConverted), metrics.NewActivePodsRecorder()), options.metricsRecorder, backoffQPopper)
+	pq.activeQ = newActiveQueue(heap.NewWithRecorder(queuedEntityKeyFunc, heap.LessFunc[framework.QueuedEntityInfo](lessConverted), metrics.NewActiveEntitiesRecorder()), options.metricsRecorder, backoffQPopper)
 	pq.nsLister = informerFactory.Core().V1().Namespaces().Lister()
 	pq.nominator = newPodNominator(options.podLister)
 
@@ -772,11 +772,14 @@ func (p *PriorityQueue) AddNominatedPod(logger klog.Logger, pi fwk.PodInfo, nomi
 // moveToActiveQ tries to add the entity to the active queue.
 // If the entity doesn't pass PreEnqueue plugins, it gets added to unschedulableEntities instead.
 // movesFromBackoffQ should be set to true, if the entity directly moves from the backoffQ, so the PreEnqueue call can be skipped.
+// strategy is the previous queuing strategy of the entity. Having a nil strategy indicates that the entity is newly added to
+// scheduler queue, and causes incoming entity metrics to be incremented unconditionally.
+// Otherwise the strategy allows metric recording to check if the entity actually moved between queues or not, to avoid double-counting in metrics.
 // It returns a boolean flag to indicate whether the entity is added successfully.
 // Entity should be removed from the backoffQ before calling moveToActiveQ.
 // Note: it does not signal the Pop() method to wake up,
 // so the caller is responsible for calling activeQ.broadcast() after executing this method.
-func (p *PriorityQueue) moveToActiveQ(logger klog.Logger, entity framework.QueuedEntityInfo, event string, movesFromBackoffQ bool) bool {
+func (p *PriorityQueue) moveToActiveQ(logger klog.Logger, entity framework.QueuedEntityInfo, event string, movesFromBackoffQ bool, strategy *queueingStrategy) bool {
 	gatedBefore := entity.Gated()
 	// If SchedulerPopFromBackoffQ feature gate is enabled,
 	// PreEnqueue plugins were called when the entity was added to the backoffQ.
@@ -793,7 +796,7 @@ func (p *PriorityQueue) moveToActiveQ(logger klog.Logger, entity framework.Queue
 		// Clearing WasFlushedFromUnschedulable is typically done on scheduling failure, but in case the flushed pod was gated, it never attempts scheduling.
 		// We clear it here to ensure it's not set the next time the pod is woken up by a non-flush event.
 		entity.SetWasFlushedFromUnschedulable(false)
-		p.unschedulableEntities.addOrUpdate(entity, gatedBefore, event)
+		p.unschedulableEntities.addOrUpdate(entity, gatedBefore, event, strategy)
 		// Entity not moved to activeQ.
 		return false
 	}
@@ -801,15 +804,18 @@ func (p *PriorityQueue) moveToActiveQ(logger klog.Logger, entity framework.Queue
 	entity.SetInitialAttemptTimestamp(now)
 	p.unschedulableEntities.delete(entity, gatedBefore)
 
-	p.activeQ.add(logger, entity, event)
+	p.activeQ.add(logger, entity, event, strategy)
 	// Pod successfully moved to activeQ.
 	return true
 }
 
 // moveToBackoffQ tries to add the entity to the backoff queue.
 // If SchedulerPopFromBackoffQ feature gate is enabled and the entity doesn't pass PreEnqueue plugins, it gets added to unschedulableEntities instead.
+// strategy is the previous queuing strategy of the entity. Having a nil strategy indicates that the entity is newly added to
+// scheduler queue, and causes incoming entity metrics to be incremented unconditionally.
+// Otherwise the strategy allows metric recording to check if the entity actually moved between queues or not, to avoid double-counting in metrics.
 // It returns a boolean flag to indicate whether the entity is added successfully.
-func (p *PriorityQueue) moveToBackoffQ(logger klog.Logger, entity framework.QueuedEntityInfo, event string) bool {
+func (p *PriorityQueue) moveToBackoffQ(logger klog.Logger, entity framework.QueuedEntityInfo, event string, strategy *queueingStrategy) bool {
 	gatedBefore := entity.Gated()
 	// If SchedulerPopFromBackoffQ feature gate is enabled,
 	// PreEnqueue plugins are called on inserting entities to the backoffQ,
@@ -823,13 +829,13 @@ func (p *PriorityQueue) moveToBackoffQ(logger klog.Logger, entity framework.Queu
 			// Clearing WasFlushedFromUnschedulable is typically done on scheduling failure, but in case the flushed pod was gated, it never attempts scheduling.
 			// We clear it here to ensure it's not set the next time the pod is woken up by a non-flush event.
 			entity.SetWasFlushedFromUnschedulable(false)
-			p.unschedulableEntities.addOrUpdate(entity, gatedBefore, event)
+			p.unschedulableEntities.addOrUpdate(entity, gatedBefore, event, strategy)
 			return false
 		}
 	}
 	p.unschedulableEntities.delete(entity, gatedBefore)
 
-	p.backoffQ.add(logger, entity, event)
+	p.backoffQ.add(logger, entity, event, strategy)
 	return true
 }
 
@@ -856,7 +862,7 @@ func (p *PriorityQueue) addPod(ctx context.Context, pod *v1.Pod) {
 		p.addPodGroupMember(logger, pInfo)
 		return
 	}
-	if added := p.moveToActiveQ(logger, pInfo, framework.EventUnscheduledPodAdd.Label(), false); added {
+	if added := p.moveToActiveQ(logger, pInfo, framework.EventUnscheduledPodAdd.Label(), false, nil); added {
 		p.activeQ.broadcast()
 	}
 }
@@ -886,7 +892,7 @@ func (p *PriorityQueue) addPodGroupMember(logger klog.Logger, pInfo *framework.Q
 
 	// Create a new group as it's the first member pod in the queue.
 	rootInfo := p.newQueuedPodGroupInfoFromRootLookup(logger, pInfo, rootInfoLookup)
-	if added := p.moveToActiveQ(logger, rootInfo, framework.EventUnscheduledPodAdd.Label(), false); added {
+	if added := p.moveToActiveQ(logger, rootInfo, framework.EventUnscheduledPodAdd.Label(), false, nil); added {
 		p.activeQ.broadcast()
 	}
 	logger.V(5).Info("Pod was added to root group as the first member pod", "rootType", rootInfo.Type(), "root", klog.KObj(rootInfo), "pod", klog.KObj(pInfo))
@@ -984,7 +990,7 @@ func (p *PriorityQueue) activate(logger klog.Logger, entityLookup framework.Queu
 		return false
 	}
 
-	return p.moveToActiveQ(logger, entity, framework.ForceActivate, movesFromBackoffQ)
+	return p.moveToActiveQ(logger, entity, framework.ForceActivate, movesFromBackoffQ, nil)
 }
 
 // SchedulingCycle returns current scheduling cycle.
@@ -1216,11 +1222,11 @@ func (p *PriorityQueue) AddAttemptedPodGroupIfNeeded(logger klog.Logger, pgInfo 
 	// If the PreEnqueue fails for this pod group, it will be moved to the unschedulableEntities.
 	queue := unschedulableQ
 	if !requeueWithoutBackoff && p.backoffQ.isEntityBackingoff(pgInfo) {
-		if added := p.moveToBackoffQ(logger, pgInfo, framework.ScheduleAttemptFailure); added {
+		if added := p.moveToBackoffQ(logger, pgInfo, framework.ScheduleAttemptFailure, nil); added {
 			queue = backoffQ
 		}
 	} else {
-		if added := p.moveToActiveQ(logger, pgInfo, framework.ScheduleAttemptFailure, false); added {
+		if added := p.moveToActiveQ(logger, pgInfo, framework.ScheduleAttemptFailure, false, nil); added {
 			queue = activeQ
 		}
 	}
@@ -1257,7 +1263,7 @@ func (p *PriorityQueue) flushBackoffQCompleted(logger klog.Logger) {
 	activated := false
 	podsCompletedBackoff := p.backoffQ.popAllBackoffCompleted(logger)
 	for _, pInfo := range podsCompletedBackoff {
-		if added := p.moveToActiveQ(logger, pInfo, framework.BackoffComplete, true); added {
+		if added := p.moveToActiveQ(logger, pInfo, framework.BackoffComplete, true, nil); added {
 			activated = true
 		}
 	}
@@ -1807,21 +1813,21 @@ func (p *PriorityQueue) MoveAllToActiveOrBackoffQueue(logger klog.Logger, event 
 func (p *PriorityQueue) requeueEntityWithQueueingStrategy(logger klog.Logger, entity framework.QueuedEntityInfo, strategy queueingStrategy, event string) string {
 	if strategy == queueSkip {
 		// Current Gate status is required for already exisiting entities. For new entities, this parameter is ignored/unused by addPod/addPodGroup.
-		p.unschedulableEntities.addOrUpdate(entity, entity.Gated(), event)
+		p.unschedulableEntities.addOrUpdate(entity, entity.Gated(), event, &strategy)
 		return unschedulableQ
 	}
 
 	// Entity might have completed its backoff time while being in unschedulableEntities,
 	// so we should check isEntityBackingoff before moving the entity to backoffQ.
 	if strategy == queueAfterBackoff && p.backoffQ.isEntityBackingoff(entity) {
-		if added := p.moveToBackoffQ(logger, entity, event); added {
+		if added := p.moveToBackoffQ(logger, entity, event, &strategy); added {
 			return backoffQ
 		}
 		return unschedulableQ
 	}
 
 	// Reach here if schedulingHint is QueueImmediately, or schedulingHint is Queue but the entity is not backing off.
-	if added := p.moveToActiveQ(logger, entity, event, false); added {
+	if added := p.moveToActiveQ(logger, entity, event, false, &strategy); added {
 		return activeQ
 	}
 	// Entity is gated. We don't have to push it back to unschedulable queue, because moveToActiveQ should already have done that.
@@ -2127,6 +2133,34 @@ func (p *PriorityQueue) newQueuedPodInfo(ctx context.Context, pod *v1.Pod, plugi
 			UnschedulablePlugins:    sets.New(plugins...),
 		},
 		PodSignature: p.signPod(ctx, pod),
+	}
+}
+
+// recordIncomingEntitiesMetrics records incoming queue metrics for pod-level and entity-level (individual pod or podgroup).
+// 'strategy' is the previous queuing strategy, helps determine if the entity moved into a different
+// queue or newly added to correctly maintain incoming entities metrics.
+// If strategy is 'nil' it means that entity is newly added.
+// If queue label defined by previous strategy is different from next queue label, it means that entity moved into a different queue.
+// In both cases, we increment the incoming entities metric for the new queue.
+func recordIncomingEntitiesMetrics(targetQueueLabel string, entity framework.QueuedEntityInfo, event string, strategy *queueingStrategy) {
+	metrics.SchedulerQueueIncomingPods.WithLabelValues(targetQueueLabel, event).Add(float64(entity.Size()))
+
+	if strategy == nil || targetQueueLabel != strategyToQueueLabel(*strategy) {
+		if entityLabel, ok := metrics.EntityToLabel(entity); ok {
+			metrics.SchedulerQueueIncomingEntities.WithLabelValues(targetQueueLabel, event, entityLabel).Inc()
+		}
+	}
+}
+
+// strategyToQueueLabel maps previous queueingStrategy to the queue label (used for metrics) where an entity was present.
+func strategyToQueueLabel(strategy queueingStrategy) string {
+	switch strategy {
+	case queueImmediately:
+		return "active"
+	case queueAfterBackoff:
+		return "backoff"
+	default:
+		return "unschedulable"
 	}
 }
 

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -58,6 +58,16 @@ const queueMetricMetadata = `
 		# TYPE scheduler_queue_incoming_pods_total counter
 	`
 
+const queueIncomingEntitiesMetricMetadata = `
+	# HELP scheduler_queue_incoming_entities_total [ALPHA] Number of scheduling entities added to scheduling queues by event, queue type, and entity type. Entity types are either 'pod' (for individual pods that are not members of any podgroup) or 'podgroup'.
+	# TYPE scheduler_queue_incoming_entities_total counter
+`
+
+const queuedEntitiesMetricMetadata = `
+	# HELP scheduler_queued_entities [ALPHA] Number of queued scheduling entities ('pod' or 'podgroup'; 'pod' stands for individual pods that are not members of any podgroup) by the queue type. 'active' means number of entities in activeQ; 'backoff' means number of entities in backoffQ; 'unschedulable' means number of entities in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable entities that the scheduler never attempted to schedule because they are gated.
+	# TYPE scheduler_queued_entities gauge
+`
+
 var (
 	// nodeAdd is the event when a new node is added to the cluster.
 	nodeAdd = fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.Add}
@@ -136,6 +146,31 @@ func withPodGroupName(pod *v1.Pod, podGroupName string) *v1.Pod {
 	pod = pod.DeepCopy()
 	pod.Spec.SchedulingGroup = &v1.PodSchedulingGroup{PodGroupName: &podGroupName}
 	return pod
+}
+
+type podInfoOpt func(*st.PodWrapper)
+
+func withPodLabel(key, value string) podInfoOpt {
+	return func(pw *st.PodWrapper) {
+		pw.Label(key, value)
+	}
+}
+
+func withPodGroup(name string) podInfoOpt {
+	return func(pw *st.PodWrapper) {
+		pw.PodGroupName(name)
+	}
+}
+
+func makeQueuedPodInfo(t *testing.T, name, ns string, params framework.QueueingParams, opts ...podInfoOpt) *framework.QueuedPodInfo {
+	podBuilder := st.MakePod().Name(name).Namespace(ns).UID(name)
+	for _, opt := range opts {
+		opt(podBuilder)
+	}
+	return &framework.QueuedPodInfo{
+		PodInfo:        mustNewTestPodInfo(t, podBuilder.Obj()),
+		QueueingParams: params,
+	}
 }
 
 func TestPriorityQueue_Add(t *testing.T) {
@@ -769,7 +804,7 @@ func Test_InFlightPods(t *testing.T) {
 				{podPopped: pod2},
 				// Simulate a bug, putting pod into activeQ, while pod is being scheduled.
 				{callback: func(t *testing.T, q *PriorityQueue) {
-					q.activeQ.add(logger, newQueuedPodInfoForLookup(pod1), framework.EventUnscheduledPodAdd.Label())
+					q.activeQ.add(logger, newQueuedPodInfoForLookup(pod1), framework.EventUnscheduledPodAdd.Label(), nil)
 				}},
 				// At this point, in the activeQ, we have pod1 and pod3 in this order.
 				{podCreated: pod3},
@@ -1468,13 +1503,13 @@ func TestPriorityQueue_Pop(t *testing.T) {
 			}
 
 			// Add medium priority entity to the activeQ
-			q.activeQ.add(logger, medEntity, framework.EventUnscheduledPodAdd.Label())
+			q.activeQ.add(logger, medEntity, framework.EventUnscheduledPodAdd.Label(), nil)
 			// Add high priority entity to the backoffQ
-			q.backoffQ.add(logger, backoffEntity, framework.EventUnscheduledPodAdd.Label())
+			q.backoffQ.add(logger, backoffEntity, framework.EventUnscheduledPodAdd.Label(), nil)
 			// Add high priority entity to the errorBackoffQ
-			q.backoffQ.add(logger, errorBackoffEntity, framework.EventUnscheduledPodAdd.Label())
+			q.backoffQ.add(logger, errorBackoffEntity, framework.EventUnscheduledPodAdd.Label(), nil)
 			// Add entity to the unschedulableEntities
-			q.unschedulableEntities.addOrUpdate(unschedEntity, false, framework.EventUnscheduledPodAdd.Label())
+			q.unschedulableEntities.addOrUpdate(unschedEntity, false, framework.EventUnscheduledPodAdd.Label(), nil)
 
 			var gotPods []string
 			for i := 0; i < len(tt.wantPods)+1; i++ {
@@ -1582,7 +1617,7 @@ func TestPriorityQueue_Update(t *testing.T) {
 			wantQ: backoffQ,
 			prepareFunc: func(tCtx ktesting.TContext, q *PriorityQueue) (oldPod, newPod *v1.Pod) {
 				podInfo := q.newQueuedPodInfo(tCtx, medPriorityPodInfo.Pod)
-				q.backoffQ.add(klog.FromContext(tCtx), podInfo, framework.EventUnscheduledPodAdd.Label())
+				q.backoffQ.add(klog.FromContext(tCtx), podInfo, framework.EventUnscheduledPodAdd.Label(), nil)
 				return podInfo.Pod, podInfo.Pod
 			},
 		},
@@ -1593,7 +1628,7 @@ func TestPriorityQueue_Update(t *testing.T) {
 				pInfo := q.newQueuedPodInfo(tCtx, medPriorityPodInfo.Pod, queuePlugin)
 				// needs to increment to make the pod backing off
 				pInfo.UnschedulableCount++
-				q.unschedulableEntities.addOrUpdate(pInfo, false, framework.EventUnscheduledPodAdd.Label())
+				q.unschedulableEntities.addOrUpdate(pInfo, false, framework.EventUnscheduledPodAdd.Label(), nil)
 				updatedPod := medPriorityPodInfo.Pod.DeepCopy()
 				updatedPod.Annotations["foo"] = "test"
 				return medPriorityPodInfo.Pod, updatedPod
@@ -1606,7 +1641,7 @@ func TestPriorityQueue_Update(t *testing.T) {
 				pInfo := q.newQueuedPodInfo(tCtx, medPriorityPodInfo.Pod, queuePlugin)
 				// needs to increment to make the pod backing off
 				pInfo.UnschedulableCount++
-				q.unschedulableEntities.addOrUpdate(pInfo, false, framework.EventUnscheduledPodAdd.Label())
+				q.unschedulableEntities.addOrUpdate(pInfo, false, framework.EventUnscheduledPodAdd.Label(), nil)
 				updatedPod := medPriorityPodInfo.Pod.DeepCopy()
 				updatedPod.Annotations["foo"] = "test1"
 				// Move clock by podMaxBackoffDuration, so that pods in the unschedulableEntities would pass the backing off,
@@ -1619,7 +1654,7 @@ func TestPriorityQueue_Update(t *testing.T) {
 			name:  "when updating a pod in unschedulableEntities, if the scheduling hint returns QueueSkip, it remains in unschedulableEntities",
 			wantQ: unschedulableQ,
 			prepareFunc: func(tCtx ktesting.TContext, q *PriorityQueue) (oldPod, newPod *v1.Pod) {
-				q.unschedulableEntities.addOrUpdate(q.newQueuedPodInfo(tCtx, medPriorityPodInfo.Pod, skipPlugin), false, framework.EventUnscheduledPodAdd.Label())
+				q.unschedulableEntities.addOrUpdate(q.newQueuedPodInfo(tCtx, medPriorityPodInfo.Pod, skipPlugin), false, framework.EventUnscheduledPodAdd.Label(), nil)
 				updatedPod := medPriorityPodInfo.Pod.DeepCopy()
 				updatedPod.Annotations["foo"] = "test1"
 				return medPriorityPodInfo.Pod, updatedPod
@@ -1974,7 +2009,7 @@ func TestPriorityQueue_Activate(t *testing.T) {
 
 			if tt.qPodInInFlightPod != nil {
 				// Put -> Pop the Pod to make it registered in inFlightPods.
-				q.activeQ.add(logger, newQueuedPodInfoForLookup(tt.qPodInInFlightPod), framework.EventUnscheduledPodAdd.Label())
+				q.activeQ.add(logger, newQueuedPodInfoForLookup(tt.qPodInInFlightPod), framework.EventUnscheduledPodAdd.Label(), nil)
 				p, err := q.activeQ.pop(logger)
 				if err != nil {
 					t.Fatalf("Pop failed: %v", err)
@@ -1993,11 +2028,11 @@ func TestPriorityQueue_Activate(t *testing.T) {
 			}
 
 			for _, qPodInfo := range tt.qPodInfoInUnschedulableEntities {
-				q.unschedulableEntities.addOrUpdate(qPodInfo, false, framework.EventUnscheduledPodAdd.Label())
+				q.unschedulableEntities.addOrUpdate(qPodInfo, false, framework.EventUnscheduledPodAdd.Label(), nil)
 			}
 
 			for _, qPodInfo := range tt.qPodInfoInBackoffQ {
-				q.backoffQ.add(logger, qPodInfo, framework.EventUnscheduledPodAdd.Label())
+				q.backoffQ.add(logger, qPodInfo, framework.EventUnscheduledPodAdd.Label(), nil)
 			}
 
 			// Activate specific pod according to the table
@@ -2202,7 +2237,7 @@ func TestPriorityQueue_moveToActiveQ(t *testing.T) {
 				}
 				q := NewTestQueueWithObjects(ctx, newDefaultQueueSort(), []runtime.Object{tt.pod}, WithPreEnqueuePluginMap(m),
 					WithPodInitialBackoffDuration(time.Second*30), WithPodMaxBackoffDuration(time.Second*60))
-				got := q.moveToActiveQ(logger, q.newQueuedPodInfo(ctx, tt.pod), tt.event, tt.movesFromBackoffQ)
+				got := q.moveToActiveQ(logger, q.newQueuedPodInfo(ctx, tt.pod), tt.event, tt.movesFromBackoffQ, nil)
 				if got != tt.wantSuccess {
 					t.Errorf("Unexpected result: want %v, but got %v", tt.wantSuccess, got)
 				}
@@ -2299,7 +2334,7 @@ func TestPriorityQueue_moveToBackoffQ(t *testing.T) {
 				q := NewTestQueueWithObjects(ctx, newDefaultQueueSort(), []runtime.Object{tt.pod}, WithPreEnqueuePluginMap(m),
 					WithPodInitialBackoffDuration(time.Second*30), WithPodMaxBackoffDuration(time.Second*60))
 				pInfo := q.newQueuedPodInfo(ctx, tt.pod)
-				got := q.moveToBackoffQ(logger, pInfo, framework.EventUnscheduledPodAdd.Label())
+				got := q.moveToBackoffQ(logger, pInfo, framework.EventUnscheduledPodAdd.Label(), nil)
 				if got != tt.wantSuccess {
 					t.Errorf("Unexpected result: want %v, but got %v", tt.wantSuccess, got)
 				}
@@ -2601,7 +2636,7 @@ func TestPriorityQueue_MoveAllToActiveOrBackoffQueueWithQueueingHint(t *testing.
 			} else {
 				// The pod was already moved to unschedulableEntities because it's gated.
 				// Update it with the test's configured podInfo to ensure custom test fields are set.
-				q.unschedulableEntities.addOrUpdate(test.podInfo, test.podInfo.Gated(), "test-setup")
+				q.unschedulableEntities.addOrUpdate(test.podInfo, test.podInfo.Gated(), "test-setup", nil)
 			}
 			cl.Step(test.duration)
 
@@ -3701,7 +3736,7 @@ func TestGatedPodFlushFrequency(t *testing.T) {
 			}
 
 			// Add gated pod directly to unschedulableEntities
-			q.unschedulableEntities.addOrUpdate(tt.entityInfo, false, "test-setup")
+			q.unschedulableEntities.addOrUpdate(tt.entityInfo, false, "test-setup", nil)
 
 			// Step clock past the flush duration and trigger flush
 			// T=5:01
@@ -4106,7 +4141,7 @@ var (
 		queue.Add(tCtx, pInfo.Pod)
 	}
 	addPodActiveQDirectly = func(tCtx ktesting.TContext, queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
-		queue.activeQ.add(klog.FromContext(tCtx), pInfo, framework.EventUnscheduledPodAdd.Label())
+		queue.activeQ.add(klog.FromContext(tCtx), pInfo, framework.EventUnscheduledPodAdd.Label(), nil)
 	}
 	addPodUnschedulablePods = func(tCtx ktesting.TContext, queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
 		if !pInfo.Gated() {
@@ -4120,7 +4155,7 @@ var (
 			// needs to increment it to make it backoff
 			pInfo.UnschedulableCount++
 		}
-		queue.unschedulableEntities.addOrUpdate(pInfo, false, framework.EventUnscheduledPodAdd.Label())
+		queue.unschedulableEntities.addOrUpdate(pInfo, false, framework.EventUnscheduledPodAdd.Label(), nil)
 	}
 	deletePod = func(tCtx ktesting.TContext, queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
 		queue.Delete(tCtx.Logger(), pInfo.Pod)
@@ -4131,7 +4166,7 @@ var (
 		queue.Update(tCtx, pInfo.Pod, newPod)
 	}
 	addPodBackoffQ = func(tCtx ktesting.TContext, queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
-		queue.backoffQ.add(klog.FromContext(tCtx), pInfo, framework.EventUnscheduledPodAdd.Label())
+		queue.backoffQ.add(klog.FromContext(tCtx), pInfo, framework.EventUnscheduledPodAdd.Label(), nil)
 	}
 	moveAllToActiveOrBackoffQ = func(tCtx ktesting.TContext, queue *PriorityQueue, _ *framework.QueuedPodInfo) {
 		queue.MoveAllToActiveOrBackoffQueue(klog.FromContext(tCtx), framework.EventUnschedulableTimeout, nil, nil, nil)
@@ -4152,6 +4187,11 @@ var (
 	}
 	updatePluginToUngateAllPods = func(tCtx ktesting.TContext, queue *PriorityQueue, _ *framework.QueuedPodInfo) {
 		queue.preEnqueuePluginMap[""]["preEnqueuePlugin"] = &preEnqueuePlugin{allowlists: []string{"queueable"}}
+	}
+	addPodGroupForPod = func(tCtx ktesting.TContext, queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
+		pgName := *pInfo.Pod.Spec.SchedulingGroup.PodGroupName
+		pg := st.MakePodGroup().Name(pgName).Namespace(pInfo.Pod.Namespace).Obj()
+		queue.AddPodGroup(klog.FromContext(tCtx), pg)
 	}
 )
 
@@ -4252,6 +4292,7 @@ func TestPodTimestamp(t *testing.T) {
 
 // TestSchedulerPodsMetric tests Prometheus metrics
 func TestSchedulerPodsMetric(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
 	timestamp := time.Now()
 	preenqueuePluginName := "preEnqueuePlugin"
 	metrics.Register()
@@ -4269,6 +4310,10 @@ func TestSchedulerPodsMetric(t *testing.T) {
 	pInfos = append(pInfos, gated...)
 	totalWithDelay := 20
 	pInfosWithDelay := makeQueuedPodInfos(totalWithDelay, "z", queueable, timestamp.Add(2*time.Second))
+
+	pInfo1 := makeQueuedPodInfo(t, "pod1", "ns1", framework.QueueingParams{}, withPodLabel("queueable", ""), withPodGroup("pg"))
+	pInfo2 := makeQueuedPodInfo(t, "pod2", "ns1", framework.QueueingParams{}, withPodLabel("queueable", ""), withPodGroup("pg"))
+	pInfoWithPgIncomplete := makeQueuedPodInfo(t, "pod3", "ns1", framework.QueueingParams{}, withPodLabel("queueable", ""), withPodGroup("pg-incomplete"))
 
 	resetPodInfos := func() {
 		// reset PodInfo's Attempts because they influence the backoff time calculation.
@@ -4303,11 +4348,13 @@ func TestSchedulerPodsMetric(t *testing.T) {
 			},
 			metricsName: "scheduler_pending_pods",
 			wants: `
-# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated.
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated; 'incomplete' means number of pods in incompletePodGroupPods; 'pending' means number of pods in pendingPodGroupPods.
 # TYPE scheduler_pending_pods gauge
 scheduler_pending_pods{queue="active"} 30
 scheduler_pending_pods{queue="backoff"} 0
 scheduler_pending_pods{queue="gated"} 10
+scheduler_pending_pods{queue="incomplete"} 0
+scheduler_pending_pods{queue="pending"} 0
 scheduler_pending_pods{queue="unschedulable"} 20
 `,
 		},
@@ -4325,11 +4372,13 @@ scheduler_pending_pods{queue="unschedulable"} 20
 			},
 			metricsName: "scheduler_pending_pods",
 			wants: `
-# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated.
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated; 'incomplete' means number of pods in incompletePodGroupPods; 'pending' means number of pods in pendingPodGroupPods.
 # TYPE scheduler_pending_pods gauge
 scheduler_pending_pods{queue="active"} 15
 scheduler_pending_pods{queue="backoff"} 25
 scheduler_pending_pods{queue="gated"} 10
+scheduler_pending_pods{queue="incomplete"} 0
+scheduler_pending_pods{queue="pending"} 0
 scheduler_pending_pods{queue="unschedulable"} 10
 `,
 		},
@@ -4347,11 +4396,13 @@ scheduler_pending_pods{queue="unschedulable"} 10
 			},
 			metricsName: "scheduler_pending_pods",
 			wants: `
-# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated.
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated; 'incomplete' means number of pods in incompletePodGroupPods; 'pending' means number of pods in pendingPodGroupPods.
 # TYPE scheduler_pending_pods gauge
 scheduler_pending_pods{queue="active"} 50
 scheduler_pending_pods{queue="backoff"} 0
 scheduler_pending_pods{queue="gated"} 10
+scheduler_pending_pods{queue="incomplete"} 0
+scheduler_pending_pods{queue="pending"} 0
 scheduler_pending_pods{queue="unschedulable"} 0
 `,
 		},
@@ -4371,11 +4422,13 @@ scheduler_pending_pods{queue="unschedulable"} 0
 			},
 			metricsName: "scheduler_pending_pods",
 			wants: `
-# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated.
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated; 'incomplete' means number of pods in incompletePodGroupPods; 'pending' means number of pods in pendingPodGroupPods.
 # TYPE scheduler_pending_pods gauge
 scheduler_pending_pods{queue="active"} 30
 scheduler_pending_pods{queue="backoff"} 20
 scheduler_pending_pods{queue="gated"} 10
+scheduler_pending_pods{queue="incomplete"} 0
+scheduler_pending_pods{queue="pending"} 0
 scheduler_pending_pods{queue="unschedulable"} 0
 `,
 		},
@@ -4395,11 +4448,13 @@ scheduler_pending_pods{queue="unschedulable"} 0
 			},
 			metricsName: "scheduler_pending_pods",
 			wants: `
-# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated.
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated; 'incomplete' means number of pods in incompletePodGroupPods; 'pending' means number of pods in pendingPodGroupPods.
 # TYPE scheduler_pending_pods gauge
 scheduler_pending_pods{queue="active"} 50
 scheduler_pending_pods{queue="backoff"} 0
 scheduler_pending_pods{queue="gated"} 0
+scheduler_pending_pods{queue="incomplete"} 0
+scheduler_pending_pods{queue="pending"} 0
 scheduler_pending_pods{queue="unschedulable"} 0
 `,
 		},
@@ -4421,11 +4476,13 @@ scheduler_pending_pods{queue="unschedulable"} 0
 			},
 			metricsName: "scheduler_pending_pods",
 			wants: `
-# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated.
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated; 'incomplete' means number of pods in incompletePodGroupPods; 'pending' means number of pods in pendingPodGroupPods.
 # TYPE scheduler_pending_pods gauge
 scheduler_pending_pods{queue="active"} 28
 scheduler_pending_pods{queue="backoff"} 0
 scheduler_pending_pods{queue="gated"} 6
+scheduler_pending_pods{queue="incomplete"} 0
+scheduler_pending_pods{queue="pending"} 0
 scheduler_pending_pods{queue="unschedulable"} 17
 `,
 		},
@@ -4443,11 +4500,13 @@ scheduler_pending_pods{queue="unschedulable"} 17
 			},
 			metricsName: "scheduler_pending_pods",
 			wants: `
-# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated.
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated; 'incomplete' means number of pods in incompletePodGroupPods; 'pending' means number of pods in pendingPodGroupPods.
 # TYPE scheduler_pending_pods gauge
 scheduler_pending_pods{queue="active"} 35
 scheduler_pending_pods{queue="backoff"} 0
 scheduler_pending_pods{queue="gated"} 5
+scheduler_pending_pods{queue="incomplete"} 0
+scheduler_pending_pods{queue="pending"} 0
 scheduler_pending_pods{queue="unschedulable"} 20
 `,
 		},
@@ -4521,11 +4580,13 @@ scheduler_plugin_execution_duration_seconds_count{extension_point="PreEnqueue",p
 			metricsName:                "scheduler_pending_pods",
 			pluginMetricsSamplePercent: 100,
 			wants: `
-# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated.
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated; 'incomplete' means number of pods in incompletePodGroupPods; 'pending' means number of pods in pendingPodGroupPods.
 # TYPE scheduler_pending_pods gauge
 scheduler_pending_pods{queue="active"} 0
 scheduler_pending_pods{queue="backoff"} 0
 scheduler_pending_pods{queue="gated"} 1
+scheduler_pending_pods{queue="incomplete"} 0
+scheduler_pending_pods{queue="pending"} 0
 scheduler_pending_pods{queue="unschedulable"} 0
 `,
 		},
@@ -4544,11 +4605,13 @@ scheduler_pending_pods{queue="unschedulable"} 0
 			metricsName:                "scheduler_pending_pods",
 			pluginMetricsSamplePercent: 100,
 			wants: `
-# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated.
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated; 'incomplete' means number of pods in incompletePodGroupPods; 'pending' means number of pods in pendingPodGroupPods.
 # TYPE scheduler_pending_pods gauge
 scheduler_pending_pods{queue="active"} 0
 scheduler_pending_pods{queue="backoff"} 0
 scheduler_pending_pods{queue="gated"} 1
+scheduler_pending_pods{queue="incomplete"} 0
+scheduler_pending_pods{queue="pending"} 0
 scheduler_pending_pods{queue="unschedulable"} 0
 `,
 		},
@@ -4570,11 +4633,13 @@ scheduler_pending_pods{queue="unschedulable"} 0
 			pluginMetricsSamplePercent: 100,
 			disablePopFromBackoffQ:     true,
 			wants: `
-# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated.
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated; 'incomplete' means number of pods in incompletePodGroupPods; 'pending' means number of pods in pendingPodGroupPods.
 # TYPE scheduler_pending_pods gauge
 scheduler_pending_pods{queue="active"} 0
 scheduler_pending_pods{queue="backoff"} 0
 scheduler_pending_pods{queue="gated"} 1
+scheduler_pending_pods{queue="incomplete"} 0
+scheduler_pending_pods{queue="pending"} 0
 scheduler_pending_pods{queue="unschedulable"} 0
 `,
 		},
@@ -4599,11 +4664,13 @@ scheduler_pending_pods{queue="unschedulable"} 0
 			pluginMetricsSamplePercent: 100,
 			metricsName:                "scheduler_pending_pods",
 			wants: `
-# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated.
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated; 'incomplete' means number of pods in incompletePodGroupPods; 'pending' means number of pods in pendingPodGroupPods.
 # TYPE scheduler_pending_pods gauge
 scheduler_pending_pods{queue="active"} 1
 scheduler_pending_pods{queue="backoff"} 0
 scheduler_pending_pods{queue="gated"} 0
+scheduler_pending_pods{queue="incomplete"} 0
+scheduler_pending_pods{queue="pending"} 0
 scheduler_pending_pods{queue="unschedulable"} 0
 `,
 		},
@@ -4626,11 +4693,13 @@ scheduler_pending_pods{queue="unschedulable"} 0
 			pluginMetricsSamplePercent: 100,
 			metricsName:                "scheduler_pending_pods",
 			wants: `
-# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated.
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated; 'incomplete' means number of pods in incompletePodGroupPods; 'pending' means number of pods in pendingPodGroupPods.
 # TYPE scheduler_pending_pods gauge
 scheduler_pending_pods{queue="active"} 0
 scheduler_pending_pods{queue="backoff"} 1
 scheduler_pending_pods{queue="gated"} 0
+scheduler_pending_pods{queue="incomplete"} 0
+scheduler_pending_pods{queue="pending"} 0
 scheduler_pending_pods{queue="unschedulable"} 0
 `,
 		},
@@ -4655,11 +4724,57 @@ scheduler_pending_pods{queue="unschedulable"} 0
 			pluginMetricsSamplePercent: 100,
 			disablePopFromBackoffQ:     true,
 			wants: `
-# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated.
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated; 'incomplete' means number of pods in incompletePodGroupPods; 'pending' means number of pods in pendingPodGroupPods.
 # TYPE scheduler_pending_pods gauge
 scheduler_pending_pods{queue="active"} 1
 scheduler_pending_pods{queue="backoff"} 0
 scheduler_pending_pods{queue="gated"} 0
+scheduler_pending_pods{queue="incomplete"} 0
+scheduler_pending_pods{queue="pending"} 0
+scheduler_pending_pods{queue="unschedulable"} 0
+`,
+		},
+		{
+			name: "adding a pod that belongs to a podgroup not yet observed by scheduler ends up in incompletePodGroupPods",
+			operations: []operation{
+				addPodActiveQ,
+			},
+			operands: [][]*framework.QueuedPodInfo{
+				{pInfoWithPgIncomplete},
+			},
+			wants: `
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated; 'incomplete' means number of pods in incompletePodGroupPods; 'pending' means number of pods in pendingPodGroupPods.
+# TYPE scheduler_pending_pods gauge
+scheduler_pending_pods{queue="active"} 0
+scheduler_pending_pods{queue="backoff"} 0
+scheduler_pending_pods{queue="gated"} 0
+scheduler_pending_pods{queue="incomplete"} 1
+scheduler_pending_pods{queue="pending"} 0
+scheduler_pending_pods{queue="unschedulable"} 0
+`,
+		},
+		{
+			name: "adding a pod that belongs to a popped podgroup ends up in pendingPodGroupPods",
+			operations: []operation{
+				addPodActiveQ,
+				addPodGroupForPod,
+				pop,
+				addPodActiveQ,
+			},
+			operands: [][]*framework.QueuedPodInfo{
+				{pInfo1},
+				{pInfo1},
+				{nil},
+				{pInfo2},
+			},
+			wants: `
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated; 'incomplete' means number of pods in incompletePodGroupPods; 'pending' means number of pods in pendingPodGroupPods.
+# TYPE scheduler_pending_pods gauge
+scheduler_pending_pods{queue="active"} 0
+scheduler_pending_pods{queue="backoff"} 0
+scheduler_pending_pods{queue="gated"} 0
+scheduler_pending_pods{queue="incomplete"} 0
+scheduler_pending_pods{queue="pending"} 1
 scheduler_pending_pods{queue="unschedulable"} 0
 `,
 		},
@@ -4670,6 +4785,8 @@ scheduler_pending_pods{queue="unschedulable"} 0
 		metrics.BackoffPods().Set(0)
 		metrics.UnschedulablePods().Set(0)
 		metrics.GatedPods().Set(0)
+		metrics.IncompletePodGroupPods().Set(0)
+		metrics.PendingPodGroupPods().Set(0)
 		metrics.PluginExecutionDuration.Reset()
 	}
 
@@ -4918,6 +5035,266 @@ func TestIncomingPodsMetrics(t *testing.T) {
 				t.Errorf("unexpected collecting result:\n%s", err)
 			}
 
+		})
+	}
+}
+
+func TestIncomingEntitiesMetrics(t *testing.T) {
+	logger := klog.Background()
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
+	timestamp := time.Now()
+
+	unschedulablePlugin := "unschedulable_plugin"
+	queuingParams := framework.QueueingParams{
+		Timestamp:            timestamp,
+		UnschedulablePlugins: sets.New(unschedulablePlugin),
+	}
+
+	pInfos := []*framework.QueuedPodInfo{
+		makeQueuedPodInfo(t, "pod1", "ns-pg", queuingParams),
+		makeQueuedPodInfo(t, "pod2", "ns-pg", queuingParams, withPodGroup("pg-1")),
+		makeQueuedPodInfo(t, "pod3", "ns-pg", queuingParams, withPodGroup("pg-1")),
+		makeQueuedPodInfo(t, "pod4", "ns-pg", queuingParams, withPodGroup("pg-1")),
+	}
+
+	metricName := metrics.SchedulerSubsystem + "_" + metrics.SchedulerQueueIncomingEntities.Name
+
+	tests := []struct {
+		name string
+		run  func(tCtx ktesting.TContext, queue *PriorityQueue)
+		want string
+	}{
+		{
+			name: "add all pods to active queue",
+			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
+				for _, pInfo := range pInfos {
+					queue.Add(tCtx, pInfo.Pod)
+				}
+			},
+			want: `
+				scheduler_queue_incoming_entities_total{event="UnscheduledPodAdd",queue="active",type="pod"} 1
+				scheduler_queue_incoming_entities_total{event="UnscheduledPodAdd",queue="active",type="podgroup"} 1
+			`,
+		},
+		{
+			name: "add pods of a podgroup to active queue, simulate scheduling failure attempt, and requeue podgroup to backoff queue",
+			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
+				queue.Add(tCtx, pInfos[1].Pod)
+				queue.Add(tCtx, pInfos[2].Pod)
+				queue.Add(tCtx, pInfos[3].Pod)
+				entityGroup, err := queue.Pop(logger)
+				if err != nil {
+					tCtx.Fatalf("Unexpected error popping from queue: %v", err)
+				}
+				pgInfo := entityGroup.(*framework.QueuedPodGroupInfo)
+				queue.pendingPodGroupPods.add(pInfos[2])
+				queue.pendingPodGroupPods.add(pInfos[3])
+				if err := queue.AddAttemptedPodGroupIfNeeded(logger, pgInfo, 1, fwk.NewStatus(fwk.Unschedulable)); err != nil {
+					tCtx.Fatalf("Unexpected error adding attempted pod group: %v", err)
+				}
+			},
+			want: `
+				scheduler_queue_incoming_entities_total{event="UnscheduledPodAdd",queue="active",type="podgroup"} 1
+				scheduler_queue_incoming_entities_total{event="ScheduleAttemptFailure",queue="backoff",type="podgroup"} 1
+			`,
+		},
+		{
+			name: "add individual pod to active queue",
+			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
+				queue.Add(tCtx, pInfos[0].Pod)
+				entity, err := queue.Pop(logger)
+				if err != nil {
+					tCtx.Fatalf("Unexpected error popping from queue: %v", err)
+				}
+				pod := entity.(*framework.QueuedPodInfo)
+				pod.UnschedulablePlugins = sets.New(unschedulablePlugin)
+				if err := queue.AddUnschedulablePodIfNotPresent(logger, pod, 1); err != nil {
+					tCtx.Fatalf("Unexpected error adding unschedulable pod: %v", err)
+				}
+			},
+			want: `
+				scheduler_queue_incoming_entities_total{event="UnscheduledPodAdd",queue="active",type="pod"} 1
+			`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+			metrics.SchedulerQueueIncomingEntities.Reset()
+			queue := NewTestQueue(tCtx, newDefaultQueueSort(), WithClock(testingclock.NewFakeClock(timestamp)))
+			queue.AddPodGroup(logger, st.MakePodGroup().Name("pg-1").Namespace("ns-pg").Obj())
+			test.run(tCtx, queue)
+			if err := testutil.CollectAndCompare(metrics.SchedulerQueueIncomingEntities, strings.NewReader(queueIncomingEntitiesMetricMetadata+test.want), metricName); err != nil {
+				t.Errorf("unexpected collecting result:\n%s", err)
+			}
+		})
+	}
+}
+
+func TestQueuedEntitiesMetrics(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
+	timestamp := time.Now()
+	unschedulablePlugin := "unschedulable_plugin"
+	logger := klog.Background()
+	queuingParams := framework.QueueingParams{
+		Timestamp:            timestamp,
+		UnschedulablePlugins: sets.New(unschedulablePlugin),
+	}
+
+	pInfos := []*framework.QueuedPodInfo{
+		makeQueuedPodInfo(t, "pod1", "ns-pg", queuingParams),
+		makeQueuedPodInfo(t, "pod2", "ns-pg", queuingParams, withPodGroup("pg-1")),
+		makeQueuedPodInfo(t, "pod3", "ns-pg", queuingParams, withPodGroup("pg-1")),
+		makeQueuedPodInfo(t, "pod4", "ns-pg", queuingParams, withPodGroup("pg-1")),
+	}
+
+	metricName := metrics.SchedulerSubsystem + "_" + metrics.QueuedEntities.Name
+
+	tests := []struct {
+		name string
+		run  func(tCtx ktesting.TContext, queue *PriorityQueue)
+		want string
+	}{
+		{
+			name: "add all pods to active queue",
+			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
+				for _, pInfo := range pInfos {
+					queue.Add(tCtx, pInfo.Pod)
+				}
+			},
+			want: `
+				scheduler_queued_entities{queue="active",type="pod"} 1
+				scheduler_queued_entities{queue="active",type="podgroup"} 1
+			`,
+		},
+		{
+			name: "add pods of a podgroup to active queue, simulate scheduling failure attempt, and requeue podgroup to backoff queue",
+			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
+				queue.Add(tCtx, pInfos[1].Pod)
+				queue.Add(tCtx, pInfos[2].Pod)
+				queue.Add(tCtx, pInfos[3].Pod)
+				entityGroup, err := queue.Pop(logger)
+				if err != nil {
+					tCtx.Fatalf("Unexpected error popping from queue: %v", err)
+				}
+				pgInfo := entityGroup.(*framework.QueuedPodGroupInfo)
+				queue.pendingPodGroupPods.add(pInfos[2])
+				queue.pendingPodGroupPods.add(pInfos[3])
+				if err := queue.AddAttemptedPodGroupIfNeeded(logger, pgInfo, 1, fwk.NewStatus(fwk.Unschedulable)); err != nil {
+					tCtx.Fatalf("Unexpected error adding attempted pod group: %v", err)
+				}
+			},
+			want: `
+				scheduler_queued_entities{queue="active",type="podgroup"} 0
+				scheduler_queued_entities{queue="backoff",type="podgroup"} 1
+			`,
+		},
+		{
+			name: "Add individual pod to active queue, then mark it as unschedulable and add it unschedulable queue",
+			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
+				queue.Add(tCtx, pInfos[0].Pod)
+				entity, err := queue.Pop(logger)
+				if err != nil {
+					tCtx.Fatalf("Unexpected error popping from queue: %v", err)
+				}
+				pod := entity.(*framework.QueuedPodInfo)
+				pod.UnschedulablePlugins = sets.New(unschedulablePlugin)
+				if err := queue.AddUnschedulablePodIfNotPresent(logger, pod, 1); err != nil {
+					tCtx.Fatalf("Unexpected error adding unschedulable pod: %v", err)
+				}
+			},
+			want: `
+				scheduler_queued_entities{queue="active",type="pod"} 0
+				scheduler_queued_entities{queue="unschedulable",type="pod"} 1
+			`,
+		},
+		{
+			name: "Add individual pod, mark it as unschedulable, and move it to unschedulable queue then backoff queue",
+			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
+				queue.Add(tCtx, pInfos[0].Pod)
+				entity, err := queue.Pop(logger)
+				if err != nil {
+					tCtx.Fatalf("Unexpected error popping from queue: %v", err)
+				}
+				pod := entity.(*framework.QueuedPodInfo)
+				pod.UnschedulablePlugins = sets.New(unschedulablePlugin)
+				if err := queue.AddUnschedulablePodIfNotPresent(logger, pod, 1); err != nil {
+					tCtx.Fatalf("Unexpected error adding unschedulable pod: %v", err)
+				}
+
+				queue.MoveAllToActiveOrBackoffQueue(logger, framework.EventUnschedulableTimeout, nil, nil, nil)
+			},
+			want: `
+				scheduler_queued_entities{queue="active",type="pod"} 0
+				scheduler_queued_entities{queue="backoff",type="pod"} 1
+				scheduler_queued_entities{queue="unschedulable",type="pod"} 0
+			`,
+		},
+		{
+			name: "Add podgroup, mark as unschedulable and move it to unschedulable queue, then to backoff queue",
+			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
+				queue.Add(tCtx, pInfos[1].Pod)
+				queue.Add(tCtx, pInfos[2].Pod)
+				queue.Add(tCtx, pInfos[3].Pod)
+				entityGroup, err := queue.Pop(logger)
+				if err != nil {
+					tCtx.Fatalf("Unexpected error popping from queue: %v", err)
+				}
+				pgInfo := entityGroup.(*framework.QueuedPodGroupInfo)
+				queue.pendingPodGroupPods.add(pInfos[2])
+				queue.pendingPodGroupPods.add(pInfos[3])
+				pgInfo.UnschedulablePlugins = sets.New(unschedulablePlugin)
+				pgInfo.UnschedulableCount = 1
+				queue.unschedulableEntities.addOrUpdate(pgInfo, false, framework.ScheduleAttemptFailure, nil)
+
+				queue.MoveAllToActiveOrBackoffQueue(logger, framework.EventUnschedulableTimeout, nil, nil, nil)
+			},
+			want: `
+				scheduler_queued_entities{queue="active",type="podgroup"} 0
+				scheduler_queued_entities{queue="backoff",type="podgroup"} 1
+				scheduler_queued_entities{queue="unschedulable",type="podgroup"} 0
+			`,
+		},
+		{
+			name: "Move a podgroup from backoff queue to active queue",
+			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
+				queue.Add(tCtx, pInfos[1].Pod)
+				queue.Add(tCtx, pInfos[2].Pod)
+				queue.Add(tCtx, pInfos[3].Pod)
+				entityGroup, err := queue.Pop(logger)
+				if err != nil {
+					tCtx.Fatalf("Unexpected error popping from queue: %v", err)
+				}
+				pgInfo := entityGroup.(*framework.QueuedPodGroupInfo)
+				queue.pendingPodGroupPods.add(pInfos[2])
+				queue.pendingPodGroupPods.add(pInfos[3])
+				pgInfo.UnschedulablePlugins = sets.New(unschedulablePlugin)
+				pgInfo.UnschedulableCount = 1
+				queue.unschedulableEntities.addOrUpdate(pgInfo, false, framework.ScheduleAttemptFailure, nil)
+
+				queue.clock.(*testingclock.FakeClock).Step(3 * time.Second)
+				queue.MoveAllToActiveOrBackoffQueue(logger, framework.EventUnschedulableTimeout, nil, nil, nil)
+			},
+			want: `
+				scheduler_queued_entities{queue="active",type="podgroup"} 1
+				scheduler_queued_entities{queue="unschedulable",type="podgroup"} 0
+			`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+			metrics.QueuedEntities.Reset()
+			queue := NewTestQueue(tCtx, newDefaultQueueSort(), WithClock(testingclock.NewFakeClock(timestamp)))
+			queue.AddPodGroup(logger, st.MakePodGroup().Name("pg-1").Namespace("ns-pg").Obj())
+
+			test.run(tCtx, queue)
+
+			if err := testutil.CollectAndCompare(metrics.QueuedEntities, strings.NewReader(queuedEntitiesMetricMetadata+test.want), metricName); err != nil {
+				t.Errorf("unexpected collecting result:\n%s", err)
+			}
 		})
 	}
 }
@@ -5505,9 +5882,9 @@ func TestPriorityQueue_GetPod(t *testing.T) {
 
 	logger, ctx := ktesting.NewTestContext(t)
 	q := NewTestQueue(ctx, newDefaultQueueSort())
-	q.activeQ.add(logger, newQueuedPodInfoForLookup(activeQPod), framework.EventUnscheduledPodAdd.Label())
-	q.backoffQ.add(logger, newQueuedPodInfoForLookup(backoffQPod), framework.EventUnscheduledPodAdd.Label())
-	q.unschedulableEntities.addOrUpdate(newQueuedPodInfoForLookup(unschedPod), false, framework.EventUnscheduledPodAdd.Label())
+	q.activeQ.add(logger, newQueuedPodInfoForLookup(activeQPod), framework.EventUnscheduledPodAdd.Label(), nil)
+	q.backoffQ.add(logger, newQueuedPodInfoForLookup(backoffQPod), framework.EventUnscheduledPodAdd.Label(), nil)
+	q.unschedulableEntities.addOrUpdate(newQueuedPodInfoForLookup(unschedPod), false, framework.EventUnscheduledPodAdd.Label(), nil)
 
 	tests := []struct {
 		name        string
@@ -5883,14 +6260,14 @@ func TestPriorityQueue_UpdateRecomputesSignature(t *testing.T) {
 			name: "pod in backoffQ",
 			prepareFunc: func(tCtx ktesting.TContext, q *PriorityQueue) {
 				pInfo := q.newQueuedPodInfo(tCtx, pod1)
-				q.backoffQ.add(klog.FromContext(tCtx), pInfo, framework.EventUnscheduledPodAdd.Label())
+				q.backoffQ.add(klog.FromContext(tCtx), pInfo, framework.EventUnscheduledPodAdd.Label(), nil)
 			},
 		},
 		{
 			name: "pod in unschedulableEntities",
 			prepareFunc: func(tCtx ktesting.TContext, q *PriorityQueue) {
 				pInfo := q.newQueuedPodInfo(tCtx, pod1)
-				q.unschedulableEntities.addOrUpdate(pInfo, false, framework.EventUnscheduledPodAdd.Label())
+				q.unschedulableEntities.addOrUpdate(pInfo, false, framework.EventUnscheduledPodAdd.Label(), nil)
 			},
 		},
 		{
@@ -6067,18 +6444,18 @@ func setupInitialPodGroupState(t *testing.T, ctx context.Context, q *PriorityQue
 				pInfo.Timestamp = q.clock.Now()
 				pInfo.UnschedulablePlugins = sets.New("fooPlugin")
 			}
-			q.backoffQ.add(logger, entity, framework.EventUnscheduledPodAdd.Label())
+			q.backoffQ.add(logger, entity, framework.EventUnscheduledPodAdd.Label(), nil)
 		}
 	case stateUnschedulable:
 		entity := q.activeQ.delete(pgLookup)
 		if entity != nil {
-			q.unschedulableEntities.addOrUpdate(entity, false, framework.EventUnscheduledPodAdd.Label())
+			q.unschedulableEntities.addOrUpdate(entity, false, framework.EventUnscheduledPodAdd.Label(), nil)
 		}
 	case stateGated:
 		entity := q.activeQ.delete(pgLookup)
 		if entity != nil {
 			entity.SetGatingPlugin("preEnqueuePlugin", []fwk.ClusterEvent{pvAdd})
-			q.unschedulableEntities.addOrUpdate(entity, false, framework.EventUnscheduledPodAdd.Label())
+			q.unschedulableEntities.addOrUpdate(entity, false, framework.EventUnscheduledPodAdd.Label(), nil)
 		}
 	}
 }

--- a/pkg/scheduler/backend/queue/unschedulable_entities.go
+++ b/pkg/scheduler/backend/queue/unschedulable_entities.go
@@ -44,37 +44,37 @@ func newUnschedulableEntities(unschedulableRecorder, gatedRecorder metrics.Metri
 
 // updateMetricsOnStateChange handles the metric accounting when an entity changes
 // between Gated and Unschedulable states.
-func (u *unschedulableEntities) updateMetricsOnStateChange(gatedBefore, isGated bool, size int) {
+func (u *unschedulableEntities) updateMetricsOnStateChange(gatedBefore, isGated bool, entity framework.QueuedEntityInfo) {
 	if gatedBefore == isGated {
 		return
 	}
 
 	if gatedBefore {
 		// Transition: Gated -> Ungated
-		u.gatedRecorder.Add(-size)
-		u.unschedulableRecorder.Add(size)
+		u.gatedRecorder.Remove(entity)
+		u.unschedulableRecorder.Add(entity)
 	} else {
 		// Transition: Ungated -> Gated
-		u.gatedRecorder.Add(size)
-		u.unschedulableRecorder.Add(-size)
+		u.gatedRecorder.Add(entity)
+		u.unschedulableRecorder.Remove(entity)
 	}
 }
 
 // addOrUpdate adds an entity to the unschedulable entityInfoMap.
 // The event should show which event triggered the addition and is used for the metric recording.
-func (u *unschedulableEntities) addOrUpdate(entity framework.QueuedEntityInfo, gatedBefore bool, event string) {
+// 'strategy' is the previous queuing strategy, helps determine if the entity moved into a different
+// queue or newly added to correctly maintain incoming entities metrics.
+func (u *unschedulableEntities) addOrUpdate(entity framework.QueuedEntityInfo, gatedBefore bool, event string, strategy *queueingStrategy) {
 	entityKey := u.keyFunc(entity)
 	if _, exists := u.entityInfoMap[entityKey]; exists {
-		u.updateMetricsOnStateChange(gatedBefore, entity.Gated(), entity.Size())
+		u.updateMetricsOnStateChange(gatedBefore, entity.Gated(), entity)
 	} else {
 		if entity.Gated() {
-			u.gatedRecorder.Add(entity.Size())
+			u.gatedRecorder.Add(entity)
 		} else {
-			u.unschedulableRecorder.Add(entity.Size())
+			u.unschedulableRecorder.Add(entity)
 		}
-		if metrics.SchedulerQueueIncomingPods != nil {
-			metrics.SchedulerQueueIncomingPods.WithLabelValues("unschedulable", event).Add(float64(entity.Size()))
-		}
+		recordIncomingEntitiesMetrics("unschedulable", entity, event, strategy)
 	}
 	u.entityInfoMap[entityKey] = entity
 }
@@ -85,9 +85,9 @@ func (u *unschedulableEntities) delete(entity framework.QueuedEntityInfo, gated 
 	entityKey := u.keyFunc(entity)
 	if _, exists := u.entityInfoMap[entityKey]; exists {
 		if gated {
-			u.gatedRecorder.Add(-entity.Size())
+			u.gatedRecorder.Remove(entity)
 		} else {
-			u.unschedulableRecorder.Add(-entity.Size())
+			u.unschedulableRecorder.Remove(entity)
 		}
 	}
 	delete(u.entityInfoMap, entityKey)

--- a/pkg/scheduler/backend/queue/unschedulable_entities_test.go
+++ b/pkg/scheduler/backend/queue/unschedulable_entities_test.go
@@ -36,16 +36,16 @@ type mockMetricRecorder struct {
 	val atomic.Int64
 }
 
-func (m *mockMetricRecorder) Add(val int) {
-	m.val.Add(int64(val))
+func (m *mockMetricRecorder) Add(entity metrics.Entity) {
+	m.val.Add(int64(entity.Size()))
 }
 
-func (m *mockMetricRecorder) Inc() {
-	m.val.Add(1)
+func (m *mockMetricRecorder) Remove(entity metrics.Entity) {
+	m.val.Add(-int64(entity.Size()))
 }
 
-func (m *mockMetricRecorder) Dec() {
-	m.val.Add(-1)
+func (m *mockMetricRecorder) Update(oldEntity, newEntity metrics.Entity) {
+	m.val.Add(int64(newEntity.Size() - oldEntity.Size()))
 }
 
 func (m *mockMetricRecorder) Clear() {
@@ -74,10 +74,10 @@ func TestUnschedulableEntities(t *testing.T) {
 
 	var actionToOperation = map[action]func(ue *unschedulableEntities, pInfo *framework.QueuedPodInfo, gatedBefore bool){
 		add: func(ue *unschedulableEntities, pInfo *framework.QueuedPodInfo, _ bool) {
-			ue.addOrUpdate(pInfo, false, framework.EventUnscheduledPodAdd.Label())
+			ue.addOrUpdate(pInfo, false, framework.EventUnscheduledPodAdd.Label(), nil)
 		},
 		update: func(ue *unschedulableEntities, pInfo *framework.QueuedPodInfo, gatedBefore bool) {
-			ue.addOrUpdate(pInfo, gatedBefore, framework.EventUnscheduledPodUpdate.Label())
+			ue.addOrUpdate(pInfo, gatedBefore, framework.EventUnscheduledPodUpdate.Label(), nil)
 		},
 		delete: func(ue *unschedulableEntities, pInfo *framework.QueuedPodInfo, gatedBefore bool) {
 			ue.delete(pInfo, gatedBefore)
@@ -258,7 +258,7 @@ func TestUnschedulablePodGroups_Unified(t *testing.T) {
 		},
 	}
 
-	ue.addOrUpdate(pgInfo, false, "test")
+	ue.addOrUpdate(pgInfo, false, "test", nil)
 	if ue.get(pgInfo) == nil {
 		t.Errorf("Expected pod group to be present")
 	}

--- a/pkg/scheduler/metrics/metric_recorder.go
+++ b/pkg/scheduler/metrics/metric_recorder.go
@@ -20,70 +20,116 @@ import (
 	"time"
 
 	"k8s.io/component-base/metrics"
+	fwk "k8s.io/kube-scheduler/framework"
 )
 
-// MetricRecorder represents a metric recorder which takes action when the
-// metric Inc(), Dec() and Clear()
+// Entity is either a pod or a podgroup that gets recorded in the metrics.
+type Entity interface {
+	// Size returns the number of pods within the entity (1 for a single pod, or the pod count for a pod group).
+	Size() int
+	// Type returns the entity type (e.g. "pod" or "podgroup").
+	Type() fwk.EntityKeyType
+}
+
+// MetricRecorder represents a metric recorder which maintains a metric through Add(), Remove(), Update(), and Clear().
 type MetricRecorder interface {
-	Add(int)
-	Inc()
-	Dec()
+	// Add records the addition of an entity.
+	Add(entity Entity)
+	// Remove records the removal of an entity.
+	Remove(entity Entity)
+	// Update records the update of an entity.
+	Update(oldEntity, newEntity Entity)
+	// Clear resets recorded metrics to zero.
 	Clear()
 }
 
-var _ MetricRecorder = &PendingPodsRecorder{}
+var _ MetricRecorder = &QueuedEntitiesRecorder{}
 
-// PendingPodsRecorder is an implementation of MetricRecorder
-type PendingPodsRecorder struct {
-	recorder metrics.GaugeMetric
+// QueuedEntitiesRecorder is an implementation of MetricRecorder.
+type QueuedEntitiesRecorder struct {
+	pods     metrics.GaugeMetric
+	entities func(entityType string) metrics.GaugeMetric
 }
 
-// NewActivePodsRecorder returns ActivePods in a Prometheus metric fashion
-func NewActivePodsRecorder() *PendingPodsRecorder {
-	return &PendingPodsRecorder{
-		recorder: ActivePods(),
+// NewActiveEntitiesRecorder returns ActivePods and ActiveEntities in a Prometheus metric fashion.
+func NewActiveEntitiesRecorder() *QueuedEntitiesRecorder {
+	return &QueuedEntitiesRecorder{
+		pods:     ActivePods(),
+		entities: ActiveEntities,
 	}
 }
 
-// NewUnschedulablePodsRecorder returns UnschedulablePods in a Prometheus metric fashion
-func NewUnschedulablePodsRecorder() *PendingPodsRecorder {
-	return &PendingPodsRecorder{
-		recorder: UnschedulablePods(),
+// NewUnschedulableEntitiesRecorder returns UnschedulablePods and UnschedulableEntities in a Prometheus metric fashion.
+func NewUnschedulableEntitiesRecorder() *QueuedEntitiesRecorder {
+	return &QueuedEntitiesRecorder{
+		pods:     UnschedulablePods(),
+		entities: UnschedulableEntities,
 	}
 }
 
-// NewBackoffPodsRecorder returns BackoffPods in a Prometheus metric fashion
-func NewBackoffPodsRecorder() *PendingPodsRecorder {
-	return &PendingPodsRecorder{
-		recorder: BackoffPods(),
+// NewBackoffEntitiesRecorder returns BackoffPods and BackoffEntities in a Prometheus metric fashion.
+func NewBackoffEntitiesRecorder() *QueuedEntitiesRecorder {
+	return &QueuedEntitiesRecorder{
+		pods:     BackoffPods(),
+		entities: BackoffEntities,
 	}
 }
 
-// NewGatedPodsRecorder returns GatedPods in a Prometheus metric fashion
-func NewGatedPodsRecorder() *PendingPodsRecorder {
-	return &PendingPodsRecorder{
-		recorder: GatedPods(),
+// NewGatedEntitiesRecorder returns GatedPods and GatedEntities in a Prometheus metric fashion.
+func NewGatedEntitiesRecorder() *QueuedEntitiesRecorder {
+	return &QueuedEntitiesRecorder{
+		pods:     GatedPods(),
+		entities: GatedEntities,
 	}
 }
 
-// Add adds a value to the metric, in an atomic way
-func (r *PendingPodsRecorder) Add(val int) {
-	r.recorder.Add(float64(val))
+// EntityToLabel converts an Entity to an entity metric label string.
+func EntityToLabel(entity Entity) (string, bool) {
+	if entity == nil {
+		return "", false
+	}
+
+	switch entity.Type() {
+	case fwk.PodKeyType:
+		return Pod, true
+	case fwk.PodGroupKeyType:
+		return PodGroup, true
+	}
+
+	return "", false
 }
 
-// Inc increases a metric counter by 1, in an atomic way
-func (r *PendingPodsRecorder) Inc() {
-	r.recorder.Inc()
+// Add records the addition of an entity.
+// It increments pending pods and queued entities metric counters.
+func (r *QueuedEntitiesRecorder) Add(entity Entity) {
+	r.pods.Add(float64(entity.Size()))
+	if label, ok := EntityToLabel(entity); ok {
+		r.entities(label).Inc()
+	}
 }
 
-// Dec decreases a metric counter by 1, in an atomic way
-func (r *PendingPodsRecorder) Dec() {
-	r.recorder.Dec()
+// Remove records the removal of an entity.
+// It decrements pending pods and queued entities metric counters.
+func (r *QueuedEntitiesRecorder) Remove(entity Entity) {
+	r.pods.Add(-float64(entity.Size()))
+	if label, ok := EntityToLabel(entity); ok {
+		r.entities(label).Dec()
+	}
 }
 
-// Clear set a metric counter to 0, in an atomic way
-func (r *PendingPodsRecorder) Clear() {
-	r.recorder.Set(float64(0))
+// Update records the update of an entity.
+// It updates pending pods metric counter only.
+// It shouldn't update queued entities metric, because the entity type cannot be changed, and an entity will always be a single object.
+func (r *QueuedEntitiesRecorder) Update(oldEntity, newEntity Entity) {
+	diff := newEntity.Size() - oldEntity.Size()
+	r.pods.Add(float64(diff))
+}
+
+// Clear resets pending pods and queued entities metric counters to 0.
+func (r *QueuedEntitiesRecorder) Clear() {
+	r.pods.Set(float64(0))
+	r.entities(Pod).Set(float64(0))
+	r.entities(PodGroup).Set(float64(0))
 }
 
 // histogramVecMetric is the data structure passed in the buffer channel between the main framework thread

--- a/pkg/scheduler/metrics/metric_recorder_test.go
+++ b/pkg/scheduler/metrics/metric_recorder_test.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -25,24 +26,40 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"k8s.io/component-base/metrics/testutil"
+	fwk "k8s.io/kube-scheduler/framework"
 )
 
 var _ MetricRecorder = &fakePodsRecorder{}
+
+type testEntity struct {
+	size int
+	t    fwk.EntityKeyType
+}
+
+func (te *testEntity) Size() int {
+	return te.size
+}
+
+func (te *testEntity) Type() fwk.EntityKeyType {
+	return te.t
+}
 
 type fakePodsRecorder struct {
 	counter int64
 }
 
-func (r *fakePodsRecorder) Add(val int) {
-	atomic.AddInt64(&r.counter, int64(val))
+func (r *fakePodsRecorder) Add(entity Entity) {
+	atomic.AddInt64(&r.counter, int64(entity.Size()))
 }
 
-func (r *fakePodsRecorder) Inc() {
-	atomic.AddInt64(&r.counter, 1)
+func (r *fakePodsRecorder) Remove(entity Entity) {
+	atomic.AddInt64(&r.counter, -int64(entity.Size()))
 }
 
-func (r *fakePodsRecorder) Dec() {
-	atomic.AddInt64(&r.counter, -1)
+func (r *fakePodsRecorder) Update(oldEntity, newEntity Entity) {
+	atomic.AddInt64(&r.counter, int64(newEntity.Size()-oldEntity.Size()))
 }
 
 func (r *fakePodsRecorder) Clear() {
@@ -56,7 +73,7 @@ func TestAdd(t *testing.T) {
 	wg.Add(loops)
 	for i := range loops {
 		go func() {
-			fakeRecorder.Add(i)
+			fakeRecorder.Add(&testEntity{size: i, t: "pod"})
 			wg.Done()
 		}()
 	}
@@ -66,37 +83,20 @@ func TestAdd(t *testing.T) {
 	}
 }
 
-func TestInc(t *testing.T) {
-	fakeRecorder := fakePodsRecorder{}
-	var wg sync.WaitGroup
-	loops := 100
-	wg.Add(loops)
-	for range loops {
-		go func() {
-			fakeRecorder.Inc()
-			wg.Done()
-		}()
-	}
-	wg.Wait()
-	if fakeRecorder.counter != int64(loops) {
-		t.Errorf("Expected %v, got %v", loops, fakeRecorder.counter)
-	}
-}
-
-func TestDec(t *testing.T) {
+func TestRemove(t *testing.T) {
 	fakeRecorder := fakePodsRecorder{counter: 100}
 	var wg sync.WaitGroup
-	loops := 100
+	loops := 50
 	wg.Add(loops)
 	for range loops {
 		go func() {
-			fakeRecorder.Dec()
+			fakeRecorder.Remove(&testEntity{size: 2, t: "podgroup"})
 			wg.Done()
 		}()
 	}
 	wg.Wait()
 	if fakeRecorder.counter != int64(0) {
-		t.Errorf("Expected %v, got %v", loops, fakeRecorder.counter)
+		t.Errorf("Expected %v, got %v", 0, fakeRecorder.counter)
 	}
 }
 
@@ -107,19 +107,21 @@ func TestClear(t *testing.T) {
 	wg.Add(incLoops + decLoops)
 	for range incLoops {
 		go func() {
-			fakeRecorder.Inc()
+			fakeRecorder.Add(&testEntity{size: 1, t: "pod"})
+			fakeRecorder.Add(&testEntity{size: 2, t: "podgroup"})
 			wg.Done()
 		}()
 	}
 	for range decLoops {
 		go func() {
-			fakeRecorder.Dec()
+			fakeRecorder.Remove(&testEntity{size: 1, t: "pod"})
 			wg.Done()
 		}()
 	}
 	wg.Wait()
-	if fakeRecorder.counter != int64(incLoops-decLoops) {
-		t.Errorf("Expected %v, got %v", incLoops-decLoops, fakeRecorder.counter)
+	expected := int64(incLoops*3 - decLoops)
+	if fakeRecorder.counter != expected {
+		t.Errorf("Expected %v, got %v", expected, fakeRecorder.counter)
 	}
 	// verify Clear() works
 	fakeRecorder.Clear()
@@ -191,5 +193,136 @@ func TestInFlightEventAsync(t *testing.T) {
 	r.ObserveInFlightEventsAsync(podAddLabel, 1, true)
 	if len(r.aggregatedInflightEventMetric) != 0 {
 		t.Errorf("aggregatedInflightEventMetric should be force-flushed, but got: %v", r.aggregatedInflightEventMetric)
+	}
+}
+
+func TestEntityToLabel(t *testing.T) {
+	tests := []struct {
+		name      string
+		entity    Entity
+		wantLabel string
+		wantOK    bool
+	}{
+		{
+			name:   "nil entity",
+			entity: nil,
+			wantOK: false,
+		},
+		{
+			name:      "pod entity",
+			entity:    &testEntity{t: "pod"},
+			wantLabel: Pod,
+			wantOK:    true,
+		},
+		{
+			name:      "podgroup entity",
+			entity:    &testEntity{t: "podgroup"},
+			wantLabel: PodGroup,
+			wantOK:    true,
+		},
+		{
+			name:   "unknown entity type",
+			entity: &testEntity{t: "unknown"},
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotLabel, gotOK := EntityToLabel(tt.entity)
+			if gotLabel != tt.wantLabel || gotOK != tt.wantOK {
+				t.Errorf("EntityToLabel() = (%v, %v), want (%v, %v)", gotLabel, gotOK, tt.wantLabel, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestQueuedEntitiesRecorder(t *testing.T) {
+	Register()
+
+	recorder := NewActiveEntitiesRecorder()
+	recorder.Clear()
+
+	pInfo1 := &testEntity{size: 1, t: "pod"}
+	pInfo2 := &testEntity{size: 5, t: "podgroup"}
+	pInfo3 := &testEntity{size: 1, t: "pod"}
+	updatedPInfo2 := &testEntity{size: 8, t: "podgroup"}
+
+	tests := []struct {
+		name string
+		op   func()
+		want string
+	}{
+		{
+			name: "Add entity",
+			op: func() {
+				recorder.Add(pInfo1)
+				recorder.Add(pInfo2)
+				recorder.Add(pInfo3)
+			},
+			want: `
+				# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated; 'incomplete' means number of pods in incompletePodGroupPods; 'pending' means number of pods in pendingPodGroupPods.
+				# TYPE scheduler_pending_pods gauge
+				scheduler_pending_pods{queue="active"} 7
+				# HELP scheduler_queued_entities [ALPHA] Number of queued scheduling entities ('pod' or 'podgroup'; 'pod' stands for individual pods that are not members of any podgroup) by the queue type. 'active' means number of entities in activeQ; 'backoff' means number of entities in backoffQ; 'unschedulable' means number of entities in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable entities that the scheduler never attempted to schedule because they are gated.
+				# TYPE scheduler_queued_entities gauge
+				scheduler_queued_entities{queue="active",type="pod"} 2
+				scheduler_queued_entities{queue="active",type="podgroup"} 1
+			`,
+		},
+		{
+			name: "Remove entity",
+			op: func() {
+				recorder.Remove(pInfo1)
+			},
+			want: `
+				# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated; 'incomplete' means number of pods in incompletePodGroupPods; 'pending' means number of pods in pendingPodGroupPods.
+				# TYPE scheduler_pending_pods gauge
+				scheduler_pending_pods{queue="active"} 6
+				# HELP scheduler_queued_entities [ALPHA] Number of queued scheduling entities ('pod' or 'podgroup'; 'pod' stands for individual pods that are not members of any podgroup) by the queue type. 'active' means number of entities in activeQ; 'backoff' means number of entities in backoffQ; 'unschedulable' means number of entities in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable entities that the scheduler never attempted to schedule because they are gated.
+				# TYPE scheduler_queued_entities gauge
+				scheduler_queued_entities{queue="active",type="pod"} 1
+				scheduler_queued_entities{queue="active",type="podgroup"} 1
+			`,
+		},
+		{
+			name: "Update entity",
+			op: func() {
+				recorder.Update(pInfo2, updatedPInfo2)
+			},
+			want: `
+				# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated; 'incomplete' means number of pods in incompletePodGroupPods; 'pending' means number of pods in pendingPodGroupPods.
+				# TYPE scheduler_pending_pods gauge
+				scheduler_pending_pods{queue="active"} 9
+				# HELP scheduler_queued_entities [ALPHA] Number of queued scheduling entities ('pod' or 'podgroup'; 'pod' stands for individual pods that are not members of any podgroup) by the queue type. 'active' means number of entities in activeQ; 'backoff' means number of entities in backoffQ; 'unschedulable' means number of entities in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable entities that the scheduler never attempted to schedule because they are gated.
+				# TYPE scheduler_queued_entities gauge
+				scheduler_queued_entities{queue="active",type="pod"} 1
+				scheduler_queued_entities{queue="active",type="podgroup"} 1
+			`,
+		},
+		{
+			name: "Clear",
+			op: func() {
+				recorder.Clear()
+			},
+			want: `
+				# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated; 'incomplete' means number of pods in incompletePodGroupPods; 'pending' means number of pods in pendingPodGroupPods.
+				# TYPE scheduler_pending_pods gauge
+				scheduler_pending_pods{queue="active"} 0
+				# HELP scheduler_queued_entities [ALPHA] Number of queued scheduling entities ('pod' or 'podgroup'; 'pod' stands for individual pods that are not members of any podgroup) by the queue type. 'active' means number of entities in activeQ; 'backoff' means number of entities in backoffQ; 'unschedulable' means number of entities in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable entities that the scheduler never attempted to schedule because they are gated.
+				# TYPE scheduler_queued_entities gauge
+				scheduler_queued_entities{queue="active",type="pod"} 0
+				scheduler_queued_entities{queue="active",type="podgroup"} 0
+			`,
+		},
+	}
+
+	for _, step := range tests {
+		t.Run(step.name, func(t *testing.T) {
+			step.op()
+			if err := testutil.GatherAndCompare(GetGather(), strings.NewReader(step.want), "scheduler_pending_pods", "scheduler_queued_entities"); err != nil {
+				t.Errorf("unexpected metrics %s: %v", step.name, err)
+			}
+		})
 	}
 }

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -99,6 +99,12 @@ const (
 	QueueingHintResultError     = "Error"
 )
 
+// Entity label values used for queued_entities and queue_incoming_entities metrics.
+const (
+	Pod      = "pod"
+	PodGroup = "podgroup"
+)
+
 const (
 	PodPoppedInFlightEvent = "PodPopped"
 )
@@ -140,6 +146,7 @@ var (
 	PreemptionVictims            *metrics.Histogram
 	PreemptionAttempts           *metrics.Counter
 	pendingPods                  *metrics.GaugeVec
+	QueuedEntities               *metrics.GaugeVec
 	InFlightEvents               *metrics.GaugeVec
 	Goroutines                   *metrics.GaugeVec
 	BatchAttemptStats            *metrics.CounterVec
@@ -158,8 +165,9 @@ var (
 	unschedulableReasons  *metrics.GaugeVec
 	PluginEvaluationTotal *metrics.CounterVec
 
-	queueingHintExecutionDuration *metrics.HistogramVec
-	SchedulerQueueIncomingPods    *metrics.CounterVec
+	queueingHintExecutionDuration  *metrics.HistogramVec
+	SchedulerQueueIncomingPods     *metrics.CounterVec
+	SchedulerQueueIncomingEntities *metrics.CounterVec
 
 	// The below two are only available when the async-preemption feature gate is enabled.
 	PreemptionGoroutinesDuration       *metrics.HistogramVec
@@ -293,9 +301,16 @@ func InitMetrics() {
 		&metrics.GaugeOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "pending_pods",
-			Help:           "Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated.",
+			Help:           "Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated; 'incomplete' means number of pods in incompletePodGroupPods; 'pending' means number of pods in pendingPodGroupPods.",
 			StabilityLevel: metrics.STABLE,
 		}, []string{"queue"})
+	QueuedEntities = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Subsystem:      SchedulerSubsystem,
+			Name:           "queued_entities",
+			Help:           "Number of queued scheduling entities ('pod' or 'podgroup'; 'pod' stands for individual pods that are not members of any podgroup) by the queue type. 'active' means number of entities in activeQ; 'backoff' means number of entities in backoffQ; 'unschedulable' means number of entities in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable entities that the scheduler never attempted to schedule because they are gated.",
+			StabilityLevel: metrics.ALPHA,
+		}, []string{"queue", "type"})
 	InFlightEvents = metrics.NewGaugeVec(
 		&metrics.GaugeOpts{
 			Subsystem:      SchedulerSubsystem,
@@ -395,6 +410,14 @@ func InitMetrics() {
 			Help:           "Number of pods added to scheduling queues by event and queue type.",
 			StabilityLevel: metrics.STABLE,
 		}, []string{"queue", "event"})
+
+	SchedulerQueueIncomingEntities = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      SchedulerSubsystem,
+			Name:           "queue_incoming_entities_total",
+			Help:           "Number of scheduling entities added to scheduling queues by event, queue type, and entity type. Entity types are either 'pod' (for individual pods that are not members of any podgroup) or 'podgroup'.",
+			StabilityLevel: metrics.ALPHA,
+		}, []string{"queue", "event", "type"})
 
 	PermitWaitDuration = metrics.NewHistogramVec(
 		&metrics.HistogramOpts{
@@ -608,12 +631,14 @@ func InitMetrics() {
 		PreemptionVictims,
 		PreemptionAttempts,
 		pendingPods,
+		QueuedEntities,
 		PodSchedulingSLIDuration,
 		PodSchedulingAttempts,
 		PodScheduledAfterFlush,
 		FrameworkExtensionPointDuration,
 		PluginExecutionDuration,
 		SchedulerQueueIncomingPods,
+		SchedulerQueueIncomingEntities,
 		Goroutines,
 		PermitWaitDuration,
 		CacheSize,
@@ -659,6 +684,36 @@ func UnschedulablePods() metrics.GaugeMetric {
 // GatedPods returns the pending pods metrics with the label gated
 func GatedPods() metrics.GaugeMetric {
 	return pendingPods.With(metrics.Labels{"queue": "gated"})
+}
+
+// IncompletePodGroupPods returns the pending pods metric with the queue label set to "incomplete".
+func IncompletePodGroupPods() metrics.GaugeMetric {
+	return pendingPods.With(metrics.Labels{"queue": "incomplete"})
+}
+
+// PendingPodGroupPods returns the pending pods metric with the queue label set to "pending".
+func PendingPodGroupPods() metrics.GaugeMetric {
+	return pendingPods.With(metrics.Labels{"queue": "pending"})
+}
+
+// ActiveEntities returns the queued entities metric with the queue label set to "active" and type label set to "Pod" or "PodGroup".
+func ActiveEntities(entityType string) metrics.GaugeMetric {
+	return QueuedEntities.With(metrics.Labels{"queue": "active", "type": entityType})
+}
+
+// BackoffEntities returns the queued entities metric with the queue label set to "backoff" and type label set to "Pod" or "PodGroup".
+func BackoffEntities(entityType string) metrics.GaugeMetric {
+	return QueuedEntities.With(metrics.Labels{"queue": "backoff", "type": entityType})
+}
+
+// UnschedulableEntities returns the queued entities metric with the queue label set to "unschedulable" and type label set to "Pod" or "PodGroup".
+func UnschedulableEntities(entityType string) metrics.GaugeMetric {
+	return QueuedEntities.With(metrics.Labels{"queue": "unschedulable", "type": entityType})
+}
+
+// GatedEntities returns the queued entities metric with the queue label set to "gated" and type label set to "Pod" or "PodGroup".
+func GatedEntities(entityType string) metrics.GaugeMetric {
+	return QueuedEntities.With(metrics.Labels{"queue": "gated", "type": entityType})
 }
 
 // SinceInSeconds gets the time since the specified start in seconds.


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/sig-scheduling

#### What this PR does / why we need it:
While we are able to count pods in scheduling queue, we also want to be able to count pod groups. For that we are introducing new metrics, by which we are able to count entities (pods or podgroups).

These metrics are:
`queued_entities`: Similar to `pending_pods`, it tracks the currently pending entities in queues (active, backoff, etc..) of scheduler.
`queue_incoming_entities_total`: Similar to `queue_incoming_pods_total` it tracks total number of entities (pods or podgroups) added to scheduling queue.

For both metrics We are using an additional label for the entity type whether a pod or podgroup.

#### Which issue(s) this PR is related to:
N/A

#### Does this PR introduce a user-facing change?
```release-note
We are adding two new metrics:

"queued_entities": This metric tracks the current entities (individual pods or podgroups) in queues (active, backoff, etc..) of scheduler. 
 
"queue_incoming_entities_total":  This metric tracks total number of entities (individual pods or podgroups) added to scheduling queues (active, backoff, etc..).
```