### PR TITLE
kubectl: add support for `--proxy-url` flag

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -59,6 +59,7 @@ const (
 	flagTimeout              = "request-timeout"
 	flagCacheDir             = "cache-dir"
 	flagDisableCompression   = "disable-compression"
+	flagProxyURL             = "proxy-url"
 )
 
 // RESTClientGetter is an interface that the ConfigFlags describe to provide an easier way to mock for commands
@@ -103,6 +104,7 @@ type ConfigFlags struct {
 	Password             *string
 	Timeout              *string
 	DisableCompression   *bool
+	ProxyURL             *string
 	// If non-nil, wrap config function can transform the Config
 	// before it is returned in ToRESTConfig function.
 	WrapConfigFn func(*rest.Config) *rest.Config
@@ -226,6 +228,9 @@ func (f *ConfigFlags) toRawKubeConfigLoader() clientcmd.ClientConfig {
 	}
 	if f.DisableCompression != nil {
 		overrides.ClusterInfo.DisableCompression = *f.DisableCompression
+	}
+	if f.ProxyURL != nil {
+		overrides.ClusterInfo.ProxyURL = *f.ProxyURL
 	}
 
 	// bind context flags
@@ -431,6 +436,9 @@ func (f *ConfigFlags) AddFlags(flags *pflag.FlagSet) {
 	if f.DisableCompression != nil {
 		flags.BoolVar(f.DisableCompression, flagDisableCompression, *f.DisableCompression, "If true, opt-out of response compression for all requests to the server")
 	}
+	if f.ProxyURL != nil {
+		flags.StringVar(f.ProxyURL, flagProxyURL, *f.ProxyURL, "Proxy URL to use for requests to the API server")
+	}
 }
 
 // WithDeprecatedPasswordFlag enables the username and password config flags
@@ -492,6 +500,7 @@ func NewConfigFlags(usePersistentConfig bool) *ConfigFlags {
 		ImpersonateGroup:     &impersonateGroup,
 		ImpersonateUserExtra: &impersonateUserExtra,
 		DisableCompression:   &disableCompression,
+		ProxyURL:             ptr.To(""),
 
 		usePersistentConfig: usePersistentConfig,
 		// The more groups you have, the more discovery requests you need to make.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR add new flag `--proxy-url`. The flag allow user to override the proxy URL configured in kubeconfig for a specific kubectl call (similar to `--server`: https://github.com/kubernetes/kubectl/issues/1655#issuecomment-2829408755).
While proxy configuration can already be specified through the kubeconfig `proxy-url` field, there is currently no equivalent cli flag for this. Environment based proxy configuration is not always sufficient, especially when interacting with localhost based API server endpoints. This is useful for localhost proxy scenarios where `HTTPS_PROXY` environment variable doesn't work. 


#### Which issue(s) this PR is related to: Fixes https://github.com/kubernetes/kubectl/issues/1655
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:

<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add a --proxy-url flag to kubectl to override the proxy URL configured in kubeconfig.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
