### PR TITLE
Validate matching priorities when scheduling pod groups

### DIFF
--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
 	schedulingapi "k8s.io/kubernetes/pkg/apis/scheduling"
@@ -48,7 +49,8 @@ func (sched *Scheduler) scheduleOnePodGroup(ctx context.Context, podGroupInfo *f
 	logger = klog.LoggerWithValues(logger, "podGroup", klog.KObj(podGroupInfo))
 	ctx = klog.NewContext(ctx, logger)
 
-	schedFwk, err := sched.frameworkForPodGroup(podGroupInfo)
+	err := sched.validatePodGroup(podGroupInfo)
+
 	if err != nil {
 		for _, podInfo := range podGroupInfo.QueuedPodInfos {
 			podFwk, podFwkErr := sched.frameworkForPod(podInfo.Pod)
@@ -67,6 +69,7 @@ func (sched *Scheduler) scheduleOnePodGroup(ctx context.Context, podGroupInfo *f
 		}
 		return
 	}
+	schedFwk := sched.frameworkForPodGroup(podGroupInfo)
 	sched.skipPodGroupPodSchedule(ctx, schedFwk, podGroupInfo)
 	// skipPodGroupPodSchedule could remove some pods from the pod group.
 	// Pod group constraints will be re-evaluated on a PlacementFeasible phase.
@@ -80,21 +83,40 @@ func (sched *Scheduler) scheduleOnePodGroup(ctx context.Context, podGroupInfo *f
 	sched.podGroupCycle(ctx, schedFwk, framework.NewCycleState(), podGroupInfo)
 }
 
-// frameworkForPodGroup obtains the concrete scheduler framework for the entire pod group.
-func (sched *Scheduler) frameworkForPodGroup(podGroupInfo *framework.QueuedPodGroupInfo) (framework.Framework, error) {
-	schedulerName := ""
+func (sched *Scheduler) validatePodGroup(podGroupInfo *framework.QueuedPodGroupInfo) error {
+	if len(podGroupInfo.QueuedPodInfos) == 0 {
+		return fmt.Errorf("pod group has no pods to schedule")
+	}
+
+	schedulerName := podGroupInfo.QueuedPodInfos[0].Pod.Spec.SchedulerName
+
+	pg, err := sched.podGroupLister.PodGroups(podGroupInfo.Namespace).Get(podGroupInfo.Name)
+	if err != nil {
+		return fmt.Errorf("pod group cannot be retrieved: %w", err)
+	}
+	podGroupPriority := util.PodGroupPriority(pg)
+
 	for _, pInfo := range podGroupInfo.QueuedPodInfos {
-		if schedulerName == "" {
-			schedulerName = pInfo.Pod.Spec.SchedulerName
-		} else if pInfo.Pod.Spec.SchedulerName != schedulerName {
-			return nil, fmt.Errorf("all pods in a single pod group should have the same .spec.schedulerName set, got: %q and %q", pInfo.Pod.Spec.SchedulerName, schedulerName)
+		if pInfo.Pod.Spec.SchedulerName != schedulerName {
+			return fmt.Errorf("all pods in a single pod group should have the same .spec.schedulerName set, got: %q and %q", pInfo.Pod.Spec.SchedulerName, schedulerName)
+		}
+		podPriority := corev1helpers.PodPriority(pInfo.Pod)
+		if podPriority != podGroupPriority {
+			return fmt.Errorf("all pods in a single pod group should have the same priority as the pod group's priority, got %d and %d", podPriority, podGroupPriority)
 		}
 	}
-	fwk, ok := sched.Profiles[schedulerName]
-	if !ok {
-		return nil, fmt.Errorf("profile not found for scheduler name %q", schedulerName)
+
+	if _, ok := sched.Profiles[schedulerName]; !ok {
+		return fmt.Errorf("profile not found for scheduler name %q", schedulerName)
 	}
-	return fwk, nil
+
+	return nil
+}
+
+// frameworkForPodGroup obtains the concrete scheduler framework for the entire pod group.
+// Assumes [Scheduler.validatePodGroup] has been called before.
+func (sched *Scheduler) frameworkForPodGroup(podGroupInfo *framework.QueuedPodGroupInfo) framework.Framework {
+	return sched.Profiles[podGroupInfo.QueuedPodInfos[0].Pod.Spec.SchedulerName]
 }
 
 // skipPodGroupPodSchedule skips the scheduling of particular pods from the group when they should no longer be considered.

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -183,32 +183,42 @@ func (mp *fakePlacementFeasiblePlugin) Permit(ctx context.Context, state fwk.Cyc
 	return fwk.NewStatus(fwk.Error, "unexpected call to permit"), 0
 }
 
-func TestFrameworkForPodGroup(t *testing.T) {
-	p1 := st.MakePod().Name("p1").PodGroupName("pg").SchedulerName("sched1").Obj()
-	p2 := st.MakePod().Name("p2").PodGroupName("pg").SchedulerName("sched1").Obj()
-	p3 := st.MakePod().Name("p3").PodGroupName("pg").SchedulerName("sched2").Obj()
-
-	qInfo1 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p1}}
-	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
-	qInfo3 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p3}}
-
+func TestValidatePodGroup(t *testing.T) {
 	tests := []struct {
 		name        string
-		pods        []*framework.QueuedPodInfo
+		podGroup    *schedulingv1alpha3.PodGroup
+		pods        []*v1.Pod
 		profiles    profile.Map
 		expectError bool
 	}{
 		{
-			name: "success for same scheduler name",
-			pods: []*framework.QueuedPodInfo{qInfo1, qInfo2},
+			name:     "failure when no pods to evaluate",
+			podGroup: st.MakePodGroup().Name("pg").Obj(),
+			pods:     []*v1.Pod{},
+			profiles: profile.Map{
+				"sched1": nil,
+			},
+			expectError: true,
+		},
+		{
+			name:     "success for same scheduler name",
+			podGroup: st.MakePodGroup().Name("pg").Obj(),
+			pods: []*v1.Pod{
+				st.MakePod().Name("p1").PodGroupName("pg").SchedulerName("sched1").Obj(),
+				st.MakePod().Name("p2").PodGroupName("pg").SchedulerName("sched1").Obj(),
+			},
 			profiles: profile.Map{
 				"sched1": nil,
 			},
 			expectError: false,
 		},
 		{
-			name: "failure for different scheduler names",
-			pods: []*framework.QueuedPodInfo{qInfo1, qInfo3},
+			name:     "failure for different scheduler names",
+			podGroup: st.MakePodGroup().Name("pg").Obj(),
+			pods: []*v1.Pod{
+				st.MakePod().Name("p1").PodGroupName("pg").SchedulerName("sched1").Obj(),
+				st.MakePod().Name("p2").PodGroupName("pg").SchedulerName("sched2").Obj(),
+			},
 			profiles: profile.Map{
 				"sched1": nil,
 				"sched2": nil,
@@ -216,10 +226,50 @@ func TestFrameworkForPodGroup(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name: "failure when profile not found",
-			pods: []*framework.QueuedPodInfo{qInfo1},
+			name:     "failure when profile not found",
+			podGroup: st.MakePodGroup().Name("pg").Obj(),
+			pods: []*v1.Pod{
+				st.MakePod().Name("p1").PodGroupName("pg").SchedulerName("sched1").Obj(),
+				st.MakePod().Name("p2").PodGroupName("pg").SchedulerName("sched1").Obj(),
+			},
 			profiles: profile.Map{
 				"other": nil,
+			},
+			expectError: true,
+		},
+		{
+			name:     "success when priorities match",
+			podGroup: st.MakePodGroup().Name("pg").Priority(10).Obj(),
+			pods: []*v1.Pod{
+				st.MakePod().Name("p1").PodGroupName("pg").Priority(10).Obj(),
+				st.MakePod().Name("p2").PodGroupName("pg").Priority(10).Obj(),
+			},
+			profiles: profile.Map{
+				"": nil,
+			},
+			expectError: false,
+		},
+		{
+			name:     "failure when different priorities across pods",
+			podGroup: st.MakePodGroup().Name("pg").Priority(10).Obj(),
+			pods: []*v1.Pod{
+				st.MakePod().Name("p1").PodGroupName("pg").Priority(9).Obj(),
+				st.MakePod().Name("p2").PodGroupName("pg").Priority(10).Obj(),
+			},
+			profiles: profile.Map{
+				"": nil,
+			},
+			expectError: true,
+		},
+		{
+			name:     "failure when different priorities across pods and pod group",
+			podGroup: st.MakePodGroup().Name("pg").Priority(9).Obj(),
+			pods: []*v1.Pod{
+				st.MakePod().Name("p1").PodGroupName("pg").Priority(10).Obj(),
+				st.MakePod().Name("p2").PodGroupName("pg").Priority(10).Obj(),
+			},
+			profiles: profile.Map{
+				"": nil,
 			},
 			expectError: true,
 		},
@@ -227,9 +277,27 @@ func TestFrameworkForPodGroup(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sched := &Scheduler{Profiles: tt.profiles}
-			podGroupInfo := &framework.QueuedPodGroupInfo{QueuedPodInfos: tt.pods}
-			_, err := sched.frameworkForPodGroup(podGroupInfo)
+			overrides := featuregatetesting.FeatureOverrides{
+				features.GenericWorkload: true,
+			}
+			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, overrides)
+			_, ctx := ktesting.NewTestContext(t)
+			testPodGroupInfo := &framework.PodGroupInfo{Name: tt.podGroup.Name, Namespace: tt.podGroup.Namespace}
+			client := clientsetfake.NewClientset(tt.podGroup)
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			podGroupLister := informerFactory.Scheduling().V1alpha3().PodGroups().Lister()
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
+			sched := &Scheduler{Profiles: tt.profiles, podGroupLister: podGroupLister}
+			podGroupInfo := &framework.QueuedPodGroupInfo{
+				PodGroupInfo: testPodGroupInfo,
+			}
+			for _, pod := range tt.pods {
+				podGroupInfo.UnscheduledPods = append(podGroupInfo.UnscheduledPods, pod)
+				podGroupInfo.QueuedPodInfos = append(podGroupInfo.QueuedPodInfos,
+					&framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: pod}})
+			}
+			err := sched.validatePodGroup(podGroupInfo)
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("Expected error, but got nil")

--- a/test/integration/scheduler/podgroup/podgroup_test.go
+++ b/test/integration/scheduler/podgroup/podgroup_test.go
@@ -64,11 +64,11 @@ func TestPodGroupScheduling(t *testing.T) {
 	basicPodGroup := st.MakePodGroup().Name("pg1").TemplateRef("t2", "workload").Priority(100).BasicPolicy().Obj()
 	podGroupWithMinCount5 := st.MakePodGroup().Name("pg-mutable").TemplateRef("t-mutable", "workload").Priority(100).MinCount(5).Obj()
 
-	mutP1 := st.MakePod().Name("mut-p1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-mutable").Priority(105).Obj()
-	mutP2 := st.MakePod().Name("mut-p2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-mutable").Priority(104).Obj()
-	mutP3 := st.MakePod().Name("mut-p3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-mutable").Priority(103).Obj()
-	mutP4 := st.MakePod().Name("mut-p4").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-mutable").Priority(102).Obj()
-	mutP5 := st.MakePod().Name("mut-p5").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-mutable").Priority(101).Obj()
+	mutP1 := st.MakePod().Name("mut-p1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-mutable").Priority(100).Obj()
+	mutP2 := st.MakePod().Name("mut-p2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-mutable").Priority(100).Obj()
+	mutP3 := st.MakePod().Name("mut-p3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-mutable").Priority(100).Obj()
+	mutP4 := st.MakePod().Name("mut-p4").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-mutable").Priority(100).Obj()
+	mutP5 := st.MakePod().Name("mut-p5").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-mutable").Priority(100).Obj()
 
 	p1 := st.MakePod().Name("p1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").
 		PodGroupName("pg1").Priority(100).Obj()
@@ -533,8 +533,8 @@ func TestPodGroupScheduling(t *testing.T) {
 					CreatePodGroup: podGroupWithMinCount5,
 				},
 				{
-					Name:       "Create 4 pods belonging to the gang (quorum is 5)",
-					CreatePods: []*v1.Pod{mutP1, mutP2, mutP3, mutP4},
+					Name:              "Create 4 pods belonging to the gang (quorum is 5)",
+					CreatePodsInOrder: []*v1.Pod{mutP1, mutP2, mutP3, mutP4},
 				},
 				{
 					Name:                               "Verify gang pods are gated at PreEnqueue",
@@ -558,8 +558,8 @@ func TestPodGroupScheduling(t *testing.T) {
 					CreatePodGroup: podGroupWithMinCount5,
 				},
 				{
-					Name:       "Create 5 pods belonging to the gang",
-					CreatePods: []*v1.Pod{mutP1, mutP2, mutP3, mutP4, mutP5},
+					Name:              "Create 5 pods belonging to the gang",
+					CreatePodsInOrder: []*v1.Pod{mutP1, mutP2, mutP3, mutP4, mutP5},
 				},
 				{
 					Name:                     "Verify gang pods are unschedulable",
@@ -587,8 +587,8 @@ func TestPodGroupScheduling(t *testing.T) {
 					CreatePodGroup: podGroupWithMinCount5,
 				},
 				{
-					Name:       "Create 4 pods belonging to the gang (quorum is 5)",
-					CreatePods: []*v1.Pod{mutP1, mutP2, mutP3, mutP4},
+					Name:              "Create 4 pods belonging to the gang (quorum is 5)",
+					CreatePodsInOrder: []*v1.Pod{mutP1, mutP2, mutP3, mutP4},
 				},
 				{
 					Name:                               "Verify gang pods are gated at PreEnqueue",

--- a/test/integration/scheduler/podgroup/stepsframework/stepsframework.go
+++ b/test/integration/scheduler/podgroup/stepsframework/stepsframework.go
@@ -138,6 +138,8 @@ type Step struct {
 	UpdatePodGroup *schedulingapi.PodGroup
 	// CreatePods is use to create pods in the cluster.
 	CreatePods []*v1.Pod
+	// CreatePodsInOrder is use to create pods in the cluster and have them enqueued by the scheduler in the specified order.
+	CreatePodsInOrder []*v1.Pod
 	// CreateWorkloads is use to create workloads in the cluster.
 	CreateWorkloads []*schedulingapi.Workload
 	// DeletePods is use to delete pods from the cluster.
@@ -219,13 +221,27 @@ func createNodes(testCtx *testutils.TestContext, nodes []*v1.Node) error {
 	return nil
 }
 
-func createPods(testCtx *testutils.TestContext, ns string, pods []*v1.Pod) error {
+func createPods(testCtx *testutils.TestContext, ns string, pods []*v1.Pod, preserveOrder bool) error {
 	cs := testCtx.ClientSet
 	for _, pod := range pods {
 		p := pod.DeepCopy()
 		p.Namespace = ns
 		if _, err := cs.CoreV1().Pods(ns).Create(testCtx.Ctx, p, metav1.CreateOptions{}); err != nil {
 			return fmt.Errorf("failed to create pod %s: %w", p.Name, err)
+		}
+		if preserveOrder {
+			podScheduledFn := testutils.PodScheduled(cs, ns, p.Name)
+			err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 10*time.Second, false, func(ctx context.Context) (bool, error) {
+				_, ok := testCtx.Scheduler.SchedulingQueue.GetPod(p.Name, p.Namespace, p.Spec.SchedulingGroup)
+				if ok {
+					return true, nil
+				}
+				// pod may have gotten queued and scheduled between the polls
+				return podScheduledFn(ctx)
+			})
+			if err != nil {
+				return fmt.Errorf("failed to ensure queueing order of pod %s: %w", p.Name, err)
+			}
 		}
 	}
 	return nil
@@ -511,7 +527,9 @@ func RunSteps(testCtx *testutils.TestContext, t *testing.T, ns string, steps []S
 		case step.CreateNodes != nil:
 			err = createNodes(testCtx, step.CreateNodes)
 		case step.CreatePods != nil:
-			err = createPods(testCtx, ns, step.CreatePods)
+			err = createPods(testCtx, ns, step.CreatePods, false)
+		case step.CreatePodsInOrder != nil:
+			err = createPods(testCtx, ns, step.CreatePodsInOrder, true)
 		case step.CreatePodGroup != nil:
 			err = createPodGroup(testCtx, ns, step.CreatePodGroup)
 		case step.UpdatePodGroup != nil:

--- a/test/integration/scheduler/podgroup/topology_aware_scheduling/tas_test.go
+++ b/test/integration/scheduler/podgroup/topology_aware_scheduling/tas_test.go
@@ -32,11 +32,11 @@ import (
 )
 
 func makeGangPodGroup(podGroupName, topologyKey string, minCount int32) *schedulingapi.PodGroup {
-	return st.MakePodGroup().Name(podGroupName).TemplateRef("t1", "workload").TopologyKey(topologyKey).MinCount(minCount).Obj()
+	return st.MakePodGroup().Name(podGroupName).TemplateRef("t1", "workload").TopologyKey(topologyKey).MinCount(minCount).Priority(100).Obj()
 }
 
 func makeBasicPodGroup(podGroupName, topologyKey string) *schedulingapi.PodGroup {
-	return st.MakePodGroup().Name(podGroupName).TemplateRef("t1", "workload").BasicPolicy().TopologyKey(topologyKey).Obj()
+	return st.MakePodGroup().Name(podGroupName).TemplateRef("t1", "workload").BasicPolicy().TopologyKey(topologyKey).Priority(100).Obj()
 }
 
 func makeNode(nodeName, rackLabel, zoneLabel string) *v1.Node {

--- a/test/integration/scheduler/preemption/podgrouppreemption_test.go
+++ b/test/integration/scheduler/preemption/podgrouppreemption_test.go
@@ -53,17 +53,19 @@ func TestPodGroupPreemption(t *testing.T) {
 		features.GenericWorkload: true,
 	})
 	tests := []struct {
-		name                       string
-		nodes                      []*v1.Node
-		podGroups                  []*schedulingapi.PodGroup
-		initialPods                []*v1.Pod // pods that should be scheduled before preemption starts
-		preemptorPods              []*v1.Pod // pods that belong to a group and should trigger preemption
-		pdb                        *policyv1.PodDisruptionBudget
-		expectedScheduled          []string
-		expectedPreempted          []string
-		expectedUnschedulable      []string
-		expectedToHaveNNNInfo      []string
-		expectedPodsPreemptedByWAP int
+		name          string
+		nodes         []*v1.Node
+		podGroups     []*schedulingapi.PodGroup
+		initialPods   []*v1.Pod // pods that should be scheduled before preemption starts
+		preemptorPods []*v1.Pod // pods that belong to a group and should trigger preemption
+		// the order may be important to ensure deterministic scheduling result, where only some of the preemptor pods will get scheduled.
+		preemptorPodsQueuedInCreationOrder bool
+		pdb                                *policyv1.PodDisruptionBudget
+		expectedScheduled                  []string
+		expectedPreempted                  []string
+		expectedUnschedulable              []string
+		expectedToHaveNNNInfo              []string
+		expectedPodsPreemptedByWAP         int
 	}{
 		{
 			name: "Full PodGroup Preemption",
@@ -312,72 +314,6 @@ func TestPodGroupPreemption(t *testing.T) {
 			expectedPodsPreemptedByWAP: 3,
 		},
 		{
-			name: "Priority divergence in PodGroups - preemptor PodGroup has higher priority than the victim candidate PodGroup",
-			nodes: []*v1.Node{
-				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "3", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
-			},
-			podGroups: []*schedulingapi.PodGroup{
-				st.MakePodGroup().Name("pg1").Namespace("default").Priority(100).MinCount(1).Obj(),
-				st.MakePodGroup().Name("pg2").Namespace("default").DisruptionModeAll().Priority(10).MinCount(3).Obj(),
-			},
-			initialPods: []*v1.Pod{
-				st.MakePod().Name("high-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg2").ZeroTerminationGracePeriod().Priority(100).Obj(),
-				st.MakePod().Name("high-2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg2").ZeroTerminationGracePeriod().Priority(100).Obj(),
-				st.MakePod().Name("high-3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg2").ZeroTerminationGracePeriod().Priority(100).Obj(),
-			},
-			preemptorPods: []*v1.Pod{
-				st.MakePod().Name("low-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg1").ZeroTerminationGracePeriod().Priority(10).Obj(),
-			},
-			expectedScheduled:          []string{"low-1"},
-			expectedPreempted:          []string{"high-1", "high-2", "high-3"},
-			expectedToHaveNNNInfo:      []string{"low-1"},
-			expectedPodsPreemptedByWAP: 3,
-		},
-		{
-			name: "Priority divergence in PodGroups - preemptor PodGroup has too low priority",
-			nodes: []*v1.Node{
-				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "3", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
-			},
-			podGroups: []*schedulingapi.PodGroup{
-				st.MakePodGroup().Name("pg1").Namespace("default").Priority(10).MinCount(1).Obj(),
-				st.MakePodGroup().Name("pg2").Namespace("default").DisruptionModeAll().Priority(100).MinCount(3).Obj(),
-			},
-			initialPods: []*v1.Pod{
-				st.MakePod().Name("low-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg2").ZeroTerminationGracePeriod().Priority(10).Obj(),
-				st.MakePod().Name("low-2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg2").ZeroTerminationGracePeriod().Priority(10).Obj(),
-				st.MakePod().Name("low-3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg2").ZeroTerminationGracePeriod().Priority(10).Obj(),
-			},
-			preemptorPods: []*v1.Pod{
-				st.MakePod().Name("high-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg1").ZeroTerminationGracePeriod().Priority(100).Obj(),
-			},
-			expectedScheduled:          []string{"low-1", "low-2", "low-3"},
-			expectedPreempted:          []string{},
-			expectedUnschedulable:      []string{"high-1"},
-			expectedToHaveNNNInfo:      []string{},
-			expectedPodsPreemptedByWAP: 0,
-		},
-		{
-			name: "Preemptor Pod without PodGroupName does not respect the PodGroup disruption mode",
-			nodes: []*v1.Node{
-				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "3", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
-			},
-			podGroups: []*schedulingapi.PodGroup{
-				st.MakePodGroup().Name("pg1").Namespace("default").Priority(10).MinCount(1).Obj(),
-			},
-			initialPods: []*v1.Pod{
-				st.MakePod().Name("low-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg1").ZeroTerminationGracePeriod().Priority(30).Obj(),
-				st.MakePod().Name("low-2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg1").ZeroTerminationGracePeriod().Priority(20).Obj(),
-				st.MakePod().Name("low-3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg1").ZeroTerminationGracePeriod().Priority(10).Obj(),
-			},
-			preemptorPods: []*v1.Pod{
-				st.MakePod().Name("high-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(100).Obj(),
-			},
-			expectedScheduled:          []string{"high-1", "low-1", "low-2"},
-			expectedPreempted:          []string{"low-3"},
-			expectedToHaveNNNInfo:      []string{"high-1"},
-			expectedPodsPreemptedByWAP: 0,
-		},
-		{
 			name: "Gang scheduling: do not reprieve if it reduces scheduled pods below max possible",
 			nodes: []*v1.Node{
 				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
@@ -393,8 +329,8 @@ func TestPodGroupPreemption(t *testing.T) {
 				st.MakePod().Name("p3").Node("node3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(50).Obj(),
 			},
 			preemptorPods: []*v1.Pod{
-				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(102).Obj(),
-				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(101).Obj(),
+				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
+				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
 				st.MakePod().Name("p-c").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
 			},
 			expectedScheduled:          []string{"p-a", "p-b", "p-c"},
@@ -420,8 +356,8 @@ func TestPodGroupPreemption(t *testing.T) {
 				st.MakePod().Name("p4").Node("node4").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(50).Obj(),
 			},
 			preemptorPods: []*v1.Pod{
-				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(102).Obj(),
-				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(101).Obj(),
+				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
+				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
 				st.MakePod().Name("p-c").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
 			},
 			expectedScheduled:          []string{"p-a", "p-b", "p-c", "p4"},
@@ -447,15 +383,16 @@ func TestPodGroupPreemption(t *testing.T) {
 				st.MakePod().Name("p4").Node("node4").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(200).Obj(),
 			},
 			preemptorPods: []*v1.Pod{
-				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(102).Obj(),
-				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(101).Obj(),
+				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
+				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
 				st.MakePod().Name("p-c").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
 			},
-			expectedScheduled:          []string{"p-a", "p-b", "p3", "p4"},
-			expectedPreempted:          []string{"p1", "p2"},
-			expectedUnschedulable:      []string{"p-c"},
-			expectedToHaveNNNInfo:      []string{"p-a", "p-b"},
-			expectedPodsPreemptedByWAP: 2,
+			preemptorPodsQueuedInCreationOrder: true,
+			expectedScheduled:                  []string{"p-a", "p-b", "p3", "p4"},
+			expectedPreempted:                  []string{"p1", "p2"},
+			expectedUnschedulable:              []string{"p-c"},
+			expectedToHaveNNNInfo:              []string{"p-a", "p-b"},
+			expectedPodsPreemptedByWAP:         2,
 		},
 		{
 			name: "Gang scheduling: do not reprieve victim pod group of lower priority",
@@ -474,8 +411,8 @@ func TestPodGroupPreemption(t *testing.T) {
 				st.MakePod().Name("v3").Node("node3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
 			},
 			preemptorPods: []*v1.Pod{
-				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(102).Obj(),
-				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(101).Obj(),
+				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
+				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
 				st.MakePod().Name("p-c").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
 			},
 			expectedScheduled:          []string{"p-a", "p-b", "p-c"},
@@ -503,10 +440,11 @@ func TestPodGroupPreemption(t *testing.T) {
 				st.MakePod().Name("v4").Node("node4").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("victim-pg2").ZeroTerminationGracePeriod().Priority(200).Obj(),
 			},
 			preemptorPods: []*v1.Pod{
-				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(102).Obj(),
-				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(101).Obj(),
+				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
+				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
 				st.MakePod().Name("p-c").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
 			},
+			preemptorPodsQueuedInCreationOrder: true,
 			// p-a will preempt victim-pg, p-b will schedule to empty space, so only p-a will have NNN info.
 			expectedScheduled:          []string{"p-a", "p-b", "v3", "v4"},
 			expectedPreempted:          []string{"v1", "v2"},
@@ -530,8 +468,8 @@ func TestPodGroupPreemption(t *testing.T) {
 				st.MakePod().Name("p3").Node("node3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(50).Obj(),
 			},
 			preemptorPods: []*v1.Pod{
-				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(102).Obj(),
-				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(101).Obj(),
+				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
+				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
 				st.MakePod().Name("p-c").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
 			},
 			expectedScheduled:          []string{"p-a", "p-b", "p-c"},
@@ -557,8 +495,8 @@ func TestPodGroupPreemption(t *testing.T) {
 				st.MakePod().Name("p4").Node("node4").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(50).Obj(),
 			},
 			preemptorPods: []*v1.Pod{
-				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(102).Obj(),
-				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(101).Obj(),
+				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
+				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
 				st.MakePod().Name("p-c").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
 			},
 			expectedScheduled:          []string{"p-a", "p-b", "p-c", "p4"},
@@ -584,15 +522,16 @@ func TestPodGroupPreemption(t *testing.T) {
 				st.MakePod().Name("p4").Node("node4").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(200).Obj(),
 			},
 			preemptorPods: []*v1.Pod{
-				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(102).Obj(),
-				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(101).Obj(),
+				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
+				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
 				st.MakePod().Name("p-c").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
 			},
-			expectedScheduled:          []string{"p-a", "p-b", "p3", "p4"},
-			expectedPreempted:          []string{"p1", "p2"},
-			expectedUnschedulable:      []string{"p-c"},
-			expectedToHaveNNNInfo:      []string{"p-a", "p-b"},
-			expectedPodsPreemptedByWAP: 2,
+			preemptorPodsQueuedInCreationOrder: true,
+			expectedScheduled:                  []string{"p-a", "p-b", "p3", "p4"},
+			expectedPreempted:                  []string{"p1", "p2"},
+			expectedUnschedulable:              []string{"p-c"},
+			expectedToHaveNNNInfo:              []string{"p-a", "p-b"},
+			expectedPodsPreemptedByWAP:         2,
 		},
 		{
 			name: "Basic scheduling: do not reprieve victim pod group of lower priority",
@@ -611,8 +550,8 @@ func TestPodGroupPreemption(t *testing.T) {
 				st.MakePod().Name("v3").Node("node3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
 			},
 			preemptorPods: []*v1.Pod{
-				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(102).Obj(),
-				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(101).Obj(),
+				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
+				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
 				st.MakePod().Name("p-c").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
 			},
 			expectedScheduled:          []string{"p-a", "p-b", "p-c"},
@@ -640,10 +579,11 @@ func TestPodGroupPreemption(t *testing.T) {
 				st.MakePod().Name("v4").Node("node4").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("victim-pg2").ZeroTerminationGracePeriod().Priority(200).Obj(),
 			},
 			preemptorPods: []*v1.Pod{
-				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(102).Obj(),
-				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(101).Obj(),
+				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
+				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
 				st.MakePod().Name("p-c").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
 			},
+			preemptorPodsQueuedInCreationOrder: true,
 			// p-a will preempt "victim-pg" and p-b will schedule to empty space, so only p-a will have NNN info.
 			expectedScheduled:          []string{"p-a", "p-b", "v3", "v4"},
 			expectedPreempted:          []string{"v1", "v2"},
@@ -825,6 +765,20 @@ func TestPodGroupPreemption(t *testing.T) {
 				p.Namespace = ns
 				if _, err := cs.CoreV1().Pods(ns).Create(testCtx.Ctx, p, metav1.CreateOptions{}); err != nil {
 					t.Fatalf("Failed to create pod %s: %v", p.Name, err)
+				}
+				if tt.preemptorPodsQueuedInCreationOrder {
+					podScheduledFn := testutils.PodScheduled(cs, ns, p.Name)
+					err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 10*time.Second, false, func(ctx context.Context) (bool, error) {
+						_, ok := testCtx.Scheduler.SchedulingQueue.GetPod(p.Name, p.Namespace, p.Spec.SchedulingGroup)
+						if ok {
+							return true, nil
+						}
+						// pod may have gotten queued and scheduled between the polls
+						return podScheduledFn(ctx)
+					})
+					if err != nil {
+						t.Fatalf("Failed to ensure order of pod %s: %v", p.Name, err)
+					}
 				}
 			}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

As described in [WAP KEP](https://github.com/kubernetes/enhancements/blob/fbadc6d9898e37c98064faed67334c62192ff586/keps/sig-scheduling/5710-workload-aware-preemption/README.md?plain=1#L343), all pods within a pod group should have the same priority. This PR adds validation to increase our confidence that it's true.

Note that some edge cases exist that this validation can miss, e.g. pods assigned directly to a node or a race when re-creating a pod group with the same name #139914.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

KEP: https://github.com/kubernetes/enhancements/issues/5710

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added validation to PodGroup scheduling which ensures priorities of the evaluated pods match the priority of the PodGroup.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/fbadc6d9898e37c98064faed67334c62192ff586/keps/sig-scheduling/5710-workload-aware-preemption/README.md?plain=1#L343
```
