### PR TITLE
CronJob controller: processNextWorkItem does not call queue.Forget on the (nil, nil) sync path, leaving stale rate-limiter backoff count

### DIFF
--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -204,6 +204,8 @@ func (jm *ControllerV2) processNextWorkItem(ctx context.Context) bool {
 	case requeueAfter != nil:
 		jm.queue.Forget(key)
 		jm.queue.AddAfter(key, *requeueAfter)
+	default:
+		jm.queue.Forget(key)
 	}
 	return true
 }

--- a/pkg/controller/cronjob/cronjob_controllerv2_test.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2_test.go
@@ -1897,3 +1897,52 @@ func TestControllerV2JobAlreadyExistsButDifferentOwner(t *testing.T) {
 		t.Fatalf("Unexpected job's namespace, got: %s, expected %s", jobControl.GetJobNamespace[0], cj.Namespace)
 	}
 }
+
+func TestControllerV2ProcessNextItemClearFailureRate(t *testing.T) {
+
+	t.Run("cronjob controller resets rate limiter successfully", func(t *testing.T) {
+		_, ctx := ktesting.NewTestContext(t)
+
+		cj := cronJob()
+		cj.Spec.Suspend = ptr.To(true)
+		cj.Spec.Schedule = onTheHour
+		cjCopy := cj.DeepCopy()
+
+		client := fake.NewSimpleClientset(cjCopy)
+		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
+		_ = informerFactory.Batch().V1().CronJobs().Informer().GetIndexer().Add(cjCopy)
+
+		jm, err := NewControllerV2(ctx, informerFactory.Batch().V1().Jobs(), informerFactory.Batch().V1().CronJobs(), client)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		jm.jobControl = &fakeJobControl{}
+		jm.cronJobControl = &fakeCJControl{CronJob: cjCopy}
+		jm.now = justBeforeTheHour
+
+		key, _ := controller.KeyFunc(cjCopy)
+
+		// add a forced N rate limit failure to replicate scenario where for a key a previous error exists.
+		for range 2 {
+			jm.queue.AddRateLimited(key)
+			k, quit := jm.queue.Get()
+			if quit {
+				t.Fatal("queue shut down unexpectedly")
+			}
+			jm.queue.Done(k)
+			// no clearing of the rate limit failure/backoff count.
+		}
+		if requeues := jm.queue.NumRequeues(key); requeues != 2 {
+			t.Fatalf("expected >0 requeues after priming, got %d", requeues)
+		}
+
+		// attempt to process a cron job.
+		jm.queue.Add(key)
+		jm.processNextWorkItem(ctx)
+
+		if requeues := jm.queue.NumRequeues(key); requeues != 0 {
+			t.Errorf("cronjob controller: expected NumRequeues 0 after successful sync, got %d "+
+				"(rate limiter failure count was not reset — queue.Forget was not called)", requeues)
+		}
+	})
+}


### PR DESCRIPTION


#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This is a minor one line change.

The CronJob controller's processNextWorkItem only resets the workqueue rate limiter (queue.Forget) in the requeueAfter != nil branch. When sync() returns (nil, nil) — Forget is never called and the key's exponential-backoff failure count is left in place.
This PR fixes the above.

How to reproduce:
I have added an unit test TestControllerV2ProcessNextItemClearFailureRate in this pr, if you run it without the .Forget path(the added path in this pr) you would see failures in unit test.

To run the unit test.
```
go test ./pkg/controller/cronjob/ -run TestProcessNextWorkItemForgetsOnSuccessfulSync  -count=50 -race 
```

AI Usage : no AI was used to write the code( its a one line code fix anyways and i followed existing unit tests guidelines to write the test case). Claude was used to reason about the kubernetes codebase though.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/139917 

#### Special notes for your reviewer:
I have included an unit test TestProcessNextWorkItemForgetsOnSuccessfulSync
I have added as much details on impact of this issue( impact is on the lower side ) and how the issue was uncovered with as much clarity as I thought would be helpful in the issue details  - https://github.com/kubernetes/kubernetes/issues/139917
Do let me know if further clarification was required.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
