### PR TITLE
Wire ObjectMeta test suite for storage, networking, scheduling, and other API groups

### DIFF
--- a/test/declarative_validation/coordination/lease/declarative_validation_test.go
+++ b/test/declarative_validation/coordination/lease/declarative_validation_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lease
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	coordination "k8s.io/kubernetes/pkg/apis/coordination"
+	registry "k8s.io/kubernetes/pkg/registry/coordination/lease"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
+)
+
+// TODO: remove this apiVersions variable once coverage tests are generated for this package.
+var apiVersions = []string{"v1", "v1beta1"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateUpdate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "coordination.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "leases",
+		IsResourceRequest: true,
+		Verb:              "create",
+	}), metav1.NamespaceDefault)
+
+	obj := mkValidLease()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy)
+}
+
+func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "coordination.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "leases",
+		Name:              "valid-obj",
+		IsResourceRequest: true,
+		Verb:              "update",
+	}), metav1.NamespaceDefault)
+
+	updateObj := mkValidLease()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy)
+}
+
+func mkValidLease() coordination.Lease {
+	return coordination.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "valid-obj",
+			Namespace: metav1.NamespaceDefault,
+		},
+	}
+}

--- a/test/declarative_validation/coordination/leasecandidate/declarative_validation_test.go
+++ b/test/declarative_validation/coordination/leasecandidate/declarative_validation_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leasecandidate
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	coordination "k8s.io/kubernetes/pkg/apis/coordination"
+	registry "k8s.io/kubernetes/pkg/registry/coordination/leasecandidate"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
+)
+
+// TODO: remove this apiVersions variable once coverage tests are generated for this package.
+var apiVersions = []string{"v1alpha2"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateUpdate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "coordination.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "leasecandidates",
+		IsResourceRequest: true,
+		Verb:              "create",
+	}), metav1.NamespaceDefault)
+
+	obj := mkValidLeaseCandidate()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy)
+}
+
+func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "coordination.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "leasecandidates",
+		Name:              "valid-obj",
+		IsResourceRequest: true,
+		Verb:              "update",
+	}), metav1.NamespaceDefault)
+
+	updateObj := mkValidLeaseCandidate()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy)
+}
+
+func mkValidLeaseCandidate() coordination.LeaseCandidate {
+	return coordination.LeaseCandidate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "valid-obj",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: coordination.LeaseCandidateSpec{
+			LeaseName:        "lease",
+			BinaryVersion:    "1.0.0",
+			EmulationVersion: "1.0.0",
+			Strategy:         coordination.OldestEmulationVersion,
+		},
+	}
+}

--- a/test/declarative_validation/flowcontrol/flowschema/declarative_validation_test.go
+++ b/test/declarative_validation/flowcontrol/flowschema/declarative_validation_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flowschema
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	flowcontrol "k8s.io/kubernetes/pkg/apis/flowcontrol"
+	registry "k8s.io/kubernetes/pkg/registry/flowcontrol/flowschema"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
+)
+
+// TODO: remove this apiVersions variable once coverage tests are generated for this package.
+var apiVersions = []string{"v1", "v1beta3"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateUpdate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "flowcontrol.apiserver.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "flowschemas",
+		IsResourceRequest: true,
+		Verb:              "create",
+	})
+
+	obj := mkValidFlowSchema()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "flowcontrol.apiserver.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "flowschemas",
+		Name:              "valid-obj",
+		IsResourceRequest: true,
+		Verb:              "update",
+	})
+
+	updateObj := mkValidFlowSchema()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func mkValidFlowSchema() flowcontrol.FlowSchema {
+	return flowcontrol.FlowSchema{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "valid-obj",
+		},
+		Spec: flowcontrol.FlowSchemaSpec{
+			MatchingPrecedence: 1000,
+			PriorityLevelConfiguration: flowcontrol.PriorityLevelConfigurationReference{
+				Name: "valid-priority-level",
+			},
+		},
+	}
+}

--- a/test/declarative_validation/flowcontrol/prioritylevelconfiguration/declarative_validation_test.go
+++ b/test/declarative_validation/flowcontrol/prioritylevelconfiguration/declarative_validation_test.go
@@ -23,8 +23,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
-	"k8s.io/kubernetes/pkg/apis/flowcontrol"
+	flowcontrol "k8s.io/kubernetes/pkg/apis/flowcontrol"
 	registry "k8s.io/kubernetes/pkg/registry/flowcontrol/prioritylevelconfiguration"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 )
 
 func TestDeclarativeValidate(t *testing.T) {
@@ -121,6 +122,8 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, registry.Strategy, tc.expectedErrs)
 		})
 	}
+	obj := mkPLC()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func TestDeclarativeValidateUpdate(t *testing.T) {
@@ -197,6 +200,18 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, registry.Strategy, tc.expectedErrs)
 		})
 	}
+
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "flowcontrol.apiserver.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "prioritylevelconfigurations",
+		Name:              "test-limited",
+		IsResourceRequest: true,
+		Verb:              "update",
+	})
+	updateObj := mkPLC()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 // mkPLC creates a valid Limited PriorityLevelConfiguration with Reject limit response.

--- a/test/declarative_validation/internal/storageversion/declarative_validation_test.go
+++ b/test/declarative_validation/internal/storageversion/declarative_validation_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storageversion
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/kubernetes/pkg/apis/apiserverinternal"
+	_ "k8s.io/kubernetes/pkg/apis/apiserverinternal/install"
+	registry "k8s.io/kubernetes/pkg/registry/apiserverinternal/storageversion"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
+)
+
+// TODO: remove this apiVersions variable once coverage tests are generated for this package.
+var apiVersions = []string{"v1alpha1"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateUpdate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "internal.apiserver.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "storageversions",
+		IsResourceRequest: true,
+		Verb:              "create",
+	})
+
+	obj := mkValidStorageVersion()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "internal.apiserver.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "storageversions",
+		Name:              "group.resource",
+		IsResourceRequest: true,
+		Verb:              "update",
+	})
+
+	updateObj := mkValidStorageVersion()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy)
+}
+
+func mkValidStorageVersion() apiserverinternal.StorageVersion {
+	return apiserverinternal.StorageVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "group.resource",
+		},
+	}
+}

--- a/test/declarative_validation/networking/ingress/declarative_validation_test.go
+++ b/test/declarative_validation/networking/ingress/declarative_validation_test.go
@@ -74,8 +74,8 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
-func mkValidIngress() networking.Ingress {
-	return networking.Ingress{
+func mkValidIngress(tweaks ...func(ing *networking.Ingress)) networking.Ingress {
+	ing := networking.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "valid-obj",
 			Namespace: metav1.NamespaceDefault,
@@ -91,4 +91,8 @@ func mkValidIngress() networking.Ingress {
 			},
 		},
 	}
+	for _, tweak := range tweaks {
+		tweak(&ing)
+	}
+	return ing
 }

--- a/test/declarative_validation/networking/ipaddress/declarative_validation_test.go
+++ b/test/declarative_validation/networking/ipaddress/declarative_validation_test.go
@@ -164,21 +164,20 @@ func TestDeclarativeValidateIPAddressUpdate(t *testing.T) {
 				},
 			}
 
+			ctx := genericapirequest.WithRequestInfo(
+				genericapirequest.NewDefaultContext(),
+				&genericapirequest.RequestInfo{
+					APIPrefix:         "apis",
+					APIGroup:          "networking.k8s.io",
+					APIVersion:        apiVersion,
+					Resource:          "ipaddresses",
+					Name:              "192.168.1.1",
+					IsResourceRequest: true,
+					Verb:              "update",
+				},
+			)
 			for name, tc := range testCases {
 				t.Run(name, func(t *testing.T) {
-					ctx := genericapirequest.WithRequestInfo(
-						genericapirequest.NewDefaultContext(),
-						&genericapirequest.RequestInfo{
-							APIPrefix:         "apis",
-							APIGroup:          "networking.k8s.io",
-							APIVersion:        apiVersion,
-							Resource:          "ipaddresses",
-							Name:              "valid-obj",
-							IsResourceRequest: true,
-							Verb:              "update",
-						},
-					)
-
 					apitesting.VerifyUpdateValidationEquivalence(
 						t,
 						ctx,
@@ -189,8 +188,8 @@ func TestDeclarativeValidateIPAddressUpdate(t *testing.T) {
 					)
 				})
 			}
-			updateObj := mkValidIPAddress()
-			meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
+			obj := mkValidIPAddress()
+			meta.RunObjectMetaUpdateTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
 		})
 	}
 }

--- a/test/declarative_validation/networking/ipaddress/declarative_validation_test.go
+++ b/test/declarative_validation/networking/ipaddress/declarative_validation_test.go
@@ -90,18 +90,6 @@ func TestDeclarativeValidateIPAddress(t *testing.T) {
 func TestDeclarativeValidateIPAddressUpdate(t *testing.T) {
 	for _, apiVersion := range apiVersions {
 		t.Run(apiVersion, func(t *testing.T) {
-			ctx := genericapirequest.WithRequestInfo(
-				genericapirequest.NewDefaultContext(),
-				&genericapirequest.RequestInfo{
-					APIPrefix:         "apis",
-					APIGroup:          "networking.k8s.io",
-					APIVersion:        apiVersion,
-					Resource:          "ipaddresses",
-					Name:              "valid-obj",
-					IsResourceRequest: true,
-					Verb:              "update",
-				},
-			)
 			testCases := map[string]struct {
 				oldObj       networking.IPAddress
 				updateObj    networking.IPAddress

--- a/test/declarative_validation/networking/servicecidr/declarative_validation_test.go
+++ b/test/declarative_validation/networking/servicecidr/declarative_validation_test.go
@@ -74,8 +74,8 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
-func mkValidServiceCIDR() networking.ServiceCIDR {
-	return networking.ServiceCIDR{
+func mkValidServiceCIDR(tweaks ...func(cidr *networking.ServiceCIDR)) networking.ServiceCIDR {
+	cidr := networking.ServiceCIDR{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "valid-obj",
 		},
@@ -83,4 +83,8 @@ func mkValidServiceCIDR() networking.ServiceCIDR {
 			CIDRs: []string{"10.0.0.0/24"},
 		},
 	}
+	for _, tweak := range tweaks {
+		tweak(&cidr)
+	}
+	return cidr
 }

--- a/test/declarative_validation/node/runtimeclass/declarative_validation_test.go
+++ b/test/declarative_validation/node/runtimeclass/declarative_validation_test.go
@@ -27,6 +27,7 @@ import (
 	node "k8s.io/kubernetes/pkg/apis/node"
 	"k8s.io/kubernetes/pkg/apis/node/validation"
 	registry "k8s.io/kubernetes/pkg/registry/node/runtimeclass"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 )
 
 func mkRuntimeClassHandlerOnly(tweaks ...func(*node.RuntimeClass)) node.RuntimeClass {
@@ -132,6 +133,9 @@ func TestRuntimeClass_DeclarativeValidate_Create(t *testing.T) {
 						apitesting.WithNormalizationRules(validation.NodeNormalizationRules...))
 				})
 			}
+
+			obj := mkRuntimeClassHandlerOnly()
+			meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithValidationConfig(apitesting.WithNormalizationRules(validation.NodeNormalizationRules...)))
 		})
 	}
 }
@@ -146,6 +150,11 @@ func TestRuntimeClass_DeclarativeValidate_Update(t *testing.T) {
 					APIVersion: apiVersion,
 				},
 			)
+
+			meta.RunObjectMetaUpdateTestCases(t, ctx, &node.RuntimeClass{
+				ObjectMeta: metav1.ObjectMeta{Name: "myrc"},
+				Handler:    "runc",
+			}, registry.Strategy, meta.WithValidationConfig(apitesting.WithNormalizationRules(validation.NodeNormalizationRules...)))
 
 			tests := map[string]struct {
 				oldObj, newObj node.RuntimeClass

--- a/test/declarative_validation/node/runtimeclass/declarative_validation_test.go
+++ b/test/declarative_validation/node/runtimeclass/declarative_validation_test.go
@@ -49,8 +49,10 @@ func TestRuntimeClass_DeclarativeValidate_Create(t *testing.T) {
 			ctx := genericapirequest.WithRequestInfo(
 				genericapirequest.NewDefaultContext(),
 				&genericapirequest.RequestInfo{
-					APIGroup:   "node.k8s.io",
-					APIVersion: apiVersion,
+					APIGroup:          "node.k8s.io",
+					APIVersion:        apiVersion,
+					IsResourceRequest: true,
+					Verb:              "create",
 				},
 			)
 
@@ -146,8 +148,10 @@ func TestRuntimeClass_DeclarativeValidate_Update(t *testing.T) {
 			ctx := genericapirequest.WithRequestInfo(
 				genericapirequest.NewDefaultContext(),
 				&genericapirequest.RequestInfo{
-					APIGroup:   "node.k8s.io",
-					APIVersion: apiVersion,
+					APIGroup:          "node.k8s.io",
+					APIVersion:        apiVersion,
+					IsResourceRequest: true,
+					Verb:              "update",
 				},
 			)
 

--- a/test/declarative_validation/policy/poddisruptionbudget/declarative_validation_test.go
+++ b/test/declarative_validation/policy/poddisruptionbudget/declarative_validation_test.go
@@ -31,10 +31,11 @@ func TestDeclarativeValidate(t *testing.T) {
 	for _, apiVersion := range apiVersions {
 		t.Run(apiVersion, func(t *testing.T) {
 			ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-				APIGroup:   "policy",
-				APIVersion: apiVersion,
-				Resource:   "poddisruptionbudgets",
-				Namespace:  metav1.NamespaceDefault,
+				APIGroup:          "policy",
+				APIVersion:        apiVersion,
+				Resource:          "poddisruptionbudgets",
+				IsResourceRequest: true,
+				Verb:              "create",
 			}), metav1.NamespaceDefault)
 
 			meta.RunObjectMetaTestCases(t, ctx, &policy.PodDisruptionBudget{
@@ -51,10 +52,11 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 	for _, apiVersion := range apiVersions {
 		t.Run(apiVersion, func(t *testing.T) {
 			ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-				APIGroup:   "policy",
-				APIVersion: apiVersion,
-				Resource:   "poddisruptionbudgets",
-				Namespace:  metav1.NamespaceDefault,
+				APIGroup:          "policy",
+				APIVersion:        apiVersion,
+				Resource:          "poddisruptionbudgets",
+				IsResourceRequest: true,
+				Verb:              "update",
 			}), metav1.NamespaceDefault)
 
 			meta.RunObjectMetaUpdateTestCases(t, ctx, &policy.PodDisruptionBudget{
@@ -71,10 +73,12 @@ func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 	for _, apiVersion := range apiVersions {
 		t.Run(apiVersion, func(t *testing.T) {
 			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-				APIGroup:    "policy",
-				APIVersion:  apiVersion,
-				Resource:    "poddisruptionbudgets",
-				Subresource: "status",
+				APIGroup:          "policy",
+				APIVersion:        apiVersion,
+				Resource:          "poddisruptionbudgets",
+				Subresource:       "status",
+				IsResourceRequest: true,
+				Verb:              "update",
 			})
 
 			meta.RunConditionTestCases(t, ctx, field.NewPath("status", "conditions"), &policy.PodDisruptionBudget{}, registry.StatusStrategy, func(obj *policy.PodDisruptionBudget, c []metav1.Condition) {

--- a/test/declarative_validation/policy/poddisruptionbudget/declarative_validation_test.go
+++ b/test/declarative_validation/policy/poddisruptionbudget/declarative_validation_test.go
@@ -27,6 +27,46 @@ import (
 	"k8s.io/kubernetes/test/declarative_validation/meta"
 )
 
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+				APIGroup:   "policy",
+				APIVersion: apiVersion,
+				Resource:   "poddisruptionbudgets",
+				Namespace:  metav1.NamespaceDefault,
+			}), metav1.NamespaceDefault)
+
+			meta.RunObjectMetaTestCases(t, ctx, &policy.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "valid-pdb",
+					Namespace: metav1.NamespaceDefault,
+				},
+			}, registry.Strategy)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+				APIGroup:   "policy",
+				APIVersion: apiVersion,
+				Resource:   "poddisruptionbudgets",
+				Namespace:  metav1.NamespaceDefault,
+			}), metav1.NamespaceDefault)
+
+			meta.RunObjectMetaUpdateTestCases(t, ctx, &policy.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "valid-pdb",
+					Namespace: metav1.NamespaceDefault,
+				},
+			}, registry.Strategy)
+		})
+	}
+}
+
 func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 	for _, apiVersion := range apiVersions {
 		t.Run(apiVersion, func(t *testing.T) {

--- a/test/declarative_validation/rbac/clusterrole/declarative_validation_test.go
+++ b/test/declarative_validation/rbac/clusterrole/declarative_validation_test.go
@@ -36,8 +36,10 @@ func TestDeclarativeValidate(t *testing.T) {
 
 func testDeclarativeValidate(t *testing.T, apiVersion string) {
 	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-		APIGroup:   "rbac.authorization.k8s.io",
-		APIVersion: apiVersion,
+		APIGroup:          "rbac.authorization.k8s.io",
+		APIVersion:        apiVersion,
+		IsResourceRequest: true,
+		Verb:              "create",
 	})
 	testCases := map[string]struct {
 		input        rbac.ClusterRole
@@ -78,8 +80,10 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 
 func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-		APIGroup:   "rbac.authorization.k8s.io",
-		APIVersion: apiVersion,
+		APIGroup:          "rbac.authorization.k8s.io",
+		APIVersion:        apiVersion,
+		IsResourceRequest: true,
+		Verb:              "update",
 	})
 	testCases := map[string]struct {
 		old          rbac.ClusterRole

--- a/test/declarative_validation/rbac/clusterrole/declarative_validation_test.go
+++ b/test/declarative_validation/rbac/clusterrole/declarative_validation_test.go
@@ -25,6 +25,7 @@ import (
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	rbac "k8s.io/kubernetes/pkg/apis/rbac"
 	registry "k8s.io/kubernetes/pkg/registry/rbac/clusterrole"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 )
 
 func TestDeclarativeValidate(t *testing.T) {
@@ -64,6 +65,9 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, registry.Strategy, tc.expectedErrs)
 		})
 	}
+
+	obj := mkValidClusterRole()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func TestDeclarativeValidateUpdate(t *testing.T) {
@@ -102,6 +106,9 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, registry.Strategy, tc.expectedErrs)
 		})
 	}
+
+	updateObj := mkValidClusterRole()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func mkValidClusterRole(tweaks ...func(*rbac.ClusterRole)) rbac.ClusterRole {

--- a/test/declarative_validation/rbac/clusterrolebinding/declarative_validation_test.go
+++ b/test/declarative_validation/rbac/clusterrolebinding/declarative_validation_test.go
@@ -36,8 +36,10 @@ func TestDeclarativeValidate(t *testing.T) {
 
 func testDeclarativeValidate(t *testing.T, apiVersion string) {
 	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-		APIGroup:   "rbac.authorization.k8s.io",
-		APIVersion: apiVersion,
+		APIGroup:          "rbac.authorization.k8s.io",
+		APIVersion:        apiVersion,
+		IsResourceRequest: true,
+		Verb:              "create",
 	})
 	testCases := map[string]struct {
 		input        rbac.ClusterRoleBinding
@@ -78,8 +80,10 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 
 func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-		APIGroup:   "rbac.authorization.k8s.io",
-		APIVersion: apiVersion,
+		APIGroup:          "rbac.authorization.k8s.io",
+		APIVersion:        apiVersion,
+		IsResourceRequest: true,
+		Verb:              "update",
 	})
 	testCases := map[string]struct {
 		old          rbac.ClusterRoleBinding

--- a/test/declarative_validation/rbac/clusterrolebinding/declarative_validation_test.go
+++ b/test/declarative_validation/rbac/clusterrolebinding/declarative_validation_test.go
@@ -25,6 +25,7 @@ import (
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	rbac "k8s.io/kubernetes/pkg/apis/rbac"
 	registry "k8s.io/kubernetes/pkg/registry/rbac/clusterrolebinding"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 )
 
 func TestDeclarativeValidate(t *testing.T) {
@@ -64,6 +65,9 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, registry.Strategy, tc.expectedErrs)
 		})
 	}
+
+	obj := mkValidClusterRoleBinding()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func TestDeclarativeValidateUpdate(t *testing.T) {
@@ -102,6 +106,9 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, registry.Strategy, tc.expectedErrs)
 		})
 	}
+
+	updateObj := mkValidClusterRoleBinding()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func mkValidClusterRoleBinding(tweaks ...func(*rbac.ClusterRoleBinding)) rbac.ClusterRoleBinding {

--- a/test/declarative_validation/rbac/role/declarative_validation_test.go
+++ b/test/declarative_validation/rbac/role/declarative_validation_test.go
@@ -25,6 +25,7 @@ import (
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	rbac "k8s.io/kubernetes/pkg/apis/rbac"
 	registry "k8s.io/kubernetes/pkg/registry/rbac/role"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 )
 
 func TestDeclarativeValidate(t *testing.T) {
@@ -71,6 +72,9 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, registry.Strategy, tc.expectedErrs)
 		})
 	}
+
+	obj := mkValidRole()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func TestDeclarativeValidateUpdate(t *testing.T) {
@@ -115,6 +119,9 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, registry.Strategy, tc.expectedErrs)
 		})
 	}
+
+	updateObj := mkValidRole()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func mkValidRole(tweaks ...func(*rbac.Role)) rbac.Role {

--- a/test/declarative_validation/rbac/role/declarative_validation_test.go
+++ b/test/declarative_validation/rbac/role/declarative_validation_test.go
@@ -40,8 +40,10 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 	ctx := genericapirequest.WithRequestInfo(
 		genericapirequest.NewDefaultContext(),
 		&genericapirequest.RequestInfo{
-			APIGroup:   "rbac.authorization.k8s.io",
-			APIVersion: apiVersion,
+			APIGroup:          "rbac.authorization.k8s.io",
+			APIVersion:        apiVersion,
+			IsResourceRequest: true,
+			Verb:              "create",
 		},
 	)
 
@@ -89,8 +91,10 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 	ctx := genericapirequest.WithRequestInfo(
 		genericapirequest.NewDefaultContext(),
 		&genericapirequest.RequestInfo{
-			APIGroup:   "rbac.authorization.k8s.io",
-			APIVersion: apiVersion,
+			APIGroup:          "rbac.authorization.k8s.io",
+			APIVersion:        apiVersion,
+			IsResourceRequest: true,
+			Verb:              "update",
 		},
 	)
 

--- a/test/declarative_validation/rbac/rolebinding/declarative_validation_test.go
+++ b/test/declarative_validation/rbac/rolebinding/declarative_validation_test.go
@@ -25,6 +25,7 @@ import (
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	rbac "k8s.io/kubernetes/pkg/apis/rbac"
 	registry "k8s.io/kubernetes/pkg/registry/rbac/rolebinding"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 )
 
 func TestDeclarativeValidate(t *testing.T) {
@@ -109,6 +110,9 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, registry.Strategy, tc.expectedErrs)
 		})
 	}
+
+	obj := mkValidRoleBinding()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func TestDeclarativeValidateUpdate(t *testing.T) {
@@ -159,20 +163,22 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 		},
 		// TODO: Add more test cases
 	}
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "rbac.authorization.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "rolebindings",
+		Name:              "test-binding",
+		IsResourceRequest: true,
+		Verb:              "update",
+	})
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-				APIPrefix:         "apis",
-				APIGroup:          "rbac.authorization.k8s.io",
-				APIVersion:        apiVersion,
-				Resource:          "rolebindings",
-				Name:              "test-binding",
-				IsResourceRequest: true,
-				Verb:              "update",
-			})
 			tc.oldObj.ResourceVersion = "1"
 			tc.updateObj.ResourceVersion = "2"
 			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, registry.Strategy, tc.expectedErrs)
 		})
 	}
+	updateObj := mkValidRoleBinding()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }

--- a/test/declarative_validation/resource/deviceclass/declarative_validation_test.go
+++ b/test/declarative_validation/resource/deviceclass/declarative_validation_test.go
@@ -37,9 +37,11 @@ func TestDeclarativeValidate(t *testing.T) {
 	for _, apiVersion := range apiVersions {
 		t.Run(apiVersion, func(t *testing.T) {
 			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-				APIGroup:   "resource.k8s.io",
-				APIVersion: apiVersion,
-				Resource:   "deviceclasses",
+				APIGroup:          "resource.k8s.io",
+				APIVersion:        apiVersion,
+				Resource:          "deviceclasses",
+				IsResourceRequest: true,
+				Verb:              "create",
 			})
 
 			strategy := registry.Strategy
@@ -182,9 +184,11 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 	for _, apiVersion := range apiVersions {
 		t.Run(apiVersion, func(t *testing.T) {
 			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-				APIGroup:   "resource.k8s.io",
-				APIVersion: apiVersion,
-				Resource:   "deviceclasses",
+				APIGroup:          "resource.k8s.io",
+				APIVersion:        apiVersion,
+				Resource:          "deviceclasses",
+				IsResourceRequest: true,
+				Verb:              "update",
 			})
 
 			strategy := registry.Strategy

--- a/test/declarative_validation/resource/deviceclass/declarative_validation_test.go
+++ b/test/declarative_validation/resource/deviceclass/declarative_validation_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/resource"
 	_ "k8s.io/kubernetes/pkg/apis/resource/install"
 	registry "k8s.io/kubernetes/pkg/registry/resource/deviceclass"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 	"k8s.io/utils/ptr"
 )
 
@@ -170,6 +171,9 @@ func TestDeclarativeValidate(t *testing.T) {
 					apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, strategy, tc.expectedErrs)
 				})
 			}
+
+			obj := mkDeviceClass()
+			meta.RunObjectMetaTestCases(t, ctx, &obj, strategy, meta.WithStringentFinalizerValidation())
 		})
 	}
 }
@@ -275,6 +279,9 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, strategy, tc.expectedErrs)
 				})
 			}
+
+			updateObj := mkDeviceClass()
+			meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, strategy, meta.WithStringentFinalizerValidation())
 		})
 	}
 }

--- a/test/declarative_validation/resource/devicetaintrule/declarative_validation_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/declarative_validation_test.go
@@ -38,9 +38,11 @@ func TestDeclarativeValidate(t *testing.T) {
 
 func testDeclarativeValidate(t *testing.T, apiVersion string) {
 	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-		APIGroup:   "resource.k8s.io",
-		APIVersion: apiVersion,
-		Resource:   "devicetaintrules",
+		APIGroup:          "resource.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "devicetaintrules",
+		IsResourceRequest: true,
+		Verb:              "create",
 	})
 
 	testCases := map[string]struct {
@@ -89,9 +91,11 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 
 func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-		APIGroup:   "resource.k8s.io",
-		APIVersion: apiVersion,
-		Resource:   "devicetaintrules",
+		APIGroup:          "resource.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "devicetaintrules",
+		IsResourceRequest: true,
+		Verb:              "update",
 	})
 
 	testCases := map[string]struct {

--- a/test/declarative_validation/resource/devicetaintrule/declarative_validation_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/declarative_validation_test.go
@@ -71,6 +71,9 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		})
 	}
 
+	obj := mkValidDeviceTaintRule()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+
 	meta.RunConditionTestCases(t, ctx, field.NewPath("status", "conditions"), &resource.DeviceTaintRule{}, registry.StatusStrategy, func(obj *resource.DeviceTaintRule, c []metav1.Condition) {
 		*obj = mkValidDeviceTaintRule(func(r *resource.DeviceTaintRule) { r.Status.Conditions = c })
 	})
@@ -128,6 +131,9 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, registry.Strategy, tc.expectedErrs)
 		})
 	}
+
+	updateObj := mkValidDeviceTaintRule()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func mkValidDeviceTaintRule(tweaks ...func(*resource.DeviceTaintRule)) resource.DeviceTaintRule {

--- a/test/declarative_validation/resource/resourceclaim/declarative_validation_test.go
+++ b/test/declarative_validation/resource/resourceclaim/declarative_validation_test.go
@@ -507,6 +507,9 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy, tc.expectedErrs, apitesting.WithNormalizationRules(validation.ResourceNormalizationRules...))
 		})
 	}
+
+	obj := mkValidResourceClaim()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func tweakDevicesConfigs(items int) func(*resource.ResourceClaim) {
@@ -825,6 +828,9 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy, tc.expectedErrs, apitesting.WithNormalizationRules(validation.ResourceNormalizationRules...))
 		})
 	}
+
+	updateObj := mkValidResourceClaim()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func TestDeclarativeValidateStatusUpdate(t *testing.T) {

--- a/test/declarative_validation/resource/resourceclaim/declarative_validation_test.go
+++ b/test/declarative_validation/resource/resourceclaim/declarative_validation_test.go
@@ -54,9 +54,11 @@ func TestDeclarativeValidate(t *testing.T) {
 
 func testDeclarativeValidate(t *testing.T, apiVersion string) {
 	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-		APIGroup:   "resource.k8s.io",
-		APIVersion: apiVersion,
-		Resource:   "resourceclaims",
+		APIGroup:          "resource.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "resourceclaims",
+		IsResourceRequest: true,
+		Verb:              "create",
 	})
 	fakeClient := fake.NewClientset()
 	mockNSClient := fakeClient.CoreV1().Namespaces()
@@ -717,9 +719,11 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 
 func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-		APIGroup:   "resource.k8s.io",
-		APIVersion: apiVersion,
-		Resource:   "resourceclaims",
+		APIGroup:          "resource.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "resourceclaims",
+		IsResourceRequest: true,
+		Verb:              "update",
 	})
 	fakeClient := fake.NewClientset()
 	mockNSClient := fakeClient.CoreV1().Namespaces()
@@ -848,10 +852,12 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 	strategy := registry.NewStatusStrategy(Strategy)
 
 	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-		APIGroup:    "resource.k8s.io",
-		APIVersion:  apiVersion,
-		Resource:    "resourceclaims",
-		Subresource: "status",
+		APIGroup:          "resource.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "resourceclaims",
+		Subresource:       "status",
+		IsResourceRequest: true,
+		Verb:              "update",
 	})
 	ctx = genericapirequest.WithUser(ctx, &user.DefaultInfo{Name: "test-user"})
 

--- a/test/declarative_validation/resource/resourceclaimtemplate/declarative_validation_test.go
+++ b/test/declarative_validation/resource/resourceclaimtemplate/declarative_validation_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/resource"
 	"k8s.io/kubernetes/pkg/apis/resource/validation"
 	registry "k8s.io/kubernetes/pkg/registry/resource/resourceclaimtemplate"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 	pointer "k8s.io/utils/ptr"
 )
 
@@ -407,6 +408,9 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy, tc.expectedErrs, apitesting.WithNormalizationRules(validation.ResourceNormalizationRules...))
 		})
 	}
+
+	obj := mkValidResourceClaimTemplate()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func TestDeclarativeValidateUpdate(t *testing.T) {
@@ -446,6 +450,9 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy, tc.expectedErrs, apitesting.WithNormalizationRules(validation.ResourceNormalizationRules...))
 		})
 	}
+
+	updateObj := mkValidResourceClaimTemplate()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, Strategy, meta.WithStringentFinalizerValidation())
 }
 
 // --- Builders & tweaks ---

--- a/test/declarative_validation/resource/resourceclaimtemplate/declarative_validation_test.go
+++ b/test/declarative_validation/resource/resourceclaimtemplate/declarative_validation_test.go
@@ -44,9 +44,11 @@ func TestDeclarativeValidate(t *testing.T) {
 
 func testDeclarativeValidate(t *testing.T, apiVersion string) {
 	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-		APIGroup:   "resource.k8s.io",
-		APIVersion: apiVersion,
-		Resource:   "resourceclaimtemplates",
+		APIGroup:          "resource.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "resourceclaimtemplates",
+		IsResourceRequest: true,
+		Verb:              "create",
 	})
 	fakeClient := fake.NewClientset()
 	nsClient := fakeClient.CoreV1().Namespaces()
@@ -423,9 +425,11 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 
 func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-		APIGroup:   "resource.k8s.io",
-		APIVersion: apiVersion,
-		Resource:   "resourceclaimtemplates",
+		APIGroup:          "resource.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "resourceclaimtemplates",
+		IsResourceRequest: true,
+		Verb:              "update",
 	})
 	fakeClient := fake.NewClientset()
 	nsClient := fakeClient.CoreV1().Namespaces()

--- a/test/declarative_validation/resource/resourcepoolstatusrequest/declarative_validation_test.go
+++ b/test/declarative_validation/resource/resourcepoolstatusrequest/declarative_validation_test.go
@@ -104,6 +104,9 @@ func TestDeclarativeValidate(t *testing.T) {
 			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, registry.Strategy, tc.expectedErrs)
 		})
 	}
+
+	obj := mkValidRPSR()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func TestDeclarativeValidateUpdate(t *testing.T) {
@@ -141,6 +144,9 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, registry.Strategy, tc.expectedErrs)
 		})
 	}
+
+	updateObj := mkValidRPSRForUpdate()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func TestDeclarativeValidateStatusUpdate(t *testing.T) {

--- a/test/declarative_validation/resource/resourceslice/declarative_validation_test.go
+++ b/test/declarative_validation/resource/resourceslice/declarative_validation_test.go
@@ -29,6 +29,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/resource/install"
 	"k8s.io/kubernetes/pkg/apis/resource/validation"
 	registry "k8s.io/kubernetes/pkg/registry/resource/resourceslice"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 	"k8s.io/utils/ptr"
 )
 
@@ -275,6 +276,9 @@ func TestDeclarativeValidate(t *testing.T) {
 					)
 				})
 			}
+
+			obj := mkResourceSliceWithDevices()
+			meta.RunObjectMetaTestCases(t, ctx, &obj, strategy, meta.WithStringentFinalizerValidation())
 		})
 	}
 }
@@ -510,6 +514,9 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, strategy, tc.expectedErrs, apitesting.WithNormalizationRules(validation.ResourceNormalizationRules...))
 				})
 			}
+
+			updateObj := mkResourceSliceWithDevices()
+			meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, strategy, meta.WithStringentFinalizerValidation())
 		})
 	}
 }

--- a/test/declarative_validation/resource/resourceslice/declarative_validation_test.go
+++ b/test/declarative_validation/resource/resourceslice/declarative_validation_test.go
@@ -37,9 +37,11 @@ func TestDeclarativeValidate(t *testing.T) {
 	for _, apiVersion := range apiVersions {
 		t.Run(apiVersion, func(t *testing.T) {
 			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-				APIGroup:   "resource.k8s.io",
-				APIVersion: apiVersion,
-				Resource:   "ResourceSlice",
+				APIGroup:          "resource.k8s.io",
+				APIVersion:        apiVersion,
+				Resource:          "ResourceSlice",
+				IsResourceRequest: true,
+				Verb:              "create",
 			})
 
 			strategy := registry.Strategy
@@ -287,9 +289,11 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 	for _, apiVersion := range apiVersions {
 		t.Run(apiVersion, func(t *testing.T) {
 			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-				APIGroup:   "resource.k8s.io",
-				APIVersion: apiVersion,
-				Resource:   "ResourceSlice",
+				APIGroup:          "resource.k8s.io",
+				APIVersion:        apiVersion,
+				Resource:          "ResourceSlice",
+				IsResourceRequest: true,
+				Verb:              "update",
 			})
 
 			strategy := registry.Strategy

--- a/test/declarative_validation/scheduling/podgroup/declarative_validation_test.go
+++ b/test/declarative_validation/scheduling/podgroup/declarative_validation_test.go
@@ -515,6 +515,9 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, strategy, tc.expectedErrs)
 		})
 	}
+
+	updateObj := mkValidPodGroup(setResourceVersion("1"))
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.NewStrategy(), meta.Options{StringentFinalizerValidation: true})
 }
 
 func TestDeclarativeValidateStatusUpdate(t *testing.T) {

--- a/test/declarative_validation/scheduling/podgroup/declarative_validation_test.go
+++ b/test/declarative_validation/scheduling/podgroup/declarative_validation_test.go
@@ -302,6 +302,9 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, strategy, tc.expectedErrs)
 		})
 	}
+
+	obj := mkValidPodGroup()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, strategy, meta.WithStringentFinalizerValidation())
 }
 
 func TestDeclarativeValidateUpdate(t *testing.T) {
@@ -516,8 +519,8 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 		})
 	}
 
-	updateObj := mkValidPodGroup(setResourceVersion("1"))
-	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.NewStrategy(), meta.Options{StringentFinalizerValidation: true})
+	updateObj := mkValidPodGroup()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.NewStrategy(), meta.WithStringentFinalizerValidation())
 }
 
 func TestDeclarativeValidateStatusUpdate(t *testing.T) {

--- a/test/declarative_validation/scheduling/priorityclass/declarative_validation_test.go
+++ b/test/declarative_validation/scheduling/priorityclass/declarative_validation_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package priorityclass
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	scheduling "k8s.io/kubernetes/pkg/apis/scheduling"
+	registry "k8s.io/kubernetes/pkg/registry/scheduling/priorityclass"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
+)
+
+// TODO: remove this apiVersions variable once coverage tests are generated for this package.
+var apiVersions = []string{"v1", "v1beta1"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateUpdate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "scheduling.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "priorityclasses",
+		IsResourceRequest: true,
+		Verb:              "create",
+	})
+
+	obj := mkPriorityClass()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "scheduling.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "priorityclasses",
+		Name:              "valid-obj",
+		IsResourceRequest: true,
+		Verb:              "update",
+	})
+
+	updateObj := mkPriorityClass()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func mkPriorityClass(tweaks ...func(pc *scheduling.PriorityClass)) scheduling.PriorityClass {
+	pc := scheduling.PriorityClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "valid-obj",
+		},
+	}
+	for _, tweak := range tweaks {
+		tweak(&pc)
+	}
+	return pc
+}

--- a/test/declarative_validation/scheduling/workload/declarative_validation_test.go
+++ b/test/declarative_validation/scheduling/workload/declarative_validation_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/scheduling"
 	"k8s.io/kubernetes/pkg/features"
 	registry "k8s.io/kubernetes/pkg/registry/scheduling/workload"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 
 	// Ensure all API groups are registered with the scheme
 	_ "k8s.io/kubernetes/pkg/apis/scheduling/install"
@@ -588,6 +589,15 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			},
 		},
 	}
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "scheduling.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "workloads",
+		Name:              "valid-workload",
+		IsResourceRequest: true,
+		Verb:              "update",
+	})
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {
 			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
@@ -595,18 +605,12 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				features.TopologyAwareWorkloadScheduling: tc.enableTopologyAwareScheduling,
 				features.DRAWorkloadResourceClaims:       tc.enableDRAWorkloadResourceClaims,
 			})
-			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-				APIPrefix:         "apis",
-				APIGroup:          "scheduling.k8s.io",
-				APIVersion:        apiVersion,
-				Resource:          "workloads",
-				Name:              "valid-workload",
-				IsResourceRequest: true,
-				Verb:              "update",
-			})
 			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, registry.Strategy, tc.expectedErrs)
 		})
 	}
+
+	updateObj := mkValidWorkload(setResourceVersion("1"))
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.Options{StringentFinalizerValidation: true})
 }
 
 func mkValidWorkload(tweaks ...func(obj *scheduling.Workload)) scheduling.Workload {

--- a/test/declarative_validation/scheduling/workload/declarative_validation_test.go
+++ b/test/declarative_validation/scheduling/workload/declarative_validation_test.go
@@ -327,6 +327,9 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, registry.Strategy, tc.expectedErrs)
 		})
 	}
+
+	obj := mkValidWorkload()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func TestDeclarativeValidateUpdate(t *testing.T) {
@@ -610,7 +613,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 	}
 
 	updateObj := mkValidWorkload(setResourceVersion("1"))
-	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.Options{StringentFinalizerValidation: true})
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func mkValidWorkload(tweaks ...func(obj *scheduling.Workload)) scheduling.Workload {

--- a/test/declarative_validation/storage/csidriver/declarative_validation_test.go
+++ b/test/declarative_validation/storage/csidriver/declarative_validation_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csidriver
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	storage "k8s.io/kubernetes/pkg/apis/storage"
+	registry "k8s.io/kubernetes/pkg/registry/storage/csidriver"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
+)
+
+// TODO: remove this apiVersions variable once coverage tests are generated for this package.
+var apiVersions = []string{"v1", "v1beta1"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateUpdate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "storage.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "csidrivers",
+		IsResourceRequest: true,
+		Verb:              "create",
+	})
+
+	obj := mkCSIDriver()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "storage.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "csidrivers",
+		Name:              "valid-obj",
+		IsResourceRequest: true,
+		Verb:              "update",
+	})
+
+	updateObj := mkCSIDriver()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func mkCSIDriver(tweaks ...func(csi *storage.CSIDriver)) storage.CSIDriver {
+	falsePtr := false
+	csi := storage.CSIDriver{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "valid-obj",
+		},
+		Spec: storage.CSIDriverSpec{
+			AttachRequired:  &falsePtr,
+			PodInfoOnMount:  &falsePtr,
+			StorageCapacity: &falsePtr,
+			SELinuxMount:    &falsePtr,
+		},
+	}
+	for _, tweak := range tweaks {
+		tweak(&csi)
+	}
+	return csi
+}

--- a/test/declarative_validation/storage/csinode/declarative_validation_test.go
+++ b/test/declarative_validation/storage/csinode/declarative_validation_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csinode
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	storage "k8s.io/kubernetes/pkg/apis/storage"
+	registry "k8s.io/kubernetes/pkg/registry/storage/csinode"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
+)
+
+// TODO: remove this apiVersions variable once coverage tests are generated for this package.
+var apiVersions = []string{"v1", "v1beta1"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateUpdate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "storage.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "csinodes",
+		IsResourceRequest: true,
+		Verb:              "create",
+	})
+
+	obj := mkCSINode()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "storage.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "csinodes",
+		Name:              "valid-obj",
+		IsResourceRequest: true,
+		Verb:              "update",
+	})
+
+	updateObj := mkCSINode()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func mkCSINode(tweaks ...func(node *storage.CSINode)) storage.CSINode {
+	node := storage.CSINode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "valid-obj",
+		},
+		Spec: storage.CSINodeSpec{
+			Drivers: []storage.CSINodeDriver{
+				{
+					Name:   "foo",
+					NodeID: "bar",
+				},
+			},
+		},
+	}
+	for _, tweak := range tweaks {
+		tweak(&node)
+	}
+	return node
+}

--- a/test/declarative_validation/storage/csistoragecapacity/declarative_validation_test.go
+++ b/test/declarative_validation/storage/csistoragecapacity/declarative_validation_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csistoragecapacity
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	storage "k8s.io/kubernetes/pkg/apis/storage"
+	registry "k8s.io/kubernetes/pkg/registry/storage/csistoragecapacity"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
+)
+
+// TODO: remove this apiVersions variable once coverage tests are generated for this package.
+var apiVersions = []string{"v1", "v1beta1", "v1alpha1"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateUpdate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "storage.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "csistoragecapacities",
+		IsResourceRequest: true,
+		Verb:              "create",
+	}), metav1.NamespaceDefault)
+
+	obj := mkCSIStorageCapacity()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithNamespace(genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "storage.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "csistoragecapacities",
+		Name:              "valid-obj",
+		IsResourceRequest: true,
+		Verb:              "update",
+	}), metav1.NamespaceDefault)
+
+	updateObj := mkCSIStorageCapacity()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func mkCSIStorageCapacity(tweaks ...func(capacity *storage.CSIStorageCapacity)) storage.CSIStorageCapacity {
+	capacity := storage.CSIStorageCapacity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "valid-obj",
+			Namespace: metav1.NamespaceDefault,
+		},
+		StorageClassName: "foo",
+	}
+	for _, tweak := range tweaks {
+		tweak(&capacity)
+	}
+	return capacity
+}

--- a/test/declarative_validation/storage/storageclass/declarative_validation_test.go
+++ b/test/declarative_validation/storage/storageclass/declarative_validation_test.go
@@ -26,6 +26,7 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/storage"
 	registry "k8s.io/kubernetes/pkg/registry/storage/storageclass"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 )
 
 func TestDeclarativeValidate(t *testing.T) {
@@ -67,6 +68,9 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, registry.Strategy, tc.expectedErrs)
 		})
 	}
+
+	obj := mkValidStorageClass()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func TestDeclarativeValidateUpdate(t *testing.T) {
@@ -78,6 +82,15 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 }
 
 func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "storage.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "storageclasses",
+		Name:              "valid-storage-class",
+		IsResourceRequest: true,
+		Verb:              "update",
+	})
 	testCases := map[string]struct {
 		oldObj       storage.StorageClass
 		updateObj    storage.StorageClass
@@ -178,18 +191,11 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 		t.Run(k, func(t *testing.T) {
 			tc.oldObj.ResourceVersion = "1"
 			tc.updateObj.ResourceVersion = "2"
-			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-				APIPrefix:         "apis",
-				APIGroup:          "storage.k8s.io",
-				APIVersion:        apiVersion,
-				Resource:          "storageclasses",
-				Name:              "valid-storage-class",
-				IsResourceRequest: true,
-				Verb:              "update",
-			})
 			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, registry.Strategy, tc.expectedErrs)
 		})
 	}
+	updateObj := mkValidStorageClass()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func mkValidStorageClass(tweaks ...func(obj *storage.StorageClass)) storage.StorageClass {

--- a/test/declarative_validation/storage/volumeattachment/declarative_validation_test.go
+++ b/test/declarative_validation/storage/volumeattachment/declarative_validation_test.go
@@ -26,6 +26,7 @@ import (
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	storage "k8s.io/kubernetes/pkg/apis/storage"
 	registry "k8s.io/kubernetes/pkg/registry/storage/volumeattachment"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 )
 
 func TestDeclarativeValidate(t *testing.T) {
@@ -91,6 +92,9 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, registry.Strategy, tc.expectedErrs)
 		})
 	}
+
+	obj := mkValidVolumeAttachment()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
@@ -127,6 +131,8 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.newInput, &tc.oldInput, registry.Strategy, tc.expectedErrs)
 		})
 	}
+	updateObj := mkValidVolumeAttachment()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func TweakAttacher(attacher string) func(obj *storage.VolumeAttachment) {

--- a/test/declarative_validation/storage/volumeattributesclass/declarative_validation_test.go
+++ b/test/declarative_validation/storage/volumeattributesclass/declarative_validation_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volumeattributesclass
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	storage "k8s.io/kubernetes/pkg/apis/storage"
+	registry "k8s.io/kubernetes/pkg/registry/storage/volumeattributesclass"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
+)
+
+// TODO: remove this apiVersions variable once coverage tests are generated for this package.
+var apiVersions = []string{"v1", "v1beta1", "v1alpha1"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateUpdate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "storage.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "volumeattributesclasses",
+		IsResourceRequest: true,
+		Verb:              "create",
+	})
+
+	obj := mkVolumeAttributesClass()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "storage.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "volumeattributesclasses",
+		Name:              "valid-obj",
+		IsResourceRequest: true,
+		Verb:              "update",
+	})
+
+	updateObj := mkVolumeAttributesClass()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
+}
+
+func mkVolumeAttributesClass(tweaks ...func(class *storage.VolumeAttributesClass)) storage.VolumeAttributesClass {
+	class := storage.VolumeAttributesClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "valid-obj",
+		},
+		DriverName: "foo",
+		Parameters: map[string]string{"foo": "bar"},
+	}
+	for _, tweak := range tweaks {
+		tweak(&class)
+	}
+	return class
+}

--- a/test/declarative_validation/storagemigration/storageversionmigration/declarative_validation_test.go
+++ b/test/declarative_validation/storagemigration/storageversionmigration/declarative_validation_test.go
@@ -32,9 +32,11 @@ func TestDeclarativeValidate(t *testing.T) {
 	for _, apiVersion := range apiVersions {
 		t.Run(apiVersion, func(t *testing.T) {
 			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-				APIGroup:   "storagemigration.k8s.io",
-				APIVersion: apiVersion,
-				Resource:   "storageversionmigrations",
+				APIGroup:          "storagemigration.k8s.io",
+				APIVersion:        apiVersion,
+				Resource:          "storageversionmigrations",
+				IsResourceRequest: true,
+				Verb:              "create",
 			})
 
 			meta.RunObjectMetaTestCases(t, ctx, &storagemigration.StorageVersionMigration{
@@ -56,9 +58,11 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 	for _, apiVersion := range apiVersions {
 		t.Run(apiVersion, func(t *testing.T) {
 			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-				APIGroup:   "storagemigration.k8s.io",
-				APIVersion: apiVersion,
-				Resource:   "storageversionmigrations",
+				APIGroup:          "storagemigration.k8s.io",
+				APIVersion:        apiVersion,
+				Resource:          "storageversionmigrations",
+				IsResourceRequest: true,
+				Verb:              "update",
 			})
 
 			meta.RunObjectMetaUpdateTestCases(t, ctx, &storagemigration.StorageVersionMigration{
@@ -80,10 +84,12 @@ func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 	for _, apiVersion := range apiVersions {
 		t.Run(apiVersion, func(t *testing.T) {
 			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-				APIGroup:    "storagemigration.k8s.io",
-				APIVersion:  apiVersion,
-				Resource:    "storageversionmigrations",
-				Subresource: "status",
+				APIGroup:          "storagemigration.k8s.io",
+				APIVersion:        apiVersion,
+				Resource:          "storageversionmigrations",
+				Subresource:       "status",
+				IsResourceRequest: true,
+				Verb:              "update",
 			})
 
 			meta.RunConditionTestCases(t, ctx, field.NewPath("status", "conditions"), &storagemigration.StorageVersionMigration{}, registry.StatusStrategy, func(obj *storagemigration.StorageVersionMigration, c []metav1.Condition) {

--- a/test/declarative_validation/storagemigration/storageversionmigration/declarative_validation_test.go
+++ b/test/declarative_validation/storagemigration/storageversionmigration/declarative_validation_test.go
@@ -28,6 +28,54 @@ import (
 	"k8s.io/kubernetes/test/declarative_validation/meta"
 )
 
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+				APIGroup:   "storagemigration.k8s.io",
+				APIVersion: apiVersion,
+				Resource:   "storageversionmigrations",
+			})
+
+			meta.RunObjectMetaTestCases(t, ctx, &storagemigration.StorageVersionMigration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "valid-svm",
+				},
+				Spec: storagemigration.StorageVersionMigrationSpec{
+					Resource: metav1.GroupResource{
+						Group:    "group",
+						Resource: "resources",
+					},
+				},
+			}, registry.Strategy, meta.WithStringentFinalizerValidation())
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+				APIGroup:   "storagemigration.k8s.io",
+				APIVersion: apiVersion,
+				Resource:   "storageversionmigrations",
+			})
+
+			meta.RunObjectMetaUpdateTestCases(t, ctx, &storagemigration.StorageVersionMigration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "valid-svm",
+				},
+				Spec: storagemigration.StorageVersionMigrationSpec{
+					Resource: metav1.GroupResource{
+						Group:    "group",
+						Resource: "resources",
+					},
+				},
+			}, registry.Strategy, meta.WithStringentFinalizerValidation())
+		})
+	}
+}
+
 func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 	for _, apiVersion := range apiVersions {
 		t.Run(apiVersion, func(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR is another follow-up to PR #139568. It continues the work of using the established template to wire the `objectMeta` test cases into the declarative validation tests for additional API groups.

Specifically, this PR wires the `objectMeta` declarative validation tests for the following API groups:
- `coordination`
- `flowcontrol`
- `internal`
- `networking`
- `node`
- `policy`
- `rbac`
- `resource`
- `scheduling`
- `storage`
- `storagemigration`

Additionally, it adds support for `StringentFinalizerValidation` in the `objectMeta` test suite.

#### Which issue(s) this PR is related to:

Follow-up to #139568

#### Special notes for your reviewer:

This PR follows the same pattern established in #139568, expanding the `objectMeta` declarative validation test coverage to the API groups mentioned above.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
