### PR TITLE
Stagger remote apiservice health checks

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/remote/remote_available_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/remote/remote_available_controller.go
@@ -288,69 +288,60 @@ func (c *AvailableConditionController) sync(key string) error {
 
 		attempts := 5
 		results := make(chan error, attempts)
-		for range attempts {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		overallTimeout := time.NewTimer(6 * time.Second)
+		defer overallTimeout.Stop()
+
+		var lastError error
+		launched := 0
+		received := 0
+
+		launchAttempt := func() {
+			launched++
 			go func() {
-				discoveryURL, err := c.serviceResolver.ResolveEndpoint(apiService.Spec.Service.Namespace, apiService.Spec.Service.Name, *apiService.Spec.Service.Port)
-				if err != nil {
-					results <- err
-					return
-				}
-				// render legacyAPIService health check path when it is delegated to a service
-				if apiService.Name == "v1." {
-					discoveryURL.Path = "/api/" + apiService.Spec.Version
-				} else {
-					discoveryURL.Path = "/apis/" + apiService.Spec.Group + "/" + apiService.Spec.Version
-				}
-
-				errCh := make(chan error, 1)
-				go func() {
-					// be sure to check a URL that the aggregated API server is required to serve
-					newReq, err := http.NewRequest("GET", discoveryURL.String(), nil)
-					if err != nil {
-						errCh <- err
-						return
-					}
-
-					// setting the system-masters identity ensures that we will always have access rights
-					transport.SetAuthProxyHeaders(newReq, "system:kube-aggregator", "", []string{"system:masters"}, nil)
-					resp, err := discoveryClient.Do(newReq)
-					if resp != nil {
-						resp.Body.Close()
-						// we should always been in the 200s or 300s
-						if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-							errCh <- fmt.Errorf("bad status from %v: %d", discoveryURL, resp.StatusCode)
-							return
-						}
-					}
-
-					errCh <- err
-				}()
-
-				select {
-				case err = <-errCh:
-					if err != nil {
-						utilnet.CloseIdleConnectionsFor(restTransport)
-						results <- fmt.Errorf("failing or missing response from %v: %w", discoveryURL, err)
-						return
-					}
-
-					// we had trouble with slow dial and DNS responses causing us to wait too long.
-					// we added this as insurance
-				case <-time.After(6 * time.Second):
-					utilnet.CloseIdleConnectionsFor(restTransport)
-					results <- fmt.Errorf("timed out waiting for %v", discoveryURL)
-					return
-				}
-
-				results <- nil
+				results <- c.checkAPIServiceAvailability(ctx, apiService, discoveryClient, restTransport)
 			}()
 		}
 
-		var lastError error
-		for range attempts {
-			lastError = <-results
-			// if we had at least one success, we are successful overall and we can return now
-			if lastError == nil {
+		launchAttempt()
+
+		staggerTimer := time.NewTimer(1 * time.Second)
+		defer staggerTimer.Stop()
+
+		for received < attempts {
+			select {
+			case err := <-results:
+				received++
+				if err == nil {
+					cancel()
+					lastError = nil
+					received = attempts // satisfy the loop condition to exit
+					break
+				}
+				lastError = err
+				if launched < attempts {
+					if !staggerTimer.Stop() {
+						select {
+						case <-staggerTimer.C:
+						default:
+						}
+					}
+					launchAttempt()
+					staggerTimer.Reset(1 * time.Second)
+				}
+			case <-staggerTimer.C:
+				if launched < attempts {
+					launchAttempt()
+					staggerTimer.Reset(1 * time.Second)
+				}
+			case <-overallTimeout.C:
+				cancel()
+				if lastError == nil {
+					lastError = fmt.Errorf("timed out waiting for remote service availability")
+				}
+				received = attempts // satisfy the loop condition to exit
 				break
 			}
 		}
@@ -375,6 +366,53 @@ func (c *AvailableConditionController) sync(key string) error {
 	apiregistrationv1apihelper.SetAPIServiceCondition(apiService, availableCondition)
 	_, err = c.updateAPIServiceStatus(originalAPIService, apiService)
 	return err
+}
+
+func (c *AvailableConditionController) checkAPIServiceAvailability(ctx context.Context, apiService *apiregistrationv1.APIService, discoveryClient *http.Client, restTransport http.RoundTripper) error {
+	discoveryURL, err := c.serviceResolver.ResolveEndpoint(apiService.Spec.Service.Namespace, apiService.Spec.Service.Name, *apiService.Spec.Service.Port)
+	if err != nil {
+		return err
+	}
+	// render legacyAPIService health check path when it is delegated to a service
+	if apiService.Name == "v1." {
+		discoveryURL.Path = "/api/" + apiService.Spec.Version
+	} else {
+		discoveryURL.Path = "/apis/" + apiService.Spec.Group + "/" + apiService.Spec.Version
+	}
+
+	newReq, err := http.NewRequestWithContext(ctx, "GET", discoveryURL.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	// setting the system-masters identity ensures that we will always have access rights
+	transport.SetAuthProxyHeaders(newReq, "system:kube-aggregator", "", []string{"system:masters"}, nil)
+
+	errCh := make(chan error, 1)
+	go func() {
+		resp, err := discoveryClient.Do(newReq)
+		if resp != nil {
+			resp.Body.Close()
+			// we should always been in the 200s or 300s
+			if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+				errCh <- fmt.Errorf("bad status from %v: %d", discoveryURL, resp.StatusCode)
+				return
+			}
+		}
+		errCh <- err
+	}()
+
+	select {
+	case err = <-errCh:
+		if err != nil {
+			utilnet.CloseIdleConnectionsFor(restTransport)
+			return fmt.Errorf("failing or missing response from %v: %w", discoveryURL, err)
+		}
+		return nil
+	case <-ctx.Done():
+		utilnet.CloseIdleConnectionsFor(restTransport)
+		return ctx.Err()
+	}
 }
 
 func hasAvailableEndpoint(portName string, es ...*discoveryv1.EndpointSlice) bool {

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/remote/remote_available_controller_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/remote/remote_available_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -609,4 +610,145 @@ func TestCloseIdleConnections(t *testing.T) {
 	case <-time.After(30 * time.Second):
 		t.Fatal("timeout waiting for connection to be closed")
 	}
+}
+
+func TestStaggeredRetries(t *testing.T) {
+	apiServiceName := "remote.group"
+	apiServices := []runtime.Object{newRemoteAPIService(apiServiceName)}
+	services := []*v1.Service{newService("foo", "bar", testServicePort, testServicePortName)}
+	endpointSlices := []*discoveryv1.EndpointSlice{newEndpointSliceWithAddress("foo", "bar", testServicePort, testServicePortName)}
+
+	apiServiceIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	serviceIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	endpointSliceIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+
+	for _, obj := range apiServices {
+		apiServiceIndexer.Add(obj)
+	}
+	for _, obj := range services {
+		serviceIndexer.Add(obj)
+	}
+	for _, obj := range endpointSlices {
+		endpointSliceIndexer.Add(obj)
+	}
+
+	endpointSliceGetter, _ := proxy.NewEndpointSliceListerGetter(discoveryv1listers.NewEndpointSliceLister(endpointSliceIndexer))
+
+	t.Run("success on first attempt makes only one request", func(t *testing.T) {
+		var requestCount int
+		var mu sync.Mutex
+		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			requestCount++
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer testServer.Close()
+
+		fakeClient := fake.NewSimpleClientset(apiServices...)
+		c := AvailableConditionController{
+			apiServiceClient:    fakeClient.ApiregistrationV1(),
+			apiServiceLister:    listers.NewAPIServiceLister(apiServiceIndexer),
+			serviceLister:       v1listers.NewServiceLister(serviceIndexer),
+			endpointSliceGetter: endpointSliceGetter,
+			serviceResolver:     &fakeServiceResolver{url: testServer.URL},
+			metrics:             availabilitymetrics.New(),
+		}
+
+		err := c.sync(apiServiceName)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+		if requestCount != 1 {
+			t.Errorf("expected exactly 1 request, got %d", requestCount)
+		}
+	})
+
+	t.Run("immediate failures trigger fast-path retries", func(t *testing.T) {
+		var requestCount int
+		var mu sync.Mutex
+		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			requestCount++
+			mu.Unlock()
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer testServer.Close()
+
+		fakeClient := fake.NewSimpleClientset(apiServices...)
+		c := AvailableConditionController{
+			apiServiceClient:    fakeClient.ApiregistrationV1(),
+			apiServiceLister:    listers.NewAPIServiceLister(apiServiceIndexer),
+			serviceLister:       v1listers.NewServiceLister(serviceIndexer),
+			endpointSliceGetter: endpointSliceGetter,
+			serviceResolver:     &fakeServiceResolver{url: testServer.URL},
+			metrics:             availabilitymetrics.New(),
+		}
+
+		startTime := time.Now()
+		err := c.sync(apiServiceName)
+		duration := time.Since(startTime)
+
+		if err == nil {
+			t.Fatal("expected failure")
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+		if requestCount != 5 {
+			t.Errorf("expected 5 attempts on failure, got %d", requestCount)
+		}
+		if duration > 1*time.Second {
+			t.Errorf("expected 5 immediate failures to take under 1 second, took %v", duration)
+		}
+	})
+
+	t.Run("slow requests trigger staggered fallback attempts", func(t *testing.T) {
+		var requestCount int
+		var mu sync.Mutex
+		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			idx := requestCount
+			requestCount++
+			mu.Unlock()
+
+			if idx == 0 {
+				time.Sleep(1500 * time.Millisecond)
+				w.WriteHeader(http.StatusInternalServerError)
+			} else {
+				w.WriteHeader(http.StatusOK)
+			}
+		}))
+		defer testServer.Close()
+
+		fakeClient := fake.NewSimpleClientset(apiServices...)
+		c := AvailableConditionController{
+			apiServiceClient:    fakeClient.ApiregistrationV1(),
+			apiServiceLister:    listers.NewAPIServiceLister(apiServiceIndexer),
+			serviceLister:       v1listers.NewServiceLister(serviceIndexer),
+			endpointSliceGetter: endpointSliceGetter,
+			serviceResolver:     &fakeServiceResolver{url: testServer.URL},
+			metrics:             availabilitymetrics.New(),
+		}
+
+		startTime := time.Now()
+		err := c.sync(apiServiceName)
+		duration := time.Since(startTime)
+
+		if err != nil {
+			t.Fatalf("expected successful sync, got err: %v", err)
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+		if requestCount != 2 {
+			t.Errorf("expected 2 requests due to staggering, got %d", requestCount)
+		}
+		if duration > 1300*time.Millisecond {
+			t.Errorf("expected staggered success to return around 1s, took %v", duration)
+		}
+	})
 }


### PR DESCRIPTION
The remote availability controller makes multiple attempts to reach the service endpoints. It launches all attempts simultaneously, but only cares about the first successful attempt.

If the apiservice is healthy and responding within the timeout, the remaining attempts are wasteful and not needed.

Change this to stagger the attempts at 1 second intervals while staying within the 6 second timeout.

/kind cleanup

```release-note
Fixed excessive concurrent health check requests on remote apiserver endpoints.
```