### PR TITLE
Increase lower bound capacity to confirm this causes regression in scalability test

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_history.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_history.go
@@ -31,7 +31,7 @@ import (
 const (
 	// defaultLowerBoundCapacity is a default value for event cache capacity's lower bound.
 	// TODO: Figure out, to what value we can decreased it.
-	defaultLowerBoundCapacity = 100
+	defaultLowerBoundCapacity = 20000
 
 	// defaultUpperBoundCapacity should be able to keep the required history.
 	defaultUpperBoundCapacity = 100 * 1024


### PR DESCRIPTION

```release-note
NONE
```
