### PR TITLE
Automated cherry pick of #139842: kubeadm: treat already promoted learner as successful

### DIFF
--- a/cmd/kubeadm/app/util/etcd/etcd.go
+++ b/cmd/kubeadm/app/util/etcd/etcd.go
@@ -626,14 +626,39 @@ func (c *Client) MemberPromote(learnerID uint64) error {
 	// 2. context deadline exceeded
 	// 3. peer URLs already exists
 	// Once the client provides a way to check if the etcd learner is ready to promote, the retry logic can be revisited.
-	var promoteResp *clientv3.MemberPromoteResponse
+	var memberList []*etcdserverpb.Member
 	err = wait.PollUntilContextTimeout(context.Background(), constants.EtcdAPICallRetryInterval, kubeadmapi.GetActiveTimeouts().EtcdAPICall.Duration,
 		true, func(_ context.Context) (bool, error) {
+			// MemberPromote can return a transient client-side error even if the
+			// promotion already succeeded on the etcd side. Check the current
+			// member state before attempting another promotion so that retries
+			// remain idempotent.
+			resp, statusErr := c.listMembersOnce()
+			if statusErr != nil {
+				klog.V(5).Infof("[etcd] Failed to list members before promoting learner %s: %v", learnerIDUint, statusErr)
+				lastError = statusErr
+				return false, nil
+			}
+
+			for _, m := range resp.Members {
+				if m.ID != learnerID {
+					continue
+				}
+
+				if !m.IsLearner {
+					klog.V(1).Infof("[etcd] Member %s is already a voting member, treating promotion as successful", learnerIDUint)
+					memberList = resp.Members
+					return true, nil
+				}
+				break
+			}
+
 			ctx, cancel := context.WithTimeout(context.Background(), etcdTimeout)
 			defer cancel()
-			promoteResp, err = cli.MemberPromote(ctx, learnerID)
+			promoteResp, err := cli.MemberPromote(ctx, learnerID)
 			if err == nil {
 				klog.V(1).Infof("[etcd] The learner was promoted as a voting member: %s", learnerIDUint)
+				memberList = promoteResp.Members
 				return true, nil
 			}
 			klog.V(5).Infof("[etcd] Promoting the learner %s failed: %v", learnerIDUint, err)
@@ -644,7 +669,7 @@ func (c *Client) MemberPromote(learnerID uint64) error {
 		return lastError
 	}
 
-	for _, m := range promoteResp.Members {
+	for _, m := range memberList {
 		if m.ID == learnerID {
 			parsedPeerAddrs, err := url.Parse(m.PeerURLs[0])
 			if err != nil {

--- a/cmd/kubeadm/app/util/etcd/etcd_test.go
+++ b/cmd/kubeadm/app/util/etcd/etcd_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	"strconv"
 	"testing"
 	"time"
@@ -44,6 +45,9 @@ var errNotImplemented = errors.New("not implemented")
 type fakeEtcdClient struct {
 	members   []*pb.Member
 	endpoints []string
+
+	memberListFunc    func(context.Context, ...clientv3.OpOption) (*clientv3.MemberListResponse, error)
+	memberPromoteFunc func(context.Context, uint64) (*clientv3.MemberPromoteResponse, error)
 }
 
 // Close shuts down the client's etcd connections.
@@ -58,7 +62,10 @@ func (f *fakeEtcdClient) Endpoints() []string {
 }
 
 // MemberList lists the current cluster membership.
-func (f *fakeEtcdClient) MemberList(_ context.Context, _ ...clientv3.OpOption) (*clientv3.MemberListResponse, error) {
+func (f *fakeEtcdClient) MemberList(ctx context.Context, opts ...clientv3.OpOption) (*clientv3.MemberListResponse, error) {
+	if f.memberListFunc != nil {
+		return f.memberListFunc(ctx, opts...)
+	}
 	return &clientv3.MemberListResponse{
 		Members: f.members,
 	}, nil
@@ -80,7 +87,10 @@ func (f *fakeEtcdClient) MemberRemove(_ context.Context, id uint64) (*clientv3.M
 }
 
 // MemberPromote promotes a member from raft learner (non-voting) to raft voting member.
-func (f *fakeEtcdClient) MemberPromote(_ context.Context, id uint64) (*clientv3.MemberPromoteResponse, error) {
+func (f *fakeEtcdClient) MemberPromote(ctx context.Context, id uint64) (*clientv3.MemberPromoteResponse, error) {
+	if f.memberPromoteFunc != nil {
+		return f.memberPromoteFunc(ctx, id)
+	}
 	return nil, errNotImplemented
 }
 
@@ -961,6 +971,201 @@ func TestEvaluateClusterStatus(t *testing.T) {
 
 			if tc.wantMemberErrors != (err != nil) {
 				t.Errorf("gotMemberErrors = %v, wantMemberErrors = %t", err, tc.wantMemberErrors)
+			}
+		})
+	}
+}
+
+func TestMemberPromote(t *testing.T) {
+	learnerID := uint64(12345)
+
+	const (
+		initialEndpoint  = "https://192.168.10.100:2379"
+		promotedEndpoint = "https://192.168.10.200:2379"
+	)
+
+	member := func(isLearner bool) *pb.Member {
+		return &pb.Member{
+			ID:         learnerID,
+			Name:       "cp-1",
+			PeerURLs:   []string{"https://192.168.10.200:2380"},
+			ClientURLs: []string{promotedEndpoint},
+			IsLearner:  isLearner,
+		}
+	}
+
+	type memberListResult struct {
+		members []*pb.Member
+		err     error
+	}
+
+	type memberPromoteResult struct {
+		resp *clientv3.MemberPromoteResponse
+		err  error
+	}
+
+	tests := []struct {
+		name                 string
+		memberListResults    []memberListResult
+		memberPromoteResults []memberPromoteResult
+		wantErr              bool
+		wantEndpoint         string
+		wantPromoteCalls     int
+		minMemberListCalls   int
+	}{
+		{
+			name: "successful promotion adds endpoint",
+			memberListResults: []memberListResult{
+				{members: []*pb.Member{member(true)}},
+				{members: []*pb.Member{member(true)}},
+			},
+			memberPromoteResults: []memberPromoteResult{
+				{
+					resp: &clientv3.MemberPromoteResponse{
+						Members: []*pb.Member{member(false)},
+					},
+				},
+			},
+			wantEndpoint:       promotedEndpoint,
+			wantPromoteCalls:   1,
+			minMemberListCalls: 2,
+		},
+		{
+			name: "already promoted after transient promote failure adds endpoint",
+			memberListResults: []memberListResult{
+				{members: []*pb.Member{member(true)}},
+				{members: []*pb.Member{member(true)}},
+				{members: []*pb.Member{member(false)}},
+			},
+			memberPromoteResults: []memberPromoteResult{
+				{
+					err: context.DeadlineExceeded,
+				},
+			},
+			wantEndpoint:       promotedEndpoint,
+			wantPromoteCalls:   1,
+			minMemberListCalls: 3,
+		},
+		{
+			name: "already promoted before promote attempt adds endpoint",
+			memberListResults: []memberListResult{
+				{members: []*pb.Member{member(true)}},
+				{members: []*pb.Member{member(false)}},
+			},
+			wantEndpoint:       promotedEndpoint,
+			wantPromoteCalls:   0,
+			minMemberListCalls: 2,
+		},
+		{
+			name: "member list error before promote is retried",
+			memberListResults: []memberListResult{
+				{members: []*pb.Member{member(true)}},
+				{err: errNotImplemented},
+				{members: []*pb.Member{member(true)}},
+			},
+			memberPromoteResults: []memberPromoteResult{
+				{
+					resp: &clientv3.MemberPromoteResponse{
+						Members: []*pb.Member{member(false)},
+					},
+				},
+			},
+			wantEndpoint:       promotedEndpoint,
+			wantPromoteCalls:   1,
+			minMemberListCalls: 3,
+		},
+		{
+			name: "promotion keeps failing",
+			memberListResults: []memberListResult{
+				{members: []*pb.Member{member(true)}},
+				{members: []*pb.Member{member(true)}},
+			},
+			memberPromoteResults: []memberPromoteResult{
+				{
+					err: context.DeadlineExceeded,
+				},
+			},
+			wantErr:            true,
+			wantPromoteCalls:   -1,
+			minMemberListCalls: 1,
+		},
+	}
+
+	oldActiveTimeout := kubeadmapi.GetActiveTimeouts()
+	newActiveTimeout := oldActiveTimeout.DeepCopy()
+	newActiveTimeout.EtcdAPICall = &metav1.Duration{
+		Duration: 3 * constants.EtcdAPICallRetryInterval,
+	}
+	kubeadmapi.SetActiveTimeouts(newActiveTimeout)
+	defer kubeadmapi.SetActiveTimeouts(oldActiveTimeout)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			memberListCalls := 0
+			memberPromoteCalls := 0
+
+			fakeClient := &fakeEtcdClient{}
+
+			fakeClient.memberListFunc = func(_ context.Context, _ ...clientv3.OpOption) (*clientv3.MemberListResponse, error) {
+				if len(tt.memberListResults) == 0 {
+					t.Fatal("MemberList called without configured results")
+				}
+
+				resultIndex := memberListCalls
+				if resultIndex >= len(tt.memberListResults) {
+					resultIndex = len(tt.memberListResults) - 1
+				}
+				result := tt.memberListResults[resultIndex]
+				memberListCalls++
+
+				if result.err != nil {
+					return nil, result.err
+				}
+				return &clientv3.MemberListResponse{
+					Members: result.members,
+				}, nil
+			}
+
+			fakeClient.memberPromoteFunc = func(_ context.Context, _ uint64) (*clientv3.MemberPromoteResponse, error) {
+				if len(tt.memberPromoteResults) == 0 {
+					t.Fatalf("unexpected MemberPromote call")
+				}
+
+				resultIndex := memberPromoteCalls
+				if resultIndex >= len(tt.memberPromoteResults) {
+					resultIndex = len(tt.memberPromoteResults) - 1
+				}
+				result := tt.memberPromoteResults[resultIndex]
+				memberPromoteCalls++
+
+				return result.resp, result.err
+			}
+
+			c := &Client{
+				Endpoints: []string{initialEndpoint},
+			}
+			c.newEtcdClient = func(_ []string) (etcdClient, error) {
+				return fakeClient, nil
+			}
+			c.listMembersFunc = func(_ time.Duration) (*clientv3.MemberListResponse, error) {
+				return fakeClient.MemberList(context.Background())
+			}
+
+			err := c.MemberPromote(learnerID)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("MemberPromote() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantPromoteCalls >= 0 && memberPromoteCalls != tt.wantPromoteCalls {
+				t.Fatalf("MemberPromote calls = %d, want %d", memberPromoteCalls, tt.wantPromoteCalls)
+			}
+
+			if memberListCalls < tt.minMemberListCalls {
+				t.Fatalf("MemberList calls = %d, want at least %d", memberListCalls, tt.minMemberListCalls)
+			}
+
+			if tt.wantEndpoint != "" && !slices.Contains(c.Endpoints, tt.wantEndpoint) {
+				t.Fatalf("expected endpoint %q to be added, got %v", tt.wantEndpoint, c.Endpoints)
 			}
 		})
 	}


### PR DESCRIPTION
Cherry pick of #139842 on release-1.35.

#139842: kubeadm: treat already promoted learner as successful

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
kubeadm: Improved resilience of kubeadm etcd learner promotion. kubeadm now correctly handles cases where learner promotion succeeds on the etcd side but a transient client-side error is returned, preventing unnecessary etcd-join failures.
```