### PR TITLE
report resource health for restartable init containers

### DIFF
--- a/pkg/api/v1/pod/util.go
+++ b/pkg/api/v1/pod/util.go
@@ -396,6 +396,25 @@ func IsRestartableInitContainer(initContainer *v1.Container) bool {
 	return *initContainer.RestartPolicy == v1.ContainerRestartPolicyAlways
 }
 
+// VisitContainersWithResourceHealthStatus invokes the visitor for containers
+// whose allocated resource health can be reported in pod status.
+func VisitContainersWithResourceHealthStatus(podSpec *v1.PodSpec, visitor ContainerVisitor) bool {
+	for i := range podSpec.InitContainers {
+		if !IsRestartableInitContainer(&podSpec.InitContainers[i]) {
+			continue
+		}
+		if !visitor(&podSpec.InitContainers[i], InitContainers) {
+			return false
+		}
+	}
+	for i := range podSpec.Containers {
+		if !visitor(&podSpec.Containers[i], Containers) {
+			return false
+		}
+	}
+	return true
+}
+
 // IsContainerRestartable returns true if the container can be restarted. A container can be
 // restarted if it has a pod-level restart policy "Always" or "OnFailure" and not override by
 // container-level restart policy, or a container-level restart policy "Always" or "OnFailure",

--- a/pkg/api/v1/pod/util_test.go
+++ b/pkg/api/v1/pod/util_test.go
@@ -1174,6 +1174,36 @@ func TestIsContainerRestartable(t *testing.T) {
 	}
 }
 
+func TestVisitContainersWithResourceHealthStatus(t *testing.T) {
+	restartAlways := v1.ContainerRestartPolicyAlways
+	podSpec := &v1.PodSpec{
+		InitContainers: []v1.Container{
+			{Name: "regular-init"},
+			{Name: "restartable-init", RestartPolicy: &restartAlways},
+		},
+		Containers: []v1.Container{
+			{Name: "app"},
+		},
+		EphemeralContainers: []v1.EphemeralContainer{
+			{EphemeralContainerCommon: v1.EphemeralContainerCommon{Name: "ephemeral"}},
+		},
+	}
+
+	gotContainers := []string{}
+	completed := VisitContainersWithResourceHealthStatus(podSpec, func(c *v1.Container, _ ContainerType) bool {
+		gotContainers = append(gotContainers, c.Name)
+		return true
+	})
+	if !completed {
+		t.Fatalf("VisitContainersWithResourceHealthStatus() = false, want true")
+	}
+
+	wantContainers := []string{"restartable-init", "app"}
+	if !cmp.Equal(gotContainers, wantContainers) {
+		t.Errorf("VisitContainersWithResourceHealthStatus() visited %+v, want %+v", gotContainers, wantContainers)
+	}
+}
+
 func TestContainerHasRestartablePolicy(t *testing.T) {
 	var (
 		containerRestartPolicyAlways    = v1.ContainerRestartPolicyAlways

--- a/pkg/api/v1/pod/util_test.go
+++ b/pkg/api/v1/pod/util_test.go
@@ -1176,31 +1176,79 @@ func TestIsContainerRestartable(t *testing.T) {
 
 func TestVisitContainersWithResourceHealthStatus(t *testing.T) {
 	restartAlways := v1.ContainerRestartPolicyAlways
-	podSpec := &v1.PodSpec{
-		InitContainers: []v1.Container{
-			{Name: "regular-init"},
-			{Name: "restartable-init", RestartPolicy: &restartAlways},
+	testCases := []struct {
+		desc           string
+		spec           *v1.PodSpec
+		stopAfter      string
+		wantContainers []string
+		wantCompleted  bool
+	}{
+		{
+			desc:           "empty podspec",
+			spec:           &v1.PodSpec{},
+			wantContainers: []string{},
+			wantCompleted:  true,
 		},
-		Containers: []v1.Container{
-			{Name: "app"},
+		{
+			desc: "restartable init and app containers",
+			spec: &v1.PodSpec{
+				InitContainers: []v1.Container{
+					{Name: "regular-init"},
+					{Name: "restartable-init", RestartPolicy: &restartAlways},
+				},
+				Containers: []v1.Container{
+					{Name: "app"},
+				},
+				EphemeralContainers: []v1.EphemeralContainer{
+					{EphemeralContainerCommon: v1.EphemeralContainerCommon{Name: "ephemeral"}},
+				},
+			},
+			wantContainers: []string{"restartable-init", "app"},
+			wantCompleted:  true,
 		},
-		EphemeralContainers: []v1.EphemeralContainer{
-			{EphemeralContainerCommon: v1.EphemeralContainerCommon{Name: "ephemeral"}},
+		{
+			desc: "only regular init and ephemeral containers",
+			spec: &v1.PodSpec{
+				InitContainers: []v1.Container{
+					{Name: "regular-init"},
+				},
+				EphemeralContainers: []v1.EphemeralContainer{
+					{EphemeralContainerCommon: v1.EphemeralContainerCommon{Name: "ephemeral"}},
+				},
+			},
+			wantContainers: []string{},
+			wantCompleted:  true,
+		},
+		{
+			desc: "short-circuits when visitor returns false",
+			spec: &v1.PodSpec{
+				InitContainers: []v1.Container{
+					{Name: "restartable-init", RestartPolicy: &restartAlways},
+				},
+				Containers: []v1.Container{
+					{Name: "app"},
+				},
+			},
+			stopAfter:      "restartable-init",
+			wantContainers: []string{"restartable-init"},
+			wantCompleted:  false,
 		},
 	}
 
-	gotContainers := []string{}
-	completed := VisitContainersWithResourceHealthStatus(podSpec, func(c *v1.Container, _ ContainerType) bool {
-		gotContainers = append(gotContainers, c.Name)
-		return true
-	})
-	if !completed {
-		t.Fatalf("VisitContainersWithResourceHealthStatus() = false, want true")
-	}
-
-	wantContainers := []string{"restartable-init", "app"}
-	if !cmp.Equal(gotContainers, wantContainers) {
-		t.Errorf("VisitContainersWithResourceHealthStatus() visited %+v, want %+v", gotContainers, wantContainers)
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			gotContainers := []string{}
+			completed := VisitContainersWithResourceHealthStatus(tc.spec, func(c *v1.Container, _ ContainerType) bool {
+				gotContainers = append(gotContainers, c.Name)
+				return c.Name != tc.stopAfter
+			})
+			if completed != tc.wantCompleted {
+				t.Fatalf("VisitContainersWithResourceHealthStatus() = %v, want %v", completed, tc.wantCompleted)
+			}
+			if !cmp.Equal(gotContainers, tc.wantContainers) {
+				t.Errorf("VisitContainersWithResourceHealthStatus() visited %+v, want %+v", gotContainers, tc.wantContainers)
+			}
+		})
 	}
 }
 

--- a/pkg/kubelet/apis/podresources/server_v1.go
+++ b/pkg/kubelet/apis/podresources/server_v1.go
@@ -87,17 +87,10 @@ func (p *v1PodResourcesServer) List(ctx context.Context, req *podresourcesv1.Lis
 		}
 
 		pRes.Containers = make([]*podresourcesv1.ContainerResources, 0, len(pod.Spec.InitContainers)+len(pod.Spec.Containers))
-		for _, container := range pod.Spec.InitContainers {
-			if !podutil.IsRestartableInitContainer(&container) {
-				continue
-			}
-
-			pRes.Containers = append(pRes.Containers, p.getContainerResources(logger, pod, &container))
-		}
-
-		for _, container := range pod.Spec.Containers {
-			pRes.Containers = append(pRes.Containers, p.getContainerResources(logger, pod, &container))
-		}
+		podutil.VisitContainersWithResourceHealthStatus(&pod.Spec, func(container *v1.Container, _ podutil.ContainerType) bool {
+			pRes.Containers = append(pRes.Containers, p.getContainerResources(logger, pod, container))
+			return true
+		})
 		podResources[i] = &pRes
 	}
 
@@ -146,17 +139,10 @@ func (p *v1PodResourcesServer) Get(ctx context.Context, req *podresourcesv1.GetP
 	}
 
 	podResources.Containers = make([]*podresourcesv1.ContainerResources, 0, len(pod.Spec.InitContainers)+len(pod.Spec.Containers))
-	for _, container := range pod.Spec.InitContainers {
-		if !podutil.IsRestartableInitContainer(&container) {
-			continue
-		}
-
-		podResources.Containers = append(podResources.Containers, p.getContainerResources(logger, pod, &container))
-	}
-
-	for _, container := range pod.Spec.Containers {
-		podResources.Containers = append(podResources.Containers, p.getContainerResources(logger, pod, &container))
-	}
+	podutil.VisitContainersWithResourceHealthStatus(&pod.Spec, func(container *v1.Container, _ podutil.ContainerType) bool {
+		podResources.Containers = append(podResources.Containers, p.getContainerResources(logger, pod, container))
+		return true
+	})
 
 	response := &podresourcesv1.GetPodResourcesResponse{
 		PodResources: podResources,

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -1161,8 +1161,27 @@ func (m *ManagerImpl) UpdateAllocatedResourcesStatus(logger klog.Logger, pod *v1
 	// Today we ignore edge cases that are not likely to happen:
 	//  - update statuses for containers that are in spec, but not in status
 	//  - update statuses for resources requested in spec, but with no information in podDevices
-	for i, containerStatus := range status.ContainerStatuses {
-		devices := m.podDevices.getContainerDevices(string(pod.UID), containerStatus.Name)
+	containerNames := containersWithResourceHealthStatusNames(pod)
+	m.updateAllocatedResourcesStatus(string(pod.UID), status.InitContainerStatuses, containerNames.Has)
+	m.updateAllocatedResourcesStatus(string(pod.UID), status.ContainerStatuses, containerNames.Has)
+}
+
+func containersWithResourceHealthStatusNames(pod *v1.Pod) sets.Set[string] {
+	names := sets.New[string]()
+	podutil.VisitContainersWithResourceHealthStatus(&pod.Spec, func(container *v1.Container, _ podutil.ContainerType) bool {
+		names.Insert(container.Name)
+		return true
+	})
+	return names
+}
+
+func (m *ManagerImpl) updateAllocatedResourcesStatus(podUID string, containerStatuses []v1.ContainerStatus, shouldUpdate func(string) bool) {
+	for i := range containerStatuses {
+		containerStatus := &containerStatuses[i]
+		if !shouldUpdate(containerStatus.Name) {
+			continue
+		}
+		devices := m.podDevices.getContainerDevices(podUID, containerStatus.Name)
 
 		for resourceName, deviceInstances := range devices {
 			for id, d := range deviceInstances {
@@ -1197,22 +1216,22 @@ func (m *ManagerImpl) UpdateAllocatedResourcesStatus(logger klog.Logger, pod *v1
 				})
 			}
 
-			if status.ContainerStatuses[i].AllocatedResourcesStatus == nil {
-				status.ContainerStatuses[i].AllocatedResourcesStatus = []v1.ResourceStatus{}
+			if containerStatus.AllocatedResourcesStatus == nil {
+				containerStatus.AllocatedResourcesStatus = []v1.ResourceStatus{}
 			}
 
 			// look up the resource status by name and update it
 			found := false
-			for j, rs := range status.ContainerStatuses[i].AllocatedResourcesStatus {
+			for j, rs := range containerStatus.AllocatedResourcesStatus {
 				if rs.Name == resourceStatus.Name {
-					status.ContainerStatuses[i].AllocatedResourcesStatus[j] = resourceStatus
+					containerStatus.AllocatedResourcesStatus[j] = resourceStatus
 					found = true
 					break
 				}
 			}
 
 			if !found {
-				status.ContainerStatuses[i].AllocatedResourcesStatus = append(status.ContainerStatuses[i].AllocatedResourcesStatus, resourceStatus)
+				containerStatus.AllocatedResourcesStatus = append(containerStatus.AllocatedResourcesStatus, resourceStatus)
 			}
 		}
 	}

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -1944,7 +1944,10 @@ func TestUpdateAllocatedResourcesStatus(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 	podUID := "test-pod-uid"
 	containerName := "test-container"
+	initContainerName := "test-init-container"
+	regularInitContainerName := "test-regular-init-container"
 	resourceName := "test-resource"
+	restartAlways := v1.ContainerRestartPolicyAlways
 
 	tmpDir, err := os.MkdirTemp("", "checkpoint")
 	if err != nil {
@@ -1979,18 +1982,49 @@ func TestUpdateAllocatedResourcesStatus(t *testing.T) {
 			withMounts(map[string]string{"/home/r1lib1": "/usr/r1lib1"}),
 		),
 	)
+	testManager.podDevices.insert(podUID, initContainerName, resourceName,
+		constructDevices([]string{"dev3"}),
+		newContainerAllocateResponse(
+			withDevices(map[string]string{"/dev/r1dev3": "/dev/r1dev3"}),
+			withMounts(map[string]string{"/home/r1lib3": "/usr/r1lib3"}),
+		),
+	)
+	testManager.podDevices.insert(podUID, regularInitContainerName, resourceName,
+		constructDevices([]string{"dev4"}),
+		newContainerAllocateResponse(
+			withDevices(map[string]string{"/dev/r1dev4": "/dev/r1dev4"}),
+			withMounts(map[string]string{"/home/r1lib4": "/usr/r1lib4"}),
+		),
+	)
 
 	testManager.genericDeviceUpdateCallback(logger, resourceName, []*pluginapi.Device{
 		{ID: "dev1", Health: pluginapi.Healthy},
 		{ID: "dev2", Health: pluginapi.Unhealthy},
+		{ID: "dev3", Health: pluginapi.Healthy},
+		{ID: "dev4", Health: pluginapi.Healthy},
 	})
 
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID: types.UID(podUID),
 		},
+		Spec: v1.PodSpec{
+			InitContainers: []v1.Container{
+				{Name: regularInitContainerName},
+				{Name: initContainerName, RestartPolicy: &restartAlways},
+			},
+			Containers: []v1.Container{{Name: containerName}},
+		},
 	}
 	status := &v1.PodStatus{
+		InitContainerStatuses: []v1.ContainerStatus{
+			{
+				Name: regularInitContainerName,
+			},
+			{
+				Name: initContainerName,
+			},
+		},
 		ContainerStatuses: []v1.ContainerStatus{
 			{
 				Name: containerName,
@@ -2012,6 +2046,24 @@ func TestUpdateAllocatedResourcesStatus(t *testing.T) {
 			},
 		},
 	}
+	expectedInitStatus := v1.ResourceStatus{
+		Name: v1.ResourceName(resourceName),
+		Resources: []v1.ResourceHealth{
+			{
+				ResourceID: "dev3",
+				Health:     pluginapi.Healthy,
+			},
+		},
+	}
+	expectedInitContainerStatuses := []v1.ContainerStatus{
+		{
+			Name: regularInitContainerName,
+		},
+		{
+			Name:                     initContainerName,
+			AllocatedResourcesStatus: []v1.ResourceStatus{expectedInitStatus},
+		},
+	}
 	expectedContainerStatuses := []v1.ContainerStatus{
 		{
 			Name:                     containerName,
@@ -2020,9 +2072,14 @@ func TestUpdateAllocatedResourcesStatus(t *testing.T) {
 	}
 
 	// Sort the resources for the expected status and actual status
+	sortContainerStatuses(status.InitContainerStatuses)
+	sortContainerStatuses(expectedInitContainerStatuses)
 	sortContainerStatuses(status.ContainerStatuses)
 	sortContainerStatuses(expectedContainerStatuses)
 
+	if !reflect.DeepEqual(status.InitContainerStatuses, expectedInitContainerStatuses) {
+		t.Errorf("UpdateAllocatedResourcesStatus failed for init containers, expected: %v, got: %v", expectedInitContainerStatuses, status.InitContainerStatuses)
+	}
 	if !reflect.DeepEqual(status.ContainerStatuses, expectedContainerStatuses) {
 		t.Errorf("UpdateAllocatedResourcesStatus failed, expected: %v, got: %v", expectedContainerStatuses, status.ContainerStatuses)
 	}

--- a/pkg/kubelet/cm/dra/manager.go
+++ b/pkg/kubelet/cm/dra/manager.go
@@ -43,6 +43,7 @@ import (
 
 	drahealthv1 "k8s.io/kubelet/pkg/apis/dra-health/v1"
 	drapb "k8s.io/kubelet/pkg/apis/dra/v1"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
 	draplugin "k8s.io/kubernetes/pkg/kubelet/cm/dra/plugin"
 	"k8s.io/kubernetes/pkg/kubelet/cm/dra/state"
@@ -873,18 +874,31 @@ func (m *Manager) UpdateAllocatedResourcesStatus(logger klog.Logger, pod *v1.Pod
 	logger = logger.WithName("dra-manager")
 	logger = klog.LoggerWithValues(logger, "pod", klog.KObj(pod))
 	enableHealthMessage := utilfeature.DefaultFeatureGate.Enabled(kubefeatures.ResourceHealthStatusMessage)
-	for i := range status.ContainerStatuses {
-		containerStatus := &status.ContainerStatuses[i]
-
-		// Find the corresponding container spec in the pod spec.
-		var containerSpec *v1.Container
-		for j := range pod.Spec.Containers {
-			if pod.Spec.Containers[j].Name == containerStatus.Name {
-				containerSpec = &pod.Spec.Containers[j]
-				break
-			}
+	containerSpecs := containerSpecsWithResourceHealthStatusByName(pod)
+	podClaimStatusMap := make(map[string]string, len(pod.Status.ResourceClaimStatuses))
+	for _, podClaimStatus := range pod.Status.ResourceClaimStatuses {
+		if podClaimStatus.ResourceClaimName != nil {
+			podClaimStatusMap[podClaimStatus.Name] = *podClaimStatus.ResourceClaimName
 		}
+	}
 
+	m.updateAllocatedResourcesStatus(logger, pod, status.InitContainerStatuses, containerSpecs, podClaimStatusMap, enableHealthMessage)
+	m.updateAllocatedResourcesStatus(logger, pod, status.ContainerStatuses, containerSpecs, podClaimStatusMap, enableHealthMessage)
+}
+
+func containerSpecsWithResourceHealthStatusByName(pod *v1.Pod) map[string]*v1.Container {
+	containerSpecs := make(map[string]*v1.Container, len(pod.Spec.Containers))
+	podutil.VisitContainersWithResourceHealthStatus(&pod.Spec, func(container *v1.Container, _ podutil.ContainerType) bool {
+		containerSpecs[container.Name] = container
+		return true
+	})
+	return containerSpecs
+}
+
+func (m *Manager) updateAllocatedResourcesStatus(logger klog.Logger, pod *v1.Pod, containerStatuses []v1.ContainerStatus, containerSpecs map[string]*v1.Container, podClaimStatusMap map[string]string, enableHealthMessage bool) {
+	for i := range containerStatuses {
+		containerStatus := &containerStatuses[i]
+		containerSpec := containerSpecs[containerStatus.Name]
 		// Skip if there's no matching container spec or it has no resource claims.
 		if containerSpec == nil || len(containerSpec.Resources.Claims) == 0 {
 			continue
@@ -894,14 +908,6 @@ func (m *Manager) UpdateAllocatedResourcesStatus(logger klog.Logger, pod *v1.Pod
 		if containerStatus.AllocatedResourcesStatus != nil {
 			for j := range containerStatus.AllocatedResourcesStatus {
 				resourceStatusMap[containerStatus.AllocatedResourcesStatus[j].Name] = &containerStatus.AllocatedResourcesStatus[j]
-			}
-		}
-
-		// Build a map of pod claim statuses for O(1) lookup
-		podClaimStatusMap := make(map[string]string, len(pod.Status.ResourceClaimStatuses))
-		for _, podClaimStatus := range pod.Status.ResourceClaimStatuses {
-			if podClaimStatus.ResourceClaimName != nil {
-				podClaimStatusMap[podClaimStatus.Name] = *podClaimStatus.ResourceClaimName
 			}
 		}
 

--- a/pkg/kubelet/cm/dra/manager_test.go
+++ b/pkg/kubelet/cm/dra/manager_test.go
@@ -2457,6 +2457,11 @@ func TestUpdateAllocatedResourcesStatus(t *testing.T) {
 	renamedClaimObject := "renamed-claim-object"
 	templateName := "template-name"
 	templatedClaimName := "pod-templated-templated-claim"
+	restartAlways := v1.ContainerRestartPolicyAlways
+	regularInitClaimObject := "regular-init-claim-object"
+	restartableInitClaimObject := "restartable-init-claim-object"
+	appClaimObject := "app-claim-object"
+	healthyDeviceMessage := "Device is operating normally"
 
 	testCases := []struct {
 		name                             string
@@ -2464,6 +2469,7 @@ func TestUpdateAllocatedResourcesStatus(t *testing.T) {
 		claimInfos                       []*ClaimInfo
 		initialStatus                    *v1.PodStatus
 		expectedAllocatedResourcesStatus []v1.ResourceStatus
+		expectedInitResourcesStatus      []v1.ResourceStatus
 	}{
 		{
 			name: "Direct claim",
@@ -2619,6 +2625,107 @@ func TestUpdateAllocatedResourcesStatus(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Restartable init container",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-restartable-init", UID: "pod-restartable-init-uid"},
+				Spec: v1.PodSpec{
+					InitContainers: []v1.Container{
+						{
+							Name: "regular-init",
+							Resources: v1.ResourceRequirements{
+								Claims: []v1.ResourceClaim{{Name: "regular-init-claim"}},
+							},
+						},
+						{
+							Name:          "restartable-init",
+							RestartPolicy: &restartAlways,
+							Resources: v1.ResourceRequirements{
+								Claims: []v1.ResourceClaim{{Name: "restartable-init-claim"}},
+							},
+						},
+					},
+					ResourceClaims: []v1.PodResourceClaim{
+						{Name: "regular-init-claim", ResourceClaimName: &regularInitClaimObject},
+						{Name: "restartable-init-claim", ResourceClaimName: &restartableInitClaimObject},
+						{Name: "app-claim", ResourceClaimName: &appClaimObject},
+					},
+					Containers: []v1.Container{
+						{
+							Name: "container1",
+							Resources: v1.ResourceRequirements{
+								Claims: []v1.ResourceClaim{{Name: "app-claim"}},
+							},
+						},
+					},
+				},
+				Status: v1.PodStatus{
+					ResourceClaimStatuses: []v1.PodResourceClaimStatus{
+						{Name: "regular-init-claim", ResourceClaimName: &regularInitClaimObject},
+						{Name: "restartable-init-claim", ResourceClaimName: &restartableInitClaimObject},
+						{Name: "app-claim", ResourceClaimName: &appClaimObject},
+					},
+				},
+			},
+			claimInfos: []*ClaimInfo{
+				{
+					ClaimInfoState: state.ClaimInfoState{
+						ClaimName: regularInitClaimObject,
+						PodUIDs:   sets.New("pod-restartable-init-uid"),
+						DriverState: map[string]state.DriverState{
+							"test-driver": {Devices: []state.Device{{
+								PoolName:   "pool",
+								DeviceName: "dev-regular-init",
+							}}},
+						},
+					},
+				},
+				{
+					ClaimInfoState: state.ClaimInfoState{
+						ClaimName: restartableInitClaimObject,
+						PodUIDs:   sets.New("pod-restartable-init-uid"),
+						DriverState: map[string]state.DriverState{
+							"test-driver": {Devices: []state.Device{{
+								PoolName:   "pool",
+								DeviceName: "dev-restartable-init",
+							}}},
+						},
+					},
+				},
+				{
+					ClaimInfoState: state.ClaimInfoState{
+						ClaimName: appClaimObject,
+						PodUIDs:   sets.New("pod-restartable-init-uid"),
+						DriverState: map[string]state.DriverState{
+							"test-driver": {Devices: []state.Device{{
+								PoolName:   "pool",
+								DeviceName: "dev-app",
+							}}},
+						},
+					},
+				},
+			},
+			initialStatus: &v1.PodStatus{
+				InitContainerStatuses: []v1.ContainerStatus{{Name: "regular-init"}, {Name: "restartable-init"}},
+				ContainerStatuses:     []v1.ContainerStatus{{Name: "container1"}},
+			},
+			expectedAllocatedResourcesStatus: []v1.ResourceStatus{
+				{
+					Name: "claim:app-claim",
+					Resources: []v1.ResourceHealth{
+						{ResourceID: "test-driver/pool/dev-app", Health: v1.ResourceHealthStatusHealthy, Message: &healthyDeviceMessage},
+					},
+				},
+			},
+			expectedInitResourcesStatus: []v1.ResourceStatus{
+				{
+					Name: "claim:restartable-init-claim",
+					Resources: []v1.ResourceHealth{
+						{ResourceID: "test-driver/pool/dev-restartable-init", Health: v1.ResourceHealthStatusHealthy, Message: &healthyDeviceMessage},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -2656,6 +2763,11 @@ func TestUpdateAllocatedResourcesStatus(t *testing.T) {
 
 			require.Len(t, status.ContainerStatuses, 1)
 			assert.Equal(t, tc.expectedAllocatedResourcesStatus, status.ContainerStatuses[0].AllocatedResourcesStatus)
+			if len(tc.expectedInitResourcesStatus) > 0 {
+				require.Len(t, status.InitContainerStatuses, 2)
+				assert.Empty(t, status.InitContainerStatuses[0].AllocatedResourcesStatus)
+				assert.Equal(t, tc.expectedInitResourcesStatus, status.InitContainerStatuses[1].AllocatedResourcesStatus)
+			}
 		})
 	}
 }

--- a/test/e2e_node/dra_test.go
+++ b/test/e2e_node/dra_test.go
@@ -92,6 +92,8 @@ const (
 	// Also used as timeout in other tests because it's a good upper bound
 	// even when the test normally completes faster.
 	retryTestTimeout = kubeletRetryPeriod + 30*time.Second
+
+	healthTestRequestName = "my-request"
 )
 
 // Tests depend on container runtime support for CDI and the DRA feature gate.
@@ -957,6 +959,53 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 			testHealthTransitions(ctx, "health-v1", nodeWatchResourcesV1Method, withoutHealthV1alpha1())
 		})
 
+		ginkgo.It("should reflect restartable init container device health changes in the Pod's status", func(ctx context.Context) {
+			ginkgo.By("Starting the test driver with channel-based control")
+			kubeletPlugin := newKubeletPlugin(ctx, f.ClientSet, f.Namespace.Name, getNodeName(ctx, f), driverName)
+
+			poolName := "restartable-init-health-pool"
+			deviceName := "restartable-init-health-device"
+			claimName := "restartable-init-health-claim"
+			pod := createRestartableInitHealthTestPodAndClaim(
+				ctx, f, driverName,
+				"restartable-init-health-class",
+				claimName,
+				"restartable-init-health-pod",
+				poolName,
+				deviceName,
+			)
+
+			ginkgo.By("wait for NodePrepareResources call to succeed")
+			gomega.Eventually(kubeletPlugin.GetGRPCCalls).WithTimeout(retryTestTimeout).Should(testdrivergomega.NodePrepareResourcesSucceeded)
+
+			ginkgo.By("Waiting for the pod to be running")
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod))
+
+			ginkgo.By("Setting restartable init container device health to Healthy")
+			kubeletPlugin.HealthControlChan <- testdriver.DeviceHealthUpdate{
+				PoolName:   poolName,
+				DeviceName: deviceName,
+				Health:     "Healthy",
+			}
+
+			ginkgo.By("Verifying restartable init container device health is Healthy")
+			gomega.Eventually(ctx, func(ctx context.Context) (string, error) {
+				return getInitContainerDeviceHealthFromAPIServer(f, pod.Namespace, pod.Name, "restartable-init", driverName, claimName, poolName, deviceName)
+			}).WithTimeout(30*time.Second).WithPolling(1*time.Second).Should(gomega.Equal("Healthy"), "Restartable init container device health should be Healthy after explicit update")
+
+			ginkgo.By("Setting restartable init container device health to Unhealthy")
+			kubeletPlugin.HealthControlChan <- testdriver.DeviceHealthUpdate{
+				PoolName:   poolName,
+				DeviceName: deviceName,
+				Health:     "Unhealthy",
+			}
+
+			ginkgo.By("Verifying restartable init container device health is now Unhealthy")
+			gomega.Eventually(ctx, func(ctx context.Context) (string, error) {
+				return getInitContainerDeviceHealthFromAPIServer(f, pod.Namespace, pod.Name, "restartable-init", driverName, claimName, poolName, deviceName)
+			}).WithTimeout(60*time.Second).WithPolling(2*time.Second).Should(gomega.Equal("Unhealthy"), "Restartable init container device health should update to Unhealthy")
+		})
+
 		// This test verifies that the Kubelet establishes only a single gRPC connection
 		// with the DRA plugin throughout the plugin lifecycle.
 		//
@@ -1788,14 +1837,35 @@ func getDeviceHealthFromAPIServer(f *framework.Framework, namespace, podName, dr
 		return "", fmt.Errorf("failed to get pod %s/%s: %w", namespace, podName, err)
 	}
 
+	return getDeviceHealthFromContainerStatuses(pod.Status.ContainerStatuses, driverName, claimName, poolName, deviceName), nil
+}
+
+func getInitContainerDeviceHealthFromAPIServer(f *framework.Framework, namespace, podName, initContainerName, driverName, claimName, poolName, deviceName string) (string, error) {
+	pod, err := f.ClientSet.CoreV1().Pods(namespace).Get(context.Background(), podName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return "NotFound", nil
+		}
+		return "", fmt.Errorf("failed to get pod %s/%s: %w", namespace, podName, err)
+	}
+
+	for _, containerStatus := range pod.Status.InitContainerStatuses {
+		if containerStatus.Name == initContainerName {
+			return getDeviceHealthFromContainerStatuses([]v1.ContainerStatus{containerStatus}, driverName, claimName, poolName, deviceName), nil
+		}
+	}
+
+	return "NotFound", nil
+}
+
+func getDeviceHealthFromContainerStatuses(statuses []v1.ContainerStatus, driverName, claimName, poolName, deviceName string) string {
 	// This is the unique ID for the device based on how Kubelet manager code constructs it.
 	expectedResourceID := v1.ResourceID(fmt.Sprintf("%s/%s/%s", driverName, poolName, deviceName))
 
 	expectedResourceStatusNameSimple := v1.ResourceName(fmt.Sprintf("claim:%s", claimName))
-	expectedResourceStatusNameWithRequest := v1.ResourceName(fmt.Sprintf("claim:%s/%s", claimName, "my-request"))
+	expectedResourceStatusNameWithRequest := v1.ResourceName(fmt.Sprintf("claim:%s/%s", claimName, healthTestRequestName))
 
-	// Loop through container statuses.
-	for _, containerStatus := range pod.Status.ContainerStatuses {
+	for _, containerStatus := range statuses {
 		if containerStatus.AllocatedResourcesStatus != nil {
 			for _, resourceStatus := range containerStatus.AllocatedResourcesStatus {
 				if resourceStatus.Name != expectedResourceStatusNameSimple && resourceStatus.Name != expectedResourceStatusNameWithRequest {
@@ -1803,20 +1873,54 @@ func getDeviceHealthFromAPIServer(f *framework.Framework, namespace, podName, dr
 				}
 				for _, resourceHealth := range resourceStatus.Resources {
 					if resourceHealth.ResourceID == expectedResourceID || strings.HasPrefix(string(resourceHealth.ResourceID), driverName) {
-						return string(resourceHealth.Health), nil
+						return string(resourceHealth.Health)
 					}
 				}
 			}
 		}
 	}
 
-	return "NotFound", nil
+	return "NotFound"
 }
 
 // createHealthTestPodAndClaim is a specialized helper for the Resource Health test.
 // It creates all necessary objects (DeviceClass, ResourceClaim, Pod) and ensures
 // the pod is long-running and the claim is allocated from the specified pool.
 func createHealthTestPodAndClaim(ctx context.Context, f *framework.Framework, driverName, podName, claimName, className, poolName, deviceName string) *v1.Pod {
+	createHealthTestDeviceClassAndClaim(ctx, f, className, claimName)
+
+	ginkgo.By(fmt.Sprintf("Creating long-running Pod %q (without claim allocation yet)", podName))
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: f.Namespace.Name,
+		},
+		Spec: v1.PodSpec{
+			NodeName:      getNodeName(ctx, f),
+			RestartPolicy: v1.RestartPolicyNever,
+			ResourceClaims: []v1.PodResourceClaim{
+				{Name: claimName, ResourceClaimName: &claimName},
+			},
+			Containers: []v1.Container{
+				{
+					Name:    "testcontainer",
+					Image:   e2epod.GetDefaultTestImage(),
+					Command: []string{"/bin/sh", "-c", "sleep 600"},
+					Resources: v1.ResourceRequirements{
+						Claims: []v1.ResourceClaim{{Name: claimName, Request: healthTestRequestName}},
+					},
+				},
+			},
+		},
+	}
+	createdPod := createHealthTestPod(ctx, f, pod)
+	patchPodResourceClaimStatus(ctx, f, createdPod.Name, claimName)
+	allocateHealthTestClaimToPod(ctx, f, driverName, claimName, createdPod, poolName, deviceName, nil)
+
+	return createdPod
+}
+
+func createHealthTestDeviceClassAndClaim(ctx context.Context, f *framework.Framework, className, claimName string) {
 	ginkgo.By(fmt.Sprintf("Creating DeviceClass %q", className))
 	dc := &resourceapi.DeviceClass{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1839,7 +1943,7 @@ func createHealthTestPodAndClaim(ctx context.Context, f *framework.Framework, dr
 		Spec: resourceapi.ResourceClaimSpec{
 			Devices: resourceapi.DeviceClaim{
 				Requests: []resourceapi.DeviceRequest{{
-					Name: "my-request",
+					Name: healthTestRequestName,
 					Exactly: &resourceapi.ExactDeviceRequest{
 						DeviceClassName: className,
 					},
@@ -1856,7 +1960,62 @@ func createHealthTestPodAndClaim(ctx context.Context, f *framework.Framework, dr
 			framework.Failf("Failed to delete ResourceClaim %s: %v", claimName, err)
 		}
 	})
-	ginkgo.By(fmt.Sprintf("Creating long-running Pod %q (without claim allocation yet)", podName))
+}
+
+func createHealthTestPod(ctx context.Context, f *framework.Framework, pod *v1.Pod) *v1.Pod {
+	createdPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
+	framework.ExpectNoError(err, "failed to create Pod "+pod.Name)
+	ginkgo.DeferCleanup(func(ctx context.Context) {
+		e2epod.DeletePodOrFail(ctx, f.ClientSet, createdPod.Namespace, createdPod.Name)
+	})
+	return createdPod
+}
+
+func patchPodResourceClaimStatus(ctx context.Context, f *framework.Framework, podName, claimName string) {
+	patch, err := json.Marshal(v1.Pod{
+		Status: v1.PodStatus{
+			ResourceClaimStatuses: []v1.PodResourceClaimStatus{
+				{Name: claimName, ResourceClaimName: &claimName},
+			},
+		},
+	})
+	framework.ExpectNoError(err, "failed to marshal patch for Pod status")
+	_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Patch(ctx, podName, apitypes.StrategicMergePatchType, patch, metav1.PatchOptions{}, "status")
+	framework.ExpectNoError(err, "failed to patch Pod status with ResourceClaimStatuses")
+}
+
+func allocateHealthTestClaimToPod(ctx context.Context, f *framework.Framework, driverName, claimName string, pod *v1.Pod, poolName, deviceName string, shareID *apitypes.UID) {
+	ginkgo.By(fmt.Sprintf("Allocating claim %q to pod %q with its real UID", claimName, pod.Name))
+	claimToUpdate, err := f.ClientSet.ResourceV1().ResourceClaims(f.Namespace.Name).Get(ctx, claimName, metav1.GetOptions{})
+	framework.ExpectNoError(err, "failed to get latest version of ResourceClaim "+claimName)
+
+	claimToUpdate.Status = resourceapi.ResourceClaimStatus{
+		ReservedFor: []resourceapi.ResourceClaimConsumerReference{
+			{Resource: "pods", Name: pod.Name, UID: pod.UID},
+		},
+		Allocation: &resourceapi.AllocationResult{
+			Devices: resourceapi.DeviceAllocationResult{
+				Results: []resourceapi.DeviceRequestAllocationResult{
+					{
+						Driver:  driverName,
+						Pool:    poolName,
+						Device:  deviceName,
+						Request: healthTestRequestName,
+						ShareID: shareID,
+					},
+				},
+			},
+		},
+	}
+	_, err = f.ClientSet.ResourceV1().ResourceClaims(f.Namespace.Name).UpdateStatus(ctx, claimToUpdate, metav1.UpdateOptions{})
+	framework.ExpectNoError(err, "failed to update ResourceClaim status for test")
+}
+
+func createRestartableInitHealthTestPodAndClaim(ctx context.Context, f *framework.Framework, driverName, className, claimName, podName, poolName, deviceName string) *v1.Pod {
+	createHealthTestDeviceClassAndClaim(ctx, f, className, claimName)
+
+	restartAlways := v1.ContainerRestartPolicyAlways
+	ginkgo.By(fmt.Sprintf("Creating Pod %q with a restartable init container", podName))
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName,
@@ -1868,62 +2027,29 @@ func createHealthTestPodAndClaim(ctx context.Context, f *framework.Framework, dr
 			ResourceClaims: []v1.PodResourceClaim{
 				{Name: claimName, ResourceClaimName: &claimName},
 			},
+			InitContainers: []v1.Container{
+				{
+					Name:          "restartable-init",
+					Image:         e2epod.GetDefaultTestImage(),
+					Command:       []string{"/bin/sh", "-c", "sleep 600"},
+					RestartPolicy: &restartAlways,
+					Resources: v1.ResourceRequirements{
+						Claims: []v1.ResourceClaim{{Name: claimName, Request: healthTestRequestName}},
+					},
+				},
+			},
 			Containers: []v1.Container{
 				{
 					Name:    "testcontainer",
 					Image:   e2epod.GetDefaultTestImage(),
 					Command: []string{"/bin/sh", "-c", "sleep 600"},
-					Resources: v1.ResourceRequirements{
-						Claims: []v1.ResourceClaim{{Name: claimName, Request: "my-request"}},
-					},
 				},
 			},
 		},
 	}
-	// Create the pod on the API server to assign the real UID.
-	createdPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-	framework.ExpectNoError(err, "failed to create Pod "+podName)
-	ginkgo.DeferCleanup(func(ctx context.Context) {
-		e2epod.DeletePodOrFail(ctx, f.ClientSet, createdPod.Namespace, createdPod.Name)
-	})
-
-	// Patch the Pod's status to include the ResourceClaimStatuses, mimicking the scheduler.
-	patch, err := json.Marshal(v1.Pod{
-		Status: v1.PodStatus{
-			ResourceClaimStatuses: []v1.PodResourceClaimStatus{
-				{Name: claimName, ResourceClaimName: &claimName},
-			},
-		},
-	})
-	framework.ExpectNoError(err, "failed to marshal patch for Pod status")
-	_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Patch(ctx, createdPod.Name, apitypes.StrategicMergePatchType, patch, metav1.PatchOptions{}, "status")
-	framework.ExpectNoError(err, "failed to patch Pod status with ResourceClaimStatuses")
-
-	ginkgo.By(fmt.Sprintf("Allocating claim %q to pod %q with its real UID", claimName, podName))
-	// Get the created claim to ensure the latest version before updating.
-	claimToUpdate, err := f.ClientSet.ResourceV1().ResourceClaims(f.Namespace.Name).Get(ctx, claimName, metav1.GetOptions{})
-	framework.ExpectNoError(err, "failed to get latest version of ResourceClaim "+claimName)
-
-	// Update the claims status to reserve it for the *real* pod UID.
-	claimToUpdate.Status = resourceapi.ResourceClaimStatus{
-		ReservedFor: []resourceapi.ResourceClaimConsumerReference{
-			{Resource: "pods", Name: createdPod.Name, UID: createdPod.UID},
-		},
-		Allocation: &resourceapi.AllocationResult{
-			Devices: resourceapi.DeviceAllocationResult{
-				Results: []resourceapi.DeviceRequestAllocationResult{
-					{
-						Driver:  driverName,
-						Pool:    poolName,
-						Device:  deviceName,
-						Request: "my-request",
-					},
-				},
-			},
-		},
-	}
-	_, err = f.ClientSet.ResourceV1().ResourceClaims(f.Namespace.Name).UpdateStatus(ctx, claimToUpdate, metav1.UpdateOptions{})
-	framework.ExpectNoError(err, "failed to update ResourceClaim status for test")
+	createdPod := createHealthTestPod(ctx, f, pod)
+	patchPodResourceClaimStatus(ctx, f, createdPod.Name, claimName)
+	allocateHealthTestClaimToPod(ctx, f, driverName, claimName, createdPod, poolName, deviceName, nil)
 
 	return createdPod
 }
@@ -1968,46 +2094,7 @@ func setupAndVerifyHealthyPod(
 // createTestObjectsWithShareID creates test objects (DeviceClass, ResourceClaim, Pod) for testing
 // ShareID with health status integration. The ShareID is included in the device allocation result.
 func createTestObjectsWithShareID(ctx context.Context, f *framework.Framework, driverName, className, claimName, podName, poolName, deviceName string, shareID *apitypes.UID) *v1.Pod {
-	ginkgo.By(fmt.Sprintf("Creating DeviceClass %q", className))
-	dc := &resourceapi.DeviceClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: className,
-		},
-	}
-	_, err := f.ClientSet.ResourceV1().DeviceClasses().Create(ctx, dc, metav1.CreateOptions{})
-	framework.ExpectNoError(err, "failed to create DeviceClass "+className)
-	ginkgo.DeferCleanup(func(ctx context.Context) {
-		err := f.ClientSet.ResourceV1().DeviceClasses().Delete(ctx, className, metav1.DeleteOptions{})
-		if err != nil && !apierrors.IsNotFound(err) {
-			framework.Failf("Failed to delete DeviceClass %s: %v", className, err)
-		}
-	})
-
-	ginkgo.By(fmt.Sprintf("Creating ResourceClaim %q", claimName))
-	claim := &resourceapi.ResourceClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: claimName,
-		},
-		Spec: resourceapi.ResourceClaimSpec{
-			Devices: resourceapi.DeviceClaim{
-				Requests: []resourceapi.DeviceRequest{{
-					Name: "my-request",
-					Exactly: &resourceapi.ExactDeviceRequest{
-						DeviceClassName: className,
-					},
-				}},
-			},
-		},
-	}
-
-	_, err = f.ClientSet.ResourceV1().ResourceClaims(f.Namespace.Name).Create(ctx, claim, metav1.CreateOptions{})
-	framework.ExpectNoError(err, "failed to create ResourceClaim "+claimName)
-	ginkgo.DeferCleanup(func(ctx context.Context) {
-		err := f.ClientSet.ResourceV1().ResourceClaims(f.Namespace.Name).Delete(ctx, claimName, metav1.DeleteOptions{})
-		if err != nil && !apierrors.IsNotFound(err) {
-			framework.Failf("Failed to delete ResourceClaim %s: %v", claimName, err)
-		}
-	})
+	createHealthTestDeviceClassAndClaim(ctx, f, className, claimName)
 
 	ginkgo.By(fmt.Sprintf("Creating long-running Pod %q", podName))
 	pod := &v1.Pod{
@@ -2027,56 +2114,15 @@ func createTestObjectsWithShareID(ctx context.Context, f *framework.Framework, d
 					Image:   e2epod.GetDefaultTestImage(),
 					Command: []string{"/bin/sh", "-c", "sleep 600"},
 					Resources: v1.ResourceRequirements{
-						Claims: []v1.ResourceClaim{{Name: claimName, Request: "my-request"}},
+						Claims: []v1.ResourceClaim{{Name: claimName, Request: healthTestRequestName}},
 					},
 				},
 			},
 		},
 	}
-
-	createdPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-	framework.ExpectNoError(err, "failed to create Pod "+podName)
-	ginkgo.DeferCleanup(func(ctx context.Context) {
-		e2epod.DeletePodOrFail(ctx, f.ClientSet, createdPod.Namespace, createdPod.Name)
-	})
-
-	// Patch the Pod's status to include the ResourceClaimStatuses
-	patch, err := json.Marshal(v1.Pod{
-		Status: v1.PodStatus{
-			ResourceClaimStatuses: []v1.PodResourceClaimStatus{
-				{Name: claimName, ResourceClaimName: &claimName},
-			},
-		},
-	})
-	framework.ExpectNoError(err, "failed to marshal patch for Pod status")
-	_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Patch(ctx, createdPod.Name, apitypes.StrategicMergePatchType, patch, metav1.PatchOptions{}, "status")
-	framework.ExpectNoError(err, "failed to patch Pod status with ResourceClaimStatuses")
-
-	ginkgo.By(fmt.Sprintf("Allocating claim %q with ShareID", claimName))
-	claimToUpdate, err := f.ClientSet.ResourceV1().ResourceClaims(f.Namespace.Name).Get(ctx, claimName, metav1.GetOptions{})
-	framework.ExpectNoError(err, "failed to get latest version of ResourceClaim "+claimName)
-
-	// Update the claims status with ShareID in the allocation result
-	claimToUpdate.Status = resourceapi.ResourceClaimStatus{
-		ReservedFor: []resourceapi.ResourceClaimConsumerReference{
-			{Resource: "pods", Name: createdPod.Name, UID: createdPod.UID},
-		},
-		Allocation: &resourceapi.AllocationResult{
-			Devices: resourceapi.DeviceAllocationResult{
-				Results: []resourceapi.DeviceRequestAllocationResult{
-					{
-						Driver:  driverName,
-						Pool:    poolName,
-						Device:  deviceName,
-						Request: "my-request",
-						ShareID: shareID, // Include ShareID in allocation
-					},
-				},
-			},
-		},
-	}
-	_, err = f.ClientSet.ResourceV1().ResourceClaims(f.Namespace.Name).UpdateStatus(ctx, claimToUpdate, metav1.UpdateOptions{})
-	framework.ExpectNoError(err, "failed to update ResourceClaim status with ShareID")
+	createdPod := createHealthTestPod(ctx, f, pod)
+	patchPodResourceClaimStatus(ctx, f, createdPod.Name, claimName)
+	allocateHealthTestClaimToPod(ctx, f, driverName, claimName, createdPod, poolName, deviceName, shareID)
 
 	return createdPod
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Kubelet currently updates `allocatedResourcesStatus` for regular container statuses, but does not update `status.initContainerStatuses` for restartable init containers.

This updates the device manager and DRA manager paths to populate resource health status for restartable init containers while continuing to skip regular init containers. It also reuses the same restartable-init-plus-app-container rule used by the PodResources API.

#### Which issue(s) this PR fixes:

Fixes #139940

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
Kubelet now reports allocated resource health status for restartable init containers, including native sidecars, when they use Device Plugin or DRA resources.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

None
