### PR TITLE
[WIP] testing contention profiling

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -1116,6 +1116,11 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {
 }
 
 func installAPI(name string, s *GenericAPIServer, c *Config) {
+	// EXPERIMENT: force-disable block profiling regardless of --contention-profiling.
+	// The only effect of EnableContentionProfiling is goruntime.SetBlockProfileRate(1)
+	// below; neutralizing it here lets us A/B the LIST p99 tail without touching the
+	// test-infra job config that still passes --contention-profiling=true.
+	c.EnableContentionProfiling = false
 	if c.EnableIndex {
 		routes.Index{}.Install(s.listedPathProvider, s.Handler.NonGoRestfulMux)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Experiment: force-disables block profiling in the apiserver to A/B the LIST p99 tail under scale. Not for merge.

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```