### PR TITLE
Use HandleCrashWithContext in controlplane controllers

### DIFF
--- a/pkg/controlplane/controller/clusterauthenticationtrust/cluster_authentication_trust_controller.go
+++ b/pkg/controlplane/controller/clusterauthenticationtrust/cluster_authentication_trust_controller.go
@@ -452,7 +452,7 @@ func (c *Controller) Enqueue() {
 
 // Run the controller until stopped.
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	// make sure the work queue is shutdown which will trigger workers to end
 	defer c.queue.ShutDown()
 

--- a/pkg/controlplane/controller/legacytokentracking/controller.go
+++ b/pkg/controlplane/controller/legacytokentracking/controller.go
@@ -119,7 +119,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 
 // RunWithContext starts the controller sync loop with a context.
 func (c *Controller) RunWithContext(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer c.queue.ShutDown()
 
 	logger := klog.FromContext(ctx)


### PR DESCRIPTION
Migrate two controlplane controllers to contextual logging by replacing
utilruntime.HandleCrash with utilruntime.HandleCrashWithContext where a
context is already in scope. This lets panic handlers log through the
context bound logger instead of the global background logger, matching the
already migrated apiserverleasegc controller.

Refs kubernetes/kubernetes#126379

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Part of the contextual logging migration. In legacytokentracking and
clusterauthenticationtrust, the panic recovery handler still called the
non contextual utilruntime.HandleCrash() even though a context.Context was
already available in the enclosing function (RunWithContext(ctx) and
Run(ctx, workers) respectively). Switching to
utilruntime.HandleCrashWithContext(ctx) routes panic logging through the
context bound logger instead of klog.Background(), consistent with the
already migrated apiserverleasegc controller. No public signatures change.

#### Which issue(s) this PR is related to:

Refs kubernetes/kubernetes#126379

#### Other notes:

Scoped intentionally small: only the two call sites where a context was
already in scope, so the change is signature preserving and low risk. The
systemnamespaces and crdregistration controllers in the same directory
still take only a stop channel and need a RunWithContext variant before
they can be migrated; those are left for a follow up.

Verified with go build, go vet, and the package unit tests for both
controllers.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```