### PR TITLE
E2E node: consider ARTIFACTS env variable for results dir

### DIFF
--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -149,7 +149,12 @@ Usage as e2e_node.test:
 	case strings.HasPrefix(cmdName, "mounter"):
 		mounter.Main()
 	case len(os.Args) > 1 && os.Args[1] == "remote":
-		node.Main(os.Args[2:])
+		// The hard-coded verbosity in `make test-e2e-node` is 4
+		// (https://github.com/kubernetes/kubernetes/blob/17e2eda6119170e6ce1a065716432b1d37d028dd/hack/make-rules/test-e2e-node.sh#L248).
+		// Pre-pending -v4 emulates that behavior, with the difference that an explicit
+		// -v passed by the caller (typically kubetest2) could be used to override it.
+		args := append([]string{"-v=4"}, os.Args[2:]...)
+		node.Main(args)
 	default:
 		testMain(m)
 	}

--- a/test/e2e_node/remote/remote.go
+++ b/test/e2e_node/remote/remote.go
@@ -31,7 +31,14 @@ import (
 )
 
 var testTimeout = CommandLine.Duration("test-timeout", 45*time.Minute, "How long (in golang duration format) to wait for ginkgo tests to complete.")
-var resultsDir = CommandLine.String("results-dir", "/tmp/", "Directory to scp test results to.")
+var resultsDir = CommandLine.String("results-dir", defaultResultsDir(), "Directory to scp test results to.")
+
+func defaultResultsDir() string {
+	if artifacts, ok := os.LookupEnv("ARTIFACTS"); ok {
+		return artifacts
+	}
+	return "/tmp"
+}
 
 const archiveName = "e2e_node_test.tar.gz"
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

[`make test-e2e-node` sets the `-results-dir`](https://github.com/kubernetes/kubernetes/blob/17e2eda6119170e6ce1a065716432b1d37d028dd/hack/make-rules/test-e2e-node.sh#L221) based on the [ARTIFACTS Prow job env variable](https://github.com/kubernetes/kubernetes/blob/17e2eda6119170e6ce1a065716432b1d37d028dd/hack/make-rules/test-e2e-node.sh#L44). When e2e_node.test gets invoked directly, it should do the same, otherwise JUnit and log files are not captured for the job.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/test-infra/pull/37296

#### Special notes for your reviewer:

Before:
- no JUnit results in https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/139896/pull-kubernetes-node-e2e-containerd-2-0-ubuntu-dra/2068634253402312704
- no "Copying test artifacts from" log output in https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/139896/pull-kubernetes-node-e2e-containerd-2-0-ubuntu-dra/2068634253402312704/build-log.txt

After:
- https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/139896/pull-kubernetes-node-e2e-containerd-2-0-ubuntu-dra/2068645944638836736/build-log.txt
- https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/139896/pull-kubernetes-node-e2e-containerd-2-0-ubuntu-dra/2068645944638836736/build-log.txt

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
