### PR TITLE
Fix AsApproximateFloat64 NaN for zero quantity

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -475,7 +475,8 @@ func (q *Quantity) AsApproximateFloat64() float64 {
 		base = float64(q.i.value)
 		exponent = int(q.i.scale)
 	}
-	if exponent == 0 {
+	// Avoid 0 * Inf, which returns NaN.
+	if base == 0 || exponent == 0 {
 		return base
 	}
 

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -1303,6 +1303,10 @@ func TestQuantityAsApproximateFloat64(t *testing.T) {
 		{decQuantity(0, 0, DecimalSI), 0.0},
 		{decQuantity(0, 0, DecimalExponent), 0.0},
 		{decQuantity(0, 0, BinarySI), 0.0},
+		{decQuantity(0, 500, DecimalSI), 0.0},
+		{intQuantity(0, 500, DecimalSI), 0.0},
+		{decQuantity(0, -500, DecimalSI), 0.0},
+		{intQuantity(0, -500, DecimalSI), 0.0},
 
 		{decQuantity(1, 0, DecimalSI), 1},
 		{decQuantity(1, 0, DecimalExponent), 1},
@@ -1374,6 +1378,10 @@ func TestQuantityAsFloat64Slow(t *testing.T) {
 		{decQuantity(0, 0, DecimalSI), 0.0},
 		{decQuantity(0, 0, DecimalExponent), 0.0},
 		{decQuantity(0, 0, BinarySI), 0.0},
+		{decQuantity(0, 500, DecimalSI), 0.0},
+		{intQuantity(0, 500, DecimalSI), 0.0},
+		{decQuantity(0, -500, DecimalSI), 0.0},
+		{intQuantity(0, -500, DecimalSI), 0.0},
 
 		{decQuantity(1, 0, DecimalSI), 1},
 		{decQuantity(1, 0, DecimalExponent), 1},


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`Quantity.AsApproximateFloat64()` only short-circuits when the exponent is zero, then returns `base * math.Pow10(exponent)`. For a quantity whose value is exactly zero but whose scale is large, `base` is `0` and `math.Pow10(scale)` overflows to `+Inf`, so it returns `0 * +Inf`, which is `NaN`, instead of `0`. The sibling `AsFloat64Slow()` returns `0` for the same input and the two test tables are kept in sync, so `0` is the intended result. This guards the zero value before the multiply and adds regression rows (a zero value at large positive and negative scale) to both tables.

#### Which issue(s) this PR is related to:
Fixes #139894

#### Special notes for your reviewer:
This PR was written in part with the assistance of generative AI; all changes were authored and reviewed by me.

#### Does this PR introduce a user-facing change?
```release-note
Fixed `resource.Quantity.AsApproximateFloat64` returning NaN instead of 0 for a zero-valued quantity with a large scale.
```
