### PR TITLE
scheduler_perf: log items in createAny step

### DIFF
--- a/test/integration/scheduler_perf/executor.go
+++ b/test/integration/scheduler_perf/executor.go
@@ -213,7 +213,7 @@ func (e *WorkloadExecutor) runCreatePodGroupsOp(tCtx ktesting.TContext, op *crea
 		env["Index"] = index
 
 		obj := &schedulingapi.PodGroup{}
-		if err := getSpecFromTextTemplateFile(op.TemplatePath, env, obj); err != nil {
+		if _, err := getSpecFromTextTemplateFile(op.TemplatePath, env, obj); err != nil {
 			return fmt.Errorf("%s: %w", op.TemplatePath, err)
 		}
 
@@ -995,7 +995,7 @@ func (n nodeTemplateWithParams) GetNodeTemplate(index, count int) (*v1.Node, err
 	env["Index"] = index
 	env["Count"] = count
 	nodeSpec := &v1.Node{}
-	if err := getSpecFromTextTemplateFile(n.path, env, nodeSpec); err != nil {
+	if _, err := getSpecFromTextTemplateFile(n.path, env, nodeSpec); err != nil {
 		return nil, fmt.Errorf("parsing Node: %w", err)
 	}
 	return nodeSpec, nil
@@ -1013,7 +1013,7 @@ func (p podTemplateWithParams) GetPodTemplate(index, count int) (*v1.Pod, error)
 	env["Index"] = index
 	env["Count"] = count
 	podSpec := &v1.Pod{}
-	if err := getSpecFromTextTemplateFile(p.path, env, podSpec); err != nil {
+	if _, err := getSpecFromTextTemplateFile(p.path, env, podSpec); err != nil {
 		return nil, fmt.Errorf("parsing Pod: %w", err)
 	}
 

--- a/test/integration/scheduler_perf/operations.go
+++ b/test/integration/scheduler_perf/operations.go
@@ -105,19 +105,43 @@ func (c *createAny) run(tCtx ktesting.TContext) {
 	if c.Count != nil {
 		count = *c.Count
 	}
+	var items []string
 	for index := 0; index < count; index++ {
 		env := make(map[string]any)
 		maps.Copy(env, c.TemplateParams)
 		env["Index"] = index
 		env["Count"] = count
-		c.create(tCtx, env)
+		item := c.create(tCtx, env)
+		// Keep first and last item for reporting.
+		if index == 0 {
+			items = []string{strings.TrimSpace(item)}
+			continue
+		}
+		if index == count-1 {
+			if index > 1 {
+				// We skipped some intermediate item(s).
+				items = append(items, "\n\n...\n\n")
+			}
+			items = append(items, strings.TrimSpace(item))
+		}
 	}
+
+	params := ""
+	if len(c.TemplateParams) > 0 {
+		params = fmt.Sprintf(" with params %v", c.TemplateParams)
+	}
+	namespace := " in cluster scope"
+	if c.Namespace != "" {
+		namespace = fmt.Sprintf(" in namespace %q", c.Namespace)
+	}
+	tCtx.Logf("Created %d item(s) from %s%s%s:\n%s", count, c.TemplatePath, params, namespace, strings.Join(items, ""))
 }
 
-func (c *createAny) create(tCtx ktesting.TContext, env map[string]any) {
+func (c *createAny) create(tCtx ktesting.TContext, env map[string]any) string {
 	var obj *unstructured.Unstructured
-	if err := getSpecFromTextTemplateFile(c.TemplatePath, env, &obj); err != nil {
-		tCtx.Fatalf("%s: parsing failed: %v", c.TemplatePath, err)
+	objData, err := getSpecFromTextTemplateFile(c.TemplatePath, env, &obj)
+	if err != nil {
+		tCtx.Fatalf("%s: parsing failed: %v\n%s", c.TemplatePath, err, objData)
 	}
 
 	// Not caching the discovery result isn't very efficient, but good enough when
@@ -155,31 +179,31 @@ func (c *createAny) create(tCtx ktesting.TContext, env map[string]any) {
 	for {
 		err := create()
 		if err == nil {
-			return
+			return objData
 		}
 		select {
 		case <-ctx.Done():
-			tCtx.Fatalf("%s: timed out (%q) while creating %q, last error was: %v", c.TemplatePath, context.Cause(ctx), klog.KObj(obj), err)
+			tCtx.Fatalf("%s: timed out (%q) while creating %q, last error was: %v\n\n%s", c.TemplatePath, context.Cause(ctx), klog.KObj(obj), err, objData)
 		case <-time.After(time.Second):
 		}
 	}
 }
 
-func getSpecFromTextTemplateFile(path string, env map[string]any, spec interface{}) error {
+func getSpecFromTextTemplateFile(path string, env map[string]any, spec interface{}) (string, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
-		return err
+		return "", err
 	}
 	tmpl, err := template.New("object").Funcs(getTemplateFuncs()).Parse(string(content))
 	if err != nil {
-		return err
+		return "", err
 	}
 	var buffer bytes.Buffer
 	if err := tmpl.Execute(&buffer, env); err != nil {
-		return err
+		return "", err
 	}
 
-	return yaml.UnmarshalStrict(buffer.Bytes(), spec)
+	return buffer.String(), yaml.UnmarshalStrict(buffer.Bytes(), spec)
 }
 
 func restMappingFromUnstructuredObj(tCtx ktesting.TContext, obj *unstructured.Unstructured) (*meta.RESTMapping, error) {

--- a/test/integration/scheduler_perf/update.go
+++ b/test/integration/scheduler_perf/update.go
@@ -125,7 +125,7 @@ func (c *updateAny) run(tCtx ktesting.TContext) {
 
 func (c *updateAny) update(tCtx ktesting.TContext, env map[string]any) error {
 	var obj *unstructured.Unstructured
-	if err := getSpecFromTextTemplateFile(c.TemplatePath, env, &obj); err != nil {
+	if _, err := getSpecFromTextTemplateFile(c.TemplatePath, env, &obj); err != nil {
 		return fmt.Errorf("%s: parsing failed: %w", c.TemplatePath, err)
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This makes it easier to understand what the state of the cluster is. It also helps debugging templating. Large number of objects are handled by showing only the first and last one, with "..." in the middle.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

I added this while extending the usage of templating for DRA workloads. Example from some upcoming PR:

```
    operations.go:137: Created 500 item(s) from templates/resourceslice-basic-devices.yaml with params map[numDevices:10] in cluster scope:
        	kind: ResourceSlice
        	apiVersion: resource.k8s.io/v1
        	metadata:
        	  name: resourceslice-0
        	spec:
        	  pool:
        	    name: resourceslice-0
        	    generation: 1
        	    resourceSliceCount: 1
        	  driver: test-driver.cdi.k8s.io
        	  nodeName: scheduler-perf-dra-0
        	  devices:
        	  - name: basic-device-0
        	    attributes:
        	      model:
        	        string: A100
        	      family:
        	        string: GPU
        	      driverVersion:
        	        version: "1.2.3"
        	      k8s.io/pciRoot:
        	        string: "0"
        	    capacity:
        	      memory:
        	        value: 1Gi
        	  - name: basic-device-1
        	    attributes:
        	      model:
        	        string: A100
        	      family:
        	        string: GPU
        	      driverVersion:
        	        version: "1.2.3"
        	      k8s.io/pciRoot:
        	        string: "1"
        	    capacity:
        	      memory:
        	        value: 1Gi
        	  - name: basic-device-2
        	    attributes:
        	      model:
        	        string: A100
        	      family:
        	        string: GPU
        	      driverVersion:
        	        version: "1.2.3"
        	      k8s.io/pciRoot:
        	        string: "2"
        	    capacity:
        	      memory:
        	        value: 1Gi
        	  - name: basic-device-3
        	    attributes:
        	      model:
        	        string: A100
        	      family:
        	        string: GPU
        	      driverVersion:
        	        version: "1.2.3"
        	      k8s.io/pciRoot:
        	        string: "3"
        	    capacity:
        	      memory:
        	        value: 1Gi
        	  - name: basic-device-4
        	    attributes:
        	      model:
        	        string: A100
        	      family:
        	        string: GPU
        	      driverVersion:
        	        version: "1.2.3"
        	      k8s.io/pciRoot:
        	        string: "4"
        	    capacity:
        	      memory:
        	        value: 1Gi
        	  - name: basic-device-5
        	    attributes:
        	      model:
        	        string: A100
        	      family:
        	        string: GPU
        	      driverVersion:
        	        version: "1.2.3"
        	      k8s.io/pciRoot:
        	        string: "5"
        	    capacity:
        	      memory:
        	        value: 1Gi
        	  - name: basic-device-6
        	    attributes:
        	      model:
        	        string: A100
        	      family:
        	        string: GPU
        	      driverVersion:
        	        version: "1.2.3"
        	      k8s.io/pciRoot:
        	        string: "6"
        	    capacity:
        	      memory:
        	        value: 1Gi
        	  - name: basic-device-7
        	    attributes:
        	      model:
        	        string: A100
        	      family:
        	        string: GPU
        	      driverVersion:
        	        version: "1.2.3"
        	      k8s.io/pciRoot:
        	        string: "7"
        	    capacity:
        	      memory:
        	        value: 1Gi
        	  - name: basic-device-8
        	    attributes:
        	      model:
        	        string: A100
        	      family:
        	        string: GPU
        	      driverVersion:
        	        version: "1.2.3"
        	      k8s.io/pciRoot:
        	        string: "8"
        	    capacity:
        	      memory:
        	        value: 1Gi
        	  - name: basic-device-9
        	    attributes:
        	      model:
        	        string: A100
        	      family:
        	        string: GPU
        	      driverVersion:
        	        version: "1.2.3"
        	      k8s.io/pciRoot:
        	        string: "9"
        	    capacity:
        	      memory:
        	        value: 1Gi
        	
        	...
        	
        	kind: ResourceSlice
        	apiVersion: resource.k8s.io/v1
        	metadata:
        	  name: resourceslice-499
        	spec:
        	  pool:
        	    name: resourceslice-499
        	    generation: 1
        	    resourceSliceCount: 1
        	  driver: test-driver.cdi.k8s.io
        	  nodeName: scheduler-perf-dra-499
        	  devices:
        	  - name: basic-device-0
        	    attributes:
        	      model:
        	        string: A100
        	      family:
        	        string: GPU
        	      driverVersion:
        	        version: "1.2.3"
        	      k8s.io/pciRoot:
        	        string: "0"
        	    capacity:
        	      memory:
        	        value: 1Gi
        	  - name: basic-device-1
        	    attributes:
        	      model:
        	        string: A100
        	      family:
        	        string: GPU
        	      driverVersion:
        	        version: "1.2.3"
        	      k8s.io/pciRoot:
        	        string: "1"
        	    capacity:
        	      memory:
        	        value: 1Gi
        	  - name: basic-device-2
        	    attributes:
        	      model:
        	        string: A100
        	      family:
        	        string: GPU
        	      driverVersion:
        	        version: "1.2.3"
        	      k8s.io/pciRoot:
        	        string: "2"
        	    capacity:
        	      memory:
        	        value: 1Gi
        	  - name: basic-device-3
        	    attributes:
        	      model:
        	        string: A100
        	      family:
        	        string: GPU
        	      driverVersion:
        	        version: "1.2.3"
        	      k8s.io/pciRoot:
        	        string: "3"
        	    capacity:
        	      memory:
        	        value: 1Gi
        	  - name: basic-device-4
        	    attributes:
        	      model:
        	        string: A100
        	      family:
        	        string: GPU
        	      driverVersion:
        	        version: "1.2.3"
        	      k8s.io/pciRoot:
        	        string: "4"
        	    capacity:
        	      memory:
        	        value: 1Gi
        	  - name: basic-device-5
        	    attributes:
        	      model:
        	        string: A100
        	      family:
        	        string: GPU
        	      driverVersion:
        	        version: "1.2.3"
        	      k8s.io/pciRoot:
        	        string: "5"
        	    capacity:
        	      memory:
        	        value: 1Gi
        	  - name: basic-device-6
        	    attributes:
        	      model:
        	        string: A100
        	      family:
        	        string: GPU
        	      driverVersion:
        	        version: "1.2.3"
        	      k8s.io/pciRoot:
        	        string: "6"
        	    capacity:
        	      memory:
        	        value: 1Gi
        	  - name: basic-device-7
        	    attributes:
        	      model:
        	        string: A100
        	      family:
        	        string: GPU
        	      driverVersion:
        	        version: "1.2.3"
        	      k8s.io/pciRoot:
        	        string: "7"
        	    capacity:
        	      memory:
        	        value: 1Gi
        	  - name: basic-device-8
        	    attributes:
        	      model:
        	        string: A100
        	      family:
        	        string: GPU
        	      driverVersion:
        	        version: "1.2.3"
        	      k8s.io/pciRoot:
        	        string: "8"
        	    capacity:
        	      memory:
        	        value: 1Gi
        	  - name: basic-device-9
        	    attributes:
        	      model:
        	        string: A100
        	      family:
        	        string: GPU
        	      driverVersion:
        	        version: "1.2.3"
        	      k8s.io/pciRoot:
        	        string: "9"
        	    capacity:
        	      memory:
        	        value: 1Gi
    operations.go:137: Created 1 item(s) from templates/deviceclass.yaml in cluster scope:
        	apiVersion: resource.k8s.io/v1
        	kind: DeviceClass
        	metadata:
        	  name: test-class
        	spec:
        	  selectors:
        	  - cel:
        	      expression: device.driver == "test-driver.cdi.k8s.io"
    operations.go:137: Created 4990 item(s) from templates/resourceclaim.yaml in namespace "init":
        	apiVersion: resource.k8s.io/v1
        	kind: ResourceClaim
        	metadata:
        	  name: test-claim-0
        	spec:
        	  devices:
        	    requests:
        	    - name: req-0
        	      exactly:
        	        deviceClassName: test-class
        	
        	...
        	
        	apiVersion: resource.k8s.io/v1
        	kind: ResourceClaim
        	metadata:
        	  name: test-claim-4989
        	spec:
        	  devices:
        	    requests:
        	    - name: req-0
        	      exactly:
        	        deviceClassName: test-class
    dra.go:280: allocating 4990 ResourceClaims
    operations.go:137: Created 1 item(s) from templates/resourceclaimtemplate.yaml in namespace "test":
        	apiVersion: resource.k8s.io/v1
        	kind: ResourceClaimTemplate
        	metadata:
        	  name: test-claim-template
        	spec:
        	  spec:
        	    devices:
        	      requests:
        	      - name: req-0
        	        exactly:
        	          deviceClassName: test-class
    util.go:570: Started pod throughput collector for namespace(s) [test], 0 pods scheduled so far
    executor.go:591: Started metrics collection (SchedulingWithResourceClaimTemplate_full_500nodes_dra_2026-06-22T16:25:33Z)
    executor.go:700: creating pods in namespace "test" for {10s}
...
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @macsko @bart0sh 

Whoever has time.
