### PR TITLE
cronjob: call queue.Forget when sync returns (nil, nil)

### DIFF
--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -204,6 +204,8 @@ func (jm *ControllerV2) processNextWorkItem(ctx context.Context) bool {
 	case requeueAfter != nil:
 		jm.queue.Forget(key)
 		jm.queue.AddAfter(key, *requeueAfter)
+	default:
+		jm.queue.Forget(key)
 	}
 	return true
 }


### PR DESCRIPTION
## What this PR does / why we need it

`processNextWorkItem` in the CronJob controller was only calling `queue.Forget(key)` inside the `requeueAfter != nil` branch. When `sync()` returns `(nil, nil)` — no error and no requeue duration — the rate-limiter failure count was never reset.

Affected paths that return `(nil, nil)`:
- CronJob not found / already deleted
- CronJob being deleted (`DeletionTimestamp != nil`)
- CronJob suspended (`spec.suspend == true`)
- Invalid `spec.timeZone`
- Unparseable / invalid `spec.schedule`

This leaves stale backoff state that can delay reconciliation after a transient error incident has passed. It also means a new CronJob created with the same `namespace/name` inherits the previous object's failure count.

The fix adds a `default` branch to call `queue.Forget(key)` on every clean `(nil, nil)` return from `sync`.

## Which issue(s) this PR fixes

Fixes #139917

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Does this PR introduce a user-facing change?

```release-note
NONE
```