### PR TITLE
Add +k8s:format=k8s-label-key declarative validation to metav1.Condit…

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
@@ -197,6 +197,7 @@ message Condition {
   // +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`
   // +kubebuilder:validation:MaxLength=316
   // +k8s:alpha(since: "1.37")=+k8s:required
+  // +k8s:alpha(since: "1.37")=+k8s:format=k8s-label-key
   optional string type = 1;
 
   // status of the condition, one of True, False, Unknown.

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -1632,6 +1632,7 @@ type Condition struct {
 	// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`
 	// +kubebuilder:validation:MaxLength=316
 	// +k8s:alpha(since: "1.37")=+k8s:required
+	// +k8s:alpha(since: "1.37")=+k8s:format=k8s-label-key
 	Type string `json:"type" protobuf:"bytes,1,opt,name=type"`
 	// status of the condition, one of True, False, Unknown.
 	// +required

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -319,7 +319,7 @@ func ValidateCondition(condition metav1.Condition, fldPath *field.Path) field.Er
 	if len(condition.Type) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("type"), "is required").MarkCoveredByDeclarative())
 	} else {
-		allErrs = append(allErrs, ValidateLabelName(condition.Type, fldPath.Child("type"))...)
+		allErrs = append(allErrs, ValidateLabelName(condition.Type, fldPath.Child("type")).MarkCoveredByDeclarative()...)
 	}
 
 	// status is set and is an accepted value

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/zz_generated.validations.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/zz_generated.validations.go
@@ -58,6 +58,9 @@ func Validate_Condition(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if e := validate.LabelKey(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/declarative_validation_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/declarative_validation_test.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/apis/admissionregistration"
 	registry "k8s.io/kubernetes/pkg/registry/admissionregistration/validatingadmissionpolicy"
 	"k8s.io/kubernetes/test/declarative_validation/meta"
@@ -47,6 +48,38 @@ func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 					},
 				}
 			})
+			testCases := []meta.ConditionTestCase{
+				{
+					Name: "invalid type format not a k8s label key",
+					Conditions: []metav1.Condition{
+						meta.MkCondition(
+							meta.TweakType("INVALID TYPE"),
+						),
+					},
+					ExpectedErrs: field.ErrorList{
+						field.Invalid(
+							field.NewPath("status", "conditions").Index(0).Child("type"),
+							"INVALID TYPE",
+							"name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')",
+						).WithOrigin("format=k8s-label-key").MarkAlpha(),
+					},
+				},
+			}
+			for _, tc := range testCases {
+				t.Run("conditions: "+tc.Name, func(t *testing.T) {
+					obj := &admissionregistration.ValidatingAdmissionPolicy{
+						ObjectMeta: metav1.ObjectMeta{Name: "valid-policy", ResourceVersion: "1"},
+						Spec:       admissionregistration.ValidatingAdmissionPolicySpec{},
+						Status: admissionregistration.ValidatingAdmissionPolicyStatus{
+							Conditions: tc.Conditions,
+						},
+					}
+					old := &admissionregistration.ValidatingAdmissionPolicy{
+						ObjectMeta: metav1.ObjectMeta{Name: "valid-policy", ResourceVersion: "1"},
+					}
+					apitesting.VerifyUpdateValidationEquivalence(t, ctx, obj, old, strategy, tc.ExpectedErrs)
+				})
+			}
 		})
 	}
 }

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1_test.go
@@ -41,6 +41,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 		},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
@@ -41,6 +41,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 		},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
@@ -41,6 +41,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 		},

--- a/test/declarative_validation/certificates/podcertificaterequest/declarative_validation_test.go
+++ b/test/declarative_validation/certificates/podcertificaterequest/declarative_validation_test.go
@@ -110,6 +110,7 @@ func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 					ExpectedErrs: nil,
 				},
 				{
+
 					Name: "invalid missing status",
 					Conditions: []metav1.Condition{
 						meta.MkCondition(
@@ -165,6 +166,23 @@ func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 					ExpectedErrs: field.ErrorList{
 						// handwritten validation requires "True"
 						field.NotSupported(field.NewPath("status", "conditions").Child("[0]", "status"), "False", []string{"True"}).MarkFromImperative(),
+					},
+				},
+				{
+					Name: "invalid type format not a k8s label key",
+					Conditions: []metav1.Condition{
+						meta.MkCondition(
+							meta.TweakType("INVALID TYPE"),
+						),
+					},
+					ExpectedErrs: field.ErrorList{
+						field.Invalid(
+							field.NewPath("status", "conditions").Index(0).Child("type"),
+							"INVALID TYPE",
+							"name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')",
+						).WithOrigin("format=k8s-label-key").MarkAlpha(),
+						// handwritten validation rejects unknown condition types and uses .[0] notation
+						field.NotSupported(field.NewPath("status", "conditions").Child("[0]", "type"), "INVALID TYPE", []string{"Issued", "Denied", "Failed"}).MarkFromImperative(),
 					},
 				},
 			}

--- a/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1beta1_test.go
@@ -41,6 +41,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 		},

--- a/test/declarative_validation/policy/poddisruptionbudget/declarative_validation_test.go
+++ b/test/declarative_validation/policy/poddisruptionbudget/declarative_validation_test.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/apis/policy"
 	registry "k8s.io/kubernetes/pkg/registry/policy/poddisruptionbudget"
 	"k8s.io/kubernetes/test/declarative_validation/meta"
@@ -46,6 +47,38 @@ func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 					},
 				}
 			})
+			testCases := []meta.ConditionTestCase{
+				{
+					Name: "invalid type format not a k8s label key",
+					Conditions: []metav1.Condition{
+						meta.MkCondition(
+							meta.TweakType("INVALID TYPE"),
+						),
+					},
+					ExpectedErrs: field.ErrorList{
+						field.Invalid(
+							field.NewPath("status", "conditions").Index(0).Child("type"),
+							"INVALID TYPE",
+							"name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')",
+						).WithOrigin("format=k8s-label-key").MarkAlpha(),
+					},
+				},
+			}
+			for _, tc := range testCases {
+				t.Run("conditions: "+tc.Name, func(t *testing.T) {
+					obj := &policy.PodDisruptionBudget{
+						ObjectMeta: metav1.ObjectMeta{Name: "valid-pdb", Namespace: "default", ResourceVersion: "1"},
+						Spec:       policy.PodDisruptionBudgetSpec{},
+						Status: policy.PodDisruptionBudgetStatus{
+							Conditions: tc.Conditions,
+						},
+					}
+					old := &policy.PodDisruptionBudget{
+						ObjectMeta: metav1.ObjectMeta{Name: "valid-pdb", Namespace: "default", ResourceVersion: "1"},
+					}
+					apitesting.VerifyUpdateValidationEquivalence(t, ctx, obj, old, registry.StatusStrategy, tc.ExpectedErrs)
+				})
+			}
 		})
 	}
 }

--- a/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1_test.go
@@ -41,6 +41,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 		},

--- a/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1beta1_test.go
@@ -41,6 +41,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 		},

--- a/test/declarative_validation/resource/devicetaintrule/declarative_validation_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/declarative_validation_test.go
@@ -128,6 +128,50 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, registry.Strategy, tc.expectedErrs)
 		})
 	}
+	extraTestCases := []meta.ConditionTestCase{
+		{
+			Name: "invalid type format not a k8s label key",
+			Conditions: []metav1.Condition{
+				meta.MkCondition(
+					meta.TweakType("INVALID TYPE"),
+				),
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(
+					field.NewPath("status", "conditions").Index(0).Child("type"),
+					"INVALID TYPE",
+					"name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')",
+				).WithOrigin("format=k8s-label-key").MarkAlpha(),
+			},
+		},
+	}
+
+	for _, tc := range extraTestCases {
+		t.Run("conditions: "+tc.Name, func(t *testing.T) {
+			obj := &resource.DeviceTaintRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid-rule", ResourceVersion: "2"},
+				Spec: resource.DeviceTaintRuleSpec{
+					Taint: resource.DeviceTaint{
+						Key:    "example.com/tainted",
+						Effect: resource.DeviceTaintEffectNoExecute,
+					},
+				},
+				Status: resource.DeviceTaintRuleStatus{
+					Conditions: tc.Conditions,
+				},
+			}
+			old := &resource.DeviceTaintRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid-rule", ResourceVersion: "1"},
+				Spec: resource.DeviceTaintRuleSpec{
+					Taint: resource.DeviceTaint{
+						Key:    "example.com/tainted",
+						Effect: resource.DeviceTaintEffectNoExecute,
+					},
+				},
+			}
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, obj, old, registry.StatusStrategy, tc.ExpectedErrs)
+		})
+	}
 }
 
 func mkValidDeviceTaintRule(tweaks ...func(*resource.DeviceTaintRule)) resource.DeviceTaintRule {

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1alpha3_test.go
@@ -45,6 +45,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 		},

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1beta2_test.go
@@ -45,6 +45,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 		},

--- a/test/declarative_validation/resource/resourceclaim/declarative_validation_test.go
+++ b/test/declarative_validation/resource/resourceclaim/declarative_validation_test.go
@@ -1526,6 +1526,48 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 			Conditions: c,
 		}))
 	})
+	meta.RunConditionTestCases(t, ctx, field.NewPath("status", "devices").Index(0).Child("conditions"), &resource.ResourceClaim{}, strategy, func(obj *resource.ResourceClaim, c []v1.Condition) {
+		*obj = mkResourceClaimWithStatus(tweakStatusDevices(resource.AllocatedDeviceStatus{
+			Driver:     "dra.example.com",
+			Pool:       "pool-0",
+			Device:     "device-0",
+			Conditions: c,
+		}))
+	})
+
+	// Extra condition test cases for status.devices[*].conditions[*].type format validation
+	extraConditionTestCases := []meta.ConditionTestCase{
+		{
+			Name: "invalid type format not a k8s label key",
+			Conditions: []v1.Condition{
+				meta.MkCondition(
+					meta.TweakType("INVALID TYPE"),
+				),
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(
+					field.NewPath("status", "devices").Index(0).Child("conditions").Index(0).Child("type"),
+					"INVALID TYPE",
+					"name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')",
+				).WithOrigin("format=k8s-label-key").MarkAlpha(),
+			},
+		},
+	}
+
+	for _, tc := range extraConditionTestCases {
+		t.Run("conditions: "+tc.Name, func(t *testing.T) {
+			obj := mkResourceClaimWithStatus(tweakStatusDevices(resource.AllocatedDeviceStatus{
+				Driver:     "dra.example.com",
+				Pool:       "pool-0",
+				Device:     "device-0",
+				Conditions: tc.Conditions,
+			}))
+			obj.ObjectMeta.ResourceVersion = "2"
+			old := mkValidResourceClaim()
+			old.ObjectMeta.ResourceVersion = "1"
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &obj, &old, strategy, tc.ExpectedErrs, apitesting.WithSubResources("status"))
+		})
+	}
 }
 
 func tweakStatusAllocation(results ...resource.DeviceRequestAllocationResult) func(rc *resource.ResourceClaim) {

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1_test.go
@@ -173,6 +173,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.devices[*].conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.devices[*].networkData.hardwareAddress": {

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta1_test.go
@@ -173,6 +173,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.devices[*].conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.devices[*].networkData.hardwareAddress": {

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta2_test.go
@@ -173,6 +173,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.devices[*].conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.devices[*].networkData.hardwareAddress": {

--- a/test/declarative_validation/resource/resourcepoolstatusrequest/declarative_validation_test.go
+++ b/test/declarative_validation/resource/resourcepoolstatusrequest/declarative_validation_test.go
@@ -378,6 +378,34 @@ func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 			withStatus(func(s *resource.ResourcePoolStatusRequestStatus) { s.Conditions = c })(obj)
 		}
 	})
+	extraConditionTestCases := []meta.ConditionTestCase{
+		{
+			Name: "invalid type format not a k8s label key",
+			Conditions: []metav1.Condition{
+				meta.MkCondition(
+					meta.TweakType("INVALID TYPE"),
+				),
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(
+					field.NewPath("status", "conditions").Index(0).Child("type"),
+					"INVALID TYPE",
+					"name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')",
+				).WithOrigin("format=k8s-label-key").MarkAlpha(),
+			},
+		},
+	}
+
+	for _, tc := range extraConditionTestCases {
+		t.Run("conditions: "+tc.Name, func(t *testing.T) {
+			obj := mkValidRPSRForUpdate(withStatus(func(s *resource.ResourcePoolStatusRequestStatus) {
+				s.Conditions = tc.Conditions
+			}))
+			obj.ResourceVersion = "2"
+			old := mkValidRPSRForUpdate()
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &obj, &old, registry.StatusStrategy, tc.ExpectedErrs)
+		})
+	}
 }
 
 // mkValidRPSR creates a valid ResourcePoolStatusRequest with optional tweaks.

--- a/test/declarative_validation/resource/resourcepoolstatusrequest/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/resource/resourcepoolstatusrequest/zz_generated.validations.v1alpha3_test.go
@@ -59,6 +59,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.poolCount": {

--- a/test/declarative_validation/scheduling/podgroup/declarative_validation_test.go
+++ b/test/declarative_validation/scheduling/podgroup/declarative_validation_test.go
@@ -647,6 +647,34 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 	meta.RunConditionTestCases(t, ctx, field.NewPath("status", "conditions"), &scheduling.PodGroup{}, registry.NewStatusStrategy(registry.NewStrategy()), func(obj *scheduling.PodGroup, c []metav1.Condition) {
 		*obj = mkValidPodGroup(setResourceVersion("1"), func(pg *scheduling.PodGroup) { pg.Status.Conditions = c })
 	})
+	extraConditionTestCases := []meta.ConditionTestCase{
+		{
+			Name: "invalid type format not a k8s label key",
+			Conditions: []metav1.Condition{
+				meta.MkCondition(
+					meta.TweakType("INVALID TYPE"),
+				),
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(
+					field.NewPath("status", "conditions").Index(0).Child("type"),
+					"INVALID TYPE",
+					"name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')",
+				).WithOrigin("format=k8s-label-key").MarkAlpha(),
+			},
+		},
+	}
+
+	for _, tc := range extraConditionTestCases {
+		t.Run("conditions: "+tc.Name, func(t *testing.T) {
+			obj := mkValidPodGroup(setResourceVersion("1"), func(pg *scheduling.PodGroup) {
+				pg.Status.Conditions = tc.Conditions
+			})
+			old := mkValidPodGroup(setResourceVersion("1"))
+			strategy := registry.NewStatusStrategy(registry.NewStrategy())
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &obj, &old, strategy, tc.ExpectedErrs)
+		})
+	}
 }
 
 // mkValidPodGroup produces a PodGroup which passes validation with no tweaks.

--- a/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1alpha3_test.go
@@ -108,6 +108,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.resourceClaimStatuses": {

--- a/test/declarative_validation/storagemigration/storageversionmigration/declarative_validation_test.go
+++ b/test/declarative_validation/storagemigration/storageversionmigration/declarative_validation_test.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/apis/storagemigration"
 	_ "k8s.io/kubernetes/pkg/apis/storagemigration/install"
 	registry "k8s.io/kubernetes/pkg/registry/storagemigration/storagemigration"
@@ -47,6 +48,40 @@ func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 					},
 				}
 			})
+			testCases := []meta.ConditionTestCase{
+				{
+					Name: "invalid type format not a k8s label key",
+					Conditions: []metav1.Condition{
+						meta.MkCondition(
+							meta.TweakType("INVALID TYPE"),
+						),
+					},
+					ExpectedErrs: field.ErrorList{
+						field.Invalid(
+							field.NewPath("status", "conditions").Index(0).Child("type"),
+							"INVALID TYPE",
+							"name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')",
+						).WithOrigin("format=k8s-label-key").MarkAlpha(),
+					},
+				},
+			}
+
+			for _, tc := range testCases {
+				t.Run("conditions: "+tc.Name, func(t *testing.T) {
+					obj := &storagemigration.StorageVersionMigration{
+						ObjectMeta: metav1.ObjectMeta{Name: "valid-svm", ResourceVersion: "2"},
+						Spec:       storagemigration.StorageVersionMigrationSpec{},
+						Status: storagemigration.StorageVersionMigrationStatus{
+							Conditions: tc.Conditions,
+						},
+					}
+					old := &storagemigration.StorageVersionMigration{
+						ObjectMeta: metav1.ObjectMeta{Name: "valid-svm", ResourceVersion: "1"},
+						Spec:       storagemigration.StorageVersionMigrationSpec{},
+					}
+					apitesting.VerifyUpdateValidationEquivalence(t, ctx, obj, old, registry.StatusStrategy, tc.ExpectedErrs)
+				})
+			}
 		})
 	}
 }

--- a/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1beta1_test.go
@@ -41,6 +41,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Migrates `metav1.Condition.Type`  validation to Declarative Validation.

This PR:

- Adds declarative validation tag to `Condition.Type`:

       +k8s:format=k8s-label-key
- Marks the corresponding handwritten validation as covered by declarative validation
- Adds declarative validation test coverage for invalid Type format values
- Regenerates validation code and generated declarative validation tests

Which issue(s) this PR is related to:
Part of #139638

Special notes for your reviewer:
This PR covers `Batch 4 (Type format)` from the`metav1.Condition` declarative validatio migration tracking issue.

Some test packages report additional uncovered `format=k8s-label-key `
rules unrelated to `metav1.Condition.Type (resourceclaim, podgroup, 
resourcepoolstatusrequest, devicetaintrule)`. These appear to be 
pre-existing gaps. Seeking reviewer guidance on whether these should 
be addressed in this PR or separately.


 Does this PR introduce a user-facing change?

        NONE

Additional documentation:

       KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api machinery/5073-             declarative-validation