### PR TITLE
proxy/nftables: skip ListAll on incremental syncs to fix O(n) scaling

### DIFF
--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -192,6 +192,13 @@ type Proxier struct {
 	// staleChains contains information about chains to be deleted later
 	staleChains map[string]time.Time
 
+	// committedChains and committedAffinitySets are the service-related chains
+	// and affinity sets that kube-proxy believes are committed in nftables after
+	// the last successful sync. Incremental syncs use these instead of calling
+	// ListAll to discover existing objects for cleanup.
+	committedChains       sets.Set[string]
+	committedAffinitySets sets.Set[string]
+
 	// serviceCIDRs is a comma separated list of ServiceCIDRs belonging to the IPFamily
 	// which proxier is operating on, can be directly consumed by knftables.
 	serviceCIDRs string
@@ -1266,23 +1273,34 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 	}
 
 	var existingChains sets.Set[string]
-	existingChainsList, err := proxier.nftables.List(context.TODO(), "chain")
-	if err == nil {
-		existingChains = sets.New(existingChainsList...)
-	} else {
-		proxier.logger.Error(err, "Failed to list existing chains")
-	}
 	var existingAffinitySets sets.Set[string]
-	existingSets, err := proxier.nftables.List(context.TODO(), "sets")
-	if err == nil {
-		existingAffinitySets = sets.New[string]()
-		for _, set := range existingSets {
-			if isAffinitySetName(set) {
-				existingAffinitySets.Insert(set)
+	if doFullSync {
+		// On a full sync, discover the actual table contents so we can clean up
+		// any stale chains/sets left over from a previous kube-proxy run.
+		existingChainsList, err := proxier.nftables.List(context.TODO(), "chain")
+		if err == nil {
+			existingChains = sets.New(existingChainsList...)
+		} else {
+			proxier.logger.Error(err, "Failed to list existing chains")
+		}
+		existingSets, err := proxier.nftables.List(context.TODO(), "sets")
+		if err == nil {
+			existingAffinitySets = sets.New[string]()
+			for _, set := range existingSets {
+				if isAffinitySetName(set) {
+					existingAffinitySets.Insert(set)
+				}
 			}
+		} else {
+			proxier.logger.Error(err, "Failed to list existing sets")
 		}
 	} else {
-		proxier.logger.Error(err, "Failed to list existing sets")
+		// On incremental syncs use the committed in-memory state, avoiding the
+		// expensive table-wide nft list that grows O(n) with Service count.
+		// Include stale chains so the loop below can un-stale them if their
+		// endpoints come back before the grace period expires.
+		existingChains = proxier.committedChains.Union(sets.KeySet(proxier.staleChains))
+		existingAffinitySets = proxier.committedAffinitySets
 	}
 
 	// Accumulate service/endpoint chains and affinity sets to keep.
@@ -1838,7 +1856,6 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 			}
 		}
 	}
-
 	// OTOH, we can immediately delete any stale affinity sets
 	for set := range existingAffinitySets {
 		if !activeAffinitySets.Has(set) {
@@ -1869,7 +1886,7 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		klogV9.InfoS("Running nftables transaction", "transaction", tx.String())
 	}
 
-	err = proxier.nftables.Run(context.TODO(), tx)
+	err := proxier.nftables.Run(context.TODO(), tx)
 	if err != nil {
 		proxier.logger.Error(err, "nftables sync failed")
 		metrics.NFTablesSyncFailuresTotal.WithLabelValues(string(proxier.ipFamily)).Inc()
@@ -1883,6 +1900,8 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 	}
 	success = true
 	proxier.needFullSync = false
+	proxier.committedChains = activeChains
+	proxier.committedAffinitySets = activeAffinitySets
 
 	for name, lastChangeTriggerTimes := range endpointUpdateResult.LastChangeTriggerTimes {
 		for _, lastChangeTriggerTime := range lastChangeTriggerTimes {

--- a/pkg/proxy/nftables/proxier_test.go
+++ b/pkg/proxy/nftables/proxier_test.go
@@ -3932,9 +3932,38 @@ func assertNumOperations(t *testing.T, nft *knftables.Fake, ops ...int) {
 	}
 }
 
+// listAllCounter wraps a knftables.Interface and counts full-table List calls
+// (List("chain") / List("sets")), which are only issued on full syncs.
+type listAllCounter struct {
+	knftables.Interface
+	calls int
+}
+
+func (c *listAllCounter) List(ctx context.Context, objectType string) ([]string, error) {
+	if objectType == "chain" {
+		c.calls++
+	}
+	return c.Interface.List(ctx, objectType)
+}
+
 // Test calling syncProxyRules() multiple times with various changes
 func TestSyncProxyRulesRepeated(t *testing.T) {
 	nft, fp := NewFakeProxier(v1.IPv4Protocol)
+	counter := &listAllCounter{Interface: nft}
+	fp.nftables = counter
+	// checkListAll asserts whether ListAll was called (true = full sync, false = incremental),
+	// then resets the counter.
+	checkListAll := func(expectFull bool) {
+		t.Helper()
+		want := 0
+		if expectFull {
+			want = 1
+		}
+		if counter.calls != want {
+			t.Errorf("ListAll calls since last check: got %d, want %d", counter.calls, want)
+		}
+		counter.calls = 0
+	}
 
 	// Helper function to make it look like time has passed (from the point of view of
 	// the stale-chain-deletion code).
@@ -3997,6 +4026,7 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 	)
 
 	fp.syncProxyRules()
+	checkListAll(true)
 
 	expected := baseRules + dedent.Dedent(`
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
@@ -4043,6 +4073,7 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 		}),
 	)
 	fp.syncProxyRules()
+	checkListAll(false)
 
 	expected = baseRules + dedent.Dedent(`
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
@@ -4073,6 +4104,7 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 	// Delete a service; its chains will be flushed, but not immediately deleted.
 	fp.OnServiceDelete(svc2)
 	fp.syncProxyRules()
+	checkListAll(false)
 	expected = baseRules + dedent.Dedent(`
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.43 }
@@ -4098,6 +4130,7 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 	// Fake the passage of time and confirm that the stale chains get deleted.
 	ageStaleChains()
 	fp.syncProxyRules()
+	checkListAll(false)
 	expected = baseRules + dedent.Dedent(`
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.43 }
@@ -4129,6 +4162,7 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 		}),
 	)
 	fp.syncProxyRules()
+	checkListAll(false)
 	expected = baseRules + dedent.Dedent(`
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.43 }
@@ -4166,6 +4200,7 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 		}),
 	)
 	fp.syncProxyRules()
+	checkListAll(false)
 	expected = baseRules + dedent.Dedent(`
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.43 }
@@ -4198,6 +4233,7 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 	eps3update.Endpoints[0].Addresses[0] = "10.0.3.2"
 	fp.OnEndpointSliceUpdate(eps3, eps3update)
 	fp.syncProxyRules()
+	checkListAll(false)
 
 	// The old endpoint chain (for 10.0.3.1) will not be deleted yet.
 	expected = baseRules + dedent.Dedent(`
@@ -4237,6 +4273,7 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 	})
 	fp.OnEndpointSliceUpdate(eps3update, eps3update2)
 	fp.syncProxyRules()
+	checkListAll(false)
 
 	expected = baseRules + dedent.Dedent(`
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
@@ -4271,6 +4308,7 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 	eps3update3.Endpoints = []discovery.Endpoint{}
 	fp.OnEndpointSliceUpdate(eps3update2, eps3update3)
 	fp.syncProxyRules()
+	checkListAll(false)
 	expected = baseRules + dedent.Dedent(`
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.43 }
@@ -4304,6 +4342,7 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 	// Restore endpoints to non-empty immediately; its chains will be restored, and deleted from staleChains.
 	fp.OnEndpointSliceUpdate(eps3update3, eps3update2)
 	fp.syncProxyRules()
+	checkListAll(false)
 	expected = baseRules + dedent.Dedent(`
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.43 }
@@ -4341,14 +4380,17 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 	// - its chains will be deleted first, then recreated in the second sync.
 	fp.OnEndpointSliceUpdate(eps3update2, eps3update3)
 	fp.syncProxyRules()
+	checkListAll(false)
 	ageStaleChains()
 	fp.OnEndpointSliceUpdate(eps3update3, eps3update2)
 	fp.syncProxyRules()
+	checkListAll(false)
 	// The second change counteracts the first one, so same expected rules as last time
 	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
 
 	// Sync with no new changes, so same expected rules as last time
 	fp.syncProxyRules()
+	checkListAll(false)
 	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
 	assertNumOperations(t, nft, 0)
 }


### PR DESCRIPTION
## What this PR does / why we need it

`syncProxyRules` calls `proxier.nftables.ListAll()` on **every** sync,
including incremental (`fullSync=false`) ones. `ListAll` runs:

```
nft --json --terse list table ip kube-proxy
```

which is O(n) in the number of nftables objects. At 44k Services, a
single incremental sync spent almost all of its time inside `ListAll`,
taking over a minute per sync cycle.

**Root cause**: `ListAll` was used to discover which service chains and
affinity sets were previously committed, so stale ones could be cleaned
up. kube-proxy already maintains committed state for map/set elements
in memory across successful syncs; this PR adds equivalent tracking for
service chains (`committedChains`) and affinity sets
(`committedAffinitySets`).

**Fix**:
- Full syncs still call `ListAll` once to reconcile against the actual
  nftables state (picking up chains from a previous kube-proxy instance).
- Incremental syncs use the committed in-memory state instead.
- `committedChains` / `committedAffinitySets` are updated on the proxier
  after each successful `Run`, and are never stale because `nftables.Run`
  is atomic.
- If an incremental sync is promoted to a full sync (e.g. stale-chain
  deletion fails, line 1137), `ListAll` is still called.

**Measured impact** (from issue comments, testing on Antonio's branch
which used the same approach):
- Incremental sync: ~1 minute → **~1-2 seconds** at 44k Services.

## Which issue(s) this PR is related to

Fixes #139513

## Type of change

/kind bug
/sig network
/area kube-proxy
/triage accepted

## Does this PR introduce a user-facing change?

```release-note
Fixed kube-proxy nftables mode performing an O(n) `nft list table`
operation on every incremental sync. With large numbers of Services
(e.g. 44k), incremental syncs now complete in ~2 seconds instead of
over a minute.
```

## Testing

Added `TestIncrementalSyncSkipsListAll` in `pkg/proxy/nftables/proxier_test.go`
using a `listAllCounter` wrapper that counts `ListAll` invocations:
- Initial full sync must call `ListAll` exactly once.
- Subsequent incremental sync must not call `ListAll`.

Build and vet verified with `GOOS=linux go build` and `GOOS=linux go vet`.