### PR TITLE
DRA: align ResourceClaim unreservation/deallocation for PodGroups with Pods

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -508,7 +508,7 @@ func (pl *DynamicResources) PreFilter(ctx context.Context, state fwk.CycleState,
 	}
 	state.Write(stateKey, s)
 
-	podGroupState, err := getPodGroupStateData(state)
+	podGroupState, err := getOrCreatePodGroupStateData(state)
 	if err != nil {
 		return nil, statusError(logger, err)
 	}
@@ -797,20 +797,11 @@ func getStateData(cs fwk.CycleState) (*stateData, error) {
 	return s, nil
 }
 
-func getPodGroupStateData(cs fwk.CycleState) (*podGroupStateData, error) {
-	podGroupCycleState := cs.GetPodGroupSchedulingCycle()
-	if podGroupCycleState == nil {
+func getPodGroupStateDataFromPodGroupCycleState(pgState fwk.PodGroupCycleState) (*podGroupStateData, error) {
+	if pgState == nil {
 		return nil, nil
 	}
-	state, err := podGroupCycleState.Read(stateKey)
-	if errors.Is(err, fwk.ErrNotFound) {
-		podGroupState := &podGroupStateData{
-			pendingAllocations: make(map[types.UID]sets.Set[types.UID]),
-			podsStateData:      make(map[types.NamespacedName]*stateData),
-		}
-		podGroupCycleState.Write(stateKey, podGroupState)
-		return podGroupState, nil
-	}
+	state, err := pgState.Read(stateKey)
 	if err != nil {
 		return nil, err
 	}
@@ -819,6 +810,33 @@ func getPodGroupStateData(cs fwk.CycleState) (*podGroupStateData, error) {
 		return nil, errors.New("state is not podGroupStateData")
 	}
 	return s, nil
+}
+
+func getPodGroupStateData(cs fwk.CycleState) (*podGroupStateData, error) {
+	// This is nil if the GenericWorkload feature is disabled, the Pod does not
+	// belong to a PodGroup, or the PodGroup is in the asynchronous binding phase.
+	podGroupCycleState := cs.GetPodGroupSchedulingCycle()
+	return getPodGroupStateDataFromPodGroupCycleState(podGroupCycleState)
+}
+
+func getOrCreatePodGroupStateData(cs fwk.CycleState) (*podGroupStateData, error) {
+	podGroupState, err := getPodGroupStateData(cs)
+	if errors.Is(err, fwk.ErrNotFound) {
+		podGroupCycleState := cs.GetPodGroupSchedulingCycle()
+		if podGroupCycleState == nil {
+			// This should never happen since [getPodGroupStateData] only returns
+			// [fwk.ErrNotFound] after [fwk.CycleState.GetPodGroupSchedulingCycle]
+			// already returns non-nil.
+			return nil, err
+		}
+		podGroupState := &podGroupStateData{
+			pendingAllocations: make(map[types.UID]sets.Set[types.UID]),
+			podsStateData:      make(map[types.NamespacedName]*stateData),
+		}
+		podGroupCycleState.Write(stateKey, podGroupState)
+		return podGroupState, nil
+	}
+	return podGroupState, err
 }
 
 // Filter invoked at the filter extension point.
@@ -1063,8 +1081,8 @@ func (pl *DynamicResources) PostFilter(ctx context.Context, cs fwk.CycleState, p
 
 func (pl *DynamicResources) deallocateOrDeletePodClaims(ctx context.Context, pod *v1.Pod, state *stateData) (bool, *fwk.Status) {
 	logger := klog.FromContext(ctx)
-	extendedResourceClaim := state.claims.extendedResourceClaim()
 
+	extendedResourceClaim := state.claims.extendedResourceClaim()
 	// Iterating over a map is random. This is intentional here, we want to
 	// pick one claim randomly because there is no better heuristic.
 	for index := range state.unavailableClaims {
@@ -1103,7 +1121,74 @@ func (pl *DynamicResources) deallocateOrDeletePodClaims(ctx context.Context, pod
 	return false, fwk.NewStatus(fwk.Unschedulable)
 }
 
-func (pl *DynamicResources) unreservePodGroupClaims(ctx context.Context, pod *v1.Pod) *fwk.Status {
+// PodGroupPostFilter checks whether there are allocated claims that could get
+// deallocated/deleted/unreserved to help get the PodGroup schedulable.
+// This only gets called when pod group cycle could not find a placement for PodGroup.
+func (pl *DynamicResources) PodGroupPostFilter(
+	ctx context.Context,
+	state fwk.PodGroupCycleState,
+	pgInfo fwk.PodGroupInfo,
+	_ fwk.PodGroupSchedulingFunc,
+) (*fwk.PodGroupPostFilterResult, *fwk.Status) {
+	logger := klog.FromContext(ctx)
+	if !pl.enabled {
+		logger.V(5).Info("Nothing to do in PodGroupPostFilter, plugin disabled", "podGroup", pgInfo.GetName())
+		return nil, fwk.NewStatus(fwk.Unschedulable)
+	}
+
+	if pgInfo.GetType() == fwk.CompositePodGroupKeyType {
+		logger.V(5).Info("DRA PodGroupPostFilter is not supporting CompositePodGroups", "podGroup", pgInfo.GetName())
+		return nil, fwk.NewStatus(fwk.Unschedulable)
+	}
+
+	if pl.fts.EnableTopologyAwareWorkloadScheduling && pgInfo.GetPodGroup() != nil && pgInfo.GetPodGroup().Spec.SchedulingConstraints != nil {
+		logger.V(5).Info("DRA PodGroupPostFilter is not supporting topology-aware workloads", "podGroup", pgInfo.GetName())
+		return nil, fwk.NewStatus(fwk.Unschedulable)
+	}
+
+	podGroupState, err := getPodGroupStateDataFromPodGroupCycleState(state)
+	if err != nil {
+		return nil, statusError(logger, err)
+	}
+
+	unreservePodGroup := false
+	// 1. Process pod-level claims deallocations/deletions.
+	// This mimics running PostFilter for each of the pods in pod group.
+	if podGroupState != nil && len(podGroupState.podsStateData) > 0 {
+		for _, pod := range pgInfo.GetUnscheduledPods() {
+			podState := podGroupState.podsStateData[types.NamespacedName{Namespace: pod.GetNamespace(), Name: pod.GetName()}]
+			if podState == nil {
+				continue
+			}
+			foundClaim, status := pl.deallocateOrDeletePodClaims(ctx, pod, podState)
+			if status.IsError() {
+				return nil, status
+			}
+			if !foundClaim {
+				// If we make it here we know that not all pods of the PodGroup could be scheduled.
+				unreservePodGroup = true
+			}
+		}
+	}
+
+	// 2. If at least one pod with claims did not deallocate/delete, try to unreserve PodGroup claims.
+	if unreservePodGroup && pl.fts.EnableDRAWorkloadResourceClaims && len(pgInfo.GetUnscheduledPods()) > 0 {
+		// To let the scheduler try to find new devices in case binding the current allocation
+		// failed in some previous cycle, deallocate any PodGroup-scoped claims
+		// unavailable on all nodes and remove the PodGroup from all its claims' status.reservedFor.
+		// Note that more Pods may exist than a PodGroup's minCount, but performing
+		// a cleanup after a previous cycle is safe as long as there are no assumed
+		// nor assigned pods yet.
+		status := pl.deallocatePodGroupClaims(ctx, podGroupState, pgInfo.GetUnscheduledPods()[0])
+		if status != nil {
+			return nil, status
+		}
+	}
+
+	return nil, fwk.NewStatus(fwk.Unschedulable, "deallocation and deletion of ResourceClaims completed")
+}
+
+func (pl *DynamicResources) deallocatePodGroupClaims(ctx context.Context, state *podGroupStateData, pod *v1.Pod) *fwk.Status {
 	if pod.Spec.SchedulingGroup == nil || pod.Spec.SchedulingGroup.PodGroupName == nil {
 		return nil
 	}
@@ -1119,12 +1204,44 @@ func (pl *DynamicResources) unreservePodGroupClaims(ctx context.Context, pod *v1
 	if err != nil {
 		return statusError(logger, err)
 	}
+	// Since this is part of the synchronous PodGroup scheduling cycle, we
+	// know that if the PodGroup is inactive, then it will stay inactive, so
+	// it is safe to deallocate its claims.
+	//
+	// If this state is not updated yet and says the PodGroup is active when
+	// it actually isn't, then a future scheduling cycle will eventually
+	// read the updated state and deallocate a claim.
 	if podGroupState.ScheduledPodsCount() > 0 {
 		return nil
 	}
 	podGroup, err := pl.getPodGroupSnapshot(pod)
 	if err != nil {
 		return statusError(logger, err)
+	}
+
+	// Iterating over a map is random. This is intentional here, we want to
+	// pick one claim randomly because there is no better heuristic.
+	for _, podState := range state.podsStateData {
+		for index := range podState.unavailableClaims {
+			claim := podState.claims.get(index)
+
+			reservedForNobody := len(claim.Status.ReservedFor) == 0
+			reservedForOnlyThisPodGroup := podGroup != nil &&
+				len(claim.Status.ReservedFor) == 1 &&
+				claim.Status.ReservedFor[0].UID == podGroup.UID
+
+			if reservedForNobody || reservedForOnlyThisPodGroup {
+				claim := claim.DeepCopy()
+				claim.Status.ReservedFor = nil
+				claim.Status.Allocation = nil
+				claim.Status.Devices = nil
+				logger.V(5).Info("Deallocation of PodGroup ResourceClaim", "pod", klog.KObj(pod), "podgroup", klog.KObj(podGroup), "resourceclaim", klog.KObj(claim))
+				if _, err := pl.clientset.ResourceV1().ResourceClaims(claim.Namespace).UpdateStatus(ctx, claim, metav1.UpdateOptions{}); err != nil {
+					return statusError(logger, err)
+				}
+				return fwk.NewStatus(fwk.Unschedulable, "deallocation of PodGroup ResourceClaim completed")
+			}
+		}
 	}
 
 	for _, podGroupClaim := range podGroup.Spec.ResourceClaims {
@@ -1168,85 +1285,6 @@ func (pl *DynamicResources) unreservePodGroupClaims(ctx context.Context, pod *v1
 	}
 
 	return nil
-}
-
-// PodGroupPostFilter checks whether there are allocated claims that could get
-// deallocated/deleted/unreserved to help get the PodGroup schedulable.
-// This only gets called when pod group cycle could not find a placement for PodGroup.
-func (pl *DynamicResources) PodGroupPostFilter(
-	ctx context.Context,
-	state fwk.PodGroupCycleState,
-	pgInfo fwk.PodGroupInfo,
-	_ fwk.PodGroupSchedulingFunc,
-) (*fwk.PodGroupPostFilterResult, *fwk.Status) {
-	logger := klog.FromContext(ctx)
-	if !pl.enabled {
-		logger.V(5).Info("Nothing to do in PodGroupPostFilter, plugin disabled", "podGroup", pgInfo.GetName())
-		return nil, fwk.NewStatus(fwk.Unschedulable)
-	}
-
-	if pl.fts.EnableTopologyAwareWorkloadScheduling && pgInfo.GetPodGroup() != nil && pgInfo.GetPodGroup().Spec.SchedulingConstraints != nil {
-		logger.V(5).Info("DRA PodGroupPostFilter is not supporting topology-aware workloads", "podGroup", pgInfo.GetName())
-		return nil, fwk.NewStatus(fwk.Unschedulable)
-	}
-
-	podGroupState, err := getPodGroupStateDataFromPodGroupCycleState(state)
-	if err != nil {
-		return nil, statusError(logger, err)
-	}
-
-	unreservePodGroup := false
-	// 1. Process pod-level claims deallocations/deletions.
-	// This mimics running PostFilter for each of the pods in pod group.
-	if podGroupState != nil && len(podGroupState.podsStateData) > 0 {
-		for _, pod := range pgInfo.GetUnscheduledPods() {
-			podState := podGroupState.podsStateData[types.NamespacedName{Namespace: pod.GetNamespace(), Name: pod.GetName()}]
-			if podState == nil {
-				continue
-			}
-			foundClaim, status := pl.deallocateOrDeletePodClaims(ctx, pod, podState)
-			if status.IsError() {
-				return nil, status
-			}
-			if !foundClaim {
-				// If we make it here we know that not all pods of the PodGroup could be scheduled.
-				unreservePodGroup = true
-			}
-		}
-	}
-
-	// 2. If at least one pod with claims did not deallocate/delete, try to unreserve PodGroup claims.
-	if unreservePodGroup && pl.fts.EnableDRAWorkloadResourceClaims && len(pgInfo.GetUnscheduledPods()) > 0 {
-		// To let the scheduler try to find new devices in case binding the current allocation
-		// failed in some previous cycle, remove the PodGroup from its claims' status.reservedFor.
-		// Note that more Pods may exist than a PodGroup's minCount, but performing
-		// a cleanup after a previous cycle is safe as long as there are no assumed
-		// nor assigned pods yet.
-		status := pl.unreservePodGroupClaims(ctx, pgInfo.GetUnscheduledPods()[0])
-		if status != nil {
-			return nil, status
-		}
-	}
-
-	return nil, fwk.NewStatus(fwk.Unschedulable, "deallocation and deletion of ResourceClaims completed")
-}
-
-func getPodGroupStateDataFromPodGroupCycleState(pgState fwk.PodGroupCycleState) (*podGroupStateData, error) {
-	if pgState == nil {
-		return nil, nil
-	}
-	state, err := pgState.Read(stateKey)
-	if errors.Is(err, fwk.ErrNotFound) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	s, ok := state.(*podGroupStateData)
-	if !ok {
-		return nil, errors.New("state is not podGroupStateData")
-	}
-	return s, nil
 }
 
 func (pl *DynamicResources) Score(ctx context.Context, cs fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) (int64, *fwk.Status) {
@@ -1490,7 +1528,7 @@ func (pl *DynamicResources) Unreserve(ctx context.Context, cs fwk.CycleState, po
 
 		// Ignore claims reserved for the PodGroup because other Pods in the
 		// group may still need this claim. The PodGroup may be unreserved and
-		// dellocated (in api-server) in the next scheduling cycle if the
+		// deallocated (in api-server) in the next scheduling cycle if the
 		// PodGroup is not schedulable (in PostFilter) and not used yet.
 		if claim.Status.Allocation != nil &&
 			resourceclaim.IsReservedForPod(pod, claim, false /* acceptPodGroupReservation */) {

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -237,12 +237,6 @@ var (
 					PodResourceClaims(v1.PodResourceClaim{Name: resourceName2, ResourceClaimName: &claimName2}).
 					PodGroupName(podGroupName).
 					Obj()
-	groupedPodWithTwoClaimNames = st.MakePod().Name(podName).Namespace(namespace).
-					UID(podUID).
-					PodResourceClaims(v1.PodResourceClaim{Name: resourceName, ResourceClaimName: &claimName}).
-					PodResourceClaims(v1.PodResourceClaim{Name: resourceName2, ResourceClaimName: &claimName2}).
-					PodGroupName(podGroupName).
-					Obj()
 	groupedPodWithClaimTemplateInStatus = func() *v1.Pod {
 		pod := podWithClaimTemplateInStatus.DeepCopy()
 		pod.Spec.SchedulingGroup = &v1.PodSchedulingGroup{
@@ -2128,7 +2122,7 @@ func testPlugin(tCtx ktesting.TContext) {
 				},
 			},
 		},
-		"postfilter-unreserve-podgroup": {
+		"postfilter-deallocate-reserved-podgroup": {
 			enableDRAWorkloadResourceClaims: true,
 			pod:                             groupedPodWithClaimName,
 			podGroups:                       []*schedulingapi.PodGroup{podGroupWithClaimName},
@@ -2148,15 +2142,16 @@ func testPlugin(tCtx ktesting.TContext) {
 					changes: change{
 						claim: func(claim *resourceapi.ResourceClaim) *resourceapi.ResourceClaim {
 							claim = claim.DeepCopy()
-							claim.Status.ReservedFor = []resourceapi.ResourceClaimConsumerReference{}
+							claim.Status.ReservedFor = nil
+							claim.Status.Allocation = nil
 							return claim
 						},
 					},
-					status: fwk.NewStatus(fwk.Unschedulable, `ResourceClaim unreserved for PodGroup`),
+					status: fwk.NewStatus(fwk.Unschedulable, `deallocation of PodGroup ResourceClaim completed`),
 				},
 			},
 		},
-		"postfilter-skip-unreserve-podgroup-feature-disabled": {
+		"postfilter-skip-deallocate-reserved-podgroup-feature-disabled": {
 			enableDRAWorkloadResourceClaims: false,
 			pod:                             groupedPodWithClaimName,
 			podGroups:                       []*schedulingapi.PodGroup{podGroupWithClaimName},
@@ -2177,7 +2172,7 @@ func testPlugin(tCtx ktesting.TContext) {
 				},
 			},
 		},
-		"postfilter-deallocate-podgroup": {
+		"postfilter-deallocate-unreserved-podgroup": {
 			enableDRAWorkloadResourceClaims: true,
 			pod:                             groupedPodWithClaimName,
 			podGroups:                       []*schedulingapi.PodGroup{podGroupWithClaimName},
@@ -2212,7 +2207,7 @@ func testPlugin(tCtx ktesting.TContext) {
 				},
 			},
 		},
-		"postfilter-skip-unreserve-podgroup-when-pods-active": {
+		"postfilter-skip-deallocate-reserved-podgroup-when-pods-active": {
 			enableDRAWorkloadResourceClaims: true,
 			pod:                             groupedPodWithClaimName,
 			podGroups:                       []*schedulingapi.PodGroup{podGroupWithClaimName},
@@ -2234,44 +2229,6 @@ func testPlugin(tCtx ktesting.TContext) {
 				},
 				postfilter: result{
 					status: fwk.NewStatus(fwk.Unschedulable),
-				},
-			},
-		},
-		"postfilter-skip-unreserve-podgroup-other-claim-deallocated": {
-			enableDRAWorkloadResourceClaims: true,
-			pod:                             groupedPodWithTwoClaimNames,
-			podGroups:                       []*schedulingapi.PodGroup{podGroupWithClaimName},
-			objs: []apiruntime.Object{
-				// Pods in the PodGroup
-				groupedPodWithClaimName,
-			},
-			classes: []*resourceapi.DeviceClass{deviceClass},
-			claims: []*resourceapi.ResourceClaim{
-				allocatedPodGroupClaimWithWrongTopology,
-				func() *resourceapi.ResourceClaim {
-					claim := allocatedClaimWithWrongTopology.DeepCopy()
-					claim.Name = claimName2
-					return claim
-				}(),
-			},
-			want: want{
-				filter: perNodeResult{
-					workerNode.Name: {
-						status: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `resourceclaim not available on the node`),
-					},
-				},
-				postfilter: result{
-					changes: change{
-						claim: func(claim *resourceapi.ResourceClaim) *resourceapi.ResourceClaim {
-							if claim.Name == claimName2 {
-								return st.FromResourceClaim(claim).
-									Allocation(nil).
-									Obj()
-							}
-							return claim
-						},
-					},
-					status: fwk.NewStatus(fwk.Unschedulable, `deallocation and deletion of ResourceClaims completed`),
 				},
 			},
 		},
@@ -4195,6 +4152,9 @@ func testPlugin(tCtx ktesting.TContext) {
 						testCtx.verify(tCtx, tc.want.unreserve, initialObjects, tc.pod, nil, status)
 					})
 				} else {
+					// PodGroup cycle state is cleared before asynchronous binding.
+					testCtx.state.(*framework.CycleState).SetPodGroupSchedulingCycle(nil)
+
 					if tc.want.unreserveBeforePreBind != nil {
 						initialObjects = testCtx.listAll(tCtx)
 						testCtx.p.Unreserve(tCtx, testCtx.state, tc.pod, selectedNodeName)
@@ -5804,6 +5764,22 @@ func TestPodGroupPostFilter(t *testing.T) {
 				assert.Nil(tCtx, claim.Status.ReservedFor)
 			},
 		},
+		"deallocate-podgroup-level-claim": {
+			pluginEnabled:                   true,
+			enableDRAWorkloadResourceClaims: true,
+			podGroups:                       []*schedulingapi.PodGroup{podGroupWithClaimName},
+			unscheduledPods:                 []*v1.Pod{groupedPodWithClaimName},
+			claims:                          []*resourceapi.ResourceClaim{inUseClaimByPodGroup},
+			objs:                            []apiruntime.Object{groupedPodWithClaimName},
+			unavailableClaimNames:           []string{inUseClaimByPodGroup.Name},
+			wantStatus:                      fwk.NewStatus(fwk.Unschedulable, "deallocation of PodGroup ResourceClaim completed"),
+			verifyClaims: func(tCtx ktesting.TContext, testCtx *testContext) {
+				claim, err := testCtx.client.ResourceV1().ResourceClaims(inUseClaimByPodGroup.Namespace).Get(tCtx, inUseClaimByPodGroup.Name, metav1.GetOptions{})
+				require.NoError(tCtx, err)
+				assert.Nil(tCtx, claim.Status.Allocation)
+				assert.Nil(tCtx, claim.Status.ReservedFor)
+			},
+		},
 		"delete-pod-level-extended-claim": {
 			pluginEnabled:             true,
 			enableDRAExtendedResource: true,
@@ -5876,6 +5852,7 @@ func TestPodGroupPostFilter(t *testing.T) {
 			verifyClaims: func(tCtx ktesting.TContext, testCtx *testContext) {
 				claimByPG, err := testCtx.client.ResourceV1().ResourceClaims(inUseClaimByPodGroup.Namespace).Get(tCtx, inUseClaimByPodGroup.Name, metav1.GetOptions{})
 				require.NoError(tCtx, err)
+				assert.NotNil(tCtx, claimByPG.Status.Allocation)
 				assert.Empty(tCtx, claimByPG.Status.ReservedFor)
 
 				claim2, err := testCtx.client.ResourceV1().ResourceClaims(inUseClaimForPodLevel.Namespace).Get(tCtx, inUseClaimForPodLevel.Name, metav1.GetOptions{})
@@ -5884,7 +5861,7 @@ func TestPodGroupPostFilter(t *testing.T) {
 				assert.Nil(tCtx, claim2.Status.ReservedFor)
 			},
 		},
-		"skip-unreserve-feature-disabled": {
+		"skip-deallocate-feature-disabled": {
 			pluginEnabled:                   true,
 			enableDRAWorkloadResourceClaims: false,
 			podGroups:                       []*schedulingapi.PodGroup{podGroupWithClaimName},
@@ -5898,7 +5875,7 @@ func TestPodGroupPostFilter(t *testing.T) {
 				assert.NotEmpty(tCtx, claim.Status.ReservedFor)
 			},
 		},
-		"skip-unreserve-topology-aware-podgroup": {
+		"skip-deallocate-topology-aware-podgroup": {
 			pluginEnabled:                         true,
 			enableDRAWorkloadResourceClaims:       true,
 			enableTopologyAwareWorkloadScheduling: true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR addresses feedback from https://github.com/kubernetes/enhancements/pull/5976#discussion_r3413838504 by unreserving and deallocating ResourceClaims for PodGroups at the same time as ResourceClaims for individual Pods:
- In `Unreserve`, PodGroups are removed from a ResourceClaim's `status.reservedFor` when there are no other active Pods in the PodGroup.
- In `PostFilter`, a ResourceClaim is unreserved and deallocated when it is reserved only for the Pod's PodGroup with no active Pods.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
KEP: https://github.com/kubernetes/enhancements/issues/5729

#### Special notes for your reviewer:

More changes are expected to the DRA plugin for WAS, in particular to `PostFilter`. I'm happy to defer this until those changes are done if that makes things easier.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
