### PR TITLE
client-go cache: remove duplicate package documentation comments

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/identity.go
+++ b/staging/src/k8s.io/client-go/tools/cache/identity.go
@@ -14,13 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package cache is a client-side caching mechanism. It is useful for
-// reducing the number of server calls you'd otherwise need to make.
-// Reflector watches a server and updates a Store. Two stores are provided;
-// one that simply caches objects (for example, to allow a scheduler to
-// list currently available nodes), and one that additionally acts as
-// a FIFO queue (for example, to allow a scheduler to process incoming
-// pods).
 package cache
 
 import (

--- a/staging/src/k8s.io/client-go/tools/cache/identity_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/identity_test.go
@@ -14,13 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package cache is a client-side caching mechanism. It is useful for
-// reducing the number of server calls you'd otherwise need to make.
-// Reflector watches a server and updates a Store. Two stores are provided;
-// one that simply caches objects (for example, to allow a scheduler to
-// list currently available nodes), and one that additionally acts as
-// a FIFO queue (for example, to allow a scheduler to process incoming
-// pods).
 package cache
 
 import (

--- a/staging/src/k8s.io/client-go/tools/cache/informer_metrics.go
+++ b/staging/src/k8s.io/client-go/tools/cache/informer_metrics.go
@@ -14,13 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package cache is a client-side caching mechanism. It is useful for
-// reducing the number of server calls you'd otherwise need to make.
-// Reflector watches a server and updates a Store. Two stores are provided;
-// one that simply caches objects (for example, to allow a scheduler to
-// list currently available nodes), and one that additionally acts as
-// a FIFO queue (for example, to allow a scheduler to process incoming
-// pods).
 package cache
 
 import (


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Removes duplicate package-level documentation comments from three files in
`staging/src/k8s.io/client-go/tools/cache/`. The canonical package comment
already lives in `doc.go`; duplicates in `informer_metrics.go`, `identity.go`,
and `identity_test.go` are unnecessary and can confuse pkg.go.dev package
documentation generation.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Comment-only change; no functional behavior change. The publishing-bot will
propagate this to kubernetes/client-go after merge.

#### Does this PR introduce a user-facing change?

Public docs on https://pkg.go.dev/k8s.io/client-go@v0.36.2/tools/cache#pkg-overview


<img width="1012" height="457" alt="image" src="https://github.com/user-attachments/assets/2337ba07-43c7-476e-8e30-1e27d3c267da" />
