### PR TITLE
Graduate OpaqueTag

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/opaque.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/opaque.go
@@ -45,11 +45,11 @@ func (opaqueTypeTagValidator) GetValidations(_ Context, _ codetags.Tag) (Validat
 	return Validations{OpaqueType: true}, nil
 }
 
-func (opaqueTypeTagValidator) Docs() TagDoc {
+func (v opaqueTypeTagValidator) Docs() TagDoc {
 	doc := TagDoc{
 		Tag:            opaqueTypeTagName,
-		StabilityLevel: TagStabilityLevelAlpha,
-		Scopes:         []Scope{ScopeField},
+		StabilityLevel: TagStabilityLevelStable,
+		Scopes:         sets.List(v.ValidScopes()),
 		Description: "Indicates that any validations declared on the referenced type will be ignored. " +
 			"If a referenced type's package is not included in the generator's current " +
 			"flags, this tag must be set, or code generation will fail (preventing silent " +


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind cleanup

#### What this PR does / why we need it:

This PR graduates the opaque type validation tag to Stable. 

As a reminder, this tag is not generating any validations. This just disables the validation generation for the given type. We are clear about the semantics and also implemented it properly.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.
-->
N/A

#### Special notes for your reviewer:

This graduation updates the scope to dynamically list valid scopes (`sets.List(v.ValidScopes())`) instead of hardcoding `ScopeField`.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
