### PR TITLE
fix: avoid panic in resourceclaim PodGroup owner check

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceclaim/resourceclaim.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceclaim/resourceclaim.go
@@ -128,7 +128,7 @@ func IsForPod(pod *v1.Pod, claim *resourceapi.ResourceClaim, acceptPodGroupOwner
 		return fmt.Errorf("ResourceClaim %s/%s is not in the same namespace as Pod %s/%s", claim.Namespace, claim.Name, pod.Namespace, pod.Name)
 	}
 	if !metav1.IsControlledBy(claim, pod) {
-		if acceptPodGroupOwner {
+		if acceptPodGroupOwner && pod.Spec.SchedulingGroup != nil && pod.Spec.SchedulingGroup.PodGroupName != nil {
 			if !isForPodGroupByPod(pod, claim) {
 				return fmt.Errorf("ResourceClaim %s/%s was not created for Pod %s/%s (neither Pod nor PodGroup %s is the owner)", claim.Namespace, claim.Name, pod.Namespace, pod.Name, *pod.Spec.SchedulingGroup.PodGroupName)
 			}

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceclaim/resourceclaim_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceclaim/resourceclaim_test.go
@@ -174,6 +174,12 @@ func TestResourceClaimIsFor(t *testing.T) {
 				claim:         claimNoOwner,
 				expectedError: `ResourceClaim kube-system/claimNoOwner was not created for Pod kube-system/podOwner (Pod is not owner)`,
 			},
+			"accept-podgroup-without-podgroup": {
+				pod:            podOwner,
+				claim:          claimNoOwner,
+				expectedError:  `ResourceClaim kube-system/claimNoOwner was not created for Pod kube-system/podOwner (Pod is not owner)`,
+				acceptPodGroup: true,
+			},
 			"different-namespace": {
 				pod:           podOwner,
 				claim:         userClaimWithOwner,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind regression

#### What this PR does / why we need it:
`resourceclaim.IsForPod` can panic when `acceptPodGroupOwner=true` and the Pod has no scheduling group.

This is reachable in real code paths when `DRAWorkloadResourceClaims` is on. Callers pass the feature gate state straight through, but not every Pod is in a PodGroup. If ownership falls back to the PodGroup path, we hit a nil deref. Kinda nasty, easy to miss.

This patch adds the missing guard and returns a normal error instead.

Repro:
`cd staging/src/k8s.io/dynamic-resource-allocation && GOWORK=off go test ./resourceclaim -run 'TestResourceClaimIsFor/Pod/accept-podgroup-without-podgroup' -count=1`

Before this change, that path panics.
After this change, it passes.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
I did not find a matching open issue or PR for this one.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
