### PR TITLE
Support etcd server overrides for CRDs

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/options/options.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/options/options.go
@@ -21,6 +21,8 @@ import (
 	"io"
 	"net"
 	"net/url"
+	"sort"
+	"strings"
 
 	"github.com/spf13/pflag"
 	noopoteltrace "go.opentelemetry.io/otel/trace/noop"
@@ -32,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/cbor"
 	"k8s.io/apimachinery/pkg/runtime/serializer/recognizer"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -40,6 +43,8 @@ import (
 	genericregistry "k8s.io/apiserver/pkg/registry/generic"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
+	serverstorage "k8s.io/apiserver/pkg/server/storage"
+	"k8s.io/apiserver/pkg/storage/storagebackend"
 	storagevalue "k8s.io/apiserver/pkg/storage/value"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	flowcontrolrequest "k8s.io/apiserver/pkg/util/flowcontrol/request"
@@ -48,6 +53,7 @@ import (
 	"k8s.io/apiserver/pkg/util/webhook"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	corev1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/klog/v2"
 	netutils "k8s.io/utils/net"
 )
 
@@ -156,7 +162,94 @@ func NewCRDRESTOptionsGetter(etcdOptions genericoptions.EtcdOptions, resourceTra
 	etcdOptionsCopy.StorageConfig.StorageObjectCountTracker = tracker
 	etcdOptionsCopy.WatchCacheSizes = nil // this control is not provided for custom resources
 
-	return etcdOptions.CreateRESTOptionsGetter(&genericoptions.SimpleStorageFactory{StorageConfig: etcdOptionsCopy.StorageConfig}, resourceTransformers)
+	return etcdOptionsCopy.CreateRESTOptionsGetter(newCRDStorageFactory(etcdOptionsCopy.StorageConfig, etcdOptionsCopy.EtcdServersOverrides), resourceTransformers)
+}
+
+var _ serverstorage.StorageFactory = &crdStorageFactory{}
+
+type crdStorageFactory struct {
+	storageConfig storagebackend.Config
+	overrides     map[schema.GroupResource]crdStorageOverride
+}
+
+type crdStorageOverride struct {
+	servers []string
+}
+
+func (o crdStorageOverride) apply(config *storagebackend.Config) {
+	if len(o.servers) > 0 {
+		config.Transport.ServerList = o.servers
+	}
+}
+
+func newCRDStorageFactory(storageConfig storagebackend.Config, etcdServersOverrides []string) *crdStorageFactory {
+	factory := &crdStorageFactory{
+		storageConfig: storageConfig,
+		overrides:     map[schema.GroupResource]crdStorageOverride{},
+	}
+
+	overrides, err := genericoptions.ParseEtcdServersOverrides(etcdServersOverrides)
+	if err != nil {
+		klog.Errorf("failed to parse etcd-servers-overrides for custom resources, ignoring overrides: %v", err)
+		return factory
+	}
+	for _, override := range overrides {
+		factory.overrides[override.GroupResource] = crdStorageOverride{servers: override.Servers}
+	}
+	return factory
+}
+
+func (f *crdStorageFactory) NewConfig(resource schema.GroupResource, example runtime.Object) (*storagebackend.ConfigForResource, error) {
+	storageConfig := f.storageConfig
+	if override, ok := f.overrides[resource]; ok {
+		override.apply(&storageConfig)
+	}
+	return storageConfig.ForResource(resource), nil
+}
+
+func (f *crdStorageFactory) ResourcePrefix(resource schema.GroupResource) string {
+	return resource.Group + "/" + resource.Resource
+}
+
+func (f *crdStorageFactory) Configs() []storagebackend.Config {
+	configs := []storagebackend.Config{f.storageConfig}
+	seen := map[string]struct{}{serverListKey(f.storageConfig.Transport.ServerList): {}}
+
+	resources := make([]schema.GroupResource, 0, len(f.overrides))
+	for resource := range f.overrides {
+		resources = append(resources, resource)
+	}
+	sort.Slice(resources, func(i, j int) bool {
+		return resources[i].String() < resources[j].String()
+	})
+
+	for _, resource := range resources {
+		config := f.storageConfig
+		f.overrides[resource].apply(&config)
+		key := serverListKey(config.Transport.ServerList)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		configs = append(configs, config)
+	}
+	return configs
+}
+
+func serverListKey(servers []string) string {
+	sorted := make([]string, len(servers))
+	copy(sorted, servers)
+	sort.Strings(sorted)
+	return strings.Join(sorted, ";")
+}
+
+func (f *crdStorageFactory) Backends() []serverstorage.Backend {
+	backends := []serverstorage.Backend{}
+	for _, config := range f.Configs() {
+		backends = append(backends, serverstorage.Backends(config)...)
+	}
+	return backends
 }
 
 type serviceResolver struct {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -130,7 +130,8 @@ func (s *EtcdOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVar(&s.EtcdServersOverrides, "etcd-servers-overrides", s.EtcdServersOverrides, ""+
 		"Per-resource etcd servers overrides, comma separated. The individual override "+
 		"format: group/resource#servers, where servers are URLs, semicolon separated. "+
-		"Note that this applies only to resources compiled into this server binary. "+
+		"This applies to resources compiled into this server binary as well as to "+
+		"custom resources served by it. "+
 		`e.g. "/pods#http://etcd4:2379;http://etcd5:2379,/events#http://etcd6:2379"`)
 
 	fs.StringVar(&s.DefaultStorageMediaType, "storage-media-type", s.DefaultStorageMediaType, ""+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature


#### What this PR does / why we need it:

Supports CRD resource splitting into separate etcd cluster.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #118858


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`--etcd-servers-overrides` can now route matching CustomResource storage to a separate etcd server list.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
