### PR TITLE
WIP: Promote ControllerManagerReleaseLeaderElectionLockOnExit to beta

### DIFF
--- a/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
@@ -42,7 +42,7 @@ const (
 	CloudControllerManagerWebhook featuregate.Feature = "CloudControllerManagerWebhook"
 
 	// owner: @jefftree, @tchap
-	//
+	// kep:  http://kep.k8s.io/5366
 	// Make kube-controller-manager release leader election lock on exit.
 	ControllerManagerReleaseLeaderElectionLockOnExit featuregate.Feature = "ControllerManagerReleaseLeaderElectionLockOnExit"
 )

--- a/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
@@ -62,5 +62,6 @@ var versionedCloudPublicFeatureGates = map[featuregate.Feature]featuregate.Versi
 	},
 	ControllerManagerReleaseLeaderElectionLockOnExit: {
 		{Version: version.MustParse("1.36"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.37"), Default: true, PreRelease: featuregate.Beta},
 	},
 }

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -247,6 +247,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.36"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.37"
 - name: CoordinatedLeaderElection
   versionedSpecs:
   - default: false

--- a/test/integration/controllermanager/leader_election_release_test.go
+++ b/test/integration/controllermanager/leader_election_release_test.go
@@ -66,7 +66,6 @@ func TestLeaderElectionReleaseOnCancel(t *testing.T) {
 	kcm, err := kubecontrollermanagertesting.StartTestServer(t, ctx, []string{
 		"--kubeconfig=" + kubeConfigFile,
 		"--leader-elect=true",
-		"--feature-gates=ControllerManagerReleaseLeaderElectionLockOnExit=true",
 	})
 	if err != nil {
 		t.Fatalf("failed to start KCM: %v", err)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Graduate `ControllerManagerReleaseLeaderElectionLockOnExit` feature gate to beta (default on) for v1.37.

WIP: Need to add more tests to be able to graduate.

#### Which issue(s) this PR is related to:

A followup to #136279 , which added the feature gate as alpha.

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- [KEP]( http://kep.k8s.io/5366)
