### PR TITLE
volume: use AddEventHandlerWithOptions in protection controllers

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -749,11 +749,14 @@ func newPersistentVolumeProtectionController(ctx context.Context, controllerCont
 		return nil, err
 	}
 
-	pvpc := pvprotection.NewPVProtectionController(
+	pvpc, err := pvprotection.NewPVProtectionController(
 		klog.FromContext(ctx),
 		controllerContext.InformerFactory.Core().V1().PersistentVolumes(),
 		client,
 	)
+	if err != nil {
+		return nil, err
+	}
 	return newControllerLoop(func(ctx context.Context) {
 		pvpc.Run(ctx, 1)
 	}, controllerName), nil

--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
@@ -134,14 +134,15 @@ func NewPVCProtectionController(logger klog.Logger, pvcInformer coreinformers.Pe
 
 	e.pvcLister = pvcInformer.Lister()
 	e.pvcListerSynced = pvcInformer.Informer().HasSynced
-	pvcInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err := pvcInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			e.pvcAddedUpdated(logger, obj)
 		},
 		UpdateFunc: func(old, new interface{}) {
 			e.pvcAddedUpdated(logger, new)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
+	utilruntime.Must(err)
 
 	e.podLister = podInformer.Lister()
 	e.podListerSynced = podInformer.Informer().HasSynced
@@ -149,7 +150,7 @@ func NewPVCProtectionController(logger klog.Logger, pvcInformer coreinformers.Pe
 	if err := common.AddIndexerIfNotPresent(e.podIndexer, common.PodPVCIndex, common.PodPVCIndexFunc()); err != nil {
 		return nil, fmt.Errorf("could not initialize pvc protection controller: %w", err)
 	}
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err = podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			e.podAddedDeletedUpdated(logger, nil, obj, false)
 		},
@@ -159,7 +160,8 @@ func NewPVCProtectionController(logger klog.Logger, pvcInformer coreinformers.Pe
 		UpdateFunc: func(old, new interface{}) {
 			e.podAddedDeletedUpdated(logger, old, new, false)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
+	utilruntime.Must(err)
 
 	return e, nil
 }

--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
@@ -142,7 +142,9 @@ func NewPVCProtectionController(logger klog.Logger, pvcInformer coreinformers.Pe
 			e.pvcAddedUpdated(logger, new)
 		},
 	}, cache.HandlerOptions{Logger: &logger})
-	utilruntime.Must(err)
+	if err != nil {
+		return nil, fmt.Errorf("could not add PVC event handler: %w", err)
+	}
 
 	e.podLister = podInformer.Lister()
 	e.podListerSynced = podInformer.Informer().HasSynced
@@ -161,7 +163,9 @@ func NewPVCProtectionController(logger klog.Logger, pvcInformer coreinformers.Pe
 			e.podAddedDeletedUpdated(logger, old, new, false)
 		},
 	}, cache.HandlerOptions{Logger: &logger})
-	utilruntime.Must(err)
+	if err != nil {
+		return nil, fmt.Errorf("could not add Pod event handler: %w", err)
+	}
 
 	return e, nil
 }

--- a/pkg/controller/volume/pvprotection/pv_protection_controller.go
+++ b/pkg/controller/volume/pvprotection/pv_protection_controller.go
@@ -50,7 +50,7 @@ type Controller struct {
 }
 
 // NewPVProtectionController returns a new *Controller.
-func NewPVProtectionController(logger klog.Logger, pvInformer coreinformers.PersistentVolumeInformer, cl clientset.Interface) *Controller {
+func NewPVProtectionController(logger klog.Logger, pvInformer coreinformers.PersistentVolumeInformer, cl clientset.Interface) (*Controller, error) {
 	e := &Controller{
 		client: cl,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
@@ -69,9 +69,11 @@ func NewPVProtectionController(logger klog.Logger, pvInformer coreinformers.Pers
 			e.pvAddedUpdated(logger, new)
 		},
 	}, cache.HandlerOptions{Logger: &logger})
-	utilruntime.Must(err)
+	if err != nil {
+		return nil, fmt.Errorf("could not add PV event handler: %w", err)
+	}
 
-	return e
+	return e, nil
 }
 
 // Run runs the controller goroutines.

--- a/pkg/controller/volume/pvprotection/pv_protection_controller.go
+++ b/pkg/controller/volume/pvprotection/pv_protection_controller.go
@@ -61,14 +61,15 @@ func NewPVProtectionController(logger klog.Logger, pvInformer coreinformers.Pers
 
 	e.pvLister = pvInformer.Lister()
 	e.pvListerSynced = pvInformer.Informer().HasSynced
-	pvInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err := pvInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			e.pvAddedUpdated(logger, obj)
 		},
 		UpdateFunc: func(old, new interface{}) {
 			e.pvAddedUpdated(logger, new)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
+	utilruntime.Must(err)
 
 	return e
 }

--- a/pkg/controller/volume/pvprotection/pv_protection_controller_test.go
+++ b/pkg/controller/volume/pvprotection/pv_protection_controller_test.go
@@ -210,7 +210,10 @@ func TestPVProtectionController(t *testing.T) {
 
 		// Create the controller
 		logger, _ := ktesting.NewTestContext(t)
-		ctrl := NewPVProtectionController(logger, pvInformer, client)
+		ctrl, err := NewPVProtectionController(logger, pvInformer, client)
+		if err != nil {
+			t.Fatalf("unexpected error constructing controller: %v", err)
+		}
 
 		// Start the test by simulating an event
 		if test.updatedPV != nil {

--- a/pkg/controller/volume/vacprotection/vac_protection_controller.go
+++ b/pkg/controller/volume/vacprotection/vac_protection_controller.go
@@ -113,16 +113,17 @@ func NewVACProtectionController(logger klog.Logger,
 		),
 	}
 
-	_, _ = vacInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err := vacInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			c.vacAddedUpdated(logger, obj)
 		},
 		UpdateFunc: func(old, new interface{}) {
 			c.vacAddedUpdated(logger, new)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
+	utilruntime.Must(err)
 
-	err := pvInformer.Informer().AddIndexers(cache.Indexers{vacNameKeyIndex: func(obj interface{}) ([]string, error) {
+	err = pvInformer.Informer().AddIndexers(cache.Indexers{vacNameKeyIndex: func(obj interface{}) ([]string, error) {
 		pv, ok := obj.(*v1.PersistentVolume)
 		if !ok {
 			return []string{}, nil
@@ -178,23 +179,25 @@ func NewVACProtectionController(logger klog.Logger,
 		return pvcs, nil
 	}
 
-	_, _ = pvcInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err = pvcInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(old, new interface{}) {
 			c.pvcUpdated(logger, old, new)
 		},
 		DeleteFunc: func(obj interface{}) {
 			c.pvcDeleted(logger, obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
+	utilruntime.Must(err)
 
-	_, _ = pvInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err = pvInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(old, new interface{}) {
 			c.pvUpdated(logger, old, new)
 		},
 		DeleteFunc: func(obj interface{}) {
 			c.pvDeleted(logger, obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
+	utilruntime.Must(err)
 	return c, nil
 }
 

--- a/pkg/controller/volume/vacprotection/vac_protection_controller.go
+++ b/pkg/controller/volume/vacprotection/vac_protection_controller.go
@@ -121,7 +121,9 @@ func NewVACProtectionController(logger klog.Logger,
 			c.vacAddedUpdated(logger, new)
 		},
 	}, cache.HandlerOptions{Logger: &logger})
-	utilruntime.Must(err)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add event handler to VAC informer: %w", err)
+	}
 
 	err = pvInformer.Informer().AddIndexers(cache.Indexers{vacNameKeyIndex: func(obj interface{}) ([]string, error) {
 		pv, ok := obj.(*v1.PersistentVolume)
@@ -187,7 +189,9 @@ func NewVACProtectionController(logger klog.Logger,
 			c.pvcDeleted(logger, obj)
 		},
 	}, cache.HandlerOptions{Logger: &logger})
-	utilruntime.Must(err)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add event handler to PVC informer: %w", err)
+	}
 
 	_, err = pvInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(old, new interface{}) {
@@ -197,7 +201,9 @@ func NewVACProtectionController(logger klog.Logger,
 			c.pvDeleted(logger, obj)
 		},
 	}, cache.HandlerOptions{Logger: &logger})
-	utilruntime.Must(err)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add event handler to PV informer: %w", err)
+	}
 	return c, nil
 }
 


### PR DESCRIPTION
**What this does**

The PV, PVC and VAC protection controllers register their informer event
handlers via `AddEventHandler`, which logs through the global
`klog.Background()` logger. This switches them to
`AddEventHandlerWithOptions` and passes the controller's logger via
`cache.HandlerOptions{Logger: &logger}`, so event-handler logging is
contextual. The registration errors that were previously discarded
(`_, _ =`) are now surfaced with `utilruntime.Must`.

Part of the contextual logging migration tracked in #126379, following
the same pattern as the other `AddEventHandlerWithOptions` controller
migrations.

**Which issue(s) this PR fixes**

Part of #126379

/sig storage
/sig instrumentation
/kind cleanup
/cc @pohly

```release-note
NONE
```