### PR TITLE
dra: add standard numaNode device attribute with SLIT-based helpers

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/attribute.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/attribute.go
@@ -37,6 +37,20 @@ const (
 	// referring to a PCI (Peripheral Component Interconnect) device.
 	// This attribute can be used to identify PCI devices.
 	StandardDeviceAttributePCIBusID resourceapi.QualifiedName = StandardDeviceAttributePrefix + "pciBusID"
+
+	// StandardDeviceAttributeNUMANode is a standard device attribute name
+	// which identifies the NUMA topology of a device. The value can be:
+	//
+	//   - A scalar int — the device's physical NUMA node (from the kernel's
+	//     numa_node sysfs entry). Works without any feature gate.
+	//   - An integer list (requires DRAListTypeAttributes feature gate) —
+	//     physical NUMA node first, followed by same-socket NUMA nodes at
+	//     the minimum ACPI SLIT distance.
+	//
+	// The helpers GetNUMANodeAttributeByPCIBusID and GetNUMANodeAttribute
+	// accept a listEnabled parameter that selects the form. Devices with
+	// no NUMA affinity (numa_node = -1) must not publish this attribute.
+	StandardDeviceAttributeNUMANode resourceapi.QualifiedName = StandardDeviceAttributePrefix + "numaNode"
 )
 
 // DeviceAttribute represents a device attribute name and its value

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/numa_linux.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/numa_linux.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"io/fs"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -42,6 +42,9 @@ const (
 	// enabled in the cluster.
 	ListAttribute
 )
+
+// maxNUMANodes is the upper bound for valid NUMA node IDs (Linux kernel maximum).
+const maxNUMANodes = 1024
 
 // GetNUMANodeAttributeByPCIBusID returns the numaNode attribute for a PCI
 // device, reading the physical NUMA node from sysfs numa_node.
@@ -96,6 +99,9 @@ func GetNUMANodeAttributeByPCIBusID(pciBusID string, attrForm AttributeForm, mod
 func GetNUMANodeAttribute(numaNode int, attrForm AttributeForm, mods ...MachineModifier) (DeviceAttribute, error) {
 	if numaNode < 0 {
 		return DeviceAttribute{}, fmt.Errorf("invalid NUMA node %d: do not publish the numaNode attribute for a device with no NUMA affinity", numaNode)
+	}
+	if numaNode >= maxNUMANodes {
+		return DeviceAttribute{}, fmt.Errorf("invalid NUMA node %d: exceeds maximum supported (%d)", numaNode, maxNUMANodes-1)
 	}
 
 	if attrForm == ScalarAttribute {
@@ -172,18 +178,20 @@ func makeNUMANodeListAttribute(mc machine, physicalNode int) DeviceAttribute {
 	}
 }
 
+func readSysfsInt(mc machine, path string) (int, error) {
+	data, err := fs.ReadFile(mc.sysfs, path)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(strings.TrimSpace(string(data)))
+}
+
 func readNUMANode(mc machine, pciBusID string) (int, error) {
 	numaNodePath := filepath.Join("bus", "pci", "devices", pciBusID, "numa_node")
-	data, err := fs.ReadFile(mc.sysfs, numaNodePath)
+	node, err := readSysfsInt(mc, numaNodePath)
 	if err != nil {
 		return -1, fmt.Errorf("failed to read NUMA node for PCI Bus ID %s: %w", pciBusID, err)
 	}
-
-	node, err := strconv.Atoi(strings.TrimSpace(string(data)))
-	if err != nil {
-		return -1, fmt.Errorf("failed to parse NUMA node for PCI Bus ID %s: %w", pciBusID, err)
-	}
-
 	return node, nil
 }
 
@@ -260,7 +268,7 @@ func getEquidistantNUMANodes(mc machine, node int) ([]int, error) {
 		nodes = append(nodes, i)
 	}
 
-	sort.Ints(nodes)
+	slices.Sort(nodes)
 	return nodes, nil
 }
 
@@ -277,12 +285,7 @@ func getSocketForNUMANode(mc machine, node int) (int, bool) {
 	}
 
 	pkgPath := filepath.Join("devices", "system", "cpu", fmt.Sprintf("cpu%d", cpus[0]), "topology", "physical_package_id")
-	pkgData, err := fs.ReadFile(mc.sysfs, pkgPath)
-	if err != nil {
-		return -1, false
-	}
-
-	socketID, err := strconv.Atoi(strings.TrimSpace(string(pkgData)))
+	socketID, err := readSysfsInt(mc, pkgPath)
 	if err != nil {
 		return -1, false
 	}

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/numa_linux.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/numa_linux.go
@@ -1,0 +1,323 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceattribute
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	resourceapi "k8s.io/api/resource/v1"
+)
+
+// GetNUMANodeAttributeByPCIBusID returns the numaNode attribute for a PCI
+// device, reading the physical NUMA node from sysfs numa_node.
+//
+// listEnabled selects the form of the attribute and MUST reflect the cluster's
+// DRAListTypeAttributes state. A driver cannot detect that state (feature gates
+// are per-process), so the operator configures it on the driver, consistent
+// with what the apiserver and scheduler have enabled. The helper renders
+// whichever form it is told; it does not detect anything:
+//
+//   - listEnabled true: the SLIT-based list (IntValues). The first element is
+//     the physical NUMA node; additional elements are same-socket nodes at the
+//     minimum ACPI SLIT distance. Falls back to a single-element list when SLIT
+//     distances are unavailable.
+//   - listEnabled false: the scalar physical NUMA node (IntValue), which has no
+//     feature-gate dependency.
+//
+// If listEnabled is true but DRAListTypeAttributes is off in the cluster, the
+// apiserver drops the list value and rejects the resulting value-less
+// attribute; the driver should treat that publish failure as fatal rather than
+// adapting.
+func GetNUMANodeAttributeByPCIBusID(pciBusID string, listEnabled bool, mods ...MachineModifier) (DeviceAttribute, error) {
+	var mc machine
+	initDefaultMachine(&mc)
+	for _, mod := range mods {
+		mod(&mc)
+	}
+
+	if err := verifyPCIBDFFormat(pciBusID); err != nil {
+		return DeviceAttribute{}, err
+	}
+
+	physicalNode, err := readNUMANode(mc, pciBusID)
+	if err != nil {
+		return DeviceAttribute{}, err
+	}
+
+	// sysfs reports numa_node = -1 for a device with no NUMA affinity. Such a
+	// device must not publish numaNode: a value of -1 would match every other
+	// NUMA-less device under matchAttribute set intersection. Return an error so
+	// the driver omits the attribute instead.
+	if physicalNode < 0 {
+		return DeviceAttribute{}, fmt.Errorf("PCI device %s has no NUMA affinity (numa_node=%d); do not publish the numaNode attribute for it", pciBusID, physicalNode)
+	}
+
+	if listEnabled {
+		return makeNUMANodeListAttribute(mc, physicalNode), nil
+	}
+	return makeNUMANodeScalarAttribute(physicalNode), nil
+}
+
+// GetNUMANodeAttribute returns the numaNode attribute for a device that already
+// knows its NUMA node (for example CPU and memory devices). See
+// GetNUMANodeAttributeByPCIBusID for the meaning of listEnabled.
+//
+// numaNode must be a valid (non-negative) NUMA node. A negative value indicates
+// no NUMA affinity, for which the attribute must not be published (it would
+// match every other NUMA-less device), so an error is returned.
+func GetNUMANodeAttribute(numaNode int, listEnabled bool, mods ...MachineModifier) (DeviceAttribute, error) {
+	if numaNode < 0 {
+		return DeviceAttribute{}, fmt.Errorf("invalid NUMA node %d: do not publish the numaNode attribute for a device with no NUMA affinity", numaNode)
+	}
+
+	if !listEnabled {
+		return makeNUMANodeScalarAttribute(numaNode), nil
+	}
+
+	var mc machine
+	initDefaultMachine(&mc)
+	for _, mod := range mods {
+		mod(&mc)
+	}
+
+	return makeNUMANodeListAttribute(mc, numaNode), nil
+}
+
+func makeNUMANodeScalarAttribute(numaNode int) DeviceAttribute {
+	value := int64(numaNode)
+	return DeviceAttribute{
+		Name:  StandardDeviceAttributeNUMANode,
+		Value: resourceapi.DeviceAttribute{IntValue: &value},
+	}
+}
+
+// GetNUMANodeForCPU returns the NUMA node ID for a given CPU core by scanning
+// /sys/devices/system/node/node*/cpulist.
+func GetNUMANodeForCPU(cpuID int, mods ...MachineModifier) (int, error) {
+	var mc machine
+	initDefaultMachine(&mc)
+	for _, mod := range mods {
+		mod(&mc)
+	}
+
+	matches, err := fs.Glob(mc.sysfs, filepath.Join("devices", "system", "node", "node*", "cpulist"))
+	if err != nil {
+		return -1, fmt.Errorf("failed to glob NUMA node cpulists: %w", err)
+	}
+
+	for _, match := range matches {
+		data, err := fs.ReadFile(mc.sysfs, match)
+		if err != nil {
+			// Skip a node whose cpulist cannot be read and keep scanning the
+			// rest; if the CPU is in no readable node, the final not-found
+			// error below is returned.
+			continue
+		}
+
+		cpus := parseCPUList(strings.TrimSpace(string(data)))
+		for _, cpu := range cpus {
+			if cpu == cpuID {
+				nodeDir := filepath.Base(filepath.Dir(match))
+				nodeNum, err := strconv.Atoi(strings.TrimPrefix(nodeDir, "node"))
+				if err != nil {
+					return -1, fmt.Errorf("failed to parse NUMA node number from %s: %w", nodeDir, err)
+				}
+				return nodeNum, nil
+			}
+		}
+	}
+
+	return -1, fmt.Errorf("CPU %d not found in any NUMA node", cpuID)
+}
+
+// makeNUMANodeListAttribute builds the list-form numaNode attribute. The caller
+// must pass a non-negative physicalNode; negative nodes (no NUMA affinity) are
+// rejected by the exported helpers before reaching here.
+func makeNUMANodeListAttribute(mc machine, physicalNode int) DeviceAttribute {
+	equidistant, err := getEquidistantNUMANodes(mc, physicalNode)
+	if err != nil || len(equidistant) <= 1 {
+		return DeviceAttribute{
+			Name:  StandardDeviceAttributeNUMANode,
+			Value: resourceapi.DeviceAttribute{IntValues: []int64{int64(physicalNode)}},
+		}
+	}
+
+	// getEquidistantNUMANodes always includes the physical node itself in the
+	// returned set, so drop it here and prepend it to keep it first.
+	result := []int64{int64(physicalNode)}
+	for _, n := range equidistant {
+		if n != physicalNode {
+			result = append(result, int64(n))
+		}
+	}
+
+	return DeviceAttribute{
+		Name:  StandardDeviceAttributeNUMANode,
+		Value: resourceapi.DeviceAttribute{IntValues: result},
+	}
+}
+
+func readNUMANode(mc machine, pciBusID string) (int, error) {
+	numaNodePath := filepath.Join("bus", "pci", "devices", pciBusID, "numa_node")
+	data, err := fs.ReadFile(mc.sysfs, numaNodePath)
+	if err != nil {
+		return -1, fmt.Errorf("failed to read NUMA node for PCI Bus ID %s: %w", pciBusID, err)
+	}
+
+	node, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return -1, fmt.Errorf("failed to parse NUMA node for PCI Bus ID %s: %w", pciBusID, err)
+	}
+
+	return node, nil
+}
+
+// getEquidistantNUMANodes reads the SLIT distance row for the given NUMA node
+// and returns all same-socket nodes at the minimum non-self distance, plus
+// the node itself.
+func getEquidistantNUMANodes(mc machine, node int) ([]int, error) {
+	if node < 0 {
+		return nil, fmt.Errorf("invalid NUMA node %d", node)
+	}
+
+	distPath := filepath.Join("devices", "system", "node", fmt.Sprintf("node%d", node), "distance")
+	data, err := fs.ReadFile(mc.sysfs, distPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read SLIT distances for NUMA node %d: %w", node, err)
+	}
+
+	fields := strings.Fields(strings.TrimSpace(string(data)))
+	if len(fields) == 0 {
+		return nil, fmt.Errorf("empty distance file for NUMA node %d", node)
+	}
+
+	if node >= len(fields) {
+		return nil, fmt.Errorf("NUMA node %d out of range for distance table with %d entries", node, len(fields))
+	}
+
+	distances := make([]int, len(fields))
+	for i, f := range fields {
+		d, err := strconv.Atoi(f)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse distance value %q for NUMA node %d: %w", f, node, err)
+		}
+		distances[i] = d
+	}
+
+	// Find minimum non-self distance
+	minDist := -1
+	for i, d := range distances {
+		if i == node {
+			continue
+		}
+		if minDist == -1 || d < minDist {
+			minDist = d
+		}
+	}
+
+	if minDist == -1 {
+		return []int{node}, nil
+	}
+
+	reportedSocket, haveSocket := getSocketForNUMANode(mc, node)
+
+	var nodes []int
+	for i, d := range distances {
+		if i == node {
+			nodes = append(nodes, i)
+			continue
+		}
+		if d != minDist {
+			continue
+		}
+		if haveSocket {
+			// Exclude a candidate only when its socket is known and differs.
+			// If the candidate's socket cannot be determined (for example a
+			// CPU-less memory node with no cpulist), it is included rather than
+			// dropped. This is a deliberate over-approximation: it is safer to
+			// include a possibly-same-socket node than to drop a genuinely
+			// same-socket one.
+			candidateSocket, ok := getSocketForNUMANode(mc, i)
+			if ok && candidateSocket != reportedSocket {
+				continue
+			}
+		}
+		nodes = append(nodes, i)
+	}
+
+	sort.Ints(nodes)
+	return nodes, nil
+}
+
+func getSocketForNUMANode(mc machine, node int) (int, bool) {
+	cpulistPath := filepath.Join("devices", "system", "node", fmt.Sprintf("node%d", node), "cpulist")
+	data, err := fs.ReadFile(mc.sysfs, cpulistPath)
+	if err != nil {
+		return -1, false
+	}
+
+	cpus := parseCPUList(strings.TrimSpace(string(data)))
+	if len(cpus) == 0 {
+		return -1, false
+	}
+
+	pkgPath := filepath.Join("devices", "system", "cpu", fmt.Sprintf("cpu%d", cpus[0]), "topology", "physical_package_id")
+	pkgData, err := fs.ReadFile(mc.sysfs, pkgPath)
+	if err != nil {
+		return -1, false
+	}
+
+	socketID, err := strconv.Atoi(strings.TrimSpace(string(pkgData)))
+	if err != nil {
+		return -1, false
+	}
+
+	return socketID, true
+}
+
+// parseCPUList parses a Linux CPU list string like "0-3,8-11" into individual
+// CPU IDs.
+func parseCPUList(cpulist string) []int {
+	if cpulist == "" {
+		return nil
+	}
+	var cpus []int
+	for _, part := range strings.Split(cpulist, ",") {
+		bounds := strings.SplitN(part, "-", 2)
+		start, err := strconv.Atoi(strings.TrimSpace(bounds[0]))
+		if err != nil {
+			continue
+		}
+		if len(bounds) == 1 {
+			cpus = append(cpus, start)
+		} else {
+			end, err := strconv.Atoi(strings.TrimSpace(bounds[1]))
+			if err != nil {
+				continue
+			}
+			for i := start; i <= end; i++ {
+				cpus = append(cpus, i)
+			}
+		}
+	}
+	return cpus
+}

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/numa_linux.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/numa_linux.go
@@ -27,27 +27,36 @@ import (
 	resourceapi "k8s.io/api/resource/v1"
 )
 
+// AttributeForm selects whether the numaNode attribute is published as a
+// scalar IntValue or a list IntValues.
+type AttributeForm int
+
+const (
+	// ScalarAttribute produces a scalar IntValue with the physical NUMA node.
+	// This form has no feature-gate dependency.
+	ScalarAttribute AttributeForm = iota
+	// ListAttribute produces an IntValues list. The first element is the
+	// physical NUMA node; additional elements are same-socket nodes at the
+	// minimum ACPI SLIT distance. Falls back to a single-element list when
+	// SLIT distances are unavailable. Requires DRAListTypeAttributes to be
+	// enabled in the cluster.
+	ListAttribute
+)
+
 // GetNUMANodeAttributeByPCIBusID returns the numaNode attribute for a PCI
 // device, reading the physical NUMA node from sysfs numa_node.
 //
-// listEnabled selects the form of the attribute and MUST reflect the cluster's
+// attrForm selects the form of the attribute and MUST reflect the cluster's
 // DRAListTypeAttributes state. A driver cannot detect that state (feature gates
 // are per-process), so the operator configures it on the driver, consistent
 // with what the apiserver and scheduler have enabled. The helper renders
-// whichever form it is told; it does not detect anything:
+// whichever form it is told; it does not detect anything.
 //
-//   - listEnabled true: the SLIT-based list (IntValues). The first element is
-//     the physical NUMA node; additional elements are same-socket nodes at the
-//     minimum ACPI SLIT distance. Falls back to a single-element list when SLIT
-//     distances are unavailable.
-//   - listEnabled false: the scalar physical NUMA node (IntValue), which has no
-//     feature-gate dependency.
-//
-// If listEnabled is true but DRAListTypeAttributes is off in the cluster, the
+// If ListAttribute is used but DRAListTypeAttributes is off in the cluster, the
 // apiserver drops the list value and rejects the resulting value-less
 // attribute; the driver should treat that publish failure as fatal rather than
 // adapting.
-func GetNUMANodeAttributeByPCIBusID(pciBusID string, listEnabled bool, mods ...MachineModifier) (DeviceAttribute, error) {
+func GetNUMANodeAttributeByPCIBusID(pciBusID string, attrForm AttributeForm, mods ...MachineModifier) (DeviceAttribute, error) {
 	var mc machine
 	initDefaultMachine(&mc)
 	for _, mod := range mods {
@@ -71,7 +80,7 @@ func GetNUMANodeAttributeByPCIBusID(pciBusID string, listEnabled bool, mods ...M
 		return DeviceAttribute{}, fmt.Errorf("PCI device %s has no NUMA affinity (numa_node=%d); do not publish the numaNode attribute for it", pciBusID, physicalNode)
 	}
 
-	if listEnabled {
+	if attrForm == ListAttribute {
 		return makeNUMANodeListAttribute(mc, physicalNode), nil
 	}
 	return makeNUMANodeScalarAttribute(physicalNode), nil
@@ -79,17 +88,17 @@ func GetNUMANodeAttributeByPCIBusID(pciBusID string, listEnabled bool, mods ...M
 
 // GetNUMANodeAttribute returns the numaNode attribute for a device that already
 // knows its NUMA node (for example CPU and memory devices). See
-// GetNUMANodeAttributeByPCIBusID for the meaning of listEnabled.
+// GetNUMANodeAttributeByPCIBusID for the meaning of attrForm.
 //
 // numaNode must be a valid (non-negative) NUMA node. A negative value indicates
 // no NUMA affinity, for which the attribute must not be published (it would
 // match every other NUMA-less device), so an error is returned.
-func GetNUMANodeAttribute(numaNode int, listEnabled bool, mods ...MachineModifier) (DeviceAttribute, error) {
+func GetNUMANodeAttribute(numaNode int, attrForm AttributeForm, mods ...MachineModifier) (DeviceAttribute, error) {
 	if numaNode < 0 {
 		return DeviceAttribute{}, fmt.Errorf("invalid NUMA node %d: do not publish the numaNode attribute for a device with no NUMA affinity", numaNode)
 	}
 
-	if !listEnabled {
+	if attrForm == ScalarAttribute {
 		return makeNUMANodeScalarAttribute(numaNode), nil
 	}
 
@@ -110,8 +119,8 @@ func makeNUMANodeScalarAttribute(numaNode int) DeviceAttribute {
 	}
 }
 
-// GetNUMANodeForCPU returns the NUMA node ID for a given CPU core by scanning
-// /sys/devices/system/node/node*/cpulist.
+// GetNUMANodeForCPU returns the NUMA node ID for a given CPU core by reading
+// the /sys/devices/system/cpu/cpuX/nodeY symlink.
 func GetNUMANodeForCPU(cpuID int, mods ...MachineModifier) (int, error) {
 	var mc machine
 	initDefaultMachine(&mc)
@@ -119,34 +128,21 @@ func GetNUMANodeForCPU(cpuID int, mods ...MachineModifier) (int, error) {
 		mod(&mc)
 	}
 
-	matches, err := fs.Glob(mc.sysfs, filepath.Join("devices", "system", "node", "node*", "cpulist"))
+	pattern := filepath.Join("devices", "system", "cpu", fmt.Sprintf("cpu%d", cpuID), "node[0-9]*")
+	matches, err := fs.Glob(mc.sysfs, pattern)
 	if err != nil {
-		return -1, fmt.Errorf("failed to glob NUMA node cpulists: %w", err)
+		return -1, fmt.Errorf("failed to find NUMA node for CPU %d: %w", cpuID, err)
+	}
+	if len(matches) == 0 {
+		return -1, fmt.Errorf("CPU %d not found in any NUMA node", cpuID)
 	}
 
-	for _, match := range matches {
-		data, err := fs.ReadFile(mc.sysfs, match)
-		if err != nil {
-			// Skip a node whose cpulist cannot be read and keep scanning the
-			// rest; if the CPU is in no readable node, the final not-found
-			// error below is returned.
-			continue
-		}
-
-		cpus := parseCPUList(strings.TrimSpace(string(data)))
-		for _, cpu := range cpus {
-			if cpu == cpuID {
-				nodeDir := filepath.Base(filepath.Dir(match))
-				nodeNum, err := strconv.Atoi(strings.TrimPrefix(nodeDir, "node"))
-				if err != nil {
-					return -1, fmt.Errorf("failed to parse NUMA node number from %s: %w", nodeDir, err)
-				}
-				return nodeNum, nil
-			}
-		}
+	nodeDir := filepath.Base(matches[0])
+	nodeNum, err := strconv.Atoi(strings.TrimPrefix(nodeDir, "node"))
+	if err != nil {
+		return -1, fmt.Errorf("failed to parse NUMA node number from %s: %w", nodeDir, err)
 	}
-
-	return -1, fmt.Errorf("CPU %d not found in any NUMA node", cpuID)
+	return nodeNum, nil
 }
 
 // makeNUMANodeListAttribute builds the list-form numaNode attribute. The caller
@@ -301,7 +297,7 @@ func parseCPUList(cpulist string) []int {
 		return nil
 	}
 	var cpus []int
-	for _, part := range strings.Split(cpulist, ",") {
+	for part := range strings.SplitSeq(cpulist, ",") {
 		bounds := strings.SplitN(part, "-", 2)
 		start, err := strconv.Atoi(strings.TrimSpace(bounds[0]))
 		if err != nil {

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/numa_linux.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/numa_linux.go
@@ -46,8 +46,8 @@ const (
 
 // maxNUMANodes is the upper bound for valid NUMA node IDs.
 // Linux defines MAX_NUMNODES = (1 << CONFIG_NODES_SHIFT) in
-// include/linux/nodemask_types.h, with CONFIG_NODES_SHIFT capped at 10
-// across all architectures (x86, arm64, riscv).
+// include/linux/nodemask_types.h (as of v7.2), with CONFIG_NODES_SHIFT
+// capped at 10 across all architectures (x86, arm64, riscv).
 const maxNUMANodes = 1024
 
 // GetNUMANodeAttributeByPCIBusID returns the numaNode attribute for a PCI
@@ -288,7 +288,7 @@ func getSocketForNUMANode(mc machine, node int) (int, bool) {
 		return -1, false
 	}
 
-	pkgPath := filepath.Join("devices", "system", "cpu", fmt.Sprintf("cpu%d", cpus.List()[0]), "topology", "physical_package_id")
+	pkgPath := filepath.Join("devices", "system", "cpu", fmt.Sprintf("cpu%d", cpus.UnsortedList()[0]), "topology", "physical_package_id")
 	socketID, err := readSysfsInt(mc, pkgPath)
 	if err != nil {
 		return -1, false

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/numa_linux.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/numa_linux.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/utils/cpuset"
 )
 
 // AttributeForm selects whether the numaNode attribute is published as a
@@ -43,7 +44,10 @@ const (
 	ListAttribute
 )
 
-// maxNUMANodes is the upper bound for valid NUMA node IDs (Linux kernel maximum).
+// maxNUMANodes is the upper bound for valid NUMA node IDs.
+// Linux defines MAX_NUMNODES = (1 << CONFIG_NODES_SHIFT) in
+// include/linux/nodemask_types.h, with CONFIG_NODES_SHIFT capped at 10
+// across all architectures (x86, arm64, riscv).
 const maxNUMANodes = 1024
 
 // GetNUMANodeAttributeByPCIBusID returns the numaNode attribute for a PCI
@@ -279,44 +283,16 @@ func getSocketForNUMANode(mc machine, node int) (int, bool) {
 		return -1, false
 	}
 
-	cpus := parseCPUList(strings.TrimSpace(string(data)))
-	if len(cpus) == 0 {
+	cpus, err := cpuset.Parse(strings.TrimSpace(string(data)))
+	if err != nil || cpus.Size() == 0 {
 		return -1, false
 	}
 
-	pkgPath := filepath.Join("devices", "system", "cpu", fmt.Sprintf("cpu%d", cpus[0]), "topology", "physical_package_id")
+	pkgPath := filepath.Join("devices", "system", "cpu", fmt.Sprintf("cpu%d", cpus.List()[0]), "topology", "physical_package_id")
 	socketID, err := readSysfsInt(mc, pkgPath)
 	if err != nil {
 		return -1, false
 	}
 
 	return socketID, true
-}
-
-// parseCPUList parses a Linux CPU list string like "0-3,8-11" into individual
-// CPU IDs.
-func parseCPUList(cpulist string) []int {
-	if cpulist == "" {
-		return nil
-	}
-	var cpus []int
-	for part := range strings.SplitSeq(cpulist, ",") {
-		bounds := strings.SplitN(part, "-", 2)
-		start, err := strconv.Atoi(strings.TrimSpace(bounds[0]))
-		if err != nil {
-			continue
-		}
-		if len(bounds) == 1 {
-			cpus = append(cpus, start)
-		} else {
-			end, err := strconv.Atoi(strings.TrimSpace(bounds[1]))
-			if err != nil {
-				continue
-			}
-			for i := start; i <= end; i++ {
-				cpus = append(cpus, i)
-			}
-		}
-	}
-	return cpus
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/numa_linux_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/numa_linux_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/numa_linux_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/numa_linux_test.go
@@ -23,8 +23,6 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/utils/ptr"
-
 	resourceapi "k8s.io/api/resource/v1"
 )
 
@@ -35,7 +33,7 @@ func TestGetNUMANodeAttributeByPCIBusID(t *testing.T) {
 	tests := map[string]struct {
 		setup             func(t *testing.T, root string)
 		address           string
-		listEnabled       bool
+		attrForm          AttributeForm
 		expectedAttribute *DeviceAttribute
 		expectsError      bool
 		expectedErrMsg    string
@@ -44,11 +42,11 @@ func TestGetNUMANodeAttributeByPCIBusID(t *testing.T) {
 			setup: func(t *testing.T, root string) {
 				writeFile(t, filepath.Join(root, numaNodePath), "4\n")
 			},
-			address:     pciBusID,
-			listEnabled: false,
+			address:  pciBusID,
+			attrForm: ScalarAttribute,
 			expectedAttribute: &DeviceAttribute{
 				Name:  StandardDeviceAttributeNUMANode,
-				Value: resourceapi.DeviceAttribute{IntValue: ptr.To(int64(4))},
+				Value: resourceapi.DeviceAttribute{IntValue: new(int64(4))},
 			},
 		},
 		"list with equidistant nodes": {
@@ -60,8 +58,8 @@ func TestGetNUMANodeAttributeByPCIBusID(t *testing.T) {
 				// all minimum-distance nodes are kept.
 				writeFile(t, filepath.Join(root, "devices", "system", "node", "node1", "distance"), "12 10 12\n")
 			},
-			address:     pciBusID,
-			listEnabled: true,
+			address:  pciBusID,
+			attrForm: ListAttribute,
 			expectedAttribute: &DeviceAttribute{
 				Name:  StandardDeviceAttributeNUMANode,
 				Value: resourceapi.DeviceAttribute{IntValues: []int64{1, 0, 2}},
@@ -73,8 +71,8 @@ func TestGetNUMANodeAttributeByPCIBusID(t *testing.T) {
 				// Only a self distance, so there are no equidistant peers.
 				writeFile(t, filepath.Join(root, "devices", "system", "node", "node0", "distance"), "10\n")
 			},
-			address:     pciBusID,
-			listEnabled: true,
+			address:  pciBusID,
+			attrForm: ListAttribute,
 			expectedAttribute: &DeviceAttribute{
 				Name:  StandardDeviceAttributeNUMANode,
 				Value: resourceapi.DeviceAttribute{IntValues: []int64{0}},
@@ -93,8 +91,8 @@ func TestGetNUMANodeAttributeByPCIBusID(t *testing.T) {
 				writeFile(t, filepath.Join(root, "devices", "system", "cpu", "cpu1", "topology", "physical_package_id"), "0\n")
 				writeFile(t, filepath.Join(root, "devices", "system", "cpu", "cpu2", "topology", "physical_package_id"), "1\n")
 			},
-			address:     pciBusID,
-			listEnabled: true,
+			address:  pciBusID,
+			attrForm: ListAttribute,
 			expectedAttribute: &DeviceAttribute{
 				Name:  StandardDeviceAttributeNUMANode,
 				Value: resourceapi.DeviceAttribute{IntValues: []int64{0, 1}},
@@ -105,19 +103,19 @@ func TestGetNUMANodeAttributeByPCIBusID(t *testing.T) {
 				writeFile(t, filepath.Join(root, numaNodePath), "-1\n")
 			},
 			address:        pciBusID,
-			listEnabled:    true,
+			attrForm:       ListAttribute,
 			expectsError:   true,
 			expectedErrMsg: "no NUMA affinity",
 		},
 		"empty PCI Bus ID": {
 			address:        "",
-			listEnabled:    true,
+			attrForm:       ListAttribute,
 			expectsError:   true,
 			expectedErrMsg: "PCI Bus ID cannot be empty",
 		},
 		"missing numa_node": {
 			address:        pciBusID,
-			listEnabled:    false,
+			attrForm:       ScalarAttribute,
 			expectsError:   true,
 			expectedErrMsg: "failed to read NUMA node",
 		},
@@ -128,7 +126,7 @@ func TestGetNUMANodeAttributeByPCIBusID(t *testing.T) {
 			if test.setup != nil {
 				test.setup(t, root)
 			}
-			got, err := GetNUMANodeAttributeByPCIBusID(test.address, test.listEnabled, WithFSFromRoot(root))
+			got, err := GetNUMANodeAttributeByPCIBusID(test.address, test.attrForm, WithFSFromRoot(root))
 			if test.expectsError {
 				if err == nil {
 					t.Fatalf("expected error but got none")
@@ -150,13 +148,13 @@ func TestGetNUMANodeAttributeByPCIBusID(t *testing.T) {
 
 func TestGetNUMANodeAttribute(t *testing.T) {
 	t.Run("scalar", func(t *testing.T) {
-		got, err := GetNUMANodeAttribute(4, false)
+		got, err := GetNUMANodeAttribute(4, ScalarAttribute)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		want := DeviceAttribute{
 			Name:  StandardDeviceAttributeNUMANode,
-			Value: resourceapi.DeviceAttribute{IntValue: ptr.To(int64(4))},
+			Value: resourceapi.DeviceAttribute{IntValue: new(int64(4))},
 		}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("expected %+v, got %+v", want, got)
@@ -169,7 +167,7 @@ func TestGetNUMANodeAttribute(t *testing.T) {
 	t.Run("list with equidistant nodes", func(t *testing.T) {
 		root := t.TempDir()
 		writeFile(t, filepath.Join(root, "devices", "system", "node", "node1", "distance"), "12 10 12\n")
-		got, err := GetNUMANodeAttribute(1, true, WithFSFromRoot(root))
+		got, err := GetNUMANodeAttribute(1, ListAttribute, WithFSFromRoot(root))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -186,7 +184,7 @@ func TestGetNUMANodeAttribute(t *testing.T) {
 	})
 
 	t.Run("no NUMA affinity is rejected", func(t *testing.T) {
-		_, err := GetNUMANodeAttribute(-1, false)
+		_, err := GetNUMANodeAttribute(-1, ScalarAttribute)
 		if err == nil {
 			t.Fatal("expected error for a device with no NUMA affinity, got none")
 		}
@@ -204,25 +202,22 @@ func TestGetNUMANodeForCPU(t *testing.T) {
 		expectsErr  bool
 		errContains string
 	}{
-		"cpu in single-range node": {
+		"cpu on node1": {
 			setup: func(t *testing.T, root string) {
-				writeFile(t, filepath.Join(root, "devices", "system", "node", "node0", "cpulist"), "0-3\n")
-				writeFile(t, filepath.Join(root, "devices", "system", "node", "node1", "cpulist"), "4-7\n")
+				mkDirAll(t, filepath.Join(root, "devices", "system", "cpu", "cpu5", "node1"))
 			},
 			cpuID:    5,
 			wantNode: 1,
 		},
-		"cpu in comma-and-range list": {
+		"cpu on node0": {
 			setup: func(t *testing.T, root string) {
-				writeFile(t, filepath.Join(root, "devices", "system", "node", "node0", "cpulist"), "0-3,8-11\n")
+				mkDirAll(t, filepath.Join(root, "devices", "system", "cpu", "cpu9", "node0"))
 			},
 			cpuID:    9,
 			wantNode: 0,
 		},
 		"cpu not found": {
-			setup: func(t *testing.T, root string) {
-				writeFile(t, filepath.Join(root, "devices", "system", "node", "node0", "cpulist"), "0-3\n")
-			},
+			setup:       func(t *testing.T, root string) {},
 			cpuID:       99,
 			expectsErr:  true,
 			errContains: "not found in any NUMA node",

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/numa_linux_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/numa_linux_test.go
@@ -1,0 +1,263 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceattribute
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"k8s.io/utils/ptr"
+
+	resourceapi "k8s.io/api/resource/v1"
+)
+
+func TestGetNUMANodeAttributeByPCIBusID(t *testing.T) {
+	pciBusID := "0000:02:00.0"
+	numaNodePath := filepath.Join("bus", "pci", "devices", pciBusID, "numa_node")
+
+	tests := map[string]struct {
+		setup             func(t *testing.T, root string)
+		address           string
+		listEnabled       bool
+		expectedAttribute *DeviceAttribute
+		expectsError      bool
+		expectedErrMsg    string
+	}{
+		"scalar": {
+			setup: func(t *testing.T, root string) {
+				writeFile(t, filepath.Join(root, numaNodePath), "4\n")
+			},
+			address:     pciBusID,
+			listEnabled: false,
+			expectedAttribute: &DeviceAttribute{
+				Name:  StandardDeviceAttributeNUMANode,
+				Value: resourceapi.DeviceAttribute{IntValue: ptr.To(int64(4))},
+			},
+		},
+		"list with equidistant nodes": {
+			setup: func(t *testing.T, root string) {
+				writeFile(t, filepath.Join(root, numaNodePath), "1\n")
+				// node1 SLIT row: node0=12, node1(self)=10, node2=12.
+				// Minimum non-self distance is 12 -> {0,2}; physical node first.
+				// No cpulist/topology files, so the socket filter is inactive and
+				// all minimum-distance nodes are kept.
+				writeFile(t, filepath.Join(root, "devices", "system", "node", "node1", "distance"), "12 10 12\n")
+			},
+			address:     pciBusID,
+			listEnabled: true,
+			expectedAttribute: &DeviceAttribute{
+				Name:  StandardDeviceAttributeNUMANode,
+				Value: resourceapi.DeviceAttribute{IntValues: []int64{1, 0, 2}},
+			},
+		},
+		"list single NUMA node": {
+			setup: func(t *testing.T, root string) {
+				writeFile(t, filepath.Join(root, numaNodePath), "0\n")
+				// Only a self distance, so there are no equidistant peers.
+				writeFile(t, filepath.Join(root, "devices", "system", "node", "node0", "distance"), "10\n")
+			},
+			address:     pciBusID,
+			listEnabled: true,
+			expectedAttribute: &DeviceAttribute{
+				Name:  StandardDeviceAttributeNUMANode,
+				Value: resourceapi.DeviceAttribute{IntValues: []int64{0}},
+			},
+		},
+		"list with same-socket filter": {
+			setup: func(t *testing.T, root string) {
+				writeFile(t, filepath.Join(root, numaNodePath), "0\n")
+				// node0 self=10; node1 and node2 both at minimum distance 12; node3 farther.
+				writeFile(t, filepath.Join(root, "devices", "system", "node", "node0", "distance"), "10 12 12 20\n")
+				// node0 and node1 are on socket 0; node2 is on socket 1, so node2 is filtered out.
+				writeFile(t, filepath.Join(root, "devices", "system", "node", "node0", "cpulist"), "0\n")
+				writeFile(t, filepath.Join(root, "devices", "system", "node", "node1", "cpulist"), "1\n")
+				writeFile(t, filepath.Join(root, "devices", "system", "node", "node2", "cpulist"), "2\n")
+				writeFile(t, filepath.Join(root, "devices", "system", "cpu", "cpu0", "topology", "physical_package_id"), "0\n")
+				writeFile(t, filepath.Join(root, "devices", "system", "cpu", "cpu1", "topology", "physical_package_id"), "0\n")
+				writeFile(t, filepath.Join(root, "devices", "system", "cpu", "cpu2", "topology", "physical_package_id"), "1\n")
+			},
+			address:     pciBusID,
+			listEnabled: true,
+			expectedAttribute: &DeviceAttribute{
+				Name:  StandardDeviceAttributeNUMANode,
+				Value: resourceapi.DeviceAttribute{IntValues: []int64{0, 1}},
+			},
+		},
+		"no NUMA affinity is rejected": {
+			setup: func(t *testing.T, root string) {
+				writeFile(t, filepath.Join(root, numaNodePath), "-1\n")
+			},
+			address:        pciBusID,
+			listEnabled:    true,
+			expectsError:   true,
+			expectedErrMsg: "no NUMA affinity",
+		},
+		"empty PCI Bus ID": {
+			address:        "",
+			listEnabled:    true,
+			expectsError:   true,
+			expectedErrMsg: "PCI Bus ID cannot be empty",
+		},
+		"missing numa_node": {
+			address:        pciBusID,
+			listEnabled:    false,
+			expectsError:   true,
+			expectedErrMsg: "failed to read NUMA node",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			if test.setup != nil {
+				test.setup(t, root)
+			}
+			got, err := GetNUMANodeAttributeByPCIBusID(test.address, test.listEnabled, WithFSFromRoot(root))
+			if test.expectsError {
+				if err == nil {
+					t.Fatalf("expected error but got none")
+				}
+				if !strings.Contains(err.Error(), test.expectedErrMsg) {
+					t.Errorf("expected error containing %q, got %q", test.expectedErrMsg, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, *test.expectedAttribute) {
+				t.Errorf("expected %+v, got %+v", *test.expectedAttribute, got)
+			}
+		})
+	}
+}
+
+func TestGetNUMANodeAttribute(t *testing.T) {
+	t.Run("scalar", func(t *testing.T) {
+		got, err := GetNUMANodeAttribute(4, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := DeviceAttribute{
+			Name:  StandardDeviceAttributeNUMANode,
+			Value: resourceapi.DeviceAttribute{IntValue: ptr.To(int64(4))},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("expected %+v, got %+v", want, got)
+		}
+		if got.Value.IntValues != nil {
+			t.Errorf("expected nil IntValues for scalar attribute, got %v", got.Value.IntValues)
+		}
+	})
+
+	t.Run("list with equidistant nodes", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, "devices", "system", "node", "node1", "distance"), "12 10 12\n")
+		got, err := GetNUMANodeAttribute(1, true, WithFSFromRoot(root))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := DeviceAttribute{
+			Name:  StandardDeviceAttributeNUMANode,
+			Value: resourceapi.DeviceAttribute{IntValues: []int64{1, 0, 2}},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("expected %+v, got %+v", want, got)
+		}
+		if got.Value.IntValue != nil {
+			t.Errorf("expected nil IntValue for list attribute, got %v", *got.Value.IntValue)
+		}
+	})
+
+	t.Run("no NUMA affinity is rejected", func(t *testing.T) {
+		_, err := GetNUMANodeAttribute(-1, false)
+		if err == nil {
+			t.Fatal("expected error for a device with no NUMA affinity, got none")
+		}
+		if !strings.Contains(err.Error(), "invalid NUMA node") {
+			t.Errorf("expected error about invalid NUMA node, got %q", err.Error())
+		}
+	})
+}
+
+func TestGetNUMANodeForCPU(t *testing.T) {
+	tests := map[string]struct {
+		setup       func(t *testing.T, root string)
+		cpuID       int
+		wantNode    int
+		expectsErr  bool
+		errContains string
+	}{
+		"cpu in single-range node": {
+			setup: func(t *testing.T, root string) {
+				writeFile(t, filepath.Join(root, "devices", "system", "node", "node0", "cpulist"), "0-3\n")
+				writeFile(t, filepath.Join(root, "devices", "system", "node", "node1", "cpulist"), "4-7\n")
+			},
+			cpuID:    5,
+			wantNode: 1,
+		},
+		"cpu in comma-and-range list": {
+			setup: func(t *testing.T, root string) {
+				writeFile(t, filepath.Join(root, "devices", "system", "node", "node0", "cpulist"), "0-3,8-11\n")
+			},
+			cpuID:    9,
+			wantNode: 0,
+		},
+		"cpu not found": {
+			setup: func(t *testing.T, root string) {
+				writeFile(t, filepath.Join(root, "devices", "system", "node", "node0", "cpulist"), "0-3\n")
+			},
+			cpuID:       99,
+			expectsErr:  true,
+			errContains: "not found in any NUMA node",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			if test.setup != nil {
+				test.setup(t, root)
+			}
+			got, err := GetNUMANodeForCPU(test.cpuID, WithFSFromRoot(root))
+			if test.expectsErr {
+				if err == nil {
+					t.Fatalf("expected error but got node %d", got)
+				}
+				if !strings.Contains(err.Error(), test.errContains) {
+					t.Errorf("expected error containing %q, got %q", test.errContains, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != test.wantNode {
+				t.Errorf("expected NUMA node %d, got %d", test.wantNode, got)
+			}
+		})
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	mkDirAll(t, filepath.Dir(path))
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write file %s: %v", path, err)
+	}
+}

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -939,6 +939,7 @@ func TestAllocator(t *testing.T,
 	stringAttribute := resourceapi.FullyQualifiedName(driverA + "/" + "stringAttribute")
 	versionAttribute := resourceapi.FullyQualifiedName(driverA + "/" + "driverVersion")
 	intAttribute := resourceapi.FullyQualifiedName(driverA + "/" + "numa")
+	numaNodeAttribute := resourceapi.FullyQualifiedName("resource.kubernetes.io/numaNode")
 	taintKey := "taint-key"
 	taintValue := "taint-value"
 	taintValue2 := "taint-value-2"
@@ -6093,6 +6094,59 @@ func TestAllocator(t *testing.T,
 				deviceAllocationResult(req0, driverA, pool1, device1, false),
 				deviceAllocationResult(req0, driverA, pool1, device2, false),
 			)},
+		},
+		// KEP-6072: standardized numaNode attribute, list form. Two devices whose
+		// numaNode lists share an element (physical node + same-socket equidistant
+		// nodes) are co-placed by matchAttribute set intersection.
+		"numanode-matchattribute-overlapping-lists-are-co-placed": {
+			features: Features{
+				ListTypeAttributes: true,
+			},
+			claimsToAllocate: objects(claimWithRequests(
+				claim0,
+				[]resourceapi.DeviceConstraint{{MatchAttribute: &numaNodeAttribute}},
+				request(req0, classA, 2)),
+			),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
+				device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"resource.kubernetes.io/numaNode": {IntValues: []int64{4}},
+				}),
+				device(device2, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"resource.kubernetes.io/numaNode": {IntValues: []int64{4, 5, 6, 7}},
+				}),
+			)),
+			node: node(node1, region1),
+
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool1, device1, false),
+				deviceAllocationResult(req0, driverA, pool1, device2, false),
+			)},
+		},
+		// KEP-6072: numaNode lists with no common element (different NUMA domains)
+		// cannot satisfy matchAttribute, so no allocation is made.
+		"numanode-matchattribute-disjoint-lists-are-not-allocated": {
+			features: Features{
+				ListTypeAttributes: true,
+			},
+			claimsToAllocate: objects(claimWithRequests(
+				claim0,
+				[]resourceapi.DeviceConstraint{{MatchAttribute: &numaNodeAttribute}},
+				request(req0, classA, 2)),
+			),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
+				device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"resource.kubernetes.io/numaNode": {IntValues: []int64{0}},
+				}),
+				device(device2, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"resource.kubernetes.io/numaNode": {IntValues: []int64{4, 5, 6, 7}},
+				}),
+			)),
+			node: node(node1, region1),
+
+			expectResults: nil,
 		},
 		"list-attributes-match-constaint-list-of-bool-values-with-common-elements": {
 			features: Features{


### PR DESCRIPTION
## Summary

Add `resource.kubernetes.io/numaNode` as a well-known DRA device attribute (KEP-6072), enabling cross-driver NUMA co-placement via `matchAttribute`.

- Add `StandardDeviceAttributeNUMANode` constant alongside existing `pcieRoot` and `pciBusID`
- Add `GetNUMANodeAttributeByPCIBusID()` for PCI/I/O devices (reads sysfs `numa_node` + ACPI SLIT distances)
- Add `GetNUMANodeAttribute()` for CPU/memory devices that already know their NUMA node
- Add `GetNUMANodeForCPU()` to look up a CPU core's NUMA node from sysfs
- Both attribute helpers accept an `AttributeForm` parameter: `ScalarAttribute` for scalar `IntValue`, `ListAttribute` for SLIT-based `IntValues` list
- Devices with no NUMA affinity (`numa_node = -1`) return an error so drivers omit the attribute

The `AttributeForm` parameter is operator-configured on the driver to match the cluster's `DRAListTypeAttributes` state (KEP-5491). Drivers do not detect the cluster's feature gates at runtime.

### KEP

- [KEP-6072: DRA: Standard numaNode Device Attribute](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/6072-dra-standard-numanode/README.md)

### Changes

| File | Description |
|------|-------------|
| `deviceattribute/attribute.go` | Add `StandardDeviceAttributeNUMANode` constant |
| `deviceattribute/numa_linux.go` | NUMA helpers: `GetNUMANodeAttributeByPCIBusID`, `GetNUMANodeAttribute`, `GetNUMANodeForCPU` |
| `deviceattribute/numa_linux_test.go` | Unit tests for scalar, list, socket filter, and error paths |
| `allocatortesting/allocator_testing.go` | Allocator integration tests for `matchAttribute` with overlapping and disjoint `numaNode` lists |

## Test plan

- [x] Unit tests: scalar and list forms, socket boundary filter, SLIT distance matrix variations, negative NUMA node rejection, PCI Bus ID validation
- [x] Allocator integration tests: `matchAttribute` intersection matching for overlapping lists (`[4]` ∩ `[4,5,6,7]` → match) and disjoint lists (`[0]` ∩ `[4,5,6,7]` → no match)

```release-note
DRA: Add `resource.kubernetes.io/numaNode` as a standard device attribute with sysfs-based helper functions for DRA drivers (KEP-6072).
```