### PR TITLE
Fixes : Ephemeral volumes cannot be reclaimed when Pod unadmitted by Kubelet  

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -3369,6 +3369,8 @@ const (
 	PodResizeInProgress PodConditionType = "PodResizeInProgress"
 	// AllContainersRestarting indicates that all containers of the pod is being restarted.
 	AllContainersRestarting PodConditionType = "AllContainersRestarting"
+
+	PodRejected PodConditionType = "PodRejected"	
 )
 
 // PodCondition represents pod's condition

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -1450,3 +1450,12 @@ func AddOrUpdateLabelsOnNode(kubeClient clientset.Interface, nodeName string, la
 		return nil
 	})
 }
+
+func PodIsRejectedFinished(pod *v1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if pod.Status.Phase == v1.PodFailed && condition.Type == v1.PodRejected && condition.Status == v1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -1787,3 +1787,24 @@ func TestFilterPodsByOwner(t *testing.T) {
 		})
 	}
 }
+
+func TestPodIsRejectedFinished(t *testing.T) {
+	finished := PodIsRejectedFinished(buildPod())
+	if !finished {
+		t.Errorf("PodIsRejectedFinished returned false")
+	}
+}
+
+func buildPod() *v1.Pod {
+	return &v1.Pod{
+		Status: v1.PodStatus{
+			Phase: v1.PodFailed,
+			Conditions: []v1.PodCondition{
+				{
+					Type:   v1.PodRejected,
+					Status: v1.ConditionTrue,
+				},
+			},
+		},
+	}
+}

--- a/pkg/controller/volume/ephemeral/controller.go
+++ b/pkg/controller/volume/ephemeral/controller.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"k8s.io/klog/v2"
+	controllerutil "k8s.io/kubernetes/pkg/controller"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -110,6 +111,7 @@ func NewController(
 		// PVC.
 		// Deletion of the PVC is handled through the owner reference and garbage collection.
 		// Therefore pod deletions also can be ignored.
+		UpdateFunc: ec.updatePod,
 	}, cache.HandlerOptions{Logger: &logger})
 	if err != nil {
 		return nil, fmt.Errorf("could not add pod event handler: %w", err)
@@ -274,8 +276,16 @@ func (ec *ephemeralController) handleVolume(ctx context.Context, pod *v1.Pod, vo
 		if err := ephemeral.VolumeIsForPod(pod, pvc); err != nil {
 			return err
 		}
+		if controllerutil.PodIsRejectedFinished(pod) {
+			return ec.kubeClient.CoreV1().PersistentVolumeClaims(pod.Namespace).Delete(ctx, pvcName, metav1.DeleteOptions{})
+		}
 		// Already created, nothing more to do.
 		logger.V(5).Info("Ephemeral: PVC already created", "volumeName", vol.Name, "PVC", klog.KObj(pvc))
+		return nil
+	}
+
+	// No need to create PVC
+	if controllerutil.PodIsRejectedFinished(pod) {
 		return nil
 	}
 
@@ -306,4 +316,27 @@ func (ec *ephemeralController) handleVolume(ctx context.Context, pod *v1.Pod, vo
 		return fmt.Errorf("create PVC %s: %v", pvcName, err)
 	}
 	return nil
+}
+
+func (ec *ephemeralController) updatePod(old, new interface{}) {
+	pod, ok := new.(*v1.Pod)
+	if !ok {
+		return
+	}
+	if pod.DeletionTimestamp != nil || !controllerutil.PodIsRejectedFinished(pod) {
+		return
+	}
+
+	for _, vol := range pod.Spec.Volumes {
+		if vol.Ephemeral != nil {
+			// It has at least one ephemeral inline volume, work on it.
+			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(pod)
+			if err != nil {
+				runtime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", pod, err))
+				return
+			}
+			ec.queue.Add(key)
+			break
+		}
+	}
 }

--- a/pkg/controller/volume/ephemeral/controller_test.go
+++ b/pkg/controller/volume/ephemeral/controller_test.go
@@ -271,3 +271,57 @@ func setupMetrics() {
 	ephemeralvolumemetrics.EphemeralVolumeCreateAttempts.Reset()
 	ephemeralvolumemetrics.EphemeralVolumeCreateFailures.Reset()
 }
+
+func Test_UpdatePodWithEnableFeature(t *testing.T) {
+	ec := buildController()
+	var pod interface{} = &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test_pod",
+			Namespace: "default",
+		},
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{
+				{
+					Name: "ephemeral_vol",
+					VolumeSource: v1.VolumeSource{
+						Ephemeral: &v1.EphemeralVolumeSource{
+							VolumeClaimTemplate: &v1.PersistentVolumeClaimTemplate{
+								Spec: v1.PersistentVolumeClaimSpec{
+									VolumeName: "ephemeral_vol",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodFailed,
+			Conditions: []v1.PodCondition{
+				{
+					Type:   v1.PodRejected,
+					Status: v1.ConditionTrue,
+				},
+			},
+		},
+	}
+	ec.updatePod(nil, pod)
+	item, _ := ec.queue.Get()
+	if item != "default/test_pod" {
+		t.Errorf("item is incorrect. : %v", item)
+	}
+}
+
+func buildController() *ephemeralController {
+	ctx, cancel := context.WithCancel(context.Background())
+	fakeKubeClient := createTestClient()
+	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
+	defer informerFactory.Shutdown()
+	defer cancel()
+	podInformer := informerFactory.Core().V1().Pods()
+	pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
+
+	c, _ := NewController(ctx, fakeKubeClient, podInformer, pvcInformer)
+	ec, _ := c.(*ephemeralController)
+	return ec
+}

--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/component-helpers/storage/ephemeral"
 	"k8s.io/klog/v2"
+	controllerutil "k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/util/protectionutil"
 	"k8s.io/kubernetes/pkg/controller/volume/common"
 	"k8s.io/kubernetes/pkg/features"
@@ -512,7 +513,7 @@ func podIsShutDown(pod *v1.Pod) bool {
 	//
 	// Therefore it is better to proceed with PVC removal,
 	// which is safe (case a) and/or desirable (case b).
-	return pod.DeletionTimestamp != nil && pod.DeletionGracePeriodSeconds != nil && *pod.DeletionGracePeriodSeconds == 0
+	return pod.DeletionTimestamp != nil && pod.DeletionGracePeriodSeconds != nil && *pod.DeletionGracePeriodSeconds == 0 || controllerutil.PodIsRejectedFinished(pod)
 }
 
 // pvcAddedUpdated reacts to pvc added/updated events

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2640,11 +2640,24 @@ func (kl *Kubelet) deletePod(ctx context.Context, pod *v1.Pod) error {
 func (kl *Kubelet) rejectPod(ctx context.Context, pod *v1.Pod, reason, message string) {
 	logger := klog.FromContext(ctx)
 	kl.recorder.WithLogger(logger).Eventf(pod, v1.EventTypeWarning, reason, "%s", message)
-	kl.statusManager.SetPodStatus(logger, pod, v1.PodStatus{
+	podStatus := v1.PodStatus{
 		QOSClass: v1qos.GetPodQOS(pod), // keep it as is
 		Phase:    v1.PodFailed,
 		Reason:   reason,
-		Message:  "Pod was rejected: " + message})
+		Message:  "Pod was rejected: " + message,
+	}
+	addRejectCondition(&podStatus, message)
+	kl.statusManager.SetPodStatus(logger, pod, podStatus)
+}
+
+func addRejectCondition(podStatus *v1.PodStatus, message string) {
+	podStatus.Conditions = []v1.PodCondition{
+		{
+			Type:    v1.PodRejected,
+			Status:  v1.ConditionTrue,
+			Message: "Pod was rejected: " + message,
+		},
+	}
 }
 
 func recordAdmissionRejection(reason string) {

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -969,6 +969,9 @@ func (m *manager) updateStatusInternal(logger klog.Logger, pod *v1.Pod, status v
 	// Set PodScheduledCondition.LastTransitionTime.
 	updateLastTransitionTime(&status, &oldStatus, v1.PodScheduled)
 
+	// Set PodRejectedCondition.LastTransitionTime.
+	updateLastTransitionTime(&status, &oldStatus, v1.PodRejected)
+
 	// Set DisruptionTarget.LastTransitionTime.
 	updateLastTransitionTime(&status, &oldStatus, v1.DisruptionTarget)
 

--- a/pkg/kubelet/types/pod_status.go
+++ b/pkg/kubelet/types/pod_status.go
@@ -30,6 +30,7 @@ var PodConditionsByKubelet = []v1.PodConditionType{
 	v1.ContainersReady,
 	v1.PodResizeInProgress,
 	v1.PodResizePending,
+	v1.PodRejected,
 }
 
 // PodConditionByKubelet returns if the pod condition type is owned by kubelet

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -195,7 +195,7 @@ func buildControllerRoles() ([]rbacv1.ClusterRole, []rbacv1.ClusterRoleBinding) 
 		Rules: []rbacv1.PolicyRule{
 			rbacv1helpers.NewRule("get", "list", "watch").Groups(legacyGroup).Resources("pods").RuleOrDie(),
 			rbacv1helpers.NewRule("update").Groups(legacyGroup).Resources("pods/finalizers").RuleOrDie(),
-			rbacv1helpers.NewRule("get", "list", "watch", "create").Groups(legacyGroup).Resources("persistentvolumeclaims").RuleOrDie(),
+			rbacv1helpers.NewRule("get", "list", "watch", "create", "delete").Groups(legacyGroup).Resources("persistentvolumeclaims").RuleOrDie(),
 			eventsRule(),
 		},
 	})

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -3767,6 +3767,8 @@ const (
 	PodResizeInProgress PodConditionType = "PodResizeInProgress"
 	// AllContainersRestarting indicates that all containers of the pod is being restarted.
 	AllContainersRestarting PodConditionType = "AllContainersRestarting"
+
+	PodRejected PodConditionType = "PodRejected"
 )
 
 // These are reasons for a pod's transition to a condition.


### PR DESCRIPTION
fix(ephemeral-volume): introduce PodRejected condition and ephemeral controller to clean orphan inline PVCs
When a Pod is rejected during admission or scheduling before being scheduled
to any node, inline ephemeral volume PVCs may become orphaned and never garbage
collected by kubelet.

1. Add PodRejected PodConditionType to mark pods rejected in admission/scheduling phase
2. Kubelet sets PodRejected=True condition when pod is rejected and marks phase Failed
3. Add helper util PodIsRejectedFinished to identify rejected terminated pods
4. Implement ephemeral controller to watch rejected pods and delete orphan ephemeral PVCs
5. Skip PVC creation upfront if pod has already been rejected
6. Update RBAC bootstrap policy for ephemeral controller permissions
7. Adapt pvc protection controller to allow cleanup for rejected pod PVCs

Fixes # 123592

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


/kind bug



#### What this PR does / why we need it:
Fixes :Ephemeral volumes cannot be reclaimed when Pod unadmitted by Kubelet  

#### Which issue(s) this PR is related to:
Fixes #123592
Fixes #139915

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
