### PR TITLE
  Degrade gracefully when etcd Maintenance.Status is PermissionDenied

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/feature/feature_support_checker.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/feature/feature_support_checker.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -193,6 +195,18 @@ type client interface {
 func endpointSupportsRequestWatchProgress(ctx context.Context, c client, endpoint string) (bool, error) {
 	resp, err := c.Status(ctx, endpoint)
 	if err != nil {
+		// etcd >= 3.6 requires admin permission on the Maintenance.Status RPC
+		// (etcd-io/etcd#21466), so an apiserver configured with a non-root etcd
+		// user gets PermissionDenied here. That error is permanent, not
+		// transient: retrying cannot succeed, and we cannot read the etcd
+		// version to decide support. Rather than silently disabling
+		// RequestWatchProgress (and spinning forever in the retry loop), assume
+		// the feature is supported and stop retrying. Any etcd new enough to
+		// enforce this permission (>= 3.6) supports RequestWatchProgress.
+		if grpcstatus.Code(err) == codes.PermissionDenied {
+			klog.Warningf("Cannot detect RequestWatchProgress support: etcd Maintenance.Status requires admin permission on endpoint %q (etcd-io/etcd#21466); assuming supported", endpoint)
+			return true, nil
+		}
 		return false, fmt.Errorf("failed checking etcd version, endpoint: %q: %w", endpoint, err)
 	}
 	ver, err := version.ParseSemantic(resp.Version)

--- a/staging/src/k8s.io/apiserver/pkg/storage/feature/feature_support_checker_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/feature/feature_support_checker_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
@@ -288,7 +289,7 @@ func TestRequestWatchProgressEtcdPermissionDenied(t *testing.T) {
 	supported, err := endpointSupportsRequestWatchProgress(context.Background(),
 		&MockEtcdClient{EndpointVersion: []mockEndpointVersion{
 			{Endpoint: "localhost:2390", Error: permErr}}}, "localhost:2390")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, supported, "PermissionDenied should be treated as supported, not disabled")
 
 	// End-to-end through the checker: feature ends up Supported, no error surfaced.
@@ -296,7 +297,7 @@ func TestRequestWatchProgressEtcdPermissionDenied(t *testing.T) {
 	mockClient := &MockEtcdClient{EndpointVersion: []mockEndpointVersion{
 		{Endpoint: "localhost:2390", Error: permErr}}}
 	for _, ep := range mockClient.Endpoints() {
-		assert.NoError(t, f.clientSupportsRequestWatchProgress(context.Background(), mockClient, ep))
+		require.NoError(t, f.clientSupportsRequestWatchProgress(context.Background(), mockClient, ep))
 	}
 	assert.True(t, f.Supports(storage.RequestWatchProgress))
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/feature/feature_support_checker_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/feature/feature_support_checker_test.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 	"k8s.io/apiserver/pkg/storage"
 	testingclock "k8s.io/utils/clock/testing"
 )
@@ -273,6 +275,30 @@ func TestSupportsRequestWatchProgress(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRequestWatchProgressEtcdPermissionDenied verifies that when the etcd
+// Maintenance.Status RPC returns PermissionDenied (etcd >= 3.6 with a non-root
+// user, etcd-io/etcd#21466), RequestWatchProgress is assumed supported and the
+// check does not return an error (so the retry loop stops).
+func TestRequestWatchProgressEtcdPermissionDenied(t *testing.T) {
+	permErr := grpcstatus.Error(codes.PermissionDenied, "etcdserver: permission denied")
+
+	// Direct check: the endpoint helper must swallow PermissionDenied and report supported.
+	supported, err := endpointSupportsRequestWatchProgress(context.Background(),
+		&MockEtcdClient{EndpointVersion: []mockEndpointVersion{
+			{Endpoint: "localhost:2390", Error: permErr}}}, "localhost:2390")
+	assert.NoError(t, err)
+	assert.True(t, supported, "PermissionDenied should be treated as supported, not disabled")
+
+	// End-to-end through the checker: feature ends up Supported, no error surfaced.
+	f := newDefaultFeatureSupportChecker()
+	mockClient := &MockEtcdClient{EndpointVersion: []mockEndpointVersion{
+		{Endpoint: "localhost:2390", Error: permErr}}}
+	for _, ep := range mockClient.Endpoints() {
+		assert.NoError(t, f.clientSupportsRequestWatchProgress(context.Background(), mockClient, ep))
+	}
+	assert.True(t, f.Supports(storage.RequestWatchProgress))
 }
 
 func TestMarkUnsupported(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -39,7 +39,9 @@ import (
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
+	grpcstatus "google.golang.org/grpc/status"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
@@ -55,6 +57,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/component-base/metrics/legacyregistry"
 	tracing "k8s.io/component-base/tracing"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -276,11 +279,26 @@ func (t *etcd3ProberMonitor) Monitor(ctx context.Context) (metrics.StorageMetric
 	}
 	status, err := t.client.Status(ctx, t.endpoints[rand.Int()%len(t.endpoints)])
 	if err != nil {
+		// etcd >= 3.6 requires admin permission on Maintenance.Status
+		// (etcd-io/etcd#21466). An apiserver using a non-root etcd user cannot
+		// read DbSize; treat that as "size unknown" rather than a probe error so
+		// we don't repeatedly report the storage backend as unhealthy.
+		if isEtcdMaintenancePermissionDenied(err) {
+			klog.V(4).Infof("Cannot read etcd db size: Maintenance.Status requires admin permission (etcd-io/etcd#21466)")
+			return metrics.StorageMetrics{}, nil
+		}
 		return metrics.StorageMetrics{}, err
 	}
 	return metrics.StorageMetrics{
 		Size: status.DbSize,
 	}, nil
+}
+
+// isEtcdMaintenancePermissionDenied reports whether err is the PermissionDenied
+// returned by etcd >= 3.6 for Maintenance RPCs (e.g. Status) when the client is
+// not an admin/root user. See etcd-io/etcd#21466.
+func isEtcdMaintenancePermissionDenied(err error) bool {
+	return grpcstatus.Code(err) == codes.PermissionDenied
 }
 
 var newETCD3Client = func(c storagebackend.TransportConfig) (*kubernetes.Client, error) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3_test.go
@@ -21,6 +21,9 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 )
 
 func Test_atomicLastError(t *testing.T) {
@@ -44,5 +47,36 @@ func Test_atomicLastError(t *testing.T) {
 	err = aError.Load()
 	if err.Error() != "now error" {
 		t.Fatalf("Expected: \"now error\" got: %s", err.Error())
+	}
+}
+
+func Test_isEtcdMaintenancePermissionDenied(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "etcd >= 3.6 maintenance permission denied",
+			err:  grpcstatus.Error(codes.PermissionDenied, "etcdserver: permission denied"),
+			want: true,
+		},
+		{
+			name: "other grpc error",
+			err:  grpcstatus.Error(codes.Unavailable, "etcdserver: unavailable"),
+			want: false,
+		},
+		{
+			name: "plain error",
+			err:  errors.New("some error"),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isEtcdMaintenancePermissionDenied(tt.err); got != tt.want {
+				t.Fatalf("isEtcdMaintenancePermissionDenied(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
 #### What type of PR is this?
  /kind bug

  #### What this PR does / why we need it:

  etcd >= 3.6 requires admin permission on the `Maintenance.Status` RPC ([etcd-io/etcd#21466](https://github.com/etcd-io/etcd/issues/21466)). An apiserver configured with a **non-root etcd user**
  therefore gets `PermissionDenied` from `Status`, which today causes two regressions:

  1. **`RequestWatchProgress` is silently disabled.** `endpointSupportsRequestWatchProgress` returns the error, so `progressNotifySupported` is never set (defaults to `false`), and the
  support-check retry loop spins **forever** retrying a permanent error.
  2. **The etcd db-size metric flaps.** Both db-size monitors error on every poll; the polling monitor sets `etcd_db_total_size_in_bytes` to `-1` each interval and the prober reports the backend
  as erroring.

  This PR treats `PermissionDenied` from `Status` as a permanent, expected condition rather than a transient failure:

  - **Feature checker:** assume `RequestWatchProgress` is supported (any etcd new enough to enforce this permission, i.e. >= 3.6, supports the feature) and stop retrying.
  - **DB-size monitors:** skip updating the metric (leave the last value) instead of flapping it to `-1`, and don't report the prober as erroring.

  A shared `isEtcdMaintenancePermissionDenied` helper centralizes the gRPC `codes.PermissionDenied` check; unit tests cover both paths.

  Note: the canonical fix is upstream in etcd relaxing the `Status` permission ([etcd-io/etcd#21663](https://github.com/etcd-io/etcd/issues/21663)). This change is a defensive graceful-degradation
  mitigation and intentionally does **not** add new apiserver flags (that would be a separate, SIG-scoped design discussion).

  #### Which issue(s) this PR fixes:

  Relates to #139220                                                                                                                                                              

  #### Does this PR introduce a user-facing change?
  ```release-note
  kube-apiserver: when the etcd Maintenance.Status RPC returns PermissionDenied (etcd >= 3.6 with a non-root etcd user), RequestWatchProgress is no longer silently disabled and the etcd db size
  metric is no longer flapped to -1.
  ```

  /sig api-machinery                                                                                                                                                              
  /kind bug

