### PR TITLE
test(e2e): reduce verbosity of network conntrack test cases

### DIFF
--- a/test/e2e/network/conntrack.go
+++ b/test/e2e/network/conntrack.go
@@ -41,6 +41,7 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 	"k8s.io/utils/ptr"
 
+	"github.com/lithammer/dedent"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
@@ -137,6 +138,66 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		}
 	})
 
+	// generateProbeCommand generates a bash script that sends a constant stream of UDP packets to a target.
+	// We need to generate a constant stream of UDP traffic to prevent the conntrack entry from expiring.
+	// UDP conntrack entries have a default timeout of 30 seconds, so sending packets periodically keeps the flow alive.
+	// Ref: https://github.com/kubernetes/kubernetes/issues/139683
+	generateProbeCommand := func(payload, targetIP string, targetPort int32, srcPort, timeout int) string {
+		return fmt.Sprintf(dedent.Dedent(`
+				TARGET_IP="%s"
+				TARGET_PORT="%d"
+				INTERVAL=1
+				TIMEOUT=%d
+				REQ_PAYLOAD="%s"
+
+				echo "Starting UDP probe to ${TARGET_IP}:${TARGET_PORT} every ${INTERVAL}s..."
+
+				PREV_RESPONSE=""
+				COUNT=0
+
+				for i in $(seq 1 3000); do
+						TIMESTAMP=$(date '+%%H:%%M:%%S')
+
+						# Send UDP packet and remove newlines from the response.
+						# The agnhost image use netcat-openbsd (flags are not portable across different netcat versions):
+						# -u: UDP mode.
+						# -w <timeout>: timeout in seconds, in UDP mode it always waits for the entire timeout.
+						# -W 1: Ensures that nc exits immediately after receiving 1 packet.
+						# -p <srcPort>: UDP source port to always use the same flow.
+						# - 2>/dev/null: Hides connection errors since we handle failures based on empty responses.
+						RESPONSE=$(echo "$REQ_PAYLOAD" | nc -w "$TIMEOUT" -W 1 -u -p %d "$TARGET_IP" "$TARGET_PORT" 2>/dev/null | tr -d '\r\n')
+
+						# If the response state changes (e.g., from SUCCESS to FAIL, or between different backends):
+						if [ "$RESPONSE" != "$PREV_RESPONSE" ]; then
+							# Print the accumulated total for the previous response state.
+							if [ "$COUNT" -gt 0 ]; then
+								if [ -n "$PREV_RESPONSE" ]; then
+									echo "[$TIMESTAMP] SUCCESS: $PREV_RESPONSE ($COUNT times)"
+								else
+									echo "[$TIMESTAMP] FAIL ($COUNT times)"
+								fi
+							fi
+
+							# Reset tracking variables for the new state.
+							PREV_RESPONSE="$RESPONSE"
+							COUNT=1
+
+							# Immediately print the first occurrence of the new state.
+							if [ -n "$RESPONSE" ]; then
+								echo "[$TIMESTAMP] SUCCESS: $RESPONSE"
+							else
+								echo "[$TIMESTAMP] FAIL"
+							fi
+						else
+							# If the response is the same as before, just increment the counter to avoid spamming the logs.
+							COUNT=$((COUNT+1))
+						fi
+
+						sleep "$INTERVAL"
+				done
+				`), targetIP, targetPort, timeout, payload, srcPort)
+	}
+
 	ginkgo.It("should be able to preserve UDP traffic when server pod cycles for a NodePort service", func(ctx context.Context) {
 
 		// Create a NodePort service
@@ -155,7 +216,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		clientPod := e2epod.NewAgnhostPod(ns, podClient, nil, nil, nil)
 		nodeSelection := e2epod.NodeSelection{Name: clientNodeInfo.name}
 		e2epod.SetNodeSelection(&clientPod.Spec, nodeSelection)
-		cmd := fmt.Sprintf(`date; for i in $(seq 1 3000); do echo "$(date) Try: ${i}"; echo hostname | nc -u -w 5 -p %d %s %d; echo; done`, srcPort, serverNodeInfo.nodeIP, udpService.Spec.Ports[0].NodePort)
+		cmd := generateProbeCommand("hostname", serverNodeInfo.nodeIP, udpService.Spec.Ports[0].NodePort, srcPort, 5)
 		clientPod.Spec.Containers[0].Command = []string{"/bin/sh", "-c", cmd}
 		clientPod.Spec.Containers[0].Name = podClient
 		e2epod.NewPodClient(fr).CreateSync(ctx, clientPod)
@@ -233,7 +294,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		clientPod := e2epod.NewAgnhostPod(ns, podClient, nil, nil, nil)
 		nodeSelection := e2epod.NodeSelection{Name: clientNodeInfo.name}
 		e2epod.SetNodeSelection(&clientPod.Spec, nodeSelection)
-		cmd := fmt.Sprintf(`date; for i in $(seq 1 3000); do echo "$(date) Try: ${i}"; echo hostname | nc -u -w 5 -p %d %s %d; echo; done`, srcPort, udpService.Spec.ClusterIP, udpService.Spec.Ports[0].Port)
+		cmd := generateProbeCommand("hostname", udpService.Spec.ClusterIP, udpService.Spec.Ports[0].Port, srcPort, 5)
 		clientPod.Spec.Containers[0].Command = []string{"/bin/sh", "-c", cmd}
 		clientPod.Spec.Containers[0].Name = podClient
 		e2epod.NewPodClient(fr).CreateSync(ctx, clientPod)
@@ -313,7 +374,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		clientPod := e2epod.NewAgnhostPod(ns, podClient, nil, nil, nil)
 		nodeSelection := e2epod.NodeSelection{Name: clientNodeInfo.name}
 		e2epod.SetNodeSelection(&clientPod.Spec, nodeSelection)
-		cmd := fmt.Sprintf(`date; for i in $(seq 1 3000); do echo "$(date) Try: ${i}"; echo hostname | nc -u -w 1 -p %d %s %d; echo; done`, srcPort, udpService.Spec.ClusterIP, udpService.Spec.Ports[0].Port)
+		cmd := generateProbeCommand("hostname", udpService.Spec.ClusterIP, udpService.Spec.Ports[0].Port, srcPort, 1)
 		clientPod.Spec.Containers[0].Command = []string{"/bin/sh", "-c", cmd}
 		clientPod.Spec.Containers[0].Name = podClient
 		e2epod.NewPodClient(fr).CreateSync(ctx, clientPod)
@@ -406,7 +467,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		clientPod := e2epod.NewAgnhostPod(ns, podClient, nil, nil, nil)
 		nodeSelection := e2epod.NodeSelection{Name: clientNodeInfo.name}
 		e2epod.SetNodeSelection(&clientPod.Spec, nodeSelection)
-		cmd := fmt.Sprintf(`date; for i in $(seq 1 3000); do echo "$(date) Try: ${i}"; echo hostname | nc -u -w 5 -p %d %s %d; echo; done`, srcPort, udpService.Spec.ClusterIP, udpService.Spec.Ports[0].Port)
+		cmd := generateProbeCommand("hostname", udpService.Spec.ClusterIP, udpService.Spec.Ports[0].Port, srcPort, 5)
 		clientPod.Spec.Containers[0].Command = []string{"/bin/sh", "-c", cmd}
 		clientPod.Spec.Containers[0].Name = podClient
 		clientPod.Spec.HostNetwork = true
@@ -496,7 +557,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		clientPod := e2epod.NewAgnhostPod(ns, podClient, nil, nil, nil)
 		nodeSelection := e2epod.NodeSelection{Name: clientNodeInfo.name}
 		e2epod.SetNodeSelection(&clientPod.Spec, nodeSelection)
-		cmd := fmt.Sprintf(`date; for i in $(seq 1 3000); do echo "$(date) Try: ${i}"; echo hostname | nc -u -w 5 -p %d %s %d; echo; done`, srcPort, udpService.Spec.ClusterIP, udpService.Spec.Ports[0].Port)
+		cmd := generateProbeCommand("hostname", udpService.Spec.ClusterIP, udpService.Spec.Ports[0].Port, srcPort, 5)
 		clientPod.Spec.Containers[0].Command = []string{"/bin/sh", "-c", cmd}
 		clientPod.Spec.Containers[0].Name = podClient
 		e2epod.NewPodClient(fr).CreateSync(ctx, clientPod)
@@ -688,7 +749,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		clientPod := e2epod.NewAgnhostPod(ns, podClient, nil, nil, nil)
 		nodeSelection := e2epod.NodeSelection{Name: clientNodeInfo.name}
 		e2epod.SetNodeSelection(&clientPod.Spec, nodeSelection)
-		cmd := fmt.Sprintf(`date; for i in $(seq 1 3000); do echo "$(date) Try: ${i}"; echo serverport | nc -u -w 5 -p %d %s %d; echo; done`, srcPort, serverNodeInfo.nodeIP, udpService.Spec.Ports[0].NodePort)
+		cmd := generateProbeCommand("serverport", serverNodeInfo.nodeIP, udpService.Spec.Ports[0].NodePort, srcPort, 5)
 		clientPod.Spec.Containers[0].Command = []string{"/bin/sh", "-c", cmd}
 		clientPod.Spec.Containers[0].Name = podClient
 		e2epod.NewPodClient(fr).CreateSync(ctx, clientPod)


### PR DESCRIPTION
The previous test probes emit a log line per packet, leading to XXXX of lines of output in the normal case. This commit aggregates log output to significantly reduce the volume of logs without losing signal.

See example run with an additional log statement at the end of the test to show the output

```
 [21.265 seconds]
[sig-network] Conntrack should be able to preserve UDP traffic when server pod cycles for a ClusterIP service and client is hostNetwork [sig-network]
k8s.io/kubernetes/test/e2e/network/conntrack.go:453

  Timeline >>
  STEP: Creating a kubernetes client @ 06/18/26 14:10:40.877
  I0618 14:10:40.877651 3435653 util.go:414] >>> kubeConfig: /usr/local/google/home/aojea/.kube/config
  STEP: Building a namespace api object, basename conntrack @ 06/18/26 14:10:40.89
  STEP: Waiting for a default service account to be provisioned in namespace @ 06/18/26 14:10:40.899
  STEP: Waiting for kube-root-ca.crt to be provisioned in namespace @ 06/18/26 14:10:40.932
  STEP: creating a UDP service svc-udp with type=ClusterIP in conntrack-7794 @ 06/18/26 14:10:40.942
  STEP: creating a client pod for probing the service svc-udp @ 06/18/26 14:10:40.958
  I0618 14:10:43.070478 3435653 conntrack.go:480] Pod client logs: Starting UDP probe to 10.96.61.252:80 every 1s...

  STEP: creating a backend pod pod-server-1 for the service svc-udp @ 06/18/26 14:10:43.07
  I0618 14:10:45.081460 3435653 wait.go:96] Waiting for service conntrack-7794/svc-udp to have endpoints pointing to [pod-server-1]
  STEP: checking client pod connected to the backend 1 on Node IP 192.168.8.4 @ 06/18/26 14:10:45.082
  STEP: creating a second backend pod pod-server-2 for the service svc-udp @ 06/18/26 14:10:50.087
  I0618 14:10:52.096950 3435653 conntrack.go:515] Cleaning up pod-server-1 pod
  I0618 14:10:52.116489 3435653 wait.go:96] Waiting for service conntrack-7794/svc-udp to have endpoints pointing to [pod-server-2]
  STEP: checking client pod connected to the backend 2 on Node IP 192.168.8.4 @ 06/18/26 14:10:52.128
  I0618 14:11:02.136827 3435653 conntrack.go:144] Pod client logs at the end of the test:
  Starting UDP probe to 10.96.61.252:80 every 1s...
  [14:10:47] FAIL (1 times)
  [14:10:47] SUCCESS: pod-server-1
  [14:10:52] SUCCESS: pod-server-1 (5 times)
  [14:10:52] FAIL
  [14:10:58] FAIL (1 times)
  [14:10:58] SUCCESS: pod-server-2

  I0618 14:11:02.137366 3435653 helper.go:127] Waiting up to 7m0s for all (but 0) nodes to be ready
  STEP: Destroying namespace "conntrack-7794" for this suite. @ 06/18/26 14:11:02.139
  << Timeline
```

Logs are deduplicated so we have only a few lines
```
  I0618 14:11:02.136827 3435653 conntrack.go:144] Pod client logs at the end of the test:
  Starting UDP probe to 10.96.61.252:80 every 1s...
  [14:10:47] FAIL (1 times)
  [14:10:47] SUCCESS: pod-server-1
  [14:10:52] SUCCESS: pod-server-1 (5 times)
  [14:10:52] FAIL
  [14:10:58] FAIL (1 times)
  [14:10:58] SUCCESS: pod-server-2
```

/kind cleanup
```release-note
NONE
```
Fixes: #139683

/assign @danwinship @joestringer