### PR TITLE
Update PlacementFeasible statuses according to KEP

### DIFF
--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -187,8 +187,8 @@ type PlacementFeasiblePlugin interface {
 
 	// PlacementFeasible is called after each pod in a pod group is evaluated.
 	// Use placementCycleState to accumulate the results from the evaluated pods in current cycle.
-	// Return Unschedulable status if the pod group cannot be scheduled in the current partially evaluated placement, but may become schedulable once more pods are evaluated.
-	// Return UnschedulableAndUnresolvable status if the pod group cannot be scheduled in the current placement.
+	// Return Wait status if the pod group cannot be scheduled in the current partially evaluated placement, but may become schedulable once more pods are evaluated.
+	// Return Unschedulable status if the pod group cannot be scheduled in the current placement.
 	// The scheduler will give up this placement and won't even evaluate remaining pods. The placement will remain eligible for preemption.
 	// Return Success status if the pod group can be scheduled in the current partially evaluated placement.
 	// After returning Success, the plugin should keep returning Success for the remaining pods.
@@ -279,10 +279,10 @@ type Framework interface {
 
 	// RunPlacementFeasiblePlugins runs the set of configured Permit plugins that implement PlacementFeasible interface.
 	// The result will be Success if all plugins return Success.
-	// The only other valid statuses are UnschedulableAndUnresolvable and Unschedulable.
+	// The only other valid statuses are Wait and Unschedulable.
 	// If any plugin returns invalid status, the result will be Error and the remaining plugins won't be invoked.
-	// Otherwise, if at least 1 plugin returns UnschedulableAndUnresolvable, the remaining plugins won't be invoked and the result will be UnschdulableAndUnresolvable. The placement will remain eligible for preemption.
-	// Otherwise, if at least 1 plugin returns Unschedulable, the remaining plugins will be invoked and the result will be Unschedulable.
+	// Otherwise, if at least 1 plugin returns Unschedulable, the remaining plugins won't be invoked and the result will be Unschedulable. The placement will remain eligible for preemption.
+	// Otherwise, if at least 1 plugin returns Wait, the remaining plugins will be invoked and the result will be Wait.
 	RunPlacementFeasiblePlugins(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroupInfo fwk.PodGroupInfo) *fwk.Status
 
 	// AddWaitingPod creates a waiting pod instance and adds it to the framework.

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
@@ -236,7 +236,7 @@ func getPlacementFeasibleState(placementCycleState fwk.PlacementCycleState) *pla
 
 // PlacementFeasible is responsible for enforcing the gang's MinCount constraint in the pod group scheduling cycle.
 // The function will only return success once the gang's MinCount is satisfied or if the pod group is not using gang scheduling policy.
-// In case there are not enough remaining pods to satisfy the gang's MinCount, it returns UnschedulableAndUnresolvable which will terminate the pod group scheduling cycle early.
+// In case there are not enough remaining pods to satisfy the gang's MinCount, it returns Unschedulable which will terminate the pod group scheduling cycle early.
 func (pl *GangScheduling) PlacementFeasible(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroupInfo fwk.PodGroupInfo) *fwk.Status {
 	pg, err := pl.podGroupLister.PodGroups(podGroupInfo.GetNamespace()).Get(podGroupInfo.GetName())
 	if err != nil {
@@ -268,12 +268,12 @@ func (pl *GangScheduling) PlacementFeasible(ctx context.Context, placementCycleS
 
 	if remaining+scheduled < minCount {
 		// minCount can't be satisfied because there are not enough remaining pods.
-		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, fmt.Sprintf("minCount (%d) cannot be satisfied: %d scheduled, %d remaining", minCount, scheduled, remaining))
+		return fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("minCount (%d) cannot be satisfied: %d scheduled, %d remaining", minCount, scheduled, remaining))
 	}
 
 	if scheduled < minCount {
 		// minCount might be satisfied once more remaining pods are evaluated.
-		return fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("minCount (%d) is not yet satisfied: %d scheduled, %d remaining", minCount, scheduled, remaining))
+		return fwk.NewStatus(fwk.Wait, fmt.Sprintf("minCount (%d) is not yet satisfied: %d scheduled, %d remaining", minCount, scheduled, remaining))
 	}
 
 	// minCount is satisfied.

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -416,7 +416,7 @@ func TestPlacementFeasible(t *testing.T) {
 				fwk.Success,
 			},
 			expectedStatuses: []fwk.Code{
-				fwk.Unschedulable,
+				fwk.Wait,
 				fwk.Success,
 			},
 		},
@@ -432,7 +432,7 @@ func TestPlacementFeasible(t *testing.T) {
 				fwk.Unschedulable,
 			},
 			expectedStatuses: []fwk.Code{
-				fwk.UnschedulableAndUnresolvable,
+				fwk.Unschedulable,
 			},
 		},
 		{
@@ -447,8 +447,8 @@ func TestPlacementFeasible(t *testing.T) {
 				fwk.Unschedulable,
 			},
 			expectedStatuses: []fwk.Code{
+				fwk.Wait,
 				fwk.Unschedulable,
-				fwk.UnschedulableAndUnresolvable,
 			},
 		},
 		{
@@ -476,7 +476,7 @@ func TestPlacementFeasible(t *testing.T) {
 				fwk.Success,
 			},
 			expectedStatuses: []fwk.Code{
-				fwk.Unschedulable,
+				fwk.Wait,
 				fwk.Success,
 				fwk.Success,
 			},
@@ -495,8 +495,8 @@ func TestPlacementFeasible(t *testing.T) {
 				fwk.Success,
 			},
 			expectedStatuses: []fwk.Code{
-				fwk.Unschedulable,
-				fwk.Unschedulable,
+				fwk.Wait,
+				fwk.Wait,
 				fwk.Success,
 			},
 		},
@@ -514,9 +514,9 @@ func TestPlacementFeasible(t *testing.T) {
 				fwk.Success,
 			},
 			expectedStatuses: []fwk.Code{
+				fwk.Wait,
 				fwk.Unschedulable,
-				fwk.UnschedulableAndUnresolvable,
-				fwk.UnschedulableAndUnresolvable,
+				fwk.Unschedulable,
 			},
 		},
 		{
@@ -531,7 +531,7 @@ func TestPlacementFeasible(t *testing.T) {
 				fwk.Success,
 			},
 			expectedStatuses: []fwk.Code{
-				fwk.Unschedulable,
+				fwk.Wait,
 				fwk.Success,
 			},
 			initialScheduledCount: 1,
@@ -561,7 +561,7 @@ func TestPlacementFeasible(t *testing.T) {
 				fwk.Unschedulable,
 			},
 			expectedStatuses: []fwk.Code{
-				fwk.UnschedulableAndUnresolvable,
+				fwk.Unschedulable,
 			},
 			initialScheduledCount: 1,
 		},
@@ -576,7 +576,7 @@ func TestPlacementFeasible(t *testing.T) {
 				fwk.Success,
 			},
 			expectedStatuses: []fwk.Code{
-				fwk.UnschedulableAndUnresolvable,
+				fwk.Unschedulable,
 			},
 			initialScheduledCount: 1,
 		},

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -2018,10 +2018,10 @@ func (f *frameworkImpl) runPermitPlugin(ctx context.Context, pl fwk.PermitPlugin
 
 // RunPlacementFeasiblePlugins runs the set of configured Permit plugins that implement PlacementFeasible interface.
 // The result will be Success if all plugins return Success.
-// The only other valid statuses are UnschedulableAndUnresolvable and Unschedulable.
+// The only other valid statuses are Wait and Unschedulable.
 // If any plugin returns invalid status, the result will be Error and the remaining plugins won't be invoked.
-// Otherwise, if at least 1 plugin returns UnschedulableAndUnresolvable, the remaining plugins won't be invoked and the result will be UnschdulableAndUnresolvable.
-// Otherwise, if at least 1 plugin returns Unschedulable, the remaining plugins will be invoked and the result will be Unschedulable.
+// Otherwise, if at least 1 plugin returns Unschedulable, the remaining plugins won't be invoked and the result will be Unschedulable.
+// Otherwise, if at least 1 plugin returns Wait, the remaining plugins will be invoked and the result will be Wait.
 func (f *frameworkImpl) RunPlacementFeasiblePlugins(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroupInfo fwk.PodGroupInfo) (status *fwk.Status) {
 	startTime := time.Now()
 	defer func() {
@@ -2033,11 +2033,11 @@ func (f *frameworkImpl) RunPlacementFeasiblePlugins(ctx context.Context, placeme
 		if plStatus.IsSuccess() {
 			continue
 		}
-		if plStatus.Code() == fwk.Unschedulable {
+		if plStatus.Code() == fwk.Wait {
 			status = plStatus.WithPlugin(pl.Name())
 			continue
 		}
-		if plStatus.Code() == fwk.UnschedulableAndUnresolvable {
+		if plStatus.Code() == fwk.Unschedulable {
 			return plStatus.WithPlugin(pl.Name())
 		}
 		if plStatus.IsError() {

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -937,39 +937,39 @@ func TestRunPlacementFeasiblePlugins(t *testing.T) {
 			expectedCalled: []bool{true, true},
 		},
 		{
-			name: "First plugin returns Unschedulable, continues",
+			name: "First plugin returns Wait, continues",
+			plugins: []*mockPlacementFeasiblePlugin{
+				{name: "p1", status: fwk.NewStatus(fwk.Wait, "wait")},
+				{name: "p2", status: nil},
+			},
+			expectedStatus: fwk.NewStatus(fwk.Wait, "wait").WithPlugin("p1"),
+			expectedCalled: []bool{true, true},
+		},
+		{
+			name: "First plugin returns Unschedulable, breaks",
 			plugins: []*mockPlacementFeasiblePlugin{
 				{name: "p1", status: fwk.NewStatus(fwk.Unschedulable, "unschedulable")},
 				{name: "p2", status: nil},
 			},
 			expectedStatus: fwk.NewStatus(fwk.Unschedulable, "unschedulable").WithPlugin("p1"),
-			expectedCalled: []bool{true, true},
-		},
-		{
-			name: "First plugin returns UnschedulableAndUnresolvable, breaks",
-			plugins: []*mockPlacementFeasiblePlugin{
-				{name: "p1", status: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "unresolvable")},
-				{name: "p2", status: nil},
-			},
-			expectedStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "unresolvable").WithPlugin("p1"),
 			expectedCalled: []bool{true, false},
 		},
 		{
-			name: "First plugin returns Unschedulable, second returns UnschedulableAndUnresolvable, returns unresolvable",
+			name: "First plugin returns Wait, second returns Unschedulable, returns Unschedulable",
 			plugins: []*mockPlacementFeasiblePlugin{
-				{name: "p1", status: fwk.NewStatus(fwk.Unschedulable, "unschedulable")},
-				{name: "p2", status: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "unresolvable")},
+				{name: "p1", status: fwk.NewStatus(fwk.Wait, "wait")},
+				{name: "p2", status: fwk.NewStatus(fwk.Unschedulable, "unschedulable")},
 			},
-			expectedStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "unresolvable").WithPlugin("p2"),
+			expectedStatus: fwk.NewStatus(fwk.Unschedulable, "unschedulable").WithPlugin("p2"),
 			expectedCalled: []bool{true, true},
 		},
 		{
-			name: "First plugin returns Unschedulable, second returns Unschedulable, returns last unschedulable",
+			name: "First plugin returns Wait, second returns Wait, returns last Wait",
 			plugins: []*mockPlacementFeasiblePlugin{
-				{name: "p1", status: fwk.NewStatus(fwk.Unschedulable, "unschedulable1")},
-				{name: "p2", status: fwk.NewStatus(fwk.Unschedulable, "unschedulable2")},
+				{name: "p1", status: fwk.NewStatus(fwk.Wait, "wait1")},
+				{name: "p2", status: fwk.NewStatus(fwk.Wait, "wait2")},
 			},
-			expectedStatus: fwk.NewStatus(fwk.Unschedulable, "unschedulable2").WithPlugin("p2"),
+			expectedStatus: fwk.NewStatus(fwk.Wait, "wait2").WithPlugin("p2"),
 			expectedCalled: []bool{true, true},
 		},
 		{

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -354,18 +354,21 @@ func (sched *Scheduler) podGroupSchedulingDefaultAlgorithm(ctx context.Context, 
 			break
 		}
 
-		// UnschedulableAndUnresolvable from PlacementFeasible plugins indicates that the pod group
+		result.status = placementFeasibleStatus
+
+		// Unschedulable from PlacementFeasible plugins indicates that the pod group
 		// cannot meet its constraints regardless of how many more pods we check.
 		// We can stop the scheduling loop early.
-		if placementFeasibleStatus.Code() == fwk.UnschedulableAndUnresolvable {
-			// We need to change the code to Unschedulable to make sure preemption can be fired.
-			result.status = fwk.NewStatus(fwk.Unschedulable).WithError(placementFeasibleStatus.AsError())
+		if placementFeasibleStatus.Code() == fwk.Unschedulable {
 			break
 		}
 
-		result.status = placementFeasibleStatus
 		requiresPreemption = requiresPreemption || podResult.requiresPreemption
 		anyScheduled = anyScheduled || podResult.status.IsSuccess()
+	}
+
+	if result.status.IsWait() {
+		result.status = fwk.NewStatus(fwk.Unschedulable, result.status.Reasons()...)
 	}
 
 	if result.status.IsSuccess() {

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -722,11 +722,32 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 				},
 			},
 			podGroupFeasibleStatuses: []fwk.Code{
-				fwk.Unschedulable,
-				fwk.Unschedulable,
+				fwk.Wait,
+				fwk.Wait,
 				fwk.Success,
 			},
 			expectedGroupStatusCode: fwk.Success,
+			expectedPodStatus: map[string]*fwk.Status{
+				"p1": nil,
+				"p2": nil,
+				"p3": nil,
+			},
+		},
+		{
+			name: "All pods feasible, podGroup waiting",
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p1": nil,
+					"p2": nil,
+					"p3": nil,
+				},
+			},
+			podGroupFeasibleStatuses: []fwk.Code{
+				fwk.Wait,
+				fwk.Wait,
+				fwk.Wait,
+			},
+			expectedGroupStatusCode: fwk.Unschedulable,
 			expectedPodStatus: map[string]*fwk.Status{
 				"p1": nil,
 				"p2": nil,
@@ -744,18 +765,15 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 			},
 			podGroupFeasibleStatuses: []fwk.Code{
 				fwk.Unschedulable,
-				fwk.Unschedulable,
-				fwk.Unschedulable,
 			},
 			expectedGroupStatusCode: fwk.Unschedulable,
 			expectedPodStatus: map[string]*fwk.Status{
 				"p1": nil,
-				"p2": nil,
-				"p3": nil,
+				// The algorithm stopped evaluating the pods after Unschedulable was received from PlacementFeasible.
 			},
 		},
 		{
-			name: "All pods feasible, podGroup UnschedulableAndUnresolvable",
+			name: "All pods feasible, podGroup unschedulable with 2 pods",
 			plugin: &fakePodGroupPlugin{
 				filterStatus: map[string]*fwk.Status{
 					"p1": nil,
@@ -764,32 +782,14 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 				},
 			},
 			podGroupFeasibleStatuses: []fwk.Code{
-				fwk.UnschedulableAndUnresolvable,
-			},
-			expectedGroupStatusCode: fwk.Unschedulable,
-			expectedPodStatus: map[string]*fwk.Status{
-				"p1": nil,
-				// The algorithm stopped evaluating the pods after UnschedulableAndUnresolvable was received from PlacementFeasible.
-			},
-		},
-		{
-			name: "All pods feasible, podGroup UnschedulableAndUnresolvable with 2 pods",
-			plugin: &fakePodGroupPlugin{
-				filterStatus: map[string]*fwk.Status{
-					"p1": nil,
-					"p2": nil,
-					"p3": nil,
-				},
-			},
-			podGroupFeasibleStatuses: []fwk.Code{
+				fwk.Wait,
 				fwk.Unschedulable,
-				fwk.UnschedulableAndUnresolvable,
 			},
 			expectedGroupStatusCode: fwk.Unschedulable,
 			expectedPodStatus: map[string]*fwk.Status{
 				"p1": nil,
 				"p2": nil,
-				// The algorithm stopped evaluating the pods after UnschedulableAndUnresolvable was received from PlacementFeasible.
+				// The algorithm stopped evaluating the pods after Unschedulable was received from PlacementFeasible.
 			},
 		},
 		{
@@ -841,8 +841,8 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 				},
 			},
 			podGroupFeasibleStatuses: []fwk.Code{
-				fwk.Unschedulable,
-				fwk.Unschedulable,
+				fwk.Wait,
+				fwk.Wait,
 				fwk.Success,
 			},
 			expectedGroupStatusCode:          fwk.Unschedulable,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

This PR changes the PlacementFeasible statuses interpreted by the framework as follows:

* Unschedulable -> Wait
* UnschedulableAndUnresolvable -> Unschedulable

Next we can return UnschedulableAndUnresolvable if there's not enough children in the podgroup in total.

This is according to the KEP: https://github.com/kubernetes/enhancements/blob/616e11d064ee6cd5ce9a77dedb8878672238143e/keps/sig-scheduling/6012-composite-podgroup-api/README.md?plain=1#L1134-L1141

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
KEP: https://github.com/kubernetes/enhancements/issues/6012

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
