### PR TITLE
Wire ObjectMeta test suite for core, apps, networking, and other API groups

### DIFF
--- a/test/declarative_validation/apps/controllerrevision/declarative_validation_test.go
+++ b/test/declarative_validation/apps/controllerrevision/declarative_validation_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllerrevision
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apps "k8s.io/kubernetes/pkg/apis/apps"
+	_ "k8s.io/kubernetes/pkg/apis/apps/install"
+	"k8s.io/kubernetes/pkg/registry/apps/controllerrevision"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
+)
+
+// TODO: remove this apiVersions variable once coverage tests are generated for this package.
+var apiVersions = []string{"v1", "v1beta1", "v1beta2"}
+
+// Helper function to create a baseline valid ControllerRevision with optional tweaks
+func mkControllerRevision(tweaks ...func(*apps.ControllerRevision)) apps.ControllerRevision {
+	obj := apps.ControllerRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "valid-resource-name",
+		},
+		Data:     runtime.RawExtension{Raw: []byte(`{"kind":"Foo"}`)},
+		Revision: 1,
+	}
+	for _, tweak := range tweaks {
+		tweak(&obj)
+	}
+	return obj
+}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			strategy := controllerrevision.Strategy
+			var namespace string
+			if strategy.NamespaceScoped() {
+				namespace = metav1.NamespaceDefault
+			}
+			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+				APIPrefix:         "apis",
+				APIGroup:          "apps",
+				APIVersion:        apiVersion,
+				Resource:          "controllerrevisions",
+				Namespace:         namespace,
+				IsResourceRequest: true,
+				Verb:              "create",
+			})
+			obj := mkControllerRevision(func(o *apps.ControllerRevision) {
+				o.Namespace = namespace
+			})
+			meta.RunObjectMetaTestCases(t, ctx, &obj, strategy, meta.WithStringentFinalizerValidation())
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			strategy := controllerrevision.Strategy
+			var namespace string
+			if strategy.NamespaceScoped() {
+				namespace = metav1.NamespaceDefault
+			}
+			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+				APIPrefix:         "apis",
+				APIGroup:          "apps",
+				APIVersion:        apiVersion,
+				Resource:          "controllerrevisions",
+				Namespace:         namespace,
+				Name:              "valid-obj",
+				IsResourceRequest: true,
+				Verb:              "update",
+			})
+			obj := mkControllerRevision(func(o *apps.ControllerRevision) {
+				o.Namespace = namespace
+			})
+			meta.RunObjectMetaUpdateTestCases(t, ctx, &obj, strategy, meta.WithStringentFinalizerValidation())
+		})
+	}
+}

--- a/test/declarative_validation/apps/daemonset/declarative_validation_test.go
+++ b/test/declarative_validation/apps/daemonset/declarative_validation_test.go
@@ -27,20 +27,37 @@ import (
 	"k8s.io/kubernetes/pkg/apis/apps"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	registry "k8s.io/kubernetes/pkg/registry/apps/daemonset"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 )
 
-func mkDaemonSet(tolerations ...api.Toleration) *apps.DaemonSet {
-	return &apps.DaemonSet{
+func tweakPodSpec(podTweaks ...podtest.Tweak) func(*apps.DaemonSet) {
+	return func(ds *apps.DaemonSet) {
+		pod := &api.Pod{
+			Spec: ds.Spec.Template.Spec,
+		}
+		for _, tweak := range podTweaks {
+			tweak(pod)
+		}
+		ds.Spec.Template.Spec = pod.Spec
+	}
+}
+
+func mkDaemonSet(tweaks ...func(*apps.DaemonSet)) *apps.DaemonSet {
+	ds := &apps.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
 		Spec: apps.DaemonSetSpec{
 			Selector:       &metav1.LabelSelector{MatchLabels: map[string]string{"name": "abc"}},
 			UpdateStrategy: apps.DaemonSetUpdateStrategy{Type: apps.OnDeleteDaemonSetStrategyType},
 			Template: api.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"name": "abc"}},
-				Spec:       podtest.MakePodSpec(podtest.SetTolerations(tolerations...)),
+				Spec:       podtest.MakePodSpec(),
 			},
 		},
 	}
+	for _, tweak := range tweaks {
+		tweak(ds)
+	}
+	return ds
 }
 
 func TestDeclarativeValidate(t *testing.T) {
@@ -57,13 +74,13 @@ func TestDeclarativeValidate(t *testing.T) {
 				input: mkDaemonSet(),
 			},
 			"valid toleration key": {
-				input: mkDaemonSet(api.Toleration{Key: "example.com/valid-key", Operator: api.TolerationOpExists}),
+				input: mkDaemonSet(tweakPodSpec(podtest.SetTolerations(api.Toleration{Key: "example.com/valid-key", Operator: api.TolerationOpExists}))),
 			},
 			"valid toleration key without prefix": {
-				input: mkDaemonSet(api.Toleration{Key: "simple-key", Operator: api.TolerationOpExists}),
+				input: mkDaemonSet(tweakPodSpec(podtest.SetTolerations(api.Toleration{Key: "simple-key", Operator: api.TolerationOpExists}))),
 			},
 			"invalid toleration key format": {
-				input: mkDaemonSet(api.Toleration{Key: "invalid key", Operator: api.TolerationOpExists}),
+				input: mkDaemonSet(tweakPodSpec(podtest.SetTolerations(api.Toleration{Key: "invalid key", Operator: api.TolerationOpExists}))),
 				expectedErrs: field.ErrorList{
 					field.Invalid(field.NewPath("spec", "template", "spec", "tolerations").Index(0).Child("key"), nil, "").WithOrigin("format=k8s-label-key").MarkAlpha(),
 				},
@@ -75,5 +92,24 @@ func TestDeclarativeValidate(t *testing.T) {
 					apitesting.WithSkipGroupVersions("extensions/v1beta1"))
 			})
 		}
+		meta.RunObjectMetaTestCases(t, ctx, mkDaemonSet(), registry.Strategy,
+			meta.WithStringentFinalizerValidation(),
+			meta.WithValidationConfig(apitesting.WithSkipGroupVersions("extensions/v1beta1")),
+		)
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+			APIGroup:   "apps",
+			APIVersion: apiVersion,
+			Name:       "abc",
+			Verb:       "update",
+		})
+		meta.RunObjectMetaUpdateTestCases(t, ctx, mkDaemonSet(), registry.Strategy,
+			meta.WithStringentFinalizerValidation(),
+			meta.WithValidationConfig(apitesting.WithSkipGroupVersions("extensions/v1beta1")),
+		)
 	}
 }

--- a/test/declarative_validation/apps/deployment/declarative_validation_test.go
+++ b/test/declarative_validation/apps/deployment/declarative_validation_test.go
@@ -28,10 +28,23 @@ import (
 	"k8s.io/kubernetes/pkg/apis/apps"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	registry "k8s.io/kubernetes/pkg/registry/apps/deployment"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 )
 
-func mkDeployment(tolerations ...api.Toleration) *apps.Deployment {
-	return &apps.Deployment{
+func tweakPodSpec(podTweaks ...podtest.Tweak) func(*apps.Deployment) {
+	return func(deploy *apps.Deployment) {
+		pod := &api.Pod{
+			Spec: deploy.Spec.Template.Spec,
+		}
+		for _, tweak := range podTweaks {
+			tweak(pod)
+		}
+		deploy.Spec.Template.Spec = pod.Spec
+	}
+}
+
+func mkDeployment(tweaks ...func(*apps.Deployment)) *apps.Deployment {
+	deploy := &apps.Deployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
 		Spec: apps.DeploymentSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"name": "abc"}},
@@ -44,10 +57,14 @@ func mkDeployment(tolerations ...api.Toleration) *apps.Deployment {
 			},
 			Template: api.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"name": "abc"}},
-				Spec:       podtest.MakePodSpec(podtest.SetTolerations(tolerations...)),
+				Spec:       podtest.MakePodSpec(),
 			},
 		},
 	}
+	for _, tweak := range tweaks {
+		tweak(deploy)
+	}
+	return deploy
 }
 
 func TestDeclarativeValidate(t *testing.T) {
@@ -64,13 +81,13 @@ func TestDeclarativeValidate(t *testing.T) {
 				input: mkDeployment(),
 			},
 			"valid toleration key": {
-				input: mkDeployment(api.Toleration{Key: "example.com/valid-key", Operator: api.TolerationOpExists}),
+				input: mkDeployment(tweakPodSpec(podtest.SetTolerations(api.Toleration{Key: "example.com/valid-key", Operator: api.TolerationOpExists}))),
 			},
 			"valid toleration key without prefix": {
-				input: mkDeployment(api.Toleration{Key: "simple-key", Operator: api.TolerationOpExists}),
+				input: mkDeployment(tweakPodSpec(podtest.SetTolerations(api.Toleration{Key: "simple-key", Operator: api.TolerationOpExists}))),
 			},
 			"invalid toleration key format": {
-				input: mkDeployment(api.Toleration{Key: "invalid key", Operator: api.TolerationOpExists}),
+				input: mkDeployment(tweakPodSpec(podtest.SetTolerations(api.Toleration{Key: "invalid key", Operator: api.TolerationOpExists}))),
 				expectedErrs: field.ErrorList{
 					field.Invalid(field.NewPath("spec", "template", "spec", "tolerations").Index(0).Child("key"), nil, "").WithOrigin("format=k8s-label-key").MarkAlpha(),
 				},
@@ -82,5 +99,24 @@ func TestDeclarativeValidate(t *testing.T) {
 					apitesting.WithSkipGroupVersions("extensions/v1beta1"))
 			})
 		}
+		meta.RunObjectMetaTestCases(t, ctx, mkDeployment(), registry.Strategy,
+			meta.WithStringentFinalizerValidation(),
+			meta.WithValidationConfig(apitesting.WithSkipGroupVersions("extensions/v1beta1")),
+		)
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+			APIGroup:   "apps",
+			APIVersion: apiVersion,
+			Name:       "abc",
+			Verb:       "update",
+		})
+		meta.RunObjectMetaUpdateTestCases(t, ctx, mkDeployment(), registry.Strategy,
+			meta.WithStringentFinalizerValidation(),
+			meta.WithValidationConfig(apitesting.WithSkipGroupVersions("extensions/v1beta1")),
+		)
 	}
 }

--- a/test/declarative_validation/apps/replicaset/declarative_validation_test.go
+++ b/test/declarative_validation/apps/replicaset/declarative_validation_test.go
@@ -27,19 +27,36 @@ import (
 	"k8s.io/kubernetes/pkg/apis/apps"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	registry "k8s.io/kubernetes/pkg/registry/apps/replicaset"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 )
 
-func mkReplicaSet(tolerations ...api.Toleration) *apps.ReplicaSet {
-	return &apps.ReplicaSet{
+func tweakPodSpec(podTweaks ...podtest.Tweak) func(*apps.ReplicaSet) {
+	return func(rs *apps.ReplicaSet) {
+		pod := &api.Pod{
+			Spec: rs.Spec.Template.Spec,
+		}
+		for _, tweak := range podTweaks {
+			tweak(pod)
+		}
+		rs.Spec.Template.Spec = pod.Spec
+	}
+}
+
+func mkReplicaSet(tweaks ...func(*apps.ReplicaSet)) *apps.ReplicaSet {
+	rs := &apps.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
 		Spec: apps.ReplicaSetSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"name": "abc"}},
 			Template: api.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"name": "abc"}},
-				Spec:       podtest.MakePodSpec(podtest.SetTolerations(tolerations...)),
+				Spec:       podtest.MakePodSpec(),
 			},
 		},
 	}
+	for _, tweak := range tweaks {
+		tweak(rs)
+	}
+	return rs
 }
 
 func TestDeclarativeValidate(t *testing.T) {
@@ -56,13 +73,13 @@ func TestDeclarativeValidate(t *testing.T) {
 				input: mkReplicaSet(),
 			},
 			"valid toleration key": {
-				input: mkReplicaSet(api.Toleration{Key: "example.com/valid-key", Operator: api.TolerationOpExists}),
+				input: mkReplicaSet(tweakPodSpec(podtest.SetTolerations(api.Toleration{Key: "example.com/valid-key", Operator: api.TolerationOpExists}))),
 			},
 			"valid toleration key without prefix": {
-				input: mkReplicaSet(api.Toleration{Key: "simple-key", Operator: api.TolerationOpExists}),
+				input: mkReplicaSet(tweakPodSpec(podtest.SetTolerations(api.Toleration{Key: "simple-key", Operator: api.TolerationOpExists}))),
 			},
 			"invalid toleration key format": {
-				input: mkReplicaSet(api.Toleration{Key: "invalid key", Operator: api.TolerationOpExists}),
+				input: mkReplicaSet(tweakPodSpec(podtest.SetTolerations(api.Toleration{Key: "invalid key", Operator: api.TolerationOpExists}))),
 				expectedErrs: field.ErrorList{
 					field.Invalid(field.NewPath("spec", "template", "spec", "tolerations").Index(0).Child("key"), nil, "").WithOrigin("format=k8s-label-key").MarkAlpha(),
 				},
@@ -74,5 +91,24 @@ func TestDeclarativeValidate(t *testing.T) {
 					apitesting.WithSkipGroupVersions("extensions/v1beta1"))
 			})
 		}
+		meta.RunObjectMetaTestCases(t, ctx, mkReplicaSet(), registry.Strategy,
+			meta.WithStringentFinalizerValidation(),
+			meta.WithValidationConfig(apitesting.WithSkipGroupVersions("extensions/v1beta1")),
+		)
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+			APIGroup:   "apps",
+			APIVersion: apiVersion,
+			Name:       "abc",
+			Verb:       "update",
+		})
+		meta.RunObjectMetaUpdateTestCases(t, ctx, mkReplicaSet(), registry.Strategy,
+			meta.WithStringentFinalizerValidation(),
+			meta.WithValidationConfig(apitesting.WithSkipGroupVersions("extensions/v1beta1")),
+		)
 	}
 }

--- a/test/declarative_validation/apps/statefulset/declarative_validation_test.go
+++ b/test/declarative_validation/apps/statefulset/declarative_validation_test.go
@@ -25,8 +25,10 @@ import (
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/apis/apps"
+	_ "k8s.io/kubernetes/pkg/apis/apps/install"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	registry "k8s.io/kubernetes/pkg/registry/apps/statefulset"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 	"k8s.io/utils/ptr"
 )
 
@@ -40,11 +42,40 @@ func TestDeclarativeValidate(t *testing.T) {
 
 func testDeclarativeValidate(t *testing.T, apiVersion string) {
 	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
 		APIGroup:          "apps",
 		APIVersion:        apiVersion,
 		Resource:          "statefulsets",
 		IsResourceRequest: true,
 		Verb:              "create",
+	})
+
+	obj := mkValidStatefulSet()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+
+	t.Run("volumeClaimTemplates_metadata_name_empty", func(t *testing.T) {
+		objWithEmptyVCTName := mkValidStatefulSet(func(o *apps.StatefulSet) {
+			o.Spec.VolumeClaimTemplates = []api.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "",
+					},
+					Spec: api.PersistentVolumeClaimSpec{
+						AccessModes: []api.PersistentVolumeAccessMode{api.ReadWriteOnce},
+						Resources: api.VolumeResourceRequirements{
+							Requests: api.ResourceList{
+								api.ResourceStorage: resource.MustParse("10G"),
+							},
+						},
+					},
+				},
+			}
+		})
+		expectedErrs := field.ErrorList{
+			field.Required(field.NewPath("spec", "template", "spec", "volumes").Index(0).Child("name"), "").MarkFromImperative(),
+			field.Required(field.NewPath("spec", "template", "spec", "volumes").Index(0).Child("persistentVolumeClaim", "claimName"), "").MarkFromImperative(),
+		}
+		apitesting.VerifyValidationEquivalence(t, ctx, &objWithEmptyVCTName, registry.Strategy, expectedErrs)
 	})
 
 	testCases := map[string]struct {
@@ -91,6 +122,19 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 }
 
 func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "apps",
+		APIVersion:        apiVersion,
+		Resource:          "statefulsets",
+		Name:              "valid-statefulset",
+		IsResourceRequest: true,
+		Verb:              "update",
+	})
+	obj := mkValidStatefulSet()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+
 	testCases := map[string]struct {
 		oldObj       apps.StatefulSet
 		updateObj    apps.StatefulSet

--- a/test/declarative_validation/autoscaling/horizontalpodautoscaler/declarative_validation_test.go
+++ b/test/declarative_validation/autoscaling/horizontalpodautoscaler/declarative_validation_test.go
@@ -29,6 +29,7 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/autoscaling"
 	"k8s.io/kubernetes/pkg/features"
 	registry "k8s.io/kubernetes/pkg/registry/autoscaling/horizontalpodautoscaler"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 	"k8s.io/utils/ptr"
 )
 
@@ -40,9 +41,12 @@ func TestDeclarativeValidate(t *testing.T) {
 
 func testDeclarativeValidate(t *testing.T, apiVersion string) {
 	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-		APIGroup:   "autoscaling",
-		APIVersion: apiVersion,
-		Resource:   "horizontalpodautoscalers",
+		APIPrefix:         "apis",
+		APIGroup:          "autoscaling",
+		APIVersion:        apiVersion,
+		Resource:          "horizontalpodautoscalers",
+		IsResourceRequest: true,
+		Verb:              "create",
 	})
 	testCases := map[string]struct {
 		input             api.HorizontalPodAutoscaler
@@ -84,6 +88,9 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, registry.Strategy, tc.expectedErrs)
 		})
 	}
+	obj := makeValidHPA(tweakMinReplicas(5))
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+
 }
 
 func TestDeclarativeValidateUpdate(t *testing.T) {
@@ -95,6 +102,15 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 }
 
 func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "autoscaling",
+		APIVersion:        apiVersion,
+		Resource:          "horizontalpodautoscalers",
+		Name:              "valid-obj",
+		IsResourceRequest: true,
+		Verb:              "update",
+	})
 	testCases := map[string]struct {
 		oldObj            api.HorizontalPodAutoscaler
 		updateObj         api.HorizontalPodAutoscaler
@@ -144,20 +160,14 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.HPAScaleToZero, tc.enableScaleToZero)
-			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-				APIGroup:          "autoscaling",
-				APIVersion:        apiVersion,
-				Resource:          "horizontalpodautoscalers",
-				Name:              "test-hpa",
-				IsResourceRequest: true,
-				Verb:              "update",
-			})
 			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, registry.Strategy, tc.expectedErrs)
 		})
 	}
+	updateObj := makeValidHPA(tweakMinReplicas(5))
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
-func makeValidHPA(mutators ...func(*api.HorizontalPodAutoscaler)) api.HorizontalPodAutoscaler {
+func makeValidHPA(tweaks ...func(*api.HorizontalPodAutoscaler)) api.HorizontalPodAutoscaler {
 	hpa := api.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "test-hpa",
@@ -173,8 +183,8 @@ func makeValidHPA(mutators ...func(*api.HorizontalPodAutoscaler)) api.Horizontal
 			MaxReplicas: 10,
 		},
 	}
-	for _, mutate := range mutators {
-		mutate(&hpa)
+	for _, tweak := range tweaks {
+		tweak(&hpa)
 	}
 	return hpa
 }

--- a/test/declarative_validation/batch/cronjob/declarative_validation_test.go
+++ b/test/declarative_validation/batch/cronjob/declarative_validation_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/batch"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	registry "k8s.io/kubernetes/pkg/registry/batch/cronjob"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 	"k8s.io/utils/ptr"
 )
 
@@ -38,8 +39,12 @@ func TestDeclarativeValidate(t *testing.T) {
 
 func testDeclarativeValidate(t *testing.T, apiVersion string) {
 	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-		APIGroup:   "batch",
-		APIVersion: apiVersion,
+		APIPrefix:         "apis",
+		APIGroup:          "batch",
+		APIVersion:        apiVersion,
+		Resource:          "cronjobs",
+		IsResourceRequest: true,
+		Verb:              "create",
 	})
 	testCases := map[string]struct {
 		input        batch.CronJob
@@ -84,6 +89,9 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, registry.Strategy, tc.expectedErrs)
 		})
 	}
+	obj := mkCronJob()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+
 }
 
 func TestDeclarativeValidateUpdate(t *testing.T) {
@@ -94,8 +102,13 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 
 func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-		APIGroup:   "batch",
-		APIVersion: apiVersion,
+		APIPrefix:         "apis",
+		APIGroup:          "batch",
+		APIVersion:        apiVersion,
+		Resource:          "cronjobs",
+		Name:              "valid-obj",
+		IsResourceRequest: true,
+		Verb:              "update",
 	})
 	testCases := map[string]struct {
 		old          batch.CronJob
@@ -122,9 +135,11 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, registry.Strategy, tc.expectedErrs)
 		})
 	}
+	updateObj := mkCronJob()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
-func mkCronJob(mutators ...func(*batch.CronJob)) batch.CronJob {
+func mkCronJob(tweaks ...func(*batch.CronJob)) batch.CronJob {
 	job := batch.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-class",
@@ -133,8 +148,8 @@ func mkCronJob(mutators ...func(*batch.CronJob)) batch.CronJob {
 		Spec: validCronjobSpec,
 	}
 
-	for _, mutate := range mutators {
-		mutate(&job)
+	for _, tweak := range tweaks {
+		tweak(&job)
 	}
 
 	return job

--- a/test/declarative_validation/certificates/certificatesigningrequest/declarative_validation_test.go
+++ b/test/declarative_validation/certificates/certificatesigningrequest/declarative_validation_test.go
@@ -33,6 +33,7 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/certificates"
 	"k8s.io/kubernetes/pkg/apis/core"
 	registry "k8s.io/kubernetes/pkg/registry/certificates/certificates"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 	"k8s.io/utils/ptr"
 )
 
@@ -44,8 +45,12 @@ func TestDeclarativeValidate(t *testing.T) {
 
 func testDeclarativeValidate(t *testing.T, apiVersion string) {
 	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-		APIGroup:   "certificates.k8s.io",
-		APIVersion: apiVersion,
+		APIPrefix:         "apis",
+		APIGroup:          "certificates.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "certificatesigningrequests",
+		IsResourceRequest: true,
+		Verb:              "create",
 	})
 	testCases := map[string]struct {
 		input        api.CertificateSigningRequest
@@ -87,6 +92,9 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, registry.Strategy, tc.expectedErrs)
 		})
 	}
+	obj := makeValidCSR()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+
 }
 
 func TestDeclarativeValidateUpdate(t *testing.T) {
@@ -197,13 +205,22 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, strategy, tc.expectedErrs)
 			})
 		}
+
+		ctx := createContextForSubresource(apiVersion, "/")
+		updateObj := makeValidCSR()
+		meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 	}
 }
 
 func createContextForSubresource(apiVersion, subresource string) context.Context {
 	requestInfo := &genericapirequest.RequestInfo{
-		APIGroup:   "certificates.k8s.io",
-		APIVersion: apiVersion,
+		APIPrefix:         "apis",
+		APIGroup:          "certificates.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "certificatesigningrequests",
+		Name:              "valid-obj",
+		IsResourceRequest: true,
+		Verb:              "update",
 	}
 
 	if subresource != "/" {
@@ -213,7 +230,7 @@ func createContextForSubresource(apiVersion, subresource string) context.Context
 	return genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), requestInfo)
 }
 
-func makeValidCSR(mutators ...func(*api.CertificateSigningRequest)) api.CertificateSigningRequest {
+func makeValidCSR(tweaks ...func(*api.CertificateSigningRequest)) api.CertificateSigningRequest {
 	csr := api.CertificateSigningRequest{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-csr",
@@ -224,8 +241,8 @@ func makeValidCSR(mutators ...func(*api.CertificateSigningRequest)) api.Certific
 			Usages:     []api.KeyUsage{api.UsageDigitalSignature, api.UsageKeyEncipherment},
 		},
 	}
-	for _, mutate := range mutators {
-		mutate(&csr)
+	for _, tweak := range tweaks {
+		tweak(&csr)
 	}
 	return csr
 }

--- a/test/declarative_validation/certificates/clustertrustbundle/declarative_validation_test.go
+++ b/test/declarative_validation/certificates/clustertrustbundle/declarative_validation_test.go
@@ -31,6 +31,7 @@ import (
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/apis/certificates"
 	registry "k8s.io/kubernetes/pkg/registry/certificates/clustertrustbundle"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 )
 
 func mustMakeTestCert(t *testing.T) string {
@@ -104,7 +105,6 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		APIGroup:          "certificates.k8s.io",
 		APIVersion:        apiVersion,
 		Resource:          "clustertrustbundles",
-		Name:              "test-bundle",
 		IsResourceRequest: true,
 		Verb:              "create",
 	})
@@ -128,6 +128,8 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, registry.Strategy, tc.expectedErrs)
 		})
 	}
+	obj := mkValidBundle(t, tweakName("test-bundle"), tweakSignerName(""))
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func TestDeclarativeValidateUpdate(t *testing.T) {
@@ -139,6 +141,16 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 }
 
 func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "certificates.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "clustertrustbundles",
+		Name:              "valid-obj",
+		IsResourceRequest: true,
+		Verb:              "update",
+	})
+
 	testCases := map[string]struct {
 		oldObj       certificates.ClusterTrustBundle
 		updateObj    certificates.ClusterTrustBundle
@@ -175,18 +187,12 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-				APIPrefix:         "apis",
-				APIGroup:          "certificates.k8s.io",
-				APIVersion:        apiVersion,
-				Resource:          "clustertrustbundles",
-				Name:              tc.oldObj.Name,
-				IsResourceRequest: true,
-				Verb:              "update",
-			})
 			tc.oldObj.ResourceVersion = "1"
 			tc.updateObj.ResourceVersion = "2"
 			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, registry.Strategy, tc.expectedErrs)
 		})
 	}
+
+	updateObj := mkValidBundle(t, tweakName("test-bundle"), tweakSignerName(""))
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }

--- a/test/declarative_validation/certificates/podcertificaterequest/declarative_validation_test.go
+++ b/test/declarative_validation/certificates/podcertificaterequest/declarative_validation_test.go
@@ -18,15 +18,19 @@ package podcertificaterequest
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
-	"k8s.io/kubernetes/pkg/apis/certificates"
+	certificates "k8s.io/kubernetes/pkg/apis/certificates"
 	_ "k8s.io/kubernetes/pkg/apis/certificates/install"
 	registry "k8s.io/kubernetes/pkg/registry/certificates/podcertificaterequest"
 	"k8s.io/kubernetes/test/declarative_validation/meta"
@@ -38,14 +42,105 @@ func (f *fakeAuthorizer) Authorize(ctx context.Context, a authorizer.Attributes)
 	return authorizer.DecisionAllow, "default accept", nil
 }
 
+// Helper function to create a baseline valid PodCertificateRequest with optional tweaks
+func mkPodCertificateRequest(tweaks ...func(*certificates.PodCertificateRequest)) certificates.PodCertificateRequest {
+	obj := func() certificates.PodCertificateRequest {
+		expiration := int32(3600)
+		_, priv, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			panic(err)
+		}
+		template := &x509.CertificateRequest{}
+		csrDER, err := x509.CreateCertificateRequest(rand.Reader, template, priv)
+		if err != nil {
+			panic(err)
+		}
+		return certificates.PodCertificateRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid-resource-name",
+			},
+			Spec: certificates.PodCertificateRequestSpec{
+				SignerName:           "kubernetes.io/kube-apiserver-client-pod",
+				PodName:              "valid-pod-name",
+				PodUID:               types.UID("a0123456-7890-abcd-ef01-234567890abc"),
+				ServiceAccountName:   "default",
+				ServiceAccountUID:    types.UID("b0123456-7890-abcd-ef01-234567890abc"),
+				NodeName:             types.NodeName("valid-node-name"),
+				NodeUID:              types.UID("c0123456-7890-abcd-ef01-234567890abc"),
+				MaxExpirationSeconds: &expiration,
+				StubPKCS10Request:    csrDER,
+			},
+		}
+	}()
+	for _, tweak := range tweaks {
+		tweak(&obj)
+	}
+	return obj
+}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			strategy := registry.NewStrategy()
+			var namespace string
+			if strategy.NamespaceScoped() {
+				namespace = metav1.NamespaceDefault
+			}
+			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+				APIPrefix:         "apis",
+				APIGroup:          "certificates.k8s.io",
+				APIVersion:        apiVersion,
+				Resource:          "podcertificaterequests",
+				Namespace:         namespace,
+				IsResourceRequest: true,
+				Verb:              "create",
+			})
+			obj := mkPodCertificateRequest(func(o *certificates.PodCertificateRequest) {
+				o.Namespace = namespace
+			})
+			meta.RunObjectMetaTestCases(t, ctx, &obj, strategy, meta.WithStringentFinalizerValidation())
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			strategy := registry.NewStrategy()
+			var namespace string
+			if strategy.NamespaceScoped() {
+				namespace = metav1.NamespaceDefault
+			}
+			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+				APIPrefix:         "apis",
+				APIGroup:          "certificates.k8s.io",
+				APIVersion:        apiVersion,
+				Resource:          "podcertificaterequests",
+				Namespace:         namespace,
+				Name:              "valid-resource-name",
+				IsResourceRequest: true,
+				Verb:              "update",
+			})
+			obj := mkPodCertificateRequest(func(o *certificates.PodCertificateRequest) {
+				o.Namespace = namespace
+			})
+			meta.RunObjectMetaUpdateTestCases(t, ctx, &obj, strategy, meta.WithStringentFinalizerValidation())
+		})
+	}
+}
+
 func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 	for _, apiVersion := range apiVersions {
 		t.Run(apiVersion, func(t *testing.T) {
 			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-				APIGroup:    "certificates.k8s.io",
-				APIVersion:  apiVersion,
-				Resource:    "podcertificaterequests",
-				Subresource: "status",
+				APIPrefix:         "apis",
+				APIGroup:          "certificates.k8s.io",
+				APIVersion:        apiVersion,
+				Resource:          "podcertificaterequests",
+				Subresource:       "status",
+				Name:              "valid-resource-name",
+				IsResourceRequest: true,
+				Verb:              "update",
 			})
 			ctx = genericapirequest.WithUser(ctx, &user.DefaultInfo{Name: "test-user"})
 

--- a/test/declarative_validation/core/configmap/declarative_validation_test.go
+++ b/test/declarative_validation/core/configmap/declarative_validation_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configmap
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	core "k8s.io/kubernetes/pkg/apis/core"
+	registry "k8s.io/kubernetes/pkg/registry/core/configmap"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
+)
+
+// TODO: remove this apiVersions variable once coverage tests are generated for this package.
+var apiVersions = []string{"v1"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateUpdate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "api",
+		APIGroup:          "",
+		APIVersion:        apiVersion,
+		Resource:          "configmaps",
+		IsResourceRequest: true,
+		Verb:              "create",
+	}), metav1.NamespaceDefault)
+
+	obj := mkValidConfigMap()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "api",
+		APIGroup:          "",
+		APIVersion:        apiVersion,
+		Resource:          "configmaps",
+		Name:              "valid-obj",
+		IsResourceRequest: true,
+		Verb:              "update",
+	}), metav1.NamespaceDefault)
+
+	updateObj := mkValidConfigMap()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func mkValidConfigMap() core.ConfigMap {
+	return core.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "valid-obj",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Data: map[string]string{"key": "value"},
+	}
+}

--- a/test/declarative_validation/core/endpoints/declarative_validation_test.go
+++ b/test/declarative_validation/core/endpoints/declarative_validation_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoints
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	core "k8s.io/kubernetes/pkg/apis/core"
+	registry "k8s.io/kubernetes/pkg/registry/core/endpoint"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
+)
+
+// TODO: remove this apiVersions variable once coverage tests are generated for this package.
+var apiVersions = []string{"v1"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateUpdate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "api",
+		APIGroup:          "",
+		APIVersion:        apiVersion,
+		Resource:          "endpoints",
+		IsResourceRequest: true,
+		Verb:              "create",
+	}), metav1.NamespaceDefault)
+
+	obj := mkValidEndpoints()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "api",
+		APIGroup:          "",
+		APIVersion:        apiVersion,
+		Resource:          "endpoints",
+		Name:              "valid-obj",
+		IsResourceRequest: true,
+		Verb:              "update",
+	}), metav1.NamespaceDefault)
+
+	updateObj := mkValidEndpoints()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func mkValidEndpoints() core.Endpoints {
+	return core.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "valid-obj",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Subsets: []core.EndpointSubset{{
+			Addresses: []core.EndpointAddress{{IP: "1.2.3.4"}},
+			Ports:     []core.EndpointPort{{Port: 80, Protocol: core.ProtocolTCP}},
+		}},
+	}
+}

--- a/test/declarative_validation/core/limitrange/declarative_validation_test.go
+++ b/test/declarative_validation/core/limitrange/declarative_validation_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package limitrange
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	core "k8s.io/kubernetes/pkg/apis/core"
+	registry "k8s.io/kubernetes/pkg/registry/core/limitrange"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
+)
+
+// TODO: remove this apiVersions variable once coverage tests are generated for this package.
+var apiVersions = []string{"v1"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateUpdate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "api",
+		APIGroup:          "",
+		APIVersion:        apiVersion,
+		Resource:          "limitranges",
+		IsResourceRequest: true,
+		Verb:              "create",
+	}), metav1.NamespaceDefault)
+
+	obj := mkValidLimitRange()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "api",
+		APIGroup:          "",
+		APIVersion:        apiVersion,
+		Resource:          "limitranges",
+		Name:              "valid-obj",
+		IsResourceRequest: true,
+		Verb:              "update",
+	}), metav1.NamespaceDefault)
+
+	updateObj := mkValidLimitRange()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func mkValidLimitRange() core.LimitRange {
+	return core.LimitRange{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "valid-obj",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: core.LimitRangeSpec{
+			Limits: []core.LimitRangeItem{},
+		},
+	}
+}

--- a/test/declarative_validation/core/namespace/declarative_validation_test.go
+++ b/test/declarative_validation/core/namespace/declarative_validation_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	core "k8s.io/kubernetes/pkg/apis/core"
+	registry "k8s.io/kubernetes/pkg/registry/core/namespace"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
+)
+
+// TODO: remove this apiVersions variable once coverage tests are generated for this package.
+var apiVersions = []string{"v1"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateUpdate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "api",
+		APIGroup:          "",
+		APIVersion:        apiVersion,
+		Resource:          "namespaces",
+		IsResourceRequest: true,
+		Verb:              "create",
+	})
+
+	obj := mkValidNamespace()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "api",
+		APIGroup:          "",
+		APIVersion:        apiVersion,
+		Resource:          "namespaces",
+		Name:              "valid-obj",
+		IsResourceRequest: true,
+		Verb:              "update",
+	})
+
+	updateObj := mkValidNamespace()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func mkValidNamespace() core.Namespace {
+	return core.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "valid-obj",
+		},
+	}
+}

--- a/test/declarative_validation/core/node/declarative_validation_test.go
+++ b/test/declarative_validation/core/node/declarative_validation_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	core "k8s.io/kubernetes/pkg/apis/core"
+	registry "k8s.io/kubernetes/pkg/registry/core/node"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
+)
+
+// TODO: remove this apiVersions variable once coverage tests are generated for this package.
+var apiVersions = []string{"v1"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateUpdate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "api",
+		APIGroup:          "",
+		APIVersion:        apiVersion,
+		Resource:          "nodes",
+		IsResourceRequest: true,
+		Verb:              "create",
+	})
+
+	obj := mkValidNode()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "api",
+		APIGroup:          "",
+		APIVersion:        apiVersion,
+		Resource:          "nodes",
+		Name:              "valid-obj",
+		IsResourceRequest: true,
+		Verb:              "update",
+	})
+
+	updateObj := mkValidNode()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func mkValidNode() core.Node {
+	return core.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "valid-obj",
+		},
+	}
+}

--- a/test/declarative_validation/core/persistentvolume/declarative_validation_test.go
+++ b/test/declarative_validation/core/persistentvolume/declarative_validation_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package persistentvolume
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	core "k8s.io/kubernetes/pkg/apis/core"
+	registry "k8s.io/kubernetes/pkg/registry/core/persistentvolume"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
+)
+
+// TODO: remove this apiVersions variable once coverage tests are generated for this package.
+var apiVersions = []string{"v1"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateUpdate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "api",
+		APIGroup:          "",
+		APIVersion:        apiVersion,
+		Resource:          "persistentvolumes",
+		IsResourceRequest: true,
+		Verb:              "create",
+	})
+
+	obj := mkValidPersistentVolume()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "api",
+		APIGroup:          "",
+		APIVersion:        apiVersion,
+		Resource:          "persistentvolumes",
+		Name:              "valid-obj",
+		IsResourceRequest: true,
+		Verb:              "update",
+	})
+
+	updateObj := mkValidPersistentVolume()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func mkValidPersistentVolume() core.PersistentVolume {
+	return core.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "valid-obj",
+		},
+		Spec: core.PersistentVolumeSpec{
+			Capacity:    core.ResourceList{core.ResourceStorage: resource.MustParse("1Gi")},
+			AccessModes: []core.PersistentVolumeAccessMode{core.ReadWriteOnce},
+			PersistentVolumeSource: core.PersistentVolumeSource{
+				HostPath: &core.HostPathVolumeSource{Path: "/tmp"},
+			},
+		},
+	}
+}

--- a/test/declarative_validation/core/persistentvolumeclaim/declarative_validation_test.go
+++ b/test/declarative_validation/core/persistentvolumeclaim/declarative_validation_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package persistentvolumeclaim
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	core "k8s.io/kubernetes/pkg/apis/core"
+	registry "k8s.io/kubernetes/pkg/registry/core/persistentvolumeclaim"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
+)
+
+// TODO: remove this apiVersions variable once coverage tests are generated for this package.
+var apiVersions = []string{"v1"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateUpdate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "api",
+		APIGroup:          "",
+		APIVersion:        apiVersion,
+		Resource:          "persistentvolumeclaims",
+		IsResourceRequest: true,
+		Verb:              "create",
+	}), metav1.NamespaceDefault)
+
+	obj := mkValidPersistentVolumeClaim()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "api",
+		APIGroup:          "",
+		APIVersion:        apiVersion,
+		Resource:          "persistentvolumeclaims",
+		Name:              "valid-obj",
+		IsResourceRequest: true,
+		Verb:              "update",
+	}), metav1.NamespaceDefault)
+
+	updateObj := mkValidPersistentVolumeClaim()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func mkValidPersistentVolumeClaim() core.PersistentVolumeClaim {
+	return core.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "valid-obj",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: core.PersistentVolumeClaimSpec{
+			AccessModes: []core.PersistentVolumeAccessMode{core.ReadWriteOnce},
+			Resources: core.VolumeResourceRequirements{
+				Requests: core.ResourceList{core.ResourceStorage: resource.MustParse("1Gi")},
+			},
+		},
+	}
+}

--- a/test/declarative_validation/core/pod/declarative_validation_test.go
+++ b/test/declarative_validation/core/pod/declarative_validation_test.go
@@ -25,13 +25,17 @@ import (
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	registry "k8s.io/kubernetes/pkg/registry/core/pod"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 )
 
 func TestDeclarativeValidate(t *testing.T) {
 	for _, apiVersion := range apiVersions {
 		ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-			APIGroup:   "",
-			APIVersion: apiVersion,
+			APIPrefix:         "api",
+			APIGroup:          "",
+			APIVersion:        apiVersion,
+			IsResourceRequest: true,
+			Verb:              "create",
 		})
 		testCases := map[string]struct {
 			input        *api.Pod
@@ -69,5 +73,22 @@ func TestDeclarativeValidate(t *testing.T) {
 				apitesting.VerifyValidationEquivalence(t, ctx, tc.input, registry.Strategy, tc.expectedErrs)
 			})
 		}
+		obj := *podtest.MakePod("foo")
+		meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+			APIPrefix:         "api",
+			APIGroup:          "",
+			APIVersion:        apiVersion,
+			Name:              "valid-obj",
+			IsResourceRequest: true,
+			Verb:              "update",
+		})
+		updateObj := *podtest.MakePod("foo")
+		meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 	}
 }

--- a/test/declarative_validation/core/podtemplate/declarative_validation_test.go
+++ b/test/declarative_validation/core/podtemplate/declarative_validation_test.go
@@ -26,6 +26,7 @@ import (
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	registry "k8s.io/kubernetes/pkg/registry/core/podtemplate"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 )
 
 func mkPodTemplate(tolerations ...api.Toleration) *api.PodTemplate {
@@ -41,8 +42,11 @@ func mkPodTemplate(tolerations ...api.Toleration) *api.PodTemplate {
 func TestDeclarativeValidate(t *testing.T) {
 	for _, apiVersion := range apiVersions {
 		ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-			APIGroup:   "",
-			APIVersion: apiVersion,
+			APIPrefix:         "api",
+			APIGroup:          "",
+			APIVersion:        apiVersion,
+			IsResourceRequest: true,
+			Verb:              "create",
 		})
 		testCases := map[string]struct {
 			input        *api.PodTemplate
@@ -69,5 +73,22 @@ func TestDeclarativeValidate(t *testing.T) {
 				apitesting.VerifyValidationEquivalence(t, ctx, tc.input, registry.Strategy, tc.expectedErrs)
 			})
 		}
+		obj := *mkPodTemplate()
+		meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+			APIPrefix:         "api",
+			APIGroup:          "",
+			APIVersion:        apiVersion,
+			Name:              "valid-obj",
+			IsResourceRequest: true,
+			Verb:              "update",
+		})
+		updateObj := *mkPodTemplate()
+		meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 	}
 }

--- a/test/declarative_validation/core/replicationcontroller/declarative_validation_test.go
+++ b/test/declarative_validation/core/replicationcontroller/declarative_validation_test.go
@@ -18,6 +18,7 @@ package replicationcontroller
 
 import (
 	"fmt"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 	"strings"
 	"testing"
 
@@ -33,8 +34,12 @@ import (
 
 func TestDeclarativeValidate(t *testing.T) {
 	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-		APIGroup:   "",
-		APIVersion: "v1",
+		APIPrefix:         "api",
+		APIGroup:          "",
+		APIVersion:        "v1",
+		Resource:          "replicationcontrollers",
+		IsResourceRequest: true,
+		Verb:              "create",
 	})
 	testCases := map[string]struct {
 		input        api.ReplicationController
@@ -206,12 +211,19 @@ func TestDeclarativeValidate(t *testing.T) {
 			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, registry.Strategy, tc.expectedErrs)
 		})
 	}
+	obj := mkValidReplicationController()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func TestDeclarativeValidateUpdate(t *testing.T) {
 	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-		APIGroup:   "",
-		APIVersion: "v1",
+		APIPrefix:         "api",
+		APIGroup:          "",
+		APIVersion:        "v1",
+		Resource:          "replicationcontrollers",
+		Name:              "valid-obj",
+		IsResourceRequest: true,
+		Verb:              "update",
 	})
 	testCases := map[string]struct {
 		old          api.ReplicationController
@@ -291,6 +303,8 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, registry.Strategy, tc.expectedErrs)
 		})
 	}
+	updateObj := mkValidReplicationController()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 // mkValidReplicationController produces a ReplicationController which passes

--- a/test/declarative_validation/core/replicationcontroller/declarative_validation_test.go
+++ b/test/declarative_validation/core/replicationcontroller/declarative_validation_test.go
@@ -18,7 +18,6 @@ package replicationcontroller
 
 import (
 	"fmt"
-	"k8s.io/kubernetes/test/declarative_validation/meta"
 	"strings"
 	"testing"
 
@@ -29,6 +28,7 @@ import (
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	registry "k8s.io/kubernetes/pkg/registry/core/replicationcontroller"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 	"k8s.io/utils/ptr"
 )
 

--- a/test/declarative_validation/core/resourcequota/declarative_validation_test.go
+++ b/test/declarative_validation/core/resourcequota/declarative_validation_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcequota
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	core "k8s.io/kubernetes/pkg/apis/core"
+	registry "k8s.io/kubernetes/pkg/registry/core/resourcequota"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
+)
+
+// TODO: remove this apiVersions variable once coverage tests are generated for this package.
+var apiVersions = []string{"v1"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateUpdate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "api",
+		APIGroup:          "",
+		APIVersion:        apiVersion,
+		Resource:          "resourcequotas",
+		IsResourceRequest: true,
+		Verb:              "create",
+	}), metav1.NamespaceDefault)
+
+	obj := mkValidResourceQuota()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "api",
+		APIGroup:          "",
+		APIVersion:        apiVersion,
+		Resource:          "resourcequotas",
+		Name:              "valid-obj",
+		IsResourceRequest: true,
+		Verb:              "update",
+	}), metav1.NamespaceDefault)
+
+	updateObj := mkValidResourceQuota()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func mkValidResourceQuota() core.ResourceQuota {
+	return core.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "valid-obj",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: core.ResourceQuotaSpec{},
+	}
+}

--- a/test/declarative_validation/core/secret/declarative_validation_test.go
+++ b/test/declarative_validation/core/secret/declarative_validation_test.go
@@ -25,12 +25,16 @@ import (
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	registry "k8s.io/kubernetes/pkg/registry/core/secret"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 )
 
 func TestDeclarativeValidate(t *testing.T) {
 	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-		APIGroup:   "",
-		APIVersion: "v1",
+		APIPrefix:         "api",
+		APIGroup:          "",
+		APIVersion:        "v1",
+		IsResourceRequest: true,
+		Verb:              "create",
 	})
 	testCases := map[string]struct {
 		input        api.Secret
@@ -45,12 +49,18 @@ func TestDeclarativeValidate(t *testing.T) {
 			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, registry.Strategy, tc.expectedErrs)
 		})
 	}
+	obj := mkValidSecret()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func TestDeclarativeValidateUpdate(t *testing.T) {
 	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-		APIGroup:   "",
-		APIVersion: "v1",
+		APIPrefix:         "api",
+		APIGroup:          "",
+		APIVersion:        "v1",
+		Name:              "valid-obj",
+		IsResourceRequest: true,
+		Verb:              "update",
 	})
 	testCases := map[string]struct {
 		old          api.Secret
@@ -90,6 +100,9 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, registry.Strategy, tc.expectedErrs)
 		})
 	}
+
+	updateObj := mkValidSecret()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func mkValidSecret(tweaks ...func(*api.Secret)) api.Secret {

--- a/test/declarative_validation/core/service/declarative_validation_test.go
+++ b/test/declarative_validation/core/service/declarative_validation_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	core "k8s.io/kubernetes/pkg/apis/core"
+	registry "k8s.io/kubernetes/pkg/registry/core/service"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
+)
+
+// TODO: remove this apiVersions variable once coverage tests are generated for this package.
+var apiVersions = []string{"v1"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateUpdate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "api",
+		APIGroup:          "",
+		APIVersion:        apiVersion,
+		Resource:          "services",
+		IsResourceRequest: true,
+		Verb:              "create",
+	}), metav1.NamespaceDefault)
+
+	obj := mkValidService()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "api",
+		APIGroup:          "",
+		APIVersion:        apiVersion,
+		Resource:          "services",
+		Name:              "valid-obj",
+		IsResourceRequest: true,
+		Verb:              "update",
+	}), metav1.NamespaceDefault)
+
+	updateObj := mkValidService()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func mkValidService() core.Service {
+	itp := core.ServiceInternalTrafficPolicyCluster
+	return core.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "valid-obj",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: core.ServiceSpec{
+			InternalTrafficPolicy: &itp,
+			Type:                  core.ServiceTypeClusterIP,
+			SessionAffinity:       core.ServiceAffinityNone,
+			Ports: []core.ServicePort{
+				{
+					Name:       "http",
+					Protocol:   core.ProtocolTCP,
+					Port:       80,
+					TargetPort: intstr.FromInt32(8080),
+				},
+			},
+		},
+	}
+}

--- a/test/declarative_validation/core/serviceaccount/declarative_validation_test.go
+++ b/test/declarative_validation/core/serviceaccount/declarative_validation_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serviceaccount
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	core "k8s.io/kubernetes/pkg/apis/core"
+	registry "k8s.io/kubernetes/pkg/registry/core/serviceaccount"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
+)
+
+// TODO: remove this apiVersions variable once coverage tests are generated for this package.
+var apiVersions = []string{"v1"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateUpdate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "api",
+		APIGroup:          "",
+		APIVersion:        apiVersion,
+		Resource:          "serviceaccounts",
+		IsResourceRequest: true,
+		Verb:              "create",
+	}), metav1.NamespaceDefault)
+
+	obj := mkValidServiceAccount()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "api",
+		APIGroup:          "",
+		APIVersion:        apiVersion,
+		Resource:          "serviceaccounts",
+		Name:              "valid-obj",
+		IsResourceRequest: true,
+		Verb:              "update",
+	}), metav1.NamespaceDefault)
+
+	updateObj := mkValidServiceAccount()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func mkValidServiceAccount() core.ServiceAccount {
+	return core.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "valid-obj",
+			Namespace: metav1.NamespaceDefault,
+		},
+	}
+}

--- a/test/declarative_validation/discovery/endpointslice/declarative_validation_test.go
+++ b/test/declarative_validation/discovery/endpointslice/declarative_validation_test.go
@@ -18,6 +18,7 @@ package endpointslice
 
 import (
 	"fmt"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,6 +39,7 @@ func TestDeclarativeValidate(t *testing.T) {
 
 func testDeclarativeValidate(t *testing.T, apiVersion string) {
 	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
 		APIGroup:          "discovery.k8s.io",
 		APIVersion:        apiVersion,
 		Resource:          "endpointslices",
@@ -87,6 +89,8 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, registry.Strategy, tc.expectedErrs)
 		})
 	}
+	obj := mkValidEndpointSlice()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func TestDeclarativeValidateUpdate(t *testing.T) {
@@ -98,6 +102,15 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 }
 
 func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "discovery.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "endpointslices",
+		Name:              "valid-endpointslice",
+		IsResourceRequest: true,
+		Verb:              "update",
+	})
 	testCases := map[string]struct {
 		oldObj       discovery.EndpointSlice
 		updateObj    discovery.EndpointSlice
@@ -137,20 +150,13 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-				APIPrefix:         "apis",
-				APIGroup:          "discovery.k8s.io",
-				APIVersion:        apiVersion,
-				Resource:          "endpointslices",
-				Name:              "valid-endpointslice",
-				IsResourceRequest: true,
-				Verb:              "update",
-			})
 			tc.oldObj.ResourceVersion = "1"
 			tc.updateObj.ResourceVersion = "2"
 			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, registry.Strategy, tc.expectedErrs)
 		})
 	}
+	updateObj := mkValidEndpointSlice()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func mkValidEndpointSlice(tweaks ...func(obj *discovery.EndpointSlice)) discovery.EndpointSlice {

--- a/test/declarative_validation/meta/objectmeta.go
+++ b/test/declarative_validation/meta/objectmeta.go
@@ -32,8 +32,32 @@ import (
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 )
 
-func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context, baseObj T, strategy rest.RESTCreateStrategy, options ...apitesting.ValidationTestConfig) {
+type Option func(*runOptions)
+
+type runOptions struct {
+	// TODO: Remove this after ensuring consistency between ObjectMeta finalizer validations for all types.
+	stringentFinalizerValidation bool
+	validationConfigs            []apitesting.ValidationTestConfig
+}
+
+func WithStringentFinalizerValidation() Option {
+	return func(o *runOptions) {
+		o.stringentFinalizerValidation = true
+	}
+}
+
+func WithValidationConfig(configs ...apitesting.ValidationTestConfig) Option {
+	return func(o *runOptions) {
+		o.validationConfigs = append(o.validationConfigs, configs...)
+	}
+}
+
+func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context, baseObj T, strategy rest.RESTCreateStrategy, opts ...Option) {
 	t.Helper()
+	o := &runOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
 	fldPath := field.NewPath("metadata")
 	trueVar := true
 
@@ -185,9 +209,15 @@ func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context,
 			Modify: func(meta metav1.Object) {
 				meta.SetFinalizers([]string{strings.Repeat("a", 317)})
 			},
-			ExpectedErrs: field.ErrorList{
-				field.Invalid(fldPath.Child("finalizers"), "", "").MarkFromImperative(),
-			},
+			ExpectedErrs: func() field.ErrorList {
+				errs := field.ErrorList{
+					field.Invalid(fldPath.Child("finalizers"), "", "").MarkFromImperative(),
+				}
+				if o.stringentFinalizerValidation {
+					errs = append(errs, field.Invalid(fldPath.Child("finalizers").Index(0), strings.Repeat("a", 317), "name is neither a standard finalizer name nor is it fully qualified").MarkFromImperative())
+				}
+				return errs
+			}(),
 		},
 		{
 			Name: "managedFields: invalid operation",
@@ -250,6 +280,21 @@ func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context,
 				})
 			},
 			ExpectedErrs: field.ErrorList{},
+		},
+		{
+			Name: "finalizers: name too long",
+			Modify: func(meta metav1.Object) {
+				meta.SetFinalizers([]string{strings.Repeat("a", 317)})
+			},
+			ExpectedErrs: func() field.ErrorList {
+				errs := field.ErrorList{
+					field.Invalid(fldPath.Child("finalizers"), "", "").MarkFromImperative(),
+				}
+				if o.stringentFinalizerValidation {
+					errs = append(errs, field.Invalid(fldPath.Child("finalizers").Index(0), strings.Repeat("a", 317), "name is neither a standard finalizer name nor is it fully qualified").MarkFromImperative())
+				}
+				return errs
+			}(),
 		},
 		{
 			Name: "labels: invalid key format",
@@ -364,13 +409,17 @@ func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context,
 			} else {
 				t.Fatalf("failed to get accessor: %v", err)
 			}
-			apitesting.VerifyValidationEquivalence(t, ctx, obj, strategy, tc.ExpectedErrs, options...)
+			apitesting.VerifyValidationEquivalence(t, ctx, obj, strategy, tc.ExpectedErrs, o.validationConfigs...)
 		})
 	}
 }
 
-func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Context, baseObj T, strategy rest.RESTUpdateStrategy, options ...apitesting.ValidationTestConfig) {
+func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Context, baseObj T, strategy rest.RESTUpdateStrategy, opts ...Option) {
 	t.Helper()
+	o := &runOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
 	fldPath := field.NewPath("metadata")
 	t1 := metav1.NewTime(time.Unix(1000, 0).UTC())
 	t2 := metav1.NewTime(time.Unix(2000, 0).UTC())
@@ -488,9 +537,15 @@ func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Co
 			Modify: func(old, new metav1.Object) {
 				new.SetFinalizers([]string{strings.Repeat("a", 317)})
 			},
-			ExpectedErrs: field.ErrorList{
-				field.Invalid(fldPath.Child("finalizers"), "", "").MarkFromImperative(),
-			},
+			ExpectedErrs: func() field.ErrorList {
+				errs := field.ErrorList{
+					field.Invalid(fldPath.Child("finalizers"), "", "").MarkFromImperative(),
+				}
+				if o.stringentFinalizerValidation {
+					errs = append(errs, field.Invalid(fldPath.Child("finalizers").Index(0), strings.Repeat("a", 317), "name is neither a standard finalizer name nor is it fully qualified").MarkFromImperative())
+				}
+				return errs
+			}(),
 		},
 		{
 			Name: "update: managedFields: subresource too long",
@@ -502,6 +557,21 @@ func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Co
 			ExpectedErrs: field.ErrorList{
 				field.TooLong(fldPath.Child("managedFields").Index(0).Child("subresource"), "", 0).MarkFromImperative(),
 			},
+		},
+		{
+			Name: "update: finalizers: name too long",
+			Modify: func(old, new metav1.Object) {
+				new.SetFinalizers([]string{strings.Repeat("a", 317)})
+			},
+			ExpectedErrs: func() field.ErrorList {
+				errs := field.ErrorList{
+					field.Invalid(fldPath.Child("finalizers"), "", "").MarkFromImperative(),
+				}
+				if o.stringentFinalizerValidation {
+					errs = append(errs, field.Invalid(fldPath.Child("finalizers").Index(0), strings.Repeat("a", 317), "name is neither a standard finalizer name nor is it fully qualified").MarkFromImperative())
+				}
+				return errs
+			}(),
 		},
 		{
 			Name: "update: labels: invalid key format",
@@ -577,7 +647,7 @@ func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Co
 			oldAcc.SetResourceVersion("1")
 			newAcc.SetResourceVersion("2")
 			tc.Modify(oldAcc, newAcc)
-			apitesting.VerifyUpdateValidationEquivalence(t, ctx, currNew, currOld, strategy, tc.ExpectedErrs, options...)
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, currNew, currOld, strategy, tc.ExpectedErrs, o.validationConfigs...)
 		})
 	}
 }

--- a/test/declarative_validation/meta/objectmeta.go
+++ b/test/declarative_validation/meta/objectmeta.go
@@ -282,21 +282,6 @@ func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context,
 			ExpectedErrs: field.ErrorList{},
 		},
 		{
-			Name: "finalizers: name too long",
-			Modify: func(meta metav1.Object) {
-				meta.SetFinalizers([]string{strings.Repeat("a", 317)})
-			},
-			ExpectedErrs: func() field.ErrorList {
-				errs := field.ErrorList{
-					field.Invalid(fldPath.Child("finalizers"), "", "").MarkFromImperative(),
-				}
-				if o.stringentFinalizerValidation {
-					errs = append(errs, field.Invalid(fldPath.Child("finalizers").Index(0), strings.Repeat("a", 317), "name is neither a standard finalizer name nor is it fully qualified").MarkFromImperative())
-				}
-				return errs
-			}(),
-		},
-		{
 			Name: "labels: invalid key format",
 			Modify: func(meta metav1.Object) {
 				meta.SetLabels(map[string]string{
@@ -557,21 +542,6 @@ func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Co
 			ExpectedErrs: field.ErrorList{
 				field.TooLong(fldPath.Child("managedFields").Index(0).Child("subresource"), "", 0).MarkFromImperative(),
 			},
-		},
-		{
-			Name: "update: finalizers: name too long",
-			Modify: func(old, new metav1.Object) {
-				new.SetFinalizers([]string{strings.Repeat("a", 317)})
-			},
-			ExpectedErrs: func() field.ErrorList {
-				errs := field.ErrorList{
-					field.Invalid(fldPath.Child("finalizers"), "", "").MarkFromImperative(),
-				}
-				if o.stringentFinalizerValidation {
-					errs = append(errs, field.Invalid(fldPath.Child("finalizers").Index(0), strings.Repeat("a", 317), "name is neither a standard finalizer name nor is it fully qualified").MarkFromImperative())
-				}
-				return errs
-			}(),
 		},
 		{
 			Name: "update: labels: invalid key format",

--- a/test/declarative_validation/networking/ingress/declarative_validation_test.go
+++ b/test/declarative_validation/networking/ingress/declarative_validation_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	networking "k8s.io/kubernetes/pkg/apis/networking"
+	registry "k8s.io/kubernetes/pkg/registry/networking/ingress"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
+)
+
+// TODO: remove this apiVersions variable once coverage tests are generated for this package.
+var apiVersions = []string{"v1", "v1beta1"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateUpdate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "networking.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "ingresses",
+		IsResourceRequest: true,
+		Verb:              "create",
+	}), metav1.NamespaceDefault)
+
+	obj := mkValidIngress()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "networking.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "ingresses",
+		Name:              "valid-obj",
+		IsResourceRequest: true,
+		Verb:              "update",
+	}), metav1.NamespaceDefault)
+
+	updateObj := mkValidIngress()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func mkValidIngress() networking.Ingress {
+	return networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "valid-obj",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: networking.IngressSpec{
+			DefaultBackend: &networking.IngressBackend{
+				Service: &networking.IngressServiceBackend{
+					Name: "default-backend",
+					Port: networking.ServiceBackendPort{
+						Number: 80,
+					},
+				},
+			},
+		},
+	}
+}

--- a/test/declarative_validation/networking/ingressclass/declarative_validation_test.go
+++ b/test/declarative_validation/networking/ingressclass/declarative_validation_test.go
@@ -25,6 +25,7 @@ import (
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	networking "k8s.io/kubernetes/pkg/apis/networking"
 	registry "k8s.io/kubernetes/pkg/registry/networking/ingressclass"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 )
 
 func TestDeclarativeValidateParameter(t *testing.T) {
@@ -33,6 +34,7 @@ func TestDeclarativeValidateParameter(t *testing.T) {
 			ctx := genericapirequest.WithRequestInfo(
 				genericapirequest.NewDefaultContext(),
 				&genericapirequest.RequestInfo{
+					APIPrefix:         "apis",
 					APIGroup:          "networking.k8s.io",
 					APIVersion:        apiVersion,
 					Resource:          "ingressclasses",
@@ -80,6 +82,8 @@ func TestDeclarativeValidateParameter(t *testing.T) {
 					)
 				})
 			}
+			obj := mkValidIngressClass()
+			meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
 		})
 	}
 }
@@ -135,20 +139,20 @@ func TestDeclarativeValidateUpdateParameters(t *testing.T) {
 				},
 			}
 
+			ctx := genericapirequest.WithRequestInfo(
+				genericapirequest.NewDefaultContext(),
+				&genericapirequest.RequestInfo{
+					APIPrefix:         "apis",
+					APIGroup:          "networking.k8s.io",
+					APIVersion:        apiVersion,
+					Resource:          "ingressclasses",
+					Name:              "valid-ingress-class",
+					IsResourceRequest: true,
+					Verb:              "update",
+				},
+			)
 			for name, tc := range testCases {
 				t.Run(name, func(t *testing.T) {
-					ctx := genericapirequest.WithRequestInfo(
-						genericapirequest.NewDefaultContext(),
-						&genericapirequest.RequestInfo{
-							APIPrefix:         "apis",
-							APIGroup:          "networking.k8s.io",
-							APIVersion:        apiVersion,
-							Resource:          "ingressclasses",
-							Name:              "valid-ingress-class",
-							IsResourceRequest: true,
-							Verb:              "update",
-						},
-					)
 					apitesting.VerifyUpdateValidationEquivalence(
 						t,
 						ctx,
@@ -159,6 +163,9 @@ func TestDeclarativeValidateUpdateParameters(t *testing.T) {
 					)
 				})
 			}
+
+			updateObj := mkValidIngressClass()
+			meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 		})
 	}
 }

--- a/test/declarative_validation/networking/ipaddress/declarative_validation_test.go
+++ b/test/declarative_validation/networking/ipaddress/declarative_validation_test.go
@@ -25,6 +25,7 @@ import (
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	networking "k8s.io/kubernetes/pkg/apis/networking"
 	registry "k8s.io/kubernetes/pkg/registry/networking/ipaddress"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 )
 
 func TestDeclarativeValidateIPAddress(t *testing.T) {
@@ -33,6 +34,7 @@ func TestDeclarativeValidateIPAddress(t *testing.T) {
 			ctx := genericapirequest.WithRequestInfo(
 				genericapirequest.NewDefaultContext(),
 				&genericapirequest.RequestInfo{
+					APIPrefix:         "apis",
 					APIGroup:          "networking.k8s.io",
 					APIVersion:        apiVersion,
 					Resource:          "ipaddresses",
@@ -78,6 +80,9 @@ func TestDeclarativeValidateIPAddress(t *testing.T) {
 					)
 				})
 			}
+
+			obj := mkValidIPAddress()
+			meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
 		})
 	}
 }
@@ -85,6 +90,18 @@ func TestDeclarativeValidateIPAddress(t *testing.T) {
 func TestDeclarativeValidateIPAddressUpdate(t *testing.T) {
 	for _, apiVersion := range apiVersions {
 		t.Run(apiVersion, func(t *testing.T) {
+			ctx := genericapirequest.WithRequestInfo(
+				genericapirequest.NewDefaultContext(),
+				&genericapirequest.RequestInfo{
+					APIPrefix:         "apis",
+					APIGroup:          "networking.k8s.io",
+					APIVersion:        apiVersion,
+					Resource:          "ipaddresses",
+					Name:              "valid-obj",
+					IsResourceRequest: true,
+					Verb:              "update",
+				},
+			)
 			testCases := map[string]struct {
 				oldObj       networking.IPAddress
 				updateObj    networking.IPAddress
@@ -156,7 +173,7 @@ func TestDeclarativeValidateIPAddressUpdate(t *testing.T) {
 							APIGroup:          "networking.k8s.io",
 							APIVersion:        apiVersion,
 							Resource:          "ipaddresses",
-							Name:              "192.168.1.1",
+							Name:              "valid-obj",
 							IsResourceRequest: true,
 							Verb:              "update",
 						},
@@ -172,6 +189,8 @@ func TestDeclarativeValidateIPAddressUpdate(t *testing.T) {
 					)
 				})
 			}
+			updateObj := mkValidIPAddress()
+			meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 		})
 	}
 }

--- a/test/declarative_validation/networking/networkpolicy/declarative_validation_test.go
+++ b/test/declarative_validation/networking/networkpolicy/declarative_validation_test.go
@@ -25,6 +25,7 @@ import (
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	networking "k8s.io/kubernetes/pkg/apis/networking"
 	registry "k8s.io/kubernetes/pkg/registry/networking/networkpolicy"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 )
 
 func TestDeclarativeValidateIPBlockCIDR(t *testing.T) {
@@ -34,6 +35,7 @@ func TestDeclarativeValidateIPBlockCIDR(t *testing.T) {
 			ctx := genericapirequest.WithRequestInfo(
 				genericapirequest.NewDefaultContext(),
 				&genericapirequest.RequestInfo{
+					APIPrefix:         "apis",
 					APIGroup:          "networking.k8s.io",
 					APIVersion:        apiVersion,
 					Resource:          "networkpolicies",
@@ -86,6 +88,9 @@ func TestDeclarativeValidateIPBlockCIDR(t *testing.T) {
 					)
 				})
 			}
+
+			obj := mkValidNetworkPolicy("ingress")
+			meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
 		})
 	}
 }
@@ -93,6 +98,18 @@ func TestDeclarativeValidateIPBlockCIDR(t *testing.T) {
 func TestDeclarativeValidateIPBlockCIDRUpdate(t *testing.T) {
 	for _, apiVersion := range apiVersions {
 		t.Run(apiVersion, func(t *testing.T) {
+			ctx := genericapirequest.WithRequestInfo(
+				genericapirequest.NewDefaultContext(),
+				&genericapirequest.RequestInfo{
+					APIPrefix:         "apis",
+					APIGroup:          "networking.k8s.io",
+					APIVersion:        apiVersion,
+					Resource:          "networkpolicies",
+					Name:              "valid-network-policy",
+					IsResourceRequest: true,
+					Verb:              "update",
+				},
+			)
 			testCases := map[string]struct {
 				oldObj       networking.NetworkPolicy
 				updateObj    networking.NetworkPolicy
@@ -131,19 +148,6 @@ func TestDeclarativeValidateIPBlockCIDRUpdate(t *testing.T) {
 
 			for name, tc := range testCases {
 				t.Run(name, func(t *testing.T) {
-					ctx := genericapirequest.WithRequestInfo(
-						genericapirequest.NewDefaultContext(),
-						&genericapirequest.RequestInfo{
-							APIPrefix:         "apis",
-							APIGroup:          "networking.k8s.io",
-							APIVersion:        apiVersion,
-							Resource:          "networkpolicies",
-							Name:              "valid-network-policy",
-							IsResourceRequest: true,
-							Verb:              "update",
-						},
-					)
-
 					apitesting.VerifyUpdateValidationEquivalence(
 						t,
 						ctx,
@@ -157,6 +161,8 @@ func TestDeclarativeValidateIPBlockCIDRUpdate(t *testing.T) {
 					)
 				})
 			}
+			updateObj := mkValidNetworkPolicy("ingress")
+			meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 		})
 	}
 }

--- a/test/declarative_validation/networking/servicecidr/declarative_validation_test.go
+++ b/test/declarative_validation/networking/servicecidr/declarative_validation_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicecidr
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	networking "k8s.io/kubernetes/pkg/apis/networking"
+	registry "k8s.io/kubernetes/pkg/registry/networking/servicecidr"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
+)
+
+// TODO: remove this apiVersions variable once coverage tests are generated for this package.
+var apiVersions = []string{"v1", "v1beta1"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateUpdate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "networking.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "servicecidrs",
+		IsResourceRequest: true,
+		Verb:              "create",
+	}), metav1.NamespaceDefault)
+
+	obj := mkValidServiceCIDR()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "networking.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "servicecidrs",
+		Name:              "valid-obj",
+		IsResourceRequest: true,
+		Verb:              "update",
+	}), metav1.NamespaceDefault)
+
+	updateObj := mkValidServiceCIDR()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func mkValidServiceCIDR() networking.ServiceCIDR {
+	return networking.ServiceCIDR{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "valid-obj",
+		},
+		Spec: networking.ServiceCIDRSpec{
+			CIDRs: []string{"10.0.0.0/24"},
+		},
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR is a follow-up to PR #139568. As established in that PR, this uses the template to wire the `objectMeta` test cases into the declarative validation tests for the remaining API groups. 

Specifically, this PR wires the declarative validation tests for the following API groups:
- `apps`
- `autoscaling`
- `batch`
- `certificates`
- `core`
- `discovery`
- `networking`

Additionally, it adds support for `StringentFinalizerValidation` in the `objectMeta` test suite.

#### Which issue(s) this PR is related to:

Follow-up to #139568

#### Special notes for your reviewer:

This PR follows the same pattern established in #139568, expanding the `objectMeta` declarative validation test coverage to the API groups mentioned above.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

