### PR TITLE
kubectl: re-enable TestGetUnknownSchemaObject

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"net/http"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -82,7 +81,6 @@ func testComponentStatusData() *corev1.ComponentStatusList {
 
 // Verifies that schemas that are not in the master tree of Kubernetes can be retrieved via Get.
 func TestGetUnknownSchemaObject(t *testing.T) {
-	t.Skip("This test is completely broken.  The first thing it does is add the object to the scheme!")
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
 	defer tf.Cleanup()
 	_, _, codec := cmdtesting.NewExternalScheme()
@@ -108,28 +106,14 @@ func TestGetUnknownSchemaObject(t *testing.T) {
 	cmd.SetErr(buf)
 	cmd.Run(cmd, []string{"type", "foo"})
 
-	expected := []runtime.Object{cmdtesting.NewInternalType("", "", "foo")}
-	actual := []runtime.Object{}
-	if len(actual) != len(expected) {
-		t.Fatalf("expected: %#v, but actual: %#v", expected, actual)
-	}
-	t.Logf("actual: %#v", actual[0])
-	for i, obj := range actual {
-		expectedJSON := runtime.EncodeOrDie(codec, expected[i])
-		expectedMap := map[string]interface{}{}
-		if err := json.Unmarshal([]byte(expectedJSON), &expectedMap); err != nil {
-			t.Fatal(err)
-		}
-
-		actualJSON := runtime.EncodeOrDie(codec, obj)
-		actualMap := map[string]interface{}{}
-		if err := json.Unmarshal([]byte(actualJSON), &actualMap); err != nil {
-			t.Fatal(err)
-		}
-
-		if !reflect.DeepEqual(expectedMap, actualMap) {
-			t.Errorf("expectedMap: %#v, but actualMap: %#v", expectedMap, actualMap)
-		}
+	// The object is served as an unknown (external) type, so get falls back to
+	// the generic table printer. ExternalType carries its name as a top-level
+	// "name" field rather than "metadata.name", so the NAME column is empty.
+	expected := `NAME   AGE
+       <unknown>
+`
+	if e, a := expected, buf.String(); e != a {
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`TestGetUnknownSchemaObject` in `pkg/cmd/get` has been skipped as broken.
Its assertion block never captured the command output: it built an empty
`actual` slice and compared it against a one-element `expected` slice
(which would fail immediately), and the comparison loop that followed was
dead code iterating over the empty slice.

This re-enables the test by rewriting the assertion to follow the same
pattern as the sibling `get` tests (`TestGetObjects`, `TestGetSchemaObject`):
run the command and compare the rendered table output captured in the
output buffer. The existing external-scheme setup already exercises
retrieving an out-of-tree (unknown) schema object via `get`, so only the
assertion needed fixing. The now-unused `reflect` import is dropped.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The object is served as an unknown (external) type, so `get` falls back to
the generic table printer. `ExternalType` carries its name as a top-level
`name` field rather than `metadata.name`, so the rendered NAME column is
empty; this is documented in a comment next to the assertion.

This is a test-only change.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
