### PR TITLE
Deferred Pod Admission for Unregistered Device Plugins

### DIFF
--- a/pkg/kubelet/allocation/allocation_manager.go
+++ b/pkg/kubelet/allocation/allocation_manager.go
@@ -18,6 +18,7 @@ package allocation
 
 import (
 	"context"
+	"maps"
 	"path/filepath"
 	"slices"
 	"sync"
@@ -60,6 +61,22 @@ const (
 	triggerReasonPeriodic = "periodic_retry"
 )
 
+// AdmitResult holds the outcome of a pod admission check.
+type AdmitResult struct {
+	// Admit is true when the pod was successfully admitted.
+	Admit bool
+	// Defer is true when admission failed but should be retried later rather
+	// than permanently rejected (e.g. a device plugin has not yet registered).
+	// Only meaningful when Admit is false.
+	Defer bool
+	// Reason is a brief single-word reason explaining why the pod was not
+	// admitted. Empty when Admit is true.
+	Reason string
+	// Message is a human-readable message explaining why the pod was not
+	// admitted. Empty when Admit is true.
+	Message string
+}
+
 // AllocationManager tracks pod resource allocations.
 type Manager interface {
 	// GetContainerResourceAllocation returns the AllocatedResources value for the container
@@ -80,13 +97,13 @@ type Manager interface {
 	// TODO: See if we can remove this and just add them in the allocation manager constructor.
 	AddPodAdmitHandlers(handlers lifecycle.PodAdmitHandlers)
 
-	// AddPod checks if a pod can be admitted. If so, it admits the pod and updates the allocation.
-	// The function returns a boolean value indicating whether the pod
-	// can be admitted, a brief single-word reason and a message explaining why
-	// the pod cannot be admitted.
-	// allocatedPods should represent the pods that have already been admitted, along with their
-	// admitted (allocated) resources.
-	AddPod(ctx context.Context, activePods []*v1.Pod, pod *v1.Pod) (ok bool, reason, message string)
+	// AddPod checks if a pod can be admitted. If so, it admits the pod and
+	// updates the allocation. The returned AdmitResult indicates whether the
+	// pod was admitted, whether admission should be deferred, and any
+	// rejection reason/message.
+	// activePods should represent the pods that have already been admitted,
+	// along with their admitted (allocated) resources.
+	AddPod(ctx context.Context, activePods []*v1.Pod, pod *v1.Pod) AdmitResult
 
 	// RemovePod removes any stored state for the given pod UID.
 	RemovePod(logger klog.Logger, uid types.UID)
@@ -109,6 +126,26 @@ type Manager interface {
 
 	// HasPodAllocatedResources returns whether a pod has been allocated resources.
 	HasPodAllocatedResources(podUID types.UID) bool
+
+	// MarkPodAdmissionDeferred records that the given pod's admission has been
+	// deferred. The first-seen time is preserved across repeated calls so the
+	// deferral timeout is measured from when the pod first entered the deferred state.
+	MarkPodAdmissionDeferred(uid types.UID)
+
+	// ClearDeferredAdmission removes any deferred-admission state for the given pod.
+	ClearDeferredAdmission(uid types.UID)
+
+	// IsPodAdmissionDeferred reports whether the given pod's admission is
+	// currently deferred (kept Pending and awaiting retry).
+	IsPodAdmissionDeferred(uid types.UID) bool
+
+	// RemoveOrphanedDeferredAdmissions prunes deferred-admission entries for
+	// pods that are no longer present in the given set of remaining pods.
+	RemoveOrphanedDeferredAdmissions(remainingPods sets.Set[types.UID])
+
+	// SnapshotDeferredAdmissions returns a copy of the deferred-admission map.
+	// The caller may iterate over it without holding the lock.
+	SnapshotDeferredAdmissions() map[types.UID]time.Time
 }
 
 type manager struct {
@@ -125,6 +162,12 @@ type manager struct {
 
 	allocationMutex        sync.Mutex
 	podsWithPendingResizes []types.UID
+
+	// deferredAdmissionLock guards podsWithDeferredAdmission.
+	deferredAdmissionLock sync.Mutex
+	// podsWithDeferredAdmission maps a pod UID to the time it first entered
+	// the deferred admission state.
+	podsWithDeferredAdmission map[types.UID]time.Time
 
 	recorder record.EventRecorderLogger
 }
@@ -559,7 +602,7 @@ func (m *manager) AddPodAdmitHandlers(handlers lifecycle.PodAdmitHandlers) {
 	}
 }
 
-func (m *manager) AddPod(ctx context.Context, activePods []*v1.Pod, pod *v1.Pod) (bool, string, string) {
+func (m *manager) AddPod(ctx context.Context, activePods []*v1.Pod, pod *v1.Pod) AdmitResult {
 	logger := klog.FromContext(ctx)
 	m.allocationMutex.Lock()
 	defer m.allocationMutex.Unlock()
@@ -572,9 +615,17 @@ func (m *manager) AddPod(ctx context.Context, activePods []*v1.Pod, pod *v1.Pod)
 
 	// Check if we can admit the pod; if so, update the allocation.
 	allocatedPods := m.getAllocatedPods(activePods)
-	ok, reason, message := m.canAdmitPod(ctx, allocatedPods, pod, lifecycle.AddOperation)
+	result := m.canAdmitPod(ctx, allocatedPods, pod, lifecycle.AddOperation)
 
-	if ok && utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
+	if !result.Admit && result.Defer {
+		// Admission failed but is deferrable (e.g. a device plugin has not yet
+		// registered). Keep the pod Pending instead of rejecting it; the caller
+		// tracks the deferral and retries admission.
+		logger.V(4).Info("Pod admission deferred; caller will retry", "pod", klog.KObj(pod), "reason", result.Reason, "message", result.Message)
+		return result
+	}
+
+	if result.Admit && utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		// Checkpoint the resource values at which the Pod has been admitted or resized.
 		if err := m.SetAllocatedResources(logger, pod); err != nil {
 			// TODO(vinaykul,InPlacePodVerticalScaling): Can we recover from this in some way? Investigate
@@ -582,7 +633,7 @@ func (m *manager) AddPod(ctx context.Context, activePods []*v1.Pod, pod *v1.Pod)
 		}
 	}
 
-	return ok, reason, message
+	return result
 }
 
 func (m *manager) RemovePod(logger klog.Logger, uid types.UID) {
@@ -596,6 +647,51 @@ func (m *manager) RemoveOrphanedPods(remainingPods sets.Set[types.UID]) {
 	m.allocated.RemoveOrphanedPods(remainingPods)
 }
 
+func (m *manager) MarkPodAdmissionDeferred(uid types.UID) {
+	m.deferredAdmissionLock.Lock()
+	defer m.deferredAdmissionLock.Unlock()
+	if m.podsWithDeferredAdmission == nil {
+		m.podsWithDeferredAdmission = make(map[types.UID]time.Time)
+	}
+	if _, alreadyTracked := m.podsWithDeferredAdmission[uid]; !alreadyTracked {
+		m.podsWithDeferredAdmission[uid] = time.Now()
+	}
+}
+
+func (m *manager) ClearDeferredAdmission(uid types.UID) {
+	m.deferredAdmissionLock.Lock()
+	defer m.deferredAdmissionLock.Unlock()
+	delete(m.podsWithDeferredAdmission, uid)
+}
+
+func (m *manager) IsPodAdmissionDeferred(uid types.UID) bool {
+	m.deferredAdmissionLock.Lock()
+	defer m.deferredAdmissionLock.Unlock()
+	_, deferred := m.podsWithDeferredAdmission[uid]
+	return deferred
+}
+
+func (m *manager) RemoveOrphanedDeferredAdmissions(remainingPods sets.Set[types.UID]) {
+	m.deferredAdmissionLock.Lock()
+	defer m.deferredAdmissionLock.Unlock()
+	for uid := range m.podsWithDeferredAdmission {
+		if !remainingPods.Has(uid) {
+			delete(m.podsWithDeferredAdmission, uid)
+		}
+	}
+}
+
+func (m *manager) SnapshotDeferredAdmissions() map[types.UID]time.Time {
+	m.deferredAdmissionLock.Lock()
+	defer m.deferredAdmissionLock.Unlock()
+	if len(m.podsWithDeferredAdmission) == 0 {
+		return nil
+	}
+	snapshot := make(map[types.UID]time.Time, len(m.podsWithDeferredAdmission))
+	maps.Copy(snapshot, m.podsWithDeferredAdmission)
+	return snapshot
+}
+
 func (m *manager) handlePodResourcesResize(ctx context.Context, pod *v1.Pod) (bool, error) {
 	logger := klog.FromContext(ctx)
 	_, updated := m.UpdatePodFromAllocation(pod)
@@ -606,8 +702,11 @@ func (m *manager) handlePodResourcesResize(ctx context.Context, pod *v1.Pod) (bo
 	}
 
 	// Desired resources != allocated resources. Can we update the allocation to the desired resources?
-	fit, reason, message := m.canAdmitPod(ctx, m.getAllocatedPods(m.getActivePods()), pod, lifecycle.ResizeOperation)
-	if fit {
+	// Deferral only applies to pod additions (device plugin not yet registered),
+	// so the deferral signal is ignored for resizes.
+	resizeResult := m.canAdmitPod(ctx, m.getAllocatedPods(m.getActivePods()), pod, lifecycle.ResizeOperation)
+	reason, message := resizeResult.Reason, resizeResult.Message
+	if resizeResult.Admit {
 		// Update pod resource allocation checkpoint
 		if err := m.SetAllocatedResources(logger, pod); err != nil {
 			return false, err
@@ -645,7 +744,7 @@ func (m *manager) handlePodResourcesResize(ctx context.Context, pod *v1.Pod) (bo
 // the pod cannot be admitted.
 // allocatedPods should represent the pods that have already been admitted, along with their
 // admitted (allocated) resources.
-func (m *manager) canAdmitPod(ctx context.Context, allocatedPods []*v1.Pod, pod *v1.Pod, operation lifecycle.Operation) (bool, string, string) {
+func (m *manager) canAdmitPod(ctx context.Context, allocatedPods []*v1.Pod, pod *v1.Pod, operation lifecycle.Operation) AdmitResult {
 	logger := klog.FromContext(ctx)
 	// Filter out the pod being evaluated.
 	allocatedPods = slices.DeleteFunc(allocatedPods, func(p *v1.Pod) bool { return p.UID == pod.UID })
@@ -654,12 +753,12 @@ func (m *manager) canAdmitPod(ctx context.Context, allocatedPods []*v1.Pod, pod 
 	attrs := &lifecycle.PodAdmitAttributes{Pod: pod, OtherPods: allocatedPods, Operation: operation}
 	for _, podAdmitHandler := range m.admitHandlers {
 		if result := podAdmitHandler.Admit(ctx, attrs); !result.Admit {
-			logger.Info("Pod admission denied", "podUID", attrs.Pod.UID, "pod", klog.KObj(attrs.Pod), "reason", result.Reason, "message", result.Message, "operation", operation)
-			return false, result.Reason, result.Message
+			logger.Info("Pod admission denied", "podUID", attrs.Pod.UID, "pod", klog.KObj(attrs.Pod), "reason", result.Reason, "message", result.Message, "operation", operation, "defer", result.Defer)
+			return AdmitResult{Admit: false, Defer: result.Defer, Reason: result.Reason, Message: result.Message}
 		}
 	}
 
-	return true, "", ""
+	return AdmitResult{Admit: true}
 }
 
 func (m *manager) getAllocatedPods(activePods []*v1.Pod) []*v1.Pod {

--- a/pkg/kubelet/allocation/allocation_manager_test.go
+++ b/pkg/kubelet/allocation/allocation_manager_test.go
@@ -1933,10 +1933,10 @@ func TestAllocationManagerAddPodWithPLR(t *testing.T) {
 				allocationManager.AddPodAdmitHandlers(lifecycle.PodAdmitHandlers{handler})
 			}
 
-			ok, reason, message := allocationManager.AddPod(tCtx, tc.currentActivePods, tc.podToAdd)
-			require.Equal(t, tc.expectAdmit, ok)
-			require.Equal(t, tc.admissionFailureReason, reason)
-			require.Equal(t, tc.admissionFailureMessage, message)
+			result := allocationManager.AddPod(tCtx, tc.currentActivePods, tc.podToAdd)
+			require.Equal(t, tc.expectAdmit, result.Admit)
+			require.Equal(t, tc.admissionFailureReason, result.Reason)
+			require.Equal(t, tc.admissionFailureMessage, result.Message)
 
 			for podUID, resources := range tc.expectedAllocatedResourcesState {
 				pod := podForAllocation(podUID, resources)
@@ -2192,10 +2192,10 @@ func TestAllocationManagerAddPod(t *testing.T) {
 				allocationManager.AddPodAdmitHandlers(lifecycle.PodAdmitHandlers{handler})
 			}
 
-			ok, reason, message := allocationManager.AddPod(tCtx, tc.currentActivePods, tc.podToAdd)
-			require.Equal(t, tc.expectAdmit, ok)
-			require.Equal(t, tc.admissionFailureReason, reason)
-			require.Equal(t, tc.admissionFailureMessage, message)
+			result := allocationManager.AddPod(tCtx, tc.currentActivePods, tc.podToAdd)
+			require.Equal(t, tc.expectAdmit, result.Admit)
+			require.Equal(t, tc.admissionFailureReason, result.Reason)
+			require.Equal(t, tc.admissionFailureMessage, result.Message)
 
 			for podUID, resources := range tc.expectedAllocatedResourcesState {
 				pod := podForAllocation(podUID, resources)
@@ -2772,8 +2772,8 @@ func TestAllocationManager_EmptyDirVolumeLimits_AddPod(t *testing.T) {
 			allocationManager := makeAllocationManager(t, &containertest.FakeRuntime{}, []*v1.Pod{test.pod}, nil)
 
 			// Admit the Pod
-			ok, reason, message := allocationManager.AddPod(tCtx, []*v1.Pod{test.pod}, test.pod)
-			require.True(t, ok, "admit should succeed: reason=%s, msg=%s", reason, message)
+			result := allocationManager.AddPod(tCtx, []*v1.Pod{test.pod}, test.pod)
+			require.True(t, result.Admit, "admit should succeed: reason=%s, msg=%s", result.Reason, result.Message)
 
 			// Verify state memory has the correct emptyDir allocation
 			memoryStore := allocationManager.(*manager).allocated
@@ -3590,8 +3590,8 @@ func TestNonAllocatedPodsExcludedFromCapacity_AddPod(t *testing.T) {
 
 	// If pendingPod was incorrectly included in capacity calculations,
 	// AddPod would fail (500m + 1000m + 10000m > 4000m allocatable).
-	ok, reason, message := allocationManager.AddPod(context.TODO(), []*v1.Pod{runningPod, pendingPod}, newPod)
-	assert.True(t, ok, "AddPod should succeed: reason=%s message=%s", reason, message)
+	result := allocationManager.AddPod(context.TODO(), []*v1.Pod{runningPod, pendingPod}, newPod)
+	assert.True(t, result.Admit, "AddPod should succeed: reason=%s message=%s", result.Reason, result.Message)
 
 	newAlloc, found := allocationManager.GetContainerResourceAllocation(newPod.UID, "c1")
 	require.True(t, found)

--- a/pkg/kubelet/cm/admission/errors.go
+++ b/pkg/kubelet/cm/admission/errors.go
@@ -26,6 +26,7 @@ import (
 const (
 	ErrorReasonUnexpected         = "UnexpectedAdmissionError"
 	ErrorReasonEmptyPodSharedPool = "EmptyPodSharedPoolError"
+	ErrorReasonDeviceNotReady     = "DeviceNotReady"
 )
 
 type Error interface {
@@ -65,6 +66,35 @@ func (e *EmptyPodSharedPoolError) Type() string {
 	return ErrorReasonEmptyPodSharedPool
 }
 
+// DeviceNotReadyError represents an admission failure that should be deferred
+// (retried later) rather than permanently rejected. It is used when a pod
+// requests a device plugin resource whose device plugin has not yet registered
+// with the kubelet. The device plugin may register shortly, so the pod is kept
+// Pending and admission is retried instead of failing the pod immediately.
+type DeviceNotReadyError struct {
+	Err error
+}
+
+var _ Error = (*DeviceNotReadyError)(nil)
+
+// NewDeviceNotReadyError returns a new DeviceNotReadyError wrapping err.
+func NewDeviceNotReadyError(err error) *DeviceNotReadyError {
+	return &DeviceNotReadyError{Err: err}
+}
+
+func (e *DeviceNotReadyError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *DeviceNotReadyError) Type() string {
+	return ErrorReasonDeviceNotReady
+}
+
+// Unwrap allows errors.As/errors.Is to traverse the wrapped error.
+func (e *DeviceNotReadyError) Unwrap() error {
+	return e.Err
+}
+
 func GetPodAdmitResult(err error) lifecycle.PodAdmitResult {
 	if err == nil {
 		return lifecycle.PodAdmitResult{Admit: true}
@@ -75,9 +105,15 @@ func GetPodAdmitResult(err error) lifecycle.PodAdmitResult {
 		admissionErr = &unexpectedAdmissionError{err}
 	}
 
+	// Device-not-ready errors are deferrable: the device plugin may register
+	// shortly, so the pod should be retried rather than permanently rejected.
+	var deviceNotReadyErr *DeviceNotReadyError
+	deferAdmission := errors.As(err, &deviceNotReadyErr)
+
 	return lifecycle.PodAdmitResult{
 		Message: admissionErr.Error(),
 		Reason:  admissionErr.Type(),
 		Admit:   false,
+		Defer:   deferAdmission,
 	}
 }

--- a/pkg/kubelet/cm/admission/errors_test.go
+++ b/pkg/kubelet/cm/admission/errors_test.go
@@ -18,6 +18,7 @@ package admission
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 )
 
@@ -83,5 +84,43 @@ func TestAdmissionErrors(t *testing.T) {
 		if h.Reason != ErrorReasonUnexpected {
 			t.Errorf("expected PodAdmitResult.Reason = %v, got %v", ErrorReasonUnexpected, h.Reason)
 		}
+	}
+}
+
+func TestDeviceNotReadyError(t *testing.T) {
+	innerErr := fmt.Errorf("cannot allocate unregistered device example.com/gpu")
+	devErr := NewDeviceNotReadyError(innerErr)
+
+	// It must satisfy the Error interface with the expected type.
+	if devErr.Type() != ErrorReasonDeviceNotReady {
+		t.Errorf("expected Type() = %q, got %q", ErrorReasonDeviceNotReady, devErr.Type())
+	}
+	if devErr.Error() != innerErr.Error() {
+		t.Errorf("expected Error() = %q, got %q", innerErr.Error(), devErr.Error())
+	}
+
+	// errors.As should find the DeviceNotReadyError even when wrapped.
+	wrapped := fmt.Errorf("admission failed: %w", devErr)
+	var asErr *DeviceNotReadyError
+	if !errors.As(wrapped, &asErr) {
+		t.Fatalf("expected errors.As to find *DeviceNotReadyError in wrapped error")
+	}
+
+	// GetPodAdmitResult must set Defer: true for a device-not-ready error.
+	result := GetPodAdmitResult(devErr)
+	if result.Admit {
+		t.Errorf("expected PodAdmitResult.Admit = false")
+	}
+	if !result.Defer {
+		t.Errorf("expected PodAdmitResult.Defer = true for DeviceNotReadyError")
+	}
+	if result.Reason != ErrorReasonDeviceNotReady {
+		t.Errorf("expected PodAdmitResult.Reason = %q, got %q", ErrorReasonDeviceNotReady, result.Reason)
+	}
+
+	// A non-deferrable error must not set Defer.
+	otherResult := GetPodAdmitResult(errors.New("some other error"))
+	if otherResult.Defer {
+		t.Errorf("expected PodAdmitResult.Defer = false for non-device error")
 	}
 }

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors"
+	"k8s.io/kubernetes/pkg/kubelet/cm/admission"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
 	"k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/checkpoint"
 	plugin "k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/plugin/v1beta1"
@@ -645,11 +646,22 @@ func (m *ManagerImpl) devicesToAllocate(ctx context.Context, podUID, contName, r
 	// Note: we need to check the device health and registration status *before* we check how many devices are needed, doing otherwise caused issue #109595
 	// Note: if the scheduler is bypassed, we fall back in scenario 1, so we still need these checks.
 	if !hasRegistered {
-		return nil, fmt.Errorf("cannot allocate unregistered device %s", resource)
+		// Wrap with DeviceNotReadyError so that admission defers (retries) the
+		// pod instead of permanently rejecting it. The device plugin may not
+		// have registered yet (e.g. on node reboot, or when the plugin pod
+		// starts after the workload pod is admitted).
+		return nil, admission.NewDeviceNotReadyError(fmt.Errorf("cannot allocate unregistered device %s", resource))
 	}
 
 	// Check if registered resource has healthy devices
 	if healthyDevices.Len() == 0 {
+		// If the endpoint is stopped (e.g. after kubelet restart or device
+		// plugin crash, before the plugin re-registers), this is a transient
+		// state. Return DeviceNotReadyError so admission defers (retries) the
+		// pod instead of permanently rejecting it.
+		if eI, ok := m.endpoints[resource]; ok && eI.e.isStopped() {
+			return nil, admission.NewDeviceNotReadyError(fmt.Errorf("no healthy devices for %s; device plugin has not re-registered yet", resource))
+		}
 		return nil, fmt.Errorf("no healthy devices present; cannot allocate unhealthy devices %s", resource)
 	}
 

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -49,6 +49,7 @@ import (
 	watcherapi "k8s.io/kubelet/pkg/apis/pluginregistration/v1"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/admission"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
 	"k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/checkpoint"
 	plugin "k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/plugin/v1beta1"
@@ -1222,7 +1223,7 @@ func TestPodContainerDeviceToAllocate(t *testing.T) {
 			required:                 1,
 			reusableDevices:          sets.New[string](),
 			expectedAllocatedDevices: nil,
-			expErr:                   fmt.Errorf("cannot allocate unregistered device %s", resourceName2),
+			expErr:                   admission.NewDeviceNotReadyError(fmt.Errorf("cannot allocate unregistered device %s", resourceName2)),
 		},
 		{
 			description:              "Admission error in case resource not devices previously allocated no longer healthy",
@@ -2478,4 +2479,83 @@ func TestLifecycleAllocatePod(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDevicesToAllocateUnregisteredDeviceReturnsDeviceNotReadyError(t *testing.T) {
+	as := assert.New(t)
+	_, tCtx := ktesting.NewTestContext(t)
+
+	resourceName := "domain1.com/unregistered"
+	testManager := &ManagerImpl{
+		endpoints:        make(map[string]endpointInfo),
+		healthyDevices:   make(map[string]sets.Set[string]),
+		unhealthyDevices: make(map[string]sets.Set[string]),
+		allocatedDevices: make(map[string]sets.Set[string]),
+		podDevices:       newPodDevices(),
+		sourcesReady:     &sourcesReadyStub{},
+	}
+
+	// The resource has not been registered (no entry in healthyDevices), so the
+	// device plugin is considered not yet registered and allocation must return a
+	// deferrable DeviceNotReadyError.
+	_, err := testManager.devicesToAllocate(tCtx, "pod1", "con1", resourceName, 1, sets.New[string]())
+	require.Error(t, err)
+
+	var devErr *admission.DeviceNotReadyError
+	require.ErrorAs(t, err, &devErr, "expected a *admission.DeviceNotReadyError for an unregistered device")
+	as.Equal(admission.ErrorReasonDeviceNotReady, admission.GetPodAdmitResult(err).Reason)
+	as.True(admission.GetPodAdmitResult(err).Defer, "unregistered device error should be deferrable")
+}
+
+func TestDevicesToAllocateStoppedEndpointReturnsDeviceNotReadyError(t *testing.T) {
+	as := assert.New(t)
+	_, tCtx := ktesting.NewTestContext(t)
+
+	resourceName := "domain1.com/gpu"
+	// Simulate kubelet restart: checkpoint restored, endpoint is stopped,
+	// healthyDevices has an empty set for the resource (device plugin has not
+	// re-registered yet).
+	testManager := &ManagerImpl{
+		endpoints: map[string]endpointInfo{
+			resourceName: {e: newStoppedEndpointImpl(resourceName), opts: nil},
+		},
+		healthyDevices:   map[string]sets.Set[string]{resourceName: sets.New[string]()},
+		unhealthyDevices: map[string]sets.Set[string]{resourceName: sets.New[string]()},
+		allocatedDevices: make(map[string]sets.Set[string]),
+		podDevices:       newPodDevices(),
+		sourcesReady:     &sourcesReadyStub{},
+	}
+
+	_, err := testManager.devicesToAllocate(tCtx, "pod1", "con1", resourceName, 1, sets.New[string]())
+	require.Error(t, err)
+
+	var devErr *admission.DeviceNotReadyError
+	require.ErrorAs(t, err, &devErr, "expected DeviceNotReadyError when endpoint is stopped with no healthy devices")
+	as.Equal(admission.ErrorReasonDeviceNotReady, admission.GetPodAdmitResult(err).Reason)
+	as.True(admission.GetPodAdmitResult(err).Defer, "stopped endpoint error should be deferrable")
+}
+
+func TestDevicesToAllocateRunningEndpointNoHealthyDevicesReturnsRegularError(t *testing.T) {
+	_, tCtx := ktesting.NewTestContext(t)
+
+	resourceName := "domain1.com/gpu"
+	// Simulate steady state: plugin is running but all devices are unhealthy.
+	// The endpoint is NOT stopped, so the error should NOT be deferrable.
+	testManager := &ManagerImpl{
+		endpoints: map[string]endpointInfo{
+			resourceName: {e: &MockEndpoint{}, opts: nil},
+		},
+		healthyDevices:   map[string]sets.Set[string]{resourceName: sets.New[string]()},
+		unhealthyDevices: map[string]sets.Set[string]{resourceName: sets.New[string]("dev1")},
+		allocatedDevices: make(map[string]sets.Set[string]),
+		podDevices:       newPodDevices(),
+		sourcesReady:     &sourcesReadyStub{},
+	}
+
+	_, err := testManager.devicesToAllocate(tCtx, "pod1", "con1", resourceName, 1, sets.New[string]())
+	require.Error(t, err)
+
+	var devErr *admission.DeviceNotReadyError
+	require.NotErrorAs(t, err, &devErr, "running endpoint with no healthy devices should NOT return DeviceNotReadyError")
+	require.False(t, admission.GetPodAdmitResult(err).Defer, "running endpoint error should not be deferrable")
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -182,6 +182,15 @@ const (
 	// Period for performing global cleanup tasks.
 	housekeepingPeriod = time.Second * 2
 
+	// deferredAdmissionTimeout bounds how long a pod may remain in the deferred
+	// admission queue before being permanently rejected. Once a pod has been
+	// continuously deferred for longer than this timeout (measured from when it
+	// first entered the deferred state), the next retry rejects it with PodFailed
+	// status, matching the existing immediate-rejection behavior. Because retries
+	// run on the periodic retry cadence, the actual rejection happens on the
+	// first retry after the timeout elapses, not exactly at the timeout.
+	deferredAdmissionTimeout = 1 * time.Minute
+
 	// Duration at which housekeeping failed to satisfy the invariant that
 	// housekeeping should be fast to avoid blocking pod config (while
 	// housekeeping is running no new pods are started or deleted).
@@ -2649,6 +2658,83 @@ func (kl *Kubelet) deletePod(ctx context.Context, pod *v1.Pod) error {
 	return nil
 }
 
+// retryDeferredAdmissions re-runs admission for every pod whose admission was
+// previously deferred. Pods that can now be admitted are dispatched to the pod
+// workers with SyncPodCreate; pods still deferred and within the timeout are
+// kept; pods that have exceeded the deferral timeout (or now fail for a
+// non-deferrable reason) are permanently rejected.
+func (kl *Kubelet) retryDeferredAdmissions(ctx context.Context) {
+	logger := klog.FromContext(ctx)
+
+	deferred := kl.allocationManager.SnapshotDeferredAdmissions()
+	if len(deferred) == 0 {
+		return
+	}
+
+	now := kl.clock.Now()
+
+	for uid, firstDeferred := range deferred {
+		pod, found := kl.podManager.GetPodByUID(uid)
+		if !found {
+			logger.V(4).Info("Deferred pod not found; removing from deferred admissions", "podUID", uid)
+			kl.allocationManager.ClearDeferredAdmission(uid)
+			continue
+		}
+
+		// A pod that has since been requested for termination or has reached a
+		// terminal phase must not be admitted. Drop it from the deferred set.
+		if kl.podWorkers.IsPodTerminationRequested(uid) || podutil.IsPodPhaseTerminal(pod.Status.Phase) {
+			logger.V(4).Info("Deferred pod is terminating or terminal; dropping from deferred admissions", "pod", klog.KObj(pod))
+			kl.allocationManager.ClearDeferredAdmission(uid)
+			continue
+		}
+
+		pod, mirrorPod, wasMirror := kl.podManager.GetPodAndMirrorPod(pod)
+		if pod == nil || wasMirror {
+			logger.V(2).Info("Programmer error, deferred pod was a mirror pod but should never be", "podUID", uid)
+			kl.allocationManager.ClearDeferredAdmission(uid)
+			continue
+		}
+
+		result := kl.allocationManager.AddPod(ctx, kl.GetActivePods(), pod)
+		switch {
+		case result.Admit:
+			// Admission now succeeds; dispatch the pod to the pod workers.
+			kl.allocationManager.ClearDeferredAdmission(uid)
+			logger.V(2).Info("Deferred pod admission succeeded; dispatching pod", "pod", klog.KObj(pod))
+			kl.podWorkers.UpdatePod(ctx, UpdatePodOptions{
+				Pod:        pod,
+				MirrorPod:  mirrorPod,
+				UpdateType: kubetypes.SyncPodCreate,
+				StartTime:  now,
+			})
+		case result.Defer && now.Sub(firstDeferred) <= deferredAdmissionTimeout:
+			// Still deferred and within the timeout; keep waiting.
+			logger.V(4).Info("Pod admission still deferred; will retry", "pod", klog.KObj(pod), "reason", result.Reason)
+		default:
+			// Either the deferral timed out, or admission now fails for a
+			// non-deferrable reason. Reject the pod.
+			kl.allocationManager.ClearDeferredAdmission(uid)
+			reason, message := result.Reason, result.Message
+			if !result.Defer {
+				logger.V(4).Info("Deferred pod admission now failing for a non-deferrable reason; rejecting", "pod", klog.KObj(pod), "reason", reason)
+			} else {
+				// The deferral timed out while still waiting on the device
+				// plugin. Use a synthetic reason only when the handler did not
+				// provide one, so a genuine non-deferrable reason is never
+				// mislabeled as a timeout.
+				if reason == "" {
+					reason = "DeferredAdmissionTimeout"
+				}
+				logger.V(2).Info("Deferred pod admission timed out; rejecting", "pod", klog.KObj(pod), "timeout", deferredAdmissionTimeout)
+				message = "deferred admission timed out: " + message
+			}
+			kl.rejectPod(ctx, pod, reason, message)
+			recordAdmissionRejection(reason)
+		}
+	}
+}
+
 // rejectPod records an event about the pod with the given reason and message,
 // and updates the pod to the failed phase in the status manager.
 func (kl *Kubelet) rejectPod(ctx context.Context, pod *v1.Pod, reason, message string) {
@@ -2858,6 +2944,10 @@ func (kl *Kubelet) syncLoopIteration(ctx context.Context, configCh <-chan kubety
 			// We do not apply the optimization by updating the status directly, but can do it later
 			handler.HandlePodSyncs(ctx, pods)
 		}
+		// A container manager update (e.g. a device plugin registering) may make a
+		// previously-deferred pod admissible, so retry deferred admissions eagerly
+		// rather than waiting for the next periodic sweep.
+		kl.retryDeferredAdmissions(ctx)
 	case <-housekeepingCh:
 		if !kl.sourcesReady.AllReady() {
 			// If the sources aren't ready or volume manager has not yet synced the states,
@@ -2869,6 +2959,10 @@ func (kl *Kubelet) syncLoopIteration(ctx context.Context, configCh <-chan kubety
 			if err := handler.HandlePodCleanups(ctx); err != nil {
 				logger.Error(err, "Failed cleaning pods")
 			}
+			// Periodically retry admission for pods whose admission was deferred
+			// (e.g. waiting on a device plugin to register), admitting or
+			// rejecting them as appropriate.
+			kl.retryDeferredAdmissions(ctx)
 			duration := time.Since(start)
 			if duration > housekeepingWarningDuration {
 				logger.Error(fmt.Errorf("housekeeping took too long"), "Housekeeping took longer than expected", "expected", housekeepingWarningDuration, "actual", duration.Round(time.Millisecond))
@@ -2934,15 +3028,33 @@ func (kl *Kubelet) HandlePodAdditions(ctx context.Context, pods []*v1.Pod) {
 			// Check if we can admit the pod; if not, reject it.
 			// We failed pods that we rejected, so activePods include all admitted
 			// pods that are alive.
-			if ok, reason, message := kl.allocationManager.AddPod(ctx, kl.GetActivePods(), pod); !ok {
-				kl.rejectPod(ctx, pod, reason, message)
+			if result := kl.allocationManager.AddPod(ctx, kl.GetActivePods(), pod); !result.Admit {
+				if result.Defer {
+					// Admission failed but is deferrable (e.g. a device plugin has
+					// not yet registered). Keep the pod Pending instead of failing
+					// it: do not reject it, and do not dispatch it to the pod
+					// workers. Track the deferral so retryDeferredAdmissions
+					// re-attempts admission and rejects the pod if it eventually
+					// times out.
+					kl.allocationManager.MarkPodAdmissionDeferred(pod.UID)
+					logger.V(2).Info("Pod admission deferred; keeping pod pending until it can be admitted or times out", "pod", klog.KObj(pod), "reason", result.Reason, "message", result.Message)
+					continue
+				}
+				// The pod is being rejected, so it is no longer deferred. Clear
+				// any previous deferral state.
+				kl.allocationManager.ClearDeferredAdmission(pod.UID)
+				kl.rejectPod(ctx, pod, result.Reason, result.Message)
 				// We avoid recording the metric in canAdmitPod because it's called
 				// repeatedly during a resize, which would inflate the metric.
 				// Instead, we record the metric here in HandlePodAdditions for new pods
 				// and capture resize events separately.
-				recordAdmissionRejection(reason)
+				recordAdmissionRejection(result.Reason)
 				continue
 			}
+
+			// The pod was admitted, so it is no longer deferred. Clear any
+			// previous deferral state.
+			kl.allocationManager.ClearDeferredAdmission(pod.UID)
 
 			if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 				// Backfill the queue of pending resizes, but only after all the pods have
@@ -3035,6 +3147,14 @@ func (kl *Kubelet) HandlePodUpdates(ctx context.Context, pods []*v1.Pod) {
 			}
 		}
 
+		// A pod whose admission is deferred must not be dispatched to the pod
+		// workers. retryDeferredAdmissions will dispatch it once it is admitted
+		// (or reject it on timeout). We still update the pod manager above so
+		// that the latest spec is available when admission is retried.
+		if kl.allocationManager.IsPodAdmissionDeferred(pod.UID) {
+			logger.V(4).Info("Skipping update for pod with deferred admission", "pod", klog.KObj(pod))
+			continue
+		}
 		kl.podWorkers.UpdatePod(ctx, UpdatePodOptions{
 			Pod:        pod,
 			MirrorPod:  mirrorPod,
@@ -3147,6 +3267,7 @@ func (kl *Kubelet) HandlePodRemoves(ctx context.Context, pods []*v1.Pod) {
 		kl.podCertificateManager.ForgetPod(ctx, pod)
 		kl.podManager.RemovePod(pod)
 		kl.allocationManager.RemovePod(logger, pod.UID)
+		kl.allocationManager.ClearDeferredAdmission(pod.UID)
 
 		pod, mirrorPod, wasMirror := kl.podManager.GetPodAndMirrorPod(pod)
 		if wasMirror {
@@ -3249,6 +3370,13 @@ func (kl *Kubelet) HandlePodReconcile(ctx context.Context, pods []*v1.Pod) {
 		// be different than Sync, or if there is a better place for it. For instance, we have
 		// needsReconcile in kubelet/config, here, and in status_manager.
 		if status.NeedToReconcilePodReadiness(pod) {
+			// A pod whose admission is deferred must not be dispatched to the
+			// pod workers. retryDeferredAdmissions will dispatch it once it is
+			// admitted (or reject it on timeout).
+			if kl.allocationManager.IsPodAdmissionDeferred(pod.UID) {
+				logger.V(4).Info("Skipping reconcile for pod with deferred admission", "pod", klog.KObj(pod))
+				continue
+			}
 			kl.podWorkers.UpdatePod(ctx, UpdatePodOptions{
 				Pod:        pod,
 				MirrorPod:  mirrorPod,
@@ -3292,6 +3420,13 @@ func (kl *Kubelet) HandlePodSyncs(ctx context.Context, pods []*v1.Pod) {
 			// batch notify all pending work. We should make it impossible to double sync,
 			// but for now log a programmer error to prevent accidental introduction.
 			logger.V(3).Info("Programmer error, HandlePodSyncs does not expect to receive mirror pods", "podUID", pod.UID, "mirrorPodUID", mirrorPod.UID)
+			continue
+		}
+		// A pod whose admission is deferred has not been admitted and must not be
+		// dispatched to the pod workers by a stale relist or sync. retryDeferredAdmissions
+		// will dispatch it once it is admitted (or reject it on timeout).
+		if kl.allocationManager.IsPodAdmissionDeferred(pod.UID) {
+			logger.V(4).Info("Skipping sync for pod with deferred admission", "pod", klog.KObj(pod))
 			continue
 		}
 		kl.podWorkers.UpdatePod(ctx, UpdatePodOptions{

--- a/pkg/kubelet/kubelet_deferred_admission_test.go
+++ b/pkg/kubelet/kubelet_deferred_admission_test.go
@@ -1,0 +1,340 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
+	"k8s.io/kubernetes/test/utils/ktesting"
+	testingclock "k8s.io/utils/clock/testing"
+)
+
+// deferAdmitHandler is a controllable admit handler used to drive deferred
+// admission tests. When admit is true it admits; otherwise it returns the
+// configured defer/reason/message.
+type deferAdmitHandler struct {
+	admit       bool
+	deferResult bool
+	reason      string
+	message     string
+}
+
+func (h *deferAdmitHandler) Admit(_ context.Context, attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult {
+	if h.admit {
+		return lifecycle.PodAdmitResult{Admit: true}
+	}
+	return lifecycle.PodAdmitResult{
+		Admit:   false,
+		Defer:   h.deferResult,
+		Reason:  h.reason,
+		Message: h.message,
+	}
+}
+
+// newDeferredAdmissionKubelet returns a test kubelet whose admission is driven
+// by the returned controllable handler. The node is configured so benign pods
+// pass the default predicate handlers, leaving admission decisions to the
+// returned handler.
+func newDeferredAdmissionKubelet(t *testing.T) (*TestKubelet, *deferAdmitHandler) {
+	t.Helper()
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	kl := testKubelet.kubelet
+	kl.nodeLister = testNodeLister{nodes: []*v1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: string(kl.nodeName)},
+			Status: v1.NodeStatus{
+				Allocatable: v1.ResourceList{
+					v1.ResourcePods: *resource.NewQuantity(110, resource.DecimalSI),
+				},
+			},
+		},
+	}}
+	h := &deferAdmitHandler{reason: "DeviceNotReady", message: "device not ready"}
+	kl.allocationManager.AddPodAdmitHandlers(lifecycle.PodAdmitHandlers{h})
+	return testKubelet, h
+}
+
+func newDeferTestPod(uid string) *v1.Pod {
+	return podWithUIDNameNsSpec(types.UID(uid), "pod-"+uid, "ns", v1.PodSpec{
+		NodeName:   string(testKubeletHostname),
+		Containers: []v1.Container{{Name: "c1"}},
+	})
+}
+
+// recordDispatches installs a syncPodFn on the fake pod workers that records the
+// update type seen per pod UID, so tests can assert how a pod was dispatched.
+func recordDispatches(kl *Kubelet) map[types.UID]kubetypes.SyncPodType {
+	dispatched := map[types.UID]kubetypes.SyncPodType{}
+	kl.podWorkers.(*fakePodWorkers).syncPodFn = func(_ context.Context, updateType kubetypes.SyncPodType, pod, _ *v1.Pod, _ *kubecontainer.PodStatus) (bool, func(), error) {
+		if pod != nil {
+			dispatched[pod.UID] = updateType
+		}
+		return false, nil, nil
+	}
+	return dispatched
+}
+
+func stepClock(t *testing.T, kl *Kubelet, d time.Duration) {
+	t.Helper()
+	fc, ok := kl.clock.(*testingclock.FakeClock)
+	require.True(t, ok, "kubelet clock must be a fake clock for deferred admission tests")
+	fc.Step(d)
+}
+
+// A pod whose admission is deferred is tracked and kept Pending (not rejected).
+func TestDeferredAdmissionTracksDeferredPod(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet, h := newDeferredAdmissionKubelet(t)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+	dispatched := recordDispatches(kl)
+
+	h.admit = false
+	h.deferResult = true
+	pod := newDeferTestPod("defer-1")
+
+	kl.HandlePodAdditions(tCtx, []*v1.Pod{pod})
+
+	require.True(t, kl.allocationManager.IsPodAdmissionDeferred(pod.UID), "deferred pod should be tracked")
+	require.NotContains(t, dispatched, pod.UID, "deferred pod must not be dispatched to the pod workers")
+	if status, found := kl.statusManager.GetPodStatus(pod.UID); found {
+		require.NotEqual(t, v1.PodFailed, status.Phase, "deferred pod must not be failed")
+	}
+}
+
+// A previously deferred pod is dispatched with SyncPodCreate once admission succeeds.
+func TestDeferredAdmissionRetrySucceeds(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet, h := newDeferredAdmissionKubelet(t)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+	dispatched := recordDispatches(kl)
+
+	h.admit = false
+	h.deferResult = true
+	pod := newDeferTestPod("defer-2")
+	kl.HandlePodAdditions(tCtx, []*v1.Pod{pod})
+	require.True(t, kl.allocationManager.IsPodAdmissionDeferred(pod.UID))
+
+	// Device becomes available.
+	h.admit = true
+	stepClock(t, kl, 10*time.Second)
+	kl.retryDeferredAdmissions(tCtx)
+
+	require.False(t, kl.allocationManager.IsPodAdmissionDeferred(pod.UID), "admitted pod should be removed from the deferred map")
+	require.Equal(t, kubetypes.SyncPodCreate, dispatched[pod.UID], "admitted pod should be dispatched with SyncPodCreate")
+	if status, found := kl.statusManager.GetPodStatus(pod.UID); found {
+		require.NotEqual(t, v1.PodFailed, status.Phase, "admitted pod must not be failed")
+	}
+}
+
+// A deferred pod still within the timeout keeps being deferred.
+func TestDeferredAdmissionStillDeferredWithinTimeout(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet, h := newDeferredAdmissionKubelet(t)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+
+	h.admit = false
+	h.deferResult = true
+	pod := newDeferTestPod("defer-3")
+	kl.HandlePodAdditions(tCtx, []*v1.Pod{pod})
+	require.True(t, kl.allocationManager.IsPodAdmissionDeferred(pod.UID))
+
+	stepClock(t, kl, deferredAdmissionTimeout/2)
+	kl.retryDeferredAdmissions(tCtx)
+
+	require.True(t, kl.allocationManager.IsPodAdmissionDeferred(pod.UID), "pod within the timeout should still be deferred")
+	if status, found := kl.statusManager.GetPodStatus(pod.UID); found {
+		require.NotEqual(t, v1.PodFailed, status.Phase, "pod within timeout must not be failed")
+	}
+}
+
+// A deferred pod past the timeout is permanently rejected, preserving the
+// original (non-synthetic) rejection reason.
+func TestDeferredAdmissionTimesOut(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet, h := newDeferredAdmissionKubelet(t)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+
+	h.admit = false
+	h.deferResult = true
+	pod := newDeferTestPod("defer-4")
+	kl.HandlePodAdditions(tCtx, []*v1.Pod{pod})
+	require.True(t, kl.allocationManager.IsPodAdmissionDeferred(pod.UID))
+
+	// Advance past the deferral timeout; device is still unavailable.
+	stepClock(t, kl, deferredAdmissionTimeout+time.Second)
+	kl.retryDeferredAdmissions(tCtx)
+
+	require.False(t, kl.allocationManager.IsPodAdmissionDeferred(pod.UID), "timed-out pod should be removed from the deferred map")
+	checkPodStatus(t, kl, pod, v1.PodFailed)
+	status, _ := kl.statusManager.GetPodStatus(pod.UID)
+	require.Equal(t, "DeviceNotReady", status.Reason, "rejection reason must not be relabeled as a timeout")
+}
+
+// A deferred pod that becomes termination-requested is dropped, not admitted.
+func TestDeferredAdmissionTerminationRequestedNotAdmitted(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet, h := newDeferredAdmissionKubelet(t)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+	dispatched := recordDispatches(kl)
+
+	h.admit = false
+	h.deferResult = true
+	pod := newDeferTestPod("defer-5")
+	kl.HandlePodAdditions(tCtx, []*v1.Pod{pod})
+	require.True(t, kl.allocationManager.IsPodAdmissionDeferred(pod.UID))
+
+	// The pod is now requested for termination, and admission would otherwise succeed.
+	kl.podWorkers.(*fakePodWorkers).terminationRequested = map[types.UID]bool{pod.UID: true}
+	h.admit = true
+	kl.retryDeferredAdmissions(tCtx)
+
+	require.False(t, kl.allocationManager.IsPodAdmissionDeferred(pod.UID), "terminating pod should be dropped from the deferred map")
+	require.NotContains(t, dispatched, pod.UID, "terminating pod must not be admitted/dispatched")
+	if status, found := kl.statusManager.GetPodStatus(pod.UID); found {
+		require.NotEqual(t, v1.PodFailed, status.Phase, "terminating deferred pod must not be rejected")
+	}
+}
+
+// A pod removed while deferred is cleaned up from the deferred map.
+func TestDeferredAdmissionClearedOnRemove(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet, h := newDeferredAdmissionKubelet(t)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+
+	h.admit = false
+	h.deferResult = true
+	pod := newDeferTestPod("defer-6")
+	kl.HandlePodAdditions(tCtx, []*v1.Pod{pod})
+	require.True(t, kl.allocationManager.IsPodAdmissionDeferred(pod.UID))
+
+	kl.HandlePodRemoves(tCtx, []*v1.Pod{pod})
+
+	require.False(t, kl.allocationManager.IsPodAdmissionDeferred(pod.UID), "removed pod should be cleared from the deferred map")
+}
+
+// removeOrphanedDeferredAdmissions prunes deferred entries for pods no longer present.
+func TestDeferredAdmissionOrphanCleanup(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet, h := newDeferredAdmissionKubelet(t)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+
+	h.admit = false
+	h.deferResult = true
+	pod := newDeferTestPod("defer-7")
+	kl.HandlePodAdditions(tCtx, []*v1.Pod{pod})
+	require.True(t, kl.allocationManager.IsPodAdmissionDeferred(pod.UID))
+
+	// The remaining set does not contain the deferred pod.
+	kl.allocationManager.RemoveOrphanedDeferredAdmissions(sets.New[types.UID]("some-other-pod"))
+
+	require.False(t, kl.allocationManager.IsPodAdmissionDeferred(pod.UID), "orphaned deferred pod should be pruned")
+}
+
+// HandlePodSyncs skips dispatch for deferred pods.
+func TestDeferredAdmissionSkippedByHandlePodSyncs(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet, h := newDeferredAdmissionKubelet(t)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+	dispatched := recordDispatches(kl)
+
+	h.admit = false
+	h.deferResult = true
+	pod := newDeferTestPod("sync-skip-1")
+	kl.HandlePodAdditions(tCtx, []*v1.Pod{pod})
+	require.True(t, kl.allocationManager.IsPodAdmissionDeferred(pod.UID))
+
+	kl.HandlePodSyncs(tCtx, []*v1.Pod{pod})
+
+	require.NotContains(t, dispatched, pod.UID, "HandlePodSyncs must not dispatch a deferred pod")
+}
+
+// HandlePodUpdates skips dispatch for deferred pods.
+func TestDeferredAdmissionSkippedByHandlePodUpdates(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet, h := newDeferredAdmissionKubelet(t)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+	dispatched := recordDispatches(kl)
+
+	h.admit = false
+	h.deferResult = true
+	pod := newDeferTestPod("update-skip-1")
+	kl.HandlePodAdditions(tCtx, []*v1.Pod{pod})
+	require.True(t, kl.allocationManager.IsPodAdmissionDeferred(pod.UID))
+
+	kl.HandlePodUpdates(tCtx, []*v1.Pod{pod})
+
+	require.NotContains(t, dispatched, pod.UID, "HandlePodUpdates must not dispatch a deferred pod")
+}
+
+// HandlePodReconcile skips dispatch for deferred pods.
+func TestDeferredAdmissionSkippedByHandlePodReconcile(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet, h := newDeferredAdmissionKubelet(t)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+	dispatched := recordDispatches(kl)
+
+	h.admit = false
+	h.deferResult = true
+	pod := newDeferTestPod("reconcile-skip-1")
+	kl.HandlePodAdditions(tCtx, []*v1.Pod{pod})
+	require.True(t, kl.allocationManager.IsPodAdmissionDeferred(pod.UID))
+
+	kl.HandlePodReconcile(tCtx, []*v1.Pod{pod})
+
+	require.NotContains(t, dispatched, pod.UID, "HandlePodReconcile must not dispatch a deferred pod")
+}
+
+// A non-deferrable rejection in HandlePodAdditions fails the pod immediately and
+// does not track it as deferred.
+func TestDeferredAdmissionNonDeferrableRejection(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet, h := newDeferredAdmissionKubelet(t)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+
+	h.admit = false
+	h.deferResult = false
+	h.reason = "OutOfMemory"
+	h.message = "node out of memory"
+	pod := newDeferTestPod("reject-1")
+
+	kl.HandlePodAdditions(tCtx, []*v1.Pod{pod})
+
+	require.False(t, kl.allocationManager.IsPodAdmissionDeferred(pod.UID), "non-deferrable rejection must not be tracked")
+	checkPodStatus(t, kl, pod, v1.PodFailed)
+}

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1309,6 +1309,7 @@ func (kl *Kubelet) HandlePodCleanups(ctx context.Context) error {
 	logger.V(3).Info("Clean up orphaned pod statuses")
 	kl.removeOrphanedPodStatuses(logger, allPods, mirrorPods)
 	kl.allocationManager.RemoveOrphanedPods(allPodsByUID)
+	kl.allocationManager.RemoveOrphanedDeferredAdmissions(allPodsByUID)
 
 	// Remove orphaned pod user namespace allocations (if any).
 	logger.V(3).Info("Clean up orphaned pod user namespace allocations")
@@ -1368,6 +1369,16 @@ func (kl *Kubelet) HandlePodCleanups(ctx context.Context) error {
 	var restartCount, restartCountStatic int
 	for _, desiredPod := range activePods {
 		if _, knownPod := workingPods[desiredPod.UID]; knownPod {
+			continue
+		}
+
+		// A pod whose admission has been deferred (e.g. it requests a device
+		// plugin resource that is not yet registered) is intentionally not known
+		// to the pod workers: HandlePodAdditions kept it Pending without
+		// dispatching it. Such a pod is not admitted, so it must not be started
+		// here. The allocation manager retries its admission and will dispatch it
+		// once it is admitted, or reject it if the deferral times out.
+		if kl.allocationManager.IsPodAdmissionDeferred(desiredPod.UID) {
 			continue
 		}
 

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -1308,11 +1308,13 @@ func TestHandlePluginResources(t *testing.T) {
 			},
 		}}},
 	}
-	// pod requiring missingResource will pass PredicateAdmit.
+	// pod requiring missingResource has its admission deferred.
 	//
-	// Extended resources missing in node status are ignored in PredicateAdmit.
-	// This is required to support extended resources that are not managed by
-	// device plugin, such as cluster-level resources.
+	// An extended resource that is absent from the node's allocatable may be
+	// provided by a device plugin that has not registered with the kubelet yet,
+	// so the pod is kept Pending (admission deferred) rather than admitted or
+	// rejected. The allocation manager retries admission and rejects the pod if
+	// the device plugin never registers before the deferral times out.
 	missingPodSpec := v1.PodSpec{NodeName: string(kl.nodeName),
 		Containers: []v1.Container{{Resources: v1.ResourceRequirements{
 			Limits: v1.ResourceList{
@@ -1345,7 +1347,12 @@ func TestHandlePluginResources(t *testing.T) {
 	// Check pod status stored in the status map.
 	checkPodStatus(t, kl, fittingPod, v1.PodPending)
 	checkPodStatus(t, kl, emptyPod, v1.PodFailed)
-	checkPodStatus(t, kl, missingPod, v1.PodPending)
+	// missingPod's admission is deferred: it is neither admitted nor rejected,
+	// so no status is recorded for it and it remains Pending until the device
+	// plugin registers or the deferral times out.
+	if _, found := kl.statusManager.GetPodStatus(missingPod.UID); found {
+		t.Errorf("expected no status for deferred pod %q, but a status was recorded", missingPod.UID)
+	}
 	checkPodStatus(t, kl, failedPod, v1.PodFailed)
 }
 

--- a/pkg/kubelet/lifecycle/interfaces.go
+++ b/pkg/kubelet/lifecycle/interfaces.go
@@ -51,6 +51,12 @@ type PodAdmitResult struct {
 	Reason string
 	// a brief message explaining why the pod could not be admitted.
 	Message string
+	// if true, admission failed but should be retried later rather than
+	// permanently rejected. This is only meaningful when Admit is false.
+	// For example, a pod requesting a device plugin resource that has not
+	// yet registered with the kubelet should be deferred (kept Pending)
+	// instead of rejected, since the device plugin may register shortly.
+	Defer bool
 }
 
 // PodAdmitHandler is notified during pod admission.

--- a/test/e2e_node/device_plugin_failures_test.go
+++ b/test/e2e_node/device_plugin_failures_test.go
@@ -373,4 +373,73 @@ var _ = SIGDescribe("Device Plugin Failures:", framework.WithNodeConformance(), 
 		// after the graceful period devices capacity will reset to zero
 		gomega.Eventually(getNodeResourceValues, devicePluginGracefulTimeout+1*time.Minute, f.Timeouts.Poll).WithContext(ctx).WithArguments(resourceName).Should(gomega.Equal(ResourceValue{Allocatable: 0, Capacity: 0}))
 	})
+
+	ginkgo.It("defers admission, keeping the pod Pending until the device plugin registers, then runs it", func(ctx context.Context) {
+		// randomizing so tests can run in parallel
+		resourceName := fmt.Sprintf("test.device/%s", f.UniqueName)
+		node := getLocalNode(ctx, f)
+
+		// The device plugin has not registered yet, so the resource is absent.
+		gomega.Eventually(getNodeResourceValues, nodeStatusUpdateTimeout, f.Timeouts.Poll).WithContext(ctx).WithArguments(resourceName).Should(gomega.Equal(ResourceValue{Allocatable: -1, Capacity: -1}))
+
+		// Create a pod requesting the device, binding it directly to the node to
+		// bypass the scheduler. Because the device plugin has not registered, the
+		// kubelet must defer admission (rather than rejecting the pod) and keep it
+		// Pending instead of failing it.
+		pod := createPod(resourceName, 1)
+		pod.Spec.NodeName = node.Name
+		client := e2epod.NewPodClient(f)
+		pod = client.Create(ctx, pod)
+
+		ginkgo.By("pod stays Pending (not Failed) while the device plugin is unregistered")
+		gomega.Consistently(func() v1.PodPhase {
+			p, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{})
+			gomega.Expect(err).To(gomega.Succeed())
+			return p.Status.Phase
+		}, 10*time.Second, f.Timeouts.Poll).Should(gomega.Equal(v1.PodPending))
+
+		ginkgo.By("registering the device plugin")
+		devices := []*kubeletdevicepluginv1beta1.Device{{ID: "testdevice", Health: kubeletdevicepluginv1beta1.Healthy}}
+		plugin := testdeviceplugin.NewDevicePlugin(nil)
+		time.Sleep(time.Second) // wait for the unix socket to be open
+		err := plugin.RegisterDevicePlugin(ctx, f.UniqueName, resourceName, devices)
+		defer plugin.Stop()
+		gomega.Expect(err).To(gomega.Succeed())
+
+		ginkgo.By("pod is admitted and becomes Running once the device plugin registers")
+		gomega.Expect(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod)).To(gomega.Succeed())
+	})
+
+	ginkgo.It("rejects a deferred pod with Failed after the admission timeout elapses if the device plugin never registers", func(ctx context.Context) {
+		// randomizing so tests can run in parallel
+		resourceName := fmt.Sprintf("test.device/%s", f.UniqueName)
+		node := getLocalNode(ctx, f)
+
+		// The device plugin is never registered for this resource.
+		gomega.Eventually(getNodeResourceValues, nodeStatusUpdateTimeout, f.Timeouts.Poll).WithContext(ctx).WithArguments(resourceName).Should(gomega.Equal(ResourceValue{Allocatable: -1, Capacity: -1}))
+
+		// Bind the pod directly to the node to bypass the scheduler.
+		pod := createPod(resourceName, 1)
+		pod.Spec.NodeName = node.Name
+		client := e2epod.NewPodClient(f)
+		pod = client.Create(ctx, pod)
+
+		// The pod must first be deferred (kept Pending), not rejected immediately:
+		// this distinguishes the deferral behavior from the pre-feature behavior
+		// of failing the pod right away. The window stays under the 1-minute
+		// deferral timeout.
+		ginkgo.By("pod stays Pending (deferred) before the admission timeout elapses")
+		gomega.Consistently(func() v1.PodPhase {
+			p, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{})
+			gomega.Expect(err).To(gomega.Succeed())
+			return p.Status.Phase
+		}, 30*time.Second, f.Timeouts.Poll).Should(gomega.Equal(v1.PodPending))
+
+		ginkgo.By("pod is permanently rejected with Failed after the deferred admission timeout")
+		gomega.Eventually(func() v1.PodPhase {
+			p, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{})
+			gomega.Expect(err).To(gomega.Succeed())
+			return p.Status.Phase
+		}, 3*time.Minute, f.Timeouts.Poll).Should(gomega.Equal(v1.PodFailed))
+	})
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we negenerteed it:

When a pod admission fails because a device plugin hasn't registered yet, defer the pod (instead of rejecting it permanently) and retry until either the device plugin registers or a timeout expires. No changes to the device plugin interface.

Replaces https://github.com/kubernetes/kubernetes/pull/137919

e2e run: ` make test-e2e-node TEST_ARGS='--kubelet-flags="--fail-swap-on=false"' SKIP= FOCUS="Device Plugin Failures"`

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/125579

#### Special notes for your reviewer:

I was experimenting with different placement of retry. I think this is better than inside allocation manager as resize retries are.

Also one of the goals was to minimize the change for the potential possibility to back port to earlier versions, where it may be more important since by the time 1.37 widely adopted, I hope DRA will be more widespread.

I also think long term we may need to have a better accounting of deferred pods so new pods are not admitted in their place. This fix is relying on scheduler to not overcommit. 

Some AI was used

#### Does this PR introduce a user-facing change?

```release-note
Defer Pod Admission for the predefined amount of time when the Device Plugin was not registered yet.
```
