### PR TITLE
Introduce incompletePodGroupPods to store pods waiting for their PodGroup to appear

### DIFF
--- a/pkg/scheduler/backend/cache/cache.go
+++ b/pkg/scheduler/backend/cache/cache.go
@@ -900,6 +900,8 @@ func (cache *cacheImpl) removePodGroupMember(pod *v1.Pod) {
 	}
 	podGroupState.deletePod(pod.UID)
 	if podGroupState.empty() {
+		// podGroupState can exist without the member pods, but when the PodGroup object exists.
+		// Only when there are no member pods and the PodGroup object is removed, the podGroupState can be removed.
 		delete(cache.podGroupStates, key)
 	}
 }
@@ -1068,6 +1070,8 @@ func (cache *cacheImpl) RemovePodGroup(podGroup *schedulingv1alpha3.PodGroup) {
 	}
 	pgs.removePodGroup()
 	if pgs.empty() {
+		// podGroupState can exist without the PodGroup object, but when any of the member pods exists.
+		// Only when there are no member pods and the PodGroup object is removed, the podGroupState can be removed.
 		delete(cache.podGroupStates, key)
 	}
 }

--- a/pkg/scheduler/backend/queue/incomplete_pod_group_pods.go
+++ b/pkg/scheduler/backend/queue/incomplete_pod_group_pods.go
@@ -1,0 +1,106 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	v1 "k8s.io/api/core/v1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+// incompletePodGroupPods stores pod infos that wait for their corresponding PodGroup object to be observed.
+// This structure is not thread-safe and should be accessed only under the lock of the PriorityQueue.
+type incompletePodGroupPods struct {
+	// podGroupToPodInfos stores QueuedPodInfos keyed by their pod group key (pg-type/namespace/pg-name),
+	// and then by pod key (namespace/pg-name).
+	podGroupToPodInfos map[string]map[string]*framework.QueuedPodInfo
+}
+
+func newIncompletePodGroupPods() *incompletePodGroupPods {
+	return &incompletePodGroupPods{
+		podGroupToPodInfos: make(map[string]map[string]*framework.QueuedPodInfo),
+	}
+}
+
+// add adds a pod info waiting for the pod group.
+func (ip *incompletePodGroupPods) add(pInfo *framework.QueuedPodInfo) {
+	pgKey, pKey := podGroupKeyForPod(pInfo.Pod), podKey(pInfo.Pod)
+	if ip.podGroupToPodInfos[pgKey] == nil {
+		ip.podGroupToPodInfos[pgKey] = make(map[string]*framework.QueuedPodInfo)
+	}
+	ip.podGroupToPodInfos[pgKey][pKey] = pInfo
+}
+
+// get returns the pod info for the given pod.
+func (ip *incompletePodGroupPods) get(pod *v1.Pod) *framework.QueuedPodInfo {
+	pgKey, pKey := podGroupKeyForPod(pod), podKey(pod)
+	return ip.podGroupToPodInfos[pgKey][pKey]
+}
+
+// has returns true if the pod is present in the incompletePodGroupPods.
+func (ip *incompletePodGroupPods) has(pod *v1.Pod) bool {
+	pgKey, pKey := podGroupKeyForPod(pod), podKey(pod)
+	return ip.podGroupToPodInfos[pgKey][pKey] != nil
+}
+
+// len returns the number of incomplete pods.
+func (ip *incompletePodGroupPods) len() int {
+	l := 0
+	for _, pods := range ip.podGroupToPodInfos {
+		l += len(pods)
+	}
+	return l
+}
+
+// update updates the pod inside the incompletePodGroupPods.
+// It returns the updated pod info if the pod was found, nil otherwise.
+func (ip *incompletePodGroupPods) update(pod *v1.Pod) *framework.QueuedPodInfo {
+	pgKey, pKey := podGroupKeyForPod(pod), podKey(pod)
+	if pInfo, ok := ip.podGroupToPodInfos[pgKey][pKey]; ok {
+		pInfo.Pod = pod
+		return pInfo
+	}
+	return nil
+}
+
+// delete removes a specific pod and returns its QueuedPodInfo.
+// If the pod list for the group becomes empty, it cleans up the key.
+func (ip *incompletePodGroupPods) delete(pod *v1.Pod) *framework.QueuedPodInfo {
+	pgKey, pKey := podGroupKeyForPod(pod), podKey(pod)
+	if pInfo, ok := ip.podGroupToPodInfos[pgKey][pKey]; ok {
+		delete(ip.podGroupToPodInfos[pgKey], pKey)
+		if len(ip.podGroupToPodInfos[pgKey]) == 0 {
+			delete(ip.podGroupToPodInfos, pgKey)
+		}
+		return pInfo
+	}
+	return nil
+}
+
+// clear removes and returns all pod infos waiting for the pod group.
+func (ip *incompletePodGroupPods) clear(podGroup *schedulingv1alpha3.PodGroup) []*framework.QueuedPodInfo {
+	pgKey := podGroupKey(podGroup)
+	if pods, ok := ip.podGroupToPodInfos[pgKey]; ok {
+		delete(ip.podGroupToPodInfos, pgKey)
+		var pInfoList []*framework.QueuedPodInfo
+		for _, pInfo := range pods {
+			pInfoList = append(pInfoList, pInfo)
+		}
+		return pInfoList
+	}
+	return nil
+}

--- a/pkg/scheduler/backend/queue/incomplete_pod_group_pods_test.go
+++ b/pkg/scheduler/backend/queue/incomplete_pod_group_pods_test.go
@@ -1,0 +1,352 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/scheduling/v1alpha3"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+)
+
+func TestIncompletePodGroupPods_Add(t *testing.T) {
+	pod1 := st.MakePod().Name("pod1").Namespace("ns1").UID("uid1").PodGroupName("pg1").Obj()
+	pod2 := st.MakePod().Name("pod2").Namespace("ns1").UID("uid2").PodGroupName("pg1").Obj()
+	pod3 := st.MakePod().Name("pod3").Namespace("ns1").UID("uid3").PodGroupName("pg2").Obj()
+
+	pInfo1 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod1)}
+	pInfo2 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod2)}
+	pInfo3 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod3)}
+
+	tests := []struct {
+		name      string
+		podsToAdd []*framework.QueuedPodInfo
+		want      map[string]map[string]*framework.QueuedPodInfo
+	}{
+		{
+			name:      "pod group with multiple pods",
+			podsToAdd: []*framework.QueuedPodInfo{pInfo1, pInfo2},
+			want: map[string]map[string]*framework.QueuedPodInfo{
+				"pg/ns1/pg1": {
+					"ns1/pod1": pInfo1,
+					"ns1/pod2": pInfo2,
+				},
+			},
+		},
+		{
+			name:      "two pod groups",
+			podsToAdd: []*framework.QueuedPodInfo{pInfo1, pInfo3},
+			want: map[string]map[string]*framework.QueuedPodInfo{
+				"pg/ns1/pg1": {
+					"ns1/pod1": pInfo1,
+				},
+				"pg/ns1/pg2": {
+					"ns1/pod3": pInfo3,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ie := newIncompletePodGroupPods()
+			for _, pInfo := range tt.podsToAdd {
+				ie.add(pInfo)
+			}
+
+			if diff := cmp.Diff(tt.want, ie.podGroupToPodInfos, cmpopts.IgnoreUnexported(framework.PodInfo{})); diff != "" {
+				t.Errorf("Unexpected podGroupToPodInfos (-want,+got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestIncompletePodGroupPods_Get(t *testing.T) {
+	pod1 := st.MakePod().Name("pod1").Namespace("ns1").UID("uid1").PodGroupName("pg1").Obj()
+	pod2 := st.MakePod().Name("pod2").Namespace("ns1").UID("uid2").PodGroupName("pg1").Obj()
+
+	pInfo1 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod1)}
+	pInfo2 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod2)}
+
+	tests := []struct {
+		name      string
+		podsToAdd []*framework.QueuedPodInfo
+		targetPod *v1.Pod
+		want      *framework.QueuedPodInfo
+	}{
+		{
+			name:      "get existing pod in pod group",
+			podsToAdd: []*framework.QueuedPodInfo{pInfo1, pInfo2},
+			targetPod: pod1,
+			want:      pInfo1,
+		},
+		{
+			name:      "get non-existent pod in existing pod group",
+			podsToAdd: []*framework.QueuedPodInfo{pInfo1},
+			targetPod: pod2,
+			want:      nil,
+		},
+		{
+			name:      "get non-existent pod in non-existing pod group",
+			podsToAdd: []*framework.QueuedPodInfo{},
+			targetPod: pod2,
+			want:      nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ie := newIncompletePodGroupPods()
+			for _, pInfo := range tt.podsToAdd {
+				ie.add(pInfo)
+			}
+
+			got := ie.get(tt.targetPod)
+			if diff := cmp.Diff(tt.want, got, cmpopts.IgnoreUnexported(framework.PodInfo{})); diff != "" {
+				t.Errorf("Unexpected pod info (-want,+got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestIncompletePodGroupPods_Has(t *testing.T) {
+	pod1 := st.MakePod().Name("pod1").Namespace("ns1").UID("uid1").PodGroupName("pg1").Obj()
+	pod2 := st.MakePod().Name("pod2").Namespace("ns1").UID("uid2").PodGroupName("pg1").Obj()
+
+	pInfo1 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod1)}
+	pInfo2 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod2)}
+
+	tests := []struct {
+		name      string
+		podsToAdd []*framework.QueuedPodInfo
+		targetPod *v1.Pod
+		want      bool
+	}{
+		{
+			name:      "has existing pod in pod group",
+			podsToAdd: []*framework.QueuedPodInfo{pInfo1, pInfo2},
+			targetPod: pod1,
+			want:      true,
+		},
+		{
+			name:      "doesn't have non-existent pod in existing pod group",
+			podsToAdd: []*framework.QueuedPodInfo{pInfo1},
+			targetPod: pod2,
+			want:      false,
+		},
+		{
+			name:      "doesn't have non-existent pod in non-existing pod group",
+			podsToAdd: []*framework.QueuedPodInfo{},
+			targetPod: pod2,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ie := newIncompletePodGroupPods()
+			for _, pInfo := range tt.podsToAdd {
+				ie.add(pInfo)
+			}
+
+			got := ie.has(tt.targetPod)
+			if got != tt.want {
+				t.Errorf("Expected has() to return %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestIncompletePodGroupPods_Update(t *testing.T) {
+	pod1 := st.MakePod().Name("pod1").Namespace("ns1").UID("uid1").PodGroupName("pg1").Obj()
+	updatedPod1 := st.MakePod().Name("pod1").Namespace("ns1").UID("uid1").Label("updated", "true").PodGroupName("pg1").Obj()
+	pod2 := st.MakePod().Name("pod2").Namespace("ns1").UID("uid2").PodGroupName("pg1").Obj()
+
+	pInfo1 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod1)}
+	updatedPodInfo1 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, updatedPod1)}
+
+	tests := []struct {
+		name        string
+		podsToAdd   []*framework.QueuedPodInfo
+		updatePod   *v1.Pod
+		wantUpdated *framework.QueuedPodInfo
+	}{
+		{
+			name:        "update existing pod",
+			podsToAdd:   []*framework.QueuedPodInfo{pInfo1},
+			updatePod:   updatedPod1,
+			wantUpdated: updatedPodInfo1,
+		},
+		{
+			name:        "update non-existent pod",
+			podsToAdd:   []*framework.QueuedPodInfo{pInfo1},
+			updatePod:   pod2,
+			wantUpdated: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ie := newIncompletePodGroupPods()
+			for _, pInfo := range tt.podsToAdd {
+				ie.add(pInfo.DeepCopy())
+			}
+
+			got := ie.update(tt.updatePod)
+			if diff := cmp.Diff(tt.wantUpdated, got, cmpopts.IgnoreUnexported(framework.PodInfo{})); diff != "" {
+				t.Errorf("Unexpected updated pod info (-want,+got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestIncompletePodGroupPods_Delete(t *testing.T) {
+	pod1 := st.MakePod().Name("pod1").Namespace("ns1").UID("uid1").PodGroupName("pg1").Obj()
+	pod2 := st.MakePod().Name("pod2").Namespace("ns1").UID("uid2").PodGroupName("pg1").Obj()
+	pod3 := st.MakePod().Name("pod3").Namespace("ns1").UID("uid3").PodGroupName("pg1").Obj()
+
+	pInfo1 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod1)}
+	pInfo2 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod2)}
+
+	tests := []struct {
+		name        string
+		podsToAdd   []*framework.QueuedPodInfo
+		podToDelete *v1.Pod
+		wantDeleted *framework.QueuedPodInfo
+		want        map[string]*framework.QueuedPodInfo
+	}{
+		{
+			name:        "delete non-existent pod from existing pod group",
+			podsToAdd:   []*framework.QueuedPodInfo{pInfo1},
+			podToDelete: pod3,
+			wantDeleted: nil,
+			want: map[string]*framework.QueuedPodInfo{
+				"ns1/pod1": pInfo1,
+			},
+		},
+		{
+			name:        "delete pod from non-existent pod group",
+			podsToAdd:   []*framework.QueuedPodInfo{},
+			podToDelete: pod3,
+			wantDeleted: nil,
+			want:        nil,
+		},
+		{
+			name:        "delete one pod from group with multiple pods",
+			podsToAdd:   []*framework.QueuedPodInfo{pInfo1, pInfo2},
+			podToDelete: pod1,
+			wantDeleted: pInfo1,
+			want: map[string]*framework.QueuedPodInfo{
+				"ns1/pod2": pInfo2,
+			},
+		},
+		{
+			name:        "delete last pod in group cleans up group key",
+			podsToAdd:   []*framework.QueuedPodInfo{pInfo1},
+			podToDelete: pod1,
+			wantDeleted: pInfo1,
+			want:        nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ie := newIncompletePodGroupPods()
+			for _, pInfo := range tt.podsToAdd {
+				ie.add(pInfo.DeepCopy())
+			}
+
+			gotDeleted := ie.delete(tt.podToDelete)
+			if diff := cmp.Diff(tt.wantDeleted, gotDeleted, cmpopts.IgnoreUnexported(framework.PodInfo{})); diff != "" {
+				t.Errorf("Unexpected deleted pod info (-want,+got)\n%s", diff)
+			}
+
+			gotRemaining := ie.podGroupToPodInfos[podGroupKeyForPod(tt.podToDelete)]
+			if diff := cmp.Diff(tt.want, gotRemaining, cmpopts.IgnoreUnexported(framework.PodInfo{})); diff != "" {
+				t.Errorf("Unexpected remaining pod infos (-want,+got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestIncompletePodGroupPods_Clear(t *testing.T) {
+	pod1 := st.MakePod().Name("pod1").Namespace("ns1").UID("uid1").PodGroupName("pg1").Obj()
+	pod2 := st.MakePod().Name("pod2").Namespace("ns1").UID("uid2").PodGroupName("pg1").Obj()
+	pod3 := st.MakePod().Name("pod3").Namespace("ns1").UID("uid3").PodGroupName("pg2").Obj()
+
+	pInfo1 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod1)}
+	pInfo2 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod2)}
+	pInfo3 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod3)}
+
+	podGroup1 := st.MakePodGroup().Name("pg1").Namespace("ns1").UID("pg1").Obj()
+	podGroup3 := st.MakePodGroup().Name("pg3").Namespace("ns1").UID("pg3").Obj()
+
+	tests := []struct {
+		name        string
+		podsToAdd   []*framework.QueuedPodInfo
+		clearGroup  *v1alpha3.PodGroup
+		wantCleared sets.Set[*framework.QueuedPodInfo]
+		want        map[string]map[string]*framework.QueuedPodInfo
+	}{
+		{
+			name:        "clear existing pod group",
+			podsToAdd:   []*framework.QueuedPodInfo{pInfo1, pInfo2, pInfo3},
+			clearGroup:  podGroup1,
+			wantCleared: sets.New(pInfo1, pInfo2),
+			want: map[string]map[string]*framework.QueuedPodInfo{
+				"pg/ns1/pg2": {
+					"ns1/pod3": pInfo3,
+				},
+			},
+		},
+		{
+			name:        "clear non-existent pod group",
+			podsToAdd:   []*framework.QueuedPodInfo{pInfo1},
+			clearGroup:  podGroup3,
+			wantCleared: nil,
+			want: map[string]map[string]*framework.QueuedPodInfo{
+				"pg/ns1/pg1": {
+					"ns1/pod1": pInfo1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ie := newIncompletePodGroupPods()
+			for _, pInfo := range tt.podsToAdd {
+				ie.add(pInfo)
+			}
+
+			gotCleared := ie.clear(tt.clearGroup)
+			gotClearedSet := sets.New(gotCleared...)
+			if diff := cmp.Diff(tt.wantCleared, gotClearedSet, cmpopts.IgnoreUnexported(framework.PodInfo{})); diff != "" {
+				t.Errorf("Unexpected cleared pod infos (-want,+got)\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tt.want, ie.podGroupToPodInfos, cmpopts.IgnoreUnexported(framework.PodInfo{})); diff != "" {
+				t.Errorf("Unexpected remaining podGroupToPodInfos (-want,+got)\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/backend/queue/pending_pod_group_pods.go
+++ b/pkg/scheduler/backend/queue/pending_pod_group_pods.go
@@ -17,8 +17,6 @@ limitations under the License.
 package queue
 
 import (
-	"fmt"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
@@ -36,12 +34,12 @@ func newPendingPodGroupMemberPods() *pendingPodGroupMemberPods {
 
 // add adds a pod info.
 func (p *pendingPodGroupMemberPods) add(pInfo *framework.QueuedPodInfo) {
-	p.keyToPod[pendingPodKey(pInfo.Pod)] = pInfo
+	p.keyToPod[podKey(pInfo.Pod)] = pInfo
 }
 
 // has checks if the pod is tracked.
 func (p *pendingPodGroupMemberPods) has(podLookup *v1.Pod) bool {
-	_, ok := p.keyToPod[pendingPodKey(podLookup)]
+	_, ok := p.keyToPod[podKey(podLookup)]
 	return ok
 }
 
@@ -52,12 +50,12 @@ func (p *pendingPodGroupMemberPods) len() int {
 
 // get returns the queued pod info for the given pod.
 func (p *pendingPodGroupMemberPods) get(podLookup *v1.Pod) *framework.QueuedPodInfo {
-	return p.keyToPod[pendingPodKey(podLookup)]
+	return p.keyToPod[podKey(podLookup)]
 }
 
 // update refreshes the pod object and returns the updated pod info if found.
 func (p *pendingPodGroupMemberPods) update(newPod *v1.Pod) *framework.QueuedPodInfo {
-	pInfo, ok := p.keyToPod[pendingPodKey(newPod)]
+	pInfo, ok := p.keyToPod[podKey(newPod)]
 	if !ok {
 		return nil
 	}
@@ -67,11 +65,11 @@ func (p *pendingPodGroupMemberPods) update(newPod *v1.Pod) *framework.QueuedPodI
 
 // delete removes a specific pod and returns its pod info if found.
 func (p *pendingPodGroupMemberPods) delete(podLookup *v1.Pod) *framework.QueuedPodInfo {
-	pInfo, ok := p.keyToPod[pendingPodKey(podLookup)]
+	pInfo, ok := p.keyToPod[podKey(podLookup)]
 	if !ok {
 		return nil
 	}
-	delete(p.keyToPod, pendingPodKey(podLookup))
+	delete(p.keyToPod, podKey(podLookup))
 	return pInfo
 }
 
@@ -83,8 +81,4 @@ func (p *pendingPodGroupMemberPods) clear() []*framework.QueuedPodInfo {
 	}
 	p.keyToPod = make(map[string]*framework.QueuedPodInfo)
 	return pods
-}
-
-func pendingPodKey(pod *v1.Pod) string {
-	return fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
 }

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -123,6 +124,14 @@ type SchedulingQueue interface {
 	// Important Note: preCheck shouldn't include anything that depends on the in-tree plugins' logic.
 	// (e.g., filter Pods based on added/updated Node's capacity, etc.)
 	MoveAllToActiveOrBackoffQueue(logger klog.Logger, event fwk.ClusterEvent, oldObj, newObj interface{}, preCheck PreEnqueueCheck)
+	// AddPodGroup adds a new PodGroup object to the queue,
+	// requeuing all pods associated with the pod group.
+	AddPodGroup(logger klog.Logger, podGroup *schedulingv1alpha3.PodGroup)
+	// UpdatePodGroup updates an existing PodGroup object in the queue.
+	UpdatePodGroup(logger klog.Logger, podGroup *schedulingv1alpha3.PodGroup)
+	// DeletePodGroup removes a PodGroup object from the queue,
+	// moving all pods associated with the pod group to the incompletePodGroupPods.
+	DeletePodGroup(logger klog.Logger, podGroup *schedulingv1alpha3.PodGroup)
 
 	// Close closes the SchedulingQueue so that the goroutine which is
 	// waiting to pop items can exit gracefully.
@@ -142,8 +151,12 @@ type SchedulingQueue interface {
 	// PodsInBackoffQ returns all the Pods in the backoffQ.
 	PodsInBackoffQ() []*v1.Pod
 	UnschedulablePods() []*v1.Pod
-	// PendingPodGroupPods returns all the pending pods waiting for their pod groups.
+	// pendingPodGroupPods stores all pending pods
+	// that wait for their corresponding pod group to be requeued.
 	PendingPodGroupPods() []*v1.Pod
+	// IncompletePodGroupPodsPods returns all the pods belonging to pod groups
+	// waiting for their API objects (PodGroups) to be observed.
+	IncompletePodGroupPodsPods() []*v1.Pod
 }
 
 // NewSchedulingQueue initializes a priority queue as a new scheduling queue.
@@ -163,6 +176,18 @@ func NewSchedulingQueue(
 //     activeQ when their backoff periods complete.
 //   - unschedulableEntities holds pods or pod groups that were already attempted for scheduling and
 //     are currently determined to be unschedulable.
+//
+// For handling PodGroups, the PriorityQueue is extended with following structures:
+//   - incompletePodGroupPods: stores pod infos that wait for their corresponding PodGroup object to be observed.
+//   - pendingPodGroupPods: stores all pending pods that wait for their corresponding in-flight pod group to be requeued.
+//   - workloadForest: workloadForest maintains a consistent view of observed PodGroup objects.
+//
+// These additional structures ensure the following lifecycle invariants for a Pod and its corresponding PodGroup are met:
+//  1. Incomplete: A Pod is placed in `incompletePodGroupPods` iff its root PodGroup is NOT present in the `workloadForest`.
+//  2. Queued: Otherwise, if the PodGroup is not currently in-flight, the Pod is encapsulated within a QueuedPodGroupInfo,
+//     residing in `activeQ`, `backoffQ`, or `unschedulableEntities`.
+//  3. In-flight: If the PodGroup is currently in-flight (popped from the queue and being evaluated),
+//     newly arriving Pods are placed in `pendingPodGroupPods` to wait for the PodGroup to be requeued.
 type PriorityQueue struct {
 	*nominator
 
@@ -182,7 +207,18 @@ type PriorityQueue struct {
 	// unschedulableEntities holds pods and pod groups that have been tried and determined unschedulable.
 	unschedulableEntities *unschedulableEntities
 	// pendingPodGroupPods stores all pending pods that wait for their corresponding pod group to be requeued.
+	// It should be only used when GenericWorkload feature is enabled.
 	pendingPodGroupPods *pendingPodGroupMemberPods
+	// incompletePodGroupPods stores pod infos that wait for their corresponding PodGroup object to be observed.
+	// It should be only used when GenericWorkload feature is enabled.
+	incompletePodGroupPods *incompletePodGroupPods
+
+	// workloadForest maintains a consistent view of observed PodGroup objects.
+	// It ensures that scheduling queue invariants are preserved, independent of
+	// asynchronous updates happening in the scheduler cache.
+	// Outside of the scheduling queue, cache should be used as the source of truth.
+	// It should be only used when GenericWorkload feature is enabled.
+	workloadForest *workloadForest
 
 	// preEnqueuePluginMap is keyed with profile and plugin name, valued with registered preEnqueue plugins.
 	preEnqueuePluginMap map[string]map[string]fwk.PreEnqueuePlugin
@@ -391,6 +427,8 @@ func NewPriorityQueue(
 		backoffQ:                          backoffQ,
 		unschedulableEntities:             newUnschedulableEntities(metrics.NewUnschedulablePodsRecorder(), metrics.NewGatedPodsRecorder()),
 		pendingPodGroupPods:               newPendingPodGroupMemberPods(),
+		incompletePodGroupPods:            newIncompletePodGroupPods(),
+		workloadForest:                    newWorkloadForest(),
 		preEnqueuePluginMap:               options.preEnqueuePluginMap,
 		queueingHintMap:                   options.queueingHintMap,
 		pluginToEventsMap:                 buildEventMap(options.queueingHintMap),
@@ -804,10 +842,18 @@ func (p *PriorityQueue) addPod(ctx context.Context, pod *v1.Pod) {
 
 // addPodGroupMember adds pInfo as a member of its pod group into the scheduling queue.
 func (p *PriorityQueue) addPodGroupMember(logger klog.Logger, pInfo *framework.QueuedPodInfo) {
-	if added := p.addToPodGroupIfExists(logger, pInfo); added {
+	pgInfoLookup := newQueuedPodGroupInfoForLookup(pInfo.Pod)
+	if added := p.addToPodGroupIfExists(logger, pgInfoLookup, pInfo); added {
 		return
 	}
-	pgInfoLookup := newQueuedPodGroupInfoForLookup(pInfo.Pod)
+	podGroup, ok := p.workloadForest.getRootForPod(pInfo.Pod)
+	if !ok {
+		// If the PodGroup object cannot be fetched, the pod cannot be scheduled.
+		// It should be put into incompletePodGroupPods waiting for the pod group to be observed.
+		p.incompletePodGroupPods.add(pInfo)
+		logger.V(5).Info("Pod with pod group added to incompletePodGroupPods, waiting for its pod group object to be observed", "podGroup", klog.KObj(pgInfoLookup), "pod", klog.KObj(pInfo))
+		return
+	}
 	if p.activeQ.isLastPoppedEntity(pgInfoLookup) {
 		// If the last popped entity is the matching pod group, add the pod to the pending pod group pods,
 		// so it will be added to the pod group when it's requeued.
@@ -815,7 +861,7 @@ func (p *PriorityQueue) addPodGroupMember(logger klog.Logger, pInfo *framework.Q
 		logger.V(5).Info("Pod added to pending pod group pods, waiting for its pod group to be requeued", "podGroup", klog.KObj(pgInfoLookup), "pod", klog.KObj(pInfo))
 	} else {
 		// Create a new group as it's the first member pod in the queue.
-		pgInfo := p.newQueuedPodGroupInfo(pInfo)
+		pgInfo := p.newQueuedPodGroupInfo(pInfo, podGroup)
 		if added := p.moveToActiveQ(logger, pgInfo, framework.EventUnscheduledPodAdd.Label(), false); added {
 			p.activeQ.broadcast()
 		}
@@ -842,9 +888,7 @@ func (p *PriorityQueue) deleteFromAnyQueue(entityLookup framework.QueuedEntityIn
 
 // addToPodGroupIfExists tries to add pInfo as a member of its pod group into the scheduling queue.
 // It returns true if pInfo was added to an existing pod group.
-func (p *PriorityQueue) addToPodGroupIfExists(logger klog.Logger, pInfo *framework.QueuedPodInfo) bool {
-	pgInfoLookup := newQueuedPodGroupInfoForLookup(pInfo.Pod)
-
+func (p *PriorityQueue) addToPodGroupIfExists(logger klog.Logger, pgInfoLookup *framework.QueuedPodGroupInfo, pInfo *framework.QueuedPodInfo) bool {
 	entity, strategy := p.deleteFromAnyQueue(pgInfoLookup)
 	if entity == nil {
 		return false
@@ -1077,6 +1121,18 @@ func (p *PriorityQueue) AddAttemptedPodGroupIfNeeded(logger klog.Logger, pgInfo 
 	}
 	pgInfo.SetPods(pendingPods)
 
+	podGroup, ok := p.workloadForest.getRootForPod(pendingPods[0].Pod)
+	if !ok {
+		// This case shouldn't happen, because if the pod group was removed,
+		// pods should be put in the incompletePodGroupPods first, making pendingPods empty.
+		for _, pInfo := range pgInfo.QueuedPodInfos {
+			p.incompletePodGroupPods.add(pInfo)
+		}
+		logger.Error(nil, "Pod group no longer exists on requeue attempt, decomposed and moved pods to incompletePodGroupPods", "podGroup", klog.KObj(pgInfo))
+		return nil
+	}
+	pgInfo.PodGroup = podGroup
+
 	hasErrorPods := false
 	pgInfo.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
 		if pInfo.UnschedulablePlugins.Len() == 0 && pInfo.PendingPlugins.Len() == 0 {
@@ -1276,6 +1332,11 @@ func (p *PriorityQueue) Update(ctx context.Context, oldPod, newPod *v1.Pod) {
 		}
 		return
 	} else if p.isPodGroupMember(newPod) {
+		if pInfo := p.incompletePodGroupPods.update(newPod); pInfo != nil {
+			p.UpdateNominatedPod(logger, oldPod, pInfo.PodInfo)
+			pInfo.PodSignature = p.signPod(ctx, newPod)
+			return
+		}
 		if pInfo := p.pendingPodGroupPods.update(newPod); pInfo != nil {
 			p.UpdateNominatedPod(logger, oldPod, pInfo.PodInfo)
 			pInfo.PodSignature = p.signPod(ctx, newPod)
@@ -1320,13 +1381,18 @@ func (p *PriorityQueue) deletePodGroupMember(logger klog.Logger, pod *v1.Pod) {
 	if entity == nil {
 		pInfo := p.pendingPodGroupPods.delete(pod)
 		if pInfo == nil {
-			return
+			pInfo = p.incompletePodGroupPods.delete(pod)
+			if pInfo == nil {
+				return
+			}
+			logger.V(5).Info("Pod deleted from incompletePodGroupPods", "podGroup", klog.KObj(pgInfoLookup), "pod", klog.KObj(pInfo))
+		} else {
+			logger.V(5).Info("Pod deleted from pending pod group info", "podGroup", klog.KObj(pgInfoLookup), "pod", klog.KObj(pInfo))
 		}
 		// Drop metric for deleted pod.
 		for plugin := range pInfo.UnschedulablePlugins.Union(pInfo.PendingPlugins) {
 			metrics.UnschedulableReason(plugin, pInfo.Pod.Spec.SchedulerName).Dec()
 		}
-		logger.V(5).Info("Pod deleted from pending pod group info", "podGroup", klog.KObj(pgInfoLookup), "pod", klog.KObj(pInfo))
 		return
 	}
 	pgInfo := entity.(*framework.QueuedPodGroupInfo)
@@ -1374,6 +1440,91 @@ func (p *PriorityQueue) deletePod(pod *v1.Pod) {
 		// Drop metric for deleted pod.
 		decreaseUnschedulableReasonMetric(entity)
 	}
+}
+
+// AddPodGroup adds a new PodGroup object to the queue,
+// requeuing all pods associated with the pod group.
+func (p *PriorityQueue) AddPodGroup(logger klog.Logger, podGroup *schedulingv1alpha3.PodGroup) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.workloadForest.addPodGroup(podGroup)
+
+	pInfos := p.incompletePodGroupPods.clear(podGroup)
+	if len(pInfos) == 0 {
+		return
+	}
+	for _, pInfo := range pInfos {
+		// To handle all cases reliably, pods removed from incompletePodGroupPods are added to the queue
+		// through the addPodGroupMember method.
+		p.addPodGroupMember(logger, pInfo)
+	}
+	logger.V(5).Info("Pod group constructed and moved from incompletePodGroupPods to the queue", "podGroup", klog.KObj(podGroup), "podsLen", len(pInfos))
+}
+
+// UpdatePodGroup updates an existing PodGroup object in the queue.
+func (p *PriorityQueue) UpdatePodGroup(logger klog.Logger, podGroup *schedulingv1alpha3.PodGroup) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.workloadForest.updatePodGroup(podGroup)
+
+	pgInfoLookup := &framework.QueuedPodGroupInfo{
+		PodGroupInfo: &framework.PodGroupInfo{
+			Namespace: podGroup.Namespace,
+			Name:      podGroup.Name,
+		},
+	}
+	p.activeQ.underLock(func(unlockedActiveQ unlockedActiveQueuer) {
+		entity := p.getEntityFromAnyQueue(unlockedActiveQ, pgInfoLookup)
+		if entity == nil {
+			return
+		}
+		pgInfo := entity.(*framework.QueuedPodGroupInfo)
+		pgInfo.PodGroup = podGroup
+		logger.V(5).Info("Pod group in the scheduling queue was updated", "podGroup", klog.KObj(podGroup))
+	})
+}
+
+// DeletePodGroup removes a PodGroup object from the queue,
+// moving all pods associated with the pod group to the incompletePodGroupPods.
+func (p *PriorityQueue) DeletePodGroup(logger klog.Logger, podGroup *schedulingv1alpha3.PodGroup) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.workloadForest.deletePodGroup(podGroup)
+
+	pgInfoLookup := &framework.QueuedPodGroupInfo{
+		PodGroupInfo: &framework.PodGroupInfo{
+			Namespace: podGroup.Namespace,
+			Name:      podGroup.Name,
+		},
+	}
+	entity, _ := p.deleteFromAnyQueue(pgInfoLookup)
+	if entity != nil {
+		pgInfo := entity.(*framework.QueuedPodGroupInfo)
+		for _, pInfo := range pgInfo.QueuedPodInfos {
+			p.incompletePodGroupPods.add(pInfo)
+		}
+		logger.V(5).Info("Pod group deleted, decomposed and enqueued pods to incompletePodGroupPods", "podGroup", klog.KObj(pgInfoLookup), "pods", len(pgInfo.QueuedPodInfos))
+		return
+	}
+	if !p.activeQ.isLastPoppedEntity(pgInfoLookup) {
+		// PodGroup isn't pending or enqueued.
+		// No pods are tracked for that PodGroup in the queue,
+		// because in such case they are either scheduled or the PodGroup has no pods left.
+		return
+	}
+	// Get the pending pods and move them to incompletePodGroupPods.
+	pendingPods := p.pendingPodGroupPods.clear()
+	if len(pendingPods) == 0 {
+		// No pending pods, nothing to move.
+		return
+	}
+	for _, pInfo := range pendingPods {
+		p.incompletePodGroupPods.add(pInfo)
+	}
+	logger.V(5).Info("Pod group deleted, decomposed and enqueued pending pods to incompletePodGroupPods", "podGroup", klog.KObj(pgInfoLookup), "pods", len(pendingPods))
 }
 
 // NOTE: this function assumes a lock has been acquired in the caller.
@@ -1518,6 +1669,20 @@ func (p *PriorityQueue) PendingPodGroupPods() []*v1.Pod {
 	return result
 }
 
+// IncompletePodGroupPodsPods returns all the pending pods in incompletePodGroupPods.
+// It should be used only in the tests.
+func (p *PriorityQueue) IncompletePodGroupPodsPods() []*v1.Pod {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	var result []*v1.Pod
+	for _, pInfos := range p.incompletePodGroupPods.podGroupToPodInfos {
+		for _, pInfo := range pInfos {
+			result = append(result, pInfo.Pod)
+		}
+	}
+	return result
+}
+
 // GetPod searches for a pod in the activeQ, backoffQ, and unschedulableEntities.
 func (p *PriorityQueue) GetPod(name, namespace string, schedulingGroup *v1.PodSchedulingGroup) (*framework.QueuedPodInfo, bool) {
 	p.lock.RLock()
@@ -1552,7 +1717,11 @@ func (p *PriorityQueue) getPod(podLookup *v1.Pod, unlockedActiveQ unlockedActive
 		if !p.isPodGroupMember(podLookup) {
 			return nil
 		}
-		return p.pendingPodGroupPods.get(podLookup)
+		pInfo := p.pendingPodGroupPods.get(podLookup)
+		if pInfo != nil {
+			return pInfo
+		}
+		return p.incompletePodGroupPods.get(podLookup)
 	}
 	var foundPodInfo *framework.QueuedPodInfo
 	entity.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
@@ -1566,7 +1735,7 @@ func (p *PriorityQueue) getPod(podLookup *v1.Pod, unlockedActiveQ unlockedActive
 }
 
 var pendingPodsSummary = "activeQ:%v; backoffQ:%v; unschedulableEntities:%v"
-var pendingPodsExtendedSummary = "activeQ:%v; backoffQ:%v; unschedulableEntities:%v; pendingPodGroupMemberPods:%v"
+var pendingPodsExtendedSummary = "activeQ:%v; backoffQ:%v; unschedulableEntities:%v; pendingPodGroupMemberPods:%v; incompletePodGroupPods:%v"
 
 // PendingPods returns all the pending pods in the queue; accompanied by a debugging string
 // recording showing the number of pods in each queue respectively.
@@ -1590,8 +1759,15 @@ func (p *PriorityQueue) PendingPods() ([]*v1.Pod, string) {
 	if !p.isGenericWorkloadEnabled {
 		return result, fmt.Sprintf(pendingPodsSummary, activeQLen, backoffQLen, unschedulablePodsLen)
 	}
+	incompletePodGroupPodsPodsLen := 0
+	for _, pInfos := range p.incompletePodGroupPods.podGroupToPodInfos {
+		for _, pInfo := range pInfos {
+			result = append(result, pInfo.Pod)
+			incompletePodGroupPodsPodsLen++
+		}
+	}
 	pendingPodGroupPodsLen := p.pendingPodGroupPods.len()
-	return result, fmt.Sprintf(pendingPodsExtendedSummary, activeQLen, backoffQLen, unschedulablePodsLen, pendingPodGroupPodsLen)
+	return result, fmt.Sprintf(pendingPodsExtendedSummary, activeQLen, backoffQLen, unschedulablePodsLen, pendingPodGroupPodsLen, incompletePodGroupPodsPodsLen)
 }
 
 // PatchPodStatus handles the pod status update by sending an update API call through API dispatcher.
@@ -1706,12 +1882,13 @@ func (p *PriorityQueue) newQueuedPodInfo(ctx context.Context, pod *v1.Pod, plugi
 }
 
 // newQueuedPodGroupInfo builds a QueuedPodGroupInfo object.
-func (p *PriorityQueue) newQueuedPodGroupInfo(podInfo *framework.QueuedPodInfo) *framework.QueuedPodGroupInfo {
+func (p *PriorityQueue) newQueuedPodGroupInfo(podInfo *framework.QueuedPodInfo, podGroup *schedulingv1alpha3.PodGroup) *framework.QueuedPodGroupInfo {
 	return &framework.QueuedPodGroupInfo{
 		PodGroupInfo: &framework.PodGroupInfo{
 			Namespace:       podInfo.Pod.Namespace,
 			Name:            *podInfo.Pod.Spec.SchedulingGroup.PodGroupName,
 			UnscheduledPods: []*v1.Pod{podInfo.Pod},
+			PodGroup:        podGroup,
 		},
 		QueuedPodInfos: []*framework.QueuedPodInfo{podInfo},
 		QueueingParams: framework.QueueingParams{
@@ -1724,4 +1901,16 @@ func (p *PriorityQueue) newQueuedPodGroupInfo(podInfo *framework.QueuedPodInfo) 
 // queuedEntityKeyFunc returns a unique key for a queued entity based on its type, namespace, and name.
 func queuedEntityKeyFunc(obj framework.QueuedEntityInfo) string {
 	return fmt.Sprintf("%s/%s/%s", obj.Type(), obj.GetNamespace(), obj.GetName())
+}
+
+func podGroupKeyForPod(pod *v1.Pod) string {
+	return fmt.Sprintf("pg/%s/%s", pod.Namespace, *pod.Spec.SchedulingGroup.PodGroupName)
+}
+
+func podGroupKey(podGroup *schedulingv1alpha3.PodGroup) string {
+	return fmt.Sprintf("pg/%s/%s", podGroup.Namespace, podGroup.Name)
+}
+
+func podKey(pod *v1.Pod) string {
+	return fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
 }

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -176,6 +177,16 @@ func TestPriorityQueue_Add(t *testing.T) {
 
 			objs := []runtime.Object{medPod, unschedPod, highPod}
 			q := NewTestQueueWithObjects(ctx, newDefaultQueueSort(), objs)
+			if tt.usePodGroups {
+				podGroups := []*schedulingv1alpha3.PodGroup{
+					st.MakePodGroup().Name("pg-med").Namespace(medPod.Namespace).Priority(midPriority).Obj(),
+					st.MakePodGroup().Name("pg-unsched").Namespace(unschedPod.Namespace).Priority(lowPriority).Obj(),
+					st.MakePodGroup().Name("pg-high").Namespace(highPod.Namespace).Priority(highPriority).Obj(),
+				}
+				for _, podGroup := range podGroups {
+					q.AddPodGroup(logger, podGroup)
+				}
+			}
 			q.Add(ctx, medPod)
 			q.Add(ctx, unschedPod)
 			q.Add(ctx, highPod)
@@ -1032,6 +1043,10 @@ func Test_InFlightPods(t *testing.T) {
 				fakeClock := testingclock.NewFakeClock(time.Now())
 				q := NewTestQueueWithObjects(ctx, newDefaultQueueSort(), obj, WithQueueingHintMapPerProfile(test.queueingHintMap), WithClock(fakeClock))
 				sortOpt := cmpopts.SortSlices(func(a, b string) bool { return a < b })
+				if genericWorkloadEnabled {
+					podGroup := st.MakePodGroup().Name(pgName).Namespace(pgPod1.Namespace).Obj()
+					q.AddPodGroup(logger, podGroup)
+				}
 
 				// When a Pod is added to the queue, the QueuedPodInfo will have a new timestamp.
 				// On Windows, time.Now() is not as precise, 2 consecutive calls may return the same timestamp.
@@ -1411,12 +1426,12 @@ func TestPriorityQueue_Pop(t *testing.T) {
 
 			var medEntity, backoffEntity, errorBackoffEntity, unschedEntity framework.QueuedEntityInfo
 			if tt.usePodGroups {
-				medEntity = q.newQueuedPodGroupInfo(q.newQueuedPodInfo(ctx, medPod))
-				backoffPodGroup := q.newQueuedPodGroupInfo(q.newQueuedPodInfo(ctx, backoffPod, "plugin"))
+				medEntity = q.newQueuedPodGroupInfo(q.newQueuedPodInfo(ctx, medPod), nil)
+				backoffPodGroup := q.newQueuedPodGroupInfo(q.newQueuedPodInfo(ctx, backoffPod, "plugin"), nil)
 				backoffPodGroup.UnschedulablePlugins = sets.New("plugin")
 				backoffEntity = backoffPodGroup
-				errorBackoffEntity = q.newQueuedPodGroupInfo(q.newQueuedPodInfo(ctx, errorBackoffPod))
-				unschedPodGroup := q.newQueuedPodGroupInfo(q.newQueuedPodInfo(ctx, unschedPod, "plugin"))
+				errorBackoffEntity = q.newQueuedPodGroupInfo(q.newQueuedPodInfo(ctx, errorBackoffPod), nil)
+				unschedPodGroup := q.newQueuedPodGroupInfo(q.newQueuedPodInfo(ctx, unschedPod, "plugin"), nil)
 				unschedPodGroup.UnschedulablePlugins = sets.New("plugin")
 				unschedEntity = unschedPodGroup
 			} else {
@@ -3712,11 +3727,13 @@ func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {
 		setup                           func(t ktesting.TContext, q *PriorityQueue, pgInfo *framework.QueuedPodGroupInfo)
 		disableBackoff                  bool
 		blockOnPreEnqueue               bool
+		skipAddPodGroup                 bool
 		expectedUnschedulableCount      int
 		expectedConsecutiveErrorsCount  int
 		expectedInActiveQ               bool
 		expectedInBackoffQ              bool
 		expectedInUnschedulableEntities bool
+		expectedInIncomplete            []*v1.Pod
 		expectedPodsInGroup             int
 	}{
 		{
@@ -3830,6 +3847,18 @@ func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {
 			expectedInUnschedulableEntities: true,
 			expectedPodsInGroup:             2,
 		},
+		{
+			name: "Pods present, but pod group is not observed, pods move to incompletePodGroupPods",
+			setup: func(tCtx ktesting.TContext, q *PriorityQueue, pgInfo *framework.QueuedPodGroupInfo) {
+				pInfo1 := q.newQueuedPodInfo(tCtx, pod1)
+				pInfo2 := q.newQueuedPodInfo(tCtx, pod2)
+				q.pendingPodGroupPods.add(pInfo1)
+				q.pendingPodGroupPods.add(pInfo2)
+			},
+			skipAddPodGroup:      true,
+			expectedInIncomplete: []*v1.Pod{pod1, pod2},
+			expectedPodsInGroup:  2,
+		},
 	}
 
 	for _, test := range tests {
@@ -3850,8 +3879,12 @@ func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {
 				opts = append(opts, WithPodInitialBackoffDuration(0), WithPodMaxBackoffDuration(0))
 			}
 			q := NewTestQueue(tCtx, newDefaultQueueSort(), opts...)
+			podGroup := st.MakePodGroup().Name(pgName).Namespace("ns1").Obj()
+			if !test.skipAddPodGroup {
+				q.AddPodGroup(tCtx.Logger(), podGroup)
+			}
 
-			pgInfo := q.newQueuedPodGroupInfo(q.newQueuedPodInfo(tCtx, pod1))
+			pgInfo := q.newQueuedPodGroupInfo(q.newQueuedPodInfo(tCtx, pod1), podGroup)
 
 			test.setup(tCtx, q, pgInfo)
 
@@ -3877,6 +3910,11 @@ func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {
 			}
 			if q.pendingPodGroupPods.len() != 0 {
 				tCtx.Errorf("Expected pendingPodGroupPods to be cleared")
+			}
+			for _, pod := range test.expectedInIncomplete {
+				if !q.incompletePodGroupPods.has(pod) {
+					tCtx.Errorf("Expected pod %v to be in incompletePodGroupPods", pod.Name)
+				}
 			}
 			if len(pgInfo.QueuedPodInfos) != test.expectedPodsInGroup {
 				tCtx.Errorf("Expected QueuedPodInfos to have %v elements, got %v", test.expectedPodsInGroup, len(pgInfo.QueuedPodInfos))
@@ -5957,10 +5995,17 @@ const (
 	stateBackoff
 	stateUnschedulable
 	stateGated
+	stateIncomplete
 )
 
-func setupInitialPodGroupState(t *testing.T, ctx context.Context, q *PriorityQueue, initialPods []*v1.Pod, initialState initialQueueState) {
+func setupInitialPodGroupState(t *testing.T, ctx context.Context, q *PriorityQueue, initialPods []*v1.Pod, initialState initialQueueState, initialPodGroup *schedulingv1alpha3.PodGroup) {
 	t.Helper()
+
+	if initialState != stateIncomplete {
+		logger := klog.FromContext(ctx)
+		q.AddPodGroup(logger, initialPodGroup)
+	}
+
 	if len(initialPods) == 0 {
 		return
 	}
@@ -6020,6 +6065,7 @@ func TestAddPodGroupMember(t *testing.T) {
 		expectedInUnschedulable       bool
 		expectedInBackoffQ            bool
 		expectedInPendingPodGroupPods bool
+		expectedInIncomplete          []*v1.Pod
 		expectedGated                 bool
 		expectedGroupSize             int
 	}{
@@ -6111,6 +6157,19 @@ func TestAddPodGroupMember(t *testing.T) {
 			expectedGated:           true,
 			expectedGroupSize:       2,
 		},
+		{
+			name:                 "first member added before pod group exists, goes to incompletePodGroupPods",
+			initialState:         stateIncomplete,
+			incomingPod:          p1,
+			expectedInIncomplete: []*v1.Pod{p1},
+		},
+		{
+			name:                 "existing pod in incompletePodGroupPods, stays in incompletePodGroupPods",
+			initialPod:           p1,
+			initialState:         stateIncomplete,
+			incomingPod:          p2,
+			expectedInIncomplete: []*v1.Pod{p1, p2},
+		},
 	}
 
 	for _, tt := range tests {
@@ -6129,13 +6188,15 @@ func TestAddPodGroupMember(t *testing.T) {
 					"preEnqueuePlugin": &preEnqueuePlugin{allowlists: []string{"allow"}},
 				},
 			}
+
 			q := NewTestQueue(ctx, newDefaultQueueSort(), WithPreEnqueuePluginMap(preEnqueueMap))
+			podGroup := st.MakePodGroup().Name(pgName).Namespace("ns1").Obj()
 
 			var initialPods []*v1.Pod
 			if tt.initialPod != nil {
 				initialPods = []*v1.Pod{tt.initialPod}
 			}
-			setupInitialPodGroupState(t, ctx, q, initialPods, tt.initialState)
+			setupInitialPodGroupState(t, ctx, q, initialPods, tt.initialState, podGroup)
 
 			// Add incoming pod
 			q.Add(ctx, tt.incomingPod)
@@ -6192,6 +6253,15 @@ func TestAddPodGroupMember(t *testing.T) {
 			if inPending != tt.expectedInPendingPodGroupPods {
 				t.Errorf("Expected incoming pod in pendingPodGroupPods: %v, got %v", tt.expectedInPendingPodGroupPods, inPending)
 			}
+
+			for _, pod := range tt.expectedInIncomplete {
+				if !q.incompletePodGroupPods.has(pod) {
+					t.Errorf("Expected pod %v in incompletePodGroupPods", pod.Name)
+				}
+			}
+			if q.incompletePodGroupPods.len() != len(tt.expectedInIncomplete) {
+				t.Errorf("Expected incompletePodGroupPods size to be %v, got %v", len(tt.expectedInIncomplete), q.incompletePodGroupPods.len())
+			}
 		})
 	}
 }
@@ -6215,6 +6285,7 @@ func TestDeletePodGroupMember(t *testing.T) {
 		expectedInUnschedulable bool
 		expectedInBackoffQ      bool
 		expectedPodsInPending   int
+		expectedInIncomplete    []*v1.Pod
 		expectedGated           bool
 		expectedGroupSize       int
 	}{
@@ -6305,6 +6376,20 @@ func TestDeletePodGroupMember(t *testing.T) {
 			expectedGated:           true,
 			expectedGroupSize:       2,
 		},
+		{
+			name:                 "delete from incompletePodGroupPods",
+			initialPods:          []*v1.Pod{p1},
+			initialState:         stateIncomplete,
+			podToDelete:          p1,
+			expectedInIncomplete: nil,
+		},
+		{
+			name:                 "delete one pod from incompletePodGroupPods with multiple pods",
+			initialPods:          []*v1.Pod{p1, p2},
+			initialState:         stateIncomplete,
+			podToDelete:          p1,
+			expectedInIncomplete: []*v1.Pod{p2},
+		},
 	}
 
 	for _, tt := range tests {
@@ -6323,8 +6408,9 @@ func TestDeletePodGroupMember(t *testing.T) {
 				},
 			}
 			q := NewTestQueue(ctx, newDefaultQueueSort(), WithPreEnqueuePluginMap(preEnqueueMap))
+			podGroup := st.MakePodGroup().Name(pgName).Namespace("ns1").Obj()
 
-			setupInitialPodGroupState(t, ctx, q, tt.initialPods, tt.initialState)
+			setupInitialPodGroupState(t, ctx, q, tt.initialPods, tt.initialState, podGroup)
 			// Add pending pods
 			for _, pod := range tt.pendingPods {
 				q.Add(ctx, pod)
@@ -6379,6 +6465,15 @@ func TestDeletePodGroupMember(t *testing.T) {
 			if q.pendingPodGroupPods.has(tt.podToDelete) {
 				t.Errorf("Deleted pod %s is still present in pendingPodGroupPods map", tt.podToDelete.Name)
 			}
+
+			for _, pod := range tt.expectedInIncomplete {
+				if !q.incompletePodGroupPods.has(pod) {
+					t.Errorf("Expected pod %s in incompletePodGroupPods", pod.Name)
+				}
+			}
+			if q.incompletePodGroupPods.len() != len(tt.expectedInIncomplete) {
+				t.Errorf("Expected incompletePodGroupPods size to be %d, got %d", len(tt.expectedInIncomplete), q.incompletePodGroupPods.len())
+			}
 		})
 	}
 }
@@ -6407,6 +6502,7 @@ func TestUpdatePodGroupMember(t *testing.T) {
 		expectedInUnschedulable bool
 		expectedInBackoffQ      bool
 		expectedPodsInPending   int
+		expectedInIncomplete    *v1.Pod
 		expectedGated           bool
 		expectedGroupSize       int
 		expectedNominatedPods   map[types.UID]string
@@ -6535,6 +6631,22 @@ func TestUpdatePodGroupMember(t *testing.T) {
 				"pod2": "node1",
 			},
 		},
+		{
+			name:                 "update pod in incompletePodGroupPods",
+			initialPods:          []*v1.Pod{p2},
+			initialState:         stateIncomplete,
+			oldPod:               p2,
+			newPod:               updatedP2,
+			expectedInIncomplete: updatedP2,
+		},
+		{
+			name:                 "updating incomplete pod that doesn't exist in any queue, adds the pod to incompletePodGroupPods",
+			initialPods:          nil,
+			initialState:         stateIncomplete,
+			oldPod:               notFoundPod,
+			newPod:               updatedNotFoundPod,
+			expectedInIncomplete: updatedNotFoundPod,
+		},
 	}
 
 	for _, tt := range tests {
@@ -6553,8 +6665,9 @@ func TestUpdatePodGroupMember(t *testing.T) {
 				},
 			}
 			q := NewTestQueueWithObjects(ctx, newDefaultQueueSort(), []runtime.Object{tt.newPod}, WithPreEnqueuePluginMap(preEnqueueMap))
+			podGroup := st.MakePodGroup().Name(pgName).Namespace("ns1").Obj()
 
-			setupInitialPodGroupState(t, ctx, q, tt.initialPods, tt.initialState)
+			setupInitialPodGroupState(t, ctx, q, tt.initialPods, tt.initialState, podGroup)
 			// Add pending pods
 			for _, pod := range tt.pendingPods {
 				q.Add(ctx, pod)
@@ -6623,6 +6736,16 @@ func TestUpdatePodGroupMember(t *testing.T) {
 					t.Errorf("Pending member pod differs from newPod (-want +got):\n%s", diff)
 				}
 			}
+
+			if tt.expectedInIncomplete != nil {
+				pInfo := q.incompletePodGroupPods.get(tt.expectedInIncomplete)
+				if diff := cmp.Diff(tt.expectedInIncomplete, pInfo.Pod); diff != "" {
+					t.Errorf("Unexpected pod in incompletePodGroupPods (-want +got):\n%s", diff)
+				}
+			} else if incompleteLen := q.incompletePodGroupPods.len(); incompleteLen != 0 {
+				t.Errorf("Expected no pods in incompletePodGroupPods, got %v", incompleteLen)
+			}
+
 			if diff := cmp.Diff(tt.expectedNominatedPods, q.nominatedPodToNode, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("Unexpected nominated pods (-want +got):\n%s", diff)
 			}
@@ -6646,6 +6769,7 @@ func TestActivatePodGroupMember(t *testing.T) {
 		expectedInActiveQ          bool
 		expectedInUnschedulable    bool
 		expectedPodsInPending      int
+		expectedInIncomplete       []*v1.Pod
 		expectedGated              bool
 		expectedForceActivateEvent bool
 	}{
@@ -6692,6 +6816,13 @@ func TestActivatePodGroupMember(t *testing.T) {
 		// 	expectedForceActivateEvent:     true,
 		// 	expectedPodsInPending:          1,
 		// },
+		{
+			name:                 "activate pod in incompletePodGroupPods is a no-op",
+			initialPods:          []*v1.Pod{p1, p2},
+			initialState:         stateIncomplete,
+			podToActivate:        p1,
+			expectedInIncomplete: []*v1.Pod{p1, p2},
+		},
 	}
 
 	for _, tt := range tests {
@@ -6710,8 +6841,9 @@ func TestActivatePodGroupMember(t *testing.T) {
 				},
 			}
 			q := NewTestQueue(ctx, newDefaultQueueSort(), WithPreEnqueuePluginMap(preEnqueueMap))
+			podGroup := st.MakePodGroup().Name(pgName).Namespace("ns1").Obj()
 
-			setupInitialPodGroupState(t, ctx, q, tt.initialPods, tt.initialState)
+			setupInitialPodGroupState(t, ctx, q, tt.initialPods, tt.initialState, podGroup)
 			// Add pending pods
 			for _, pod := range tt.pendingPods {
 				q.Add(ctx, pod)
@@ -6755,6 +6887,15 @@ func TestActivatePodGroupMember(t *testing.T) {
 			}
 			if tt.expectedPodsInPending > 0 && !q.pendingPodGroupPods.has(tt.podToActivate) {
 				t.Errorf("Pod %s was not found in pendingPodGroupPods map", tt.podToActivate.Name)
+			}
+
+			for _, pod := range tt.expectedInIncomplete {
+				if !q.incompletePodGroupPods.has(pod) {
+					t.Errorf("Expected pod %s in incompletePodGroupPods", pod.Name)
+				}
+			}
+			if q.incompletePodGroupPods.len() != len(tt.expectedInIncomplete) {
+				t.Errorf("Expected incompletePodGroupPods size to be %d, got %d", len(tt.expectedInIncomplete), q.incompletePodGroupPods.len())
 			}
 
 			if tt.expectedForceActivateEvent {
@@ -6884,8 +7025,9 @@ func TestMoveAllToActiveOrBackoffQueuePodGroupMember(t *testing.T) {
 			}
 
 			q := NewTestQueue(ctx, newDefaultQueueSort(), WithPreEnqueuePluginMap(preEnqueueMap), WithQueueingHintMapPerProfile(m))
+			podGroup := st.MakePodGroup().Name(pgName).Namespace("ns1").Obj()
 
-			setupInitialPodGroupState(t, ctx, q, tt.initialPods, tt.initialState)
+			setupInitialPodGroupState(t, ctx, q, tt.initialPods, tt.initialState, podGroup)
 
 			// MoveAllToActiveOrBackoffQueue with the given event
 			q.MoveAllToActiveOrBackoffQueue(logger, tt.event, nil, nil, tt.preCheck)
@@ -7007,8 +7149,9 @@ func TestFlushBackoffQCompletedPodGroupMember(t *testing.T) {
 
 			fakeClock := testingclock.NewFakeClock(time.Now())
 			q := NewTestQueue(ctx, newDefaultQueueSort(), WithPreEnqueuePluginMap(preEnqueueMap), WithClock(fakeClock))
+			podGroup := st.MakePodGroup().Name(pgName).Namespace("ns1").Obj()
 
-			setupInitialPodGroupState(t, ctx, q, tt.initialPods, tt.initialState)
+			setupInitialPodGroupState(t, ctx, q, tt.initialPods, tt.initialState, podGroup)
 
 			if tt.advanceClock > 0 {
 				fakeClock.Step(tt.advanceClock)
@@ -7109,8 +7252,9 @@ func TestFlushUnschedulableEntitiesLeftoverPodGroupMember(t *testing.T) {
 
 			fakeClock := testingclock.NewFakeClock(time.Now())
 			q := NewTestQueue(ctx, newDefaultQueueSort(), WithPreEnqueuePluginMap(preEnqueueMap), WithClock(fakeClock))
+			podGroup := st.MakePodGroup().Name(pgName).Namespace("ns1").Obj()
 
-			setupInitialPodGroupState(t, ctx, q, tt.initialPods, tt.initialState)
+			setupInitialPodGroupState(t, ctx, q, tt.initialPods, tt.initialState, podGroup)
 
 			if tt.advanceClock > 0 {
 				fakeClock.Step(tt.advanceClock)
@@ -7189,11 +7333,13 @@ func TestAddUnschedulablePodIfNotPresentPodGroupMember(t *testing.T) {
 		initialPods             []*v1.Pod
 		initialState            initialQueueState
 		clearLastPopped         bool
+		deletePodGroup          bool
 		podsToAdd               []*framework.QueuedPodInfo
 		expectedPodsInPending   int
 		expectedInActiveQ       bool
 		expectedInUnschedulable bool
 		expectedInBackoffQ      bool
+		expectedInIncomplete    []*v1.Pod
 		expectedGated           bool
 		expectedGroupSize       int
 	}{
@@ -7262,6 +7408,23 @@ func TestAddUnschedulablePodIfNotPresentPodGroupMember(t *testing.T) {
 			expectedGated:           true,
 			expectedGroupSize:       2,
 		},
+		{
+			name:                 "requeuing a pod group members after PodGroup was deleted moves them to incompletePodGroupPods",
+			initialPods:          []*v1.Pod{p1, p2},
+			initialState:         statePopped,
+			deletePodGroup:       true,
+			podsToAdd:            []*framework.QueuedPodInfo{pInfo1, pInfo2},
+			expectedInIncomplete: []*v1.Pod{p1, p2},
+		},
+		{
+			name:                 "requeuing a pod group members after PodGroup was deleted and is not last popped entity moves them to incompletePodGroupPods",
+			initialPods:          []*v1.Pod{p1, p2},
+			initialState:         statePopped,
+			clearLastPopped:      true,
+			deletePodGroup:       true,
+			podsToAdd:            []*framework.QueuedPodInfo{pInfo1, pInfo2},
+			expectedInIncomplete: []*v1.Pod{p1, p2},
+		},
 	}
 
 	for _, tt := range tests {
@@ -7281,11 +7444,16 @@ func TestAddUnschedulablePodIfNotPresentPodGroupMember(t *testing.T) {
 			}
 
 			q := NewTestQueue(ctx, newDefaultQueueSort(), WithPreEnqueuePluginMap(preEnqueueMap))
+			podGroup := st.MakePodGroup().Name(pgName).Namespace("ns1").Obj()
 
-			setupInitialPodGroupState(t, ctx, q, tt.initialPods, tt.initialState)
+			setupInitialPodGroupState(t, ctx, q, tt.initialPods, tt.initialState, podGroup)
 
 			if tt.clearLastPopped {
 				q.activeQ.clearPoppedEntity()
+			}
+
+			if tt.deletePodGroup {
+				q.DeletePodGroup(logger, podGroup)
 			}
 
 			// Add unschedulable pods
@@ -7334,6 +7502,371 @@ func TestAddUnschedulablePodIfNotPresentPodGroupMember(t *testing.T) {
 
 			if pendingLen := q.pendingPodGroupPods.len(); pendingLen != tt.expectedPodsInPending {
 				t.Errorf("Expected pod group to have %d pods in pendingPodGroupPods, got %d", tt.expectedPodsInPending, pendingLen)
+			}
+
+			for _, pod := range tt.expectedInIncomplete {
+				if !q.incompletePodGroupPods.has(pod) {
+					t.Errorf("Expected pod %s in incompletePodGroupPods", pod.Name)
+				}
+			}
+			if q.incompletePodGroupPods.len() != len(tt.expectedInIncomplete) {
+				t.Errorf("Expected incompletePodGroupPods size to be %d, got %d", len(tt.expectedInIncomplete), q.incompletePodGroupPods.len())
+			}
+		})
+	}
+}
+
+func TestAddPodGroup(t *testing.T) {
+	pgName := "pg-test"
+	p1 := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Label("allow", "").PodGroupName(pgName).Obj()
+	p2 := st.MakePod().Name("pod2").Namespace("ns1").UID("pod2").Label("allow", "").PodGroupName(pgName).Obj()
+	gatedP1 := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").PodGroupName(pgName).Obj()
+	podGroup := st.MakePodGroup().Name(pgName).Namespace("ns1").Obj()
+
+	tests := []struct {
+		name                    string
+		initialPods             []*v1.Pod
+		initialState            initialQueueState
+		expectedInActiveQ       bool
+		expectedInUnschedulable bool
+		expectedGated           bool
+		expectedGroupSize       int
+	}{
+		{
+			name:              "add pod group without waiting pods",
+			initialState:      stateIncomplete,
+			expectedInActiveQ: false,
+		},
+		{
+			name:              "add pod group moves pods from incompletePodGroupPods to activeQ",
+			initialPods:       []*v1.Pod{p1, p2},
+			initialState:      stateIncomplete,
+			expectedInActiveQ: true,
+			expectedGroupSize: 2,
+		},
+		{
+			name:                    "add pod group moves gated pods from incompletePodGroupPods to unschedulableEntities",
+			initialPods:             []*v1.Pod{gatedP1, p2},
+			initialState:            stateIncomplete,
+			expectedInUnschedulable: true,
+			expectedGated:           true,
+			expectedGroupSize:       2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+				features.GenericWorkload: true,
+			})
+
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			// Configure a PreEnqueue plugin that allows pods with label "allow", but gates others.
+			preEnqueueMap := map[string]map[string]fwk.PreEnqueuePlugin{
+				"": {
+					"preEnqueuePlugin": &preEnqueuePlugin{allowlists: []string{"allow"}},
+				},
+			}
+			q := NewTestQueue(ctx, newDefaultQueueSort(), WithPreEnqueuePluginMap(preEnqueueMap))
+
+			setupInitialPodGroupState(t, ctx, q, tt.initialPods, tt.initialState, podGroup)
+
+			q.AddPodGroup(logger, podGroup)
+
+			pgLookup := &framework.QueuedPodGroupInfo{
+				PodGroupInfo: &framework.PodGroupInfo{
+					Namespace: podGroup.Namespace,
+					Name:      podGroup.Name,
+				},
+			}
+			gotPodGroup, ok := q.workloadForest.getPodGroup(podGroup)
+			if !ok {
+				t.Fatalf("Expected pod group to be in workloadForest")
+			}
+			if diff := cmp.Diff(podGroup, gotPodGroup); diff != "" {
+				t.Errorf("Unexpected pod group object (-want +got):\n%s", diff)
+			}
+
+			if inActive := q.activeQ.has(pgLookup); inActive != tt.expectedInActiveQ {
+				t.Errorf("Expected incoming pod in activeQ: %v, got %v", tt.expectedInActiveQ, inActive)
+			}
+			var entity framework.QueuedEntityInfo
+			if tt.expectedInActiveQ {
+				entity, _ = q.activeQ.get(pgLookup)
+			}
+
+			unschedulableEntity := q.unschedulableEntities.get(pgLookup)
+			inUnschedulable := unschedulableEntity != nil
+			if inUnschedulable != tt.expectedInUnschedulable {
+				t.Errorf("Expected incoming pod in unschedulableEntities: %v, got %v", tt.expectedInUnschedulable, inUnschedulable)
+			}
+			if tt.expectedInUnschedulable {
+				entity = unschedulableEntity
+			}
+
+			if entity != nil {
+				if isGated := entity.Gated(); isGated != tt.expectedGated {
+					t.Errorf("Expected pod group to be gated: %v, got %v", tt.expectedGated, isGated)
+				}
+				if size := entity.Size(); size != tt.expectedGroupSize {
+					t.Errorf("Expected pod group to be of size: %d, got %d", tt.expectedGroupSize, size)
+				}
+				pgInfo := entity.(*framework.QueuedPodGroupInfo)
+				if diff := cmp.Diff(podGroup, pgInfo.PodGroup); diff != "" {
+					t.Errorf("Unexpected pod group object in QueuedPodGroupInfo (-want +got):\n%s", diff)
+				}
+			}
+
+			for _, pod := range tt.initialPods {
+				if q.incompletePodGroupPods.has(pod) {
+					t.Errorf("Expected pod %s not to be present in incompletePodGroupPods", pod.Name)
+				}
+			}
+		})
+	}
+}
+
+func TestUpdatePodGroup(t *testing.T) {
+	pgName := "pg-test"
+	p1 := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Label("allow", "").PodGroupName(pgName).Obj()
+	p2 := st.MakePod().Name("pod2").Namespace("ns1").UID("pod2").Label("allow", "").PodGroupName(pgName).Obj()
+	gatedP1 := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").PodGroupName(pgName).Obj()
+	podGroup := st.MakePodGroup().Name(pgName).Namespace("ns1").MinCount(1).Obj()
+	updatedPodGroup := st.MakePodGroup().Name(pgName).Namespace("ns1").MinCount(2).Obj()
+
+	tests := []struct {
+		name                          string
+		initialPods                   []*v1.Pod
+		initialState                  initialQueueState
+		expectedInActiveQ             bool
+		expectedInBackoffQ            bool
+		expectedInUnschedulable       bool
+		expectedInPendingPodGroupPods bool
+		expectedGated                 bool
+	}{
+		{
+			name:         "update pod group without pods",
+			initialState: stateActive, // will just add the PodGroup
+		},
+		{
+			name:              "update active pod group",
+			initialPods:       []*v1.Pod{p1, p2},
+			initialState:      stateActive,
+			expectedInActiveQ: true,
+		},
+		{
+			name:               "update backoff pod group",
+			initialPods:        []*v1.Pod{p1, p2},
+			initialState:       stateBackoff,
+			expectedInBackoffQ: true,
+		},
+		{
+			name:                    "update unschedulable pod group",
+			initialPods:             []*v1.Pod{p1, p2},
+			initialState:            stateUnschedulable,
+			expectedInUnschedulable: true,
+		},
+		{
+			name:                    "update gated pod group",
+			initialPods:             []*v1.Pod{gatedP1, p2},
+			initialState:            stateGated,
+			expectedInUnschedulable: true,
+			expectedGated:           true,
+		},
+		{
+			name:                          "update in-flight pod group",
+			initialPods:                   []*v1.Pod{p1, p2},
+			initialState:                  statePopped,
+			expectedInPendingPodGroupPods: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+				features.GenericWorkload: true,
+			})
+
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			preEnqueueMap := map[string]map[string]fwk.PreEnqueuePlugin{
+				"": {
+					"preEnqueuePlugin": &preEnqueuePlugin{allowlists: []string{"allow"}},
+				},
+			}
+			q := NewTestQueue(ctx, newDefaultQueueSort(), WithPreEnqueuePluginMap(preEnqueueMap))
+
+			setupInitialPodGroupState(t, ctx, q, tt.initialPods, tt.initialState, podGroup)
+
+			q.UpdatePodGroup(logger, updatedPodGroup)
+
+			gotPodGroup, ok := q.workloadForest.getPodGroup(podGroup)
+			if !ok {
+				t.Fatalf("Expected pod group to be in workloadForest")
+			}
+			if diff := cmp.Diff(updatedPodGroup, gotPodGroup); diff != "" {
+				t.Errorf("Unexpected pod group object (-want +got):\n%s", diff)
+			}
+
+			pgLookup := &framework.QueuedPodGroupInfo{
+				PodGroupInfo: &framework.PodGroupInfo{
+					Namespace: podGroup.Namespace,
+					Name:      podGroup.Name,
+				},
+			}
+			if inActive := q.activeQ.has(pgLookup); inActive != tt.expectedInActiveQ {
+				t.Errorf("Expected target pod group in activeQ: %v, got %v", tt.expectedInActiveQ, inActive)
+			}
+			var entity framework.QueuedEntityInfo
+			if tt.expectedInActiveQ {
+				entity, _ = q.activeQ.get(pgLookup)
+			}
+
+			if inBackoff := q.backoffQ.has(pgLookup); inBackoff != tt.expectedInBackoffQ {
+				t.Errorf("Expected target pod group in backoffQ: %v, got %v", tt.expectedInBackoffQ, inBackoff)
+			}
+			if tt.expectedInBackoffQ {
+				entity, _ = q.backoffQ.get(pgLookup)
+			}
+
+			unschedulableEntity := q.unschedulableEntities.get(pgLookup)
+			inUnschedulable := unschedulableEntity != nil
+			if inUnschedulable != tt.expectedInUnschedulable {
+				t.Errorf("Expected target pod group in unschedulableEntities: %v, got %v", tt.expectedInUnschedulable, inUnschedulable)
+			}
+			if tt.expectedInUnschedulable {
+				entity = unschedulableEntity
+			}
+
+			if entity != nil {
+				if isGated := entity.Gated(); isGated != tt.expectedGated {
+					t.Errorf("Expected pod group to be gated: %v, got %v", tt.expectedGated, isGated)
+				}
+				pgInfo := entity.(*framework.QueuedPodGroupInfo)
+				if diff := cmp.Diff(updatedPodGroup, pgInfo.PodGroup); diff != "" {
+					t.Errorf("Unexpected pod group object in QueuedPodGroupInfo (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestDeletePodGroup(t *testing.T) {
+	pgName := "pg-test"
+	p1 := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Label("allow", "").PodGroupName(pgName).Obj()
+	p2 := st.MakePod().Name("pod2").Namespace("ns1").UID("pod2").Label("allow", "").PodGroupName(pgName).Obj()
+	gatedP1 := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").PodGroupName(pgName).Obj()
+	podGroup := st.MakePodGroup().Name(pgName).Namespace("ns1").Obj()
+
+	tests := []struct {
+		name                 string
+		initialPods          []*v1.Pod
+		initialState         initialQueueState
+		pendingPods          []*v1.Pod
+		expectedInIncomplete []*v1.Pod
+	}{
+		{
+			name:                 "delete active pod group moves pods to incompletePodGroupPods",
+			initialPods:          []*v1.Pod{p1, p2},
+			initialState:         stateActive,
+			expectedInIncomplete: []*v1.Pod{p1, p2},
+		},
+		{
+			name:                 "delete backoff pod group moves pods to incompletePodGroupPods",
+			initialPods:          []*v1.Pod{p1, p2},
+			initialState:         stateBackoff,
+			expectedInIncomplete: []*v1.Pod{p1, p2},
+		},
+		{
+			name:                 "delete unschedulable pod group moves pods to incompletePodGroupPods",
+			initialPods:          []*v1.Pod{p1, p2},
+			initialState:         stateUnschedulable,
+			expectedInIncomplete: []*v1.Pod{p1, p2},
+		},
+		{
+			name:                 "delete gated pod group moves pods to incompletePodGroupPods",
+			initialPods:          []*v1.Pod{gatedP1, p2},
+			initialState:         stateGated,
+			expectedInIncomplete: []*v1.Pod{gatedP1, p2},
+		},
+		{
+			name:                 "delete in-flight pod group moves pending pods to incompletePodGroupPods",
+			initialPods:          []*v1.Pod{p1, p2},
+			initialState:         statePopped,
+			pendingPods:          []*v1.Pod{p1, p2},
+			expectedInIncomplete: []*v1.Pod{p1, p2},
+		},
+		{
+			name:                 "delete in-flight pod group with no pending pods",
+			initialPods:          []*v1.Pod{p1, p2},
+			initialState:         statePopped,
+			expectedInIncomplete: []*v1.Pod{},
+		},
+		{
+			name:                 "delete pod group with no pods",
+			expectedInIncomplete: []*v1.Pod{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+				features.GenericWorkload: true,
+			})
+
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			preEnqueueMap := map[string]map[string]fwk.PreEnqueuePlugin{
+				"": {
+					"preEnqueuePlugin": &preEnqueuePlugin{allowlists: []string{"allow"}},
+				},
+			}
+			q := NewTestQueue(ctx, newDefaultQueueSort(), WithPreEnqueuePluginMap(preEnqueueMap))
+
+			setupInitialPodGroupState(t, ctx, q, tt.initialPods, tt.initialState, podGroup)
+
+			for _, pod := range tt.pendingPods {
+				q.Add(ctx, pod)
+			}
+
+			q.DeletePodGroup(logger, podGroup)
+
+			_, ok := q.workloadForest.getPodGroup(podGroup)
+			if ok {
+				t.Errorf("Expected pod group not to be present in workloadForest")
+			}
+
+			pgLookup := newQueuedPodGroupInfoForLookup(p1)
+			if q.activeQ.has(pgLookup) {
+				t.Errorf("Expected pod group not to be in activeQ")
+			}
+			if q.backoffQ.has(pgLookup) {
+				t.Errorf("Expected pod group not to be in backoffQ")
+			}
+			if q.unschedulableEntities.get(pgLookup) != nil {
+				t.Errorf("Expected pod group not to be in unschedulableEntities")
+			}
+
+			for _, pod := range tt.pendingPods {
+				if q.pendingPodGroupPods.has(pod) {
+					t.Errorf("Expected pod %s not to be in pendingPodGroupPods", pod.Name)
+				}
+			}
+
+			for _, pod := range tt.expectedInIncomplete {
+				if !q.incompletePodGroupPods.has(pod) {
+					t.Errorf("Expected pod %s in incompletePodGroupPods", pod.Name)
+				}
+			}
+			if q.incompletePodGroupPods.len() != len(tt.expectedInIncomplete) {
+				t.Errorf("Expected incompletePodGroupPods size to be %d, got %d", len(tt.expectedInIncomplete), q.incompletePodGroupPods.len())
 			}
 		})
 	}

--- a/pkg/scheduler/backend/queue/testing.go
+++ b/pkg/scheduler/backend/queue/testing.go
@@ -47,7 +47,8 @@ func NewTestQueueWithObjects(
 	recorder := metrics.NewMetricsAsyncRecorder(10, 20*time.Microsecond, ctx.Done())
 	// We set it before the options that users provide, so that users can override it.
 	opts = append([]Option{WithMetricsRecorder(recorder)}, opts...)
-	return NewTestQueueWithInformerFactory(ctx, lessFn, informerFactory, opts...)
+	pq := NewTestQueueWithInformerFactory(ctx, lessFn, informerFactory, opts...)
+	return pq
 }
 
 func NewTestQueueWithInformerFactory(

--- a/pkg/scheduler/backend/queue/workload_forest.go
+++ b/pkg/scheduler/backend/queue/workload_forest.go
@@ -1,0 +1,64 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	v1 "k8s.io/api/core/v1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
+)
+
+// workloadForest maintains a consistent view of observed PodGroup objects.
+// It ensures that scheduling queue invariants are preserved, independent of
+// asynchronous updates happening in the scheduler cache.
+// Outside of the scheduling queue, cache should be used as the source of truth.
+// This structure is not thread-safe and should be accessed only under the lock of the PriorityQueue.
+type workloadForest struct {
+	podGroups map[string]*schedulingv1alpha3.PodGroup
+}
+
+func newWorkloadForest() *workloadForest {
+	return &workloadForest{
+		podGroups: make(map[string]*schedulingv1alpha3.PodGroup),
+	}
+}
+
+// addPodGroup adds a PodGroup to the forest.
+func (wf *workloadForest) addPodGroup(podGroup *schedulingv1alpha3.PodGroup) {
+	wf.podGroups[podGroupKey(podGroup)] = podGroup
+}
+
+// updatePodGroup updates a PodGroup in the forest.
+func (wf *workloadForest) updatePodGroup(podGroup *schedulingv1alpha3.PodGroup) {
+	wf.podGroups[podGroupKey(podGroup)] = podGroup
+}
+
+// deletePodGroup removes a PodGroup from the forest.
+func (wf *workloadForest) deletePodGroup(podGroup *schedulingv1alpha3.PodGroup) {
+	delete(wf.podGroups, podGroupKey(podGroup))
+}
+
+// getRootForPod returns the current root PodGroup object for a given pod.
+func (wf *workloadForest) getRootForPod(pod *v1.Pod) (*schedulingv1alpha3.PodGroup, bool) {
+	podGroup, ok := wf.podGroups[podGroupKeyForPod(pod)]
+	return podGroup, ok
+}
+
+// getPodGroup returns the current PodGroup object for a given lookup.
+func (wf *workloadForest) getPodGroup(pgLookup *schedulingv1alpha3.PodGroup) (*schedulingv1alpha3.PodGroup, bool) {
+	podGroup, ok := wf.podGroups[podGroupKey(pgLookup)]
+	return podGroup, ok
+}

--- a/pkg/scheduler/backend/queue/workload_forest_test.go
+++ b/pkg/scheduler/backend/queue/workload_forest_test.go
@@ -1,0 +1,240 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+)
+
+func TestWorkloadForest_AddPodGroup(t *testing.T) {
+	pg1 := st.MakePodGroup().Name("pg1").Namespace("ns1").UID("uid1").Obj()
+	pg2 := st.MakePodGroup().Name("pg2").Namespace("ns1").UID("uid2").Obj()
+
+	tests := []struct {
+		name           string
+		podGroupsToAdd []*schedulingv1alpha3.PodGroup
+		want           map[string]*schedulingv1alpha3.PodGroup
+	}{
+		{
+			name:           "add single pod group",
+			podGroupsToAdd: []*schedulingv1alpha3.PodGroup{pg1},
+			want: map[string]*schedulingv1alpha3.PodGroup{
+				"pg/ns1/pg1": pg1,
+			},
+		},
+		{
+			name:           "add multiple pod groups",
+			podGroupsToAdd: []*schedulingv1alpha3.PodGroup{pg1, pg2},
+			want: map[string]*schedulingv1alpha3.PodGroup{
+				"pg/ns1/pg1": pg1,
+				"pg/ns1/pg2": pg2,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wf := newWorkloadForest()
+			for _, pg := range tt.podGroupsToAdd {
+				wf.addPodGroup(pg)
+			}
+
+			if diff := cmp.Diff(tt.want, wf.podGroups); diff != "" {
+				t.Errorf("Unexpected podGroups (-want,+got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestWorkloadForest_UpdatePodGroup(t *testing.T) {
+	pg1 := st.MakePodGroup().Name("pg1").Namespace("ns1").UID("uid1").MinCount(1).Obj()
+	updatedPG1 := st.MakePodGroup().Name("pg1").Namespace("ns1").UID("uid1").MinCount(2).Obj()
+	pg2 := st.MakePodGroup().Name("pg2").Namespace("ns1").UID("uid2").MinCount(1).Obj()
+
+	tests := []struct {
+		name             string
+		initialPodGroups []*schedulingv1alpha3.PodGroup
+		podGroupToUpdate *schedulingv1alpha3.PodGroup
+		want             map[string]*schedulingv1alpha3.PodGroup
+	}{
+		{
+			name:             "update existing pod group",
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg1},
+			podGroupToUpdate: updatedPG1,
+			want: map[string]*schedulingv1alpha3.PodGroup{
+				"pg/ns1/pg1": updatedPG1,
+			},
+		},
+		{
+			name:             "update non-existent pod group adds it",
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg1},
+			podGroupToUpdate: pg2,
+			want: map[string]*schedulingv1alpha3.PodGroup{
+				"pg/ns1/pg1": pg1,
+				"pg/ns1/pg2": pg2,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wf := newWorkloadForest()
+			for _, pg := range tt.initialPodGroups {
+				wf.addPodGroup(pg)
+			}
+
+			wf.updatePodGroup(tt.podGroupToUpdate)
+
+			if diff := cmp.Diff(tt.want, wf.podGroups); diff != "" {
+				t.Errorf("Unexpected podGroups (-want,+got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestWorkloadForest_DeletePodGroup(t *testing.T) {
+	pg1 := st.MakePodGroup().Name("pg1").Namespace("ns1").UID("uid1").Obj()
+	pg2 := st.MakePodGroup().Name("pg2").Namespace("ns1").UID("uid2").Obj()
+
+	tests := []struct {
+		name             string
+		initialPodGroups []*schedulingv1alpha3.PodGroup
+		podGroupToDelete *schedulingv1alpha3.PodGroup
+		want             map[string]*schedulingv1alpha3.PodGroup
+	}{
+		{
+			name:             "delete existing pod group",
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg1, pg2},
+			podGroupToDelete: pg1,
+			want: map[string]*schedulingv1alpha3.PodGroup{
+				"pg/ns1/pg2": pg2,
+			},
+		},
+		{
+			name:             "delete non-existent pod group is no-op",
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg1},
+			podGroupToDelete: pg2,
+			want: map[string]*schedulingv1alpha3.PodGroup{
+				"pg/ns1/pg1": pg1,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wf := newWorkloadForest()
+			for _, pg := range tt.initialPodGroups {
+				wf.addPodGroup(pg)
+			}
+
+			wf.deletePodGroup(tt.podGroupToDelete)
+
+			if diff := cmp.Diff(tt.want, wf.podGroups); diff != "" {
+				t.Errorf("Unexpected podGroups (-want,+got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestWorkloadForest_GetRootForPod(t *testing.T) {
+	pg1 := st.MakePodGroup().Name("pg1").Namespace("ns1").UID("uid1").Obj()
+	podWithPG1 := st.MakePod().Name("pod1").Namespace("ns1").PodGroupName("pg1").Obj()
+	podWithNonExistentPG := st.MakePod().Name("pod3").Namespace("ns1").PodGroupName("pg2").Obj()
+
+	tests := []struct {
+		name             string
+		initialPodGroups []*schedulingv1alpha3.PodGroup
+		pod              *v1.Pod
+		wantPodGroup     *schedulingv1alpha3.PodGroup
+	}{
+		{
+			name:             "pod belongs to existing pod group",
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg1},
+			pod:              podWithPG1,
+			wantPodGroup:     pg1,
+		},
+		{
+			name:             "pod belongs to non-existent pod group",
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg1},
+			pod:              podWithNonExistentPG,
+			wantPodGroup:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wf := newWorkloadForest()
+			for _, pg := range tt.initialPodGroups {
+				wf.addPodGroup(pg)
+			}
+
+			gotPG, gotFound := wf.getRootForPod(tt.pod)
+			if wantFound := tt.wantPodGroup != nil; gotFound != wantFound {
+				t.Errorf("Expected found: %v, got: %v", wantFound, gotFound)
+			}
+			if diff := cmp.Diff(tt.wantPodGroup, gotPG); diff != "" {
+				t.Errorf("Unexpected pod group (-want,+got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestWorkloadForest_GetPodGroup(t *testing.T) {
+	pg1 := st.MakePodGroup().Name("pg1").Namespace("ns1").UID("uid1").Obj()
+
+	tests := []struct {
+		name             string
+		initialPodGroups []*schedulingv1alpha3.PodGroup
+		podGroupLookup   *schedulingv1alpha3.PodGroup
+		wantPodGroup     *schedulingv1alpha3.PodGroup
+	}{
+		{
+			name:             "get existing pod group",
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg1},
+			podGroupLookup:   pg1,
+			wantPodGroup:     pg1,
+		},
+		{
+			name:             "get non-existent pod group",
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{},
+			podGroupLookup:   pg1,
+			wantPodGroup:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wf := newWorkloadForest()
+			for _, pg := range tt.initialPodGroups {
+				wf.addPodGroup(pg)
+			}
+
+			gotPG, gotFound := wf.getPodGroup(tt.podGroupLookup)
+			if wantFound := tt.wantPodGroup != nil; gotFound != wantFound {
+				t.Errorf("Expected found: %v, got: %v", wantFound, gotFound)
+			}
+			if diff := cmp.Diff(tt.wantPodGroup, gotPG); diff != "" {
+				t.Errorf("Unexpected pod group (-want,+got)\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -448,6 +448,7 @@ func (sched *Scheduler) addPodGroup(obj any) {
 
 	logger.V(3).Info("Add event for pod group", "podGroup", klog.KObj(pg))
 	sched.Cache.AddPodGroup(pg)
+	sched.SchedulingQueue.AddPodGroup(logger, pg)
 	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, nil, pg, nil)
 }
 
@@ -472,6 +473,7 @@ func (sched *Scheduler) updatePodGroup(oldObj, newObj any) {
 
 	logger.V(4).Info("Update event for pod group", "podGroup", klog.KObj(newPG))
 	sched.Cache.UpdatePodGroup(logger, oldPG, newPG)
+	sched.SchedulingQueue.UpdatePodGroup(logger, newPG)
 	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, oldPG, newPG, nil)
 }
 
@@ -498,6 +500,7 @@ func (sched *Scheduler) deletePodGroup(obj any) {
 
 	logger.V(3).Info("Delete event for pod group", "podGroup", klog.KObj(pg))
 	sched.Cache.RemovePodGroup(pg)
+	sched.SchedulingQueue.DeletePodGroup(logger, pg)
 	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, pg, nil, nil)
 }
 

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -897,10 +897,8 @@ func (pgqi *QueuedPodGroupInfo) Gated() bool {
 }
 
 // GetPriority returns the pod group's priority.
-// It returns the priority of the first member pod, because all member pods should have the same priority.
 func (pgqi *QueuedPodGroupInfo) GetPriority() int32 {
-	// TODO(macsko): Update this to return PodGroup object's priority instead.
-	return pgqi.QueuedPodInfos[0].GetPriority()
+	return schedutil.PodGroupPriority(pgqi.PodGroup)
 }
 
 func (pgqi *QueuedPodGroupInfo) Size() int {

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -3158,14 +3158,14 @@ func TestScheduleOnePodGroup_PodGroupNotFound(t *testing.T) {
 
 	sched.scheduleOnePodGroup(ctx, podGroupInfo)
 
-	// Verify that the pods are put back into the scheduling queue.
-	pendingPods, _ := queue.PendingPods()
-	gotPendingPods := sets.New[string]()
-	for _, pod := range pendingPods {
-		gotPendingPods.Insert(pod.Name)
+	// Verify that the pods are put back into the scheduling queue's incompletePodGroupPods.
+	incompletePods := queue.IncompletePodGroupPodsPods()
+	gotIncompletePods := sets.New[string]()
+	for _, pod := range incompletePods {
+		gotIncompletePods.Insert(pod.Name)
 	}
 	expectedPods := sets.New("p1", "p2")
-	if diff := cmp.Diff(expectedPods, gotPendingPods); diff != "" {
-		t.Errorf("Unexpected pods in scheduling queue (-want,+got)\n%s", diff)
+	if diff := cmp.Diff(expectedPods, gotIncompletePods); diff != "" {
+		t.Errorf("Unexpected pods in incompletePodGroupPods (-want,+got)\n%s", diff)
 	}
 }

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -1155,6 +1155,9 @@ func TestSchedulerScheduleOne(t *testing.T) {
 		informerFactory.Start(ctx.Done())
 		informerFactory.WaitForCacheSync(ctx.Done())
 
+		if scheduleAsPodGroup {
+			queue.AddPodGroup(logger, podGroup)
+		}
 		queue.Add(ctx, item.sendPod)
 
 		sched.SchedulePod = func(ctx context.Context, fwk framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (ScheduleResult, error) {

--- a/test/integration/scheduler/podgroup/podgroup_test.go
+++ b/test/integration/scheduler/podgroup/podgroup_test.go
@@ -187,15 +187,15 @@ func TestPodGroupScheduling(t *testing.T) {
 					CreatePods: []*v1.Pod{p1, p2, p3},
 				},
 				{
-					Name:                               "Verify pods are gated at PreEnqueue (no PodGroup object)",
-					WaitForPodsInUnschedulableEntities: []string{"p1", "p2", "p3"},
+					Name:                                "Verify pods are waiting in incompletePodGroupPods (no PodGroup object)",
+					WaitForPodsInIncompletePodGroupPods: []string{"p1", "p2", "p3"},
 				},
 				{
-					Name:           "Create the PodGroup to unblock PreEnqueue",
+					Name:           "Create the PodGroup to unblock the pods",
 					CreatePodGroup: gangPodGroup,
 				},
 				{
-					Name:                     "Verify pods become unschedulable (Permit timeout due to resource blocker)",
+					Name:                     "Verify pods become unschedulable due to resource blocker pod",
 					WaitForPodsUnschedulable: []string{"p1", "p2", "p3"},
 				},
 				{
@@ -240,7 +240,7 @@ func TestPodGroupScheduling(t *testing.T) {
 					CreatePods: []*v1.Pod{p1, p2, p3, p4},
 				},
 				{
-					Name:           "Create the PodGroup to unblock PreEnqueue",
+					Name:           "Create the PodGroup to unblock pods",
 					CreatePodGroup: gangPodGroup,
 				},
 				{
@@ -352,11 +352,11 @@ func TestPodGroupScheduling(t *testing.T) {
 					CreatePods: []*v1.Pod{p1, p2, p3},
 				},
 				{
-					Name:                               "Verify pods are gated at PreEnqueue (no PodGroup object)",
-					WaitForPodsInUnschedulableEntities: []string{"p1", "p2", "p3"},
+					Name:                                "Verify pods are waiting in incompletePodGroupPods (no PodGroup object)",
+					WaitForPodsInIncompletePodGroupPods: []string{"p1", "p2", "p3"},
 				},
 				{
-					Name:           "Create the PodGroup to unblock PreEnqueue",
+					Name:           "Create the PodGroup to unblock pods",
 					CreatePodGroup: basicPodGroup,
 				},
 				{

--- a/test/integration/scheduler/podgroup/queueing/queueing_test.go
+++ b/test/integration/scheduler/podgroup/queueing/queueing_test.go
@@ -126,12 +126,16 @@ func TestPodGroupQueueing(t *testing.T) {
 
 	podGroupGang := st.MakePodGroup().Name("pg").MinCount(2).Obj()
 	podGroupGangSingle := st.MakePodGroup().Name("pg").MinCount(1).Obj()
+	podGroupGangTriple := st.MakePodGroup().Name("pg").MinCount(3).Obj()
 	podGroupBasic := st.MakePodGroup().Name("pg").BasicPolicy().Obj()
 
 	p1 := st.MakePod().Name("p1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg").Obj()
 	p2 := st.MakePod().Name("p2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg").Obj()
 	p3 := st.MakePod().Name("p3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg").Obj()
 	p4 := st.MakePod().Name("p4").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg").Obj()
+
+	smallP1 := st.MakePod().Name("p1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg").Obj()
+	smallP2 := st.MakePod().Name("p2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg").Obj()
 
 	p1Gated := st.MakePod().Name("p1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg").SchedulingGates([]string{"foo-gate"}).Obj()
 	p3Gated := st.MakePod().Name("p3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg").SchedulingGates([]string{"foo-gate"}).Obj()
@@ -628,8 +632,8 @@ func TestPodGroupQueueing(t *testing.T) {
 					CreatePods: []*v1.Pod{p1, p2Large},
 				},
 				{
-					Name:                               "Verify pods are gated at PreEnqueue (no PodGroup object)",
-					WaitForPodsInUnschedulableEntities: []string{"p1", "p2"},
+					Name:                                "Verify pods are gated at PreEnqueue (no PodGroup object)",
+					WaitForPodsInIncompletePodGroupPods: []string{"p1", "p2"},
 				},
 				{
 					Name:           "Create Gang Policy PodGroup with MinCount 1",
@@ -682,6 +686,147 @@ func TestPodGroupQueueing(t *testing.T) {
 				{
 					Name:                 "Verify all pods scheduled successfully",
 					WaitForPodsScheduled: []string{"p1", "p2"},
+				},
+			},
+		},
+		{
+			name: "gang is scheduled, then pod group is deleted, and new enqueued pods belong to it end up in incompletePodGroupPods",
+			steps: []stepsframework.Step{
+				{
+					Name:           "Create the PodGroup object",
+					CreatePodGroup: podGroupGang,
+				},
+				{
+					Name:       "Create gang pods",
+					CreatePods: []*v1.Pod{smallP1, smallP2},
+				},
+				{
+					Name:                 "Verify gang pods are scheduled successfully",
+					WaitForPodsScheduled: []string{"p1", "p2"},
+				},
+				{
+					Name:           "Delete the PodGroup",
+					DeletePodGroup: "pg",
+				},
+				{
+					Name:       "Create a new pod belonging to the deleted gang",
+					CreatePods: []*v1.Pod{p3},
+				},
+				{
+					Name:                                "Verify the new pod ends up in incompletePodGroupPods",
+					WaitForPodsInIncompletePodGroupPods: []string{"p3"},
+				},
+			},
+		},
+		{
+			name: "basic group is scheduled, then pod group is deleted, and new enqueued pods belong to it end up in incompletePodGroupPods",
+			steps: []stepsframework.Step{
+				{
+					Name:           "Create the PodGroup object with Basic policy",
+					CreatePodGroup: podGroupBasic,
+				},
+				{
+					Name:       "Create basic group pods",
+					CreatePods: []*v1.Pod{smallP1, smallP2},
+				},
+				{
+					Name:                 "Verify group pods are scheduled successfully",
+					WaitForPodsScheduled: []string{"p1", "p2"},
+				},
+				{
+					Name:           "Delete the PodGroup",
+					DeletePodGroup: "pg",
+				},
+				{
+					Name:       "Create a new pod belonging to the deleted basic group",
+					CreatePods: []*v1.Pod{p3},
+				},
+				{
+					Name:                                "Verify the new pod ends up in incompletePodGroupPods",
+					WaitForPodsInIncompletePodGroupPods: []string{"p3"},
+				},
+			},
+		},
+		{
+			name: "gang is partially scheduled, then pod group is deleted, unschedulable pods end up in incompletePodGroupPods",
+			steps: []stepsframework.Step{
+				{
+					Name:           "Create the PodGroup object",
+					CreatePodGroup: podGroupGang,
+				},
+				{
+					Name:       "Create gang pods",
+					CreatePods: []*v1.Pod{smallP1, smallP2, p3},
+				},
+				{
+					Name:                 "Verify gang pods are scheduled successfully",
+					WaitForPodsScheduled: []string{"p1", "p2"},
+				},
+				{
+					Name:                     "Verify p3 is unschedulable",
+					WaitForPodsUnschedulable: []string{"p3"},
+				},
+				{
+					Name:           "Delete the PodGroup",
+					DeletePodGroup: "pg",
+				},
+				{
+					Name:                                "Verify p3 ends up in incompletePodGroupPods",
+					WaitForPodsInIncompletePodGroupPods: []string{"p3"},
+				},
+			},
+		},
+		{
+			name: "basic group is partially scheduled, then pod group is deleted, unschedulable pods end up in incompletePodGroupPods",
+			steps: []stepsframework.Step{
+				{
+					Name:           "Create the PodGroup object with Basic policy",
+					CreatePodGroup: podGroupBasic,
+				},
+				{
+					Name:       "Create basic group pods",
+					CreatePods: []*v1.Pod{smallP1, smallP2, p3},
+				},
+				{
+					Name:                 "Verify group pods are scheduled successfully",
+					WaitForPodsScheduled: []string{"p1", "p2"},
+				},
+				{
+					Name:                     "Verify p3 is unschedulable",
+					WaitForPodsUnschedulable: []string{"p3"},
+				},
+				{
+					Name:           "Delete the PodGroup",
+					DeletePodGroup: "pg",
+				},
+				{
+					Name:                                "Verify p3 ends up in incompletePodGroupPods",
+					WaitForPodsInIncompletePodGroupPods: []string{"p3"},
+				},
+			},
+		},
+		{
+			name: "gang is unschedulable, then pod group is deleted, unschedulable pods end up in incompletePodGroupPods",
+			steps: []stepsframework.Step{
+				{
+					Name:           "Create the PodGroup object",
+					CreatePodGroup: podGroupGangTriple,
+				},
+				{
+					Name:       "Create gang pods",
+					CreatePods: []*v1.Pod{smallP1, smallP2, p3},
+				},
+				{
+					Name:                     "Verify gang pods are unschedulable",
+					WaitForPodsUnschedulable: []string{"p1", "p2", "p3"},
+				},
+				{
+					Name:           "Delete the PodGroup",
+					DeletePodGroup: "pg",
+				},
+				{
+					Name:                                "Verify gang pods end up in incompletePodGroupPods",
+					WaitForPodsInIncompletePodGroupPods: []string{"p1", "p2", "p3"},
 				},
 			},
 		},

--- a/test/integration/scheduler/podgroup/stepsframework/stepsframework.go
+++ b/test/integration/scheduler/podgroup/stepsframework/stepsframework.go
@@ -137,6 +137,8 @@ type Step struct {
 	CreatePodGroup *schedulingapi.PodGroup
 	// UpdatePodGroup is used to update an existing pod group and wait for it to propagate.
 	UpdatePodGroup *schedulingapi.PodGroup
+	// DeletePodGroup is used to delete a pod group by name and wait for it to propagate.
+	DeletePodGroup string
 	// CreatePods is use to create pods in the cluster.
 	CreatePods []*v1.Pod
 	// CreatePodsInOrder is use to create pods in the cluster and have them enqueued by the scheduler in the specified order.
@@ -151,6 +153,8 @@ type Step struct {
 	WaitForPodsInActiveQ []string
 	// WaitForPodsInUnschedulableEntities is use to wait for pods to be in unschedulableEntities.
 	WaitForPodsInUnschedulableEntities []string
+	// WaitForPodsInIncompletePodGroupPods is use to wait for pods to be in incompletePodGroupPods.
+	WaitForPodsInIncompletePodGroupPods []string
 	// WaitForPodsUnschedulable is use to wait for pods to be unschedulable.
 	WaitForPodsUnschedulable []string
 	// WaitForPodsScheduled is use to wait for pods to be scheduled.
@@ -192,6 +196,16 @@ func podSchedulingAttempted(cs kubernetes.Interface, ns, name string) wait.Condi
 		_, cond := podutil.GetPodCondition(&pod.Status, v1.PodScheduled)
 		return cond != nil, nil
 	}
+}
+
+func podInIncompletePodGroupPods(queue queue.SchedulingQueue, podName string) bool {
+	incompletePods := queue.IncompletePodGroupPodsPods()
+	for _, pod := range incompletePods {
+		if pod.Name == podName {
+			return true
+		}
+	}
+	return false
 }
 
 func podGroupHasScheduledCondition(cs kubernetes.Interface, ns, name string, status metav1.ConditionStatus, reason string) wait.ConditionWithContextFunc {
@@ -318,6 +332,37 @@ func updatePodGroup(testCtx *testutils.TestContext, ns string, pg *schedulingapi
 	return nil
 }
 
+func deletePodGroup(testCtx *testutils.TestContext, ns string, pgName string) error {
+	cs := testCtx.ClientSet
+
+	pg, err := cs.SchedulingV1alpha3().PodGroups(ns).Get(testCtx.Ctx, pgName, metav1.GetOptions{})
+	if err == nil && len(pg.Finalizers) > 0 {
+		pg.Finalizers = nil
+		if _, err = cs.SchedulingV1alpha3().PodGroups(ns).Update(testCtx.Ctx, pg, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("failed to clear finalizers of pod group %s: %w", pgName, err)
+		}
+	}
+	if err := cs.SchedulingV1alpha3().PodGroups(ns).Delete(testCtx.Ctx, pgName, metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("failed to delete pod group %s: %w", pgName, err)
+	}
+	err = wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
+		func(_ context.Context) (bool, error) {
+			_, err := testCtx.InformerFactory.Scheduling().V1alpha3().PodGroups().Lister().PodGroups(ns).Get(pgName)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					return true, nil
+				}
+				return false, err
+			}
+			return false, nil
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to wait for pod group %s deletion to propagate: %w", pgName, err)
+	}
+	return nil
+}
+
 func createWorkloads(testCtx *testutils.TestContext, ns string, wls []*schedulingapi.Workload) error {
 	cs := testCtx.ClientSet
 	for _, wl := range wls {
@@ -380,6 +425,20 @@ func waitForPodsInUnschedulableEntities(testCtx *testutils.TestContext, ns strin
 		)
 		if err != nil {
 			return fmt.Errorf("failed to wait for pod %s to be in unschedulable entities: %w", podName, err)
+		}
+	}
+	return nil
+}
+
+func waitForPodsInIncompletePodGroupPods(testCtx *testutils.TestContext, ns string, podNames []string) error {
+	for _, podName := range podNames {
+		err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
+			func(_ context.Context) (bool, error) {
+				return podInIncompletePodGroupPods(testCtx.Scheduler.SchedulingQueue, podName), nil
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("failed to wait for pod %s to be in incompletePodGroupPods: %w", podName, err)
 		}
 	}
 	return nil
@@ -548,6 +607,8 @@ func RunSteps(testCtx *testutils.TestContext, t *testing.T, ns string, steps []S
 			err = createPodGroup(testCtx, ns, step.CreatePodGroup)
 		case step.UpdatePodGroup != nil:
 			err = updatePodGroup(testCtx, ns, step.UpdatePodGroup)
+		case step.DeletePodGroup != "":
+			err = deletePodGroup(testCtx, ns, step.DeletePodGroup)
 		case step.CreateWorkloads != nil:
 			err = createWorkloads(testCtx, ns, step.CreateWorkloads)
 		case step.DeletePods != nil:
@@ -558,6 +619,8 @@ func RunSteps(testCtx *testutils.TestContext, t *testing.T, ns string, steps []S
 			err = waitForPodsInActiveQ(testCtx, step.WaitForPodsInActiveQ)
 		case step.WaitForPodsInUnschedulableEntities != nil:
 			err = waitForPodsInUnschedulableEntities(testCtx, ns, step.WaitForPodsInUnschedulableEntities)
+		case step.WaitForPodsInIncompletePodGroupPods != nil:
+			err = waitForPodsInIncompletePodGroupPods(testCtx, ns, step.WaitForPodsInIncompletePodGroupPods)
 		case step.WaitForPodsUnschedulable != nil:
 			err = waitForPodsUnschedulable(testCtx, ns, step.WaitForPodsUnschedulable)
 		case step.WaitForPodsScheduled != nil:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This PR proposes new `incompletePodGroupPods` data structure in the scheduling queue, which holds pods that wait for one of their parents (currently only the parent PodGroup) to be observed by the scheduler. It shifts this responsibility from GangScheduling's PreEnqueue. Such mechanism is primarily needed for CompositePodGroups, but is also useful for flat PodGroups.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

This PR relies on https://github.com/kubernetes/kubernetes/pull/140075 and https://github.com/kubernetes/kubernetes/pull/140077 to be merged first. First two commits belong to those PRs.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added the incompletePodGroupPods data structure to the scheduling queue to store pods waiting for their PodGroup object to be observed by kube-scheduler.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
