### PR TITLE
apiserver/pod: preserve DRA status fields when old clients clear them via pods/status

### DIFF
--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -239,6 +239,19 @@ func (podStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.
 		newPod.Status.QOSClass = oldPod.Status.QOSClass
 	}
 
+	// Preserve DRA-related status fields when an old or misbehaving client
+	// strips fields that it does not know about during a pods/status update.
+	// For the slice fields, a non-nil empty slice can still clear the field.
+	if newPod.Status.ResourceClaimStatuses == nil && oldPod.Status.ResourceClaimStatuses != nil {
+		newPod.Status.ResourceClaimStatuses = oldPod.Status.ResourceClaimStatuses
+	}
+	if newPod.Status.ExtendedResourceClaimStatus == nil && oldPod.Status.ExtendedResourceClaimStatus != nil {
+		newPod.Status.ExtendedResourceClaimStatus = oldPod.Status.ExtendedResourceClaimStatus
+	}
+	if newPod.Status.NodeAllocatableResourceClaimStatuses == nil && oldPod.Status.NodeAllocatableResourceClaimStatuses != nil {
+		newPod.Status.NodeAllocatableResourceClaimStatuses = oldPod.Status.NodeAllocatableResourceClaimStatuses
+	}
+
 	preserveOldObservedGeneration(newPod, oldPod)
 	podutil.DropDisabledPodFields(newPod, oldPod)
 }

--- a/pkg/registry/core/pod/strategy_test.go
+++ b/pkg/registry/core/pod/strategy_test.go
@@ -5349,6 +5349,214 @@ func TestStatusPrepareForUpdate(t *testing.T) {
 				},
 			},
 		},
+		{
+			description: "preserve old ResourceClaimStatuses when misbehaving client clears them on terminating pod",
+			features: map[featuregate.Feature]bool{
+				features.DynamicResourceAllocation: true,
+			},
+			oldPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod", DeletionTimestamp: &metav1.Time{}},
+				Status: api.PodStatus{
+					ResourceClaimStatuses: []api.PodResourceClaimStatus{
+						{Name: "my-claim", ResourceClaimName: new("pod-my-claim")},
+					},
+				},
+			},
+			newPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Status:     api.PodStatus{},
+			},
+			expected: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Status: api.PodStatus{
+					ResourceClaimStatuses: []api.PodResourceClaimStatus{
+						{Name: "my-claim", ResourceClaimName: new("pod-my-claim")},
+					},
+				},
+			},
+		},
+		{
+			description: "preserve old ResourceClaimStatuses when omitted on non-terminating pod",
+			features: map[featuregate.Feature]bool{
+				features.DynamicResourceAllocation: true,
+			},
+			oldPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Status: api.PodStatus{
+					ResourceClaimStatuses: []api.PodResourceClaimStatus{
+						{Name: "my-claim", ResourceClaimName: new("pod-my-claim")},
+					},
+				},
+			},
+			newPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Status:     api.PodStatus{},
+			},
+			expected: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Status: api.PodStatus{
+					ResourceClaimStatuses: []api.PodResourceClaimStatus{
+						{Name: "my-claim", ResourceClaimName: new("pod-my-claim")},
+					},
+				},
+			},
+		},
+		{
+			description: "allow explicit empty-slice removal of ResourceClaimStatuses on non-terminating pod",
+			features: map[featuregate.Feature]bool{
+				features.DynamicResourceAllocation: true,
+			},
+			oldPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Status: api.PodStatus{
+					ResourceClaimStatuses: []api.PodResourceClaimStatus{
+						{Name: "my-claim", ResourceClaimName: new("pod-my-claim")},
+					},
+				},
+			},
+			newPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Status: api.PodStatus{
+					ResourceClaimStatuses: []api.PodResourceClaimStatus{},
+				},
+			},
+			expected: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Status: api.PodStatus{
+					ResourceClaimStatuses: []api.PodResourceClaimStatus{},
+				},
+			},
+		},
+		{
+			description: "preserve old ExtendedResourceClaimStatus when misbehaving client clears it on terminating pod",
+			features: map[featuregate.Feature]bool{
+				features.DRAExtendedResource: true,
+			},
+			oldPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod", DeletionTimestamp: &metav1.Time{}},
+				Status: api.PodStatus{
+					ExtendedResourceClaimStatus: &api.PodExtendedResourceClaimStatus{
+						ResourceClaimName: "pod-ext-claim",
+					},
+				},
+			},
+			newPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Status:     api.PodStatus{},
+			},
+			expected: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Status: api.PodStatus{
+					ExtendedResourceClaimStatus: &api.PodExtendedResourceClaimStatus{
+						ResourceClaimName: "pod-ext-claim",
+					},
+				},
+			},
+		},
+		{
+			description: "preserve old ExtendedResourceClaimStatus when omitted on non-terminating pod",
+			features: map[featuregate.Feature]bool{
+				features.DRAExtendedResource: true,
+			},
+			oldPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Status: api.PodStatus{
+					ExtendedResourceClaimStatus: &api.PodExtendedResourceClaimStatus{
+						ResourceClaimName: "pod-ext-claim",
+					},
+				},
+			},
+			newPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Status:     api.PodStatus{},
+			},
+			expected: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Status: api.PodStatus{
+					ExtendedResourceClaimStatus: &api.PodExtendedResourceClaimStatus{
+						ResourceClaimName: "pod-ext-claim",
+					},
+				},
+			},
+		},
+		{
+			description: "preserve old NodeAllocatableResourceClaimStatuses when misbehaving client clears them on terminating pod",
+			features: map[featuregate.Feature]bool{
+				features.DRANodeAllocatableResources: true,
+			},
+			oldPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod", DeletionTimestamp: &metav1.Time{}},
+				Status: api.PodStatus{
+					NodeAllocatableResourceClaimStatuses: []api.NodeAllocatableResourceClaimStatus{
+						{ResourceClaimName: "pod-node-claim"},
+					},
+				},
+			},
+			newPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Status:     api.PodStatus{},
+			},
+			expected: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Status: api.PodStatus{
+					NodeAllocatableResourceClaimStatuses: []api.NodeAllocatableResourceClaimStatus{
+						{ResourceClaimName: "pod-node-claim"},
+					},
+				},
+			},
+		},
+		{
+			description: "preserve old NodeAllocatableResourceClaimStatuses when omitted on non-terminating pod",
+			features: map[featuregate.Feature]bool{
+				features.DRANodeAllocatableResources: true,
+			},
+			oldPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Status: api.PodStatus{
+					NodeAllocatableResourceClaimStatuses: []api.NodeAllocatableResourceClaimStatus{
+						{ResourceClaimName: "pod-node-claim"},
+					},
+				},
+			},
+			newPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Status:     api.PodStatus{},
+			},
+			expected: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Status: api.PodStatus{
+					NodeAllocatableResourceClaimStatuses: []api.NodeAllocatableResourceClaimStatus{
+						{ResourceClaimName: "pod-node-claim"},
+					},
+				},
+			},
+		},
+		{
+			description: "allow explicit empty-slice removal of NodeAllocatableResourceClaimStatuses on non-terminating pod",
+			features: map[featuregate.Feature]bool{
+				features.DRANodeAllocatableResources: true,
+			},
+			oldPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Status: api.PodStatus{
+					NodeAllocatableResourceClaimStatuses: []api.NodeAllocatableResourceClaimStatus{
+						{ResourceClaimName: "pod-node-claim"},
+					},
+				},
+			},
+			newPod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Status: api.PodStatus{
+					NodeAllocatableResourceClaimStatuses: []api.NodeAllocatableResourceClaimStatus{},
+				},
+			},
+			expected: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Status: api.PodStatus{
+					NodeAllocatableResourceClaimStatuses: []api.NodeAllocatableResourceClaimStatus{},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/scheduler/framework/plugins/dynamicresources/nodeallocatabledynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/nodeallocatabledynamicresources.go
@@ -26,6 +26,7 @@ import (
 	resourceapi "k8s.io/api/resource/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	resourcehelper "k8s.io/component-helpers/resource"
@@ -432,13 +433,22 @@ func (pl *DynamicResources) patchNodeAllocatableResourceClaimStatus(ctx context.
 }
 
 func (pl *DynamicResources) clearNodeAllocatableResourceClaimStatus(ctx context.Context, pod *v1.Pod) {
+	if len(pod.Status.NodeAllocatableResourceClaimStatuses) == 0 {
+		return
+	}
+
 	logger := klog.FromContext(ctx)
 	logger.V(5).Info("Clearing NodeAllocatableResourceClaimStatuses on Unreserve", "pod", klog.KObj(pod))
 
-	targetStatus := pod.Status.DeepCopy()
-	targetStatus.NodeAllocatableResourceClaimStatuses = nil
-
-	if err := schedutil.PatchPodStatus(ctx, pl.clientset, pod.Name, pod.Namespace, &pod.Status, targetStatus); err != nil {
+	// An explicit empty list distinguishes an intentional clear from an old
+	// client omitting a field that it does not know about. PatchPodStatus cannot
+	// preserve that distinction because the field has an omitempty JSON tag.
+	//
+	// The uid is included as a precondition so the patch cannot silently apply
+	// to a different pod object if this one got deleted and recreated with the
+	// same name in the meantime.
+	patch := fmt.Appendf(nil, `{"metadata":{"uid":%q},"status":{"nodeAllocatableResourceClaimStatuses":[]}}`, pod.UID)
+	if _, err := pl.clientset.CoreV1().Pods(pod.Namespace).Patch(ctx, pod.Name, types.MergePatchType, patch, metav1.PatchOptions{}, "status"); err != nil {
 		logger.Error(err, "Failed to clear NodeAllocatableResourceClaimStatuses on Unreserve", "pod", klog.KObj(pod))
 	} else {
 		logger.V(5).Info("Cleared NodeAllocatableResourceClaimStatuses", "pod", klog.KObj(pod))

--- a/pkg/scheduler/framework/plugins/dynamicresources/nodeallocatabledynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/nodeallocatabledynamicresources_test.go
@@ -809,12 +809,20 @@ func TestClearNodeAllocatableResourceClaimStatus(t *testing.T) {
 			for _, action := range actions {
 				if action.Matches("patch", "pods") && action.GetSubresource() == "status" {
 					gotPatch = true
+					patchAction := action.(clienttesting.PatchAction)
+					if patchAction.GetPatchType() != types.MergePatchType {
+						t.Errorf("patch type = %q, want %q", patchAction.GetPatchType(), types.MergePatchType)
+					}
+					wantPatch := `{"metadata":{"uid":"pod-uid"},"status":{"nodeAllocatableResourceClaimStatuses":[]}}`
+					if diff := cmp.Diff(wantPatch, string(patchAction.GetPatch())); diff != "" {
+						t.Errorf("clear patch mismatch (-want +got):\n%s", diff)
+					}
 					break
 				}
 			}
 
 			if gotPatch != tt.wantPatch {
-				t.Errorf("patchNodeAllocatableResourceClaimStatus() gotPatch = %v, want %v", gotPatch, tt.wantPatch)
+				t.Errorf("clearNodeAllocatableResourceClaimStatus() gotPatch = %v, want %v", gotPatch, tt.wantPatch)
 			}
 		})
 	}

--- a/test/integration/auth/node_test.go
+++ b/test/integration/auth/node_test.go
@@ -217,8 +217,10 @@ func TestNodeAuthorizer(t *testing.T) {
 	}
 	removeResourceClaimReference := func(client clientset.Interface) func() error {
 		return func() error {
+			// An explicit empty slice clears the field; null would be
+			// treated as an omitted field and preserved by the apiserver.
 			_, err := client.CoreV1().Pods("ns").Patch(context.TODO(), "node2normalpod", types.MergePatchType,
-				[]byte(`{"status":{"resourceClaimStatuses":null}}`),
+				[]byte(`{"status":{"resourceClaimStatuses":[]}}`),
 				metav1.PatchOptions{}, "status")
 			return err
 		}

--- a/test/integration/pods/pods_test.go
+++ b/test/integration/pods/pods_test.go
@@ -2598,3 +2598,78 @@ func TestPodLevelResourcesValidationAndDefaulting(t *testing.T) {
 		})
 	}
 }
+
+// TestDRAStatusPreservedOnStatusUpdate verifies that the apiserver preserves
+// ResourceClaimStatuses when a DRA-unaware client overwrites the status of a
+// running pod and omits fields that it does not know about.
+func TestDRAStatusPreservedOnStatusUpdate(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DynamicResourceAllocation, true)
+
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
+	defer server.TearDownFn()
+
+	client := clientset.NewForConfigOrDie(server.ClientConfig)
+	ns := framework.CreateNamespaceOrDie(client, "dra-status-preserve", t)
+	defer framework.DeleteNamespaceOrDie(client, ns, t)
+
+	ctx := context.Background()
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dra-pod",
+			Namespace: ns.Name,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{
+				Name:  "c",
+				Image: "pause",
+			}},
+			ResourceClaims: []v1.PodResourceClaim{
+				{Name: "gpu", ResourceClaimName: new("dra-pod-gpu")},
+			},
+		},
+	}
+	pod, err := client.CoreV1().Pods(ns.Name).Create(ctx, pod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("create pod: %v", err)
+	}
+
+	// Simulate DRA controller writing resourceClaimStatuses.
+	wantStatuses := []v1.PodResourceClaimStatus{
+		{Name: "gpu", ResourceClaimName: new("dra-pod-gpu")},
+	}
+	pod.Status.ResourceClaimStatuses = wantStatuses
+	pod, err = client.CoreV1().Pods(ns.Name).UpdateStatus(ctx, pod, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("set ResourceClaimStatuses: %v", err)
+	}
+	if len(pod.Status.ResourceClaimStatuses) == 0 {
+		t.Fatal("ResourceClaimStatuses not persisted after initial UpdateStatus")
+	}
+
+	// Simulate an old DRA-unaware client (e.g. Multus using k8s.io/client-go v0.29)
+	// calling UpdateStatus to write annotations. The round-tripped pod omits
+	// ResourceClaimStatuses because the old client does not know the field.
+	oldClientPod := pod.DeepCopy()
+	oldClientPod.Status.ResourceClaimStatuses = nil
+
+	updated, err := client.CoreV1().Pods(ns.Name).UpdateStatus(ctx, oldClientPod, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("old-client UpdateStatus: %v", err)
+	}
+
+	if diff := cmp.Diff(wantStatuses, updated.Status.ResourceClaimStatuses); diff != "" {
+		t.Errorf("ResourceClaimStatuses changed after old-client UpdateStatus (-want,+got):\n%s", diff)
+	}
+
+	// An explicit empty list remains a valid way for a field-aware client to
+	// clear a slice field.
+	clearPatch := []byte(`{"status":{"resourceClaimStatuses":[]}}`)
+	cleared, err := client.CoreV1().Pods(ns.Name).Patch(ctx, pod.Name, types.MergePatchType, clearPatch, metav1.PatchOptions{}, "status")
+	if err != nil {
+		t.Fatalf("clear ResourceClaimStatuses: %v", err)
+	}
+	if len(cleared.Status.ResourceClaimStatuses) != 0 {
+		t.Errorf("ResourceClaimStatuses not cleared: %v", cleared.Status.ResourceClaimStatuses)
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it

When a client that predates the DRA fields (`ResourceClaimStatuses`,
`ExtendedResourceClaimStatus`, `NodeAllocatableResourceClaimStatuses`)
issues a `pods/status` update, those fields are absent from the Pod it
sends back. The apiserver stores the update as-is, effectively clearing
DRA status. On the next termination sync, kubelet has no claim info from
the pod status and logs:

```
unprepare dynamic resources: pod "…": ResourceClaim not created yet
```

This leaves pods permanently stuck in `Terminating`.

**Root cause** (from #139772 discussion): Multus CNI uses
`network-attachment-definition-client` which pins `k8s.io/client-go
v0.29.0` — predating DRA fields. It calls `UpdateStatus` to write an
annotation, but the round-tripped Pod has the DRA fields zeroed.

**Fix**: extend `podStatusStrategy.PrepareForUpdate` to restore all three
DRA-related status fields from the old pod when the incoming update omits
them. This applies to running and terminating pods because the old client
can issue status updates throughout the pod lifecycle. For the two slice
fields, an explicit non-nil empty slice (`[]`) remains an allowed way to
clear the field.

The scheduler's Unreserve path now sends that explicit empty list when it
clears `NodeAllocatableResourceClaimStatuses`; its previous generic status
patch serialized the clear as an omitted field.

`DropDisabledPodFields` runs afterwards and will still strip the fields
when the corresponding feature gate is disabled, so there is no
interaction with the feature gate lifecycle.

This complements the kubelet-side resilience fix in #139845.

## Which issue(s) this PR is related to

Fixes #139772

## Type of change

/kind feature
/sig node
/sig api-machinery
/wg device-management
/triage accepted

## Does this PR introduce a user-facing change?

```release-note
Data in DRA-related fields in pod status (resourceClaimStatuses, extendedResourceClaimStatus, and nodeAllocatableResourceClaimStatuses) is now preserved when handling pod status updates that omit those fields. This prevents data loss due to updates from old clients accidentally unsetting these DRA fields, which could leave pods permanently stuck in Terminating.
```

## Testing

- Added eight cases to `TestStatusPrepareForUpdate` covering omitted DRA
  fields on running and terminating pods, plus explicit empty-slice updates.
- Added `TestDRAStatusPreservedOnStatusUpdate`, which exercises the
  running-pod regression and explicit empty-list clearing through the
  apiserver.
- Updated the scheduler Unreserve test to assert the explicit empty-list
  merge patch used to clear `NodeAllocatableResourceClaimStatuses`.
- `make test WHAT=./pkg/registry/core/pod GOFLAGS=-v`
- `make test WHAT=./pkg/scheduler/framework/plugins/dynamicresources GOFLAGS=-v`
- `make test-integration WHAT=./test/integration/pods GOFLAGS=-v KUBE_TEST_ARGS='-run ^TestDRAStatusPreservedOnStatusUpdate$'`
