### PR TITLE
kubectl: re-enable TestGetUnknownSchemaObject

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"net/http"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -82,7 +81,6 @@ func testComponentStatusData() *corev1.ComponentStatusList {
 
 // Verifies that schemas that are not in the master tree of Kubernetes can be retrieved via Get.
 func TestGetUnknownSchemaObject(t *testing.T) {
-	t.Skip("This test is completely broken.  The first thing it does is add the object to the scheme!")
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
 	defer tf.Cleanup()
 	_, _, codec := cmdtesting.NewExternalScheme()
@@ -108,28 +106,14 @@ func TestGetUnknownSchemaObject(t *testing.T) {
 	cmd.SetErr(buf)
 	cmd.Run(cmd, []string{"type", "foo"})
 
-	expected := []runtime.Object{cmdtesting.NewInternalType("", "", "foo")}
-	actual := []runtime.Object{}
-	if len(actual) != len(expected) {
-		t.Fatalf("expected: %#v, but actual: %#v", expected, actual)
-	}
-	t.Logf("actual: %#v", actual[0])
-	for i, obj := range actual {
-		expectedJSON := runtime.EncodeOrDie(codec, expected[i])
-		expectedMap := map[string]interface{}{}
-		if err := json.Unmarshal([]byte(expectedJSON), &expectedMap); err != nil {
-			t.Fatal(err)
-		}
-
-		actualJSON := runtime.EncodeOrDie(codec, obj)
-		actualMap := map[string]interface{}{}
-		if err := json.Unmarshal([]byte(actualJSON), &actualMap); err != nil {
-			t.Fatal(err)
-		}
-
-		if !reflect.DeepEqual(expectedMap, actualMap) {
-			t.Errorf("expectedMap: %#v, but actualMap: %#v", expectedMap, actualMap)
-		}
+	// The object is served as an unknown (external) type, so get falls back to
+	// the generic table printer. ExternalType carries its name as a top-level
+	// "name" field rather than "metadata.name", so the NAME column is empty.
+	expected := `NAME   AGE
+       <unknown>
+`
+	if e, a := expected, buf.String(); e != a {
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`TestGetUnknownSchemaObject` in `pkg/cmd/get` has been skipped as broken.
Its assertion block never captured the command output: it built an empty
`actual` slice and compared it against a one-element `expected` slice
(which would fail immediately), and the comparison loop that followed was
dead code iterating over the empty slice. As a result the
"retrieve an out-of-tree (external) schema object via `get`" path had no
working unit assertion.

This rewrites the assertion to follow the pattern used by the sibling
`TestGetSchemaObject`: run the command and compare the rendered table
output captured in the output buffer. The existing external-scheme setup
already exercises the path under test, so only the assertion needed
fixing. The now-unused `reflect` import is dropped.

Verified locally:

```
$ go test ./pkg/cmd/get/ -run 'TestGetUnknownSchemaObject|TestGetSchemaObject' -v
--- PASS: TestGetUnknownSchemaObject (0.00s)
--- PASS: TestGetSchemaObject (0.01s)
PASS
```

`gofmt` and `go vet ./pkg/cmd/get/` are both clean.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

Supersedes #139960 (self-closed; the commit was reworked here).

The captured output has an empty `NAME` column because `ExternalType`
stores its name as a top-level `name` field rather than `metadata.name`,
so the generic table printer finds nothing for the name cell. This is the
genuine current behavior of `get` for this type; an inline comment
documents it.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
