### PR TITLE
Reduce WatchList RLock hold time from O(N) to O(1) via lazy snapshot

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -1374,95 +1374,100 @@ func TestCacherSendBookmarkEvents(t *testing.T) {
 }
 
 func TestInitialEventsEndBookmark(t *testing.T) {
-	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WatchList, true)
-	forceRequestWatchProgressSupport(t)
+	for _, listFromCacheSnapshot := range []bool{true, false} {
+		t.Run(fmt.Sprintf("ListFromCacheSnapshot=%v", listFromCacheSnapshot), func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WatchList, true)
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ListFromCacheSnapshot, listFromCacheSnapshot)
+			forceRequestWatchProgressSupport(t)
 
-	backingStorage := &cachertesting.MockStorage{}
-	cacher, _, err := newTestCacher(backingStorage)
-	if err != nil {
-		t.Fatalf("Couldn't create cacher: %v", err)
-	}
-	defer cacher.Stop()
+			backingStorage := &cachertesting.MockStorage{}
+			cacher, _, err := newTestCacher(backingStorage)
+			if err != nil {
+				t.Fatalf("Couldn't create cacher: %v", err)
+			}
+			defer cacher.Stop()
 
-	makePod := func(index uint64) *example.Pod {
-		return &example.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            fmt.Sprintf("pod-%d", index),
-				Namespace:       "ns",
-				ResourceVersion: fmt.Sprintf("%v", 100+index),
-			},
-		}
-	}
-
-	numberOfPods := 3
-	var expectedPodEvents []watch.Event
-	for i := 1; i <= numberOfPods; i++ {
-		pod := makePod(uint64(i))
-		if err := cacher.watchCache.Add(pod); err != nil {
-			t.Fatalf("failed to add a pod: %v", err)
-		}
-		expectedPodEvents = append(expectedPodEvents, watch.Event{Type: watch.Added, Object: pod})
-	}
-	var currentResourceVersion uint64 = 100 + 3
-
-	trueVal, falseVal := true, false
-
-	scenarios := []struct {
-		name                string
-		allowWatchBookmarks bool
-		sendInitialEvents   *bool
-	}{
-		{
-			name:                "allowWatchBookmarks=false, sendInitialEvents=false",
-			allowWatchBookmarks: false,
-			sendInitialEvents:   &falseVal,
-		},
-		{
-			name:                "allowWatchBookmarks=false, sendInitialEvents=true",
-			allowWatchBookmarks: false,
-			sendInitialEvents:   &trueVal,
-		},
-		{
-			name:                "allowWatchBookmarks=true, sendInitialEvents=true",
-			allowWatchBookmarks: true,
-			sendInitialEvents:   &trueVal,
-		},
-		{
-			name:                "allowWatchBookmarks=true, sendInitialEvents=false",
-			allowWatchBookmarks: true,
-			sendInitialEvents:   &falseVal,
-		},
-		{
-			name:                "allowWatchBookmarks=false, sendInitialEvents=nil",
-			allowWatchBookmarks: true,
-		},
-	}
-
-	for _, scenario := range scenarios {
-		t.Run(scenario.name, func(t *testing.T) {
-			expectedWatchEvents := expectedPodEvents
-			if scenario.allowWatchBookmarks && scenario.sendInitialEvents != nil && *scenario.sendInitialEvents {
-				expectedWatchEvents = append(expectedWatchEvents, watch.Event{
-					Type: watch.Bookmark,
-					Object: &example.Pod{
-						ObjectMeta: metav1.ObjectMeta{
-							ResourceVersion: strconv.FormatUint(currentResourceVersion, 10),
-							Annotations:     map[string]string{metav1.InitialEventsAnnotationKey: "true"},
-						},
+			makePod := func(index uint64) *example.Pod {
+				return &example.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            fmt.Sprintf("pod-%d", index),
+						Namespace:       "ns",
+						ResourceVersion: fmt.Sprintf("%v", 100+index),
 					},
+				}
+			}
+
+			numberOfPods := 3
+			var expectedPodEvents []watch.Event
+			for i := 1; i <= numberOfPods; i++ {
+				pod := makePod(uint64(i))
+				if err := cacher.watchCache.Add(pod); err != nil {
+					t.Fatalf("failed to add a pod: %v", err)
+				}
+				expectedPodEvents = append(expectedPodEvents, watch.Event{Type: watch.Added, Object: pod})
+			}
+			var currentResourceVersion uint64 = 100 + 3
+
+			trueVal, falseVal := true, false
+
+			scenarios := []struct {
+				name                string
+				allowWatchBookmarks bool
+				sendInitialEvents   *bool
+			}{
+				{
+					name:                "allowWatchBookmarks=false, sendInitialEvents=false",
+					allowWatchBookmarks: false,
+					sendInitialEvents:   &falseVal,
+				},
+				{
+					name:                "allowWatchBookmarks=false, sendInitialEvents=true",
+					allowWatchBookmarks: false,
+					sendInitialEvents:   &trueVal,
+				},
+				{
+					name:                "allowWatchBookmarks=true, sendInitialEvents=true",
+					allowWatchBookmarks: true,
+					sendInitialEvents:   &trueVal,
+				},
+				{
+					name:                "allowWatchBookmarks=true, sendInitialEvents=false",
+					allowWatchBookmarks: true,
+					sendInitialEvents:   &falseVal,
+				},
+				{
+					name:                "allowWatchBookmarks=false, sendInitialEvents=nil",
+					allowWatchBookmarks: true,
+				},
+			}
+
+			for _, scenario := range scenarios {
+				t.Run(scenario.name, func(t *testing.T) {
+					expectedWatchEvents := expectedPodEvents
+					if scenario.allowWatchBookmarks && scenario.sendInitialEvents != nil && *scenario.sendInitialEvents {
+						expectedWatchEvents = append(expectedWatchEvents, watch.Event{
+							Type: watch.Bookmark,
+							Object: &example.Pod{
+								ObjectMeta: metav1.ObjectMeta{
+									ResourceVersion: strconv.FormatUint(currentResourceVersion, 10),
+									Annotations:     map[string]string{metav1.InitialEventsAnnotationKey: "true"},
+								},
+							},
+						})
+					}
+
+					pred := storage.Everything
+					pred.AllowWatchBookmarks = scenario.allowWatchBookmarks
+					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+					defer cancel()
+					w, err := cacher.Watch(ctx, "/pods/ns", storage.ListOptions{ResourceVersion: "100", SendInitialEvents: scenario.sendInitialEvents, Predicate: pred})
+					if err != nil {
+						t.Fatalf("Failed to create watch: %v", err)
+					}
+					storagetesting.TestCheckResultsInStrictOrder(t, w, expectedWatchEvents)
+					storagetesting.TestCheckNoMoreResultsWithIgnoreFunc(t, w, nil)
 				})
 			}
-
-			pred := storage.Everything
-			pred.AllowWatchBookmarks = scenario.allowWatchBookmarks
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
-			defer cancel()
-			w, err := cacher.Watch(ctx, "/pods/ns", storage.ListOptions{ResourceVersion: "100", SendInitialEvents: scenario.sendInitialEvents, Predicate: pred})
-			if err != nil {
-				t.Fatalf("Failed to create watch: %v", err)
-			}
-			storagetesting.TestCheckResultsInStrictOrder(t, w, expectedWatchEvents)
-			storagetesting.TestCheckNoMoreResultsWithIgnoreFunc(t, w, nil)
 		})
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -631,5 +631,12 @@ func (w *watchCache) getAllEventsSinceLocked(resourceVersion uint64, key string,
 // that covers the entire storage state.
 // This function assumes to be called under the watchCache lock.
 func (w *watchCache) getIntervalFromStoreLocked(key string, matchesSingle bool) (*watchCacheInterval, error) {
+	// When not matching a single key, an immutable snapshot lets us
+	// defer the O(N) interval build off the watchCache lock.
+	if !matchesSingle {
+		if snapshot, ok := w.storage.LatestSnapshotLocked(); ok {
+			return newCacheIntervalFromLazySnapshot(w.resourceVersion, snapshot), nil
+		}
+	}
 	return newCacheIntervalFromStore(w.resourceVersion, w.storage.StoreLocked(), key, matchesSingle)
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval.go
@@ -107,6 +107,19 @@ func newCacheIntervalFromStore(resourceVersion uint64, snap store.Snapshot, key 
 	return ci, nil
 }
 
+// newCacheIntervalFromLazySnapshot builds an interval backed by an immutable store snapshot
+// Unlike newCacheIntervalFromStore, it captures snapshot reference which takes O(1) under watch-cache RLock
+// and defers O(N) traversal to first Next() call post lock release
+func newCacheIntervalFromLazySnapshot(resourceVersion uint64, snap store.Snapshot) *watchCacheInterval {
+	return &watchCacheInterval{
+		source: &lazySnapshotCacheIntervalSource{
+			snapshot:        snap,
+			resourceVersion: resourceVersion,
+		},
+		resourceVersion: resourceVersion,
+	}
+}
+
 func storeElementToWatchCacheEvent(elem *store.Element, resourceVersion uint64) *watchCacheEvent {
 	return &watchCacheEvent{
 		Type:            watch.Added,
@@ -243,6 +256,43 @@ func (s *snapshotCacheIntervalSource) Next() (*watchCacheEvent, error) {
 		return nil, nil
 	}
 	return event, nil
+}
+
+// lazySnapshotCacheIntervalSource serves events from an immutable snapshot.
+// The snapshot reference is captured under the watchCache lock, but the O(N)
+// traversal that materializes the events is deferred until the first Next()
+// call so that it runs off the watchCache lock.
+type lazySnapshotCacheIntervalSource struct {
+	// snapshot is an immutable point-in-time copy of the store.
+	snapshot store.Snapshot
+	// resourceVersion is assigned to every watchCacheEvent produced by this source.
+	resourceVersion uint64
+	// loaded indicates whether items has been materialized from the snapshot.
+	loaded bool
+	// items holds the result of OrderedListPrefix, populated on the first Next() call
+	items []interface{}
+	// currentIndex tracks the current position within items.
+	currentIndex int
+}
+
+func (s *lazySnapshotCacheIntervalSource) Next() (*watchCacheEvent, error) {
+	if !s.loaded {
+		items, err := s.snapshot.OrderedListPrefix("", "")
+		if err != nil {
+			return nil, err
+		}
+		s.items = items
+		s.loaded = true
+	}
+	if s.currentIndex >= len(s.items) {
+		return nil, nil
+	}
+	elem, ok := s.items[s.currentIndex].(*store.Element)
+	if !ok {
+		return nil, fmt.Errorf("not a storeElement: %v", s.items[s.currentIndex])
+	}
+	s.currentIndex++
+	return storeElementToWatchCacheEvent(elem, s.resourceVersion), nil
 }
 
 const bufferSize = 100

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval_test.go
@@ -29,9 +29,11 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/tools/cache"
-
+	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/storage/cacher/store"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/tools/cache"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 )
 
 func intervalFromEvents(events []*watchCacheEvent) *watchCacheInterval {
@@ -474,5 +476,88 @@ func TestCacheIntervalFromStoreSorted(t *testing.T) {
 				t.Errorf("events not sorted by key: %v", got)
 			}
 		})
+	}
+}
+
+// TestCacheIntervalSourceSelection verifies that getIntervalFromStoreLocked builds the
+// interval from the lazy snapshot source when snapshotting is enabled and falls back to the
+// eager snapshot source when it is disabled.
+func TestCacheIntervalSourceSelection(t *testing.T) {
+	cases := []struct {
+		name             string
+		snapshottingOn   bool
+		wantLazySnapshot bool
+	}{
+		{
+			name:             "snapshotting enabled serves from lazy snapshot",
+			snapshottingOn:   true,
+			wantLazySnapshot: true,
+		},
+		{
+			name:             "snapshotting disabled falls back to eager snapshot",
+			snapshottingOn:   false,
+			wantLazySnapshot: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ListFromCacheSnapshot, tc.snapshottingOn)
+			wc := newTestWatchCache(3, DefaultEventFreshDuration, &cache.Indexers{})
+			defer wc.Stop()
+			if err := wc.Add(makeTestPod("pod1", 100)); err != nil {
+				t.Fatal(err)
+			}
+
+			wc.Lock()
+			wci, err := wc.getIntervalFromStoreLocked("", false)
+			wc.Unlock()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tc.wantLazySnapshot {
+				if _, ok := wci.source.(*lazySnapshotCacheIntervalSource); !ok {
+					t.Errorf("expected *lazySnapshotCacheIntervalSource, got %T", wci.source)
+				}
+			} else {
+				if _, ok := wci.source.(*snapshotCacheIntervalSource); !ok {
+					t.Errorf("expected *snapshotCacheIntervalSource, got %T", wci.source)
+				}
+			}
+		})
+	}
+}
+
+type countingSnapshot struct {
+	items                  []interface{}
+	orderedListPrefixCalls int
+}
+
+func (s *countingSnapshot) GetByKey(string) (interface{}, bool, error) {
+	return nil, false, nil
+}
+
+func (s *countingSnapshot) OrderedListPrefix(_, _ string) ([]interface{}, error) {
+	s.orderedListPrefixCalls++
+	return s.items, nil
+}
+
+// TestLazySnapshotCacheIntervalSourceEmpty checks that on an empty snapshot Next() returns
+// no events, and that repeated calls still read the snapshot only once.
+func TestLazySnapshotCacheIntervalSourceEmpty(t *testing.T) {
+	snap := &countingSnapshot{}
+	wci := newCacheIntervalFromLazySnapshot(100, snap)
+
+	for range 2 {
+		event, err := wci.Next()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if event != nil {
+			t.Errorf("expected nil event from empty snapshot, got %v", *event)
+		}
+	}
+	if snap.orderedListPrefixCalls != 1 {
+		t.Errorf("expected OrderedListPrefix to be called once, got %d", snap.orderedListPrefixCalls)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:



Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

For WatchList (SendInitialEvents=true) requests, the watch setup path held watchCache.RLock for the entire duration of newCacheIntervalFromStore which performs 2×O(N) work: store.List() + event wrapping loop.

This PR optimizes the RLock held time on watch-cache from O(N) to O(1), to help avoid watch-cache staleness during flood of watch-lists. 




#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
https://github.com/kubernetes/kubernetes/issues/139526
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

