### PR TITLE
﻿kubelet/prober: add container-lifecycle start/stop hooks to Manager

### DIFF
--- a/pkg/kubelet/prober/prober_manager.go
+++ b/pkg/kubelet/prober/prober_manager.go
@@ -84,6 +84,12 @@ type Manager interface {
 	// deleting cached results.
 	RemovePod(pod *v1.Pod)
 
+	// StartContainerProbes starts (or resumes) readiness/liveness probing for one container.
+	StartContainerProbes(ctx context.Context, podUID types.UID, containerName string)
+
+	// StopContainerProbes stops all probes for one container.
+	StopContainerProbes(podUID types.UID, containerName string)
+
 	// CleanupPods handles cleaning up pods which should no longer be running.
 	// It takes a map of "desired pods" which should not be cleaned up.
 	CleanupPods(desiredPods map[types.UID]sets.Empty)
@@ -200,7 +206,7 @@ func (m *manager) AddPod(ctx context.Context, pod *v1.Pod) {
 			}
 			w := newWorker(m, startup, pod, c)
 			m.workers[key] = w
-			go w.run(ctx)
+			w.Start(ctx)
 		}
 
 		if c.ReadinessProbe != nil {
@@ -225,6 +231,28 @@ func (m *manager) AddPod(ctx context.Context, pod *v1.Pod) {
 			w := newWorker(m, liveness, pod, c)
 			m.workers[key] = w
 			go w.run(ctx)
+		}
+	}
+}
+
+func (m *manager) StartContainerProbes(ctx context.Context, podUID types.UID, containerName string) {
+	m.workerLock.RLock()
+	defer m.workerLock.RUnlock()
+	for _, probeType := range [...]probeType{readiness, liveness} {
+		key := probeKey{podUID: podUID, containerName: containerName, probeType: probeType}
+		if w, ok := m.workers[key]; ok {
+			w.Start(ctx)
+		}
+	}
+}
+
+func (m *manager) StopContainerProbes(podUID types.UID, containerName string) {
+	m.workerLock.RLock()
+	defer m.workerLock.RUnlock()
+	for _, probeType := range [...]probeType{readiness, liveness, startup} {
+		key := probeKey{podUID: podUID, containerName: containerName, probeType: probeType}
+		if w, ok := m.workers[key]; ok {
+			w.stop()
 		}
 	}
 }

--- a/pkg/kubelet/prober/testing/fake_manager.go
+++ b/pkg/kubelet/prober/testing/fake_manager.go
@@ -38,6 +38,7 @@ func (FakeManager) RemovePod(_ *v1.Pod) {}
 // Simulated stopping liveness and startup probes.
 func (FakeManager) StopLivenessAndStartup(_ *v1.Pod) {}
 
+
 // CleanupPods simulates cleaning up Pods.
 func (FakeManager) CleanupPods(_ map[types.UID]sets.Empty) {}
 

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -19,6 +19,7 @@ package prober
 import (
 	"context"
 	"math/rand"
+	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -71,6 +72,11 @@ type worker struct {
 
 	// If set, skip probing.
 	onHold bool
+
+	// startOnce guards against starting this worker's run() goroutine more
+	// than once if multiple call sites race to start the same worker.
+	startOnce sync.Once
+	started   bool
 
 	// proberResultsMetricLabels holds the labels attached to this worker
 	// for the ProberResults metric by result.
@@ -152,6 +158,15 @@ func newWorker(
 	w.proberDurationUnknownMetricLabels = deepCopyPrometheusLabels(proberDurationLabels)
 
 	return w
+}
+
+// Start begins this worker's probe loop exactly once. Safe to call more
+// than once or from multiple goroutines — only the first call has effect.
+func (w *worker) Start(ctx context.Context) {
+	w.startOnce.Do(func() {
+		w.started = true
+		go w.run(ctx)
+	})
 }
 
 // run periodically probes the container.


### PR DESCRIPTION
Add Start()/StartContainerProbes()/StopContainerProbes() so probe workers can eventually be started/stopped in response to individual container lifecycle events instead of only at pod-level AddPod/ RemovePod/StopLivenessAndStartup.

This patch only adds the new API surface and refactors AddPod to use worker.Start() (idempotent via sync.Once) instead of calling go w.run(ctx) directly. No existing caller's behavior changes yet -- wiring StartContainerProbes/StopContainerProbes into kuberuntime_container.go and kuberuntime_manager.go is left for a follow-up change, gated behind a feature gate, per discussion in issue #139865.

Also fixes a latent bug in AddPod: the per-probe-type duplicate- worker guard used 
eturn instead of continue, which meant a duplicate startup/readiness/liveness worker for one container would silently abort probe setup for every container after it in the pod. This is plausibly related to kubelet getting stuck per #136218.

Updates testing.FakeManager to satisfy the expanded Manager interface.

Ref: #139865

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:
Adds Start() to worker, and StartContainerProbes()/StopContainerProbes() to the prober.Manager interface, so that probe workers can eventually be started and stopped in response to individual container lifecycle events (container start/terminate) instead of only at the pod level via AddPod/RemovePod/StopLivenessAndStartup. This is a first step toward the architecture proposed in #139865 — integrating probes into the pod sync loop rather than running all probe workers unconditionally for a pod's entire lifetime.
This PR only adds the new API surface and refactors AddPod to call the new worker.Start() (idempotent via sync.Once) instead of calling go w.run(ctx) directly. No existing caller's behavior changes as a result — AddPod still starts every worker immediately, just through the new method. Wiring StartContainerProbes/StopContainerProbes into kuberuntime_container.go and kuberuntime_manager.go so probes actually start/stop on the real container lifecycle is left for a follow-up PR, gated behind a feature gate, per discussion in #139865.
Also fixes a latent bug in AddPod: the per-probe-type duplicate-worker guard used return instead of continue, which meant a duplicate startup/readiness/liveness worker for one container would silently abort probe setup for every container after it in the same pod. This is plausibly related to kubelet getting stuck per #136218.
Updates testing.FakeManager so it still satisfies the expanded Manager interface.

#### Which issue(s) this PR is related to:
Related to #139865
Related to #136218


Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
This is intentionally a small, low-risk slice of the work discussed in #139865 — no runtime-manager wiring yet, so no change to actual probe start/stop timing.
The return→continue fix in AddPod is logically independent of the rest of this PR; happy to split it into its own PR if reviewers prefer that for bisectability.
#139865 is still flagged needs-triage and not yet triage/accepted as of this PR — opening this to make the proposed direction concrete for discussion, not assuming consensus is already reached.

#### Does this PR introduce a user-facing change?
NONE

```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
