### PR TITLE
kubeadm: treat already promoted learner as successful

### DIFF
--- a/cmd/kubeadm/app/util/etcd/etcd.go
+++ b/cmd/kubeadm/app/util/etcd/etcd.go
@@ -629,14 +629,39 @@ func (c *Client) MemberPromote(learnerID uint64) error {
 	// 2. context deadline exceeded
 	// 3. peer URLs already exists
 	// Once the client provides a way to check if the etcd learner is ready to promote, the retry logic can be revisited.
-	var promoteResp *clientv3.MemberPromoteResponse
+	var memberList []*etcdserverpb.Member
 	err = wait.PollUntilContextTimeout(context.Background(), constants.EtcdAPICallRetryInterval, kubeadmapi.GetActiveTimeouts().EtcdAPICall.Duration,
 		true, func(_ context.Context) (bool, error) {
+			// MemberPromote can return a transient client-side error even if the
+			// promotion already succeeded on the etcd side. Check the current
+			// member state before attempting another promotion so that retries
+			// remain idempotent.
+			resp, statusErr := c.listMembersOnce()
+			if statusErr != nil {
+				klog.V(5).Infof("[etcd] Failed to list members before promoting learner %s: %v", learnerIDUint, statusErr)
+				lastError = statusErr
+				return false, nil
+			}
+
+			for _, m := range resp.Members {
+				if m.ID != learnerID {
+					continue
+				}
+
+				if !m.IsLearner {
+					klog.V(1).Infof("[etcd] Member %s is already a voting member, treating promotion as successful", learnerIDUint)
+					memberList = resp.Members
+					return true, nil
+				}
+				break
+			}
+
 			ctx, cancel := context.WithTimeout(context.Background(), etcdTimeout)
 			defer cancel()
-			promoteResp, err = cli.MemberPromote(ctx, learnerID)
+			promoteResp, err := cli.MemberPromote(ctx, learnerID)
 			if err == nil {
 				klog.V(1).Infof("[etcd] The learner was promoted as a voting member: %s", learnerIDUint)
+				memberList = promoteResp.Members
 				return true, nil
 			}
 			klog.V(5).Infof("[etcd] Promoting the learner %s failed: %v", learnerIDUint, err)
@@ -647,7 +672,7 @@ func (c *Client) MemberPromote(learnerID uint64) error {
 		return lastError
 	}
 
-	for _, m := range promoteResp.Members {
+	for _, m := range memberList {
 		if m.ID == learnerID {
 			parsedPeerAddrs, err := url.Parse(m.PeerURLs[0])
 			if err != nil {

--- a/cmd/kubeadm/app/util/etcd/etcd_test.go
+++ b/cmd/kubeadm/app/util/etcd/etcd_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	"strconv"
 	"testing"
 	"time"
@@ -44,6 +45,9 @@ var errNotImplemented = errors.New("not implemented")
 type fakeEtcdClient struct {
 	members   []*pb.Member
 	endpoints []string
+
+	memberListFunc    func(context.Context, ...clientv3.OpOption) (*clientv3.MemberListResponse, error)
+	memberPromoteFunc func(context.Context, uint64) (*clientv3.MemberPromoteResponse, error)
 }
 
 // Close shuts down the client's etcd connections.
@@ -58,7 +62,10 @@ func (f *fakeEtcdClient) Endpoints() []string {
 }
 
 // MemberList lists the current cluster membership.
-func (f *fakeEtcdClient) MemberList(_ context.Context, _ ...clientv3.OpOption) (*clientv3.MemberListResponse, error) {
+func (f *fakeEtcdClient) MemberList(ctx context.Context, opts ...clientv3.OpOption) (*clientv3.MemberListResponse, error) {
+	if f.memberListFunc != nil {
+		return f.memberListFunc(ctx, opts...)
+	}
 	return &clientv3.MemberListResponse{
 		Members: f.members,
 	}, nil
@@ -80,7 +87,10 @@ func (f *fakeEtcdClient) MemberRemove(_ context.Context, id uint64) (*clientv3.M
 }
 
 // MemberPromote promotes a member from raft learner (non-voting) to raft voting member.
-func (f *fakeEtcdClient) MemberPromote(_ context.Context, id uint64) (*clientv3.MemberPromoteResponse, error) {
+func (f *fakeEtcdClient) MemberPromote(ctx context.Context, id uint64) (*clientv3.MemberPromoteResponse, error) {
+	if f.memberPromoteFunc != nil {
+		return f.memberPromoteFunc(ctx, id)
+	}
 	return nil, errNotImplemented
 }
 
@@ -961,6 +971,201 @@ func TestEvaluateClusterStatus(t *testing.T) {
 
 			if tc.wantMemberErrors != (err != nil) {
 				t.Errorf("gotMemberErrors = %v, wantMemberErrors = %t", err, tc.wantMemberErrors)
+			}
+		})
+	}
+}
+
+func TestMemberPromote(t *testing.T) {
+	learnerID := uint64(12345)
+
+	const (
+		initialEndpoint  = "https://192.168.10.100:2379"
+		promotedEndpoint = "https://192.168.10.200:2379"
+	)
+
+	member := func(isLearner bool) *pb.Member {
+		return &pb.Member{
+			ID:         learnerID,
+			Name:       "cp-1",
+			PeerURLs:   []string{"https://192.168.10.200:2380"},
+			ClientURLs: []string{promotedEndpoint},
+			IsLearner:  isLearner,
+		}
+	}
+
+	type memberListResult struct {
+		members []*pb.Member
+		err     error
+	}
+
+	type memberPromoteResult struct {
+		resp *clientv3.MemberPromoteResponse
+		err  error
+	}
+
+	tests := []struct {
+		name                 string
+		memberListResults    []memberListResult
+		memberPromoteResults []memberPromoteResult
+		wantErr              bool
+		wantEndpoint         string
+		wantPromoteCalls     int
+		minMemberListCalls   int
+	}{
+		{
+			name: "successful promotion adds endpoint",
+			memberListResults: []memberListResult{
+				{members: []*pb.Member{member(true)}},
+				{members: []*pb.Member{member(true)}},
+			},
+			memberPromoteResults: []memberPromoteResult{
+				{
+					resp: &clientv3.MemberPromoteResponse{
+						Members: []*pb.Member{member(false)},
+					},
+				},
+			},
+			wantEndpoint:       promotedEndpoint,
+			wantPromoteCalls:   1,
+			minMemberListCalls: 2,
+		},
+		{
+			name: "already promoted after transient promote failure adds endpoint",
+			memberListResults: []memberListResult{
+				{members: []*pb.Member{member(true)}},
+				{members: []*pb.Member{member(true)}},
+				{members: []*pb.Member{member(false)}},
+			},
+			memberPromoteResults: []memberPromoteResult{
+				{
+					err: context.DeadlineExceeded,
+				},
+			},
+			wantEndpoint:       promotedEndpoint,
+			wantPromoteCalls:   1,
+			minMemberListCalls: 3,
+		},
+		{
+			name: "already promoted before promote attempt adds endpoint",
+			memberListResults: []memberListResult{
+				{members: []*pb.Member{member(true)}},
+				{members: []*pb.Member{member(false)}},
+			},
+			wantEndpoint:       promotedEndpoint,
+			wantPromoteCalls:   0,
+			minMemberListCalls: 2,
+		},
+		{
+			name: "member list error before promote is retried",
+			memberListResults: []memberListResult{
+				{members: []*pb.Member{member(true)}},
+				{err: errNotImplemented},
+				{members: []*pb.Member{member(true)}},
+			},
+			memberPromoteResults: []memberPromoteResult{
+				{
+					resp: &clientv3.MemberPromoteResponse{
+						Members: []*pb.Member{member(false)},
+					},
+				},
+			},
+			wantEndpoint:       promotedEndpoint,
+			wantPromoteCalls:   1,
+			minMemberListCalls: 3,
+		},
+		{
+			name: "promotion keeps failing",
+			memberListResults: []memberListResult{
+				{members: []*pb.Member{member(true)}},
+				{members: []*pb.Member{member(true)}},
+			},
+			memberPromoteResults: []memberPromoteResult{
+				{
+					err: context.DeadlineExceeded,
+				},
+			},
+			wantErr:            true,
+			wantPromoteCalls:   -1,
+			minMemberListCalls: 1,
+		},
+	}
+
+	oldActiveTimeout := kubeadmapi.GetActiveTimeouts()
+	newActiveTimeout := oldActiveTimeout.DeepCopy()
+	newActiveTimeout.EtcdAPICall = &metav1.Duration{
+		Duration: 3 * constants.EtcdAPICallRetryInterval,
+	}
+	kubeadmapi.SetActiveTimeouts(newActiveTimeout)
+	defer kubeadmapi.SetActiveTimeouts(oldActiveTimeout)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			memberListCalls := 0
+			memberPromoteCalls := 0
+
+			fakeClient := &fakeEtcdClient{}
+
+			fakeClient.memberListFunc = func(_ context.Context, _ ...clientv3.OpOption) (*clientv3.MemberListResponse, error) {
+				if len(tt.memberListResults) == 0 {
+					t.Fatal("MemberList called without configured results")
+				}
+
+				resultIndex := memberListCalls
+				if resultIndex >= len(tt.memberListResults) {
+					resultIndex = len(tt.memberListResults) - 1
+				}
+				result := tt.memberListResults[resultIndex]
+				memberListCalls++
+
+				if result.err != nil {
+					return nil, result.err
+				}
+				return &clientv3.MemberListResponse{
+					Members: result.members,
+				}, nil
+			}
+
+			fakeClient.memberPromoteFunc = func(_ context.Context, _ uint64) (*clientv3.MemberPromoteResponse, error) {
+				if len(tt.memberPromoteResults) == 0 {
+					t.Fatalf("unexpected MemberPromote call")
+				}
+
+				resultIndex := memberPromoteCalls
+				if resultIndex >= len(tt.memberPromoteResults) {
+					resultIndex = len(tt.memberPromoteResults) - 1
+				}
+				result := tt.memberPromoteResults[resultIndex]
+				memberPromoteCalls++
+
+				return result.resp, result.err
+			}
+
+			c := &Client{
+				Endpoints: []string{initialEndpoint},
+			}
+			c.newEtcdClient = func(_ []string) (etcdClient, error) {
+				return fakeClient, nil
+			}
+			c.listMembersFunc = func(_ time.Duration) (*clientv3.MemberListResponse, error) {
+				return fakeClient.MemberList(context.Background())
+			}
+
+			err := c.MemberPromote(learnerID)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("MemberPromote() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantPromoteCalls >= 0 && memberPromoteCalls != tt.wantPromoteCalls {
+				t.Fatalf("MemberPromote calls = %d, want %d", memberPromoteCalls, tt.wantPromoteCalls)
+			}
+
+			if memberListCalls < tt.minMemberListCalls {
+				t.Fatalf("MemberList calls = %d, want at least %d", memberListCalls, tt.minMemberListCalls)
+			}
+
+			if tt.wantEndpoint != "" && !slices.Contains(c.Endpoints, tt.wantEndpoint) {
+				t.Fatalf("expected endpoint %q to be added, got %v", tt.wantEndpoint, c.Endpoints)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This PR makes the etcd learner promotion path more resilient to transient client-side failures.

During investigation of intermittent etcd-join failures, I observed a scenario where MemberPromote() could return an error such as DeadlineExceeded, while the promotion may already have succeeded on the etcd side.

In that situation, kubeadm currently treats the promotion as failed and retries. However, if the learner has already been promoted to a voting member, subsequent calls can return below log:

```bash
etcdserver: can only promote a learner member
```

and kubeadm may continue retrying until the etcd-join phase fails.

This change re-checks the learner state after a failed MemberPromote() call. If the member is no longer a learner, kubeadm treats the promotion as successful and continues.

The fallback success path also re-lists members and adds the promoted member endpoint to preserve the existing endpoint update behavior that normally occurs when MemberPromote() succeeds and returns a response.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes [kubernetes/kubeadm#3317](https://github.com/kubernetes/kubeadm/issues/3317)

#### Special notes for your reviewer:

This implementation follows the discussion in #3317.

The goal is not to change the promotion flow itself, but to make the retry path idempotent when the promotion has already completed on the etcd side but the client observed a transient error.

A unit test has been added to cover the scenario where:

1. `MemberPromote()` returns DeadlineExceeded
2. The member is already a voting member when queried afterward
3. `kubeadm` treats the operation as successful
4. The member endpoint is still added to the client endpoint list

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: Improved resilience of kubeadm etcd learner promotion. kubeadm now correctly handles cases where learner promotion succeeds on the etcd side but a transient client-side error is returned, preventing unnecessary etcd-join failures.
```


#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None.
See kubernetes/kubeadm#3317  for background and investigation details.
```
