### PR TITLE
etcd3: extract feature support checker reset into a test helper

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -378,12 +378,16 @@ func TestWatchChanSyncStreamMatchesPaginated(t *testing.T) {
 	}
 }
 
+func resetFeatureSupportCheckerDuringTest(t *testing.T) {
+	t.Helper()
+	orig := etcdfeature.DefaultFeatureSupportChecker
+	etcdfeature.DefaultFeatureSupportChecker = etcdfeature.NewDefaultFeatureSupportChecker()
+	t.Cleanup(func() { etcdfeature.DefaultFeatureSupportChecker = orig })
+}
+
 func TestWatchChanSyncStreamFallsBackToPaginated(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EtcdRangeStream, true)
-
-	origChecker := etcdfeature.DefaultFeatureSupportChecker
-	etcdfeature.DefaultFeatureSupportChecker = etcdfeature.NewDefaultFeatureSupportChecker()
-	t.Cleanup(func() { etcdfeature.DefaultFeatureSupportChecker = origChecker })
+	resetFeatureSupportCheckerDuringTest(t)
 
 	origCtx, store, _ := testSetup(t)
 	initList, err := initStoreData(origCtx, store)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Extracts the inline save/swap/restore of the global etcd `DefaultFeatureSupportChecker` in `TestWatchChanSyncStreamFallsBackToPaginated` into a shared `resetFeatureSupportCheckerDuringTest` test helper, so other tests that toggle RangeStream support can reuse it.

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```