### PR TITLE
kubelet/dra: derive claim names from claim info cache

### DIFF
--- a/pkg/kubelet/cm/dra/claiminfo.go
+++ b/pkg/kubelet/cm/dra/claiminfo.go
@@ -236,6 +236,22 @@ func (cache *claimInfoCache) hasPodReference(uid types.UID) bool {
 	return false
 }
 
+// claimNamesForPod returns the names of all claims referenced by the pod with
+// the given UID. The claim info cache is the authoritative record of what was
+// prepared for the pod (it is checkpointed and survives kubelet restarts), so
+// this does not depend on pod.Status.ResourceClaimStatuses being present.
+//
+// Must be called while the rlock is held.
+func (cache *claimInfoCache) claimNamesForPod(uid types.UID) []string {
+	var claimNames []string
+	for _, claimInfo := range cache.claimInfo {
+		if claimInfo.hasPodReference(uid) {
+			claimNames = append(claimNames, claimInfo.ClaimName)
+		}
+	}
+	return claimNames
+}
+
 // syncToCheckpoint syncs the full claim info cache state to a checkpoint.
 func (cache *claimInfoCache) syncToCheckpoint() error {
 	claimInfoStateList := make(state.ClaimInfoStateList, 0, len(cache.claimInfo))

--- a/pkg/kubelet/cm/dra/manager.go
+++ b/pkg/kubelet/cm/dra/manager.go
@@ -586,24 +586,36 @@ func (m *Manager) UnprepareResources(ctx context.Context, pod *v1.Pod) error {
 }
 
 func (m *Manager) unprepareResourcesForPod(ctx context.Context, pod *v1.Pod) error {
+	// Try to get claim names from the cache first.
 	var claimNames []string
-	for i := range pod.Spec.ResourceClaims {
-		claimName, _, err := resourceclaim.Name(pod, &pod.Spec.ResourceClaims[i])
-		if err != nil {
-			// No wrapping, the error is already informative.
-			return err
+	_ = m.cache.withRLock(func() error {
+		claimNames = m.cache.claimNamesForPod(pod.UID)
+		return nil
+	})
+
+	// If the cache doesn't have any claim names for this pod, it may be because Kubelet was
+	// restarted and claiminfo checkpoint was removed.
+	// We should try to get claim names from the pod spec and status to ensure that we
+	// unprepare all relevant claims.
+	if len(claimNames) == 0 {
+		for i := range pod.Spec.ResourceClaims {
+			claimName, _, err := resourceclaim.Name(pod, &pod.Spec.ResourceClaims[i])
+			if err != nil {
+				// No wrapping, the error is already informative.
+				return err
+			}
+			if claimName == nil {
+				// The claim name might be nil if no underlying resource claim
+				// was generated for the referenced claim. There are valid use
+				// cases when this might happen, so we simply skip it.
+				continue
+			}
+			claimNames = append(claimNames, *claimName)
 		}
-		// The claim name might be nil if no underlying resource claim
-		// was generated for the referenced claim. There are valid use
-		// cases when this might happen, so we simply skip it.
-		if claimName == nil {
-			continue
-		}
-		claimNames = append(claimNames, *claimName)
-	}
-	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.DRAExtendedResource) {
-		if pod.Status.ExtendedResourceClaimStatus != nil {
-			claimNames = append(claimNames, pod.Status.ExtendedResourceClaimStatus.ResourceClaimName)
+		if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.DRAExtendedResource) {
+			if pod.Status.ExtendedResourceClaimStatus != nil {
+				claimNames = append(claimNames, pod.Status.ExtendedResourceClaimStatus.ResourceClaimName)
+			}
 		}
 	}
 

--- a/pkg/kubelet/cm/dra/manager_test.go
+++ b/pkg/kubelet/cm/dra/manager_test.go
@@ -385,6 +385,43 @@ func genTestPod() *v1.Pod {
 	}
 }
 
+// genTestPodWithClaimTemplateNoStatus generates a pod that references its claim
+// via a ResourceClaimTemplateName but whose Status.ResourceClaimStatuses is
+// empty. This mimics https://github.com/kubernetes/kubernetes/issues/139772, where an external component overwrote
+// the pod status and dropped the generated claim name. resourceclaim.Name API
+// returns ErrClaimNotFound for such a pod, so unprepare must rely on the claim
+// info cache.
+func genTestPodWithClaimTemplateNoStatus() *v1.Pod {
+	templateName := claimName + "-template"
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace,
+			UID:       podUID,
+		},
+		Spec: v1.PodSpec{
+			ResourceClaims: []v1.PodResourceClaim{
+				{
+					Name:                      claimName,
+					ResourceClaimTemplateName: &templateName,
+				},
+			},
+			Containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Claims: []v1.ResourceClaim{
+							{
+								Name: claimName,
+							},
+						},
+					},
+				},
+			},
+		},
+		// Status.ResourceClaimStatuses intentionally left empty.
+	}
+}
+
 func genTestPodWithClaims(claimNames ...string) *v1.Pod {
 	podCounter := testPodCounter.Add(1)
 
@@ -1463,6 +1500,30 @@ dra_operations_duration_seconds_count{is_error="false",operation_name="Unprepare
 `,
 		},
 		{
+			// Regression test for https://github.com/kubernetes/kubernetes/issues/139772: the pod references its
+			// claim via a template, but Status.ResourceClaimStatuses is empty
+			// (an external component overwrote the status). resourceclaim.Name
+			// returns ErrClaimNotFound, so the claim name must come from the
+			// cache instead. Previously this wedged the pod in terminating.
+			description:            "should unprepare using cache when ResourceClaimStatuses is missing",
+			driverName:             driverName,
+			pod:                    genTestPodWithClaimTemplateNoStatus(),
+			claim:                  genTestClaim(claimName, driverName, deviceName, podUID),
+			claimInfo:              genTestClaimInfo(claimUID, []string{podUID}, true, nil),
+			expectedUnprepareCalls: 1,
+			expectedMetric: `# HELP dra_grpc_operations_duration_seconds [ALPHA] Duration in seconds of the DRA gRPC operations
+# TYPE dra_grpc_operations_duration_seconds histogram
+dra_grpc_operations_duration_seconds_bucket{driver_name="test-driver",grpc_status_code="OK",method_name="/k8s.io.kubelet.pkg.apis.dra.v1.DRAPlugin/NodeUnprepareResources",le="+Inf"} 1
+dra_grpc_operations_duration_seconds_sum{driver_name="test-driver",grpc_status_code="OK",method_name="/k8s.io.kubelet.pkg.apis.dra.v1.DRAPlugin/NodeUnprepareResources"} 0
+dra_grpc_operations_duration_seconds_count{driver_name="test-driver",grpc_status_code="OK",method_name="/k8s.io.kubelet.pkg.apis.dra.v1.DRAPlugin/NodeUnprepareResources"} 1
+# HELP dra_operations_duration_seconds [ALPHA] Latency histogram in seconds for the duration of handling all ResourceClaims referenced by a pod when the pod starts or stops. Identified by the name of the operation (PrepareResources or UnprepareResources) and separated by the success of the operation. The number of failed operations is provided through the histogram's overall count.
+# TYPE dra_operations_duration_seconds histogram
+dra_operations_duration_seconds_bucket{is_error="false",operation_name="UnprepareResources",le="+Inf"} 1
+dra_operations_duration_seconds_sum{is_error="false",operation_name="UnprepareResources"} 0
+dra_operations_duration_seconds_count{is_error="false",operation_name="UnprepareResources"} 1
+`,
+		},
+		{
 			description:            "should unprepare resource when driver returns nil value",
 			driverName:             driverName,
 			pod:                    genTestPod(),
@@ -1550,8 +1611,10 @@ dra_operations_duration_seconds_count{is_error="false",operation_name="Unprepare
 			// Check cache was cleared only on successful unprepare
 			var podClaimName *string
 			if len(test.pod.Spec.ResourceClaims) > 0 {
-				podClaimName, _, err = resourceclaim.Name(test.pod, &test.pod.Spec.ResourceClaims[0])
-				require.NoError(t, err)
+				// The claim name may not be derivable from the pod (e.g. when
+				// Status.ResourceClaimStatuses is missing, as in #139772). That
+				// is fine: we fall back to the known claimName constant below.
+				podClaimName, _, _ = resourceclaim.Name(test.pod, &test.pod.Spec.ResourceClaims[0])
 			}
 			claimName := claimName
 			if podClaimName == nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

UnprepareResources now uses claim info cache to get a list of claim names for the pod and falls back to the current approach - to get them from `pod.Status.ResourceClaimStatuses` using `resourceclaim.Name` API. This should help unpreparing resources even if pod.Status.ResourceClaimStatuses is empty.

The claim info cache is the authoritative record of what was actually prepared for a pod: `PrepareResources` stores a reference to every prepared claim keyed by claim name and pod UID and checkpoints it, so it survives `kubelet` restarts. 

Added a regression test covering a pod with an empty Status.ResourceClaimStatuses that references its claim via a template .

#### Which issue(s) this PR is related to:

Ref: https://github.com/kubernetes/kubernetes/issues/139772

This addresses the kubelet side of the issue (unprepare no longer depends on `pod.Status.ResourceClaimStatuses`). The broader problem - a client doing a full status PUT can drop status fields  (e.g. fields newer than its vendored `k8s.io/api`) - is wider than this fix, so the issue is intentionally left open to track that separately rather than auto-closed.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/sig node
/wg device-management