### PR TITLE
volume: use AddEventHandlerWithOptions in more controllers

### DIFF
--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -204,7 +204,9 @@ func NewAttachDetachController(
 			adc.podDelete(logger, obj)
 		},
 	}, kcache.HandlerOptions{Logger: &logger})
-	runtime.Must(err)
+	if err != nil {
+		return nil, fmt.Errorf("could not add pod event handler: %w", err)
+	}
 
 	// This custom indexer will index pods by its PVC keys. Then we don't need
 	// to iterate all pods every time to find pods which reference given PVC.
@@ -223,7 +225,9 @@ func NewAttachDetachController(
 			adc.nodeDelete(logger, obj)
 		},
 	}, kcache.HandlerOptions{Logger: &logger})
-	runtime.Must(err)
+	if err != nil {
+		return nil, fmt.Errorf("could not add node event handler: %w", err)
+	}
 
 	_, err = pvcInformer.Informer().AddEventHandlerWithOptions(kcache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
@@ -233,7 +237,9 @@ func NewAttachDetachController(
 			adc.enqueuePVC(new)
 		},
 	}, kcache.HandlerOptions{Logger: &logger})
-	runtime.Must(err)
+	if err != nil {
+		return nil, fmt.Errorf("could not add pvc event handler: %w", err)
+	}
 
 	return adc, nil
 }

--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -193,7 +193,7 @@ func NewAttachDetachController(
 		adc.csiMigratedPluginManager,
 		adc.intreeToCSITranslator)
 
-	podInformer.Informer().AddEventHandler(kcache.ResourceEventHandlerFuncs{
+	_, err := podInformer.Informer().AddEventHandlerWithOptions(kcache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			adc.podAdd(logger, obj)
 		},
@@ -203,7 +203,8 @@ func NewAttachDetachController(
 		DeleteFunc: func(obj interface{}) {
 			adc.podDelete(logger, obj)
 		},
-	})
+	}, kcache.HandlerOptions{Logger: &logger})
+	runtime.Must(err)
 
 	// This custom indexer will index pods by its PVC keys. Then we don't need
 	// to iterate all pods every time to find pods which reference given PVC.
@@ -211,7 +212,7 @@ func NewAttachDetachController(
 		return nil, fmt.Errorf("could not initialize attach detach controller: %w", err)
 	}
 
-	nodeInformer.Informer().AddEventHandler(kcache.ResourceEventHandlerFuncs{
+	_, err = nodeInformer.Informer().AddEventHandlerWithOptions(kcache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			adc.nodeAdd(logger, obj)
 		},
@@ -221,16 +222,18 @@ func NewAttachDetachController(
 		DeleteFunc: func(obj interface{}) {
 			adc.nodeDelete(logger, obj)
 		},
-	})
+	}, kcache.HandlerOptions{Logger: &logger})
+	runtime.Must(err)
 
-	pvcInformer.Informer().AddEventHandler(kcache.ResourceEventHandlerFuncs{
+	_, err = pvcInformer.Informer().AddEventHandlerWithOptions(kcache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			adc.enqueuePVC(obj)
 		},
 		UpdateFunc: func(old, new interface{}) {
 			adc.enqueuePVC(new)
 		},
-	})
+	}, kcache.HandlerOptions{Logger: &logger})
+	runtime.Must(err)
 
 	return adc, nil
 }

--- a/pkg/controller/volume/ephemeral/controller.go
+++ b/pkg/controller/volume/ephemeral/controller.go
@@ -111,11 +111,15 @@ func NewController(
 		// Deletion of the PVC is handled through the owner reference and garbage collection.
 		// Therefore pod deletions also can be ignored.
 	}, cache.HandlerOptions{Logger: &logger})
-	runtime.Must(err)
+	if err != nil {
+		return nil, fmt.Errorf("could not add pod event handler: %w", err)
+	}
 	_, err = pvcInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		DeleteFunc: ec.onPVCDelete,
 	}, cache.HandlerOptions{Logger: &logger})
-	runtime.Must(err)
+	if err != nil {
+		return nil, fmt.Errorf("could not add pvc event handler: %w", err)
+	}
 	if err := common.AddPodPVCIndexerIfNotPresent(ec.podIndexer); err != nil {
 		return nil, fmt.Errorf("could not initialize ephemeral volume controller: %w", err)
 	}

--- a/pkg/controller/volume/ephemeral/controller.go
+++ b/pkg/controller/volume/ephemeral/controller.go
@@ -102,17 +102,20 @@ func NewController(
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
 	ec.recorder = eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "ephemeral_volume"})
 
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	logger := klog.FromContext(ctx)
+	_, err := podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: ec.enqueuePod,
 		// The pod spec is immutable. Therefore the controller can ignore pod updates
 		// because there cannot be any changes that have to be copied into the generated
 		// PVC.
 		// Deletion of the PVC is handled through the owner reference and garbage collection.
 		// Therefore pod deletions also can be ignored.
-	})
-	pvcInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	}, cache.HandlerOptions{Logger: &logger})
+	runtime.Must(err)
+	_, err = pvcInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		DeleteFunc: ec.onPVCDelete,
-	})
+	}, cache.HandlerOptions{Logger: &logger})
+	runtime.Must(err)
 	if err := common.AddPodPVCIndexerIfNotPresent(ec.podIndexer); err != nil {
 		return nil, fmt.Errorf("could not initialize ephemeral volume controller: %w", err)
 	}

--- a/pkg/controller/volume/expand/expand_controller.go
+++ b/pkg/controller/volume/expand/expand_controller.go
@@ -159,7 +159,9 @@ func NewExpandController(
 		},
 		DeleteFunc: expc.enqueuePVC,
 	}, cache.HandlerOptions{Logger: &logger})
-	runtime.Must(err)
+	if err != nil {
+		return nil, fmt.Errorf("could not add pvc event handler: %w", err)
+	}
 
 	return expc, nil
 }

--- a/pkg/controller/volume/expand/expand_controller.go
+++ b/pkg/controller/volume/expand/expand_controller.go
@@ -133,7 +133,8 @@ func NewExpandController(
 		expc.recorder,
 		blkutil)
 
-	pvcInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	logger := klog.FromContext(ctx)
+	_, err := pvcInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: expc.enqueuePVC,
 		UpdateFunc: func(old, new interface{}) {
 			oldPVC, ok := old.(*v1.PersistentVolumeClaim)
@@ -157,7 +158,8 @@ func NewExpandController(
 			}
 		},
 		DeleteFunc: expc.enqueuePVC,
-	})
+	}, cache.HandlerOptions{Logger: &logger})
+	runtime.Must(err)
 
 	return expc, nil
 }

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -104,23 +104,28 @@ func NewController(ctx context.Context, p ControllerParameters) (*PersistentVolu
 		return nil, fmt.Errorf("could not initialize volume plugins for PersistentVolume Controller: %w", err)
 	}
 
-	p.VolumeInformer.Informer().AddEventHandler(
+	logger := klog.FromContext(ctx)
+	_, err := p.VolumeInformer.Informer().AddEventHandlerWithOptions(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    func(obj interface{}) { controller.enqueueWork(ctx, controller.volumeQueue, obj) },
 			UpdateFunc: func(oldObj, newObj interface{}) { controller.enqueueWork(ctx, controller.volumeQueue, newObj) },
 			DeleteFunc: func(obj interface{}) { controller.enqueueWork(ctx, controller.volumeQueue, obj) },
 		},
+		cache.HandlerOptions{Logger: &logger},
 	)
+	utilruntime.Must(err)
 	controller.volumeLister = p.VolumeInformer.Lister()
 	controller.volumeListerSynced = p.VolumeInformer.Informer().HasSynced
 
-	p.ClaimInformer.Informer().AddEventHandler(
+	_, err = p.ClaimInformer.Informer().AddEventHandlerWithOptions(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    func(obj interface{}) { controller.enqueueWork(ctx, controller.claimQueue, obj) },
 			UpdateFunc: func(oldObj, newObj interface{}) { controller.enqueueWork(ctx, controller.claimQueue, newObj) },
 			DeleteFunc: func(obj interface{}) { controller.enqueueWork(ctx, controller.claimQueue, obj) },
 		},
+		cache.HandlerOptions{Logger: &logger},
 	)
+	utilruntime.Must(err)
 	controller.claimLister = p.ClaimInformer.Lister()
 	controller.claimListerSynced = p.ClaimInformer.Informer().HasSynced
 

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -113,7 +113,9 @@ func NewController(ctx context.Context, p ControllerParameters) (*PersistentVolu
 		},
 		cache.HandlerOptions{Logger: &logger},
 	)
-	utilruntime.Must(err)
+	if err != nil {
+		return nil, fmt.Errorf("could not add volume event handler: %w", err)
+	}
 	controller.volumeLister = p.VolumeInformer.Lister()
 	controller.volumeListerSynced = p.VolumeInformer.Informer().HasSynced
 
@@ -125,7 +127,9 @@ func NewController(ctx context.Context, p ControllerParameters) (*PersistentVolu
 		},
 		cache.HandlerOptions{Logger: &logger},
 	)
-	utilruntime.Must(err)
+	if err != nil {
+		return nil, fmt.Errorf("could not add claim event handler: %w", err)
+	}
 	controller.claimLister = p.ClaimInformer.Lister()
 	controller.claimListerSynced = p.ClaimInformer.Informer().HasSynced
 

--- a/pkg/controller/volume/selinuxwarning/selinux_warning_controller.go
+++ b/pkg/controller/volume/selinuxwarning/selinux_warning_controller.go
@@ -139,36 +139,36 @@ func NewController(
 	}
 
 	logger := klog.FromContext(ctx)
-	_, err = podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err = podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(obj interface{}) { c.enqueuePod(logger, obj) },
 		UpdateFunc: func(oldObj, newObj interface{}) { c.updatePod(logger, oldObj, newObj) },
 		DeleteFunc: func(obj interface{}) { c.enqueuePod(logger, obj) },
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = pvcInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err = pvcInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(obj interface{}) { c.addPVC(logger, obj) },
 		UpdateFunc: func(oldObj, newObj interface{}) { c.updatePVC(logger, oldObj, newObj) },
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = pvInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err = pvInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(obj interface{}) { c.addPV(logger, obj) },
 		UpdateFunc: func(oldObj, newObj interface{}) { c.updatePV(logger, oldObj, newObj) },
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = csiDriverInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err = csiDriverInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(obj interface{}) { c.addCSIDriver(logger, obj) },
 		UpdateFunc: func(oldObj, newObj interface{}) { c.updateCSIDriver(logger, oldObj, newObj) },
 		DeleteFunc: func(obj interface{}) { c.deleteCSIDriver(logger, obj) },
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

The attachdetach, expand, ephemeral, selinuxwarning and persistentvolume
controllers registered their informer event handlers via `AddEventHandler`,
which logs through the global `klog.Background()` logger. This switches them to
`AddEventHandlerWithOptions` and passes the controller's contextual logger so
event-handler logging is contextual.

For the controllers that previously discarded the registration result, the
returned error is now surfaced via `runtime.Must` instead of being ignored.
`selinuxwarning` already returned the registration error, so its handling is
left as-is.

This is a follow-up to #139943 (the PV/PVC/VAC protection controllers) for the
remaining volume controllers, and is part of the contextual logging migration
tracked in #126379.

No behavior change, so no new tests are added; the existing unit tests for these
packages continue to pass.

**Which issue(s) this PR fixes**:

Part of #126379

**Special notes for your reviewer**:

Mechanical change, single SIG (sig/storage). Verified locally with
`go build`, `go vet`, the unit tests for all five packages, and
`hack/verify-golangci-lint.sh` (0 issues).

/sig storage
/sig instrumentation
/kind cleanup
/cc @pohly

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```