### PR TITLE
Fix kubelet node status update data race

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -396,6 +396,8 @@ func (kl *Kubelet) fastNodeStatusUpdate(ctx context.Context, timeout bool) (comp
 		logger.Error(err, "Error getting the current node from lister")
 		return false
 	}
+	// GetNode reads from the shared informer cache. Copy before any downstream reads.
+	originalNode = originalNode.DeepCopy()
 
 	readyIdx, originalNodeReady := nodeutil.GetNodeCondition(&originalNode.Status, v1.NodeReady)
 	if readyIdx == -1 {
@@ -507,6 +509,10 @@ func (kl *Kubelet) tryUpdateNodeStatus(ctx context.Context, tryNumber int) error
 	}
 	if originalNode == nil {
 		return fmt.Errorf("nil %q node object", kl.nodeName)
+	}
+	if tryNumber == 0 {
+		// nodeLister reads from the shared informer cache. Copy before any downstream reads.
+		originalNode = originalNode.DeepCopy()
 	}
 
 	node, changed := kl.updateNode(ctx, originalNode)

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -537,6 +537,55 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 	assert.True(t, apiequality.Semantic.DeepEqual(expectedNode, updatedNode), "%s", cmp.Diff(expectedNode, updatedNode))
 }
 
+func TestUpdateNodeStatusCopiesSharedListerNode(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+	kubelet := testKubelet.kubelet
+	kubelet.kubeClient = nil // ensure only the heartbeat client is used
+
+	sharedNode := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: testKubeletHostname},
+		Status: v1.NodeStatus{
+			Conditions: []v1.NodeCondition{
+				{
+					Type:   v1.NodeReady,
+					Status: v1.ConditionTrue,
+				},
+			},
+		},
+	}
+	sharedNodeSnapshot := sharedNode.DeepCopy()
+	kubelet.nodeLister = testNodeLister{nodes: []*v1.Node{sharedNode}}
+	kubelet.setNodeStatusFuncs = []func(context.Context, *v1.Node) error{
+		func(ctx context.Context, node *v1.Node) error {
+			// Simulate the shared informer cache changing after kubelet read the node.
+			sharedNode.Labels = map[string]string{
+				v1.LabelOSStable:   goruntime.GOOS,
+				v1.LabelArchStable: goruntime.GOARCH,
+			}
+			return nil
+		},
+	}
+
+	var patches [][]byte
+	kubeClient := testKubelet.fakeKubeClient
+	kubeClient.AddReactor("patch", "nodes", func(action core.Action) (bool, runtime.Object, error) {
+		patchAction := action.(core.PatchAction)
+		patches = append(patches, patchAction.GetPatch())
+		updatedNode, err := applyNodeStatusPatch(sharedNodeSnapshot, patchAction.GetPatch())
+		return true, updatedNode, err
+	})
+
+	require.NoError(t, kubelet.tryUpdateNodeStatus(tCtx, 0))
+	require.Len(t, patches, 1)
+
+	updatedNode, err := applyNodeStatusPatch(sharedNodeSnapshot, patches[0])
+	require.NoError(t, err)
+	assert.Equal(t, goruntime.GOOS, updatedNode.Labels[v1.LabelOSStable])
+	assert.Equal(t, goruntime.GOARCH, updatedNode.Labels[v1.LabelArchStable])
+}
+
 func TestUpdateExistingNodeStatusTimeout(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	if testing.Short() {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

On the first try, `tryUpdateNodeStatus` obtains the node from `kl.nodeLister.Get`, and `fastNodeStatusUpdate` obtains it from `kl.GetNode`. Both return the shared informer-cache object. The kubelet then reads that object (via `GetNodeCondition`, `updateNode`, and ultimately `nodeutil.PatchNodeStatus`, which JSON-marshals it) while the informer can concurrently modify it, which is a data race and the cause of the panic reported in the issue.

This deep-copies the node immediately after it is read from the lister, so every downstream read operates on a private copy. The copy is taken only on the paths that return the shared object (the `tryNumber == 0` branch and `fastNodeStatusUpdate`); the retry path already fetches a fresh object from the API server, so it is left unchanged.

**Which issue(s) this PR fixes:**

Fixes #139838

**Special notes for your reviewer:**

The panic was reported from a downstream (OpenShift) vendor of the kubelet, but the root cause is upstream in `pkg/kubelet/kubelet_node_status.go`, so the fix belongs here. I added `TestUpdateNodeStatusCopiesSharedListerNode`, which wires a lister that returns a shared node and asserts the kubelet works on a copy rather than the shared object. The existing node-status tests, including `TestUpdateNodeStatusWithLease`, pass under `go test -race`.

This PR was written in part with the assistance of generative AI; all changes were authored and reviewed by me.

**Does this PR introduce a user-facing change?**

```release-note
Fixed a data race in the kubelet that could cause a panic while updating node status when the node object from the informer cache was concurrently modified.
```
