### PR TITLE
Warn about upcoming default change when defaulting kube-proxy mode

### DIFF
--- a/cmd/kube-proxy/app/server_linux.go
+++ b/cmd/kube-proxy/app/server_linux.go
@@ -42,12 +42,14 @@ import (
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
 )
 
+var defaultedMode bool
+
 // platformApplyDefaults is called after parsing command-line flags and/or reading the
 // config file, to apply platform-specific default values to config.
 func (o *Options) platformApplyDefaults(config *kubeproxyconfig.KubeProxyConfiguration) {
 	if config.Mode == "" {
-		o.logger.Info("Using iptables proxy")
 		config.Mode = kubeproxyconfig.ProxyModeIPTables
+		defaultedMode = true
 	}
 
 	if config.Mode == kubeproxyconfig.ProxyModeNFTables && len(config.NodePortAddresses) == 0 {
@@ -134,6 +136,11 @@ func (s *ProxyServer) createProxier(ctx context.Context, config *kubeproxyconfig
 	localDetectors := getLocalDetectors(logger, s.PrimaryIPFamily, config, s.podCIDRs)
 
 	if config.Mode == kubeproxyconfig.ProxyModeIPTables {
+		if defaultedMode {
+			message := "No kube-proxy mode specified: defaulting to 'iptables'. Note that in Kubernetes 1.40 the default mode will switch to 'nftables'. If you wish to continue using 'iptables' mode, you must explicitly specify 'mode: iptables' in the kube-proxy config file, or '--proxy-mode iptables' on the kube-proxy command line."
+			logger.Error(nil, message)
+			s.Recorder.Eventf(s.NodeRef, nil, v1.EventTypeWarning, "KubeProxyDefaultMode", "StartKubeProxy", message)
+		}
 		logger.Info("Using iptables Proxier")
 		ipts := utiliptables.NewBestEffort()
 


### PR DESCRIPTION
#### What type of PR is this?
uh... let's say
/kind feature

#### What this PR does / why we need it:
When defaulting the kube-proxy mode to `iptables`, warn users that the default will be changing in 1.40, so they should explicitly set it to `iptables` if they don't want that.

This should not affect new clusters created by kubeadm (#139777)  or by the the `cluster/` stuff  (https://github.com/kubernetes/kubernetes/blob/v1.37.0-alpha.1/cluster/gce/gci/configure-helper.sh#L1778), so it mostly shouldn't show up in CI. (?)

#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/issues/5343

#### Does this PR introduce a user-facing change?
```release-note
Kube-proxy now warns you if you start it without explicitly specifying the proxy
mode that you want (iptables, ipvs, or nftables), because the default on Linux
will be switching from 'iptables' to 'nftables' in a future release.
```
