### PR TITLE
Marked deprecated field as optional in comment

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/types.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/types.go
@@ -41,6 +41,7 @@ type Config struct {
 	APIVersion string `json:"apiVersion,omitempty"`
 	// Preferences holds general information to be use for cli interactions
 	// Deprecated: this field is deprecated in v1.34. It is not used by any of the Kubernetes components.
+	// +optional
 	Preferences Preferences `json:"preferences,omitzero"`
 	// Clusters is a map of referencable names to cluster configs
 	Clusters map[string]*Cluster `json:"clusters"`

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/types.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/types.go
@@ -38,6 +38,7 @@ type Config struct {
 	APIVersion string `json:"apiVersion,omitempty"`
 	// Preferences holds general information to be use for cli interactions
 	// Deprecated: this field is deprecated in v1.34. It is not used by any of the Kubernetes components.
+	// +optional
 	Preferences Preferences `json:"preferences,omitzero"`
 	// Clusters is a map of referencable names to cluster configs
 	Clusters []NamedCluster `json:"clusters"`


### PR DESCRIPTION
To get in the generated documentation the text "[Required]" avoided.


#### What type of PR is this?

/kind documentation

/kind deprecation



#### What this PR does / why we need it:

`required` **and** `deprecated` conflicts.

<img width="1076" height="415" alt="afbeelding" src="https://github.com/user-attachments/assets/e0e04984-d41f-4ddd-8cd6-700bb263ff70" />


#### Which issue(s) this PR is related to:

https://github.com/kubernetes/website/pull/56183

#### Special notes for your reviewer:

For me started this as _let's do a quick clean-up_, meanwhile am I way beyond _quick_.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
