### PR TITLE
Adds ability to setup nodeInfoSnapshot for scheduler

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -145,6 +145,7 @@ type schedulerOptions struct {
 	frameworkCapturer          FrameworkCapturer
 	parallelism                int32
 	applyDefaultProfile        bool
+	nodeInfoSnapshot           *internalcache.Snapshot
 }
 
 // Option configures a Scheduler
@@ -259,6 +260,13 @@ func WithBuildFrameworkCapturer(fc FrameworkCapturer) Option {
 	}
 }
 
+// WithNodeInfoSnapshot sets the nodeInfoSnapshot for Scheduler.
+func WithNodeInfoSnapshot(snapshot *internalcache.Snapshot) Option {
+	return func(o *schedulerOptions) {
+		o.nodeInfoSnapshot = snapshot
+	}
+}
+
 var defaultSchedulerOptions = schedulerOptions{
 	clock:                             clock.RealClock{},
 	percentageOfNodesToScore:          schedulerapi.DefaultPercentageOfNodesToScore,
@@ -318,7 +326,10 @@ func New(ctx context.Context,
 		podGroupLister = informerFactory.Scheduling().V1alpha3().PodGroups().Lister()
 	}
 
-	snapshot := internalcache.NewEmptySnapshot()
+	snapshot := options.nodeInfoSnapshot
+	if snapshot == nil {
+		snapshot = internalcache.NewEmptySnapshot()
+	}
 	metricsRecorder := metrics.NewMetricsAsyncRecorder(1000, time.Second, stopEverything)
 	// waitingPods holds all the pods that are in the scheduler and waiting in the permit stage
 	waitingPods := frameworkruntime.NewWaitingPodsMap()

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -82,12 +82,14 @@ func TestSchedulerCreation(t *testing.T) {
 	validRegistry := map[string]frameworkruntime.PluginFactory{
 		"Foo": defaultbinder.New,
 	}
+	customSnapshot := internalcache.NewEmptySnapshot()
 	cases := []struct {
-		name          string
-		opts          []Option
-		wantErr       string
-		wantProfiles  []string
-		wantExtenders []string
+		name                 string
+		opts                 []Option
+		wantErr              string
+		wantProfiles         []string
+		wantExtenders        []string
+		wantNodeInfoSnapshot *internalcache.Snapshot
 	}{
 		{
 			name: "valid out-of-tree registry",
@@ -190,6 +192,14 @@ func TestSchedulerCreation(t *testing.T) {
 			wantProfiles:  []string{"default-scheduler"},
 			wantExtenders: []string{"http://extender.kube-system/"},
 		},
+		{
+			name: "With custom nodeInfoSnapshot",
+			opts: []Option{
+				WithNodeInfoSnapshot(customSnapshot),
+			},
+			wantProfiles:         []string{"default-scheduler"},
+			wantNodeInfoSnapshot: customSnapshot,
+		},
 	}
 
 	for _, tc := range cases {
@@ -253,6 +263,11 @@ func TestSchedulerCreation(t *testing.T) {
 						t.Errorf("unexpected extenders (-want, +got):\n%s", diff)
 					}
 				}
+			}
+
+			// nodeInfoSnapshot
+			if tc.wantNodeInfoSnapshot != nil && s.nodeInfoSnapshot != tc.wantNodeInfoSnapshot {
+				t.Errorf("unexpected nodeInfoSnapshot: got %p, want %p", s.nodeInfoSnapshot, tc.wantNodeInfoSnapshot)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds the  `WithNodeInfoSnapshot` scheduler option, allowing custom  `internalcache.Snapshot`  instances to be passed during scheduler initialization.

#### Which issue(s) this PR is related to:
PR: https://github.com/kubernetes-sigs/scheduler-library/pull/2
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
These changes are primarily intended to satisfy the scheduling library's requirements. To reuse scheduling logic on the library side, we need the ability to provide a custom `nodeInfoSnapshot` for the scheduler. `WithNodeInfoSnapshot` is the initial step; we eventually need to align with a new struct on the scheduler side, which will be used for algorithm execution.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required". 

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
