### PR TITLE
Add ResourceQuota integration tests #139659

### DIFF
--- a/test/integration/quota/quota_admission_test.go
+++ b/test/integration/quota/quota_admission_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package quota
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+// TestQuotaDryRun verifies that a dry-run create is enforced by quota (an over-quota dry-run is
+// still denied) but is never charged (an in-budget dry-run does not consume the quota).
+func TestQuotaDryRun(t *testing.T) {
+	srv, tearDown := startQuotaTestServer(t, quotaServerOptions{})
+	defer tearDown()
+
+	ns := framework.CreateNamespaceOrDie(srv.client, "quota-dry-run", t)
+	defer framework.DeleteNamespaceOrDie(srv.client, ns, t)
+
+	quota := newResourceQuota(ns.Name, "quota", v1.ResourceList{v1.ResourcePods: resource.MustParse("1")})
+	waitForQuota(t, quota, srv.client)
+	expectedQuotaUsed := v1.ResourceList{
+		v1.ResourcePods: resource.MustParse("0"),
+	}
+	waitForUsedResourceQuota(t, srv.client, ns.Name, quota.Name, expectedQuotaUsed)
+
+	dryRun := metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}}
+
+	// An in-budget dry-run create succeeds but must not consume the single pod slot.
+	if _, err := srv.client.CoreV1().Pods(ns.Name).Create(srv.ctx, newPod("dry-a", nil, nil), dryRun); err != nil {
+		t.Fatalf("in-budget dry-run create should succeed: %v", err)
+	}
+
+	// The real create still fits, proving the dry-run above did not charge the quota.
+	createPodExpectAllowed(srv.ctx, srv.client, ns.Name, newPod("real-b", nil, nil), t)
+	expectedQuotaUsed = v1.ResourceList{
+		v1.ResourcePods: resource.MustParse("1"),
+	}
+	waitForUsedResourceQuota(t, srv.client, ns.Name, quota.Name, expectedQuotaUsed)
+
+	// With the quota now full, an over-quota dry-run create is denied just like a real create.
+	err := wait.PollUntilContextTimeout(srv.ctx, quotaPollInterval, quotaPollTimeout, true, func(ctx context.Context) (bool, error) {
+		_, err := srv.client.CoreV1().Pods(ns.Name).Create(ctx, newPod("dry-c", nil, nil), dryRun)
+		switch {
+		case apierrors.IsForbidden(err):
+			return true, nil
+		case err != nil:
+			return false, err
+		default:
+			// Dry-run success is not persisted, so just keep polling until usage propagates.
+			return false, nil
+		}
+	})
+	if err != nil {
+		t.Fatalf("over-quota dry-run create should eventually be forbidden but got: %v", err)
+	}
+}
+
+// TestQuotaMultipleQuotas verifies that when a namespace has multiple ResourceQuotas, the most
+// restrictive one binds: both are charged, and the smaller limit denies first.
+func TestQuotaMultipleQuotas(t *testing.T) {
+	srv, tearDown := startQuotaTestServer(t, quotaServerOptions{})
+	defer tearDown()
+
+	ns := framework.CreateNamespaceOrDie(srv.client, "quota-multiple", t)
+	defer framework.DeleteNamespaceOrDie(srv.client, ns, t)
+
+	loose := newResourceQuota(ns.Name, "loose", v1.ResourceList{v1.ResourcePods: resource.MustParse("5")})
+	tight := newResourceQuota(ns.Name, "tight", v1.ResourceList{v1.ResourcePods: resource.MustParse("1")})
+	waitForQuota(t, loose, srv.client)
+	waitForQuota(t, tight, srv.client)
+
+	// The single allowed pod is charged against both quotas.
+	createPodExpectAllowed(srv.ctx, srv.client, ns.Name, newPod("pod-1", nil, nil), t)
+	expectedQuotaUsed := v1.ResourceList{
+		v1.ResourcePods: resource.MustParse("1"),
+	}
+	waitForUsedResourceQuota(t, srv.client, ns.Name, loose.Name, expectedQuotaUsed)
+	waitForUsedResourceQuota(t, srv.client, ns.Name, tight.Name, expectedQuotaUsed)
+
+	// The tighter quota (pods: 1) denies the second pod even though the looser one (pods: 5) has room.
+	createPodExpectForbidden(srv.ctx, srv.client, ns.Name, newPod("pod-2", nil, nil), t)
+}
+
+// TestQuotaLimitedResourceComputeDenial verifies the limitedResources admission config for a
+// compute dimension: when requests.cpu is a limited resource, a pod that requests cpu is denied
+// unless a quota covering requests.cpu exists. This extends the existing pods/count-based
+// limitedResources coverage (TestQuotaLimitedResourceDenial) to a compute resource.
+func TestQuotaLimitedResourceComputeDenial(t *testing.T) {
+	configFile, err := os.CreateTemp("", "admission-config.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(configFile.Name())
+	if err := os.WriteFile(configFile.Name(), []byte(`
+apiVersion: apiserver.k8s.io/v1alpha1
+kind: AdmissionConfiguration
+plugins:
+- name: ResourceQuota
+  configuration:
+    apiVersion: apiserver.config.k8s.io/v1
+    kind: ResourceQuotaConfiguration
+    limitedResources:
+    - resource: pods
+      matchContains:
+      - requests.cpu
+`), os.FileMode(0644)); err != nil {
+		t.Fatal(err)
+	}
+
+	srv, tearDown := startQuotaTestServer(t, quotaServerOptions{admissionConfigFile: configFile.Name()})
+	defer tearDown()
+
+	ns := framework.CreateNamespaceOrDie(srv.client, "quota-limited-compute", t)
+	defer framework.DeleteNamespaceOrDie(srv.client, ns, t)
+
+	cpuPod := func(name string) *v1.Pod {
+		return newPod(name, v1.ResourceList{v1.ResourceCPU: resource.MustParse("100m")}, nil)
+	}
+
+	// With no covering quota, a pod that consumes requests.cpu is denied by limitedResources.
+	createPodExpectForbidden(srv.ctx, srv.client, ns.Name, cpuPod("needs-cpu"), t)
+
+	// A pod that does not consume requests.cpu is unaffected by the limited resource.
+	createPodExpectAllowed(srv.ctx, srv.client, ns.Name, newPod("no-cpu", nil, nil), t)
+
+	// Once a quota covering requests.cpu exists, the cpu-requesting pod is admitted.
+	quota := newResourceQuota(ns.Name, "quota", v1.ResourceList{v1.ResourceRequestsCPU: resource.MustParse("10")})
+	waitForQuota(t, quota, srv.client)
+	createPodExpectAllowed(srv.ctx, srv.client, ns.Name, cpuPod("needs-cpu-allowed"), t)
+}

--- a/test/integration/quota/quota_compute_test.go
+++ b/test/integration/quota/quota_compute_test.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package quota
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+// TestQuotaPodCountReplenishOnDelete verifies that a quota on the pods object count blocks creation
+// past the limit, and that deleting a pod replenishes usage so a create succeeds again.
+func TestQuotaPodCountReplenishOnDelete(t *testing.T) {
+	srv, tearDown := startQuotaTestServer(t, quotaServerOptions{})
+	defer tearDown()
+
+	ns := framework.CreateNamespaceOrDie(srv.client, "quota-pod-count", t)
+	defer framework.DeleteNamespaceOrDie(srv.client, ns, t)
+
+	quota := newResourceQuota(ns.Name, "quota", v1.ResourceList{
+		v1.ResourcePods: resource.MustParse("2"),
+	})
+	waitForQuota(t, quota, srv.client)
+
+	// Fill the quota: two pods are allowed, the third is denied.
+	createPodExpectAllowed(srv.ctx, srv.client, ns.Name, newPod("pod-1", nil, nil), t)
+	createPodExpectAllowed(srv.ctx, srv.client, ns.Name, newPod("pod-2", nil, nil), t)
+	expectedQuotaUsed := v1.ResourceList{
+		v1.ResourcePods: resource.MustParse("2"),
+	}
+	waitForUsedResourceQuota(t, srv.client, ns.Name, quota.Name, expectedQuotaUsed)
+	createPodExpectForbidden(srv.ctx, srv.client, ns.Name, newPod("pod-3", nil, nil), t)
+
+	// Deleting a pod replenishes the quota, so the previously-denied pod can be created.
+	if err := srv.client.CoreV1().Pods(ns.Name).Delete(srv.ctx, "pod-1", metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("deleting pod-1: %v", err)
+	}
+	createPodExpectAllowed(srv.ctx, srv.client, ns.Name, newPod("pod-3", nil, nil), t)
+	expectedQuotaUsed = v1.ResourceList{
+		v1.ResourcePods: resource.MustParse("2"),
+	}
+	waitForUsedResourceQuota(t, srv.client, ns.Name, quota.Name, expectedQuotaUsed)
+}
+
+// TestQuotaComputeResources verifies that compute request/limit quotas (cpu and memory) are charged
+// from pod specs and deny pods that would exceed the hard limit.
+func TestQuotaComputeResources(t *testing.T) {
+	srv, tearDown := startQuotaTestServer(t, quotaServerOptions{})
+	defer tearDown()
+
+	ns := framework.CreateNamespaceOrDie(srv.client, "quota-compute", t)
+	defer framework.DeleteNamespaceOrDie(srv.client, ns, t)
+
+	quota := newResourceQuota(ns.Name, "quota", v1.ResourceList{
+		v1.ResourceRequestsCPU:    resource.MustParse("1"),
+		v1.ResourceRequestsMemory: resource.MustParse("1Gi"),
+		v1.ResourceLimitsCPU:      resource.MustParse("2"),
+		v1.ResourceLimitsMemory:   resource.MustParse("2Gi"),
+	})
+	waitForQuota(t, quota, srv.client)
+
+	// A pod within budget is charged for all four compute dimensions.
+	pod := newPod("pod-1",
+		v1.ResourceList{v1.ResourceCPU: resource.MustParse("500m"), v1.ResourceMemory: resource.MustParse("512Mi")},
+		v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("1Gi")},
+	)
+	createPodExpectAllowed(srv.ctx, srv.client, ns.Name, pod, t)
+	expectedQuotaUsed := v1.ResourceList{
+		v1.ResourceRequestsCPU:    resource.MustParse("500m"),
+		v1.ResourceRequestsMemory: resource.MustParse("512Mi"),
+		v1.ResourceLimitsCPU:      resource.MustParse("1"),
+		v1.ResourceLimitsMemory:   resource.MustParse("1Gi"),
+	}
+	waitForUsedResourceQuota(t, srv.client, ns.Name, quota.Name, expectedQuotaUsed)
+
+	// A second pod pushing requests.cpu over the hard limit (500m + 600m > 1) is denied. The other
+	// dimensions stay within budget, so the only possible denial cause is requests.cpu.
+	overBudget := newPod("pod-2",
+		v1.ResourceList{v1.ResourceCPU: resource.MustParse("600m"), v1.ResourceMemory: resource.MustParse("256Mi")},
+		v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("512Mi")},
+	)
+	createPodExpectForbidden(srv.ctx, srv.client, ns.Name, overBudget, t)
+}
+
+// TestQuotaPodConstraintsDenial verifies the admission Constraints check: once a quota tracks a
+// compute resource, a pod that omits that request is denied ("must specify ...").
+//
+// Guard: this namespace must have no LimitRange, otherwise the LimitRanger admission plugin would
+// default the missing request and the pod would pass, masking the denial.
+func TestQuotaPodConstraintsDenial(t *testing.T) {
+	srv, tearDown := startQuotaTestServer(t, quotaServerOptions{})
+	defer tearDown()
+
+	ns := framework.CreateNamespaceOrDie(srv.client, "quota-constraints", t)
+	defer framework.DeleteNamespaceOrDie(srv.client, ns, t)
+
+	// Hard limit is generous so a denial can only be the Constraints check, not an over-quota.
+	quota := newResourceQuota(ns.Name, "quota", v1.ResourceList{
+		v1.ResourceRequestsCPU: resource.MustParse("10"),
+	})
+	waitForQuota(t, quota, srv.client)
+
+	// A pod that omits the cpu request is denied.
+	createPodExpectForbidden(srv.ctx, srv.client, ns.Name, newPod("no-request", nil, nil), t)
+
+	// A pod that specifies the cpu request is admitted.
+	withRequest := newPod("with-request",
+		v1.ResourceList{v1.ResourceCPU: resource.MustParse("100m")},
+		nil,
+	)
+	createPodExpectAllowed(srv.ctx, srv.client, ns.Name, withRequest, t)
+}
+
+// TestQuotaHugepages verifies that a quota on requests.hugepages-2Mi is charged from a pod's
+// hugepages request and denies pods that would exceed it.
+func TestQuotaHugepages(t *testing.T) {
+	srv, tearDown := startQuotaTestServer(t, quotaServerOptions{})
+	defer tearDown()
+
+	ns := framework.CreateNamespaceOrDie(srv.client, "quota-hugepages", t)
+	defer framework.DeleteNamespaceOrDie(srv.client, ns, t)
+
+	hugepages := v1.ResourceName("hugepages-2Mi")
+	requestsHugepages := v1.ResourceName("requests.hugepages-2Mi")
+
+	quota := newResourceQuota(ns.Name, "quota", v1.ResourceList{
+		requestsHugepages: resource.MustParse("2Mi"),
+	})
+	waitForQuota(t, quota, srv.client)
+
+	// Hugepages validation requires limit == request and that the container also sets cpu or memory.
+	newHugepagePod := func(name string) *v1.Pod {
+		return newPod(name,
+			v1.ResourceList{v1.ResourceCPU: resource.MustParse("100m"), hugepages: resource.MustParse("2Mi")},
+			v1.ResourceList{hugepages: resource.MustParse("2Mi")},
+		)
+	}
+
+	createPodExpectAllowed(srv.ctx, srv.client, ns.Name, newHugepagePod("pod-1"), t)
+	expectedQuotaUsed := v1.ResourceList{
+		requestsHugepages: resource.MustParse("2Mi"),
+	}
+	waitForUsedResourceQuota(t, srv.client, ns.Name, quota.Name, expectedQuotaUsed)
+
+	// A second hugepage pod exceeds the 2Mi hard limit and is denied.
+	createPodExpectForbidden(srv.ctx, srv.client, ns.Name, newHugepagePod("pod-2"), t)
+}
+
+// TestQuotaTerminatedPodExclusion verifies that when a pod reaches a terminal phase, the controller
+// replenishes the compute/pods usage it was charged, while the count/pods object-count usage stays.
+// This exercises update-driven replenishment via the
+// DefaultUpdateFilter pods branch, which the helper wires into the controller.
+func TestQuotaTerminatedPodExclusion(t *testing.T) {
+	srv, tearDown := startQuotaTestServer(t, quotaServerOptions{})
+	defer tearDown()
+
+	ns := framework.CreateNamespaceOrDie(srv.client, "quota-terminated", t)
+	defer framework.DeleteNamespaceOrDie(srv.client, ns, t)
+
+	countPods := v1.ResourceName("count/pods")
+	quota := newResourceQuota(ns.Name, "quota", v1.ResourceList{
+		v1.ResourcePods:        resource.MustParse("10"),
+		v1.ResourceRequestsCPU: resource.MustParse("10"),
+		countPods:              resource.MustParse("10"),
+	})
+	waitForQuota(t, quota, srv.client)
+
+	// Create a pod with a cpu request (required because the quota tracks requests.cpu).
+	pod := newPod("pod-1",
+		v1.ResourceList{v1.ResourceCPU: resource.MustParse("500m")},
+		nil,
+	)
+	createPodExpectAllowed(srv.ctx, srv.client, ns.Name, pod, t)
+	expectedQuotaUsed := v1.ResourceList{
+		v1.ResourcePods:        resource.MustParse("1"),
+		v1.ResourceRequestsCPU: resource.MustParse("500m"),
+		countPods:              resource.MustParse("1"),
+	}
+	waitForUsedResourceQuota(t, srv.client, ns.Name, quota.Name, expectedQuotaUsed)
+
+	// Drive the pod to a terminal phase via the status subresource (no kubelet runs here).
+	got, err := srv.client.CoreV1().Pods(ns.Name).Get(srv.ctx, pod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("getting pod %s: %v", pod.Name, err)
+	}
+	got.Status.Phase = v1.PodSucceeded
+	got.Status.ContainerStatuses = []v1.ContainerStatus{{
+		Name: "container",
+		State: v1.ContainerState{
+			Terminated: &v1.ContainerStateTerminated{FinishedAt: metav1.Now()},
+		},
+	}}
+	if _, err := srv.client.CoreV1().Pods(ns.Name).UpdateStatus(srv.ctx, got, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("updating pod %s status to Succeeded: %v", pod.Name, err)
+	}
+
+	// The controller replenishes compute/pods usage for the terminal pod, but count/pods keeps it.
+	expectedQuotaUsed = v1.ResourceList{
+		v1.ResourcePods:        resource.MustParse("0"),
+		v1.ResourceRequestsCPU: resource.MustParse("0"),
+		countPods:              resource.MustParse("1"),
+	}
+	waitForUsedResourceQuota(t, srv.client, ns.Name, quota.Name, expectedQuotaUsed)
+}

--- a/test/integration/quota/quota_lifecycle_test.go
+++ b/test/integration/quota/quota_lifecycle_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package quota
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+// waitForResourceQuotaHard polls until the quota's Status.Hard exactly matches the expected hard
+// list (both the set of keys and each value), so it also detects resources being removed.
+func waitForResourceQuotaHard(t *testing.T, srv *quotaTestServer, ns, name string, hard v1.ResourceList) {
+	t.Helper()
+	err := wait.PollUntilContextTimeout(srv.ctx, quotaPollInterval, quotaPollTimeout, true, func(ctx context.Context) (bool, error) {
+		q, err := srv.client.CoreV1().ResourceQuotas(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if len(q.Status.Hard) != len(hard) {
+			return false, nil
+		}
+		for k, v := range hard {
+			actual, ok := q.Status.Hard[k]
+			if !ok || !actual.Equal(v) {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("quota %s status.hard did not converge to %v: %v", name, hard, err)
+	}
+}
+
+// updateQuotaHard replaces a quota's Spec.Hard, retrying on conflict because the controller writes
+// the status subresource concurrently and bumps the resourceVersion.
+func updateQuotaHard(t *testing.T, srv *quotaTestServer, ns, name string, hard v1.ResourceList) {
+	t.Helper()
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		q, err := srv.client.CoreV1().ResourceQuotas(ns).Get(srv.ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		q.Spec.Hard = hard
+		_, err = srv.client.CoreV1().ResourceQuotas(ns).Update(srv.ctx, q, metav1.UpdateOptions{})
+		return err
+	}); err != nil {
+		t.Fatalf("updating quota %s hard: %v", name, err)
+	}
+}
+
+// TestQuotaStatusInitialized verifies that creating a ResourceQuota leads the controller to
+// initialize Status.Hard (mirroring Spec.Hard) and Status.Used (zero for every tracked resource).
+func TestQuotaStatusInitialized(t *testing.T) {
+	srv, tearDown := startQuotaTestServer(t, quotaServerOptions{})
+	defer tearDown()
+
+	ns := framework.CreateNamespaceOrDie(srv.client, "quota-status-init", t)
+	defer framework.DeleteNamespaceOrDie(srv.client, ns, t)
+
+	hard := v1.ResourceList{
+		v1.ResourcePods:        resource.MustParse("5"),
+		v1.ResourceRequestsCPU: resource.MustParse("1"),
+	}
+	quota := newResourceQuota(ns.Name, "quota", hard)
+	waitForQuota(t, quota, srv.client)
+
+	waitForResourceQuotaHard(t, srv, ns.Name, quota.Name, hard)
+	expectedQuotaUsed := v1.ResourceList{
+		v1.ResourcePods:        resource.MustParse("0"),
+		v1.ResourceRequestsCPU: resource.MustParse("0"),
+	}
+	waitForUsedResourceQuota(t, srv.client, ns.Name, quota.Name, expectedQuotaUsed)
+}
+
+// TestQuotaUpdateHardRecompute verifies that editing Spec.Hard re-drives the controller: adding a
+// resource makes it appear in Status.Hard/Used, and removing one drops it.
+func TestQuotaUpdateHardRecompute(t *testing.T) {
+	srv, tearDown := startQuotaTestServer(t, quotaServerOptions{})
+	defer tearDown()
+
+	ns := framework.CreateNamespaceOrDie(srv.client, "quota-update-hard", t)
+	defer framework.DeleteNamespaceOrDie(srv.client, ns, t)
+
+	quota := newResourceQuota(ns.Name, "quota", v1.ResourceList{v1.ResourcePods: resource.MustParse("5")})
+	waitForQuota(t, quota, srv.client)
+	waitForResourceQuotaHard(t, srv, ns.Name, quota.Name, v1.ResourceList{v1.ResourcePods: resource.MustParse("5")})
+
+	// Add a resource and tighten pods: the controller recomputes both Hard and Used.
+	updateQuotaHard(t, srv, ns.Name, quota.Name, v1.ResourceList{
+		v1.ResourcePods:        resource.MustParse("3"),
+		v1.ResourceRequestsCPU: resource.MustParse("2"),
+	})
+	waitForResourceQuotaHard(t, srv, ns.Name, quota.Name, v1.ResourceList{
+		v1.ResourcePods:        resource.MustParse("3"),
+		v1.ResourceRequestsCPU: resource.MustParse("2"),
+	})
+	expectedQuotaUsed := v1.ResourceList{
+		v1.ResourcePods:        resource.MustParse("0"),
+		v1.ResourceRequestsCPU: resource.MustParse("0"),
+	}
+	waitForUsedResourceQuota(t, srv.client, ns.Name, quota.Name, expectedQuotaUsed)
+
+	// Remove the added resource: it drops out of Status.Hard.
+	updateQuotaHard(t, srv, ns.Name, quota.Name, v1.ResourceList{v1.ResourcePods: resource.MustParse("3")})
+	waitForResourceQuotaHard(t, srv, ns.Name, quota.Name, v1.ResourceList{v1.ResourcePods: resource.MustParse("3")})
+}
+
+// TestQuotaListAndDeleteCollection verifies the ResourceQuota collection endpoints: List returns
+// every quota in the namespace and DeleteCollection removes them all.
+func TestQuotaListAndDeleteCollection(t *testing.T) {
+	srv, tearDown := startQuotaTestServer(t, quotaServerOptions{})
+	defer tearDown()
+
+	ns := framework.CreateNamespaceOrDie(srv.client, "quota-list", t)
+	defer framework.DeleteNamespaceOrDie(srv.client, ns, t)
+
+	for _, name := range []string{"quota-a", "quota-b", "quota-c"} {
+		q := newResourceQuota(ns.Name, name, v1.ResourceList{v1.ResourcePods: resource.MustParse("1")})
+		if _, err := srv.client.CoreV1().ResourceQuotas(ns.Name).Create(srv.ctx, q, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("creating quota %s: %v", name, err)
+		}
+	}
+
+	list, err := srv.client.CoreV1().ResourceQuotas(ns.Name).List(srv.ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("listing quotas: %v", err)
+	}
+	if len(list.Items) != 3 {
+		t.Fatalf("expected 3 quotas, got %d", len(list.Items))
+	}
+
+	if err := srv.client.CoreV1().ResourceQuotas(ns.Name).DeleteCollection(srv.ctx, metav1.DeleteOptions{}, metav1.ListOptions{}); err != nil {
+		t.Fatalf("delete collection: %v", err)
+	}
+
+	// DeleteCollection is observed asynchronously, so poll until the namespace has no quotas.
+	err = wait.PollUntilContextTimeout(srv.ctx, quotaPollInterval, quotaPollTimeout, true, func(ctx context.Context) (bool, error) {
+		remaining, err := srv.client.CoreV1().ResourceQuotas(ns.Name).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, err
+		}
+		return len(remaining.Items) == 0, nil
+	})
+	if err != nil {
+		t.Fatalf("quotas were not all deleted: %v", err)
+	}
+}

--- a/test/integration/quota/quota_scopes_test.go
+++ b/test/integration/quota/quota_scopes_test.go
@@ -1,0 +1,278 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package quota
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/integration/framework"
+	"k8s.io/utils/ptr"
+)
+
+// mustCreatePriorityClass creates a (cluster-scoped) PriorityClass, tolerating AlreadyExists. The
+// Priority admission plugin is on by default and rejects pods referencing a class that does not
+// exist, so scope tests must create their classes before creating pods that reference them.
+func mustCreatePriorityClass(t *testing.T, srv *quotaTestServer, name string, value int32) {
+	t.Helper()
+	_, err := srv.client.SchedulingV1().PriorityClasses().Create(srv.ctx, &schedulingv1.PriorityClass{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Value:      value,
+	}, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("creating priority class %s: %v", name, err)
+	}
+}
+
+// newPriorityClassScopedQuota builds a ResourceQuota whose PriorityClass scope is expressed via a
+// single scope-selector requirement (the only supported form for the PriorityClass scope).
+func newPriorityClassScopedQuota(ns, name string, hard v1.ResourceList, op v1.ScopeSelectorOperator, values []string) *v1.ResourceQuota {
+	return &v1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: v1.ResourceQuotaSpec{
+			Hard: hard,
+			ScopeSelector: &v1.ScopeSelector{
+				MatchExpressions: []v1.ScopedResourceSelectorRequirement{
+					{ScopeName: v1.ResourceQuotaScopePriorityClass, Operator: op, Values: values},
+				},
+			},
+		},
+	}
+}
+
+// terminatingPod returns a pod that the quota system treats as Terminating (activeDeadlineSeconds set).
+func terminatingPod(name string) *v1.Pod {
+	pod := newPod(name, nil, nil)
+	pod.Spec.ActiveDeadlineSeconds = ptr.To(int64(100))
+	return pod
+}
+
+// priorityPod returns a pod that references the given priority class.
+func priorityPod(name, pclass string, requests v1.ResourceList) *v1.Pod {
+	pod := newPod(name, requests, nil)
+	pod.Spec.PriorityClassName = pclass
+	return pod
+}
+
+// burstablePod returns a Burstable pod (it sets a cpu request but no limit).
+func burstablePod(name string) *v1.Pod {
+	requests := v1.ResourceList{v1.ResourceCPU: resource.MustParse("100m")}
+	return newPod(name, requests, nil)
+}
+
+// crossNamespaceAffinityPod returns a pod whose required pod affinity targets another namespace,
+// which the CrossNamespacePodAffinity scope matches.
+func crossNamespaceAffinityPod(name string) *v1.Pod {
+	pod := newPod(name, nil, nil)
+	pod.Spec.Affinity = &v1.Affinity{
+		PodAffinity: &v1.PodAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{{
+				LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
+				Namespaces:    []string{"other-namespace"},
+				TopologyKey:   "kubernetes.io/hostname",
+			}},
+		},
+	}
+	return pod
+}
+
+// TestQuotaScopes verifies that a scoped pods=1 quota counts only the pods matching its scope: the
+// "uncounted" pod does not match the scope and never charges the quota, while a "counted" pod
+// matches, fills the single-pod budget, and a second matching pod is denied. Each scope (Terminating
+// / BestEffort / PriorityClass / CrossNamespacePodAffinity, and their negations) is a row.
+func TestQuotaScopes(t *testing.T) {
+	podsHard := v1.ResourceList{v1.ResourcePods: resource.MustParse("1")}
+
+	tests := []struct {
+		name string
+		// priorityClasses, if set, are created (cluster-scoped) before the quota.
+		priorityClasses []string
+		quota           func(ns string) *v1.ResourceQuota
+		uncounted       func(name string) *v1.Pod
+		counted         func(name string) *v1.Pod
+	}{
+		{
+			name: "Terminating",
+			quota: func(ns string) *v1.ResourceQuota {
+				return newResourceQuota(ns, "quota", podsHard, v1.ResourceQuotaScopeTerminating)
+			},
+			uncounted: func(name string) *v1.Pod { return newPod(name, nil, nil) },
+			counted:   terminatingPod,
+		},
+		{
+			name: "NotTerminating",
+			quota: func(ns string) *v1.ResourceQuota {
+				return newResourceQuota(ns, "quota", podsHard, v1.ResourceQuotaScopeNotTerminating)
+			},
+			uncounted: terminatingPod,
+			counted:   func(name string) *v1.Pod { return newPod(name, nil, nil) },
+		},
+		{
+			name: "BestEffort",
+			quota: func(ns string) *v1.ResourceQuota {
+				return newResourceQuota(ns, "quota", podsHard, v1.ResourceQuotaScopeBestEffort)
+			},
+			uncounted: burstablePod,
+			counted:   func(name string) *v1.Pod { return newPod(name, nil, nil) },
+		},
+		{
+			name: "NotBestEffort",
+			quota: func(ns string) *v1.ResourceQuota {
+				return newResourceQuota(ns, "quota", podsHard, v1.ResourceQuotaScopeNotBestEffort)
+			},
+			uncounted: func(name string) *v1.Pod { return newPod(name, nil, nil) },
+			counted:   burstablePod,
+		},
+		{
+			name:            "PriorityClassIn",
+			priorityClasses: []string{"pclass-in"},
+			quota: func(ns string) *v1.ResourceQuota {
+				return newPriorityClassScopedQuota(ns, "quota", podsHard, v1.ScopeSelectorOpIn, []string{"pclass-in"})
+			},
+			uncounted: func(name string) *v1.Pod { return newPod(name, nil, nil) },
+			counted:   func(name string) *v1.Pod { return priorityPod(name, "pclass-in", nil) },
+		},
+		{
+			name:            "PriorityClassNotIn",
+			priorityClasses: []string{"pclass-excluded", "pclass-counted"},
+			quota: func(ns string) *v1.ResourceQuota {
+				return newPriorityClassScopedQuota(ns, "quota", podsHard, v1.ScopeSelectorOpNotIn, []string{"pclass-excluded"})
+			},
+			uncounted: func(name string) *v1.Pod { return priorityPod(name, "pclass-excluded", nil) },
+			counted:   func(name string) *v1.Pod { return priorityPod(name, "pclass-counted", nil) },
+		},
+		{
+			name:            "PriorityClassExists",
+			priorityClasses: []string{"pclass-exists"},
+			quota: func(ns string) *v1.ResourceQuota {
+				return newPriorityClassScopedQuota(ns, "quota", podsHard, v1.ScopeSelectorOpExists, nil)
+			},
+			uncounted: func(name string) *v1.Pod { return newPod(name, nil, nil) },
+			counted:   func(name string) *v1.Pod { return priorityPod(name, "pclass-exists", nil) },
+		},
+		{
+			name: "CrossNamespacePodAffinity",
+			quota: func(ns string) *v1.ResourceQuota {
+				return newResourceQuota(ns, "quota", podsHard, v1.ResourceQuotaScopeCrossNamespacePodAffinity)
+			},
+			uncounted: func(name string) *v1.Pod { return newPod(name, nil, nil) },
+			counted:   crossNamespaceAffinityPod,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, tearDown := startQuotaTestServer(t, quotaServerOptions{})
+			defer tearDown()
+
+			ns := framework.CreateNamespaceOrDie(srv.client, "quota-scope", t)
+			defer framework.DeleteNamespaceOrDie(srv.client, ns, t)
+
+			for _, pc := range tc.priorityClasses {
+				mustCreatePriorityClass(t, srv, pc, 1000)
+			}
+
+			quota := tc.quota(ns.Name)
+			waitForQuota(t, quota, srv.client)
+			wantUsedZero := v1.ResourceList{v1.ResourcePods: resource.MustParse("0")}
+			waitForUsedResourceQuota(t, srv.client, ns.Name, quota.Name, wantUsedZero)
+
+			// The uncounted pod does not match the scope, so it never charges the quota.
+			createPodExpectAllowed(srv.ctx, srv.client, ns.Name, tc.uncounted("uncounted"), t)
+			// The first matching pod fills the single-pod scoped quota.
+			createPodExpectAllowed(srv.ctx, srv.client, ns.Name, tc.counted("counted-1"), t)
+			wantUsedOne := v1.ResourceList{v1.ResourcePods: resource.MustParse("1")}
+			waitForUsedResourceQuota(t, srv.client, ns.Name, quota.Name, wantUsedOne)
+			// A second matching pod exceeds it.
+			createPodExpectForbidden(srv.ctx, srv.client, ns.Name, tc.counted("counted-2"), t)
+		})
+	}
+}
+
+// TestQuotaScopePriorityClassMultiCount verifies that when a quota's PriorityClass scope uses "In" with several classes,
+// pods of any listed class draw from the same pod budget.
+func TestQuotaScopePriorityClassMultiCount(t *testing.T) {
+	srv, tearDown := startQuotaTestServer(t, quotaServerOptions{})
+	defer tearDown()
+
+	ns := framework.CreateNamespaceOrDie(srv.client, "quota-pc-multi", t)
+	defer framework.DeleteNamespaceOrDie(srv.client, ns, t)
+
+	mustCreatePriorityClass(t, srv, "pclass-a", 1000)
+	mustCreatePriorityClass(t, srv, "pclass-b", 1000)
+
+	podsHard := v1.ResourceList{v1.ResourcePods: resource.MustParse("2")}
+	classes := []string{"pclass-a", "pclass-b"}
+	quota := newPriorityClassScopedQuota(ns.Name, "quota", podsHard, v1.ScopeSelectorOpIn, classes)
+	waitForQuota(t, quota, srv.client)
+	wantUsedZero := v1.ResourceList{v1.ResourcePods: resource.MustParse("0")}
+	waitForUsedResourceQuota(t, srv.client, ns.Name, quota.Name, wantUsedZero)
+
+	createPodExpectAllowed(srv.ctx, srv.client, ns.Name, priorityPod("pod-a", "pclass-a", nil), t)
+	createPodExpectAllowed(srv.ctx, srv.client, ns.Name, priorityPod("pod-b", "pclass-b", nil), t)
+	wantUsedTwo := v1.ResourceList{v1.ResourcePods: resource.MustParse("2")}
+	waitForUsedResourceQuota(t, srv.client, ns.Name, quota.Name, wantUsedTwo)
+	createPodExpectForbidden(srv.ctx, srv.client, ns.Name, priorityPod("pod-c", "pclass-a", nil), t)
+}
+
+// TestQuotaScopePriorityClassCompute verifies a PriorityClass-scoped quota can limit compute
+// resources (not just pod count): a matching pod charges the scoped compute usage and exceeding it
+// denies, while a pod without the class is unscoped and not charged.
+func TestQuotaScopePriorityClassCompute(t *testing.T) {
+	srv, tearDown := startQuotaTestServer(t, quotaServerOptions{})
+	defer tearDown()
+
+	ns := framework.CreateNamespaceOrDie(srv.client, "quota-pc-compute", t)
+	defer framework.DeleteNamespaceOrDie(srv.client, ns, t)
+
+	mustCreatePriorityClass(t, srv, "pclass-compute", 1000)
+
+	computeHard := v1.ResourceList{
+		v1.ResourceRequestsCPU:    resource.MustParse("1"),
+		v1.ResourceRequestsMemory: resource.MustParse("1Gi"),
+	}
+	quota := newPriorityClassScopedQuota(ns.Name, "quota", computeHard, v1.ScopeSelectorOpIn, []string{"pclass-compute"})
+	waitForQuota(t, quota, srv.client)
+
+	// A matching pod charges the scoped compute usage.
+	matchingRequests := v1.ResourceList{
+		v1.ResourceCPU:    resource.MustParse("500m"),
+		v1.ResourceMemory: resource.MustParse("512Mi"),
+	}
+	matching := priorityPod("matching", "pclass-compute", matchingRequests)
+	createPodExpectAllowed(srv.ctx, srv.client, ns.Name, matching, t)
+
+	// A pod without the class is unscoped: it is allowed and does not change the scoped usage.
+	createPodExpectAllowed(srv.ctx, srv.client, ns.Name, newPod("unscoped", nil, nil), t)
+	wantUsed := v1.ResourceList{
+		v1.ResourceRequestsCPU:    resource.MustParse("500m"),
+		v1.ResourceRequestsMemory: resource.MustParse("512Mi"),
+	}
+	waitForUsedResourceQuota(t, srv.client, ns.Name, quota.Name, wantUsed)
+
+	// A second matching pod pushing requests.cpu over the hard limit (500m + 600m > 1) is denied.
+	overBudgetRequests := v1.ResourceList{
+		v1.ResourceCPU:    resource.MustParse("600m"),
+		v1.ResourceMemory: resource.MustParse("256Mi"),
+	}
+	overBudget := priorityPod("over-budget", "pclass-compute", overBudgetRequests)
+	createPodExpectForbidden(srv.ctx, srv.client, ns.Name, overBudget, t)
+}

--- a/test/integration/quota/util_test.go
+++ b/test/integration/quota/util_test.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package quota
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/quota/v1/generic"
+	"k8s.io/client-go/informers"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
+	"k8s.io/kubernetes/pkg/controller"
+	resourcequotacontroller "k8s.io/kubernetes/pkg/controller/resourcequota"
+	quotainstall "k8s.io/kubernetes/pkg/quota/v1/install"
+	"k8s.io/kubernetes/test/integration/framework"
+	"k8s.io/kubernetes/test/utils/ktesting"
+)
+
+// quotaPollInterval/quotaPollTimeout are the poll budget for quota assertions on this race-prone
+// surface. The historical resourceQuotaTimeout (10s) was raised to a full minute by several
+// deflake commits, so new tests use the larger budget.
+const (
+	quotaPollInterval = time.Second
+	quotaPollTimeout  = time.Minute
+)
+
+// quotaServerOptions configures a quota integration test server. The zero value is valid: no
+// admission config.
+type quotaServerOptions struct {
+	// admissionConfigFile is the path to an apiserver admission ConfigFile (e.g. for
+	// limitedResources). "" disables it.
+	admissionConfigFile string
+}
+
+// quotaTestServer is a running apiserver wired to the resourcequota controller. client is the
+// concrete type so the existing package helpers (waitForQuota, scale) can be reused directly.
+type quotaTestServer struct {
+	client *clientset.Clientset
+	ctx    context.Context
+}
+
+// startQuotaTestServer starts an apiserver (with the ServiceAccount admission plugin disabled,
+// since no service-account controller runs here) and the resourcequota controller. It mirrors the
+// inline setup in quota_test.go, with one addition: the
+// controller is wired with quotainstall.DefaultUpdateFilter so that update-driven replenishment
+// (e.g. a pod transitioning to a terminal phase) fires exactly as it does under the real
+// controller-manager (cmd/kube-controller-manager/app/core.go). Returns the server handle and a
+// teardown func; callers defer the teardown before creating namespaces so they tear down first.
+func startQuotaTestServer(t *testing.T, opts quotaServerOptions) (*quotaTestServer, func()) {
+	t.Helper()
+	tCtx := ktesting.Init(t)
+
+	_, kubeConfig, tearDownFn := framework.StartTestServer(tCtx, t, framework.TestServerSetup{
+		ModifyServerRunOptions: func(o *options.ServerRunOptions) {
+			// Disable ServiceAccount admission plugin as we don't have a serviceaccount controller running.
+			o.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
+			if opts.admissionConfigFile != "" {
+				o.Admission.GenericAdmission.ConfigFile = opts.admissionConfigFile
+			}
+		},
+	})
+
+	clientSet := clientset.NewForConfigOrDie(kubeConfig)
+
+	informerFactory := informers.NewSharedInformerFactory(clientSet, controller.NoResyncPeriodFunc())
+
+	discoveryFunc := clientSet.Discovery().ServerPreferredNamespacedResources
+	listerFuncForResource := generic.ListerFuncForResourceFunc(informerFactory.ForResource)
+	qc, err := quotainstall.NewQuotaConfigurationForControllers(listerFuncForResource, informerFactory)
+	if err != nil {
+		tearDownFn()
+		t.Fatalf("unexpected err: %v", err)
+	}
+	informersStarted := make(chan struct{})
+	resourceQuotaControllerOptions := &resourcequotacontroller.ControllerOptions{
+		QuotaClient:               clientSet.CoreV1(),
+		ResourceQuotaInformer:     informerFactory.Core().V1().ResourceQuotas(),
+		ResyncPeriod:              controller.NoResyncPeriodFunc,
+		InformerFactory:           informerFactory,
+		ReplenishmentResyncPeriod: controller.NoResyncPeriodFunc,
+		DiscoveryFunc:             discoveryFunc,
+		IgnoredResourcesFunc:      qc.IgnoredResources,
+		InformersStarted:          informersStarted,
+		Registry:                  generic.NewRegistry(qc.Evaluators()),
+		// Match the real controller-manager so update events drive replenishment.
+		UpdateFilter: quotainstall.DefaultUpdateFilter(),
+	}
+	resourceQuotaController, err := resourcequotacontroller.NewController(tCtx, resourceQuotaControllerOptions)
+	if err != nil {
+		tearDownFn()
+		t.Fatalf("unexpected err: %v", err)
+	}
+	go resourceQuotaController.Run(tCtx, 2)
+
+	// Periodically the quota controller to detect new resource types
+	go resourceQuotaController.Sync(tCtx, discoveryFunc, 30*time.Second)
+
+	informerFactory.Start(tCtx.Done())
+	close(informersStarted)
+
+	return &quotaTestServer{client: clientSet, ctx: tCtx}, tearDownFn
+}
+
+// newResourceQuota builds a ResourceQuota in ns with the given hard limits and optional scopes.
+// The namespace is set on the object so it can be passed to waitForQuota.
+func newResourceQuota(ns, name string, hard v1.ResourceList, scopes ...v1.ResourceQuotaScope) *v1.ResourceQuota {
+	return &v1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: v1.ResourceQuotaSpec{
+			Hard:   hard,
+			Scopes: scopes,
+		},
+	}
+}
+
+// newPod builds a single-container pod. requests/limits may be nil. The namespace is taken from
+// the create call (createPodExpectAllowed, createPodExpectForbidden), not set here.
+func newPod(name string, requests, limits v1.ResourceList) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{
+				Name:  "container",
+				Image: "busybox",
+				Resources: v1.ResourceRequirements{
+					Requests: requests,
+					Limits:   limits,
+				},
+			}},
+		},
+	}
+}
+
+// createPodExpectAllowed polls attempting to create pod until the create succeeds, absorbing the
+// admission-cache lag that follows a quota create or an object delete (the "now allowed"
+// direction; cf. deflake commit b8676e4763f, which retries creates for the same reason). Returns
+// the created pod.
+func createPodExpectAllowed(ctx context.Context, c clientset.Interface, namespace string, pod *v1.Pod, t *testing.T) *v1.Pod {
+	t.Helper()
+	var created *v1.Pod
+	err := wait.PollUntilContextTimeout(ctx, quotaPollInterval, quotaPollTimeout, true, func(ctx context.Context) (bool, error) {
+		p, err := c.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
+		switch {
+		case err == nil:
+			created = p
+			return true, nil
+		case apierrors.IsForbidden(err):
+			return false, nil
+		default:
+			return false, err
+		}
+	})
+	if err != nil {
+		t.Fatalf("creating pod %s/%s should eventually be allowed but got: %v", namespace, pod.Name, err)
+	}
+	return created
+}
+
+// createPodExpectForbidden polls creating the pod until rejected with 403 Forbidden (a quota denial).
+// Quota admission is eventually consistent: while its cached status.used still lags, a create that
+// should be denied may briefly succeed; that pod (or a leftover) is deleted and polling continues until
+// it stays forbidden. Never forbidden = test fails.
+func createPodExpectForbidden(ctx context.Context, c clientset.Interface, namespace string, pod *v1.Pod, t *testing.T) {
+	t.Helper()
+	err := wait.PollUntilContextTimeout(ctx, quotaPollInterval, quotaPollTimeout, true, func(ctx context.Context) (bool, error) {
+		p, err := c.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
+		switch {
+		case apierrors.IsForbidden(err):
+			return true, nil
+		case err != nil:
+			return false, err
+		default:
+			// Unexpected success due to admission-cache lag (pods here are unscheduled, so the
+			// delete is immediate): clean it up and keep polling.
+			if delErr := c.CoreV1().Pods(namespace).Delete(ctx, p.Name, metav1.DeleteOptions{}); delErr != nil && !apierrors.IsNotFound(delErr) {
+				return false, delErr
+			}
+			return false, nil
+		}
+	})
+	if err != nil {
+		t.Fatalf("creating pod %s/%s should eventually be forbidden by quota but got: %v", namespace, pod.Name, err)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area test

#### What this PR does / why we need it:
Add integration tests for `ResourceQuota`:
  - Compute: requests/limits.cpu + .memory, hugepages, pod-count replenishment on delete, terminal-phase pod exclusion.
  - Scopes: Terminating/NotTerminating, BestEffort/NotBestEffort, PriorityClass (In/NotIn/Exists, multi-class, compute-scoped), CrossNamespacePodAffinity.
  - Admission: dry-run enforcement, multiple quotas (most restrictive binds), limitedResources on a compute dimension.
  - Lifecycle: status init, Spec.Hard recompute on update, List/DeleteCollection.

#### Which issue(s) this PR is related to:
#139659


#### Special notes for your reviewer:
I believe ResourceQuota also caps object counts (count/secrets, count/configmaps, replicationcontrollers/replicasets, custom resources) and storage (PVC requests.storage, per storageclass limits). Should those be tested too? If yes, would you rather I include them in this PR or different one?

#### Does this PR introduce a user-facing change?
```
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```
