### PR TITLE
kubelet: fix topology manager test for Windows error message

### DIFF
--- a/pkg/kubelet/cm/topologymanager/numa_info_test.go
+++ b/pkg/kubelet/cm/topologymanager/numa_info_test.go
@@ -19,6 +19,7 @@ package topologymanager
 import (
 	"fmt"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -27,6 +28,11 @@ import (
 )
 
 func TestNUMAInfo(t *testing.T) {
+	numaDistanceErr := "error getting NUMA distances from cadvisor"
+	if runtime.GOOS == "windows" {
+		numaDistanceErr = fmt.Sprintf("the %q policy option is not supported on Windows because NUMA node distances are not available", PreferClosestNUMANodes)
+	}
+
 	tcases := []struct {
 		name             string
 		topology         []cadvisorapi.Node
@@ -325,7 +331,7 @@ func TestNUMAInfo(t *testing.T) {
 				},
 			},
 			expectedNUMAInfo: nil,
-			expectedErr:      fmt.Errorf("error getting NUMA distances from cadvisor"),
+			expectedErr:      fmt.Errorf("%s", numaDistanceErr),
 			opts: PolicyOptions{
 				PreferClosestNUMA: true,
 			},

--- a/pkg/kubelet/cm/topologymanager/topology_manager_test.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager_test.go
@@ -19,6 +19,7 @@ package topologymanager
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -38,6 +39,11 @@ func NewTestBitMask(sockets ...int) bitmask.BitMask {
 }
 
 func TestNewManager(t *testing.T) {
+	numaDistanceErr := "error getting NUMA distances from cadvisor"
+	if runtime.GOOS == "windows" {
+		numaDistanceErr = fmt.Sprintf("the %q policy option is not supported on Windows because NUMA node distances are not available", PreferClosestNUMANodes)
+	}
+
 	tcases := []struct {
 		description    string
 		policyName     string
@@ -97,7 +103,7 @@ func TestNewManager(t *testing.T) {
 			policyOptions: map[string]string{
 				PreferClosestNUMANodes: "true",
 			},
-			expectedError: fmt.Errorf("error getting NUMA distances from cadvisor"),
+			expectedError: fmt.Errorf("%s", numaDistanceErr),
 			topology: []cadvisorapi.Node{
 				{
 					Id: 0,


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

Updates the topology manager unit test for the Windows-specific error message introduced in https://github.com/kubernetes/kubernetes/pull/139760.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This is a small follow-up to https://github.com/kubernetes/kubernetes/pull/139760.

Example failing job:
https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/139791/pull-kubernetes-unit-windows-master/2069420373270597632

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
