### PR TITLE
discovery: enable commentstart kube-api-linter rule

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -147,7 +147,7 @@ linters:
       # Commentstart - Ignore commentstart issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "godoc for field .* should start with '.* ...'"
-        path: "staging/src/k8s.io/api/(apps|batch|certificates|core|discovery|extensions|flowcontrol|imagepolicy|networking|resource|scheduling|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(apps|batch|certificates|core|extensions|flowcontrol|imagepolicy|networking|resource|scheduling|storage|storagemigration)"
       
       # notimestamp: Legacy 'Timestamp' fields retained for backward compatibility
       - text: 'notimestamp: naming convention "notimestamp": field TokenRequestStatus.ExpirationTimestamp: prefer use of the term ''time'' over ''timestamp'''

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -162,7 +162,7 @@ linters:
       # Commentstart - Ignore commentstart issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "godoc for field .* should start with '.* ...'"
-        path: "staging/src/k8s.io/api/(apps|batch|certificates|core|discovery|extensions|flowcontrol|imagepolicy|networking|resource|scheduling|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(apps|batch|certificates|core|extensions|flowcontrol|imagepolicy|networking|resource|scheduling|storage|storagemigration)"
       
       # notimestamp: Legacy 'Timestamp' fields retained for backward compatibility
       - text: 'notimestamp: naming convention "notimestamp": field TokenRequestStatus.ExpirationTimestamp: prefer use of the term ''time'' over ''timestamp'''

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -23,7 +23,7 @@
 # Commentstart - Ignore commentstart issues for existing API group
 # TODO: For each existing API group, we aim to remove it over time.
 - text: "godoc for field .* should start with '.* ...'"
-  path: "staging/src/k8s.io/api/(apps|batch|certificates|core|discovery|extensions|flowcontrol|imagepolicy|networking|resource|scheduling|storage|storagemigration)"
+  path: "staging/src/k8s.io/api/(apps|batch|certificates|core|extensions|flowcontrol|imagepolicy|networking|resource|scheduling|storage|storagemigration)"
 
 # notimestamp: Legacy 'Timestamp' fields retained for backward compatibility
 - text: 'notimestamp: naming convention "notimestamp": field TokenRequestStatus.ExpirationTimestamp: prefer use of the term ''time'' over ''timestamp'''


### PR DESCRIPTION
#### What type of PR is this?

/kind api-change

#### What this PR does / why we need it:

Enables the `commentstart` kube-api-linter rule for the discovery.k8s.io API group by removing it from the rule's exception list. The group has no remaining violations, so this just enforces the rule and prevents future regressions.

#### Which issue(s) this PR is related to:

Part of #134671

#### Special notes for your reviewer:

Source edit is in `hack/kube-api-linter/exceptions.yaml`; `hack/golangci.yaml` and `hack/golangci-hints.yaml` are regenerated via `hack/update-golangci-lint-config.sh`. Verified with `hack/verify-golangci-lint.sh staging/src/k8s.io/api/discovery/...` (0 issues).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```