### PR TITLE
fix(certificate): prevent deadlock when template changes during wait

### DIFF
--- a/staging/src/k8s.io/client-go/util/certificate/certificate_manager.go
+++ b/staging/src/k8s.io/client-go/util/certificate/certificate_manager.go
@@ -433,7 +433,7 @@ func (m *manager) run() {
 	var wg sync.WaitGroup
 	defer wg.Wait()
 
-	templateChanged := make(chan struct{})
+	templateChanged := make(chan struct{}, 1)
 	rotate := func(ctx context.Context) {
 		deadline := m.nextRotationDeadline(logger)
 		if sleepInterval := deadline.Sub(m.now()); sleepInterval > 0 {
@@ -492,7 +492,7 @@ func (m *manager) run() {
 				}
 				select {
 				case templateChanged <- struct{}{}:
-				case <-ctx.Done():
+				default:
 				}
 			}
 		}

--- a/staging/src/k8s.io/client-go/util/certificate/certificate_manager_test.go
+++ b/staging/src/k8s.io/client-go/util/certificate/certificate_manager_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"net"
@@ -1623,4 +1624,114 @@ func certificateString(c *tls.Certificate) string {
 		return "certificate.Leaf == nil"
 	}
 	return c.Leaf.Subject.CommonName
+}
+
+func TestTemplateChangedDuringWait(t *testing.T) {
+	logger := ktesting.NewLogger(t, ktesting.NewConfig(
+		ktesting.BufferLogs(true),
+		ktesting.Verbosity(2),
+	))
+	ctx := klog.NewContext(context.Background(), logger)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Initial store with a valid cert
+	store := &fakeStore{
+		cert: &tls.Certificate{
+			Leaf: &x509.Certificate{
+				Subject: pkix.Name{
+					CommonName: "system:node:initial-name",
+				},
+				NotBefore: time.Now().Add(-1 * time.Hour),
+				NotAfter:  time.Now().Add(1 * time.Hour),
+			},
+		},
+	}
+
+	var mu sync.Mutex
+	templateCN := "system:node:name-A"
+	getTemplate := func() *x509.CertificateRequest {
+		mu.Lock()
+		defer mu.Unlock()
+		return &x509.CertificateRequest{
+			Subject: pkix.Name{
+				Organization: []string{"system:nodes"},
+				CommonName:   templateCN,
+			},
+		}
+	}
+
+	csrCreated := make(chan string, 10)
+	f := fake.NewSimpleClientset()
+	f.PrependReactor("create", "certificatesigningrequests", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+		createAction := action.(clienttesting.CreateAction)
+		switch action.GetResource().Version {
+		case "v1":
+			csr := createAction.GetObject().(*certificatesv1.CertificateSigningRequest)
+			block, _ := pem.Decode(csr.Spec.Request)
+			req, _ := x509.ParseCertificateRequest(block.Bytes)
+			csrCreated <- req.Subject.CommonName
+			return true, &certificatesv1.CertificateSigningRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fake-csr-name",
+					UID:  "fake-uid",
+				},
+			}, nil
+		default:
+			return false, nil, nil
+		}
+	})
+	f.PrependReactor("list", "certificatesigningrequests", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+		switch action.GetResource().Version {
+		case "v1":
+			return true, &certificatesv1.CertificateSigningRequestList{}, nil
+		default:
+			return false, nil, nil
+		}
+	})
+	f.PrependWatchReactor("certificatesigningrequests", func(action clienttesting.Action) (handled bool, ret watch.Interface, err error) {
+		// return a watch that never sends events, simulating waiting for approval
+		return true, watch.NewFake(), nil
+	})
+
+	m, err := NewManager(&Config{
+		Ctx:              &ctx,
+		GetTemplate:      getTemplate,
+		SignerName:       "kubernetes.io/kube-apiserver-client-kubelet",
+		Usages:           []certificatesv1.KeyUsage{certificatesv1.UsageClientAuth},
+		CertificateStore: store,
+		ClientsetFn: func(_ *tls.Certificate) (clientset.Interface, error) {
+			return f, nil
+		},
+	})
+	require.NoError(t, err, "initialize the certificate manager")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		m.(*manager).run()
+	}()
+	defer m.Stop()
+
+	// Wait for the first CSR to be created (should have common name A)
+	select {
+	case cn := <-csrCreated:
+		require.Equal(t, "system:node:name-A", cn)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timeout waiting for first CSR")
+	}
+
+	// Change template CN to name-B
+	mu.Lock()
+	templateCN = "system:node:name-B"
+	mu.Unlock()
+
+	// The manager should detect the change, cancel the wait, and issue a new CSR with name-B
+	select {
+	case cn := <-csrCreated:
+		require.Equal(t, "system:node:name-B", cn)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timeout waiting for second CSR - WaitForCertificate was not interrupted")
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This PR fixes a deadlock/long-timeout (up to 15 minutes) issue in `CertificateManager` that occurs when the certificate template changes while the manager is waiting for an outstanding CertificateSigningRequest (CSR) to be approved. 

Specifically, in `staging/src/k8s.io/client-go/util/certificate/certificate_manager.go`, the goroutines interact as follows:
1. `rotate` triggers a CSR request and blocks in `csr.WaitForCertificate`.
2. Meanwhile, a template change is detected by the `template` goroutine. It attempts to wake `rotate` by sending a signal via `templateChanged <- struct{}{}`.
3. However, `templateChanged` was an unbuffered channel and `rotate` is blocked in `WaitForCertificate` rather than selecting on `templateChanged`. This blocks the `template` goroutine indefinitely on the channel send.
4. Because the `template` goroutine is blocked, it cannot perform further checks or cancel the active wait when the cancel function is finally set (resolving the initial read-before-set race condition).

We fix this by:
1. Making `templateChanged` a channel with a buffer size of 1.
2. Making the send in the `template` goroutine non-blocking using a `select` block with a `default` case. This prevents the `template` goroutine from ever deadlocking, allowing it to continue polling on subsequent ticks and correctly trigger the cancellation.

#### Which issue(s) this PR is related to:
Fixes #136485

#### Special notes for your reviewer:
This is a lightweight and localized alternative to the larger refactoring attempted in #131952. The second race condition (read-before-set window of the cancel context) becomes self-healing because the `template` goroutine is no longer deadlocked: it retries on the next 1-second tick and correctly cancels the wait using the newly-set cancel context.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```
