### PR TITLE
Migrate IngressClass Controller to declarative validation

### DIFF
--- a/pkg/apis/networking/v1/zz_generated.validations.go
+++ b/pkg/apis/networking/v1/zz_generated.validations.go
@@ -424,7 +424,37 @@ func Validate_IngressClassSpec(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *networkingv1.IngressClassSpec) (errs field.ErrorList) {
 
-	// field networkingv1.IngressClassSpec.Controller has no validation
+	{ // field networkingv1.IngressClassSpec.Controller
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *string,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *networkingv1.IngressClassSpec) *string {
+				return &oldObj.Controller
+			})
+		errs = append(errs, fn(fldPath.Child("controller"), &obj.Controller, oldVal, oldObj != nil)...)
+	}
 
 	{ // field networkingv1.IngressClassSpec.Parameters
 		fn := func(

--- a/pkg/apis/networking/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/networking/v1beta1/zz_generated.validations.go
@@ -370,7 +370,37 @@ func Validate_IngressClassSpec(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *networkingv1beta1.IngressClassSpec) (errs field.ErrorList) {
 
-	// field networkingv1beta1.IngressClassSpec.Controller has no validation
+	{ // field networkingv1beta1.IngressClassSpec.Controller
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *string,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *networkingv1beta1.IngressClassSpec) *string {
+				return &oldObj.Controller
+			})
+		errs = append(errs, fn(fldPath.Child("controller"), &obj.Controller, oldVal, oldObj != nil)...)
+	}
 
 	{ // field networkingv1beta1.IngressClassSpec.Parameters
 		fn := func(

--- a/pkg/apis/networking/validation/validation.go
+++ b/pkg/apis/networking/validation/validation.go
@@ -585,7 +585,7 @@ func validateIngressClassSpec(spec *networking.IngressClassSpec, fldPath *field.
 // validateIngressClassSpecUpdate ensures that IngressClassSpec updates are
 // valid.
 func validateIngressClassSpecUpdate(newSpec, oldSpec *networking.IngressClassSpec, fldPath *field.Path) field.ErrorList {
-	return apivalidation.ValidateImmutableField(newSpec.Controller, oldSpec.Controller, fldPath.Child("controller"))
+	return apivalidation.ValidateImmutableField(newSpec.Controller, oldSpec.Controller, fldPath.Child("controller")).MarkCoveredByDeclarative().WithOrigin("immutable")
 }
 
 // validateIngressTypedLocalObjectReference ensures that Parameters fields are valid.

--- a/staging/src/k8s.io/api/networking/v1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1/generated.proto
@@ -233,6 +233,8 @@ message IngressClassSpec {
   // same implementing controller. This should be specified as a
   // domain-prefixed path no more than 250 characters in length, e.g.
   // "acme.io/ingress-controller". This field is immutable.
+  // +k8s:alpha(since: "1.37")=+k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:immutable
   optional string controller = 1;
 
   // parameters is a link to a custom resource containing additional

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -585,6 +585,8 @@ type IngressClassSpec struct {
 	// same implementing controller. This should be specified as a
 	// domain-prefixed path no more than 250 characters in length, e.g.
 	// "acme.io/ingress-controller". This field is immutable.
+	// +k8s:alpha(since: "1.37")=+k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:immutable
 	Controller string `json:"controller,omitempty" protobuf:"bytes,1,opt,name=controller"`
 
 	// parameters is a link to a custom resource containing additional

--- a/staging/src/k8s.io/api/networking/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1beta1/generated.proto
@@ -217,6 +217,8 @@ message IngressClassSpec {
   // same implementing controller. This should be specified as a
   // domain-prefixed path no more than 250 characters in length, e.g.
   // "acme.io/ingress-controller". This field is immutable.
+  // +k8s:alpha(since: "1.37")=+k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:immutable
   optional string controller = 1;
 
   // parameters is a link to a custom resource containing additional

--- a/staging/src/k8s.io/api/networking/v1beta1/types.go
+++ b/staging/src/k8s.io/api/networking/v1beta1/types.go
@@ -363,6 +363,8 @@ type IngressClassSpec struct {
 	// same implementing controller. This should be specified as a
 	// domain-prefixed path no more than 250 characters in length, e.g.
 	// "acme.io/ingress-controller". This field is immutable.
+	// +k8s:alpha(since: "1.37")=+k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:immutable
 	Controller string `json:"controller,omitempty" protobuf:"bytes,1,opt,name=controller"`
 
 	// parameters is a link to a custom resource containing additional

--- a/test/declarative_validation/networking/ingressclass/declarative_validation_test.go
+++ b/test/declarative_validation/networking/ingressclass/declarative_validation_test.go
@@ -88,7 +88,7 @@ func TestDeclarativeValidateParameter(t *testing.T) {
 	}
 }
 
-func TestDeclarativeValidateUpdateParameters(t *testing.T) {
+func TestDeclarativeValidateUpdate(t *testing.T) {
 	for _, apiVersion := range apiVersions {
 		t.Run(apiVersion, func(t *testing.T) {
 			testCases := map[string]struct {
@@ -135,6 +135,18 @@ func TestDeclarativeValidateUpdateParameters(t *testing.T) {
 					}),
 					expectedErrs: field.ErrorList{
 						field.Required(field.NewPath("spec", "parameters", "kind"), "").MarkBeta(),
+					},
+				},
+				"update fails when controller is changed": {
+					oldObj: mkValidIngressClass(func(obj *networking.IngressClass) {
+						obj.ResourceVersion = "1"
+					}),
+					updateObj: mkValidIngressClass(func(obj *networking.IngressClass) {
+						obj.ResourceVersion = "1"
+						obj.Spec.Controller = "example.com/different-controller"
+					}),
+					expectedErrs: field.ErrorList{
+						field.Invalid(field.NewPath("spec", "controller"), "example.com/different-controller", "field is immutable").WithOrigin("immutable").MarkAlpha(),
 					},
 				},
 			}

--- a/test/declarative_validation/networking/ingressclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/networking/ingressclass/zz_generated.validations.v1_test.go
@@ -37,6 +37,9 @@ func init() {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
 			},
+			"spec.controller": {
+				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
+			},
 			"spec.parameters.kind": {
 				{ErrorType: "FieldValueRequired"},
 			},

--- a/test/declarative_validation/networking/ingressclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/networking/ingressclass/zz_generated.validations.v1beta1_test.go
@@ -37,6 +37,9 @@ func init() {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
 			},
+			"spec.controller": {
+				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
+			},
 			"spec.parameters.kind": {
 				{ErrorType: "FieldValueRequired"},
 			},


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR migrates the `immutable` validation for `IngressClass.Spec.Controller` to declarative validation.

Following the pattern established for this migration:
1. Added `+k8s:alpha(since: "1.37")=+k8s:immutable` to the `v1` and `v1beta1` structs.
2. Added `+k8s:alpha(since: "1.37")=+k8s:optional` to avoid incorrectly generating a CEL rule for the "Required" check (since the field uses `omitempty` in the OpenAPI spec and has complex imperative required validation).
3. Used `.MarkCoveredByDeclarative().WithOrigin("immutable")` in `validation.go` to cover the handwritten check.
4. Added an `update fails when controller is changed` equivalence test in `declarative_validation_test.go`.

#### Which issue(s) this PR is related to:

Updates #136785

#### Special notes for your reviewer:

I explicitly did *not* include `set -> unset` and `unset -> set` test cases in `declarative_validation_test.go` because the handcrafted `IsDomainPrefixedPath` validation emits a `Required` error when the field is empty, which is intentionally not migrated to declarative validation (hence the `+k8s:optional` tag). Including those test cases causes an uncovered declarative-validation rule failure.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```