### PR TITLE
kubelet: populate Node UID on recorded node events (best-effort)

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1401,6 +1401,11 @@ type Kubelet struct {
 	// Reference to this node.
 	nodeRef *v1.ObjectReference
 
+	// cachedNodeRef caches a copy of nodeRef with the Node's UID resolved, so the
+	// common path of recording a node event allocates nothing and does no lister
+	// lookup. It is populated lazily once the UID is known; see nodeRefWithUID.
+	cachedNodeRef atomic.Pointer[v1.ObjectReference]
+
 	// Container runtime.
 	containerRuntime kubecontainer.Runtime
 
@@ -1709,7 +1714,7 @@ func (kl *Kubelet) StartGarbageCollection(ctx context.Context) {
 	go wait.UntilWithContext(ctx, func(ctx context.Context) {
 		if err := kl.containerGC.GarbageCollect(ctx); err != nil {
 			logger.Error(err, "Container garbage collection failed")
-			kl.recorder.WithLogger(logger).Eventf(kl.nodeRef, v1.EventTypeWarning, events.ContainerGCFailed, "%s", err.Error())
+			kl.recorder.WithLogger(logger).Eventf(kl.nodeRefWithUID(), v1.EventTypeWarning, events.ContainerGCFailed, "%s", err.Error())
 			loggedContainerGCFailure = true
 		} else {
 			var vLevel klog.Level = 4
@@ -1736,7 +1741,7 @@ func (kl *Kubelet) StartGarbageCollection(ctx context.Context) {
 			if prevImageGCFailed {
 				logger.Error(err, "Image garbage collection failed multiple times in a row")
 				// Only create an event for repeated failures
-				kl.recorder.WithLogger(logger).Event(kl.nodeRef, v1.EventTypeWarning, events.ImageGCFailed, err.Error())
+				kl.recorder.WithLogger(logger).Event(kl.nodeRefWithUID(), v1.EventTypeWarning, events.ImageGCFailed, err.Error())
 			} else {
 				logger.Error(err, "Image garbage collection failed once. Stats initialization may not have completed yet")
 			}
@@ -1909,7 +1914,7 @@ func (kl *Kubelet) Run(ctx context.Context, updates <-chan kubetypes.PodUpdate) 
 	}
 
 	if err := kl.initializeModules(ctx); err != nil {
-		kl.recorder.WithLogger(logger).Eventf(kl.nodeRef, v1.EventTypeWarning, events.KubeletSetupFailed, "%s", err.Error())
+		kl.recorder.WithLogger(logger).Eventf(kl.nodeRefWithUID(), v1.EventTypeWarning, events.KubeletSetupFailed, "%s", err.Error())
 		logger.Error(err, "Failed to initialize internal modules")
 		os.Exit(1)
 	}
@@ -3313,7 +3318,7 @@ func (kl *Kubelet) GetConfiguration() kubeletconfiginternal.KubeletConfiguration
 // BirthCry sends an event that the kubelet has started up.
 func (kl *Kubelet) BirthCry() {
 	// Make an event that kubelet restarted.
-	kl.recorder.Eventf(kl.nodeRef, v1.EventTypeNormal, events.StartingKubelet, "Starting kubelet.")
+	kl.recorder.Eventf(kl.nodeRefWithUID(), v1.EventTypeNormal, events.StartingKubelet, "Starting kubelet.")
 }
 
 // ListenAndServe runs the kubelet HTTP server.

--- a/pkg/kubelet/kubelet_linux.go
+++ b/pkg/kubelet/kubelet_linux.go
@@ -36,7 +36,7 @@ func (kl *Kubelet) cgroupVersionCheck() error {
 	metrics.CgroupVersion.Set(float64(cgroupVersion))
 	switch cgroupVersion {
 	case 1:
-		kl.recorder.Eventf(kl.nodeRef, v1.EventTypeWarning, events.CgroupV1, cm.CgroupV1DeprecatedWarning)
+		kl.recorder.Eventf(kl.nodeRefWithUID(), v1.EventTypeWarning, events.CgroupV1, cm.CgroupV1DeprecatedWarning)
 		return errors.New(cm.CgroupV1DeprecatedWarning)
 	case 2:
 		cpustat := filepath.Join(util.CgroupRoot, "cpu.stat")

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -633,16 +633,64 @@ func (kl *Kubelet) markVolumesFromNode(node *v1.Node) {
 	kl.volumeManager.MarkVolumesAsReportedInUse(node.Status.VolumesInUse)
 }
 
+// nodeRefWithUID returns a copy of the Kubelet's static node ObjectReference with
+// the Node's UID populated on a best-effort basis.
+//
+// kl.nodeRef is constructed once at Kubelet startup (see NewMainKubelet), before
+// the Node object is guaranteed to exist in the apiserver, so it intentionally
+// carries only kind+name and no UID (see https://github.com/kubernetes/kubernetes/issues/42701).
+// As a result every event the kubelet records against the node has
+// involvedObject.uid unset, which prevents consumers such as `kubectl describe
+// node` from correlating those events with the Node by UID
+// (see https://github.com/kubernetes/kubernetes/issues/138524).
+//
+// Once the Node is visible in the local cache we resolve the UID once and cache
+// the resulting reference in kl.cachedNodeRef. It is not refreshed: if the Node
+// were deleted and recreated with a new UID while this kubelet keeps running,
+// events would keep using the original UID.
+func (kl *Kubelet) nodeRefWithUID() *v1.ObjectReference {
+	// Fast path: a reference with the UID already resolved has been cached.
+	if ref := kl.cachedNodeRef.Load(); ref != nil {
+		return ref
+	}
+
+	// kl.nodeRef is written once at construction in NewMainKubelet and never
+	// reassigned, so there is no concurrent writer to guard against here. The nil
+	// check only matters for tests that do not set it.
+	if kl.nodeRef == nil {
+		return nil
+	}
+
+	ref := *kl.nodeRef
+	if ref.UID == "" {
+		// In standalone mode there is no apiserver, hence no Node UID to resolve.
+		if kl.kubeClient == nil {
+			return kl.nodeRef
+		}
+		node, err := kl.nodeLister.Get(string(kl.nodeName))
+		if err != nil || node.UID == "" {
+			// UID not known yet; return the name-only reference and retry next time.
+			return kl.nodeRef
+		}
+		ref.UID = node.UID
+	}
+
+	// Cache the resolved reference. CompareAndSwap keeps the first winner if two
+	// goroutines resolve concurrently; Load then returns whichever won.
+	kl.cachedNodeRef.CompareAndSwap(nil, &ref)
+	return kl.cachedNodeRef.Load()
+}
+
 // recordNodeStatusEvent records an event of the given type with the given
 // message for the node.
 func (kl *Kubelet) recordNodeStatusEvent(logger klog.Logger, eventType, event string) {
 	logger.V(2).Info("Recording event message for node", "node", klog.KRef("", string(kl.nodeName)), "event", event)
-	kl.recorder.Eventf(kl.nodeRef, eventType, event, "Node %s status is now: %s", kl.nodeName, event)
+	kl.recorder.Eventf(kl.nodeRefWithUID(), eventType, event, "Node %s status is now: %s", kl.nodeName, event)
 }
 
 // recordEvent records an event for this node, the Kubelet's nodeRef is passed to the recorder
 func (kl *Kubelet) recordEvent(eventType, event, message string) {
-	kl.recorder.Eventf(kl.nodeRef, eventType, event, "%s", message)
+	kl.recorder.Eventf(kl.nodeRefWithUID(), eventType, event, "%s", message)
 }
 
 // record if node schedulable change.

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -3231,3 +3231,71 @@ func TestSetNodeStatusDeclaredFeatures(t *testing.T) {
 		})
 	}
 }
+
+func TestNodeRefWithUID(t *testing.T) {
+	const nodeUID = "66cedd99-0823-46bf-a36d-5db3fa6f28cd"
+
+	newKubelet := func(t *testing.T) *Kubelet {
+		testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+		t.Cleanup(testKubelet.Cleanup)
+		kubelet := testKubelet.kubelet
+		// Mirror the static, UID-less reference built in NewMainKubelet.
+		kubelet.nodeRef = &v1.ObjectReference{
+			APIVersion: "v1",
+			Kind:       "Node",
+			Name:       string(kubelet.nodeName),
+		}
+		return kubelet
+	}
+
+	t.Run("fills the UID from the node cache when nodeRef has none", func(t *testing.T) {
+		kubelet := newKubelet(t)
+		node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: testKubeletHostname, UID: nodeUID}}
+		kubelet.nodeLister = testNodeLister{nodes: []*v1.Node{node}}
+
+		ref := kubelet.nodeRefWithUID()
+		assert.Equal(t, nodeUID, string(ref.UID), "expected the node UID to be populated")
+		// The shared reference must remain untouched (no in-place mutation/data race).
+		assert.Empty(t, string(kubelet.nodeRef.UID), "shared nodeRef must not be mutated")
+	})
+
+	t.Run("falls back to the name-only reference when the node is not cached", func(t *testing.T) {
+		kubelet := newKubelet(t)
+		kubelet.nodeLister = testNodeLister{}
+
+		ref := kubelet.nodeRefWithUID()
+		assert.Empty(t, string(ref.UID), "UID should stay empty when the node is unavailable")
+		assert.Equal(t, testKubeletHostname, ref.Name)
+		assert.Equal(t, "Node", ref.Kind)
+	})
+
+	t.Run("does not override an already populated UID", func(t *testing.T) {
+		kubelet := newKubelet(t)
+		kubelet.nodeRef.UID = "preset-uid"
+		// A different UID in the cache must be ignored when one is already set.
+		node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: testKubeletHostname, UID: nodeUID}}
+		kubelet.nodeLister = testNodeLister{nodes: []*v1.Node{node}}
+
+		ref := kubelet.nodeRefWithUID()
+		assert.Equal(t, "preset-uid", string(ref.UID))
+	})
+
+	t.Run("caches the resolved reference and does not refresh", func(t *testing.T) {
+		kubelet := newKubelet(t)
+		node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: testKubeletHostname, UID: nodeUID}}
+		kubelet.nodeLister = testNodeLister{nodes: []*v1.Node{node}}
+
+		first := kubelet.nodeRefWithUID()
+		require.Equal(t, nodeUID, string(first.UID))
+
+		// Simulate the node being recreated with a new UID. Because the resolved
+		// reference is cached once, later calls keep returning the original pointer
+		// and UID rather than re-reading the lister.
+		recreated := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: testKubeletHostname, UID: "new-uid"}}
+		kubelet.nodeLister = testNodeLister{nodes: []*v1.Node{recreated}}
+
+		second := kubelet.nodeRefWithUID()
+		assert.Same(t, first, second, "expected the cached reference to be reused")
+		assert.Equal(t, nodeUID, string(second.UID))
+	})
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The kubelet builds one static node `ObjectReference` at startup with only kind and name, no UID, because the reference must work before the Node exists in the apiserver (#42701). As a result every node event the kubelet records has `involvedObject.uid` unset, so consumers that match by UID (for example `kubectl describe node`) silently drop them.

This PR keeps that behavior but adds a `nodeRefWithUID()` helper that returns a per-call copy of the reference with the UID filled in from the node lister cache (no apiserver round-trip). When the UID isn't known yet, such as early startup or standalone mode, it falls back to the name-only reference. Copying per call keeps the shared reference immutable and the helper safe under concurrent event recording.

The kubelet's own node event sites now use it: `recordNodeStatusEvent`, `recordEvent`, and the `ContainerGCFailed`, `ImageGCFailed`, `KubeletSetupFailed`, `StartingKubelet`, and `CgroupV1` events. This covers the node-status events users most commonly inspect.

A few node events are out of scope. Events emitted before the node is registered genuinely can't carry a UID. Several subsystems also capture the static reference by pointer and emit their own node events: the oom watcher, eviction manager, image GC manager, node-shutdown manager, and DNS configurer. Routing those through a UID-aware reference needs a getter threaded into each subsystem, so it's left as follow-up. #138362 remains the complementary CLI-side fix.

#### Which issue(s) this PR is related to:

Related to #138524

#### Special notes for your reviewer:

The shared reference is used by pointer across subsystems, so the helper copies rather than mutates it to avoid a data race. The added unit test runs under `-race` and asserts the shared `nodeRef` is never mutated.

#### Does this PR introduce a user-facing change?

```release-note
kubelet: node events recorded by the kubelet now populate `involvedObject.uid` on a best-effort basis once the node is registered, so node events can be correlated by UID (for example in `kubectl describe node`). The UID is resolved once and not refreshed afterward. If a node is deleted and recreated with a new UID while the kubelet keeps running, its events continue to use the original UID until the kubelet restarts.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
