### PR TITLE
kubelet/prober: add ProbeErrorAsFailure feature gate to treat exec errors as probe failures

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -361,6 +361,16 @@ const (
 	// Locked to default, will remove in v1.38. Progress is reflected in KEP #1972 update
 	ExecProbeTimeout featuregate.Feature = "ExecProbeTimeout"
 
+	// owner: @rawrmonster17
+	//
+	// When enabled, probe execution errors (e.g. command not found, permission
+	// denied) are treated as probe failures and count toward the FailureThreshold.
+	// Without this gate, such errors are silently discarded by the probe worker,
+	// so a container with a permanently broken liveness probe never restarts and
+	// ContainersReady stays True indefinitely.
+	// See https://github.com/kubernetes/kubernetes/issues/106682
+	ProbeErrorAsFailure featuregate.Feature = "ProbeErrorAsFailure"
+
 	// owner: @seans3
 	// kep: http://kep.k8s.io/4006
 	//
@@ -1388,6 +1398,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.35"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in v1.38
 	},
 
+	ProbeErrorAsFailure: {
+		{Version: version.MustParse("1.38"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
 	ExtendWebSocketsToKubelet: {
 		{Version: version.MustParse("1.36"), Default: true, PreRelease: featuregate.Beta},
 	},
@@ -2314,6 +2328,8 @@ var defaultKubernetesFeatureGateDependencies = map[featuregate.Feature][]feature
 	EventedPLEG: {},
 
 	ExecProbeTimeout: {},
+
+	ProbeErrorAsFailure: {},
 
 	ExtendWebSocketsToKubelet: {NodeDeclaredFeatures},
 

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -348,8 +348,15 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 	// Note, exec probe does NOT have access to pod environment variables or downward API
 	result, err := w.probeManager.prober.probe(ctx, w.probeType, w.pod, status, w.container, w.containerID)
 	if err != nil {
-		// Prober error, throw away the result.
-		return true
+		// The prober already maps execution errors (e.g. command not found, permission denied)
+		// to results.Failure before returning them here. When ProbeErrorAsFailure is enabled,
+		// let those mapped Failure results fall through to the normal threshold/hold logic so
+		// the container gets restarted as intended. Without the gate we preserve the historical
+		// behavior of discarding all errored probe results silently.
+		if !utilfeature.DefaultFeatureGate.Enabled(features.ProbeErrorAsFailure) || result != results.Failure {
+			// Prober error, throw away the result.
+			return true
+		}
 	}
 
 	switch result {

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -1107,3 +1107,99 @@ func TestChangeContainerStatusOnKubeletRestart(t *testing.T) {
 		})
 	}
 }
+
+// TestProbeErrorAsFailure verifies the ProbeErrorAsFailure feature gate behavior.
+//
+// Without the gate: a probe that returns an error (e.g. exec command not found)
+// is silently discarded — the failure threshold is never reached, the container
+// is never restarted, and ContainersReady stays True.
+//
+// With the gate: the prober maps such errors to results.Failure before returning
+// them to the worker. The worker must let those through to the normal threshold
+// and hold logic so the container actually gets restarted.
+func TestProbeErrorAsFailure(t *testing.T) {
+	probeErr := fmt.Errorf("exec: command not found")
+
+	tests := []struct {
+		name         string
+		gateEnabled  bool
+		probeType    probeType
+		// wantOnHold is true when liveness/startup should set onHold after hitting threshold.
+		wantOnHold   bool
+		// wantFailure is true when the resultsManager should reflect Failure.
+		wantFailure  bool
+	}{
+		{
+			name:        "gate disabled: liveness exec error is discarded",
+			gateEnabled: false,
+			probeType:   liveness,
+			wantOnHold:  false,
+			wantFailure: false,
+		},
+		{
+			name:        "gate disabled: readiness exec error is discarded",
+			gateEnabled: false,
+			probeType:   readiness,
+			wantOnHold:  false,
+			wantFailure: false,
+		},
+		{
+			name:        "gate enabled: liveness exec error counts as failure, triggers restart hold",
+			gateEnabled: true,
+			probeType:   liveness,
+			wantOnHold:  true,
+			wantFailure: true,
+		},
+		{
+			name:        "gate enabled: readiness exec error counts as failure",
+			gateEnabled: true,
+			probeType:   readiness,
+			wantOnHold:  false, // readiness doesn't set onHold
+			wantFailure: true,
+		},
+		{
+			name:        "gate enabled: startup exec error counts as failure, triggers restart hold",
+			gateEnabled: true,
+			probeType:   startup,
+			wantOnHold:  true,
+			wantFailure: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ProbeErrorAsFailure, tc.gateEnabled)
+
+			logger, ctx := ktesting.NewTestContext(t)
+			m := newTestManager()
+			// FailureThreshold=1 so a single error-as-failure immediately triggers the hold.
+			w := newTestWorker(m, tc.probeType, v1.Probe{SuccessThreshold: 1, FailureThreshold: 1})
+			m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatus())
+
+			// Simulate a probe that errors — fakeExecProber returns (probe.Failure, "", err).
+			// prober.go maps (err != nil) → results.Failure, so worker receives (results.Failure, err).
+			m.prober.exec = fakeExecProber{probe.Failure, probeErr}
+
+			expectContinue(t, w, w.doProbe(ctx), "probe error run")
+
+			if w.onHold != tc.wantOnHold {
+				t.Errorf("onHold: got %v, want %v", w.onHold, tc.wantOnHold)
+			}
+
+			result, ok := resultsManager(m, tc.probeType).Get(testContainerID)
+			if tc.wantFailure {
+				if !ok {
+					t.Errorf("expected Failure result to be set in resultsManager, but it was not")
+				} else if result != results.Failure {
+					t.Errorf("resultsManager result: got %v, want %v", result, results.Failure)
+				}
+			} else {
+				// Gate disabled: result should not have been updated (stays at initialValue).
+				if ok && result == results.Failure {
+					t.Errorf("gate disabled: resultsManager was set to Failure but should have been discarded")
+				}
+			}
+		})
+	}
+}
+


### PR DESCRIPTION
## What this does

Probe execution errors — command not found, permission denied, CRI transport failure — are already mapped to `results.Failure` by `prober.go` before being returned. However `worker.go` has an unconditional guard:

```go
if err != nil {
    // Prober error, throw away the result.
    return true
}
```

This discards the result entirely, so the failure threshold is never reached, the container is never restarted, and `ContainersReady` stays `True` indefinitely. Users see a flood of `Unhealthy` warning events but no container restart. Broken since the prober was introduced; tracked in #106682 (opened 2021, still open).

## Why a feature gate

SIG-Node explicitly requested a gate before merging (#106682 comment thread, June 2025), citing the `ExecProbeTimeout` precedent: some workloads may currently rely on exec probes that always error silently "passing" through. Gating the new behavior allows operators to opt in, audit affected pods, and roll out safely.

## What changed

**`pkg/features/kube_features.go`**
- New gate `ProbeErrorAsFailure` — Alpha, default `false`, v1.38.

**`pkg/kubelet/prober/worker.go`**
- The `if err != nil { return true }` guard now checks the gate. When enabled **and** the returned result is already `results.Failure`, it falls through to the normal threshold/hold logic. All other error cases (Unknown, etc.) are still discarded as before.
- Gate disabled: zero behavior change.

**`pkg/kubelet/prober/worker_test.go`**
- `TestProbeErrorAsFailure`: table-driven test covering gate-off (silent discard) and gate-on (failure counted, threshold hit, `onHold` set) for liveness, readiness, and startup probe types.

## Why this approach is correct

`prober.go:probe()` (line 104-108) already maps `err != nil` to `results.Failure, err` — it records the `Unhealthy` event and returns the failure. The worker receiving `(results.Failure, err)` has all the information it needs to act. The only thing preventing correct behavior was the unconditional error discard.

The fix is deliberately minimal: one conditional, no new paths through the threshold logic, gate-off is a no-op.

## Testing

```
make test WHAT=./pkg/kubelet/prober GOFLAGS=-v
```

`TestProbeErrorAsFailure` is the new test; existing tests are unchanged (gate defaults to off).

## Related

- Closes #106682
- Follows `ExecProbeTimeout` / kep #1972 pattern for behavioral opt-in gates
- Previous attempt: #139550 (same fix, no feature gate — stalled on this exact issue)

```release-note
Add `ProbeErrorAsFailure` feature gate (Alpha, default off). When enabled,
exec probe errors (e.g. command not found) are treated as probe failures and
count toward the FailureThreshold, allowing liveness probes to correctly
trigger container restarts for misconfigured or broken probe commands.
```
