### PR TITLE
[kubelet] DRA PrepareDynamicResources failures should be reported in SyncResult

### DIFF
--- a/pkg/kubelet/container/sync_result.go
+++ b/pkg/kubelet/container/sync_result.go
@@ -97,6 +97,8 @@ var (
 	ErrResizePodInPlace = errors.New("ResizePodInPlaceError")
 	// ErrRemoveContainer returned when runtime failed to remove a container.
 	ErrRemoveContainer = errors.New("RemoveContainerError")
+	// ErrPrepareDynamicResources returned when runtime failed to prepare dynamic resources for a pod.
+	ErrPrepareDynamicResources = errors.New("PrepareDynamicResourcesError")
 )
 
 // SyncAction indicates different kind of actions in SyncPod() and KillPod(). Now there are only actions
@@ -120,6 +122,8 @@ const (
 	ResizePodInPlace SyncAction = "ResizePodInPlace"
 	// RemoveContainer action
 	RemoveContainer SyncAction = "RemoveContainer"
+	// PrepareDynamicResources action
+	PrepareDynamicResources SyncAction = "PrepareDynamicResources"
 )
 
 // SyncResult is the result of sync action.

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1718,9 +1718,9 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 		// Prepare resources allocated by the Dynammic Resource Allocation feature for the pod
 		if utilfeature.DefaultFeatureGate.Enabled(features.DynamicResourceAllocation) {
 			prepareDynamicResourcesResult := kubecontainer.NewSyncResult(kubecontainer.PrepareDynamicResources, format.Pod(pod))
+			result.AddSyncResult(prepareDynamicResourcesResult)
 			if err := m.runtimeHelper.PrepareDynamicResources(ctx, pod); err != nil {
 				prepareDynamicResourcesResult.Fail(kubecontainer.ErrPrepareDynamicResources, err.Error())
-				result.AddSyncResult(prepareDynamicResourcesResult)
 				ref, referr := ref.GetReference(legacyscheme.Scheme, pod)
 				if referr != nil {
 					logger.Error(referr, "Couldn't make a ref to pod", "pod", klog.KObj(pod))

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1717,7 +1717,10 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 
 		// Prepare resources allocated by the Dynammic Resource Allocation feature for the pod
 		if utilfeature.DefaultFeatureGate.Enabled(features.DynamicResourceAllocation) {
+			prepareDynamicResourcesResult := kubecontainer.NewSyncResult(kubecontainer.PrepareDynamicResources, format.Pod(pod))
 			if err := m.runtimeHelper.PrepareDynamicResources(ctx, pod); err != nil {
+				prepareDynamicResourcesResult.Fail(kubecontainer.ErrPrepareDynamicResources, err.Error())
+				result.AddSyncResult(prepareDynamicResourcesResult)
 				ref, referr := ref.GetReference(legacyscheme.Scheme, pod)
 				if referr != nil {
 					logger.Error(referr, "Couldn't make a ref to pod", "pod", klog.KObj(pod))

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -6508,9 +6508,9 @@ func TestOnPodSandboxReadyInvocation(t *testing.T) {
 			onPodSandboxReadyShouldErr: false,
 			deviceAllocationShouldErr:  true,
 			expectOnPodSandboxReady:    false,
-			expectSyncPodSuccess:       true, // SyncPod doesn't return error, just returns early if `PrepareDynamicResources` call ends up failing
+			expectSyncPodSuccess:       false,
 			expectDeviceAllocation:     true,
-			description:                "Verifies PrepareDynamicResources failure causes early return in case of pod with ResourceClaims",
+			description:                "Verifies PrepareDynamicResources failure is reported in SyncResult in case of pod with ResourceClaims",
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

When `PrepareDynamicResources` fails, the error was not being recorded in the `PodSyncResult`. As a result, the pod would be retried on the default resync interval (60–90s) rather than the faster error-backoff path, increasing startup latency for pods using DRA when the first prepare attempts fail.

This fix adds a `SyncResult` for the `PrepareDynamicResources` action, following the same pattern used by `createSandboxResult` in `SyncPod`. The result is added unconditionally, and marked as failed only if the call returns an error.

**Which issue(s) this PR is related to:**

Fixes #139836

**Special notes for your reviewer:**

Two new identifiers are added to `pkg/kubelet/container/sync_result.go`:
- `ErrPrepareDynamicResources` error value
- `PrepareDynamicResources` SyncAction constant

These follow the same conventions as the existing entries in that file.

**Does this PR introduce a user-facing change?**

```release-note
Fixed a bug where the kubelet did not report DynamicResourceAllocation PrepareDynamicResources failures in the pod sync result, causing affected pods to retry on the default resync interval instead of the faster error-backoff path.
```

**AI usage disclosure:**

An AI assistant was used for minor help with boilerplate lookup (existing error/constant naming conventions in sync_result.go). The bug identification, fix design, and code changes were done manually.