### PR TITLE
resource: avoid double-counting pod overhead

### DIFF
--- a/staging/src/k8s.io/component-helpers/resource/helpers.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers.go
@@ -154,6 +154,13 @@ func PodRequests(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 		reqs = AggregateContainerRequests(pod, opts)
 	}
 
+	var overheadAlreadyIncluded map[v1.ResourceName]struct{}
+	markOverheadAlreadyIncluded := func(resourceName v1.ResourceName) {
+		if overheadAlreadyIncluded == nil {
+			overheadAlreadyIncluded = map[v1.ResourceName]struct{}{}
+		}
+		overheadAlreadyIncluded[resourceName] = struct{}{}
+	}
 	if !opts.SkipPodLevelResources && IsPodLevelRequestsSet(pod) {
 
 		var effectiveReqs v1.ResourceList
@@ -171,7 +178,18 @@ func PodRequests(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 			if IsSupportedPodLevelResource(resourceName) {
 				reqs[resourceName] = quantity
 				if effectiveReqs != nil {
-					reqs[resourceName] = effectiveReqs[resourceName]
+					effectiveReq := effectiveReqs[resourceName]
+					reqs[resourceName] = effectiveReq
+					expectedWithOverhead := quantity.DeepCopy()
+					if overhead, ok := pod.Spec.Overhead[resourceName]; ok {
+						expectedWithOverhead.Add(overhead)
+					}
+					if statusReq, ok := pod.Status.Resources.Requests[resourceName]; ok && statusReq.Equal(effectiveReq) && statusReq.Cmp(expectedWithOverhead) >= 0 {
+						markOverheadAlreadyIncluded(resourceName)
+					}
+					if allocatedReq, ok := pod.Status.AllocatedResources[resourceName]; ok && allocatedReq.Equal(effectiveReq) && allocatedReq.Cmp(expectedWithOverhead) >= 0 {
+						markOverheadAlreadyIncluded(resourceName)
+					}
 				}
 
 			}
@@ -180,7 +198,14 @@ func PodRequests(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 
 	// Add overhead for running a pod to the sum of requests if requested:
 	if !opts.ExcludeOverhead && pod.Spec.Overhead != nil {
-		addResourceList(reqs, pod.Spec.Overhead)
+		for name, quantity := range pod.Spec.Overhead {
+			if _, ok := overheadAlreadyIncluded[name]; ok {
+				continue
+			}
+			rk := reqs[name]
+			rk.Add(quantity)
+			reqs[name] = rk
+		}
 	}
 
 	return reqs

--- a/staging/src/k8s.io/component-helpers/resource/helpers.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers.go
@@ -154,22 +154,21 @@ func PodRequests(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 		reqs = AggregateContainerRequests(pod, opts)
 	}
 
-	var overheadAlreadyIncluded map[v1.ResourceName]struct{}
-	markOverheadAlreadyIncluded := func(resourceName v1.ResourceName) {
-		if overheadAlreadyIncluded == nil {
-			overheadAlreadyIncluded = map[v1.ResourceName]struct{}{}
-		}
-		overheadAlreadyIncluded[resourceName] = struct{}{}
-	}
 	if !opts.SkipPodLevelResources && IsPodLevelRequestsSet(pod) {
 
 		var effectiveReqs v1.ResourceList
 		if opts.InPlacePodLevelResourcesVerticalScalingEnabled && opts.UseStatusResources {
 			if pod.Status.Resources != nil {
+				statusRequests := pod.Status.Resources.Requests.DeepCopy()
+				allocatedRequests := pod.Status.AllocatedResources.DeepCopy()
+				if pod.Spec.Overhead != nil {
+					subtractResourceList(statusRequests, pod.Spec.Overhead)
+					subtractResourceList(allocatedRequests, pod.Spec.Overhead)
+				}
 				effectiveReqs = determineEffectiveRequests(pod, &ResourceState{
 					Spec:      pod.Spec.Resources.Requests,
-					Actuated:  pod.Status.Resources.Requests,
-					Allocated: pod.Status.AllocatedResources,
+					Actuated:  statusRequests,
+					Allocated: allocatedRequests,
 				})
 			}
 		}
@@ -178,18 +177,7 @@ func PodRequests(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 			if IsSupportedPodLevelResource(resourceName) {
 				reqs[resourceName] = quantity
 				if effectiveReqs != nil {
-					effectiveReq := effectiveReqs[resourceName]
-					reqs[resourceName] = effectiveReq
-					expectedWithOverhead := quantity.DeepCopy()
-					if overhead, ok := pod.Spec.Overhead[resourceName]; ok {
-						expectedWithOverhead.Add(overhead)
-					}
-					if statusReq, ok := pod.Status.Resources.Requests[resourceName]; ok && statusReq.Equal(effectiveReq) && statusReq.Cmp(expectedWithOverhead) >= 0 {
-						markOverheadAlreadyIncluded(resourceName)
-					}
-					if allocatedReq, ok := pod.Status.AllocatedResources[resourceName]; ok && allocatedReq.Equal(effectiveReq) && allocatedReq.Cmp(expectedWithOverhead) >= 0 {
-						markOverheadAlreadyIncluded(resourceName)
-					}
+					reqs[resourceName] = effectiveReqs[resourceName]
 				}
 
 			}
@@ -198,14 +186,7 @@ func PodRequests(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 
 	// Add overhead for running a pod to the sum of requests if requested:
 	if !opts.ExcludeOverhead && pod.Spec.Overhead != nil {
-		for name, quantity := range pod.Spec.Overhead {
-			if _, ok := overheadAlreadyIncluded[name]; ok {
-				continue
-			}
-			rk := reqs[name]
-			rk.Add(quantity)
-			reqs[name] = rk
-		}
+		addResourceList(reqs, pod.Spec.Overhead)
 	}
 
 	return reqs
@@ -502,6 +483,20 @@ func addResourceList(list, newList v1.ResourceList) {
 			list[name] = quantity.DeepCopy()
 		} else {
 			value.Add(quantity)
+			list[name] = value
+		}
+	}
+}
+
+// subtractResourceList subtracts the resources in newList from list.
+// If the subtraction results in a value less than zero, it sets it to zero.
+func subtractResourceList(list, newList v1.ResourceList) {
+	for name, quantity := range newList {
+		if value, ok := list[name]; ok {
+			value.Sub(quantity)
+			if value.Sign() < 0 {
+				value.Set(0)
+			}
 			list[name] = value
 		}
 	}

--- a/staging/src/k8s.io/component-helpers/resource/helpers_test.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers_test.go
@@ -2041,6 +2041,21 @@ func TestPodLevelResourceRequestsWithStatusResourcesDoesNotDoubleCountOverhead(t
 				v1.ResourceMemory: resource.MustParse("110Mi"),
 			},
 		},
+		{
+			name: "allocated resources include stale overhead during resize",
+			statusRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1"),
+				v1.ResourceMemory: resource.MustParse("100Mi"),
+			},
+			allocated: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1050m"),
+				v1.ResourceMemory: resource.MustParse("105Mi"),
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1100m"),
+				v1.ResourceMemory: resource.MustParse("110Mi"),
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/staging/src/k8s.io/component-helpers/resource/helpers_test.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers_test.go
@@ -1976,6 +1976,107 @@ func TestPodLevelResourceRequests(t *testing.T) {
 	}
 }
 
+func TestPodLevelResourceRequestsWithStatusResourcesDoesNotDoubleCountOverhead(t *testing.T) {
+	testCases := []struct {
+		name             string
+		statusRequests   v1.ResourceList
+		allocated        v1.ResourceList
+		expectedRequests v1.ResourceList
+	}{
+		{
+			name: "status resources include overhead for all pod-level resources",
+			statusRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1100m"),
+				v1.ResourceMemory: resource.MustParse("110Mi"),
+			},
+			allocated: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1100m"),
+				v1.ResourceMemory: resource.MustParse("110Mi"),
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1100m"),
+				v1.ResourceMemory: resource.MustParse("110Mi"),
+			},
+		},
+		{
+			name: "status resources include overhead for only one pod-level resource",
+			statusRequests: v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("1100m"),
+			},
+			allocated: v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("1100m"),
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1100m"),
+				v1.ResourceMemory: resource.MustParse("110Mi"),
+			},
+		},
+		{
+			name: "status resources without overhead still receive overhead",
+			statusRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1"),
+				v1.ResourceMemory: resource.MustParse("100Mi"),
+			},
+			allocated: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1"),
+				v1.ResourceMemory: resource.MustParse("100Mi"),
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1100m"),
+				v1.ResourceMemory: resource.MustParse("110Mi"),
+			},
+		},
+		{
+			name: "allocated resources include overhead when status requests do not",
+			statusRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1"),
+				v1.ResourceMemory: resource.MustParse("100Mi"),
+			},
+			allocated: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1100m"),
+				v1.ResourceMemory: resource.MustParse("110Mi"),
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1100m"),
+				v1.ResourceMemory: resource.MustParse("110Mi"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := &v1.Pod{
+				Spec: v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("1"),
+							v1.ResourceMemory: resource.MustParse("100Mi"),
+						},
+					},
+					Overhead: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("100m"),
+						v1.ResourceMemory: resource.MustParse("10Mi"),
+					},
+				},
+				Status: v1.PodStatus{
+					Resources: &v1.ResourceRequirements{
+						Requests: tc.statusRequests,
+					},
+					AllocatedResources: tc.allocated,
+				},
+			}
+
+			requests := PodRequests(pod, PodResourcesOptions{
+				UseStatusResources: true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			})
+			if diff := diff.Diff(tc.expectedRequests, requests); diff != "" {
+				t.Errorf("PodRequests() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestIsSupportedPodLevelResource(t *testing.T) {
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When pod-level requests are computed from status or allocated resources, those values can already include pod overhead. This avoids adding the same overhead a second time for those resources, while still adding overhead for resources that fall back to spec or container-level requests.

#### Which issue(s) this PR is related to:

Addresses #139627

#### Special notes for your reviewer:

Added regression coverage for all-status, partial-status, spec-fallback, and allocated-resource paths.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```