### PR TITLE
kubeadm: Add etcd test coverage for MemberPromote retry scenarios

### DIFF
--- a/cmd/kubeadm/app/util/etcd/etcd_test.go
+++ b/cmd/kubeadm/app/util/etcd/etcd_test.go
@@ -976,6 +976,16 @@ func TestEvaluateClusterStatus(t *testing.T) {
 	}
 }
 
+type memberListResult struct {
+	members []*pb.Member
+	err     error
+}
+
+type memberPromoteResult struct {
+	resp *clientv3.MemberPromoteResponse
+	err  error
+}
+
 func TestMemberPromote(t *testing.T) {
 	learnerID := uint64(12345)
 
@@ -984,110 +994,167 @@ func TestMemberPromote(t *testing.T) {
 		promotedEndpoint = "https://192.168.10.200:2379"
 	)
 
-	member := func(isLearner bool) *pb.Member {
+	member := func(name string, isLearner bool) *pb.Member {
 		return &pb.Member{
 			ID:         learnerID,
-			Name:       "cp-1",
+			Name:       name,
 			PeerURLs:   []string{"https://192.168.10.200:2380"},
 			ClientURLs: []string{promotedEndpoint},
 			IsLearner:  isLearner,
 		}
 	}
 
-	type memberListResult struct {
-		members []*pb.Member
-		err     error
+	learner := func() *pb.Member {
+		return member("cp-1", true)
 	}
-
-	type memberPromoteResult struct {
-		resp *clientv3.MemberPromoteResponse
-		err  error
+	notStartedLearner := func() *pb.Member {
+		return member("", true)
+	}
+	votingMember := func() *pb.Member {
+		return member("cp-1", false)
+	}
+	promoteSuccess := memberPromoteResult{
+		resp: &clientv3.MemberPromoteResponse{
+			Members: []*pb.Member{votingMember()},
+		},
 	}
 
 	tests := []struct {
 		name                 string
+		initialEndpoints     []string
 		memberListResults    []memberListResult
 		memberPromoteResults []memberPromoteResult
 		wantErr              bool
 		wantEndpoint         string
+		wantEndpointCount    int
 		wantPromoteCalls     int
 		minMemberListCalls   int
 	}{
+		// Normal path: learner is started, promotion succeeds, and the new endpoint is added.
 		{
 			name: "successful promotion adds endpoint",
 			memberListResults: []memberListResult{
-				{members: []*pb.Member{member(true)}},
-				{members: []*pb.Member{member(true)}},
+				{members: []*pb.Member{learner()}},
+				{members: []*pb.Member{learner()}},
 			},
 			memberPromoteResults: []memberPromoteResult{
-				{
-					resp: &clientv3.MemberPromoteResponse{
-						Members: []*pb.Member{member(false)},
-					},
-				},
+				promoteSuccess,
 			},
 			wantEndpoint:       promotedEndpoint,
+			wantEndpointCount:  1,
 			wantPromoteCalls:   1,
 			minMemberListCalls: 2,
 		},
+		// The learner exists but has not started yet, so kubeadm should wait before promoting.
+		{
+			name: "learner not started yet and retried before promotion",
+			memberListResults: []memberListResult{
+				{members: []*pb.Member{notStartedLearner()}},
+				{members: []*pb.Member{learner()}},
+				{members: []*pb.Member{learner()}},
+			},
+			memberPromoteResults: []memberPromoteResult{
+				promoteSuccess,
+			},
+			wantEndpoint:       promotedEndpoint,
+			wantEndpointCount:  1,
+			wantPromoteCalls:   1,
+			minMemberListCalls: 3,
+		},
+		// A transient error of member listing while waiting for the learner to start should be retried.
+		{
+			name: "member list error while waiting for learner start",
+			memberListResults: []memberListResult{
+				{err: errNotImplemented},
+				{members: []*pb.Member{learner()}},
+				{members: []*pb.Member{learner()}},
+			},
+			memberPromoteResults: []memberPromoteResult{
+				promoteSuccess,
+			},
+			wantEndpoint:       promotedEndpoint,
+			wantEndpointCount:  1,
+			wantPromoteCalls:   1,
+			minMemberListCalls: 3,
+		},
+		// A transient error of member listing before promotion, and it should be retried before calling MemberPromote.
+		{
+			name: "member list error before promotion is retried",
+			memberListResults: []memberListResult{
+				{members: []*pb.Member{learner()}},
+				{err: errNotImplemented},
+				{members: []*pb.Member{learner()}},
+			},
+			memberPromoteResults: []memberPromoteResult{
+				promoteSuccess,
+			},
+			wantEndpoint:       promotedEndpoint,
+			wantEndpointCount:  1,
+			wantPromoteCalls:   1,
+			minMemberListCalls: 3,
+		},
+		// A transient promotion error should be retried then can succeed later.
+		{
+			name: "transient promote error is retried and then succeeds",
+			memberListResults: []memberListResult{
+				{members: []*pb.Member{learner()}},
+				{members: []*pb.Member{learner()}},
+				{members: []*pb.Member{learner()}},
+			},
+			memberPromoteResults: []memberPromoteResult{
+				{err: context.DeadlineExceeded},
+				promoteSuccess,
+			},
+			wantEndpoint:       promotedEndpoint,
+			wantEndpointCount:  1,
+			wantPromoteCalls:   2,
+			minMemberListCalls: 3,
+		},
+		// If promotion succeeded on the etcd side but the client saw an error,
+		// the next retry should treat an already promoted member as success.
 		{
 			name: "already promoted after transient promote failure adds endpoint",
 			memberListResults: []memberListResult{
-				{members: []*pb.Member{member(true)}},
-				{members: []*pb.Member{member(true)}},
-				{members: []*pb.Member{member(false)}},
+				{members: []*pb.Member{learner()}},
+				{members: []*pb.Member{learner()}},
+				{members: []*pb.Member{votingMember()}},
 			},
 			memberPromoteResults: []memberPromoteResult{
-				{
-					err: context.DeadlineExceeded,
-				},
+				{err: context.DeadlineExceeded},
 			},
 			wantEndpoint:       promotedEndpoint,
+			wantEndpointCount:  1,
 			wantPromoteCalls:   1,
 			minMemberListCalls: 3,
 		},
+		// If the member is already promoted before the promote attempt,
+		// kubeadm should not call MemberPromote again.
 		{
 			name: "already promoted before promote attempt adds endpoint",
 			memberListResults: []memberListResult{
-				{members: []*pb.Member{member(true)}},
-				{members: []*pb.Member{member(false)}},
+				{members: []*pb.Member{learner()}},
+				{members: []*pb.Member{votingMember()}},
 			},
 			wantEndpoint:       promotedEndpoint,
+			wantEndpointCount:  1,
 			wantPromoteCalls:   0,
 			minMemberListCalls: 2,
 		},
+		// If the endpoint is already present, promoting should still succeed without duplicating it.
 		{
-			name: "member list error before promote is retried",
+			name:             "endpoint is already present",
+			initialEndpoints: []string{initialEndpoint, promotedEndpoint},
 			memberListResults: []memberListResult{
-				{members: []*pb.Member{member(true)}},
-				{err: errNotImplemented},
-				{members: []*pb.Member{member(true)}},
+				{members: []*pb.Member{learner()}},
+				{members: []*pb.Member{learner()}},
 			},
 			memberPromoteResults: []memberPromoteResult{
-				{
-					resp: &clientv3.MemberPromoteResponse{
-						Members: []*pb.Member{member(false)},
-					},
-				},
+				promoteSuccess,
 			},
 			wantEndpoint:       promotedEndpoint,
+			wantEndpointCount:  1,
 			wantPromoteCalls:   1,
-			minMemberListCalls: 3,
-		},
-		{
-			name: "promotion keeps failing",
-			memberListResults: []memberListResult{
-				{members: []*pb.Member{member(true)}},
-				{members: []*pb.Member{member(true)}},
-			},
-			memberPromoteResults: []memberPromoteResult{
-				{
-					err: context.DeadlineExceeded,
-				},
-			},
-			wantErr:            true,
-			wantPromoteCalls:   -1,
-			minMemberListCalls: 1,
+			minMemberListCalls: 2,
 		},
 	}
 
@@ -1166,6 +1233,17 @@ func TestMemberPromote(t *testing.T) {
 
 			if tt.wantEndpoint != "" && !slices.Contains(c.Endpoints, tt.wantEndpoint) {
 				t.Fatalf("expected endpoint %q to be added, got %v", tt.wantEndpoint, c.Endpoints)
+			}
+			if tt.wantEndpointCount > 0 {
+				endpointCount := 0
+				for _, endpoint := range c.Endpoints {
+					if endpoint == tt.wantEndpoint {
+						endpointCount++
+					}
+				}
+				if endpointCount != tt.wantEndpointCount {
+					t.Fatalf("endpoint %q count = %d, want %d; endpoints = %v", tt.wantEndpoint, endpointCount, tt.wantEndpointCount, c.Endpoints)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

This PR expands the unit test coverage of `MemberPromote()`.

Recently, a bug was fixed in `MemberPromote()` where a learner already be promoted on the etcd's server side even  kubeadm observed a transient error from client-side(for example, `DeadlineExceeded`). 

During that investigation, it became clear that `MemberPromote()` contains several retry and state transition paths that are difficult to reason about and have historically been a source of bugs.

This PR adds coverage for scenarios including,

- if learner not started
- if listing transient member failed
- if listing persistent member failed
- if transient promotion failures
- when already-promoted members exist
- member's endpoint handling after promotion

The goal is not to change behavior, but to make the expected behavior of `MemberPromote()` explicit and verifiable through tests.

In particular, these tests would hopefully help 1) prevent regressions of recent fixed promotion logic, 2) document expected state transitions during learner promotion, 3) provide a safety net for future refactoring and bug fixes..

This work was motivated by investigating intermittent etcd learner promotion failures observed in Kubernetes workload clusters created by [Azimuth](https://github.com/azimuth-cloud) CI, where understanding retry behavior and promotion state transitions was important for root-cause analysis.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Part of #3317
Follow-up PR of kubernetes/kubernetes#139842

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
