### PR TITLE
ipallocator: replace sets.String with sets.Set

### DIFF
--- a/pkg/registry/core/service/ipallocator/bitmap_test.go
+++ b/pkg/registry/core/service/ipallocator/bitmap_test.go
@@ -105,7 +105,7 @@ func TestAllocate(t *testing.T) {
 			if f := r.Used(); f != 0 {
 				t.Errorf("[%s]: wrong used: expected %d, got %d", tc.name, 0, f)
 			}
-			found := sets.NewString()
+			found := sets.New[string]()
 			count := 0
 			for r.Free() > 0 {
 				ip, err := r.AllocateNext()
@@ -252,7 +252,7 @@ func TestAllocateSmall(t *testing.T) {
 	if f := r.Free(); f != 2 {
 		t.Errorf("expected free equal to 2 got: %d", f)
 	}
-	found := sets.NewString()
+	found := sets.New[string]()
 	for i := 0; i < 2; i++ {
 		ip, err := r.AllocateNext()
 		if err != nil {
@@ -292,11 +292,11 @@ func TestForEach(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testCases := []sets.String{
-		sets.NewString(),
-		sets.NewString("192.168.1.1"),
-		sets.NewString("192.168.1.1", "192.168.1.254"),
-		sets.NewString("192.168.1.1", "192.168.1.128", "192.168.1.254"),
+	testCases := []sets.Set[string]{
+		sets.New[string](),
+		sets.New[string]("192.168.1.1"),
+		sets.New[string]("192.168.1.1", "192.168.1.254"),
+		sets.New[string]("192.168.1.1", "192.168.1.128", "192.168.1.254"),
 	}
 
 	for i, tc := range testCases {
@@ -313,7 +313,7 @@ func TestForEach(t *testing.T) {
 				t.Errorf("[%d] expected IP %v allocated", i, ip)
 			}
 		}
-		calls := sets.NewString()
+		calls := sets.New[string]()
 		r.ForEach(func(ip net.IP) {
 			calls.Insert(ip.String())
 		})
@@ -321,7 +321,7 @@ func TestForEach(t *testing.T) {
 			t.Errorf("[%d] expected %d calls, got %d", i, len(tc), len(calls))
 		}
 		if !calls.Equal(tc) {
-			t.Errorf("[%d] expected calls to equal testcase: %v vs %v", i, calls.List(), tc.List())
+			t.Errorf("[%d] expected calls to equal testcase: %v vs %v", i, sets.List(calls), sets.List(tc))
 		}
 	}
 }
@@ -466,7 +466,7 @@ func TestClusterIPMetrics(t *testing.T) {
 	expectMetrics(t, cidrIPv6, em)
 
 	// allocate 2 IPv4 addresses
-	found := sets.NewString()
+	found := sets.New[string]()
 	for i := 0; i < 2; i++ {
 		ip, err := a.AllocateNext()
 		if err != nil {
@@ -562,7 +562,7 @@ func TestClusterIPAllocatedMetrics(t *testing.T) {
 	expectMetrics(t, cidrIPv4, em)
 
 	// allocate 2 dynamic IPv4 addresses
-	found := sets.NewString()
+	found := sets.New[string]()
 	for i := 0; i < 2; i++ {
 		ip, err := a.AllocateNext()
 		if err != nil {

--- a/pkg/registry/core/service/ipallocator/cidrallocator_test.go
+++ b/pkg/registry/core/service/ipallocator/cidrallocator_test.go
@@ -138,7 +138,7 @@ func TestCIDRAllocateMultiple(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	found := sets.NewString()
+	found := sets.New[string]()
 	count := 0
 	for r.Free() > 0 {
 		ip, err := r.AllocateNext()
@@ -308,7 +308,7 @@ func TestCIDRAllocateGrow(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	found := sets.NewString()
+	found := sets.New[string]()
 	count := 0
 	for r.Free() > 0 {
 		ip, err := r.AllocateNext()
@@ -400,7 +400,7 @@ func TestCIDRAllocateShrink(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	found := sets.NewString()
+	found := sets.New[string]()
 	count := 0
 	for r.Free() > 0 {
 		ip, err := r.AllocateNext()
@@ -419,7 +419,7 @@ func TestCIDRAllocateShrink(t *testing.T) {
 	if _, err := r.AllocateNext(); err == nil {
 		t.Fatal(err)
 	}
-	for _, ip := range found.List() {
+	for _, ip := range sets.List(found) {
 		err = r.Release(netutils.ParseIPSloppy(ip))
 		if err != nil {
 			t.Fatalf("unexpected error releasing ip %s", err)
@@ -525,7 +525,7 @@ func TestCIDRAllocateDualWrite(t *testing.T) {
 	}
 	r.bitmapAllocator = bitmapAllocator
 
-	found := sets.NewString()
+	found := sets.New[string]()
 	count := 0
 	for r.Free() > 0 {
 		ip, err := r.AllocateNext()
@@ -641,7 +641,7 @@ func TestCIDRAllocateIPv6(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	found := sets.NewString()
+	found := sets.New[string]()
 	count := 0
 	for r.Free() > 0 {
 		ip, err := r.AllocateNext()
@@ -665,7 +665,7 @@ func TestCIDRAllocateIPv6(t *testing.T) {
 	}
 
 	// releasing every address must make the whole range available again
-	for _, ip := range found.List() {
+	for _, ip := range sets.List(found) {
 		if err := r.Release(netutils.ParseIPSloppy(ip)); err != nil {
 			t.Fatalf("unexpected error releasing ip %s: %v", ip, err)
 		}
@@ -829,7 +829,7 @@ func TestCIDRAllocatorClusterIPAllocatedMetrics(t *testing.T) {
 	expectMetrics(t, "192.168.1.0/30", em1)
 
 	// Allocate all IPs from first CIDR (should be 2 usable IPs: .1 and .2)
-	found := sets.NewString()
+	found := sets.New[string]()
 	allocatedFromCIDR1 := 0
 	for r.Free() > 0 && allocatedFromCIDR1 < 2 {
 		ip, err := r.AllocateNext()

--- a/pkg/registry/core/service/ipallocator/ipallocator_test.go
+++ b/pkg/registry/core/service/ipallocator/ipallocator_test.go
@@ -128,7 +128,7 @@ func TestAllocateIPAllocator(t *testing.T) {
 			if f := r.Used(); f != 0 {
 				t.Errorf("[%s]: wrong used: expected %d, got %d", tc.name, 0, f)
 			}
-			found := sets.NewString()
+			found := sets.New[string]()
 			count := 0
 			for r.Free() > 0 {
 				ip, err := r.AllocateNext()
@@ -337,7 +337,7 @@ func TestAllocateSmallIPAllocator(t *testing.T) {
 	if f := r.Free(); f != 2 {
 		t.Errorf("expected free equal to 2 got: %d", f)
 	}
-	found := sets.NewString()
+	found := sets.New[string]()
 	for i := 0; i < 2; i++ {
 		ip, err := r.AllocateNext()
 		if err != nil {
@@ -373,11 +373,11 @@ func TestForEachIPAllocator(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	testCases := []sets.String{
-		sets.NewString(),
-		sets.NewString("192.168.1.1"),
-		sets.NewString("192.168.1.1", "192.168.1.254"),
-		sets.NewString("192.168.1.1", "192.168.1.128", "192.168.1.254"),
+	testCases := []sets.Set[string]{
+		sets.New[string](),
+		sets.New[string]("192.168.1.1"),
+		sets.New[string]("192.168.1.1", "192.168.1.254"),
+		sets.New[string]("192.168.1.1", "192.168.1.128", "192.168.1.254"),
 	}
 
 	for i, tc := range testCases {
@@ -396,7 +396,7 @@ func TestForEachIPAllocator(t *testing.T) {
 				t.Errorf("[%d] expected IP %v allocated", i, ip)
 			}
 		}
-		calls := sets.NewString()
+		calls := sets.New[string]()
 		r.ForEach(func(ip net.IP) {
 			calls.Insert(ip.String())
 		})
@@ -404,7 +404,7 @@ func TestForEachIPAllocator(t *testing.T) {
 			t.Errorf("[%d] expected %d calls, got %d", i, len(tc), len(calls))
 		}
 		if !calls.Equal(tc) {
-			t.Errorf("[%d] expected calls to equal testcase: %v vs %v", i, calls.List(), tc.List())
+			t.Errorf("[%d] expected calls to equal testcase: %v vs %v", i, sets.List(calls), sets.List(tc))
 		}
 	}
 }
@@ -445,7 +445,7 @@ func TestIPAllocatorClusterIPMetrics(t *testing.T) {
 	expectMetrics(t, cidrIPv6, em)
 
 	// allocate 2 IPv4 addresses
-	found := sets.NewString()
+	found := sets.New[string]()
 	for i := 0; i < 2; i++ {
 		ip, err := a.AllocateNext()
 		if err != nil {
@@ -541,7 +541,7 @@ func TestIPAllocatorClusterIPAllocatedMetrics(t *testing.T) {
 	expectMetrics(t, cidrIPv4, em)
 
 	// allocate 2 dynamic IPv4 addresses
-	found := sets.NewString()
+	found := sets.New[string]()
 	for i := 0; i < 2; i++ {
 		ip, err := a.AllocateNext()
 		if err != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
The `sets.String` type and `sets.NewString` constructor are deprecated in favor of the generic `sets.Set[string]` / `sets.New[string]`. This replaces them in the `pkg/registry/core/service/ipallocator` tests. Sorted `List()` calls are converted to the `sets.List()` helper to preserve ordering. Test-only change; no behavior difference.

#### Which issue(s) this PR is related to:
Related to: #133935

#### Special notes for your reviewer:
Mechanical change confined to `*_test.go` in a single package. Verified locally: `go test -race`, `go vet`, `gofmt`, and `hack/verify-golangci-lint.sh` all pass with no issues.

/sig api-machinery
/assign @aojea @thockin

#### Does this PR introduce a user-facing change?
```release-note
NONE
```