### PR TITLE
Use unsafe pointer casts for memory-identical struct conversions in conversion-gen

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1/zz_generated.conversion.go
@@ -24,7 +24,6 @@ package v1
 import (
 	unsafe "unsafe"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -333,8 +332,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1_APIEndpoint_To_kubeadm_APIEndpoint(in *APIEndpoint, out *kubeadm.APIEndpoint, s conversion.Scope) error {
-	out.AdvertiseAddress = in.AdvertiseAddress
-	out.BindPort = in.BindPort
+	*out = *(*kubeadm.APIEndpoint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -344,8 +342,7 @@ func Convert_v1_APIEndpoint_To_kubeadm_APIEndpoint(in *APIEndpoint, out *kubeadm
 }
 
 func autoConvert_kubeadm_APIEndpoint_To_v1_APIEndpoint(in *kubeadm.APIEndpoint, out *APIEndpoint, s conversion.Scope) error {
-	out.AdvertiseAddress = in.AdvertiseAddress
-	out.BindPort = in.BindPort
+	*out = *(*APIEndpoint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -355,10 +352,7 @@ func Convert_kubeadm_APIEndpoint_To_v1_APIEndpoint(in *kubeadm.APIEndpoint, out 
 }
 
 func autoConvert_v1_APIServer_To_kubeadm_APIServer(in *APIServer, out *kubeadm.APIServer, s conversion.Scope) error {
-	if err := Convert_v1_ControlPlaneComponent_To_kubeadm_ControlPlaneComponent(&in.ControlPlaneComponent, &out.ControlPlaneComponent, s); err != nil {
-		return err
-	}
-	out.CertSANs = *(*[]string)(unsafe.Pointer(&in.CertSANs))
+	*out = *(*kubeadm.APIServer)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -368,10 +362,7 @@ func Convert_v1_APIServer_To_kubeadm_APIServer(in *APIServer, out *kubeadm.APISe
 }
 
 func autoConvert_kubeadm_APIServer_To_v1_APIServer(in *kubeadm.APIServer, out *APIServer, s conversion.Scope) error {
-	if err := Convert_kubeadm_ControlPlaneComponent_To_v1_ControlPlaneComponent(&in.ControlPlaneComponent, &out.ControlPlaneComponent, s); err != nil {
-		return err
-	}
-	out.CertSANs = *(*[]string)(unsafe.Pointer(&in.CertSANs))
+	*out = *(*APIServer)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -381,8 +372,7 @@ func Convert_kubeadm_APIServer_To_v1_APIServer(in *kubeadm.APIServer, out *APISe
 }
 
 func autoConvert_v1_Arg_To_kubeadm_Arg(in *Arg, out *kubeadm.Arg, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Value = in.Value
+	*out = *(*kubeadm.Arg)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -392,8 +382,7 @@ func Convert_v1_Arg_To_kubeadm_Arg(in *Arg, out *kubeadm.Arg, s conversion.Scope
 }
 
 func autoConvert_kubeadm_Arg_To_v1_Arg(in *kubeadm.Arg, out *Arg, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Value = in.Value
+	*out = *(*Arg)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -403,10 +392,7 @@ func Convert_kubeadm_Arg_To_v1_Arg(in *kubeadm.Arg, out *Arg, s conversion.Scope
 }
 
 func autoConvert_v1_BootstrapTokenDiscovery_To_kubeadm_BootstrapTokenDiscovery(in *BootstrapTokenDiscovery, out *kubeadm.BootstrapTokenDiscovery, s conversion.Scope) error {
-	out.Token = in.Token
-	out.APIServerEndpoint = in.APIServerEndpoint
-	out.CACertHashes = *(*[]string)(unsafe.Pointer(&in.CACertHashes))
-	out.UnsafeSkipCAVerification = in.UnsafeSkipCAVerification
+	*out = *(*kubeadm.BootstrapTokenDiscovery)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -416,10 +402,7 @@ func Convert_v1_BootstrapTokenDiscovery_To_kubeadm_BootstrapTokenDiscovery(in *B
 }
 
 func autoConvert_kubeadm_BootstrapTokenDiscovery_To_v1_BootstrapTokenDiscovery(in *kubeadm.BootstrapTokenDiscovery, out *BootstrapTokenDiscovery, s conversion.Scope) error {
-	out.Token = in.Token
-	out.APIServerEndpoint = in.APIServerEndpoint
-	out.CACertHashes = *(*[]string)(unsafe.Pointer(&in.CACertHashes))
-	out.UnsafeSkipCAVerification = in.UnsafeSkipCAVerification
+	*out = *(*BootstrapTokenDiscovery)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -510,9 +493,7 @@ func Convert_kubeadm_ClusterConfiguration_To_v1_ClusterConfiguration(in *kubeadm
 }
 
 func autoConvert_v1_ControlPlaneComponent_To_kubeadm_ControlPlaneComponent(in *ControlPlaneComponent, out *kubeadm.ControlPlaneComponent, s conversion.Scope) error {
-	out.ExtraArgs = *(*[]kubeadm.Arg)(unsafe.Pointer(&in.ExtraArgs))
-	out.ExtraVolumes = *(*[]kubeadm.HostPathMount)(unsafe.Pointer(&in.ExtraVolumes))
-	out.ExtraEnvs = *(*[]kubeadm.EnvVar)(unsafe.Pointer(&in.ExtraEnvs))
+	*out = *(*kubeadm.ControlPlaneComponent)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -522,9 +503,7 @@ func Convert_v1_ControlPlaneComponent_To_kubeadm_ControlPlaneComponent(in *Contr
 }
 
 func autoConvert_kubeadm_ControlPlaneComponent_To_v1_ControlPlaneComponent(in *kubeadm.ControlPlaneComponent, out *ControlPlaneComponent, s conversion.Scope) error {
-	out.ExtraArgs = *(*[]Arg)(unsafe.Pointer(&in.ExtraArgs))
-	out.ExtraVolumes = *(*[]HostPathMount)(unsafe.Pointer(&in.ExtraVolumes))
-	out.ExtraEnvs = *(*[]EnvVar)(unsafe.Pointer(&in.ExtraEnvs))
+	*out = *(*ControlPlaneComponent)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -534,10 +513,7 @@ func Convert_kubeadm_ControlPlaneComponent_To_v1_ControlPlaneComponent(in *kubea
 }
 
 func autoConvert_v1_DNS_To_kubeadm_DNS(in *DNS, out *kubeadm.DNS, s conversion.Scope) error {
-	if err := Convert_v1_ImageMeta_To_kubeadm_ImageMeta(&in.ImageMeta, &out.ImageMeta, s); err != nil {
-		return err
-	}
-	out.Disabled = in.Disabled
+	*out = *(*kubeadm.DNS)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -547,10 +523,7 @@ func Convert_v1_DNS_To_kubeadm_DNS(in *DNS, out *kubeadm.DNS, s conversion.Scope
 }
 
 func autoConvert_kubeadm_DNS_To_v1_DNS(in *kubeadm.DNS, out *DNS, s conversion.Scope) error {
-	if err := Convert_kubeadm_ImageMeta_To_v1_ImageMeta(&in.ImageMeta, &out.ImageMeta, s); err != nil {
-		return err
-	}
-	out.Disabled = in.Disabled
+	*out = *(*DNS)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -560,9 +533,7 @@ func Convert_kubeadm_DNS_To_v1_DNS(in *kubeadm.DNS, out *DNS, s conversion.Scope
 }
 
 func autoConvert_v1_Discovery_To_kubeadm_Discovery(in *Discovery, out *kubeadm.Discovery, s conversion.Scope) error {
-	out.BootstrapToken = (*kubeadm.BootstrapTokenDiscovery)(unsafe.Pointer(in.BootstrapToken))
-	out.File = (*kubeadm.FileDiscovery)(unsafe.Pointer(in.File))
-	out.TLSBootstrapToken = in.TLSBootstrapToken
+	*out = *(*kubeadm.Discovery)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -572,9 +543,7 @@ func Convert_v1_Discovery_To_kubeadm_Discovery(in *Discovery, out *kubeadm.Disco
 }
 
 func autoConvert_kubeadm_Discovery_To_v1_Discovery(in *kubeadm.Discovery, out *Discovery, s conversion.Scope) error {
-	out.BootstrapToken = (*BootstrapTokenDiscovery)(unsafe.Pointer(in.BootstrapToken))
-	out.File = (*FileDiscovery)(unsafe.Pointer(in.File))
-	out.TLSBootstrapToken = in.TLSBootstrapToken
+	*out = *(*Discovery)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -584,7 +553,7 @@ func Convert_kubeadm_Discovery_To_v1_Discovery(in *kubeadm.Discovery, out *Disco
 }
 
 func autoConvert_v1_EnvVar_To_kubeadm_EnvVar(in *EnvVar, out *kubeadm.EnvVar, s conversion.Scope) error {
-	out.EnvVar = in.EnvVar
+	*out = *(*kubeadm.EnvVar)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -594,7 +563,7 @@ func Convert_v1_EnvVar_To_kubeadm_EnvVar(in *EnvVar, out *kubeadm.EnvVar, s conv
 }
 
 func autoConvert_kubeadm_EnvVar_To_v1_EnvVar(in *kubeadm.EnvVar, out *EnvVar, s conversion.Scope) error {
-	out.EnvVar = in.EnvVar
+	*out = *(*EnvVar)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -604,8 +573,7 @@ func Convert_kubeadm_EnvVar_To_v1_EnvVar(in *kubeadm.EnvVar, out *EnvVar, s conv
 }
 
 func autoConvert_v1_Etcd_To_kubeadm_Etcd(in *Etcd, out *kubeadm.Etcd, s conversion.Scope) error {
-	out.Local = (*kubeadm.LocalEtcd)(unsafe.Pointer(in.Local))
-	out.External = (*kubeadm.ExternalEtcd)(unsafe.Pointer(in.External))
+	*out = *(*kubeadm.Etcd)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -615,8 +583,7 @@ func Convert_v1_Etcd_To_kubeadm_Etcd(in *Etcd, out *kubeadm.Etcd, s conversion.S
 }
 
 func autoConvert_kubeadm_Etcd_To_v1_Etcd(in *kubeadm.Etcd, out *Etcd, s conversion.Scope) error {
-	out.Local = (*LocalEtcd)(unsafe.Pointer(in.Local))
-	out.External = (*ExternalEtcd)(unsafe.Pointer(in.External))
+	*out = *(*Etcd)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -626,11 +593,7 @@ func Convert_kubeadm_Etcd_To_v1_Etcd(in *kubeadm.Etcd, out *Etcd, s conversion.S
 }
 
 func autoConvert_v1_ExternalEtcd_To_kubeadm_ExternalEtcd(in *ExternalEtcd, out *kubeadm.ExternalEtcd, s conversion.Scope) error {
-	out.Endpoints = *(*[]string)(unsafe.Pointer(&in.Endpoints))
-	out.HTTPEndpoints = *(*[]string)(unsafe.Pointer(&in.HTTPEndpoints))
-	out.CAFile = in.CAFile
-	out.CertFile = in.CertFile
-	out.KeyFile = in.KeyFile
+	*out = *(*kubeadm.ExternalEtcd)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -640,11 +603,7 @@ func Convert_v1_ExternalEtcd_To_kubeadm_ExternalEtcd(in *ExternalEtcd, out *kube
 }
 
 func autoConvert_kubeadm_ExternalEtcd_To_v1_ExternalEtcd(in *kubeadm.ExternalEtcd, out *ExternalEtcd, s conversion.Scope) error {
-	out.Endpoints = *(*[]string)(unsafe.Pointer(&in.Endpoints))
-	out.HTTPEndpoints = *(*[]string)(unsafe.Pointer(&in.HTTPEndpoints))
-	out.CAFile = in.CAFile
-	out.CertFile = in.CertFile
-	out.KeyFile = in.KeyFile
+	*out = *(*ExternalEtcd)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -654,7 +613,7 @@ func Convert_kubeadm_ExternalEtcd_To_v1_ExternalEtcd(in *kubeadm.ExternalEtcd, o
 }
 
 func autoConvert_v1_FileDiscovery_To_kubeadm_FileDiscovery(in *FileDiscovery, out *kubeadm.FileDiscovery, s conversion.Scope) error {
-	out.KubeConfigPath = in.KubeConfigPath
+	*out = *(*kubeadm.FileDiscovery)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -664,7 +623,7 @@ func Convert_v1_FileDiscovery_To_kubeadm_FileDiscovery(in *FileDiscovery, out *k
 }
 
 func autoConvert_kubeadm_FileDiscovery_To_v1_FileDiscovery(in *kubeadm.FileDiscovery, out *FileDiscovery, s conversion.Scope) error {
-	out.KubeConfigPath = in.KubeConfigPath
+	*out = *(*FileDiscovery)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -674,11 +633,7 @@ func Convert_kubeadm_FileDiscovery_To_v1_FileDiscovery(in *kubeadm.FileDiscovery
 }
 
 func autoConvert_v1_HostPathMount_To_kubeadm_HostPathMount(in *HostPathMount, out *kubeadm.HostPathMount, s conversion.Scope) error {
-	out.Name = in.Name
-	out.HostPath = in.HostPath
-	out.MountPath = in.MountPath
-	out.ReadOnly = in.ReadOnly
-	out.PathType = corev1.HostPathType(in.PathType)
+	*out = *(*kubeadm.HostPathMount)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -688,11 +643,7 @@ func Convert_v1_HostPathMount_To_kubeadm_HostPathMount(in *HostPathMount, out *k
 }
 
 func autoConvert_kubeadm_HostPathMount_To_v1_HostPathMount(in *kubeadm.HostPathMount, out *HostPathMount, s conversion.Scope) error {
-	out.Name = in.Name
-	out.HostPath = in.HostPath
-	out.MountPath = in.MountPath
-	out.ReadOnly = in.ReadOnly
-	out.PathType = corev1.HostPathType(in.PathType)
+	*out = *(*HostPathMount)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -702,8 +653,7 @@ func Convert_kubeadm_HostPathMount_To_v1_HostPathMount(in *kubeadm.HostPathMount
 }
 
 func autoConvert_v1_ImageMeta_To_kubeadm_ImageMeta(in *ImageMeta, out *kubeadm.ImageMeta, s conversion.Scope) error {
-	out.ImageRepository = in.ImageRepository
-	out.ImageTag = in.ImageTag
+	*out = *(*kubeadm.ImageMeta)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -713,8 +663,7 @@ func Convert_v1_ImageMeta_To_kubeadm_ImageMeta(in *ImageMeta, out *kubeadm.Image
 }
 
 func autoConvert_kubeadm_ImageMeta_To_v1_ImageMeta(in *kubeadm.ImageMeta, out *ImageMeta, s conversion.Scope) error {
-	out.ImageRepository = in.ImageRepository
-	out.ImageTag = in.ImageTag
+	*out = *(*ImageMeta)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -799,10 +748,7 @@ func Convert_kubeadm_JoinConfiguration_To_v1_JoinConfiguration(in *kubeadm.JoinC
 }
 
 func autoConvert_v1_JoinControlPlane_To_kubeadm_JoinControlPlane(in *JoinControlPlane, out *kubeadm.JoinControlPlane, s conversion.Scope) error {
-	if err := Convert_v1_APIEndpoint_To_kubeadm_APIEndpoint(&in.LocalAPIEndpoint, &out.LocalAPIEndpoint, s); err != nil {
-		return err
-	}
-	out.CertificateKey = in.CertificateKey
+	*out = *(*kubeadm.JoinControlPlane)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -812,10 +758,7 @@ func Convert_v1_JoinControlPlane_To_kubeadm_JoinControlPlane(in *JoinControlPlan
 }
 
 func autoConvert_kubeadm_JoinControlPlane_To_v1_JoinControlPlane(in *kubeadm.JoinControlPlane, out *JoinControlPlane, s conversion.Scope) error {
-	if err := Convert_kubeadm_APIEndpoint_To_v1_APIEndpoint(&in.LocalAPIEndpoint, &out.LocalAPIEndpoint, s); err != nil {
-		return err
-	}
-	out.CertificateKey = in.CertificateKey
+	*out = *(*JoinControlPlane)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -825,14 +768,7 @@ func Convert_kubeadm_JoinControlPlane_To_v1_JoinControlPlane(in *kubeadm.JoinCon
 }
 
 func autoConvert_v1_LocalEtcd_To_kubeadm_LocalEtcd(in *LocalEtcd, out *kubeadm.LocalEtcd, s conversion.Scope) error {
-	if err := Convert_v1_ImageMeta_To_kubeadm_ImageMeta(&in.ImageMeta, &out.ImageMeta, s); err != nil {
-		return err
-	}
-	out.DataDir = in.DataDir
-	out.ExtraArgs = *(*[]kubeadm.Arg)(unsafe.Pointer(&in.ExtraArgs))
-	out.ExtraEnvs = *(*[]kubeadm.EnvVar)(unsafe.Pointer(&in.ExtraEnvs))
-	out.ServerCertSANs = *(*[]string)(unsafe.Pointer(&in.ServerCertSANs))
-	out.PeerCertSANs = *(*[]string)(unsafe.Pointer(&in.PeerCertSANs))
+	*out = *(*kubeadm.LocalEtcd)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -842,14 +778,7 @@ func Convert_v1_LocalEtcd_To_kubeadm_LocalEtcd(in *LocalEtcd, out *kubeadm.Local
 }
 
 func autoConvert_kubeadm_LocalEtcd_To_v1_LocalEtcd(in *kubeadm.LocalEtcd, out *LocalEtcd, s conversion.Scope) error {
-	if err := Convert_kubeadm_ImageMeta_To_v1_ImageMeta(&in.ImageMeta, &out.ImageMeta, s); err != nil {
-		return err
-	}
-	out.DataDir = in.DataDir
-	out.ExtraArgs = *(*[]Arg)(unsafe.Pointer(&in.ExtraArgs))
-	out.ExtraEnvs = *(*[]EnvVar)(unsafe.Pointer(&in.ExtraEnvs))
-	out.ServerCertSANs = *(*[]string)(unsafe.Pointer(&in.ServerCertSANs))
-	out.PeerCertSANs = *(*[]string)(unsafe.Pointer(&in.PeerCertSANs))
+	*out = *(*LocalEtcd)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -859,9 +788,7 @@ func Convert_kubeadm_LocalEtcd_To_v1_LocalEtcd(in *kubeadm.LocalEtcd, out *Local
 }
 
 func autoConvert_v1_Networking_To_kubeadm_Networking(in *Networking, out *kubeadm.Networking, s conversion.Scope) error {
-	out.ServiceSubnet = in.ServiceSubnet
-	out.PodSubnet = in.PodSubnet
-	out.DNSDomain = in.DNSDomain
+	*out = *(*kubeadm.Networking)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -871,9 +798,7 @@ func Convert_v1_Networking_To_kubeadm_Networking(in *Networking, out *kubeadm.Ne
 }
 
 func autoConvert_kubeadm_Networking_To_v1_Networking(in *kubeadm.Networking, out *Networking, s conversion.Scope) error {
-	out.ServiceSubnet = in.ServiceSubnet
-	out.PodSubnet = in.PodSubnet
-	out.DNSDomain = in.DNSDomain
+	*out = *(*Networking)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -883,13 +808,7 @@ func Convert_kubeadm_Networking_To_v1_Networking(in *kubeadm.Networking, out *Ne
 }
 
 func autoConvert_v1_NodeRegistrationOptions_To_kubeadm_NodeRegistrationOptions(in *NodeRegistrationOptions, out *kubeadm.NodeRegistrationOptions, s conversion.Scope) error {
-	out.Name = in.Name
-	out.CRISocket = in.CRISocket
-	out.Taints = *(*[]corev1.Taint)(unsafe.Pointer(&in.Taints))
-	out.KubeletExtraArgs = *(*[]kubeadm.Arg)(unsafe.Pointer(&in.KubeletExtraArgs))
-	out.IgnorePreflightErrors = *(*[]string)(unsafe.Pointer(&in.IgnorePreflightErrors))
-	out.ImagePullPolicy = corev1.PullPolicy(in.ImagePullPolicy)
-	out.ImagePullSerial = (*bool)(unsafe.Pointer(in.ImagePullSerial))
+	*out = *(*kubeadm.NodeRegistrationOptions)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -899,13 +818,7 @@ func Convert_v1_NodeRegistrationOptions_To_kubeadm_NodeRegistrationOptions(in *N
 }
 
 func autoConvert_kubeadm_NodeRegistrationOptions_To_v1_NodeRegistrationOptions(in *kubeadm.NodeRegistrationOptions, out *NodeRegistrationOptions, s conversion.Scope) error {
-	out.Name = in.Name
-	out.CRISocket = in.CRISocket
-	out.Taints = *(*[]corev1.Taint)(unsafe.Pointer(&in.Taints))
-	out.KubeletExtraArgs = *(*[]Arg)(unsafe.Pointer(&in.KubeletExtraArgs))
-	out.IgnorePreflightErrors = *(*[]string)(unsafe.Pointer(&in.IgnorePreflightErrors))
-	out.ImagePullPolicy = corev1.PullPolicy(in.ImagePullPolicy)
-	out.ImagePullSerial = (*bool)(unsafe.Pointer(in.ImagePullSerial))
+	*out = *(*NodeRegistrationOptions)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -915,7 +828,7 @@ func Convert_kubeadm_NodeRegistrationOptions_To_v1_NodeRegistrationOptions(in *k
 }
 
 func autoConvert_v1_Patches_To_kubeadm_Patches(in *Patches, out *kubeadm.Patches, s conversion.Scope) error {
-	out.Directory = in.Directory
+	*out = *(*kubeadm.Patches)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -925,7 +838,7 @@ func Convert_v1_Patches_To_kubeadm_Patches(in *Patches, out *kubeadm.Patches, s 
 }
 
 func autoConvert_kubeadm_Patches_To_v1_Patches(in *kubeadm.Patches, out *Patches, s conversion.Scope) error {
-	out.Directory = in.Directory
+	*out = *(*Patches)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -935,7 +848,7 @@ func Convert_kubeadm_Patches_To_v1_Patches(in *kubeadm.Patches, out *Patches, s 
 }
 
 func autoConvert_v1_Proxy_To_kubeadm_Proxy(in *Proxy, out *kubeadm.Proxy, s conversion.Scope) error {
-	out.Disabled = in.Disabled
+	*out = *(*kubeadm.Proxy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -945,7 +858,7 @@ func Convert_v1_Proxy_To_kubeadm_Proxy(in *Proxy, out *kubeadm.Proxy, s conversi
 }
 
 func autoConvert_kubeadm_Proxy_To_v1_Proxy(in *kubeadm.Proxy, out *Proxy, s conversion.Scope) error {
-	out.Disabled = in.Disabled
+	*out = *(*Proxy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -991,13 +904,7 @@ func Convert_kubeadm_ResetConfiguration_To_v1_ResetConfiguration(in *kubeadm.Res
 }
 
 func autoConvert_v1_Timeouts_To_kubeadm_Timeouts(in *Timeouts, out *kubeadm.Timeouts, s conversion.Scope) error {
-	out.ControlPlaneComponentHealthCheck = (*metav1.Duration)(unsafe.Pointer(in.ControlPlaneComponentHealthCheck))
-	out.KubeletHealthCheck = (*metav1.Duration)(unsafe.Pointer(in.KubeletHealthCheck))
-	out.KubernetesAPICall = (*metav1.Duration)(unsafe.Pointer(in.KubernetesAPICall))
-	out.EtcdAPICall = (*metav1.Duration)(unsafe.Pointer(in.EtcdAPICall))
-	out.TLSBootstrap = (*metav1.Duration)(unsafe.Pointer(in.TLSBootstrap))
-	out.Discovery = (*metav1.Duration)(unsafe.Pointer(in.Discovery))
-	out.UpgradeManifests = (*metav1.Duration)(unsafe.Pointer(in.UpgradeManifests))
+	*out = *(*kubeadm.Timeouts)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1007,13 +914,7 @@ func Convert_v1_Timeouts_To_kubeadm_Timeouts(in *Timeouts, out *kubeadm.Timeouts
 }
 
 func autoConvert_kubeadm_Timeouts_To_v1_Timeouts(in *kubeadm.Timeouts, out *Timeouts, s conversion.Scope) error {
-	out.ControlPlaneComponentHealthCheck = (*metav1.Duration)(unsafe.Pointer(in.ControlPlaneComponentHealthCheck))
-	out.KubeletHealthCheck = (*metav1.Duration)(unsafe.Pointer(in.KubeletHealthCheck))
-	out.KubernetesAPICall = (*metav1.Duration)(unsafe.Pointer(in.KubernetesAPICall))
-	out.EtcdAPICall = (*metav1.Duration)(unsafe.Pointer(in.EtcdAPICall))
-	out.TLSBootstrap = (*metav1.Duration)(unsafe.Pointer(in.TLSBootstrap))
-	out.Discovery = (*metav1.Duration)(unsafe.Pointer(in.Discovery))
-	out.UpgradeManifests = (*metav1.Duration)(unsafe.Pointer(in.UpgradeManifests))
+	*out = *(*Timeouts)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1023,19 +924,7 @@ func Convert_kubeadm_Timeouts_To_v1_Timeouts(in *kubeadm.Timeouts, out *Timeouts
 }
 
 func autoConvert_v1_UpgradeApplyConfiguration_To_kubeadm_UpgradeApplyConfiguration(in *UpgradeApplyConfiguration, out *kubeadm.UpgradeApplyConfiguration, s conversion.Scope) error {
-	out.KubernetesVersion = in.KubernetesVersion
-	out.AllowExperimentalUpgrades = (*bool)(unsafe.Pointer(in.AllowExperimentalUpgrades))
-	out.AllowRCUpgrades = (*bool)(unsafe.Pointer(in.AllowRCUpgrades))
-	out.CertificateRenewal = (*bool)(unsafe.Pointer(in.CertificateRenewal))
-	out.DryRun = (*bool)(unsafe.Pointer(in.DryRun))
-	out.EtcdUpgrade = (*bool)(unsafe.Pointer(in.EtcdUpgrade))
-	out.ForceUpgrade = (*bool)(unsafe.Pointer(in.ForceUpgrade))
-	out.IgnorePreflightErrors = *(*[]string)(unsafe.Pointer(&in.IgnorePreflightErrors))
-	out.Patches = (*kubeadm.Patches)(unsafe.Pointer(in.Patches))
-	out.PrintConfig = (*bool)(unsafe.Pointer(in.PrintConfig))
-	out.SkipPhases = *(*[]string)(unsafe.Pointer(&in.SkipPhases))
-	out.ImagePullPolicy = corev1.PullPolicy(in.ImagePullPolicy)
-	out.ImagePullSerial = (*bool)(unsafe.Pointer(in.ImagePullSerial))
+	*out = *(*kubeadm.UpgradeApplyConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1045,19 +934,7 @@ func Convert_v1_UpgradeApplyConfiguration_To_kubeadm_UpgradeApplyConfiguration(i
 }
 
 func autoConvert_kubeadm_UpgradeApplyConfiguration_To_v1_UpgradeApplyConfiguration(in *kubeadm.UpgradeApplyConfiguration, out *UpgradeApplyConfiguration, s conversion.Scope) error {
-	out.KubernetesVersion = in.KubernetesVersion
-	out.AllowExperimentalUpgrades = (*bool)(unsafe.Pointer(in.AllowExperimentalUpgrades))
-	out.AllowRCUpgrades = (*bool)(unsafe.Pointer(in.AllowRCUpgrades))
-	out.CertificateRenewal = (*bool)(unsafe.Pointer(in.CertificateRenewal))
-	out.DryRun = (*bool)(unsafe.Pointer(in.DryRun))
-	out.EtcdUpgrade = (*bool)(unsafe.Pointer(in.EtcdUpgrade))
-	out.ForceUpgrade = (*bool)(unsafe.Pointer(in.ForceUpgrade))
-	out.IgnorePreflightErrors = *(*[]string)(unsafe.Pointer(&in.IgnorePreflightErrors))
-	out.Patches = (*Patches)(unsafe.Pointer(in.Patches))
-	out.PrintConfig = (*bool)(unsafe.Pointer(in.PrintConfig))
-	out.SkipPhases = *(*[]string)(unsafe.Pointer(&in.SkipPhases))
-	out.ImagePullPolicy = corev1.PullPolicy(in.ImagePullPolicy)
-	out.ImagePullSerial = (*bool)(unsafe.Pointer(in.ImagePullSerial))
+	*out = *(*UpgradeApplyConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1111,8 +988,7 @@ func Convert_kubeadm_UpgradeConfiguration_To_v1_UpgradeConfiguration(in *kubeadm
 }
 
 func autoConvert_v1_UpgradeDiffConfiguration_To_kubeadm_UpgradeDiffConfiguration(in *UpgradeDiffConfiguration, out *kubeadm.UpgradeDiffConfiguration, s conversion.Scope) error {
-	out.KubernetesVersion = in.KubernetesVersion
-	out.DiffContextLines = in.DiffContextLines
+	*out = *(*kubeadm.UpgradeDiffConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1122,8 +998,7 @@ func Convert_v1_UpgradeDiffConfiguration_To_kubeadm_UpgradeDiffConfiguration(in 
 }
 
 func autoConvert_kubeadm_UpgradeDiffConfiguration_To_v1_UpgradeDiffConfiguration(in *kubeadm.UpgradeDiffConfiguration, out *UpgradeDiffConfiguration, s conversion.Scope) error {
-	out.KubernetesVersion = in.KubernetesVersion
-	out.DiffContextLines = in.DiffContextLines
+	*out = *(*UpgradeDiffConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1133,14 +1008,7 @@ func Convert_kubeadm_UpgradeDiffConfiguration_To_v1_UpgradeDiffConfiguration(in 
 }
 
 func autoConvert_v1_UpgradeNodeConfiguration_To_kubeadm_UpgradeNodeConfiguration(in *UpgradeNodeConfiguration, out *kubeadm.UpgradeNodeConfiguration, s conversion.Scope) error {
-	out.CertificateRenewal = (*bool)(unsafe.Pointer(in.CertificateRenewal))
-	out.DryRun = (*bool)(unsafe.Pointer(in.DryRun))
-	out.EtcdUpgrade = (*bool)(unsafe.Pointer(in.EtcdUpgrade))
-	out.IgnorePreflightErrors = *(*[]string)(unsafe.Pointer(&in.IgnorePreflightErrors))
-	out.SkipPhases = *(*[]string)(unsafe.Pointer(&in.SkipPhases))
-	out.Patches = (*kubeadm.Patches)(unsafe.Pointer(in.Patches))
-	out.ImagePullPolicy = corev1.PullPolicy(in.ImagePullPolicy)
-	out.ImagePullSerial = (*bool)(unsafe.Pointer(in.ImagePullSerial))
+	*out = *(*kubeadm.UpgradeNodeConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1150,14 +1018,7 @@ func Convert_v1_UpgradeNodeConfiguration_To_kubeadm_UpgradeNodeConfiguration(in 
 }
 
 func autoConvert_kubeadm_UpgradeNodeConfiguration_To_v1_UpgradeNodeConfiguration(in *kubeadm.UpgradeNodeConfiguration, out *UpgradeNodeConfiguration, s conversion.Scope) error {
-	out.CertificateRenewal = (*bool)(unsafe.Pointer(in.CertificateRenewal))
-	out.DryRun = (*bool)(unsafe.Pointer(in.DryRun))
-	out.EtcdUpgrade = (*bool)(unsafe.Pointer(in.EtcdUpgrade))
-	out.IgnorePreflightErrors = *(*[]string)(unsafe.Pointer(&in.IgnorePreflightErrors))
-	out.SkipPhases = *(*[]string)(unsafe.Pointer(&in.SkipPhases))
-	out.Patches = (*Patches)(unsafe.Pointer(in.Patches))
-	out.ImagePullPolicy = corev1.PullPolicy(in.ImagePullPolicy)
-	out.ImagePullSerial = (*bool)(unsafe.Pointer(in.ImagePullSerial))
+	*out = *(*UpgradeNodeConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1167,13 +1028,7 @@ func Convert_kubeadm_UpgradeNodeConfiguration_To_v1_UpgradeNodeConfiguration(in 
 }
 
 func autoConvert_v1_UpgradePlanConfiguration_To_kubeadm_UpgradePlanConfiguration(in *UpgradePlanConfiguration, out *kubeadm.UpgradePlanConfiguration, s conversion.Scope) error {
-	out.KubernetesVersion = in.KubernetesVersion
-	out.AllowExperimentalUpgrades = (*bool)(unsafe.Pointer(in.AllowExperimentalUpgrades))
-	out.AllowRCUpgrades = (*bool)(unsafe.Pointer(in.AllowRCUpgrades))
-	out.DryRun = (*bool)(unsafe.Pointer(in.DryRun))
-	out.EtcdUpgrade = (*bool)(unsafe.Pointer(in.EtcdUpgrade))
-	out.IgnorePreflightErrors = *(*[]string)(unsafe.Pointer(&in.IgnorePreflightErrors))
-	out.PrintConfig = (*bool)(unsafe.Pointer(in.PrintConfig))
+	*out = *(*kubeadm.UpgradePlanConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1183,13 +1038,7 @@ func Convert_v1_UpgradePlanConfiguration_To_kubeadm_UpgradePlanConfiguration(in 
 }
 
 func autoConvert_kubeadm_UpgradePlanConfiguration_To_v1_UpgradePlanConfiguration(in *kubeadm.UpgradePlanConfiguration, out *UpgradePlanConfiguration, s conversion.Scope) error {
-	out.KubernetesVersion = in.KubernetesVersion
-	out.AllowExperimentalUpgrades = (*bool)(unsafe.Pointer(in.AllowExperimentalUpgrades))
-	out.AllowRCUpgrades = (*bool)(unsafe.Pointer(in.AllowRCUpgrades))
-	out.DryRun = (*bool)(unsafe.Pointer(in.DryRun))
-	out.EtcdUpgrade = (*bool)(unsafe.Pointer(in.EtcdUpgrade))
-	out.IgnorePreflightErrors = *(*[]string)(unsafe.Pointer(&in.IgnorePreflightErrors))
-	out.PrintConfig = (*bool)(unsafe.Pointer(in.PrintConfig))
+	*out = *(*UpgradePlanConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta4/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta4/zz_generated.conversion.go
@@ -24,7 +24,6 @@ package v1beta4
 import (
 	unsafe "unsafe"
 
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -333,8 +332,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1beta4_APIEndpoint_To_kubeadm_APIEndpoint(in *APIEndpoint, out *kubeadm.APIEndpoint, s conversion.Scope) error {
-	out.AdvertiseAddress = in.AdvertiseAddress
-	out.BindPort = in.BindPort
+	*out = *(*kubeadm.APIEndpoint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -344,8 +342,7 @@ func Convert_v1beta4_APIEndpoint_To_kubeadm_APIEndpoint(in *APIEndpoint, out *ku
 }
 
 func autoConvert_kubeadm_APIEndpoint_To_v1beta4_APIEndpoint(in *kubeadm.APIEndpoint, out *APIEndpoint, s conversion.Scope) error {
-	out.AdvertiseAddress = in.AdvertiseAddress
-	out.BindPort = in.BindPort
+	*out = *(*APIEndpoint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -355,10 +352,7 @@ func Convert_kubeadm_APIEndpoint_To_v1beta4_APIEndpoint(in *kubeadm.APIEndpoint,
 }
 
 func autoConvert_v1beta4_APIServer_To_kubeadm_APIServer(in *APIServer, out *kubeadm.APIServer, s conversion.Scope) error {
-	if err := Convert_v1beta4_ControlPlaneComponent_To_kubeadm_ControlPlaneComponent(&in.ControlPlaneComponent, &out.ControlPlaneComponent, s); err != nil {
-		return err
-	}
-	out.CertSANs = *(*[]string)(unsafe.Pointer(&in.CertSANs))
+	*out = *(*kubeadm.APIServer)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -368,10 +362,7 @@ func Convert_v1beta4_APIServer_To_kubeadm_APIServer(in *APIServer, out *kubeadm.
 }
 
 func autoConvert_kubeadm_APIServer_To_v1beta4_APIServer(in *kubeadm.APIServer, out *APIServer, s conversion.Scope) error {
-	if err := Convert_kubeadm_ControlPlaneComponent_To_v1beta4_ControlPlaneComponent(&in.ControlPlaneComponent, &out.ControlPlaneComponent, s); err != nil {
-		return err
-	}
-	out.CertSANs = *(*[]string)(unsafe.Pointer(&in.CertSANs))
+	*out = *(*APIServer)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -381,8 +372,7 @@ func Convert_kubeadm_APIServer_To_v1beta4_APIServer(in *kubeadm.APIServer, out *
 }
 
 func autoConvert_v1beta4_Arg_To_kubeadm_Arg(in *Arg, out *kubeadm.Arg, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Value = in.Value
+	*out = *(*kubeadm.Arg)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -392,8 +382,7 @@ func Convert_v1beta4_Arg_To_kubeadm_Arg(in *Arg, out *kubeadm.Arg, s conversion.
 }
 
 func autoConvert_kubeadm_Arg_To_v1beta4_Arg(in *kubeadm.Arg, out *Arg, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Value = in.Value
+	*out = *(*Arg)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -403,10 +392,7 @@ func Convert_kubeadm_Arg_To_v1beta4_Arg(in *kubeadm.Arg, out *Arg, s conversion.
 }
 
 func autoConvert_v1beta4_BootstrapTokenDiscovery_To_kubeadm_BootstrapTokenDiscovery(in *BootstrapTokenDiscovery, out *kubeadm.BootstrapTokenDiscovery, s conversion.Scope) error {
-	out.Token = in.Token
-	out.APIServerEndpoint = in.APIServerEndpoint
-	out.CACertHashes = *(*[]string)(unsafe.Pointer(&in.CACertHashes))
-	out.UnsafeSkipCAVerification = in.UnsafeSkipCAVerification
+	*out = *(*kubeadm.BootstrapTokenDiscovery)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -416,10 +402,7 @@ func Convert_v1beta4_BootstrapTokenDiscovery_To_kubeadm_BootstrapTokenDiscovery(
 }
 
 func autoConvert_kubeadm_BootstrapTokenDiscovery_To_v1beta4_BootstrapTokenDiscovery(in *kubeadm.BootstrapTokenDiscovery, out *BootstrapTokenDiscovery, s conversion.Scope) error {
-	out.Token = in.Token
-	out.APIServerEndpoint = in.APIServerEndpoint
-	out.CACertHashes = *(*[]string)(unsafe.Pointer(&in.CACertHashes))
-	out.UnsafeSkipCAVerification = in.UnsafeSkipCAVerification
+	*out = *(*BootstrapTokenDiscovery)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -510,9 +493,7 @@ func Convert_kubeadm_ClusterConfiguration_To_v1beta4_ClusterConfiguration(in *ku
 }
 
 func autoConvert_v1beta4_ControlPlaneComponent_To_kubeadm_ControlPlaneComponent(in *ControlPlaneComponent, out *kubeadm.ControlPlaneComponent, s conversion.Scope) error {
-	out.ExtraArgs = *(*[]kubeadm.Arg)(unsafe.Pointer(&in.ExtraArgs))
-	out.ExtraVolumes = *(*[]kubeadm.HostPathMount)(unsafe.Pointer(&in.ExtraVolumes))
-	out.ExtraEnvs = *(*[]kubeadm.EnvVar)(unsafe.Pointer(&in.ExtraEnvs))
+	*out = *(*kubeadm.ControlPlaneComponent)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -522,9 +503,7 @@ func Convert_v1beta4_ControlPlaneComponent_To_kubeadm_ControlPlaneComponent(in *
 }
 
 func autoConvert_kubeadm_ControlPlaneComponent_To_v1beta4_ControlPlaneComponent(in *kubeadm.ControlPlaneComponent, out *ControlPlaneComponent, s conversion.Scope) error {
-	out.ExtraArgs = *(*[]Arg)(unsafe.Pointer(&in.ExtraArgs))
-	out.ExtraVolumes = *(*[]HostPathMount)(unsafe.Pointer(&in.ExtraVolumes))
-	out.ExtraEnvs = *(*[]EnvVar)(unsafe.Pointer(&in.ExtraEnvs))
+	*out = *(*ControlPlaneComponent)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -534,10 +513,7 @@ func Convert_kubeadm_ControlPlaneComponent_To_v1beta4_ControlPlaneComponent(in *
 }
 
 func autoConvert_v1beta4_DNS_To_kubeadm_DNS(in *DNS, out *kubeadm.DNS, s conversion.Scope) error {
-	if err := Convert_v1beta4_ImageMeta_To_kubeadm_ImageMeta(&in.ImageMeta, &out.ImageMeta, s); err != nil {
-		return err
-	}
-	out.Disabled = in.Disabled
+	*out = *(*kubeadm.DNS)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -547,10 +523,7 @@ func Convert_v1beta4_DNS_To_kubeadm_DNS(in *DNS, out *kubeadm.DNS, s conversion.
 }
 
 func autoConvert_kubeadm_DNS_To_v1beta4_DNS(in *kubeadm.DNS, out *DNS, s conversion.Scope) error {
-	if err := Convert_kubeadm_ImageMeta_To_v1beta4_ImageMeta(&in.ImageMeta, &out.ImageMeta, s); err != nil {
-		return err
-	}
-	out.Disabled = in.Disabled
+	*out = *(*DNS)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -560,9 +533,7 @@ func Convert_kubeadm_DNS_To_v1beta4_DNS(in *kubeadm.DNS, out *DNS, s conversion.
 }
 
 func autoConvert_v1beta4_Discovery_To_kubeadm_Discovery(in *Discovery, out *kubeadm.Discovery, s conversion.Scope) error {
-	out.BootstrapToken = (*kubeadm.BootstrapTokenDiscovery)(unsafe.Pointer(in.BootstrapToken))
-	out.File = (*kubeadm.FileDiscovery)(unsafe.Pointer(in.File))
-	out.TLSBootstrapToken = in.TLSBootstrapToken
+	*out = *(*kubeadm.Discovery)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -572,9 +543,7 @@ func Convert_v1beta4_Discovery_To_kubeadm_Discovery(in *Discovery, out *kubeadm.
 }
 
 func autoConvert_kubeadm_Discovery_To_v1beta4_Discovery(in *kubeadm.Discovery, out *Discovery, s conversion.Scope) error {
-	out.BootstrapToken = (*BootstrapTokenDiscovery)(unsafe.Pointer(in.BootstrapToken))
-	out.File = (*FileDiscovery)(unsafe.Pointer(in.File))
-	out.TLSBootstrapToken = in.TLSBootstrapToken
+	*out = *(*Discovery)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -584,7 +553,7 @@ func Convert_kubeadm_Discovery_To_v1beta4_Discovery(in *kubeadm.Discovery, out *
 }
 
 func autoConvert_v1beta4_EnvVar_To_kubeadm_EnvVar(in *EnvVar, out *kubeadm.EnvVar, s conversion.Scope) error {
-	out.EnvVar = in.EnvVar
+	*out = *(*kubeadm.EnvVar)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -594,7 +563,7 @@ func Convert_v1beta4_EnvVar_To_kubeadm_EnvVar(in *EnvVar, out *kubeadm.EnvVar, s
 }
 
 func autoConvert_kubeadm_EnvVar_To_v1beta4_EnvVar(in *kubeadm.EnvVar, out *EnvVar, s conversion.Scope) error {
-	out.EnvVar = in.EnvVar
+	*out = *(*EnvVar)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -604,8 +573,7 @@ func Convert_kubeadm_EnvVar_To_v1beta4_EnvVar(in *kubeadm.EnvVar, out *EnvVar, s
 }
 
 func autoConvert_v1beta4_Etcd_To_kubeadm_Etcd(in *Etcd, out *kubeadm.Etcd, s conversion.Scope) error {
-	out.Local = (*kubeadm.LocalEtcd)(unsafe.Pointer(in.Local))
-	out.External = (*kubeadm.ExternalEtcd)(unsafe.Pointer(in.External))
+	*out = *(*kubeadm.Etcd)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -615,8 +583,7 @@ func Convert_v1beta4_Etcd_To_kubeadm_Etcd(in *Etcd, out *kubeadm.Etcd, s convers
 }
 
 func autoConvert_kubeadm_Etcd_To_v1beta4_Etcd(in *kubeadm.Etcd, out *Etcd, s conversion.Scope) error {
-	out.Local = (*LocalEtcd)(unsafe.Pointer(in.Local))
-	out.External = (*ExternalEtcd)(unsafe.Pointer(in.External))
+	*out = *(*Etcd)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -626,11 +593,7 @@ func Convert_kubeadm_Etcd_To_v1beta4_Etcd(in *kubeadm.Etcd, out *Etcd, s convers
 }
 
 func autoConvert_v1beta4_ExternalEtcd_To_kubeadm_ExternalEtcd(in *ExternalEtcd, out *kubeadm.ExternalEtcd, s conversion.Scope) error {
-	out.Endpoints = *(*[]string)(unsafe.Pointer(&in.Endpoints))
-	out.HTTPEndpoints = *(*[]string)(unsafe.Pointer(&in.HTTPEndpoints))
-	out.CAFile = in.CAFile
-	out.CertFile = in.CertFile
-	out.KeyFile = in.KeyFile
+	*out = *(*kubeadm.ExternalEtcd)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -640,11 +603,7 @@ func Convert_v1beta4_ExternalEtcd_To_kubeadm_ExternalEtcd(in *ExternalEtcd, out 
 }
 
 func autoConvert_kubeadm_ExternalEtcd_To_v1beta4_ExternalEtcd(in *kubeadm.ExternalEtcd, out *ExternalEtcd, s conversion.Scope) error {
-	out.Endpoints = *(*[]string)(unsafe.Pointer(&in.Endpoints))
-	out.HTTPEndpoints = *(*[]string)(unsafe.Pointer(&in.HTTPEndpoints))
-	out.CAFile = in.CAFile
-	out.CertFile = in.CertFile
-	out.KeyFile = in.KeyFile
+	*out = *(*ExternalEtcd)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -654,7 +613,7 @@ func Convert_kubeadm_ExternalEtcd_To_v1beta4_ExternalEtcd(in *kubeadm.ExternalEt
 }
 
 func autoConvert_v1beta4_FileDiscovery_To_kubeadm_FileDiscovery(in *FileDiscovery, out *kubeadm.FileDiscovery, s conversion.Scope) error {
-	out.KubeConfigPath = in.KubeConfigPath
+	*out = *(*kubeadm.FileDiscovery)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -664,7 +623,7 @@ func Convert_v1beta4_FileDiscovery_To_kubeadm_FileDiscovery(in *FileDiscovery, o
 }
 
 func autoConvert_kubeadm_FileDiscovery_To_v1beta4_FileDiscovery(in *kubeadm.FileDiscovery, out *FileDiscovery, s conversion.Scope) error {
-	out.KubeConfigPath = in.KubeConfigPath
+	*out = *(*FileDiscovery)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -674,11 +633,7 @@ func Convert_kubeadm_FileDiscovery_To_v1beta4_FileDiscovery(in *kubeadm.FileDisc
 }
 
 func autoConvert_v1beta4_HostPathMount_To_kubeadm_HostPathMount(in *HostPathMount, out *kubeadm.HostPathMount, s conversion.Scope) error {
-	out.Name = in.Name
-	out.HostPath = in.HostPath
-	out.MountPath = in.MountPath
-	out.ReadOnly = in.ReadOnly
-	out.PathType = corev1.HostPathType(in.PathType)
+	*out = *(*kubeadm.HostPathMount)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -688,11 +643,7 @@ func Convert_v1beta4_HostPathMount_To_kubeadm_HostPathMount(in *HostPathMount, o
 }
 
 func autoConvert_kubeadm_HostPathMount_To_v1beta4_HostPathMount(in *kubeadm.HostPathMount, out *HostPathMount, s conversion.Scope) error {
-	out.Name = in.Name
-	out.HostPath = in.HostPath
-	out.MountPath = in.MountPath
-	out.ReadOnly = in.ReadOnly
-	out.PathType = corev1.HostPathType(in.PathType)
+	*out = *(*HostPathMount)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -702,8 +653,7 @@ func Convert_kubeadm_HostPathMount_To_v1beta4_HostPathMount(in *kubeadm.HostPath
 }
 
 func autoConvert_v1beta4_ImageMeta_To_kubeadm_ImageMeta(in *ImageMeta, out *kubeadm.ImageMeta, s conversion.Scope) error {
-	out.ImageRepository = in.ImageRepository
-	out.ImageTag = in.ImageTag
+	*out = *(*kubeadm.ImageMeta)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -713,8 +663,7 @@ func Convert_v1beta4_ImageMeta_To_kubeadm_ImageMeta(in *ImageMeta, out *kubeadm.
 }
 
 func autoConvert_kubeadm_ImageMeta_To_v1beta4_ImageMeta(in *kubeadm.ImageMeta, out *ImageMeta, s conversion.Scope) error {
-	out.ImageRepository = in.ImageRepository
-	out.ImageTag = in.ImageTag
+	*out = *(*ImageMeta)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -799,10 +748,7 @@ func Convert_kubeadm_JoinConfiguration_To_v1beta4_JoinConfiguration(in *kubeadm.
 }
 
 func autoConvert_v1beta4_JoinControlPlane_To_kubeadm_JoinControlPlane(in *JoinControlPlane, out *kubeadm.JoinControlPlane, s conversion.Scope) error {
-	if err := Convert_v1beta4_APIEndpoint_To_kubeadm_APIEndpoint(&in.LocalAPIEndpoint, &out.LocalAPIEndpoint, s); err != nil {
-		return err
-	}
-	out.CertificateKey = in.CertificateKey
+	*out = *(*kubeadm.JoinControlPlane)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -812,10 +758,7 @@ func Convert_v1beta4_JoinControlPlane_To_kubeadm_JoinControlPlane(in *JoinContro
 }
 
 func autoConvert_kubeadm_JoinControlPlane_To_v1beta4_JoinControlPlane(in *kubeadm.JoinControlPlane, out *JoinControlPlane, s conversion.Scope) error {
-	if err := Convert_kubeadm_APIEndpoint_To_v1beta4_APIEndpoint(&in.LocalAPIEndpoint, &out.LocalAPIEndpoint, s); err != nil {
-		return err
-	}
-	out.CertificateKey = in.CertificateKey
+	*out = *(*JoinControlPlane)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -825,14 +768,7 @@ func Convert_kubeadm_JoinControlPlane_To_v1beta4_JoinControlPlane(in *kubeadm.Jo
 }
 
 func autoConvert_v1beta4_LocalEtcd_To_kubeadm_LocalEtcd(in *LocalEtcd, out *kubeadm.LocalEtcd, s conversion.Scope) error {
-	if err := Convert_v1beta4_ImageMeta_To_kubeadm_ImageMeta(&in.ImageMeta, &out.ImageMeta, s); err != nil {
-		return err
-	}
-	out.DataDir = in.DataDir
-	out.ExtraArgs = *(*[]kubeadm.Arg)(unsafe.Pointer(&in.ExtraArgs))
-	out.ExtraEnvs = *(*[]kubeadm.EnvVar)(unsafe.Pointer(&in.ExtraEnvs))
-	out.ServerCertSANs = *(*[]string)(unsafe.Pointer(&in.ServerCertSANs))
-	out.PeerCertSANs = *(*[]string)(unsafe.Pointer(&in.PeerCertSANs))
+	*out = *(*kubeadm.LocalEtcd)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -842,14 +778,7 @@ func Convert_v1beta4_LocalEtcd_To_kubeadm_LocalEtcd(in *LocalEtcd, out *kubeadm.
 }
 
 func autoConvert_kubeadm_LocalEtcd_To_v1beta4_LocalEtcd(in *kubeadm.LocalEtcd, out *LocalEtcd, s conversion.Scope) error {
-	if err := Convert_kubeadm_ImageMeta_To_v1beta4_ImageMeta(&in.ImageMeta, &out.ImageMeta, s); err != nil {
-		return err
-	}
-	out.DataDir = in.DataDir
-	out.ExtraArgs = *(*[]Arg)(unsafe.Pointer(&in.ExtraArgs))
-	out.ExtraEnvs = *(*[]EnvVar)(unsafe.Pointer(&in.ExtraEnvs))
-	out.ServerCertSANs = *(*[]string)(unsafe.Pointer(&in.ServerCertSANs))
-	out.PeerCertSANs = *(*[]string)(unsafe.Pointer(&in.PeerCertSANs))
+	*out = *(*LocalEtcd)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -859,9 +788,7 @@ func Convert_kubeadm_LocalEtcd_To_v1beta4_LocalEtcd(in *kubeadm.LocalEtcd, out *
 }
 
 func autoConvert_v1beta4_Networking_To_kubeadm_Networking(in *Networking, out *kubeadm.Networking, s conversion.Scope) error {
-	out.ServiceSubnet = in.ServiceSubnet
-	out.PodSubnet = in.PodSubnet
-	out.DNSDomain = in.DNSDomain
+	*out = *(*kubeadm.Networking)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -871,9 +798,7 @@ func Convert_v1beta4_Networking_To_kubeadm_Networking(in *Networking, out *kubea
 }
 
 func autoConvert_kubeadm_Networking_To_v1beta4_Networking(in *kubeadm.Networking, out *Networking, s conversion.Scope) error {
-	out.ServiceSubnet = in.ServiceSubnet
-	out.PodSubnet = in.PodSubnet
-	out.DNSDomain = in.DNSDomain
+	*out = *(*Networking)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -883,13 +808,7 @@ func Convert_kubeadm_Networking_To_v1beta4_Networking(in *kubeadm.Networking, ou
 }
 
 func autoConvert_v1beta4_NodeRegistrationOptions_To_kubeadm_NodeRegistrationOptions(in *NodeRegistrationOptions, out *kubeadm.NodeRegistrationOptions, s conversion.Scope) error {
-	out.Name = in.Name
-	out.CRISocket = in.CRISocket
-	out.Taints = *(*[]corev1.Taint)(unsafe.Pointer(&in.Taints))
-	out.KubeletExtraArgs = *(*[]kubeadm.Arg)(unsafe.Pointer(&in.KubeletExtraArgs))
-	out.IgnorePreflightErrors = *(*[]string)(unsafe.Pointer(&in.IgnorePreflightErrors))
-	out.ImagePullPolicy = corev1.PullPolicy(in.ImagePullPolicy)
-	out.ImagePullSerial = (*bool)(unsafe.Pointer(in.ImagePullSerial))
+	*out = *(*kubeadm.NodeRegistrationOptions)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -899,13 +818,7 @@ func Convert_v1beta4_NodeRegistrationOptions_To_kubeadm_NodeRegistrationOptions(
 }
 
 func autoConvert_kubeadm_NodeRegistrationOptions_To_v1beta4_NodeRegistrationOptions(in *kubeadm.NodeRegistrationOptions, out *NodeRegistrationOptions, s conversion.Scope) error {
-	out.Name = in.Name
-	out.CRISocket = in.CRISocket
-	out.Taints = *(*[]corev1.Taint)(unsafe.Pointer(&in.Taints))
-	out.KubeletExtraArgs = *(*[]Arg)(unsafe.Pointer(&in.KubeletExtraArgs))
-	out.IgnorePreflightErrors = *(*[]string)(unsafe.Pointer(&in.IgnorePreflightErrors))
-	out.ImagePullPolicy = corev1.PullPolicy(in.ImagePullPolicy)
-	out.ImagePullSerial = (*bool)(unsafe.Pointer(in.ImagePullSerial))
+	*out = *(*NodeRegistrationOptions)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -915,7 +828,7 @@ func Convert_kubeadm_NodeRegistrationOptions_To_v1beta4_NodeRegistrationOptions(
 }
 
 func autoConvert_v1beta4_Patches_To_kubeadm_Patches(in *Patches, out *kubeadm.Patches, s conversion.Scope) error {
-	out.Directory = in.Directory
+	*out = *(*kubeadm.Patches)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -925,7 +838,7 @@ func Convert_v1beta4_Patches_To_kubeadm_Patches(in *Patches, out *kubeadm.Patche
 }
 
 func autoConvert_kubeadm_Patches_To_v1beta4_Patches(in *kubeadm.Patches, out *Patches, s conversion.Scope) error {
-	out.Directory = in.Directory
+	*out = *(*Patches)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -935,7 +848,7 @@ func Convert_kubeadm_Patches_To_v1beta4_Patches(in *kubeadm.Patches, out *Patche
 }
 
 func autoConvert_v1beta4_Proxy_To_kubeadm_Proxy(in *Proxy, out *kubeadm.Proxy, s conversion.Scope) error {
-	out.Disabled = in.Disabled
+	*out = *(*kubeadm.Proxy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -945,7 +858,7 @@ func Convert_v1beta4_Proxy_To_kubeadm_Proxy(in *Proxy, out *kubeadm.Proxy, s con
 }
 
 func autoConvert_kubeadm_Proxy_To_v1beta4_Proxy(in *kubeadm.Proxy, out *Proxy, s conversion.Scope) error {
-	out.Disabled = in.Disabled
+	*out = *(*Proxy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -991,13 +904,7 @@ func Convert_kubeadm_ResetConfiguration_To_v1beta4_ResetConfiguration(in *kubead
 }
 
 func autoConvert_v1beta4_Timeouts_To_kubeadm_Timeouts(in *Timeouts, out *kubeadm.Timeouts, s conversion.Scope) error {
-	out.ControlPlaneComponentHealthCheck = (*v1.Duration)(unsafe.Pointer(in.ControlPlaneComponentHealthCheck))
-	out.KubeletHealthCheck = (*v1.Duration)(unsafe.Pointer(in.KubeletHealthCheck))
-	out.KubernetesAPICall = (*v1.Duration)(unsafe.Pointer(in.KubernetesAPICall))
-	out.EtcdAPICall = (*v1.Duration)(unsafe.Pointer(in.EtcdAPICall))
-	out.TLSBootstrap = (*v1.Duration)(unsafe.Pointer(in.TLSBootstrap))
-	out.Discovery = (*v1.Duration)(unsafe.Pointer(in.Discovery))
-	out.UpgradeManifests = (*v1.Duration)(unsafe.Pointer(in.UpgradeManifests))
+	*out = *(*kubeadm.Timeouts)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1007,13 +914,7 @@ func Convert_v1beta4_Timeouts_To_kubeadm_Timeouts(in *Timeouts, out *kubeadm.Tim
 }
 
 func autoConvert_kubeadm_Timeouts_To_v1beta4_Timeouts(in *kubeadm.Timeouts, out *Timeouts, s conversion.Scope) error {
-	out.ControlPlaneComponentHealthCheck = (*v1.Duration)(unsafe.Pointer(in.ControlPlaneComponentHealthCheck))
-	out.KubeletHealthCheck = (*v1.Duration)(unsafe.Pointer(in.KubeletHealthCheck))
-	out.KubernetesAPICall = (*v1.Duration)(unsafe.Pointer(in.KubernetesAPICall))
-	out.EtcdAPICall = (*v1.Duration)(unsafe.Pointer(in.EtcdAPICall))
-	out.TLSBootstrap = (*v1.Duration)(unsafe.Pointer(in.TLSBootstrap))
-	out.Discovery = (*v1.Duration)(unsafe.Pointer(in.Discovery))
-	out.UpgradeManifests = (*v1.Duration)(unsafe.Pointer(in.UpgradeManifests))
+	*out = *(*Timeouts)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1023,19 +924,7 @@ func Convert_kubeadm_Timeouts_To_v1beta4_Timeouts(in *kubeadm.Timeouts, out *Tim
 }
 
 func autoConvert_v1beta4_UpgradeApplyConfiguration_To_kubeadm_UpgradeApplyConfiguration(in *UpgradeApplyConfiguration, out *kubeadm.UpgradeApplyConfiguration, s conversion.Scope) error {
-	out.KubernetesVersion = in.KubernetesVersion
-	out.AllowExperimentalUpgrades = (*bool)(unsafe.Pointer(in.AllowExperimentalUpgrades))
-	out.AllowRCUpgrades = (*bool)(unsafe.Pointer(in.AllowRCUpgrades))
-	out.CertificateRenewal = (*bool)(unsafe.Pointer(in.CertificateRenewal))
-	out.DryRun = (*bool)(unsafe.Pointer(in.DryRun))
-	out.EtcdUpgrade = (*bool)(unsafe.Pointer(in.EtcdUpgrade))
-	out.ForceUpgrade = (*bool)(unsafe.Pointer(in.ForceUpgrade))
-	out.IgnorePreflightErrors = *(*[]string)(unsafe.Pointer(&in.IgnorePreflightErrors))
-	out.Patches = (*kubeadm.Patches)(unsafe.Pointer(in.Patches))
-	out.PrintConfig = (*bool)(unsafe.Pointer(in.PrintConfig))
-	out.SkipPhases = *(*[]string)(unsafe.Pointer(&in.SkipPhases))
-	out.ImagePullPolicy = corev1.PullPolicy(in.ImagePullPolicy)
-	out.ImagePullSerial = (*bool)(unsafe.Pointer(in.ImagePullSerial))
+	*out = *(*kubeadm.UpgradeApplyConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1045,19 +934,7 @@ func Convert_v1beta4_UpgradeApplyConfiguration_To_kubeadm_UpgradeApplyConfigurat
 }
 
 func autoConvert_kubeadm_UpgradeApplyConfiguration_To_v1beta4_UpgradeApplyConfiguration(in *kubeadm.UpgradeApplyConfiguration, out *UpgradeApplyConfiguration, s conversion.Scope) error {
-	out.KubernetesVersion = in.KubernetesVersion
-	out.AllowExperimentalUpgrades = (*bool)(unsafe.Pointer(in.AllowExperimentalUpgrades))
-	out.AllowRCUpgrades = (*bool)(unsafe.Pointer(in.AllowRCUpgrades))
-	out.CertificateRenewal = (*bool)(unsafe.Pointer(in.CertificateRenewal))
-	out.DryRun = (*bool)(unsafe.Pointer(in.DryRun))
-	out.EtcdUpgrade = (*bool)(unsafe.Pointer(in.EtcdUpgrade))
-	out.ForceUpgrade = (*bool)(unsafe.Pointer(in.ForceUpgrade))
-	out.IgnorePreflightErrors = *(*[]string)(unsafe.Pointer(&in.IgnorePreflightErrors))
-	out.Patches = (*Patches)(unsafe.Pointer(in.Patches))
-	out.PrintConfig = (*bool)(unsafe.Pointer(in.PrintConfig))
-	out.SkipPhases = *(*[]string)(unsafe.Pointer(&in.SkipPhases))
-	out.ImagePullPolicy = corev1.PullPolicy(in.ImagePullPolicy)
-	out.ImagePullSerial = (*bool)(unsafe.Pointer(in.ImagePullSerial))
+	*out = *(*UpgradeApplyConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1111,8 +988,7 @@ func Convert_kubeadm_UpgradeConfiguration_To_v1beta4_UpgradeConfiguration(in *ku
 }
 
 func autoConvert_v1beta4_UpgradeDiffConfiguration_To_kubeadm_UpgradeDiffConfiguration(in *UpgradeDiffConfiguration, out *kubeadm.UpgradeDiffConfiguration, s conversion.Scope) error {
-	out.KubernetesVersion = in.KubernetesVersion
-	out.DiffContextLines = in.DiffContextLines
+	*out = *(*kubeadm.UpgradeDiffConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1122,8 +998,7 @@ func Convert_v1beta4_UpgradeDiffConfiguration_To_kubeadm_UpgradeDiffConfiguratio
 }
 
 func autoConvert_kubeadm_UpgradeDiffConfiguration_To_v1beta4_UpgradeDiffConfiguration(in *kubeadm.UpgradeDiffConfiguration, out *UpgradeDiffConfiguration, s conversion.Scope) error {
-	out.KubernetesVersion = in.KubernetesVersion
-	out.DiffContextLines = in.DiffContextLines
+	*out = *(*UpgradeDiffConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1133,14 +1008,7 @@ func Convert_kubeadm_UpgradeDiffConfiguration_To_v1beta4_UpgradeDiffConfiguratio
 }
 
 func autoConvert_v1beta4_UpgradeNodeConfiguration_To_kubeadm_UpgradeNodeConfiguration(in *UpgradeNodeConfiguration, out *kubeadm.UpgradeNodeConfiguration, s conversion.Scope) error {
-	out.CertificateRenewal = (*bool)(unsafe.Pointer(in.CertificateRenewal))
-	out.DryRun = (*bool)(unsafe.Pointer(in.DryRun))
-	out.EtcdUpgrade = (*bool)(unsafe.Pointer(in.EtcdUpgrade))
-	out.IgnorePreflightErrors = *(*[]string)(unsafe.Pointer(&in.IgnorePreflightErrors))
-	out.SkipPhases = *(*[]string)(unsafe.Pointer(&in.SkipPhases))
-	out.Patches = (*kubeadm.Patches)(unsafe.Pointer(in.Patches))
-	out.ImagePullPolicy = corev1.PullPolicy(in.ImagePullPolicy)
-	out.ImagePullSerial = (*bool)(unsafe.Pointer(in.ImagePullSerial))
+	*out = *(*kubeadm.UpgradeNodeConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1150,14 +1018,7 @@ func Convert_v1beta4_UpgradeNodeConfiguration_To_kubeadm_UpgradeNodeConfiguratio
 }
 
 func autoConvert_kubeadm_UpgradeNodeConfiguration_To_v1beta4_UpgradeNodeConfiguration(in *kubeadm.UpgradeNodeConfiguration, out *UpgradeNodeConfiguration, s conversion.Scope) error {
-	out.CertificateRenewal = (*bool)(unsafe.Pointer(in.CertificateRenewal))
-	out.DryRun = (*bool)(unsafe.Pointer(in.DryRun))
-	out.EtcdUpgrade = (*bool)(unsafe.Pointer(in.EtcdUpgrade))
-	out.IgnorePreflightErrors = *(*[]string)(unsafe.Pointer(&in.IgnorePreflightErrors))
-	out.SkipPhases = *(*[]string)(unsafe.Pointer(&in.SkipPhases))
-	out.Patches = (*Patches)(unsafe.Pointer(in.Patches))
-	out.ImagePullPolicy = corev1.PullPolicy(in.ImagePullPolicy)
-	out.ImagePullSerial = (*bool)(unsafe.Pointer(in.ImagePullSerial))
+	*out = *(*UpgradeNodeConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1167,13 +1028,7 @@ func Convert_kubeadm_UpgradeNodeConfiguration_To_v1beta4_UpgradeNodeConfiguratio
 }
 
 func autoConvert_v1beta4_UpgradePlanConfiguration_To_kubeadm_UpgradePlanConfiguration(in *UpgradePlanConfiguration, out *kubeadm.UpgradePlanConfiguration, s conversion.Scope) error {
-	out.KubernetesVersion = in.KubernetesVersion
-	out.AllowExperimentalUpgrades = (*bool)(unsafe.Pointer(in.AllowExperimentalUpgrades))
-	out.AllowRCUpgrades = (*bool)(unsafe.Pointer(in.AllowRCUpgrades))
-	out.DryRun = (*bool)(unsafe.Pointer(in.DryRun))
-	out.EtcdUpgrade = (*bool)(unsafe.Pointer(in.EtcdUpgrade))
-	out.IgnorePreflightErrors = *(*[]string)(unsafe.Pointer(&in.IgnorePreflightErrors))
-	out.PrintConfig = (*bool)(unsafe.Pointer(in.PrintConfig))
+	*out = *(*kubeadm.UpgradePlanConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1183,13 +1038,7 @@ func Convert_v1beta4_UpgradePlanConfiguration_To_kubeadm_UpgradePlanConfiguratio
 }
 
 func autoConvert_kubeadm_UpgradePlanConfiguration_To_v1beta4_UpgradePlanConfiguration(in *kubeadm.UpgradePlanConfiguration, out *UpgradePlanConfiguration, s conversion.Scope) error {
-	out.KubernetesVersion = in.KubernetesVersion
-	out.AllowExperimentalUpgrades = (*bool)(unsafe.Pointer(in.AllowExperimentalUpgrades))
-	out.AllowRCUpgrades = (*bool)(unsafe.Pointer(in.AllowRCUpgrades))
-	out.DryRun = (*bool)(unsafe.Pointer(in.DryRun))
-	out.EtcdUpgrade = (*bool)(unsafe.Pointer(in.EtcdUpgrade))
-	out.IgnorePreflightErrors = *(*[]string)(unsafe.Pointer(&in.IgnorePreflightErrors))
-	out.PrintConfig = (*bool)(unsafe.Pointer(in.PrintConfig))
+	*out = *(*UpgradePlanConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/cmd/kubeadm/app/apis/output/v1alpha3/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/output/v1alpha3/zz_generated.conversion.go
@@ -162,12 +162,7 @@ func Convert_output_BootstrapToken_To_v1alpha3_BootstrapToken(in *output.Bootstr
 }
 
 func autoConvert_v1alpha3_Certificate_To_output_Certificate(in *Certificate, out *output.Certificate, s conversion.Scope) error {
-	out.Name = in.Name
-	out.ExpirationDate = in.ExpirationDate
-	out.ResidualTimeSeconds = in.ResidualTimeSeconds
-	out.ExternallyManaged = in.ExternallyManaged
-	out.CAName = in.CAName
-	out.Missing = in.Missing
+	*out = *(*output.Certificate)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -177,12 +172,7 @@ func Convert_v1alpha3_Certificate_To_output_Certificate(in *Certificate, out *ou
 }
 
 func autoConvert_output_Certificate_To_v1alpha3_Certificate(in *output.Certificate, out *Certificate, s conversion.Scope) error {
-	out.Name = in.Name
-	out.ExpirationDate = in.ExpirationDate
-	out.ResidualTimeSeconds = in.ResidualTimeSeconds
-	out.ExternallyManaged = in.ExternallyManaged
-	out.CAName = in.CAName
-	out.Missing = in.Missing
+	*out = *(*Certificate)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -214,10 +204,7 @@ func Convert_output_CertificateExpirationInfo_To_v1alpha3_CertificateExpirationI
 }
 
 func autoConvert_v1alpha3_ComponentConfigVersionState_To_output_ComponentConfigVersionState(in *ComponentConfigVersionState, out *output.ComponentConfigVersionState, s conversion.Scope) error {
-	out.Group = in.Group
-	out.CurrentVersion = in.CurrentVersion
-	out.PreferredVersion = in.PreferredVersion
-	out.ManualUpgradeRequired = in.ManualUpgradeRequired
+	*out = *(*output.ComponentConfigVersionState)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -227,10 +214,7 @@ func Convert_v1alpha3_ComponentConfigVersionState_To_output_ComponentConfigVersi
 }
 
 func autoConvert_output_ComponentConfigVersionState_To_v1alpha3_ComponentConfigVersionState(in *output.ComponentConfigVersionState, out *ComponentConfigVersionState, s conversion.Scope) error {
-	out.Group = in.Group
-	out.CurrentVersion = in.CurrentVersion
-	out.PreferredVersion = in.PreferredVersion
-	out.ManualUpgradeRequired = in.ManualUpgradeRequired
+	*out = *(*ComponentConfigVersionState)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/abac/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/abac/v1beta1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1beta1
 
 import (
+	unsafe "unsafe"
+
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	abac "k8s.io/kubernetes/pkg/apis/abac"
@@ -77,13 +79,7 @@ func Convert_abac_Policy_To_v1beta1_Policy(in *abac.Policy, out *Policy, s conve
 }
 
 func autoConvert_v1beta1_PolicySpec_To_abac_PolicySpec(in *PolicySpec, out *abac.PolicySpec, s conversion.Scope) error {
-	out.User = in.User
-	out.Group = in.Group
-	out.Readonly = in.Readonly
-	out.APIGroup = in.APIGroup
-	out.Resource = in.Resource
-	out.Namespace = in.Namespace
-	out.NonResourcePath = in.NonResourcePath
+	*out = *(*abac.PolicySpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -93,13 +89,7 @@ func Convert_v1beta1_PolicySpec_To_abac_PolicySpec(in *PolicySpec, out *abac.Pol
 }
 
 func autoConvert_abac_PolicySpec_To_v1beta1_PolicySpec(in *abac.PolicySpec, out *PolicySpec, s conversion.Scope) error {
-	out.User = in.User
-	out.Group = in.Group
-	out.Readonly = in.Readonly
-	out.APIGroup = in.APIGroup
-	out.Resource = in.Resource
-	out.Namespace = in.Namespace
-	out.NonResourcePath = in.NonResourcePath
+	*out = *(*PolicySpec)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/admissionregistration/v1/zz_generated.conversion.go
+++ b/pkg/apis/admissionregistration/v1/zz_generated.conversion.go
@@ -402,7 +402,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1_ApplyConfiguration_To_admissionregistration_ApplyConfiguration(in *admissionregistrationv1.ApplyConfiguration, out *admissionregistration.ApplyConfiguration, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*admissionregistration.ApplyConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -412,7 +412,7 @@ func Convert_v1_ApplyConfiguration_To_admissionregistration_ApplyConfiguration(i
 }
 
 func autoConvert_admissionregistration_ApplyConfiguration_To_v1_ApplyConfiguration(in *admissionregistration.ApplyConfiguration, out *admissionregistrationv1.ApplyConfiguration, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*admissionregistrationv1.ApplyConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -422,8 +422,7 @@ func Convert_admissionregistration_ApplyConfiguration_To_v1_ApplyConfiguration(i
 }
 
 func autoConvert_v1_AuditAnnotation_To_admissionregistration_AuditAnnotation(in *admissionregistrationv1.AuditAnnotation, out *admissionregistration.AuditAnnotation, s conversion.Scope) error {
-	out.Key = in.Key
-	out.ValueExpression = in.ValueExpression
+	*out = *(*admissionregistration.AuditAnnotation)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -433,8 +432,7 @@ func Convert_v1_AuditAnnotation_To_admissionregistration_AuditAnnotation(in *adm
 }
 
 func autoConvert_admissionregistration_AuditAnnotation_To_v1_AuditAnnotation(in *admissionregistration.AuditAnnotation, out *admissionregistrationv1.AuditAnnotation, s conversion.Scope) error {
-	out.Key = in.Key
-	out.ValueExpression = in.ValueExpression
+	*out = *(*admissionregistrationv1.AuditAnnotation)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -444,8 +442,7 @@ func Convert_admissionregistration_AuditAnnotation_To_v1_AuditAnnotation(in *adm
 }
 
 func autoConvert_v1_ExpressionWarning_To_admissionregistration_ExpressionWarning(in *admissionregistrationv1.ExpressionWarning, out *admissionregistration.ExpressionWarning, s conversion.Scope) error {
-	out.FieldRef = in.FieldRef
-	out.Warning = in.Warning
+	*out = *(*admissionregistration.ExpressionWarning)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -455,8 +452,7 @@ func Convert_v1_ExpressionWarning_To_admissionregistration_ExpressionWarning(in 
 }
 
 func autoConvert_admissionregistration_ExpressionWarning_To_v1_ExpressionWarning(in *admissionregistration.ExpressionWarning, out *admissionregistrationv1.ExpressionWarning, s conversion.Scope) error {
-	out.FieldRef = in.FieldRef
-	out.Warning = in.Warning
+	*out = *(*admissionregistrationv1.ExpressionWarning)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -466,7 +462,7 @@ func Convert_admissionregistration_ExpressionWarning_To_v1_ExpressionWarning(in 
 }
 
 func autoConvert_v1_JSONPatch_To_admissionregistration_JSONPatch(in *admissionregistrationv1.JSONPatch, out *admissionregistration.JSONPatch, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*admissionregistration.JSONPatch)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -476,7 +472,7 @@ func Convert_v1_JSONPatch_To_admissionregistration_JSONPatch(in *admissionregist
 }
 
 func autoConvert_admissionregistration_JSONPatch_To_v1_JSONPatch(in *admissionregistration.JSONPatch, out *admissionregistrationv1.JSONPatch, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*admissionregistrationv1.JSONPatch)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -486,8 +482,7 @@ func Convert_admissionregistration_JSONPatch_To_v1_JSONPatch(in *admissionregist
 }
 
 func autoConvert_v1_MatchCondition_To_admissionregistration_MatchCondition(in *admissionregistrationv1.MatchCondition, out *admissionregistration.MatchCondition, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Expression = in.Expression
+	*out = *(*admissionregistration.MatchCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -497,8 +492,7 @@ func Convert_v1_MatchCondition_To_admissionregistration_MatchCondition(in *admis
 }
 
 func autoConvert_admissionregistration_MatchCondition_To_v1_MatchCondition(in *admissionregistration.MatchCondition, out *admissionregistrationv1.MatchCondition, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Expression = in.Expression
+	*out = *(*admissionregistrationv1.MatchCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -950,9 +944,7 @@ func Convert_admissionregistration_MutatingWebhookConfigurationList_To_v1_Mutati
 }
 
 func autoConvert_v1_Mutation_To_admissionregistration_Mutation(in *admissionregistrationv1.Mutation, out *admissionregistration.Mutation, s conversion.Scope) error {
-	out.PatchType = admissionregistration.PatchType(in.PatchType)
-	out.ApplyConfiguration = (*admissionregistration.ApplyConfiguration)(unsafe.Pointer(in.ApplyConfiguration))
-	out.JSONPatch = (*admissionregistration.JSONPatch)(unsafe.Pointer(in.JSONPatch))
+	*out = *(*admissionregistration.Mutation)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -962,9 +954,7 @@ func Convert_v1_Mutation_To_admissionregistration_Mutation(in *admissionregistra
 }
 
 func autoConvert_admissionregistration_Mutation_To_v1_Mutation(in *admissionregistration.Mutation, out *admissionregistrationv1.Mutation, s conversion.Scope) error {
-	out.PatchType = admissionregistrationv1.PatchType(in.PatchType)
-	out.ApplyConfiguration = (*admissionregistrationv1.ApplyConfiguration)(unsafe.Pointer(in.ApplyConfiguration))
-	out.JSONPatch = (*admissionregistrationv1.JSONPatch)(unsafe.Pointer(in.JSONPatch))
+	*out = *(*admissionregistrationv1.Mutation)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1000,8 +990,7 @@ func Convert_admissionregistration_NamedRuleWithOperations_To_v1_NamedRuleWithOp
 }
 
 func autoConvert_v1_ParamKind_To_admissionregistration_ParamKind(in *admissionregistrationv1.ParamKind, out *admissionregistration.ParamKind, s conversion.Scope) error {
-	out.APIVersion = in.APIVersion
-	out.Kind = in.Kind
+	*out = *(*admissionregistration.ParamKind)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1011,8 +1000,7 @@ func Convert_v1_ParamKind_To_admissionregistration_ParamKind(in *admissionregist
 }
 
 func autoConvert_admissionregistration_ParamKind_To_v1_ParamKind(in *admissionregistration.ParamKind, out *admissionregistrationv1.ParamKind, s conversion.Scope) error {
-	out.APIVersion = in.APIVersion
-	out.Kind = in.Kind
+	*out = *(*admissionregistrationv1.ParamKind)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1022,10 +1010,7 @@ func Convert_admissionregistration_ParamKind_To_v1_ParamKind(in *admissionregist
 }
 
 func autoConvert_v1_ParamRef_To_admissionregistration_ParamRef(in *admissionregistrationv1.ParamRef, out *admissionregistration.ParamRef, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Namespace = in.Namespace
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
-	out.ParameterNotFoundAction = (*admissionregistration.ParameterNotFoundActionType)(unsafe.Pointer(in.ParameterNotFoundAction))
+	*out = *(*admissionregistration.ParamRef)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1035,10 +1020,7 @@ func Convert_v1_ParamRef_To_admissionregistration_ParamRef(in *admissionregistra
 }
 
 func autoConvert_admissionregistration_ParamRef_To_v1_ParamRef(in *admissionregistration.ParamRef, out *admissionregistrationv1.ParamRef, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Namespace = in.Namespace
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
-	out.ParameterNotFoundAction = (*admissionregistrationv1.ParameterNotFoundActionType)(unsafe.Pointer(in.ParameterNotFoundAction))
+	*out = *(*admissionregistrationv1.ParamRef)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1048,10 +1030,7 @@ func Convert_admissionregistration_ParamRef_To_v1_ParamRef(in *admissionregistra
 }
 
 func autoConvert_v1_Rule_To_admissionregistration_Rule(in *admissionregistrationv1.Rule, out *admissionregistration.Rule, s conversion.Scope) error {
-	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
-	out.APIVersions = *(*[]string)(unsafe.Pointer(&in.APIVersions))
-	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
-	out.Scope = (*admissionregistration.ScopeType)(unsafe.Pointer(in.Scope))
+	*out = *(*admissionregistration.Rule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1061,10 +1040,7 @@ func Convert_v1_Rule_To_admissionregistration_Rule(in *admissionregistrationv1.R
 }
 
 func autoConvert_admissionregistration_Rule_To_v1_Rule(in *admissionregistration.Rule, out *admissionregistrationv1.Rule, s conversion.Scope) error {
-	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
-	out.APIVersions = *(*[]string)(unsafe.Pointer(&in.APIVersions))
-	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
-	out.Scope = (*admissionregistrationv1.ScopeType)(unsafe.Pointer(in.Scope))
+	*out = *(*admissionregistrationv1.Rule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1120,7 +1096,7 @@ func Convert_admissionregistration_ServiceReference_To_v1_ServiceReference(in *a
 }
 
 func autoConvert_v1_TypeChecking_To_admissionregistration_TypeChecking(in *admissionregistrationv1.TypeChecking, out *admissionregistration.TypeChecking, s conversion.Scope) error {
-	out.ExpressionWarnings = *(*[]admissionregistration.ExpressionWarning)(unsafe.Pointer(&in.ExpressionWarnings))
+	*out = *(*admissionregistration.TypeChecking)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1130,7 +1106,7 @@ func Convert_v1_TypeChecking_To_admissionregistration_TypeChecking(in *admission
 }
 
 func autoConvert_admissionregistration_TypeChecking_To_v1_TypeChecking(in *admissionregistration.TypeChecking, out *admissionregistrationv1.TypeChecking, s conversion.Scope) error {
-	out.ExpressionWarnings = *(*[]admissionregistrationv1.ExpressionWarning)(unsafe.Pointer(&in.ExpressionWarnings))
+	*out = *(*admissionregistrationv1.TypeChecking)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1372,9 +1348,7 @@ func Convert_admissionregistration_ValidatingAdmissionPolicySpec_To_v1_Validatin
 }
 
 func autoConvert_v1_ValidatingAdmissionPolicyStatus_To_admissionregistration_ValidatingAdmissionPolicyStatus(in *admissionregistrationv1.ValidatingAdmissionPolicyStatus, out *admissionregistration.ValidatingAdmissionPolicyStatus, s conversion.Scope) error {
-	out.ObservedGeneration = in.ObservedGeneration
-	out.TypeChecking = (*admissionregistration.TypeChecking)(unsafe.Pointer(in.TypeChecking))
-	out.Conditions = *(*[]metav1.Condition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*admissionregistration.ValidatingAdmissionPolicyStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1384,9 +1358,7 @@ func Convert_v1_ValidatingAdmissionPolicyStatus_To_admissionregistration_Validat
 }
 
 func autoConvert_admissionregistration_ValidatingAdmissionPolicyStatus_To_v1_ValidatingAdmissionPolicyStatus(in *admissionregistration.ValidatingAdmissionPolicyStatus, out *admissionregistrationv1.ValidatingAdmissionPolicyStatus, s conversion.Scope) error {
-	out.ObservedGeneration = in.ObservedGeneration
-	out.TypeChecking = (*admissionregistrationv1.TypeChecking)(unsafe.Pointer(in.TypeChecking))
-	out.Conditions = *(*[]metav1.Condition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*admissionregistrationv1.ValidatingAdmissionPolicyStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1544,10 +1516,7 @@ func Convert_admissionregistration_ValidatingWebhookConfigurationList_To_v1_Vali
 }
 
 func autoConvert_v1_Validation_To_admissionregistration_Validation(in *admissionregistrationv1.Validation, out *admissionregistration.Validation, s conversion.Scope) error {
-	out.Expression = in.Expression
-	out.Message = in.Message
-	out.Reason = (*metav1.StatusReason)(unsafe.Pointer(in.Reason))
-	out.MessageExpression = in.MessageExpression
+	*out = *(*admissionregistration.Validation)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1557,10 +1526,7 @@ func Convert_v1_Validation_To_admissionregistration_Validation(in *admissionregi
 }
 
 func autoConvert_admissionregistration_Validation_To_v1_Validation(in *admissionregistration.Validation, out *admissionregistrationv1.Validation, s conversion.Scope) error {
-	out.Expression = in.Expression
-	out.Message = in.Message
-	out.Reason = (*metav1.StatusReason)(unsafe.Pointer(in.Reason))
-	out.MessageExpression = in.MessageExpression
+	*out = *(*admissionregistrationv1.Validation)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1570,8 +1536,7 @@ func Convert_admissionregistration_Validation_To_v1_Validation(in *admissionregi
 }
 
 func autoConvert_v1_Variable_To_admissionregistration_Variable(in *admissionregistrationv1.Variable, out *admissionregistration.Variable, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Expression = in.Expression
+	*out = *(*admissionregistration.Variable)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1581,8 +1546,7 @@ func Convert_v1_Variable_To_admissionregistration_Variable(in *admissionregistra
 }
 
 func autoConvert_admissionregistration_Variable_To_v1_Variable(in *admissionregistration.Variable, out *admissionregistrationv1.Variable, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Expression = in.Expression
+	*out = *(*admissionregistrationv1.Variable)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/admissionregistration/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/admissionregistration/v1alpha1/zz_generated.conversion.go
@@ -304,7 +304,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_ApplyConfiguration_To_admissionregistration_ApplyConfiguration(in *admissionregistrationv1alpha1.ApplyConfiguration, out *admissionregistration.ApplyConfiguration, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*admissionregistration.ApplyConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -314,7 +314,7 @@ func Convert_v1alpha1_ApplyConfiguration_To_admissionregistration_ApplyConfigura
 }
 
 func autoConvert_admissionregistration_ApplyConfiguration_To_v1alpha1_ApplyConfiguration(in *admissionregistration.ApplyConfiguration, out *admissionregistrationv1alpha1.ApplyConfiguration, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*admissionregistrationv1alpha1.ApplyConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -324,8 +324,7 @@ func Convert_admissionregistration_ApplyConfiguration_To_v1alpha1_ApplyConfigura
 }
 
 func autoConvert_v1alpha1_AuditAnnotation_To_admissionregistration_AuditAnnotation(in *admissionregistrationv1alpha1.AuditAnnotation, out *admissionregistration.AuditAnnotation, s conversion.Scope) error {
-	out.Key = in.Key
-	out.ValueExpression = in.ValueExpression
+	*out = *(*admissionregistration.AuditAnnotation)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -335,8 +334,7 @@ func Convert_v1alpha1_AuditAnnotation_To_admissionregistration_AuditAnnotation(i
 }
 
 func autoConvert_admissionregistration_AuditAnnotation_To_v1alpha1_AuditAnnotation(in *admissionregistration.AuditAnnotation, out *admissionregistrationv1alpha1.AuditAnnotation, s conversion.Scope) error {
-	out.Key = in.Key
-	out.ValueExpression = in.ValueExpression
+	*out = *(*admissionregistrationv1alpha1.AuditAnnotation)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -346,8 +344,7 @@ func Convert_admissionregistration_AuditAnnotation_To_v1alpha1_AuditAnnotation(i
 }
 
 func autoConvert_v1alpha1_ExpressionWarning_To_admissionregistration_ExpressionWarning(in *admissionregistrationv1alpha1.ExpressionWarning, out *admissionregistration.ExpressionWarning, s conversion.Scope) error {
-	out.FieldRef = in.FieldRef
-	out.Warning = in.Warning
+	*out = *(*admissionregistration.ExpressionWarning)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -357,8 +354,7 @@ func Convert_v1alpha1_ExpressionWarning_To_admissionregistration_ExpressionWarni
 }
 
 func autoConvert_admissionregistration_ExpressionWarning_To_v1alpha1_ExpressionWarning(in *admissionregistration.ExpressionWarning, out *admissionregistrationv1alpha1.ExpressionWarning, s conversion.Scope) error {
-	out.FieldRef = in.FieldRef
-	out.Warning = in.Warning
+	*out = *(*admissionregistrationv1alpha1.ExpressionWarning)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -368,7 +364,7 @@ func Convert_admissionregistration_ExpressionWarning_To_v1alpha1_ExpressionWarni
 }
 
 func autoConvert_v1alpha1_JSONPatch_To_admissionregistration_JSONPatch(in *admissionregistrationv1alpha1.JSONPatch, out *admissionregistration.JSONPatch, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*admissionregistration.JSONPatch)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -378,7 +374,7 @@ func Convert_v1alpha1_JSONPatch_To_admissionregistration_JSONPatch(in *admission
 }
 
 func autoConvert_admissionregistration_JSONPatch_To_v1alpha1_JSONPatch(in *admissionregistration.JSONPatch, out *admissionregistrationv1alpha1.JSONPatch, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*admissionregistrationv1alpha1.JSONPatch)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -388,8 +384,7 @@ func Convert_admissionregistration_JSONPatch_To_v1alpha1_JSONPatch(in *admission
 }
 
 func autoConvert_v1alpha1_MatchCondition_To_admissionregistration_MatchCondition(in *admissionregistrationv1alpha1.MatchCondition, out *admissionregistration.MatchCondition, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Expression = in.Expression
+	*out = *(*admissionregistration.MatchCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -399,8 +394,7 @@ func Convert_v1alpha1_MatchCondition_To_admissionregistration_MatchCondition(in 
 }
 
 func autoConvert_admissionregistration_MatchCondition_To_v1alpha1_MatchCondition(in *admissionregistration.MatchCondition, out *admissionregistrationv1alpha1.MatchCondition, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Expression = in.Expression
+	*out = *(*admissionregistrationv1alpha1.MatchCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -702,9 +696,7 @@ func Convert_admissionregistration_MutatingAdmissionPolicySpec_To_v1alpha1_Mutat
 }
 
 func autoConvert_v1alpha1_Mutation_To_admissionregistration_Mutation(in *admissionregistrationv1alpha1.Mutation, out *admissionregistration.Mutation, s conversion.Scope) error {
-	out.PatchType = admissionregistration.PatchType(in.PatchType)
-	out.ApplyConfiguration = (*admissionregistration.ApplyConfiguration)(unsafe.Pointer(in.ApplyConfiguration))
-	out.JSONPatch = (*admissionregistration.JSONPatch)(unsafe.Pointer(in.JSONPatch))
+	*out = *(*admissionregistration.Mutation)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -714,9 +706,7 @@ func Convert_v1alpha1_Mutation_To_admissionregistration_Mutation(in *admissionre
 }
 
 func autoConvert_admissionregistration_Mutation_To_v1alpha1_Mutation(in *admissionregistration.Mutation, out *admissionregistrationv1alpha1.Mutation, s conversion.Scope) error {
-	out.PatchType = admissionregistrationv1alpha1.PatchType(in.PatchType)
-	out.ApplyConfiguration = (*admissionregistrationv1alpha1.ApplyConfiguration)(unsafe.Pointer(in.ApplyConfiguration))
-	out.JSONPatch = (*admissionregistrationv1alpha1.JSONPatch)(unsafe.Pointer(in.JSONPatch))
+	*out = *(*admissionregistrationv1alpha1.Mutation)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -752,8 +742,7 @@ func Convert_admissionregistration_NamedRuleWithOperations_To_v1alpha1_NamedRule
 }
 
 func autoConvert_v1alpha1_ParamKind_To_admissionregistration_ParamKind(in *admissionregistrationv1alpha1.ParamKind, out *admissionregistration.ParamKind, s conversion.Scope) error {
-	out.APIVersion = in.APIVersion
-	out.Kind = in.Kind
+	*out = *(*admissionregistration.ParamKind)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -763,8 +752,7 @@ func Convert_v1alpha1_ParamKind_To_admissionregistration_ParamKind(in *admission
 }
 
 func autoConvert_admissionregistration_ParamKind_To_v1alpha1_ParamKind(in *admissionregistration.ParamKind, out *admissionregistrationv1alpha1.ParamKind, s conversion.Scope) error {
-	out.APIVersion = in.APIVersion
-	out.Kind = in.Kind
+	*out = *(*admissionregistrationv1alpha1.ParamKind)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -774,10 +762,7 @@ func Convert_admissionregistration_ParamKind_To_v1alpha1_ParamKind(in *admission
 }
 
 func autoConvert_v1alpha1_ParamRef_To_admissionregistration_ParamRef(in *admissionregistrationv1alpha1.ParamRef, out *admissionregistration.ParamRef, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Namespace = in.Namespace
-	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
-	out.ParameterNotFoundAction = (*admissionregistration.ParameterNotFoundActionType)(unsafe.Pointer(in.ParameterNotFoundAction))
+	*out = *(*admissionregistration.ParamRef)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -787,10 +772,7 @@ func Convert_v1alpha1_ParamRef_To_admissionregistration_ParamRef(in *admissionre
 }
 
 func autoConvert_admissionregistration_ParamRef_To_v1alpha1_ParamRef(in *admissionregistration.ParamRef, out *admissionregistrationv1alpha1.ParamRef, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Namespace = in.Namespace
-	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
-	out.ParameterNotFoundAction = (*admissionregistrationv1alpha1.ParameterNotFoundActionType)(unsafe.Pointer(in.ParameterNotFoundAction))
+	*out = *(*admissionregistrationv1alpha1.ParamRef)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -800,7 +782,7 @@ func Convert_admissionregistration_ParamRef_To_v1alpha1_ParamRef(in *admissionre
 }
 
 func autoConvert_v1alpha1_TypeChecking_To_admissionregistration_TypeChecking(in *admissionregistrationv1alpha1.TypeChecking, out *admissionregistration.TypeChecking, s conversion.Scope) error {
-	out.ExpressionWarnings = *(*[]admissionregistration.ExpressionWarning)(unsafe.Pointer(&in.ExpressionWarnings))
+	*out = *(*admissionregistration.TypeChecking)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -810,7 +792,7 @@ func Convert_v1alpha1_TypeChecking_To_admissionregistration_TypeChecking(in *adm
 }
 
 func autoConvert_admissionregistration_TypeChecking_To_v1alpha1_TypeChecking(in *admissionregistration.TypeChecking, out *admissionregistrationv1alpha1.TypeChecking, s conversion.Scope) error {
-	out.ExpressionWarnings = *(*[]admissionregistrationv1alpha1.ExpressionWarning)(unsafe.Pointer(&in.ExpressionWarnings))
+	*out = *(*admissionregistrationv1alpha1.TypeChecking)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1052,9 +1034,7 @@ func Convert_admissionregistration_ValidatingAdmissionPolicySpec_To_v1alpha1_Val
 }
 
 func autoConvert_v1alpha1_ValidatingAdmissionPolicyStatus_To_admissionregistration_ValidatingAdmissionPolicyStatus(in *admissionregistrationv1alpha1.ValidatingAdmissionPolicyStatus, out *admissionregistration.ValidatingAdmissionPolicyStatus, s conversion.Scope) error {
-	out.ObservedGeneration = in.ObservedGeneration
-	out.TypeChecking = (*admissionregistration.TypeChecking)(unsafe.Pointer(in.TypeChecking))
-	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*admissionregistration.ValidatingAdmissionPolicyStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1064,9 +1044,7 @@ func Convert_v1alpha1_ValidatingAdmissionPolicyStatus_To_admissionregistration_V
 }
 
 func autoConvert_admissionregistration_ValidatingAdmissionPolicyStatus_To_v1alpha1_ValidatingAdmissionPolicyStatus(in *admissionregistration.ValidatingAdmissionPolicyStatus, out *admissionregistrationv1alpha1.ValidatingAdmissionPolicyStatus, s conversion.Scope) error {
-	out.ObservedGeneration = in.ObservedGeneration
-	out.TypeChecking = (*admissionregistrationv1alpha1.TypeChecking)(unsafe.Pointer(in.TypeChecking))
-	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*admissionregistrationv1alpha1.ValidatingAdmissionPolicyStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1076,10 +1054,7 @@ func Convert_admissionregistration_ValidatingAdmissionPolicyStatus_To_v1alpha1_V
 }
 
 func autoConvert_v1alpha1_Validation_To_admissionregistration_Validation(in *admissionregistrationv1alpha1.Validation, out *admissionregistration.Validation, s conversion.Scope) error {
-	out.Expression = in.Expression
-	out.Message = in.Message
-	out.Reason = (*v1.StatusReason)(unsafe.Pointer(in.Reason))
-	out.MessageExpression = in.MessageExpression
+	*out = *(*admissionregistration.Validation)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1089,10 +1064,7 @@ func Convert_v1alpha1_Validation_To_admissionregistration_Validation(in *admissi
 }
 
 func autoConvert_admissionregistration_Validation_To_v1alpha1_Validation(in *admissionregistration.Validation, out *admissionregistrationv1alpha1.Validation, s conversion.Scope) error {
-	out.Expression = in.Expression
-	out.Message = in.Message
-	out.Reason = (*v1.StatusReason)(unsafe.Pointer(in.Reason))
-	out.MessageExpression = in.MessageExpression
+	*out = *(*admissionregistrationv1alpha1.Validation)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1102,8 +1074,7 @@ func Convert_admissionregistration_Validation_To_v1alpha1_Validation(in *admissi
 }
 
 func autoConvert_v1alpha1_Variable_To_admissionregistration_Variable(in *admissionregistrationv1alpha1.Variable, out *admissionregistration.Variable, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Expression = in.Expression
+	*out = *(*admissionregistration.Variable)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1113,8 +1084,7 @@ func Convert_v1alpha1_Variable_To_admissionregistration_Variable(in *admissionre
 }
 
 func autoConvert_admissionregistration_Variable_To_v1alpha1_Variable(in *admissionregistration.Variable, out *admissionregistrationv1alpha1.Variable, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Expression = in.Expression
+	*out = *(*admissionregistrationv1alpha1.Variable)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/admissionregistration/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/admissionregistration/v1beta1/zz_generated.conversion.go
@@ -384,7 +384,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1beta1_ApplyConfiguration_To_admissionregistration_ApplyConfiguration(in *admissionregistrationv1beta1.ApplyConfiguration, out *admissionregistration.ApplyConfiguration, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*admissionregistration.ApplyConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -394,7 +394,7 @@ func Convert_v1beta1_ApplyConfiguration_To_admissionregistration_ApplyConfigurat
 }
 
 func autoConvert_admissionregistration_ApplyConfiguration_To_v1beta1_ApplyConfiguration(in *admissionregistration.ApplyConfiguration, out *admissionregistrationv1beta1.ApplyConfiguration, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*admissionregistrationv1beta1.ApplyConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -404,8 +404,7 @@ func Convert_admissionregistration_ApplyConfiguration_To_v1beta1_ApplyConfigurat
 }
 
 func autoConvert_v1beta1_AuditAnnotation_To_admissionregistration_AuditAnnotation(in *admissionregistrationv1beta1.AuditAnnotation, out *admissionregistration.AuditAnnotation, s conversion.Scope) error {
-	out.Key = in.Key
-	out.ValueExpression = in.ValueExpression
+	*out = *(*admissionregistration.AuditAnnotation)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -415,8 +414,7 @@ func Convert_v1beta1_AuditAnnotation_To_admissionregistration_AuditAnnotation(in
 }
 
 func autoConvert_admissionregistration_AuditAnnotation_To_v1beta1_AuditAnnotation(in *admissionregistration.AuditAnnotation, out *admissionregistrationv1beta1.AuditAnnotation, s conversion.Scope) error {
-	out.Key = in.Key
-	out.ValueExpression = in.ValueExpression
+	*out = *(*admissionregistrationv1beta1.AuditAnnotation)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -426,8 +424,7 @@ func Convert_admissionregistration_AuditAnnotation_To_v1beta1_AuditAnnotation(in
 }
 
 func autoConvert_v1beta1_ExpressionWarning_To_admissionregistration_ExpressionWarning(in *admissionregistrationv1beta1.ExpressionWarning, out *admissionregistration.ExpressionWarning, s conversion.Scope) error {
-	out.FieldRef = in.FieldRef
-	out.Warning = in.Warning
+	*out = *(*admissionregistration.ExpressionWarning)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -437,8 +434,7 @@ func Convert_v1beta1_ExpressionWarning_To_admissionregistration_ExpressionWarnin
 }
 
 func autoConvert_admissionregistration_ExpressionWarning_To_v1beta1_ExpressionWarning(in *admissionregistration.ExpressionWarning, out *admissionregistrationv1beta1.ExpressionWarning, s conversion.Scope) error {
-	out.FieldRef = in.FieldRef
-	out.Warning = in.Warning
+	*out = *(*admissionregistrationv1beta1.ExpressionWarning)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -448,7 +444,7 @@ func Convert_admissionregistration_ExpressionWarning_To_v1beta1_ExpressionWarnin
 }
 
 func autoConvert_v1beta1_JSONPatch_To_admissionregistration_JSONPatch(in *admissionregistrationv1beta1.JSONPatch, out *admissionregistration.JSONPatch, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*admissionregistration.JSONPatch)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -458,7 +454,7 @@ func Convert_v1beta1_JSONPatch_To_admissionregistration_JSONPatch(in *admissionr
 }
 
 func autoConvert_admissionregistration_JSONPatch_To_v1beta1_JSONPatch(in *admissionregistration.JSONPatch, out *admissionregistrationv1beta1.JSONPatch, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*admissionregistrationv1beta1.JSONPatch)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -468,8 +464,7 @@ func Convert_admissionregistration_JSONPatch_To_v1beta1_JSONPatch(in *admissionr
 }
 
 func autoConvert_v1beta1_MatchCondition_To_admissionregistration_MatchCondition(in *admissionregistrationv1beta1.MatchCondition, out *admissionregistration.MatchCondition, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Expression = in.Expression
+	*out = *(*admissionregistration.MatchCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -479,8 +474,7 @@ func Convert_v1beta1_MatchCondition_To_admissionregistration_MatchCondition(in *
 }
 
 func autoConvert_admissionregistration_MatchCondition_To_v1beta1_MatchCondition(in *admissionregistration.MatchCondition, out *admissionregistrationv1beta1.MatchCondition, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Expression = in.Expression
+	*out = *(*admissionregistrationv1beta1.MatchCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -932,9 +926,7 @@ func Convert_admissionregistration_MutatingWebhookConfigurationList_To_v1beta1_M
 }
 
 func autoConvert_v1beta1_Mutation_To_admissionregistration_Mutation(in *admissionregistrationv1beta1.Mutation, out *admissionregistration.Mutation, s conversion.Scope) error {
-	out.PatchType = admissionregistration.PatchType(in.PatchType)
-	out.ApplyConfiguration = (*admissionregistration.ApplyConfiguration)(unsafe.Pointer(in.ApplyConfiguration))
-	out.JSONPatch = (*admissionregistration.JSONPatch)(unsafe.Pointer(in.JSONPatch))
+	*out = *(*admissionregistration.Mutation)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -944,9 +936,7 @@ func Convert_v1beta1_Mutation_To_admissionregistration_Mutation(in *admissionreg
 }
 
 func autoConvert_admissionregistration_Mutation_To_v1beta1_Mutation(in *admissionregistration.Mutation, out *admissionregistrationv1beta1.Mutation, s conversion.Scope) error {
-	out.PatchType = admissionregistrationv1beta1.PatchType(in.PatchType)
-	out.ApplyConfiguration = (*admissionregistrationv1beta1.ApplyConfiguration)(unsafe.Pointer(in.ApplyConfiguration))
-	out.JSONPatch = (*admissionregistrationv1beta1.JSONPatch)(unsafe.Pointer(in.JSONPatch))
+	*out = *(*admissionregistrationv1beta1.Mutation)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -982,8 +972,7 @@ func Convert_admissionregistration_NamedRuleWithOperations_To_v1beta1_NamedRuleW
 }
 
 func autoConvert_v1beta1_ParamKind_To_admissionregistration_ParamKind(in *admissionregistrationv1beta1.ParamKind, out *admissionregistration.ParamKind, s conversion.Scope) error {
-	out.APIVersion = in.APIVersion
-	out.Kind = in.Kind
+	*out = *(*admissionregistration.ParamKind)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -993,8 +982,7 @@ func Convert_v1beta1_ParamKind_To_admissionregistration_ParamKind(in *admissionr
 }
 
 func autoConvert_admissionregistration_ParamKind_To_v1beta1_ParamKind(in *admissionregistration.ParamKind, out *admissionregistrationv1beta1.ParamKind, s conversion.Scope) error {
-	out.APIVersion = in.APIVersion
-	out.Kind = in.Kind
+	*out = *(*admissionregistrationv1beta1.ParamKind)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1004,10 +992,7 @@ func Convert_admissionregistration_ParamKind_To_v1beta1_ParamKind(in *admissionr
 }
 
 func autoConvert_v1beta1_ParamRef_To_admissionregistration_ParamRef(in *admissionregistrationv1beta1.ParamRef, out *admissionregistration.ParamRef, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Namespace = in.Namespace
-	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
-	out.ParameterNotFoundAction = (*admissionregistration.ParameterNotFoundActionType)(unsafe.Pointer(in.ParameterNotFoundAction))
+	*out = *(*admissionregistration.ParamRef)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1017,10 +1002,7 @@ func Convert_v1beta1_ParamRef_To_admissionregistration_ParamRef(in *admissionreg
 }
 
 func autoConvert_admissionregistration_ParamRef_To_v1beta1_ParamRef(in *admissionregistration.ParamRef, out *admissionregistrationv1beta1.ParamRef, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Namespace = in.Namespace
-	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
-	out.ParameterNotFoundAction = (*admissionregistrationv1beta1.ParameterNotFoundActionType)(unsafe.Pointer(in.ParameterNotFoundAction))
+	*out = *(*admissionregistrationv1beta1.ParamRef)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1060,7 +1042,7 @@ func Convert_admissionregistration_ServiceReference_To_v1beta1_ServiceReference(
 }
 
 func autoConvert_v1beta1_TypeChecking_To_admissionregistration_TypeChecking(in *admissionregistrationv1beta1.TypeChecking, out *admissionregistration.TypeChecking, s conversion.Scope) error {
-	out.ExpressionWarnings = *(*[]admissionregistration.ExpressionWarning)(unsafe.Pointer(&in.ExpressionWarnings))
+	*out = *(*admissionregistration.TypeChecking)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1070,7 +1052,7 @@ func Convert_v1beta1_TypeChecking_To_admissionregistration_TypeChecking(in *admi
 }
 
 func autoConvert_admissionregistration_TypeChecking_To_v1beta1_TypeChecking(in *admissionregistration.TypeChecking, out *admissionregistrationv1beta1.TypeChecking, s conversion.Scope) error {
-	out.ExpressionWarnings = *(*[]admissionregistrationv1beta1.ExpressionWarning)(unsafe.Pointer(&in.ExpressionWarnings))
+	*out = *(*admissionregistrationv1beta1.TypeChecking)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1312,9 +1294,7 @@ func Convert_admissionregistration_ValidatingAdmissionPolicySpec_To_v1beta1_Vali
 }
 
 func autoConvert_v1beta1_ValidatingAdmissionPolicyStatus_To_admissionregistration_ValidatingAdmissionPolicyStatus(in *admissionregistrationv1beta1.ValidatingAdmissionPolicyStatus, out *admissionregistration.ValidatingAdmissionPolicyStatus, s conversion.Scope) error {
-	out.ObservedGeneration = in.ObservedGeneration
-	out.TypeChecking = (*admissionregistration.TypeChecking)(unsafe.Pointer(in.TypeChecking))
-	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*admissionregistration.ValidatingAdmissionPolicyStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1324,9 +1304,7 @@ func Convert_v1beta1_ValidatingAdmissionPolicyStatus_To_admissionregistration_Va
 }
 
 func autoConvert_admissionregistration_ValidatingAdmissionPolicyStatus_To_v1beta1_ValidatingAdmissionPolicyStatus(in *admissionregistration.ValidatingAdmissionPolicyStatus, out *admissionregistrationv1beta1.ValidatingAdmissionPolicyStatus, s conversion.Scope) error {
-	out.ObservedGeneration = in.ObservedGeneration
-	out.TypeChecking = (*admissionregistrationv1beta1.TypeChecking)(unsafe.Pointer(in.TypeChecking))
-	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*admissionregistrationv1beta1.ValidatingAdmissionPolicyStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1484,10 +1462,7 @@ func Convert_admissionregistration_ValidatingWebhookConfigurationList_To_v1beta1
 }
 
 func autoConvert_v1beta1_Validation_To_admissionregistration_Validation(in *admissionregistrationv1beta1.Validation, out *admissionregistration.Validation, s conversion.Scope) error {
-	out.Expression = in.Expression
-	out.Message = in.Message
-	out.Reason = (*v1.StatusReason)(unsafe.Pointer(in.Reason))
-	out.MessageExpression = in.MessageExpression
+	*out = *(*admissionregistration.Validation)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1497,10 +1472,7 @@ func Convert_v1beta1_Validation_To_admissionregistration_Validation(in *admissio
 }
 
 func autoConvert_admissionregistration_Validation_To_v1beta1_Validation(in *admissionregistration.Validation, out *admissionregistrationv1beta1.Validation, s conversion.Scope) error {
-	out.Expression = in.Expression
-	out.Message = in.Message
-	out.Reason = (*v1.StatusReason)(unsafe.Pointer(in.Reason))
-	out.MessageExpression = in.MessageExpression
+	*out = *(*admissionregistrationv1beta1.Validation)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1510,8 +1482,7 @@ func Convert_admissionregistration_Validation_To_v1beta1_Validation(in *admissio
 }
 
 func autoConvert_v1beta1_Variable_To_admissionregistration_Variable(in *admissionregistrationv1beta1.Variable, out *admissionregistration.Variable, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Expression = in.Expression
+	*out = *(*admissionregistration.Variable)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1521,8 +1492,7 @@ func Convert_v1beta1_Variable_To_admissionregistration_Variable(in *admissionreg
 }
 
 func autoConvert_admissionregistration_Variable_To_v1beta1_Variable(in *admissionregistration.Variable, out *admissionregistrationv1beta1.Variable, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Expression = in.Expression
+	*out = *(*admissionregistrationv1beta1.Variable)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/apidiscovery/v2/zz_generated.conversion.go
+++ b/pkg/apis/apidiscovery/v2/zz_generated.conversion.go
@@ -25,7 +25,6 @@ import (
 	unsafe "unsafe"
 
 	apidiscoveryv2 "k8s.io/api/apidiscovery/v2"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	apidiscovery "k8s.io/kubernetes/pkg/apis/apidiscovery"
@@ -136,14 +135,7 @@ func Convert_apidiscovery_APIGroupDiscoveryList_To_v2_APIGroupDiscoveryList(in *
 }
 
 func autoConvert_v2_APIResourceDiscovery_To_apidiscovery_APIResourceDiscovery(in *apidiscoveryv2.APIResourceDiscovery, out *apidiscovery.APIResourceDiscovery, s conversion.Scope) error {
-	out.Resource = in.Resource
-	out.ResponseKind = (*v1.GroupVersionKind)(unsafe.Pointer(in.ResponseKind))
-	out.Scope = apidiscovery.ResourceScope(in.Scope)
-	out.SingularResource = in.SingularResource
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.ShortNames = *(*[]string)(unsafe.Pointer(&in.ShortNames))
-	out.Categories = *(*[]string)(unsafe.Pointer(&in.Categories))
-	out.Subresources = *(*[]apidiscovery.APISubresourceDiscovery)(unsafe.Pointer(&in.Subresources))
+	*out = *(*apidiscovery.APIResourceDiscovery)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -153,14 +145,7 @@ func Convert_v2_APIResourceDiscovery_To_apidiscovery_APIResourceDiscovery(in *ap
 }
 
 func autoConvert_apidiscovery_APIResourceDiscovery_To_v2_APIResourceDiscovery(in *apidiscovery.APIResourceDiscovery, out *apidiscoveryv2.APIResourceDiscovery, s conversion.Scope) error {
-	out.Resource = in.Resource
-	out.ResponseKind = (*v1.GroupVersionKind)(unsafe.Pointer(in.ResponseKind))
-	out.Scope = apidiscoveryv2.ResourceScope(in.Scope)
-	out.SingularResource = in.SingularResource
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.ShortNames = *(*[]string)(unsafe.Pointer(&in.ShortNames))
-	out.Categories = *(*[]string)(unsafe.Pointer(&in.Categories))
-	out.Subresources = *(*[]apidiscoveryv2.APISubresourceDiscovery)(unsafe.Pointer(&in.Subresources))
+	*out = *(*apidiscoveryv2.APIResourceDiscovery)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -170,10 +155,7 @@ func Convert_apidiscovery_APIResourceDiscovery_To_v2_APIResourceDiscovery(in *ap
 }
 
 func autoConvert_v2_APISubresourceDiscovery_To_apidiscovery_APISubresourceDiscovery(in *apidiscoveryv2.APISubresourceDiscovery, out *apidiscovery.APISubresourceDiscovery, s conversion.Scope) error {
-	out.Subresource = in.Subresource
-	out.ResponseKind = (*v1.GroupVersionKind)(unsafe.Pointer(in.ResponseKind))
-	out.AcceptedTypes = *(*[]v1.GroupVersionKind)(unsafe.Pointer(&in.AcceptedTypes))
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
+	*out = *(*apidiscovery.APISubresourceDiscovery)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -183,10 +165,7 @@ func Convert_v2_APISubresourceDiscovery_To_apidiscovery_APISubresourceDiscovery(
 }
 
 func autoConvert_apidiscovery_APISubresourceDiscovery_To_v2_APISubresourceDiscovery(in *apidiscovery.APISubresourceDiscovery, out *apidiscoveryv2.APISubresourceDiscovery, s conversion.Scope) error {
-	out.Subresource = in.Subresource
-	out.ResponseKind = (*v1.GroupVersionKind)(unsafe.Pointer(in.ResponseKind))
-	out.AcceptedTypes = *(*[]v1.GroupVersionKind)(unsafe.Pointer(&in.AcceptedTypes))
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
+	*out = *(*apidiscoveryv2.APISubresourceDiscovery)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -196,9 +175,7 @@ func Convert_apidiscovery_APISubresourceDiscovery_To_v2_APISubresourceDiscovery(
 }
 
 func autoConvert_v2_APIVersionDiscovery_To_apidiscovery_APIVersionDiscovery(in *apidiscoveryv2.APIVersionDiscovery, out *apidiscovery.APIVersionDiscovery, s conversion.Scope) error {
-	out.Version = in.Version
-	out.Resources = *(*[]apidiscovery.APIResourceDiscovery)(unsafe.Pointer(&in.Resources))
-	out.Freshness = apidiscovery.DiscoveryFreshness(in.Freshness)
+	*out = *(*apidiscovery.APIVersionDiscovery)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -208,9 +185,7 @@ func Convert_v2_APIVersionDiscovery_To_apidiscovery_APIVersionDiscovery(in *apid
 }
 
 func autoConvert_apidiscovery_APIVersionDiscovery_To_v2_APIVersionDiscovery(in *apidiscovery.APIVersionDiscovery, out *apidiscoveryv2.APIVersionDiscovery, s conversion.Scope) error {
-	out.Version = in.Version
-	out.Resources = *(*[]apidiscoveryv2.APIResourceDiscovery)(unsafe.Pointer(&in.Resources))
-	out.Freshness = apidiscoveryv2.DiscoveryFreshness(in.Freshness)
+	*out = *(*apidiscoveryv2.APIVersionDiscovery)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/apidiscovery/v2beta1/zz_generated.conversion.go
+++ b/pkg/apis/apidiscovery/v2beta1/zz_generated.conversion.go
@@ -25,7 +25,6 @@ import (
 	unsafe "unsafe"
 
 	apidiscoveryv2beta1 "k8s.io/api/apidiscovery/v2beta1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	apidiscovery "k8s.io/kubernetes/pkg/apis/apidiscovery"
@@ -136,14 +135,7 @@ func Convert_apidiscovery_APIGroupDiscoveryList_To_v2beta1_APIGroupDiscoveryList
 }
 
 func autoConvert_v2beta1_APIResourceDiscovery_To_apidiscovery_APIResourceDiscovery(in *apidiscoveryv2beta1.APIResourceDiscovery, out *apidiscovery.APIResourceDiscovery, s conversion.Scope) error {
-	out.Resource = in.Resource
-	out.ResponseKind = (*v1.GroupVersionKind)(unsafe.Pointer(in.ResponseKind))
-	out.Scope = apidiscovery.ResourceScope(in.Scope)
-	out.SingularResource = in.SingularResource
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.ShortNames = *(*[]string)(unsafe.Pointer(&in.ShortNames))
-	out.Categories = *(*[]string)(unsafe.Pointer(&in.Categories))
-	out.Subresources = *(*[]apidiscovery.APISubresourceDiscovery)(unsafe.Pointer(&in.Subresources))
+	*out = *(*apidiscovery.APIResourceDiscovery)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -153,14 +145,7 @@ func Convert_v2beta1_APIResourceDiscovery_To_apidiscovery_APIResourceDiscovery(i
 }
 
 func autoConvert_apidiscovery_APIResourceDiscovery_To_v2beta1_APIResourceDiscovery(in *apidiscovery.APIResourceDiscovery, out *apidiscoveryv2beta1.APIResourceDiscovery, s conversion.Scope) error {
-	out.Resource = in.Resource
-	out.ResponseKind = (*v1.GroupVersionKind)(unsafe.Pointer(in.ResponseKind))
-	out.Scope = apidiscoveryv2beta1.ResourceScope(in.Scope)
-	out.SingularResource = in.SingularResource
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.ShortNames = *(*[]string)(unsafe.Pointer(&in.ShortNames))
-	out.Categories = *(*[]string)(unsafe.Pointer(&in.Categories))
-	out.Subresources = *(*[]apidiscoveryv2beta1.APISubresourceDiscovery)(unsafe.Pointer(&in.Subresources))
+	*out = *(*apidiscoveryv2beta1.APIResourceDiscovery)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -170,10 +155,7 @@ func Convert_apidiscovery_APIResourceDiscovery_To_v2beta1_APIResourceDiscovery(i
 }
 
 func autoConvert_v2beta1_APISubresourceDiscovery_To_apidiscovery_APISubresourceDiscovery(in *apidiscoveryv2beta1.APISubresourceDiscovery, out *apidiscovery.APISubresourceDiscovery, s conversion.Scope) error {
-	out.Subresource = in.Subresource
-	out.ResponseKind = (*v1.GroupVersionKind)(unsafe.Pointer(in.ResponseKind))
-	out.AcceptedTypes = *(*[]v1.GroupVersionKind)(unsafe.Pointer(&in.AcceptedTypes))
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
+	*out = *(*apidiscovery.APISubresourceDiscovery)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -183,10 +165,7 @@ func Convert_v2beta1_APISubresourceDiscovery_To_apidiscovery_APISubresourceDisco
 }
 
 func autoConvert_apidiscovery_APISubresourceDiscovery_To_v2beta1_APISubresourceDiscovery(in *apidiscovery.APISubresourceDiscovery, out *apidiscoveryv2beta1.APISubresourceDiscovery, s conversion.Scope) error {
-	out.Subresource = in.Subresource
-	out.ResponseKind = (*v1.GroupVersionKind)(unsafe.Pointer(in.ResponseKind))
-	out.AcceptedTypes = *(*[]v1.GroupVersionKind)(unsafe.Pointer(&in.AcceptedTypes))
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
+	*out = *(*apidiscoveryv2beta1.APISubresourceDiscovery)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -196,9 +175,7 @@ func Convert_apidiscovery_APISubresourceDiscovery_To_v2beta1_APISubresourceDisco
 }
 
 func autoConvert_v2beta1_APIVersionDiscovery_To_apidiscovery_APIVersionDiscovery(in *apidiscoveryv2beta1.APIVersionDiscovery, out *apidiscovery.APIVersionDiscovery, s conversion.Scope) error {
-	out.Version = in.Version
-	out.Resources = *(*[]apidiscovery.APIResourceDiscovery)(unsafe.Pointer(&in.Resources))
-	out.Freshness = apidiscovery.DiscoveryFreshness(in.Freshness)
+	*out = *(*apidiscovery.APIVersionDiscovery)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -208,9 +185,7 @@ func Convert_v2beta1_APIVersionDiscovery_To_apidiscovery_APIVersionDiscovery(in 
 }
 
 func autoConvert_apidiscovery_APIVersionDiscovery_To_v2beta1_APIVersionDiscovery(in *apidiscovery.APIVersionDiscovery, out *apidiscoveryv2beta1.APIVersionDiscovery, s conversion.Scope) error {
-	out.Version = in.Version
-	out.Resources = *(*[]apidiscoveryv2beta1.APIResourceDiscovery)(unsafe.Pointer(&in.Resources))
-	out.Freshness = apidiscoveryv2beta1.DiscoveryFreshness(in.Freshness)
+	*out = *(*apidiscoveryv2beta1.APIVersionDiscovery)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/apiserverinternal/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/apiserverinternal/v1alpha1/zz_generated.conversion.go
@@ -101,10 +101,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_ServerStorageVersion_To_apiserverinternal_ServerStorageVersion(in *apiserverinternalv1alpha1.ServerStorageVersion, out *apiserverinternal.ServerStorageVersion, s conversion.Scope) error {
-	out.APIServerID = in.APIServerID
-	out.EncodingVersion = in.EncodingVersion
-	out.DecodableVersions = *(*[]string)(unsafe.Pointer(&in.DecodableVersions))
-	out.ServedVersions = *(*[]string)(unsafe.Pointer(&in.ServedVersions))
+	*out = *(*apiserverinternal.ServerStorageVersion)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -114,10 +111,7 @@ func Convert_v1alpha1_ServerStorageVersion_To_apiserverinternal_ServerStorageVer
 }
 
 func autoConvert_apiserverinternal_ServerStorageVersion_To_v1alpha1_ServerStorageVersion(in *apiserverinternal.ServerStorageVersion, out *apiserverinternalv1alpha1.ServerStorageVersion, s conversion.Scope) error {
-	out.APIServerID = in.APIServerID
-	out.EncodingVersion = in.EncodingVersion
-	out.DecodableVersions = *(*[]string)(unsafe.Pointer(&in.DecodableVersions))
-	out.ServedVersions = *(*[]string)(unsafe.Pointer(&in.ServedVersions))
+	*out = *(*apiserverinternalv1alpha1.ServerStorageVersion)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -159,12 +153,7 @@ func Convert_apiserverinternal_StorageVersion_To_v1alpha1_StorageVersion(in *api
 }
 
 func autoConvert_v1alpha1_StorageVersionCondition_To_apiserverinternal_StorageVersionCondition(in *apiserverinternalv1alpha1.StorageVersionCondition, out *apiserverinternal.StorageVersionCondition, s conversion.Scope) error {
-	out.Type = apiserverinternal.StorageVersionConditionType(in.Type)
-	out.Status = apiserverinternal.ConditionStatus(in.Status)
-	out.ObservedGeneration = in.ObservedGeneration
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*apiserverinternal.StorageVersionCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -174,12 +163,7 @@ func Convert_v1alpha1_StorageVersionCondition_To_apiserverinternal_StorageVersio
 }
 
 func autoConvert_apiserverinternal_StorageVersionCondition_To_v1alpha1_StorageVersionCondition(in *apiserverinternal.StorageVersionCondition, out *apiserverinternalv1alpha1.StorageVersionCondition, s conversion.Scope) error {
-	out.Type = apiserverinternalv1alpha1.StorageVersionConditionType(in.Type)
-	out.Status = apiserverinternalv1alpha1.ConditionStatus(in.Status)
-	out.ObservedGeneration = in.ObservedGeneration
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*apiserverinternalv1alpha1.StorageVersionCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -211,6 +195,7 @@ func Convert_apiserverinternal_StorageVersionList_To_v1alpha1_StorageVersionList
 }
 
 func autoConvert_v1alpha1_StorageVersionSpec_To_apiserverinternal_StorageVersionSpec(in *apiserverinternalv1alpha1.StorageVersionSpec, out *apiserverinternal.StorageVersionSpec, s conversion.Scope) error {
+	*out = *(*apiserverinternal.StorageVersionSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -220,6 +205,7 @@ func Convert_v1alpha1_StorageVersionSpec_To_apiserverinternal_StorageVersionSpec
 }
 
 func autoConvert_apiserverinternal_StorageVersionSpec_To_v1alpha1_StorageVersionSpec(in *apiserverinternal.StorageVersionSpec, out *apiserverinternalv1alpha1.StorageVersionSpec, s conversion.Scope) error {
+	*out = *(*apiserverinternalv1alpha1.StorageVersionSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -229,9 +215,7 @@ func Convert_apiserverinternal_StorageVersionSpec_To_v1alpha1_StorageVersionSpec
 }
 
 func autoConvert_v1alpha1_StorageVersionStatus_To_apiserverinternal_StorageVersionStatus(in *apiserverinternalv1alpha1.StorageVersionStatus, out *apiserverinternal.StorageVersionStatus, s conversion.Scope) error {
-	out.StorageVersions = *(*[]apiserverinternal.ServerStorageVersion)(unsafe.Pointer(&in.StorageVersions))
-	out.CommonEncodingVersion = (*string)(unsafe.Pointer(in.CommonEncodingVersion))
-	out.Conditions = *(*[]apiserverinternal.StorageVersionCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*apiserverinternal.StorageVersionStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -241,9 +225,7 @@ func Convert_v1alpha1_StorageVersionStatus_To_apiserverinternal_StorageVersionSt
 }
 
 func autoConvert_apiserverinternal_StorageVersionStatus_To_v1alpha1_StorageVersionStatus(in *apiserverinternal.StorageVersionStatus, out *apiserverinternalv1alpha1.StorageVersionStatus, s conversion.Scope) error {
-	out.StorageVersions = *(*[]apiserverinternalv1alpha1.ServerStorageVersion)(unsafe.Pointer(&in.StorageVersions))
-	out.CommonEncodingVersion = (*string)(unsafe.Pointer(in.CommonEncodingVersion))
-	out.Conditions = *(*[]apiserverinternalv1alpha1.StorageVersionCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*apiserverinternalv1alpha1.StorageVersionStatus)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/apps/v1/zz_generated.conversion.go
+++ b/pkg/apis/apps/v1/zz_generated.conversion.go
@@ -25,14 +25,14 @@ import (
 	unsafe "unsafe"
 
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
+	apicorev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
 	apps "k8s.io/kubernetes/pkg/apis/apps"
 	core "k8s.io/kubernetes/pkg/apis/core"
-	apiscorev1 "k8s.io/kubernetes/pkg/apis/core/v1"
+	corev1 "k8s.io/kubernetes/pkg/apis/core/v1"
 )
 
 func init() {
@@ -414,11 +414,7 @@ func autoConvert_apps_DaemonSet_To_v1_DaemonSet(in *apps.DaemonSet, out *appsv1.
 }
 
 func autoConvert_v1_DaemonSetCondition_To_apps_DaemonSetCondition(in *appsv1.DaemonSetCondition, out *apps.DaemonSetCondition, s conversion.Scope) error {
-	out.Type = apps.DaemonSetConditionType(in.Type)
-	out.Status = core.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*apps.DaemonSetCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -428,11 +424,7 @@ func Convert_v1_DaemonSetCondition_To_apps_DaemonSetCondition(in *appsv1.DaemonS
 }
 
 func autoConvert_apps_DaemonSetCondition_To_v1_DaemonSetCondition(in *apps.DaemonSetCondition, out *appsv1.DaemonSetCondition, s conversion.Scope) error {
-	out.Type = appsv1.DaemonSetConditionType(in.Type)
-	out.Status = corev1.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*appsv1.DaemonSetCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -485,7 +477,7 @@ func Convert_apps_DaemonSetList_To_v1_DaemonSetList(in *apps.DaemonSetList, out 
 
 func autoConvert_v1_DaemonSetSpec_To_apps_DaemonSetSpec(in *appsv1.DaemonSetSpec, out *apps.DaemonSetSpec, s conversion.Scope) error {
 	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
-	if err := apiscorev1.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
+	if err := corev1.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
 	if err := Convert_v1_DaemonSetUpdateStrategy_To_apps_DaemonSetUpdateStrategy(&in.UpdateStrategy, &out.UpdateStrategy, s); err != nil {
@@ -503,7 +495,7 @@ func Convert_v1_DaemonSetSpec_To_apps_DaemonSetSpec(in *appsv1.DaemonSetSpec, ou
 
 func autoConvert_apps_DaemonSetSpec_To_v1_DaemonSetSpec(in *apps.DaemonSetSpec, out *appsv1.DaemonSetSpec, s conversion.Scope) error {
 	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
-	if err := apiscorev1.Convert_core_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
+	if err := corev1.Convert_core_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
 	if err := Convert_apps_DaemonSetUpdateStrategy_To_v1_DaemonSetUpdateStrategy(&in.UpdateStrategy, &out.UpdateStrategy, s); err != nil {
@@ -516,16 +508,7 @@ func autoConvert_apps_DaemonSetSpec_To_v1_DaemonSetSpec(in *apps.DaemonSetSpec, 
 }
 
 func autoConvert_v1_DaemonSetStatus_To_apps_DaemonSetStatus(in *appsv1.DaemonSetStatus, out *apps.DaemonSetStatus, s conversion.Scope) error {
-	out.CurrentNumberScheduled = in.CurrentNumberScheduled
-	out.NumberMisscheduled = in.NumberMisscheduled
-	out.DesiredNumberScheduled = in.DesiredNumberScheduled
-	out.NumberReady = in.NumberReady
-	out.ObservedGeneration = in.ObservedGeneration
-	out.UpdatedNumberScheduled = in.UpdatedNumberScheduled
-	out.NumberAvailable = in.NumberAvailable
-	out.NumberUnavailable = in.NumberUnavailable
-	out.CollisionCount = (*int32)(unsafe.Pointer(in.CollisionCount))
-	out.Conditions = *(*[]apps.DaemonSetCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*apps.DaemonSetStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -535,16 +518,7 @@ func Convert_v1_DaemonSetStatus_To_apps_DaemonSetStatus(in *appsv1.DaemonSetStat
 }
 
 func autoConvert_apps_DaemonSetStatus_To_v1_DaemonSetStatus(in *apps.DaemonSetStatus, out *appsv1.DaemonSetStatus, s conversion.Scope) error {
-	out.CurrentNumberScheduled = in.CurrentNumberScheduled
-	out.NumberMisscheduled = in.NumberMisscheduled
-	out.DesiredNumberScheduled = in.DesiredNumberScheduled
-	out.NumberReady = in.NumberReady
-	out.ObservedGeneration = in.ObservedGeneration
-	out.UpdatedNumberScheduled = in.UpdatedNumberScheduled
-	out.NumberAvailable = in.NumberAvailable
-	out.NumberUnavailable = in.NumberUnavailable
-	out.CollisionCount = (*int32)(unsafe.Pointer(in.CollisionCount))
-	out.Conditions = *(*[]appsv1.DaemonSetCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*appsv1.DaemonSetStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -614,12 +588,7 @@ func autoConvert_apps_Deployment_To_v1_Deployment(in *apps.Deployment, out *apps
 }
 
 func autoConvert_v1_DeploymentCondition_To_apps_DeploymentCondition(in *appsv1.DeploymentCondition, out *apps.DeploymentCondition, s conversion.Scope) error {
-	out.Type = apps.DeploymentConditionType(in.Type)
-	out.Status = core.ConditionStatus(in.Status)
-	out.LastUpdateTime = in.LastUpdateTime
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*apps.DeploymentCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -629,12 +598,7 @@ func Convert_v1_DeploymentCondition_To_apps_DeploymentCondition(in *appsv1.Deplo
 }
 
 func autoConvert_apps_DeploymentCondition_To_v1_DeploymentCondition(in *apps.DeploymentCondition, out *appsv1.DeploymentCondition, s conversion.Scope) error {
-	out.Type = appsv1.DeploymentConditionType(in.Type)
-	out.Status = corev1.ConditionStatus(in.Status)
-	out.LastUpdateTime = in.LastUpdateTime
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*appsv1.DeploymentCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -690,7 +654,7 @@ func autoConvert_v1_DeploymentSpec_To_apps_DeploymentSpec(in *appsv1.DeploymentS
 		return err
 	}
 	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
-	if err := apiscorev1.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
+	if err := corev1.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
 	if err := Convert_v1_DeploymentStrategy_To_apps_DeploymentStrategy(&in.Strategy, &out.Strategy, s); err != nil {
@@ -713,7 +677,7 @@ func autoConvert_apps_DeploymentSpec_To_v1_DeploymentSpec(in *apps.DeploymentSpe
 		return err
 	}
 	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
-	if err := apiscorev1.Convert_core_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
+	if err := corev1.Convert_core_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
 	if err := Convert_apps_DeploymentStrategy_To_v1_DeploymentStrategy(&in.Strategy, &out.Strategy, s); err != nil {
@@ -728,15 +692,7 @@ func autoConvert_apps_DeploymentSpec_To_v1_DeploymentSpec(in *apps.DeploymentSpe
 }
 
 func autoConvert_v1_DeploymentStatus_To_apps_DeploymentStatus(in *appsv1.DeploymentStatus, out *apps.DeploymentStatus, s conversion.Scope) error {
-	out.ObservedGeneration = in.ObservedGeneration
-	out.Replicas = in.Replicas
-	out.UpdatedReplicas = in.UpdatedReplicas
-	out.ReadyReplicas = in.ReadyReplicas
-	out.AvailableReplicas = in.AvailableReplicas
-	out.UnavailableReplicas = in.UnavailableReplicas
-	out.TerminatingReplicas = (*int32)(unsafe.Pointer(in.TerminatingReplicas))
-	out.Conditions = *(*[]apps.DeploymentCondition)(unsafe.Pointer(&in.Conditions))
-	out.CollisionCount = (*int32)(unsafe.Pointer(in.CollisionCount))
+	*out = *(*apps.DeploymentStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -746,15 +702,7 @@ func Convert_v1_DeploymentStatus_To_apps_DeploymentStatus(in *appsv1.DeploymentS
 }
 
 func autoConvert_apps_DeploymentStatus_To_v1_DeploymentStatus(in *apps.DeploymentStatus, out *appsv1.DeploymentStatus, s conversion.Scope) error {
-	out.ObservedGeneration = in.ObservedGeneration
-	out.Replicas = in.Replicas
-	out.UpdatedReplicas = in.UpdatedReplicas
-	out.ReadyReplicas = in.ReadyReplicas
-	out.AvailableReplicas = in.AvailableReplicas
-	out.UnavailableReplicas = in.UnavailableReplicas
-	out.TerminatingReplicas = (*int32)(unsafe.Pointer(in.TerminatingReplicas))
-	out.Conditions = *(*[]appsv1.DeploymentCondition)(unsafe.Pointer(&in.Conditions))
-	out.CollisionCount = (*int32)(unsafe.Pointer(in.CollisionCount))
+	*out = *(*appsv1.DeploymentStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -834,11 +782,7 @@ func Convert_apps_ReplicaSet_To_v1_ReplicaSet(in *apps.ReplicaSet, out *appsv1.R
 }
 
 func autoConvert_v1_ReplicaSetCondition_To_apps_ReplicaSetCondition(in *appsv1.ReplicaSetCondition, out *apps.ReplicaSetCondition, s conversion.Scope) error {
-	out.Type = apps.ReplicaSetConditionType(in.Type)
-	out.Status = core.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*apps.ReplicaSetCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -848,11 +792,7 @@ func Convert_v1_ReplicaSetCondition_To_apps_ReplicaSetCondition(in *appsv1.Repli
 }
 
 func autoConvert_apps_ReplicaSetCondition_To_v1_ReplicaSetCondition(in *apps.ReplicaSetCondition, out *appsv1.ReplicaSetCondition, s conversion.Scope) error {
-	out.Type = appsv1.ReplicaSetConditionType(in.Type)
-	out.Status = corev1.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*appsv1.ReplicaSetCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -909,7 +849,7 @@ func autoConvert_v1_ReplicaSetSpec_To_apps_ReplicaSetSpec(in *appsv1.ReplicaSetS
 	}
 	out.MinReadySeconds = in.MinReadySeconds
 	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
-	if err := apiscorev1.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
+	if err := corev1.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
 	return nil
@@ -926,7 +866,7 @@ func autoConvert_apps_ReplicaSetSpec_To_v1_ReplicaSetSpec(in *apps.ReplicaSetSpe
 	}
 	out.MinReadySeconds = in.MinReadySeconds
 	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
-	if err := apiscorev1.Convert_core_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
+	if err := corev1.Convert_core_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
 	return nil
@@ -938,13 +878,7 @@ func Convert_apps_ReplicaSetSpec_To_v1_ReplicaSetSpec(in *apps.ReplicaSetSpec, o
 }
 
 func autoConvert_v1_ReplicaSetStatus_To_apps_ReplicaSetStatus(in *appsv1.ReplicaSetStatus, out *apps.ReplicaSetStatus, s conversion.Scope) error {
-	out.Replicas = in.Replicas
-	out.FullyLabeledReplicas = in.FullyLabeledReplicas
-	out.ReadyReplicas = in.ReadyReplicas
-	out.AvailableReplicas = in.AvailableReplicas
-	out.TerminatingReplicas = (*int32)(unsafe.Pointer(in.TerminatingReplicas))
-	out.ObservedGeneration = in.ObservedGeneration
-	out.Conditions = *(*[]apps.ReplicaSetCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*apps.ReplicaSetStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -954,13 +888,7 @@ func Convert_v1_ReplicaSetStatus_To_apps_ReplicaSetStatus(in *appsv1.ReplicaSetS
 }
 
 func autoConvert_apps_ReplicaSetStatus_To_v1_ReplicaSetStatus(in *apps.ReplicaSetStatus, out *appsv1.ReplicaSetStatus, s conversion.Scope) error {
-	out.Replicas = in.Replicas
-	out.FullyLabeledReplicas = in.FullyLabeledReplicas
-	out.ReadyReplicas = in.ReadyReplicas
-	out.AvailableReplicas = in.AvailableReplicas
-	out.TerminatingReplicas = (*int32)(unsafe.Pointer(in.TerminatingReplicas))
-	out.ObservedGeneration = in.ObservedGeneration
-	out.Conditions = *(*[]appsv1.ReplicaSetCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*appsv1.ReplicaSetStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1088,11 +1016,7 @@ func Convert_apps_StatefulSet_To_v1_StatefulSet(in *apps.StatefulSet, out *appsv
 }
 
 func autoConvert_v1_StatefulSetCondition_To_apps_StatefulSetCondition(in *appsv1.StatefulSetCondition, out *apps.StatefulSetCondition, s conversion.Scope) error {
-	out.Type = apps.StatefulSetConditionType(in.Type)
-	out.Status = core.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*apps.StatefulSetCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1102,11 +1026,7 @@ func Convert_v1_StatefulSetCondition_To_apps_StatefulSetCondition(in *appsv1.Sta
 }
 
 func autoConvert_apps_StatefulSetCondition_To_v1_StatefulSetCondition(in *apps.StatefulSetCondition, out *appsv1.StatefulSetCondition, s conversion.Scope) error {
-	out.Type = appsv1.StatefulSetConditionType(in.Type)
-	out.Status = corev1.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*appsv1.StatefulSetCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1158,7 +1078,7 @@ func Convert_apps_StatefulSetList_To_v1_StatefulSetList(in *apps.StatefulSetList
 }
 
 func autoConvert_v1_StatefulSetOrdinals_To_apps_StatefulSetOrdinals(in *appsv1.StatefulSetOrdinals, out *apps.StatefulSetOrdinals, s conversion.Scope) error {
-	out.Start = in.Start
+	*out = *(*apps.StatefulSetOrdinals)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1168,7 +1088,7 @@ func Convert_v1_StatefulSetOrdinals_To_apps_StatefulSetOrdinals(in *appsv1.State
 }
 
 func autoConvert_apps_StatefulSetOrdinals_To_v1_StatefulSetOrdinals(in *apps.StatefulSetOrdinals, out *appsv1.StatefulSetOrdinals, s conversion.Scope) error {
-	out.Start = in.Start
+	*out = *(*appsv1.StatefulSetOrdinals)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1178,8 +1098,7 @@ func Convert_apps_StatefulSetOrdinals_To_v1_StatefulSetOrdinals(in *apps.Statefu
 }
 
 func autoConvert_v1_StatefulSetPersistentVolumeClaimRetentionPolicy_To_apps_StatefulSetPersistentVolumeClaimRetentionPolicy(in *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy, out *apps.StatefulSetPersistentVolumeClaimRetentionPolicy, s conversion.Scope) error {
-	out.WhenDeleted = apps.PersistentVolumeClaimRetentionPolicyType(in.WhenDeleted)
-	out.WhenScaled = apps.PersistentVolumeClaimRetentionPolicyType(in.WhenScaled)
+	*out = *(*apps.StatefulSetPersistentVolumeClaimRetentionPolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1189,8 +1108,7 @@ func Convert_v1_StatefulSetPersistentVolumeClaimRetentionPolicy_To_apps_Stateful
 }
 
 func autoConvert_apps_StatefulSetPersistentVolumeClaimRetentionPolicy_To_v1_StatefulSetPersistentVolumeClaimRetentionPolicy(in *apps.StatefulSetPersistentVolumeClaimRetentionPolicy, out *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy, s conversion.Scope) error {
-	out.WhenDeleted = appsv1.PersistentVolumeClaimRetentionPolicyType(in.WhenDeleted)
-	out.WhenScaled = appsv1.PersistentVolumeClaimRetentionPolicyType(in.WhenScaled)
+	*out = *(*appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1204,7 +1122,7 @@ func autoConvert_v1_StatefulSetSpec_To_apps_StatefulSetSpec(in *appsv1.StatefulS
 		return err
 	}
 	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
-	if err := apiscorev1.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
+	if err := corev1.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
 	out.VolumeClaimTemplates = *(*[]core.PersistentVolumeClaim)(unsafe.Pointer(&in.VolumeClaimTemplates))
@@ -1225,10 +1143,10 @@ func autoConvert_apps_StatefulSetSpec_To_v1_StatefulSetSpec(in *apps.StatefulSet
 		return err
 	}
 	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
-	if err := apiscorev1.Convert_core_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
+	if err := corev1.Convert_core_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
-	out.VolumeClaimTemplates = *(*[]corev1.PersistentVolumeClaim)(unsafe.Pointer(&in.VolumeClaimTemplates))
+	out.VolumeClaimTemplates = *(*[]apicorev1.PersistentVolumeClaim)(unsafe.Pointer(&in.VolumeClaimTemplates))
 	out.ServiceName = in.ServiceName
 	out.PodManagementPolicy = appsv1.PodManagementPolicyType(in.PodManagementPolicy)
 	if err := Convert_apps_StatefulSetUpdateStrategy_To_v1_StatefulSetUpdateStrategy(&in.UpdateStrategy, &out.UpdateStrategy, s); err != nil {

--- a/pkg/apis/apps/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/apps/v1beta1/zz_generated.conversion.go
@@ -25,8 +25,8 @@ import (
 	unsafe "unsafe"
 
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apicorev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
@@ -355,12 +355,7 @@ func Convert_apps_Deployment_To_v1beta1_Deployment(in *apps.Deployment, out *app
 }
 
 func autoConvert_v1beta1_DeploymentCondition_To_apps_DeploymentCondition(in *appsv1beta1.DeploymentCondition, out *apps.DeploymentCondition, s conversion.Scope) error {
-	out.Type = apps.DeploymentConditionType(in.Type)
-	out.Status = core.ConditionStatus(in.Status)
-	out.LastUpdateTime = in.LastUpdateTime
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*apps.DeploymentCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -370,12 +365,7 @@ func Convert_v1beta1_DeploymentCondition_To_apps_DeploymentCondition(in *appsv1b
 }
 
 func autoConvert_apps_DeploymentCondition_To_v1beta1_DeploymentCondition(in *apps.DeploymentCondition, out *appsv1beta1.DeploymentCondition, s conversion.Scope) error {
-	out.Type = appsv1beta1.DeploymentConditionType(in.Type)
-	out.Status = v1.ConditionStatus(in.Status)
-	out.LastUpdateTime = in.LastUpdateTime
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*appsv1beta1.DeploymentCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -455,10 +445,10 @@ func Convert_apps_DeploymentRollback_To_v1beta1_DeploymentRollback(in *apps.Depl
 }
 
 func autoConvert_v1beta1_DeploymentSpec_To_apps_DeploymentSpec(in *appsv1beta1.DeploymentSpec, out *apps.DeploymentSpec, s conversion.Scope) error {
-	if err := metav1.Convert_Pointer_int32_To_int32(&in.Replicas, &out.Replicas, s); err != nil {
+	if err := v1.Convert_Pointer_int32_To_int32(&in.Replicas, &out.Replicas, s); err != nil {
 		return err
 	}
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
+	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
 	if err := corev1.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -479,10 +469,10 @@ func Convert_v1beta1_DeploymentSpec_To_apps_DeploymentSpec(in *appsv1beta1.Deplo
 }
 
 func autoConvert_apps_DeploymentSpec_To_v1beta1_DeploymentSpec(in *apps.DeploymentSpec, out *appsv1beta1.DeploymentSpec, s conversion.Scope) error {
-	if err := metav1.Convert_int32_To_Pointer_int32(&in.Replicas, &out.Replicas, s); err != nil {
+	if err := v1.Convert_int32_To_Pointer_int32(&in.Replicas, &out.Replicas, s); err != nil {
 		return err
 	}
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
+	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
 	if err := corev1.Convert_core_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -503,15 +493,7 @@ func Convert_apps_DeploymentSpec_To_v1beta1_DeploymentSpec(in *apps.DeploymentSp
 }
 
 func autoConvert_v1beta1_DeploymentStatus_To_apps_DeploymentStatus(in *appsv1beta1.DeploymentStatus, out *apps.DeploymentStatus, s conversion.Scope) error {
-	out.ObservedGeneration = in.ObservedGeneration
-	out.Replicas = in.Replicas
-	out.UpdatedReplicas = in.UpdatedReplicas
-	out.ReadyReplicas = in.ReadyReplicas
-	out.AvailableReplicas = in.AvailableReplicas
-	out.UnavailableReplicas = in.UnavailableReplicas
-	out.TerminatingReplicas = (*int32)(unsafe.Pointer(in.TerminatingReplicas))
-	out.Conditions = *(*[]apps.DeploymentCondition)(unsafe.Pointer(&in.Conditions))
-	out.CollisionCount = (*int32)(unsafe.Pointer(in.CollisionCount))
+	*out = *(*apps.DeploymentStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -521,15 +503,7 @@ func Convert_v1beta1_DeploymentStatus_To_apps_DeploymentStatus(in *appsv1beta1.D
 }
 
 func autoConvert_apps_DeploymentStatus_To_v1beta1_DeploymentStatus(in *apps.DeploymentStatus, out *appsv1beta1.DeploymentStatus, s conversion.Scope) error {
-	out.ObservedGeneration = in.ObservedGeneration
-	out.Replicas = in.Replicas
-	out.UpdatedReplicas = in.UpdatedReplicas
-	out.ReadyReplicas = in.ReadyReplicas
-	out.AvailableReplicas = in.AvailableReplicas
-	out.UnavailableReplicas = in.UnavailableReplicas
-	out.TerminatingReplicas = (*int32)(unsafe.Pointer(in.TerminatingReplicas))
-	out.Conditions = *(*[]appsv1beta1.DeploymentCondition)(unsafe.Pointer(&in.Conditions))
-	out.CollisionCount = (*int32)(unsafe.Pointer(in.CollisionCount))
+	*out = *(*appsv1beta1.DeploymentStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -577,7 +551,7 @@ func Convert_apps_DeploymentStrategy_To_v1beta1_DeploymentStrategy(in *apps.Depl
 }
 
 func autoConvert_v1beta1_RollbackConfig_To_apps_RollbackConfig(in *appsv1beta1.RollbackConfig, out *apps.RollbackConfig, s conversion.Scope) error {
-	out.Revision = in.Revision
+	*out = *(*apps.RollbackConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -587,7 +561,7 @@ func Convert_v1beta1_RollbackConfig_To_apps_RollbackConfig(in *appsv1beta1.Rollb
 }
 
 func autoConvert_apps_RollbackConfig_To_v1beta1_RollbackConfig(in *apps.RollbackConfig, out *appsv1beta1.RollbackConfig, s conversion.Scope) error {
-	out.Revision = in.Revision
+	*out = *(*appsv1beta1.RollbackConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -597,10 +571,10 @@ func Convert_apps_RollbackConfig_To_v1beta1_RollbackConfig(in *apps.RollbackConf
 }
 
 func autoConvert_v1beta1_RollingUpdateDeployment_To_apps_RollingUpdateDeployment(in *appsv1beta1.RollingUpdateDeployment, out *apps.RollingUpdateDeployment, s conversion.Scope) error {
-	if err := metav1.Convert_Pointer_intstr_IntOrString_To_intstr_IntOrString(&in.MaxUnavailable, &out.MaxUnavailable, s); err != nil {
+	if err := v1.Convert_Pointer_intstr_IntOrString_To_intstr_IntOrString(&in.MaxUnavailable, &out.MaxUnavailable, s); err != nil {
 		return err
 	}
-	if err := metav1.Convert_Pointer_intstr_IntOrString_To_intstr_IntOrString(&in.MaxSurge, &out.MaxSurge, s); err != nil {
+	if err := v1.Convert_Pointer_intstr_IntOrString_To_intstr_IntOrString(&in.MaxSurge, &out.MaxSurge, s); err != nil {
 		return err
 	}
 	return nil
@@ -612,10 +586,10 @@ func Convert_v1beta1_RollingUpdateDeployment_To_apps_RollingUpdateDeployment(in 
 }
 
 func autoConvert_apps_RollingUpdateDeployment_To_v1beta1_RollingUpdateDeployment(in *apps.RollingUpdateDeployment, out *appsv1beta1.RollingUpdateDeployment, s conversion.Scope) error {
-	if err := metav1.Convert_intstr_IntOrString_To_Pointer_intstr_IntOrString(&in.MaxUnavailable, &out.MaxUnavailable, s); err != nil {
+	if err := v1.Convert_intstr_IntOrString_To_Pointer_intstr_IntOrString(&in.MaxUnavailable, &out.MaxUnavailable, s); err != nil {
 		return err
 	}
-	if err := metav1.Convert_intstr_IntOrString_To_Pointer_intstr_IntOrString(&in.MaxSurge, &out.MaxSurge, s); err != nil {
+	if err := v1.Convert_intstr_IntOrString_To_Pointer_intstr_IntOrString(&in.MaxSurge, &out.MaxSurge, s); err != nil {
 		return err
 	}
 	return nil
@@ -627,7 +601,7 @@ func Convert_apps_RollingUpdateDeployment_To_v1beta1_RollingUpdateDeployment(in 
 }
 
 func autoConvert_v1beta1_RollingUpdateStatefulSetStrategy_To_apps_RollingUpdateStatefulSetStrategy(in *appsv1beta1.RollingUpdateStatefulSetStrategy, out *apps.RollingUpdateStatefulSetStrategy, s conversion.Scope) error {
-	if err := metav1.Convert_Pointer_int32_To_int32(&in.Partition, &out.Partition, s); err != nil {
+	if err := v1.Convert_Pointer_int32_To_int32(&in.Partition, &out.Partition, s); err != nil {
 		return err
 	}
 	out.MaxUnavailable = (*intstr.IntOrString)(unsafe.Pointer(in.MaxUnavailable))
@@ -640,7 +614,7 @@ func Convert_v1beta1_RollingUpdateStatefulSetStrategy_To_apps_RollingUpdateState
 }
 
 func autoConvert_apps_RollingUpdateStatefulSetStrategy_To_v1beta1_RollingUpdateStatefulSetStrategy(in *apps.RollingUpdateStatefulSetStrategy, out *appsv1beta1.RollingUpdateStatefulSetStrategy, s conversion.Scope) error {
-	if err := metav1.Convert_int32_To_Pointer_int32(&in.Partition, &out.Partition, s); err != nil {
+	if err := v1.Convert_int32_To_Pointer_int32(&in.Partition, &out.Partition, s); err != nil {
 		return err
 	}
 	out.MaxUnavailable = (*intstr.IntOrString)(unsafe.Pointer(in.MaxUnavailable))
@@ -685,7 +659,7 @@ func Convert_autoscaling_Scale_To_v1beta1_Scale(in *autoscaling.Scale, out *apps
 }
 
 func autoConvert_v1beta1_ScaleSpec_To_autoscaling_ScaleSpec(in *appsv1beta1.ScaleSpec, out *autoscaling.ScaleSpec, s conversion.Scope) error {
-	out.Replicas = in.Replicas
+	*out = *(*autoscaling.ScaleSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -695,7 +669,7 @@ func Convert_v1beta1_ScaleSpec_To_autoscaling_ScaleSpec(in *appsv1beta1.ScaleSpe
 }
 
 func autoConvert_autoscaling_ScaleSpec_To_v1beta1_ScaleSpec(in *autoscaling.ScaleSpec, out *appsv1beta1.ScaleSpec, s conversion.Scope) error {
-	out.Replicas = in.Replicas
+	*out = *(*appsv1beta1.ScaleSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -750,11 +724,7 @@ func Convert_apps_StatefulSet_To_v1beta1_StatefulSet(in *apps.StatefulSet, out *
 }
 
 func autoConvert_v1beta1_StatefulSetCondition_To_apps_StatefulSetCondition(in *appsv1beta1.StatefulSetCondition, out *apps.StatefulSetCondition, s conversion.Scope) error {
-	out.Type = apps.StatefulSetConditionType(in.Type)
-	out.Status = core.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*apps.StatefulSetCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -764,11 +734,7 @@ func Convert_v1beta1_StatefulSetCondition_To_apps_StatefulSetCondition(in *appsv
 }
 
 func autoConvert_apps_StatefulSetCondition_To_v1beta1_StatefulSetCondition(in *apps.StatefulSetCondition, out *appsv1beta1.StatefulSetCondition, s conversion.Scope) error {
-	out.Type = appsv1beta1.StatefulSetConditionType(in.Type)
-	out.Status = v1.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*appsv1beta1.StatefulSetCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -820,7 +786,7 @@ func Convert_apps_StatefulSetList_To_v1beta1_StatefulSetList(in *apps.StatefulSe
 }
 
 func autoConvert_v1beta1_StatefulSetOrdinals_To_apps_StatefulSetOrdinals(in *appsv1beta1.StatefulSetOrdinals, out *apps.StatefulSetOrdinals, s conversion.Scope) error {
-	out.Start = in.Start
+	*out = *(*apps.StatefulSetOrdinals)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -830,7 +796,7 @@ func Convert_v1beta1_StatefulSetOrdinals_To_apps_StatefulSetOrdinals(in *appsv1b
 }
 
 func autoConvert_apps_StatefulSetOrdinals_To_v1beta1_StatefulSetOrdinals(in *apps.StatefulSetOrdinals, out *appsv1beta1.StatefulSetOrdinals, s conversion.Scope) error {
-	out.Start = in.Start
+	*out = *(*appsv1beta1.StatefulSetOrdinals)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -840,8 +806,7 @@ func Convert_apps_StatefulSetOrdinals_To_v1beta1_StatefulSetOrdinals(in *apps.St
 }
 
 func autoConvert_v1beta1_StatefulSetPersistentVolumeClaimRetentionPolicy_To_apps_StatefulSetPersistentVolumeClaimRetentionPolicy(in *appsv1beta1.StatefulSetPersistentVolumeClaimRetentionPolicy, out *apps.StatefulSetPersistentVolumeClaimRetentionPolicy, s conversion.Scope) error {
-	out.WhenDeleted = apps.PersistentVolumeClaimRetentionPolicyType(in.WhenDeleted)
-	out.WhenScaled = apps.PersistentVolumeClaimRetentionPolicyType(in.WhenScaled)
+	*out = *(*apps.StatefulSetPersistentVolumeClaimRetentionPolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -851,8 +816,7 @@ func Convert_v1beta1_StatefulSetPersistentVolumeClaimRetentionPolicy_To_apps_Sta
 }
 
 func autoConvert_apps_StatefulSetPersistentVolumeClaimRetentionPolicy_To_v1beta1_StatefulSetPersistentVolumeClaimRetentionPolicy(in *apps.StatefulSetPersistentVolumeClaimRetentionPolicy, out *appsv1beta1.StatefulSetPersistentVolumeClaimRetentionPolicy, s conversion.Scope) error {
-	out.WhenDeleted = appsv1beta1.PersistentVolumeClaimRetentionPolicyType(in.WhenDeleted)
-	out.WhenScaled = appsv1beta1.PersistentVolumeClaimRetentionPolicyType(in.WhenScaled)
+	*out = *(*appsv1beta1.StatefulSetPersistentVolumeClaimRetentionPolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -862,10 +826,10 @@ func Convert_apps_StatefulSetPersistentVolumeClaimRetentionPolicy_To_v1beta1_Sta
 }
 
 func autoConvert_v1beta1_StatefulSetSpec_To_apps_StatefulSetSpec(in *appsv1beta1.StatefulSetSpec, out *apps.StatefulSetSpec, s conversion.Scope) error {
-	if err := metav1.Convert_Pointer_int32_To_int32(&in.Replicas, &out.Replicas, s); err != nil {
+	if err := v1.Convert_Pointer_int32_To_int32(&in.Replicas, &out.Replicas, s); err != nil {
 		return err
 	}
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
+	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
 	if err := corev1.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -883,14 +847,14 @@ func autoConvert_v1beta1_StatefulSetSpec_To_apps_StatefulSetSpec(in *appsv1beta1
 }
 
 func autoConvert_apps_StatefulSetSpec_To_v1beta1_StatefulSetSpec(in *apps.StatefulSetSpec, out *appsv1beta1.StatefulSetSpec, s conversion.Scope) error {
-	if err := metav1.Convert_int32_To_Pointer_int32(&in.Replicas, &out.Replicas, s); err != nil {
+	if err := v1.Convert_int32_To_Pointer_int32(&in.Replicas, &out.Replicas, s); err != nil {
 		return err
 	}
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
+	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
 	if err := corev1.Convert_core_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
-	out.VolumeClaimTemplates = *(*[]v1.PersistentVolumeClaim)(unsafe.Pointer(&in.VolumeClaimTemplates))
+	out.VolumeClaimTemplates = *(*[]apicorev1.PersistentVolumeClaim)(unsafe.Pointer(&in.VolumeClaimTemplates))
 	out.ServiceName = in.ServiceName
 	out.PodManagementPolicy = appsv1beta1.PodManagementPolicyType(in.PodManagementPolicy)
 	if err := Convert_apps_StatefulSetUpdateStrategy_To_v1beta1_StatefulSetUpdateStrategy(&in.UpdateStrategy, &out.UpdateStrategy, s); err != nil {
@@ -904,16 +868,7 @@ func autoConvert_apps_StatefulSetSpec_To_v1beta1_StatefulSetSpec(in *apps.Statef
 }
 
 func autoConvert_v1beta1_StatefulSetStatus_To_apps_StatefulSetStatus(in *appsv1beta1.StatefulSetStatus, out *apps.StatefulSetStatus, s conversion.Scope) error {
-	out.ObservedGeneration = (*int64)(unsafe.Pointer(in.ObservedGeneration))
-	out.Replicas = in.Replicas
-	out.ReadyReplicas = in.ReadyReplicas
-	out.CurrentReplicas = in.CurrentReplicas
-	out.UpdatedReplicas = in.UpdatedReplicas
-	out.CurrentRevision = in.CurrentRevision
-	out.UpdateRevision = in.UpdateRevision
-	out.CollisionCount = (*int32)(unsafe.Pointer(in.CollisionCount))
-	out.Conditions = *(*[]apps.StatefulSetCondition)(unsafe.Pointer(&in.Conditions))
-	out.AvailableReplicas = in.AvailableReplicas
+	*out = *(*apps.StatefulSetStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -923,16 +878,7 @@ func Convert_v1beta1_StatefulSetStatus_To_apps_StatefulSetStatus(in *appsv1beta1
 }
 
 func autoConvert_apps_StatefulSetStatus_To_v1beta1_StatefulSetStatus(in *apps.StatefulSetStatus, out *appsv1beta1.StatefulSetStatus, s conversion.Scope) error {
-	out.ObservedGeneration = (*int64)(unsafe.Pointer(in.ObservedGeneration))
-	out.Replicas = in.Replicas
-	out.ReadyReplicas = in.ReadyReplicas
-	out.CurrentReplicas = in.CurrentReplicas
-	out.UpdatedReplicas = in.UpdatedReplicas
-	out.CurrentRevision = in.CurrentRevision
-	out.UpdateRevision = in.UpdateRevision
-	out.CollisionCount = (*int32)(unsafe.Pointer(in.CollisionCount))
-	out.Conditions = *(*[]appsv1beta1.StatefulSetCondition)(unsafe.Pointer(&in.Conditions))
-	out.AvailableReplicas = in.AvailableReplicas
+	*out = *(*appsv1beta1.StatefulSetStatus)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/apps/v1beta2/zz_generated.conversion.go
+++ b/pkg/apis/apps/v1beta2/zz_generated.conversion.go
@@ -25,8 +25,8 @@ import (
 	unsafe "unsafe"
 
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apicorev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
@@ -445,11 +445,7 @@ func autoConvert_apps_DaemonSet_To_v1beta2_DaemonSet(in *apps.DaemonSet, out *ap
 }
 
 func autoConvert_v1beta2_DaemonSetCondition_To_apps_DaemonSetCondition(in *appsv1beta2.DaemonSetCondition, out *apps.DaemonSetCondition, s conversion.Scope) error {
-	out.Type = apps.DaemonSetConditionType(in.Type)
-	out.Status = core.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*apps.DaemonSetCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -459,11 +455,7 @@ func Convert_v1beta2_DaemonSetCondition_To_apps_DaemonSetCondition(in *appsv1bet
 }
 
 func autoConvert_apps_DaemonSetCondition_To_v1beta2_DaemonSetCondition(in *apps.DaemonSetCondition, out *appsv1beta2.DaemonSetCondition, s conversion.Scope) error {
-	out.Type = appsv1beta2.DaemonSetConditionType(in.Type)
-	out.Status = v1.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*appsv1beta2.DaemonSetCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -515,7 +507,7 @@ func Convert_apps_DaemonSetList_To_v1beta2_DaemonSetList(in *apps.DaemonSetList,
 }
 
 func autoConvert_v1beta2_DaemonSetSpec_To_apps_DaemonSetSpec(in *appsv1beta2.DaemonSetSpec, out *apps.DaemonSetSpec, s conversion.Scope) error {
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
+	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
 	if err := corev1.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -533,7 +525,7 @@ func Convert_v1beta2_DaemonSetSpec_To_apps_DaemonSetSpec(in *appsv1beta2.DaemonS
 }
 
 func autoConvert_apps_DaemonSetSpec_To_v1beta2_DaemonSetSpec(in *apps.DaemonSetSpec, out *appsv1beta2.DaemonSetSpec, s conversion.Scope) error {
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
+	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
 	if err := corev1.Convert_core_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -547,16 +539,7 @@ func autoConvert_apps_DaemonSetSpec_To_v1beta2_DaemonSetSpec(in *apps.DaemonSetS
 }
 
 func autoConvert_v1beta2_DaemonSetStatus_To_apps_DaemonSetStatus(in *appsv1beta2.DaemonSetStatus, out *apps.DaemonSetStatus, s conversion.Scope) error {
-	out.CurrentNumberScheduled = in.CurrentNumberScheduled
-	out.NumberMisscheduled = in.NumberMisscheduled
-	out.DesiredNumberScheduled = in.DesiredNumberScheduled
-	out.NumberReady = in.NumberReady
-	out.ObservedGeneration = in.ObservedGeneration
-	out.UpdatedNumberScheduled = in.UpdatedNumberScheduled
-	out.NumberAvailable = in.NumberAvailable
-	out.NumberUnavailable = in.NumberUnavailable
-	out.CollisionCount = (*int32)(unsafe.Pointer(in.CollisionCount))
-	out.Conditions = *(*[]apps.DaemonSetCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*apps.DaemonSetStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -566,16 +549,7 @@ func Convert_v1beta2_DaemonSetStatus_To_apps_DaemonSetStatus(in *appsv1beta2.Dae
 }
 
 func autoConvert_apps_DaemonSetStatus_To_v1beta2_DaemonSetStatus(in *apps.DaemonSetStatus, out *appsv1beta2.DaemonSetStatus, s conversion.Scope) error {
-	out.CurrentNumberScheduled = in.CurrentNumberScheduled
-	out.NumberMisscheduled = in.NumberMisscheduled
-	out.DesiredNumberScheduled = in.DesiredNumberScheduled
-	out.NumberReady = in.NumberReady
-	out.ObservedGeneration = in.ObservedGeneration
-	out.UpdatedNumberScheduled = in.UpdatedNumberScheduled
-	out.NumberAvailable = in.NumberAvailable
-	out.NumberUnavailable = in.NumberUnavailable
-	out.CollisionCount = (*int32)(unsafe.Pointer(in.CollisionCount))
-	out.Conditions = *(*[]appsv1beta2.DaemonSetCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*appsv1beta2.DaemonSetStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -645,12 +619,7 @@ func autoConvert_apps_Deployment_To_v1beta2_Deployment(in *apps.Deployment, out 
 }
 
 func autoConvert_v1beta2_DeploymentCondition_To_apps_DeploymentCondition(in *appsv1beta2.DeploymentCondition, out *apps.DeploymentCondition, s conversion.Scope) error {
-	out.Type = apps.DeploymentConditionType(in.Type)
-	out.Status = core.ConditionStatus(in.Status)
-	out.LastUpdateTime = in.LastUpdateTime
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*apps.DeploymentCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -660,12 +629,7 @@ func Convert_v1beta2_DeploymentCondition_To_apps_DeploymentCondition(in *appsv1b
 }
 
 func autoConvert_apps_DeploymentCondition_To_v1beta2_DeploymentCondition(in *apps.DeploymentCondition, out *appsv1beta2.DeploymentCondition, s conversion.Scope) error {
-	out.Type = appsv1beta2.DeploymentConditionType(in.Type)
-	out.Status = v1.ConditionStatus(in.Status)
-	out.LastUpdateTime = in.LastUpdateTime
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*appsv1beta2.DeploymentCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -717,10 +681,10 @@ func Convert_apps_DeploymentList_To_v1beta2_DeploymentList(in *apps.DeploymentLi
 }
 
 func autoConvert_v1beta2_DeploymentSpec_To_apps_DeploymentSpec(in *appsv1beta2.DeploymentSpec, out *apps.DeploymentSpec, s conversion.Scope) error {
-	if err := metav1.Convert_Pointer_int32_To_int32(&in.Replicas, &out.Replicas, s); err != nil {
+	if err := v1.Convert_Pointer_int32_To_int32(&in.Replicas, &out.Replicas, s); err != nil {
 		return err
 	}
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
+	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
 	if err := corev1.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -740,10 +704,10 @@ func Convert_v1beta2_DeploymentSpec_To_apps_DeploymentSpec(in *appsv1beta2.Deplo
 }
 
 func autoConvert_apps_DeploymentSpec_To_v1beta2_DeploymentSpec(in *apps.DeploymentSpec, out *appsv1beta2.DeploymentSpec, s conversion.Scope) error {
-	if err := metav1.Convert_int32_To_Pointer_int32(&in.Replicas, &out.Replicas, s); err != nil {
+	if err := v1.Convert_int32_To_Pointer_int32(&in.Replicas, &out.Replicas, s); err != nil {
 		return err
 	}
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
+	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
 	if err := corev1.Convert_core_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -759,15 +723,7 @@ func autoConvert_apps_DeploymentSpec_To_v1beta2_DeploymentSpec(in *apps.Deployme
 }
 
 func autoConvert_v1beta2_DeploymentStatus_To_apps_DeploymentStatus(in *appsv1beta2.DeploymentStatus, out *apps.DeploymentStatus, s conversion.Scope) error {
-	out.ObservedGeneration = in.ObservedGeneration
-	out.Replicas = in.Replicas
-	out.UpdatedReplicas = in.UpdatedReplicas
-	out.ReadyReplicas = in.ReadyReplicas
-	out.AvailableReplicas = in.AvailableReplicas
-	out.UnavailableReplicas = in.UnavailableReplicas
-	out.TerminatingReplicas = (*int32)(unsafe.Pointer(in.TerminatingReplicas))
-	out.Conditions = *(*[]apps.DeploymentCondition)(unsafe.Pointer(&in.Conditions))
-	out.CollisionCount = (*int32)(unsafe.Pointer(in.CollisionCount))
+	*out = *(*apps.DeploymentStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -777,15 +733,7 @@ func Convert_v1beta2_DeploymentStatus_To_apps_DeploymentStatus(in *appsv1beta2.D
 }
 
 func autoConvert_apps_DeploymentStatus_To_v1beta2_DeploymentStatus(in *apps.DeploymentStatus, out *appsv1beta2.DeploymentStatus, s conversion.Scope) error {
-	out.ObservedGeneration = in.ObservedGeneration
-	out.Replicas = in.Replicas
-	out.UpdatedReplicas = in.UpdatedReplicas
-	out.ReadyReplicas = in.ReadyReplicas
-	out.AvailableReplicas = in.AvailableReplicas
-	out.UnavailableReplicas = in.UnavailableReplicas
-	out.TerminatingReplicas = (*int32)(unsafe.Pointer(in.TerminatingReplicas))
-	out.Conditions = *(*[]appsv1beta2.DeploymentCondition)(unsafe.Pointer(&in.Conditions))
-	out.CollisionCount = (*int32)(unsafe.Pointer(in.CollisionCount))
+	*out = *(*appsv1beta2.DeploymentStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -865,11 +813,7 @@ func Convert_apps_ReplicaSet_To_v1beta2_ReplicaSet(in *apps.ReplicaSet, out *app
 }
 
 func autoConvert_v1beta2_ReplicaSetCondition_To_apps_ReplicaSetCondition(in *appsv1beta2.ReplicaSetCondition, out *apps.ReplicaSetCondition, s conversion.Scope) error {
-	out.Type = apps.ReplicaSetConditionType(in.Type)
-	out.Status = core.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*apps.ReplicaSetCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -879,11 +823,7 @@ func Convert_v1beta2_ReplicaSetCondition_To_apps_ReplicaSetCondition(in *appsv1b
 }
 
 func autoConvert_apps_ReplicaSetCondition_To_v1beta2_ReplicaSetCondition(in *apps.ReplicaSetCondition, out *appsv1beta2.ReplicaSetCondition, s conversion.Scope) error {
-	out.Type = appsv1beta2.ReplicaSetConditionType(in.Type)
-	out.Status = v1.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*appsv1beta2.ReplicaSetCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -935,11 +875,11 @@ func Convert_apps_ReplicaSetList_To_v1beta2_ReplicaSetList(in *apps.ReplicaSetLi
 }
 
 func autoConvert_v1beta2_ReplicaSetSpec_To_apps_ReplicaSetSpec(in *appsv1beta2.ReplicaSetSpec, out *apps.ReplicaSetSpec, s conversion.Scope) error {
-	if err := metav1.Convert_Pointer_int32_To_int32(&in.Replicas, &out.Replicas, s); err != nil {
+	if err := v1.Convert_Pointer_int32_To_int32(&in.Replicas, &out.Replicas, s); err != nil {
 		return err
 	}
 	out.MinReadySeconds = in.MinReadySeconds
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
+	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
 	if err := corev1.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -952,11 +892,11 @@ func Convert_v1beta2_ReplicaSetSpec_To_apps_ReplicaSetSpec(in *appsv1beta2.Repli
 }
 
 func autoConvert_apps_ReplicaSetSpec_To_v1beta2_ReplicaSetSpec(in *apps.ReplicaSetSpec, out *appsv1beta2.ReplicaSetSpec, s conversion.Scope) error {
-	if err := metav1.Convert_int32_To_Pointer_int32(&in.Replicas, &out.Replicas, s); err != nil {
+	if err := v1.Convert_int32_To_Pointer_int32(&in.Replicas, &out.Replicas, s); err != nil {
 		return err
 	}
 	out.MinReadySeconds = in.MinReadySeconds
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
+	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
 	if err := corev1.Convert_core_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -969,13 +909,7 @@ func Convert_apps_ReplicaSetSpec_To_v1beta2_ReplicaSetSpec(in *apps.ReplicaSetSp
 }
 
 func autoConvert_v1beta2_ReplicaSetStatus_To_apps_ReplicaSetStatus(in *appsv1beta2.ReplicaSetStatus, out *apps.ReplicaSetStatus, s conversion.Scope) error {
-	out.Replicas = in.Replicas
-	out.FullyLabeledReplicas = in.FullyLabeledReplicas
-	out.ReadyReplicas = in.ReadyReplicas
-	out.AvailableReplicas = in.AvailableReplicas
-	out.TerminatingReplicas = (*int32)(unsafe.Pointer(in.TerminatingReplicas))
-	out.ObservedGeneration = in.ObservedGeneration
-	out.Conditions = *(*[]apps.ReplicaSetCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*apps.ReplicaSetStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -985,13 +919,7 @@ func Convert_v1beta2_ReplicaSetStatus_To_apps_ReplicaSetStatus(in *appsv1beta2.R
 }
 
 func autoConvert_apps_ReplicaSetStatus_To_v1beta2_ReplicaSetStatus(in *apps.ReplicaSetStatus, out *appsv1beta2.ReplicaSetStatus, s conversion.Scope) error {
-	out.Replicas = in.Replicas
-	out.FullyLabeledReplicas = in.FullyLabeledReplicas
-	out.ReadyReplicas = in.ReadyReplicas
-	out.AvailableReplicas = in.AvailableReplicas
-	out.TerminatingReplicas = (*int32)(unsafe.Pointer(in.TerminatingReplicas))
-	out.ObservedGeneration = in.ObservedGeneration
-	out.Conditions = *(*[]appsv1beta2.ReplicaSetCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*appsv1beta2.ReplicaSetStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1001,10 +929,10 @@ func Convert_apps_ReplicaSetStatus_To_v1beta2_ReplicaSetStatus(in *apps.ReplicaS
 }
 
 func autoConvert_v1beta2_RollingUpdateDaemonSet_To_apps_RollingUpdateDaemonSet(in *appsv1beta2.RollingUpdateDaemonSet, out *apps.RollingUpdateDaemonSet, s conversion.Scope) error {
-	if err := metav1.Convert_Pointer_intstr_IntOrString_To_intstr_IntOrString(&in.MaxUnavailable, &out.MaxUnavailable, s); err != nil {
+	if err := v1.Convert_Pointer_intstr_IntOrString_To_intstr_IntOrString(&in.MaxUnavailable, &out.MaxUnavailable, s); err != nil {
 		return err
 	}
-	if err := metav1.Convert_Pointer_intstr_IntOrString_To_intstr_IntOrString(&in.MaxSurge, &out.MaxSurge, s); err != nil {
+	if err := v1.Convert_Pointer_intstr_IntOrString_To_intstr_IntOrString(&in.MaxSurge, &out.MaxSurge, s); err != nil {
 		return err
 	}
 	return nil
@@ -1016,10 +944,10 @@ func Convert_v1beta2_RollingUpdateDaemonSet_To_apps_RollingUpdateDaemonSet(in *a
 }
 
 func autoConvert_apps_RollingUpdateDaemonSet_To_v1beta2_RollingUpdateDaemonSet(in *apps.RollingUpdateDaemonSet, out *appsv1beta2.RollingUpdateDaemonSet, s conversion.Scope) error {
-	if err := metav1.Convert_intstr_IntOrString_To_Pointer_intstr_IntOrString(&in.MaxUnavailable, &out.MaxUnavailable, s); err != nil {
+	if err := v1.Convert_intstr_IntOrString_To_Pointer_intstr_IntOrString(&in.MaxUnavailable, &out.MaxUnavailable, s); err != nil {
 		return err
 	}
-	if err := metav1.Convert_intstr_IntOrString_To_Pointer_intstr_IntOrString(&in.MaxSurge, &out.MaxSurge, s); err != nil {
+	if err := v1.Convert_intstr_IntOrString_To_Pointer_intstr_IntOrString(&in.MaxSurge, &out.MaxSurge, s); err != nil {
 		return err
 	}
 	return nil
@@ -1031,10 +959,10 @@ func Convert_apps_RollingUpdateDaemonSet_To_v1beta2_RollingUpdateDaemonSet(in *a
 }
 
 func autoConvert_v1beta2_RollingUpdateDeployment_To_apps_RollingUpdateDeployment(in *appsv1beta2.RollingUpdateDeployment, out *apps.RollingUpdateDeployment, s conversion.Scope) error {
-	if err := metav1.Convert_Pointer_intstr_IntOrString_To_intstr_IntOrString(&in.MaxUnavailable, &out.MaxUnavailable, s); err != nil {
+	if err := v1.Convert_Pointer_intstr_IntOrString_To_intstr_IntOrString(&in.MaxUnavailable, &out.MaxUnavailable, s); err != nil {
 		return err
 	}
-	if err := metav1.Convert_Pointer_intstr_IntOrString_To_intstr_IntOrString(&in.MaxSurge, &out.MaxSurge, s); err != nil {
+	if err := v1.Convert_Pointer_intstr_IntOrString_To_intstr_IntOrString(&in.MaxSurge, &out.MaxSurge, s); err != nil {
 		return err
 	}
 	return nil
@@ -1046,10 +974,10 @@ func Convert_v1beta2_RollingUpdateDeployment_To_apps_RollingUpdateDeployment(in 
 }
 
 func autoConvert_apps_RollingUpdateDeployment_To_v1beta2_RollingUpdateDeployment(in *apps.RollingUpdateDeployment, out *appsv1beta2.RollingUpdateDeployment, s conversion.Scope) error {
-	if err := metav1.Convert_intstr_IntOrString_To_Pointer_intstr_IntOrString(&in.MaxUnavailable, &out.MaxUnavailable, s); err != nil {
+	if err := v1.Convert_intstr_IntOrString_To_Pointer_intstr_IntOrString(&in.MaxUnavailable, &out.MaxUnavailable, s); err != nil {
 		return err
 	}
-	if err := metav1.Convert_intstr_IntOrString_To_Pointer_intstr_IntOrString(&in.MaxSurge, &out.MaxSurge, s); err != nil {
+	if err := v1.Convert_intstr_IntOrString_To_Pointer_intstr_IntOrString(&in.MaxSurge, &out.MaxSurge, s); err != nil {
 		return err
 	}
 	return nil
@@ -1061,7 +989,7 @@ func Convert_apps_RollingUpdateDeployment_To_v1beta2_RollingUpdateDeployment(in 
 }
 
 func autoConvert_v1beta2_RollingUpdateStatefulSetStrategy_To_apps_RollingUpdateStatefulSetStrategy(in *appsv1beta2.RollingUpdateStatefulSetStrategy, out *apps.RollingUpdateStatefulSetStrategy, s conversion.Scope) error {
-	if err := metav1.Convert_Pointer_int32_To_int32(&in.Partition, &out.Partition, s); err != nil {
+	if err := v1.Convert_Pointer_int32_To_int32(&in.Partition, &out.Partition, s); err != nil {
 		return err
 	}
 	out.MaxUnavailable = (*intstr.IntOrString)(unsafe.Pointer(in.MaxUnavailable))
@@ -1074,7 +1002,7 @@ func Convert_v1beta2_RollingUpdateStatefulSetStrategy_To_apps_RollingUpdateState
 }
 
 func autoConvert_apps_RollingUpdateStatefulSetStrategy_To_v1beta2_RollingUpdateStatefulSetStrategy(in *apps.RollingUpdateStatefulSetStrategy, out *appsv1beta2.RollingUpdateStatefulSetStrategy, s conversion.Scope) error {
-	if err := metav1.Convert_int32_To_Pointer_int32(&in.Partition, &out.Partition, s); err != nil {
+	if err := v1.Convert_int32_To_Pointer_int32(&in.Partition, &out.Partition, s); err != nil {
 		return err
 	}
 	out.MaxUnavailable = (*intstr.IntOrString)(unsafe.Pointer(in.MaxUnavailable))
@@ -1119,7 +1047,7 @@ func Convert_autoscaling_Scale_To_v1beta2_Scale(in *autoscaling.Scale, out *apps
 }
 
 func autoConvert_v1beta2_ScaleSpec_To_autoscaling_ScaleSpec(in *appsv1beta2.ScaleSpec, out *autoscaling.ScaleSpec, s conversion.Scope) error {
-	out.Replicas = in.Replicas
+	*out = *(*autoscaling.ScaleSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1129,7 +1057,7 @@ func Convert_v1beta2_ScaleSpec_To_autoscaling_ScaleSpec(in *appsv1beta2.ScaleSpe
 }
 
 func autoConvert_autoscaling_ScaleSpec_To_v1beta2_ScaleSpec(in *autoscaling.ScaleSpec, out *appsv1beta2.ScaleSpec, s conversion.Scope) error {
-	out.Replicas = in.Replicas
+	*out = *(*appsv1beta2.ScaleSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1184,11 +1112,7 @@ func Convert_apps_StatefulSet_To_v1beta2_StatefulSet(in *apps.StatefulSet, out *
 }
 
 func autoConvert_v1beta2_StatefulSetCondition_To_apps_StatefulSetCondition(in *appsv1beta2.StatefulSetCondition, out *apps.StatefulSetCondition, s conversion.Scope) error {
-	out.Type = apps.StatefulSetConditionType(in.Type)
-	out.Status = core.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*apps.StatefulSetCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1198,11 +1122,7 @@ func Convert_v1beta2_StatefulSetCondition_To_apps_StatefulSetCondition(in *appsv
 }
 
 func autoConvert_apps_StatefulSetCondition_To_v1beta2_StatefulSetCondition(in *apps.StatefulSetCondition, out *appsv1beta2.StatefulSetCondition, s conversion.Scope) error {
-	out.Type = appsv1beta2.StatefulSetConditionType(in.Type)
-	out.Status = v1.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*appsv1beta2.StatefulSetCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1254,7 +1174,7 @@ func Convert_apps_StatefulSetList_To_v1beta2_StatefulSetList(in *apps.StatefulSe
 }
 
 func autoConvert_v1beta2_StatefulSetOrdinals_To_apps_StatefulSetOrdinals(in *appsv1beta2.StatefulSetOrdinals, out *apps.StatefulSetOrdinals, s conversion.Scope) error {
-	out.Start = in.Start
+	*out = *(*apps.StatefulSetOrdinals)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1264,7 +1184,7 @@ func Convert_v1beta2_StatefulSetOrdinals_To_apps_StatefulSetOrdinals(in *appsv1b
 }
 
 func autoConvert_apps_StatefulSetOrdinals_To_v1beta2_StatefulSetOrdinals(in *apps.StatefulSetOrdinals, out *appsv1beta2.StatefulSetOrdinals, s conversion.Scope) error {
-	out.Start = in.Start
+	*out = *(*appsv1beta2.StatefulSetOrdinals)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1274,8 +1194,7 @@ func Convert_apps_StatefulSetOrdinals_To_v1beta2_StatefulSetOrdinals(in *apps.St
 }
 
 func autoConvert_v1beta2_StatefulSetPersistentVolumeClaimRetentionPolicy_To_apps_StatefulSetPersistentVolumeClaimRetentionPolicy(in *appsv1beta2.StatefulSetPersistentVolumeClaimRetentionPolicy, out *apps.StatefulSetPersistentVolumeClaimRetentionPolicy, s conversion.Scope) error {
-	out.WhenDeleted = apps.PersistentVolumeClaimRetentionPolicyType(in.WhenDeleted)
-	out.WhenScaled = apps.PersistentVolumeClaimRetentionPolicyType(in.WhenScaled)
+	*out = *(*apps.StatefulSetPersistentVolumeClaimRetentionPolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1285,8 +1204,7 @@ func Convert_v1beta2_StatefulSetPersistentVolumeClaimRetentionPolicy_To_apps_Sta
 }
 
 func autoConvert_apps_StatefulSetPersistentVolumeClaimRetentionPolicy_To_v1beta2_StatefulSetPersistentVolumeClaimRetentionPolicy(in *apps.StatefulSetPersistentVolumeClaimRetentionPolicy, out *appsv1beta2.StatefulSetPersistentVolumeClaimRetentionPolicy, s conversion.Scope) error {
-	out.WhenDeleted = appsv1beta2.PersistentVolumeClaimRetentionPolicyType(in.WhenDeleted)
-	out.WhenScaled = appsv1beta2.PersistentVolumeClaimRetentionPolicyType(in.WhenScaled)
+	*out = *(*appsv1beta2.StatefulSetPersistentVolumeClaimRetentionPolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1296,10 +1214,10 @@ func Convert_apps_StatefulSetPersistentVolumeClaimRetentionPolicy_To_v1beta2_Sta
 }
 
 func autoConvert_v1beta2_StatefulSetSpec_To_apps_StatefulSetSpec(in *appsv1beta2.StatefulSetSpec, out *apps.StatefulSetSpec, s conversion.Scope) error {
-	if err := metav1.Convert_Pointer_int32_To_int32(&in.Replicas, &out.Replicas, s); err != nil {
+	if err := v1.Convert_Pointer_int32_To_int32(&in.Replicas, &out.Replicas, s); err != nil {
 		return err
 	}
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
+	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
 	if err := corev1.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -1317,14 +1235,14 @@ func autoConvert_v1beta2_StatefulSetSpec_To_apps_StatefulSetSpec(in *appsv1beta2
 }
 
 func autoConvert_apps_StatefulSetSpec_To_v1beta2_StatefulSetSpec(in *apps.StatefulSetSpec, out *appsv1beta2.StatefulSetSpec, s conversion.Scope) error {
-	if err := metav1.Convert_int32_To_Pointer_int32(&in.Replicas, &out.Replicas, s); err != nil {
+	if err := v1.Convert_int32_To_Pointer_int32(&in.Replicas, &out.Replicas, s); err != nil {
 		return err
 	}
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
+	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
 	if err := corev1.Convert_core_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
-	out.VolumeClaimTemplates = *(*[]v1.PersistentVolumeClaim)(unsafe.Pointer(&in.VolumeClaimTemplates))
+	out.VolumeClaimTemplates = *(*[]apicorev1.PersistentVolumeClaim)(unsafe.Pointer(&in.VolumeClaimTemplates))
 	out.ServiceName = in.ServiceName
 	out.PodManagementPolicy = appsv1beta2.PodManagementPolicyType(in.PodManagementPolicy)
 	if err := Convert_apps_StatefulSetUpdateStrategy_To_v1beta2_StatefulSetUpdateStrategy(&in.UpdateStrategy, &out.UpdateStrategy, s); err != nil {
@@ -1338,7 +1256,7 @@ func autoConvert_apps_StatefulSetSpec_To_v1beta2_StatefulSetSpec(in *apps.Statef
 }
 
 func autoConvert_v1beta2_StatefulSetStatus_To_apps_StatefulSetStatus(in *appsv1beta2.StatefulSetStatus, out *apps.StatefulSetStatus, s conversion.Scope) error {
-	if err := metav1.Convert_int64_To_Pointer_int64(&in.ObservedGeneration, &out.ObservedGeneration, s); err != nil {
+	if err := v1.Convert_int64_To_Pointer_int64(&in.ObservedGeneration, &out.ObservedGeneration, s); err != nil {
 		return err
 	}
 	out.Replicas = in.Replicas
@@ -1359,7 +1277,7 @@ func Convert_v1beta2_StatefulSetStatus_To_apps_StatefulSetStatus(in *appsv1beta2
 }
 
 func autoConvert_apps_StatefulSetStatus_To_v1beta2_StatefulSetStatus(in *apps.StatefulSetStatus, out *appsv1beta2.StatefulSetStatus, s conversion.Scope) error {
-	if err := metav1.Convert_Pointer_int64_To_int64(&in.ObservedGeneration, &out.ObservedGeneration, s); err != nil {
+	if err := v1.Convert_Pointer_int64_To_int64(&in.ObservedGeneration, &out.ObservedGeneration, s); err != nil {
 		return err
 	}
 	out.Replicas = in.Replicas

--- a/pkg/apis/authentication/v1/zz_generated.conversion.go
+++ b/pkg/apis/authentication/v1/zz_generated.conversion.go
@@ -28,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	types "k8s.io/apimachinery/pkg/types"
 	authentication "k8s.io/kubernetes/pkg/apis/authentication"
 )
 
@@ -143,10 +142,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1_BoundObjectReference_To_authentication_BoundObjectReference(in *authenticationv1.BoundObjectReference, out *authentication.BoundObjectReference, s conversion.Scope) error {
-	out.Kind = in.Kind
-	out.APIVersion = in.APIVersion
-	out.Name = in.Name
-	out.UID = types.UID(in.UID)
+	*out = *(*authentication.BoundObjectReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -156,10 +152,7 @@ func Convert_v1_BoundObjectReference_To_authentication_BoundObjectReference(in *
 }
 
 func autoConvert_authentication_BoundObjectReference_To_v1_BoundObjectReference(in *authentication.BoundObjectReference, out *authenticationv1.BoundObjectReference, s conversion.Scope) error {
-	out.Kind = in.Kind
-	out.APIVersion = in.APIVersion
-	out.Name = in.Name
-	out.UID = types.UID(in.UID)
+	*out = *(*authenticationv1.BoundObjectReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -279,8 +272,7 @@ func Convert_authentication_TokenRequestSpec_To_v1_TokenRequestSpec(in *authenti
 }
 
 func autoConvert_v1_TokenRequestStatus_To_authentication_TokenRequestStatus(in *authenticationv1.TokenRequestStatus, out *authentication.TokenRequestStatus, s conversion.Scope) error {
-	out.Token = in.Token
-	out.ExpirationTimestamp = in.ExpirationTimestamp
+	*out = *(*authentication.TokenRequestStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -290,8 +282,7 @@ func Convert_v1_TokenRequestStatus_To_authentication_TokenRequestStatus(in *auth
 }
 
 func autoConvert_authentication_TokenRequestStatus_To_v1_TokenRequestStatus(in *authentication.TokenRequestStatus, out *authenticationv1.TokenRequestStatus, s conversion.Scope) error {
-	out.Token = in.Token
-	out.ExpirationTimestamp = in.ExpirationTimestamp
+	*out = *(*authenticationv1.TokenRequestStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -333,8 +324,7 @@ func Convert_authentication_TokenReview_To_v1_TokenReview(in *authentication.Tok
 }
 
 func autoConvert_v1_TokenReviewSpec_To_authentication_TokenReviewSpec(in *authenticationv1.TokenReviewSpec, out *authentication.TokenReviewSpec, s conversion.Scope) error {
-	out.Token = in.Token
-	out.Audiences = *(*[]string)(unsafe.Pointer(&in.Audiences))
+	*out = *(*authentication.TokenReviewSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -344,8 +334,7 @@ func Convert_v1_TokenReviewSpec_To_authentication_TokenReviewSpec(in *authentica
 }
 
 func autoConvert_authentication_TokenReviewSpec_To_v1_TokenReviewSpec(in *authentication.TokenReviewSpec, out *authenticationv1.TokenReviewSpec, s conversion.Scope) error {
-	out.Token = in.Token
-	out.Audiences = *(*[]string)(unsafe.Pointer(&in.Audiences))
+	*out = *(*authenticationv1.TokenReviewSpec)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/authentication/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/authentication/v1beta1/zz_generated.conversion.go
@@ -184,8 +184,7 @@ func Convert_authentication_TokenReview_To_v1beta1_TokenReview(in *authenticatio
 }
 
 func autoConvert_v1beta1_TokenReviewSpec_To_authentication_TokenReviewSpec(in *authenticationv1beta1.TokenReviewSpec, out *authentication.TokenReviewSpec, s conversion.Scope) error {
-	out.Token = in.Token
-	out.Audiences = *(*[]string)(unsafe.Pointer(&in.Audiences))
+	*out = *(*authentication.TokenReviewSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -195,8 +194,7 @@ func Convert_v1beta1_TokenReviewSpec_To_authentication_TokenReviewSpec(in *authe
 }
 
 func autoConvert_authentication_TokenReviewSpec_To_v1beta1_TokenReviewSpec(in *authentication.TokenReviewSpec, out *authenticationv1beta1.TokenReviewSpec, s conversion.Scope) error {
-	out.Token = in.Token
-	out.Audiences = *(*[]string)(unsafe.Pointer(&in.Audiences))
+	*out = *(*authenticationv1beta1.TokenReviewSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -206,12 +204,7 @@ func Convert_authentication_TokenReviewSpec_To_v1beta1_TokenReviewSpec(in *authe
 }
 
 func autoConvert_v1beta1_TokenReviewStatus_To_authentication_TokenReviewStatus(in *authenticationv1beta1.TokenReviewStatus, out *authentication.TokenReviewStatus, s conversion.Scope) error {
-	out.Authenticated = in.Authenticated
-	if err := Convert_v1beta1_UserInfo_To_authentication_UserInfo(&in.User, &out.User, s); err != nil {
-		return err
-	}
-	out.Audiences = *(*[]string)(unsafe.Pointer(&in.Audiences))
-	out.Error = in.Error
+	*out = *(*authentication.TokenReviewStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -221,12 +214,7 @@ func Convert_v1beta1_TokenReviewStatus_To_authentication_TokenReviewStatus(in *a
 }
 
 func autoConvert_authentication_TokenReviewStatus_To_v1beta1_TokenReviewStatus(in *authentication.TokenReviewStatus, out *authenticationv1beta1.TokenReviewStatus, s conversion.Scope) error {
-	out.Authenticated = in.Authenticated
-	if err := Convert_authentication_UserInfo_To_v1beta1_UserInfo(&in.User, &out.User, s); err != nil {
-		return err
-	}
-	out.Audiences = *(*[]string)(unsafe.Pointer(&in.Audiences))
-	out.Error = in.Error
+	*out = *(*authenticationv1beta1.TokenReviewStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -236,10 +224,7 @@ func Convert_authentication_TokenReviewStatus_To_v1beta1_TokenReviewStatus(in *a
 }
 
 func autoConvert_v1beta1_UserInfo_To_authentication_UserInfo(in *authenticationv1beta1.UserInfo, out *authentication.UserInfo, s conversion.Scope) error {
-	out.Username = in.Username
-	out.UID = in.UID
-	out.Groups = *(*[]string)(unsafe.Pointer(&in.Groups))
-	out.Extra = *(*map[string]authentication.ExtraValue)(unsafe.Pointer(&in.Extra))
+	*out = *(*authentication.UserInfo)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -249,10 +234,7 @@ func Convert_v1beta1_UserInfo_To_authentication_UserInfo(in *authenticationv1bet
 }
 
 func autoConvert_authentication_UserInfo_To_v1beta1_UserInfo(in *authentication.UserInfo, out *authenticationv1beta1.UserInfo, s conversion.Scope) error {
-	out.Username = in.Username
-	out.UID = in.UID
-	out.Groups = *(*[]string)(unsafe.Pointer(&in.Groups))
-	out.Extra = *(*map[string]authenticationv1beta1.ExtraValue)(unsafe.Pointer(&in.Extra))
+	*out = *(*authenticationv1beta1.UserInfo)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/authorization/v1/zz_generated.conversion.go
+++ b/pkg/apis/authorization/v1/zz_generated.conversion.go
@@ -25,7 +25,6 @@ import (
 	unsafe "unsafe"
 
 	authorizationv1 "k8s.io/api/authorization/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	authorization "k8s.io/kubernetes/pkg/apis/authorization"
@@ -192,8 +191,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1_FieldSelectorAttributes_To_authorization_FieldSelectorAttributes(in *authorizationv1.FieldSelectorAttributes, out *authorization.FieldSelectorAttributes, s conversion.Scope) error {
-	out.RawSelector = in.RawSelector
-	out.Requirements = *(*[]metav1.FieldSelectorRequirement)(unsafe.Pointer(&in.Requirements))
+	*out = *(*authorization.FieldSelectorAttributes)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -203,8 +201,7 @@ func Convert_v1_FieldSelectorAttributes_To_authorization_FieldSelectorAttributes
 }
 
 func autoConvert_authorization_FieldSelectorAttributes_To_v1_FieldSelectorAttributes(in *authorization.FieldSelectorAttributes, out *authorizationv1.FieldSelectorAttributes, s conversion.Scope) error {
-	out.RawSelector = in.RawSelector
-	out.Requirements = *(*[]metav1.FieldSelectorRequirement)(unsafe.Pointer(&in.Requirements))
+	*out = *(*authorizationv1.FieldSelectorAttributes)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -214,8 +211,7 @@ func Convert_authorization_FieldSelectorAttributes_To_v1_FieldSelectorAttributes
 }
 
 func autoConvert_v1_LabelSelectorAttributes_To_authorization_LabelSelectorAttributes(in *authorizationv1.LabelSelectorAttributes, out *authorization.LabelSelectorAttributes, s conversion.Scope) error {
-	out.RawSelector = in.RawSelector
-	out.Requirements = *(*[]metav1.LabelSelectorRequirement)(unsafe.Pointer(&in.Requirements))
+	*out = *(*authorization.LabelSelectorAttributes)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -225,8 +221,7 @@ func Convert_v1_LabelSelectorAttributes_To_authorization_LabelSelectorAttributes
 }
 
 func autoConvert_authorization_LabelSelectorAttributes_To_v1_LabelSelectorAttributes(in *authorization.LabelSelectorAttributes, out *authorizationv1.LabelSelectorAttributes, s conversion.Scope) error {
-	out.RawSelector = in.RawSelector
-	out.Requirements = *(*[]metav1.LabelSelectorRequirement)(unsafe.Pointer(&in.Requirements))
+	*out = *(*authorizationv1.LabelSelectorAttributes)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -268,8 +263,7 @@ func Convert_authorization_LocalSubjectAccessReview_To_v1_LocalSubjectAccessRevi
 }
 
 func autoConvert_v1_NonResourceAttributes_To_authorization_NonResourceAttributes(in *authorizationv1.NonResourceAttributes, out *authorization.NonResourceAttributes, s conversion.Scope) error {
-	out.Path = in.Path
-	out.Verb = in.Verb
+	*out = *(*authorization.NonResourceAttributes)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -279,8 +273,7 @@ func Convert_v1_NonResourceAttributes_To_authorization_NonResourceAttributes(in 
 }
 
 func autoConvert_authorization_NonResourceAttributes_To_v1_NonResourceAttributes(in *authorization.NonResourceAttributes, out *authorizationv1.NonResourceAttributes, s conversion.Scope) error {
-	out.Path = in.Path
-	out.Verb = in.Verb
+	*out = *(*authorizationv1.NonResourceAttributes)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -290,8 +283,7 @@ func Convert_authorization_NonResourceAttributes_To_v1_NonResourceAttributes(in 
 }
 
 func autoConvert_v1_NonResourceRule_To_authorization_NonResourceRule(in *authorizationv1.NonResourceRule, out *authorization.NonResourceRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.NonResourceURLs = *(*[]string)(unsafe.Pointer(&in.NonResourceURLs))
+	*out = *(*authorization.NonResourceRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -301,8 +293,7 @@ func Convert_v1_NonResourceRule_To_authorization_NonResourceRule(in *authorizati
 }
 
 func autoConvert_authorization_NonResourceRule_To_v1_NonResourceRule(in *authorization.NonResourceRule, out *authorizationv1.NonResourceRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.NonResourceURLs = *(*[]string)(unsafe.Pointer(&in.NonResourceURLs))
+	*out = *(*authorizationv1.NonResourceRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -312,15 +303,7 @@ func Convert_authorization_NonResourceRule_To_v1_NonResourceRule(in *authorizati
 }
 
 func autoConvert_v1_ResourceAttributes_To_authorization_ResourceAttributes(in *authorizationv1.ResourceAttributes, out *authorization.ResourceAttributes, s conversion.Scope) error {
-	out.Namespace = in.Namespace
-	out.Verb = in.Verb
-	out.Group = in.Group
-	out.Version = in.Version
-	out.Resource = in.Resource
-	out.Subresource = in.Subresource
-	out.Name = in.Name
-	out.FieldSelector = (*authorization.FieldSelectorAttributes)(unsafe.Pointer(in.FieldSelector))
-	out.LabelSelector = (*authorization.LabelSelectorAttributes)(unsafe.Pointer(in.LabelSelector))
+	*out = *(*authorization.ResourceAttributes)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -330,15 +313,7 @@ func Convert_v1_ResourceAttributes_To_authorization_ResourceAttributes(in *autho
 }
 
 func autoConvert_authorization_ResourceAttributes_To_v1_ResourceAttributes(in *authorization.ResourceAttributes, out *authorizationv1.ResourceAttributes, s conversion.Scope) error {
-	out.Namespace = in.Namespace
-	out.Verb = in.Verb
-	out.Group = in.Group
-	out.Version = in.Version
-	out.Resource = in.Resource
-	out.Subresource = in.Subresource
-	out.Name = in.Name
-	out.FieldSelector = (*authorizationv1.FieldSelectorAttributes)(unsafe.Pointer(in.FieldSelector))
-	out.LabelSelector = (*authorizationv1.LabelSelectorAttributes)(unsafe.Pointer(in.LabelSelector))
+	*out = *(*authorizationv1.ResourceAttributes)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -348,10 +323,7 @@ func Convert_authorization_ResourceAttributes_To_v1_ResourceAttributes(in *autho
 }
 
 func autoConvert_v1_ResourceRule_To_authorization_ResourceRule(in *authorizationv1.ResourceRule, out *authorization.ResourceRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
-	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
-	out.ResourceNames = *(*[]string)(unsafe.Pointer(&in.ResourceNames))
+	*out = *(*authorization.ResourceRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -361,10 +333,7 @@ func Convert_v1_ResourceRule_To_authorization_ResourceRule(in *authorizationv1.R
 }
 
 func autoConvert_authorization_ResourceRule_To_v1_ResourceRule(in *authorization.ResourceRule, out *authorizationv1.ResourceRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
-	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
-	out.ResourceNames = *(*[]string)(unsafe.Pointer(&in.ResourceNames))
+	*out = *(*authorizationv1.ResourceRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -406,8 +375,7 @@ func Convert_authorization_SelfSubjectAccessReview_To_v1_SelfSubjectAccessReview
 }
 
 func autoConvert_v1_SelfSubjectAccessReviewSpec_To_authorization_SelfSubjectAccessReviewSpec(in *authorizationv1.SelfSubjectAccessReviewSpec, out *authorization.SelfSubjectAccessReviewSpec, s conversion.Scope) error {
-	out.ResourceAttributes = (*authorization.ResourceAttributes)(unsafe.Pointer(in.ResourceAttributes))
-	out.NonResourceAttributes = (*authorization.NonResourceAttributes)(unsafe.Pointer(in.NonResourceAttributes))
+	*out = *(*authorization.SelfSubjectAccessReviewSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -417,8 +385,7 @@ func Convert_v1_SelfSubjectAccessReviewSpec_To_authorization_SelfSubjectAccessRe
 }
 
 func autoConvert_authorization_SelfSubjectAccessReviewSpec_To_v1_SelfSubjectAccessReviewSpec(in *authorization.SelfSubjectAccessReviewSpec, out *authorizationv1.SelfSubjectAccessReviewSpec, s conversion.Scope) error {
-	out.ResourceAttributes = (*authorizationv1.ResourceAttributes)(unsafe.Pointer(in.ResourceAttributes))
-	out.NonResourceAttributes = (*authorizationv1.NonResourceAttributes)(unsafe.Pointer(in.NonResourceAttributes))
+	*out = *(*authorizationv1.SelfSubjectAccessReviewSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -460,7 +427,7 @@ func Convert_authorization_SelfSubjectRulesReview_To_v1_SelfSubjectRulesReview(i
 }
 
 func autoConvert_v1_SelfSubjectRulesReviewSpec_To_authorization_SelfSubjectRulesReviewSpec(in *authorizationv1.SelfSubjectRulesReviewSpec, out *authorization.SelfSubjectRulesReviewSpec, s conversion.Scope) error {
-	out.Namespace = in.Namespace
+	*out = *(*authorization.SelfSubjectRulesReviewSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -470,7 +437,7 @@ func Convert_v1_SelfSubjectRulesReviewSpec_To_authorization_SelfSubjectRulesRevi
 }
 
 func autoConvert_authorization_SelfSubjectRulesReviewSpec_To_v1_SelfSubjectRulesReviewSpec(in *authorization.SelfSubjectRulesReviewSpec, out *authorizationv1.SelfSubjectRulesReviewSpec, s conversion.Scope) error {
-	out.Namespace = in.Namespace
+	*out = *(*authorizationv1.SelfSubjectRulesReviewSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -512,12 +479,7 @@ func Convert_authorization_SubjectAccessReview_To_v1_SubjectAccessReview(in *aut
 }
 
 func autoConvert_v1_SubjectAccessReviewSpec_To_authorization_SubjectAccessReviewSpec(in *authorizationv1.SubjectAccessReviewSpec, out *authorization.SubjectAccessReviewSpec, s conversion.Scope) error {
-	out.ResourceAttributes = (*authorization.ResourceAttributes)(unsafe.Pointer(in.ResourceAttributes))
-	out.NonResourceAttributes = (*authorization.NonResourceAttributes)(unsafe.Pointer(in.NonResourceAttributes))
-	out.User = in.User
-	out.Groups = *(*[]string)(unsafe.Pointer(&in.Groups))
-	out.Extra = *(*map[string]authorization.ExtraValue)(unsafe.Pointer(&in.Extra))
-	out.UID = in.UID
+	*out = *(*authorization.SubjectAccessReviewSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -527,12 +489,7 @@ func Convert_v1_SubjectAccessReviewSpec_To_authorization_SubjectAccessReviewSpec
 }
 
 func autoConvert_authorization_SubjectAccessReviewSpec_To_v1_SubjectAccessReviewSpec(in *authorization.SubjectAccessReviewSpec, out *authorizationv1.SubjectAccessReviewSpec, s conversion.Scope) error {
-	out.ResourceAttributes = (*authorizationv1.ResourceAttributes)(unsafe.Pointer(in.ResourceAttributes))
-	out.NonResourceAttributes = (*authorizationv1.NonResourceAttributes)(unsafe.Pointer(in.NonResourceAttributes))
-	out.User = in.User
-	out.Groups = *(*[]string)(unsafe.Pointer(&in.Groups))
-	out.Extra = *(*map[string]authorizationv1.ExtraValue)(unsafe.Pointer(&in.Extra))
-	out.UID = in.UID
+	*out = *(*authorizationv1.SubjectAccessReviewSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -542,10 +499,7 @@ func Convert_authorization_SubjectAccessReviewSpec_To_v1_SubjectAccessReviewSpec
 }
 
 func autoConvert_v1_SubjectAccessReviewStatus_To_authorization_SubjectAccessReviewStatus(in *authorizationv1.SubjectAccessReviewStatus, out *authorization.SubjectAccessReviewStatus, s conversion.Scope) error {
-	out.Allowed = in.Allowed
-	out.Denied = in.Denied
-	out.Reason = in.Reason
-	out.EvaluationError = in.EvaluationError
+	*out = *(*authorization.SubjectAccessReviewStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -555,10 +509,7 @@ func Convert_v1_SubjectAccessReviewStatus_To_authorization_SubjectAccessReviewSt
 }
 
 func autoConvert_authorization_SubjectAccessReviewStatus_To_v1_SubjectAccessReviewStatus(in *authorization.SubjectAccessReviewStatus, out *authorizationv1.SubjectAccessReviewStatus, s conversion.Scope) error {
-	out.Allowed = in.Allowed
-	out.Denied = in.Denied
-	out.Reason = in.Reason
-	out.EvaluationError = in.EvaluationError
+	*out = *(*authorizationv1.SubjectAccessReviewStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -568,10 +519,7 @@ func Convert_authorization_SubjectAccessReviewStatus_To_v1_SubjectAccessReviewSt
 }
 
 func autoConvert_v1_SubjectRulesReviewStatus_To_authorization_SubjectRulesReviewStatus(in *authorizationv1.SubjectRulesReviewStatus, out *authorization.SubjectRulesReviewStatus, s conversion.Scope) error {
-	out.ResourceRules = *(*[]authorization.ResourceRule)(unsafe.Pointer(&in.ResourceRules))
-	out.NonResourceRules = *(*[]authorization.NonResourceRule)(unsafe.Pointer(&in.NonResourceRules))
-	out.Incomplete = in.Incomplete
-	out.EvaluationError = in.EvaluationError
+	*out = *(*authorization.SubjectRulesReviewStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -581,10 +529,7 @@ func Convert_v1_SubjectRulesReviewStatus_To_authorization_SubjectRulesReviewStat
 }
 
 func autoConvert_authorization_SubjectRulesReviewStatus_To_v1_SubjectRulesReviewStatus(in *authorization.SubjectRulesReviewStatus, out *authorizationv1.SubjectRulesReviewStatus, s conversion.Scope) error {
-	out.ResourceRules = *(*[]authorizationv1.ResourceRule)(unsafe.Pointer(&in.ResourceRules))
-	out.NonResourceRules = *(*[]authorizationv1.NonResourceRule)(unsafe.Pointer(&in.NonResourceRules))
-	out.Incomplete = in.Incomplete
-	out.EvaluationError = in.EvaluationError
+	*out = *(*authorizationv1.SubjectRulesReviewStatus)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/authorization/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/authorization/v1beta1/zz_generated.conversion.go
@@ -24,7 +24,6 @@ package v1beta1
 import (
 	unsafe "unsafe"
 
-	v1 "k8s.io/api/authorization/v1"
 	authorizationv1beta1 "k8s.io/api/authorization/v1beta1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -204,8 +203,7 @@ func Convert_authorization_LocalSubjectAccessReview_To_v1beta1_LocalSubjectAcces
 }
 
 func autoConvert_v1beta1_NonResourceAttributes_To_authorization_NonResourceAttributes(in *authorizationv1beta1.NonResourceAttributes, out *authorization.NonResourceAttributes, s conversion.Scope) error {
-	out.Path = in.Path
-	out.Verb = in.Verb
+	*out = *(*authorization.NonResourceAttributes)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -215,8 +213,7 @@ func Convert_v1beta1_NonResourceAttributes_To_authorization_NonResourceAttribute
 }
 
 func autoConvert_authorization_NonResourceAttributes_To_v1beta1_NonResourceAttributes(in *authorization.NonResourceAttributes, out *authorizationv1beta1.NonResourceAttributes, s conversion.Scope) error {
-	out.Path = in.Path
-	out.Verb = in.Verb
+	*out = *(*authorizationv1beta1.NonResourceAttributes)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -226,8 +223,7 @@ func Convert_authorization_NonResourceAttributes_To_v1beta1_NonResourceAttribute
 }
 
 func autoConvert_v1beta1_NonResourceRule_To_authorization_NonResourceRule(in *authorizationv1beta1.NonResourceRule, out *authorization.NonResourceRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.NonResourceURLs = *(*[]string)(unsafe.Pointer(&in.NonResourceURLs))
+	*out = *(*authorization.NonResourceRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -237,8 +233,7 @@ func Convert_v1beta1_NonResourceRule_To_authorization_NonResourceRule(in *author
 }
 
 func autoConvert_authorization_NonResourceRule_To_v1beta1_NonResourceRule(in *authorization.NonResourceRule, out *authorizationv1beta1.NonResourceRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.NonResourceURLs = *(*[]string)(unsafe.Pointer(&in.NonResourceURLs))
+	*out = *(*authorizationv1beta1.NonResourceRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -248,15 +243,7 @@ func Convert_authorization_NonResourceRule_To_v1beta1_NonResourceRule(in *author
 }
 
 func autoConvert_v1beta1_ResourceAttributes_To_authorization_ResourceAttributes(in *authorizationv1beta1.ResourceAttributes, out *authorization.ResourceAttributes, s conversion.Scope) error {
-	out.Namespace = in.Namespace
-	out.Verb = in.Verb
-	out.Group = in.Group
-	out.Version = in.Version
-	out.Resource = in.Resource
-	out.Subresource = in.Subresource
-	out.Name = in.Name
-	out.FieldSelector = (*authorization.FieldSelectorAttributes)(unsafe.Pointer(in.FieldSelector))
-	out.LabelSelector = (*authorization.LabelSelectorAttributes)(unsafe.Pointer(in.LabelSelector))
+	*out = *(*authorization.ResourceAttributes)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -266,15 +253,7 @@ func Convert_v1beta1_ResourceAttributes_To_authorization_ResourceAttributes(in *
 }
 
 func autoConvert_authorization_ResourceAttributes_To_v1beta1_ResourceAttributes(in *authorization.ResourceAttributes, out *authorizationv1beta1.ResourceAttributes, s conversion.Scope) error {
-	out.Namespace = in.Namespace
-	out.Verb = in.Verb
-	out.Group = in.Group
-	out.Version = in.Version
-	out.Resource = in.Resource
-	out.Subresource = in.Subresource
-	out.Name = in.Name
-	out.FieldSelector = (*v1.FieldSelectorAttributes)(unsafe.Pointer(in.FieldSelector))
-	out.LabelSelector = (*v1.LabelSelectorAttributes)(unsafe.Pointer(in.LabelSelector))
+	*out = *(*authorizationv1beta1.ResourceAttributes)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -284,10 +263,7 @@ func Convert_authorization_ResourceAttributes_To_v1beta1_ResourceAttributes(in *
 }
 
 func autoConvert_v1beta1_ResourceRule_To_authorization_ResourceRule(in *authorizationv1beta1.ResourceRule, out *authorization.ResourceRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
-	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
-	out.ResourceNames = *(*[]string)(unsafe.Pointer(&in.ResourceNames))
+	*out = *(*authorization.ResourceRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -297,10 +273,7 @@ func Convert_v1beta1_ResourceRule_To_authorization_ResourceRule(in *authorizatio
 }
 
 func autoConvert_authorization_ResourceRule_To_v1beta1_ResourceRule(in *authorization.ResourceRule, out *authorizationv1beta1.ResourceRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
-	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
-	out.ResourceNames = *(*[]string)(unsafe.Pointer(&in.ResourceNames))
+	*out = *(*authorizationv1beta1.ResourceRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -342,8 +315,7 @@ func Convert_authorization_SelfSubjectAccessReview_To_v1beta1_SelfSubjectAccessR
 }
 
 func autoConvert_v1beta1_SelfSubjectAccessReviewSpec_To_authorization_SelfSubjectAccessReviewSpec(in *authorizationv1beta1.SelfSubjectAccessReviewSpec, out *authorization.SelfSubjectAccessReviewSpec, s conversion.Scope) error {
-	out.ResourceAttributes = (*authorization.ResourceAttributes)(unsafe.Pointer(in.ResourceAttributes))
-	out.NonResourceAttributes = (*authorization.NonResourceAttributes)(unsafe.Pointer(in.NonResourceAttributes))
+	*out = *(*authorization.SelfSubjectAccessReviewSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -353,8 +325,7 @@ func Convert_v1beta1_SelfSubjectAccessReviewSpec_To_authorization_SelfSubjectAcc
 }
 
 func autoConvert_authorization_SelfSubjectAccessReviewSpec_To_v1beta1_SelfSubjectAccessReviewSpec(in *authorization.SelfSubjectAccessReviewSpec, out *authorizationv1beta1.SelfSubjectAccessReviewSpec, s conversion.Scope) error {
-	out.ResourceAttributes = (*authorizationv1beta1.ResourceAttributes)(unsafe.Pointer(in.ResourceAttributes))
-	out.NonResourceAttributes = (*authorizationv1beta1.NonResourceAttributes)(unsafe.Pointer(in.NonResourceAttributes))
+	*out = *(*authorizationv1beta1.SelfSubjectAccessReviewSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -396,7 +367,7 @@ func Convert_authorization_SelfSubjectRulesReview_To_v1beta1_SelfSubjectRulesRev
 }
 
 func autoConvert_v1beta1_SelfSubjectRulesReviewSpec_To_authorization_SelfSubjectRulesReviewSpec(in *authorizationv1beta1.SelfSubjectRulesReviewSpec, out *authorization.SelfSubjectRulesReviewSpec, s conversion.Scope) error {
-	out.Namespace = in.Namespace
+	*out = *(*authorization.SelfSubjectRulesReviewSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -406,7 +377,7 @@ func Convert_v1beta1_SelfSubjectRulesReviewSpec_To_authorization_SelfSubjectRule
 }
 
 func autoConvert_authorization_SelfSubjectRulesReviewSpec_To_v1beta1_SelfSubjectRulesReviewSpec(in *authorization.SelfSubjectRulesReviewSpec, out *authorizationv1beta1.SelfSubjectRulesReviewSpec, s conversion.Scope) error {
-	out.Namespace = in.Namespace
+	*out = *(*authorizationv1beta1.SelfSubjectRulesReviewSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -448,12 +419,7 @@ func Convert_authorization_SubjectAccessReview_To_v1beta1_SubjectAccessReview(in
 }
 
 func autoConvert_v1beta1_SubjectAccessReviewSpec_To_authorization_SubjectAccessReviewSpec(in *authorizationv1beta1.SubjectAccessReviewSpec, out *authorization.SubjectAccessReviewSpec, s conversion.Scope) error {
-	out.ResourceAttributes = (*authorization.ResourceAttributes)(unsafe.Pointer(in.ResourceAttributes))
-	out.NonResourceAttributes = (*authorization.NonResourceAttributes)(unsafe.Pointer(in.NonResourceAttributes))
-	out.User = in.User
-	out.Groups = *(*[]string)(unsafe.Pointer(&in.Groups))
-	out.Extra = *(*map[string]authorization.ExtraValue)(unsafe.Pointer(&in.Extra))
-	out.UID = in.UID
+	*out = *(*authorization.SubjectAccessReviewSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -463,12 +429,7 @@ func Convert_v1beta1_SubjectAccessReviewSpec_To_authorization_SubjectAccessRevie
 }
 
 func autoConvert_authorization_SubjectAccessReviewSpec_To_v1beta1_SubjectAccessReviewSpec(in *authorization.SubjectAccessReviewSpec, out *authorizationv1beta1.SubjectAccessReviewSpec, s conversion.Scope) error {
-	out.ResourceAttributes = (*authorizationv1beta1.ResourceAttributes)(unsafe.Pointer(in.ResourceAttributes))
-	out.NonResourceAttributes = (*authorizationv1beta1.NonResourceAttributes)(unsafe.Pointer(in.NonResourceAttributes))
-	out.User = in.User
-	out.Groups = *(*[]string)(unsafe.Pointer(&in.Groups))
-	out.Extra = *(*map[string]authorizationv1beta1.ExtraValue)(unsafe.Pointer(&in.Extra))
-	out.UID = in.UID
+	*out = *(*authorizationv1beta1.SubjectAccessReviewSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -478,10 +439,7 @@ func Convert_authorization_SubjectAccessReviewSpec_To_v1beta1_SubjectAccessRevie
 }
 
 func autoConvert_v1beta1_SubjectAccessReviewStatus_To_authorization_SubjectAccessReviewStatus(in *authorizationv1beta1.SubjectAccessReviewStatus, out *authorization.SubjectAccessReviewStatus, s conversion.Scope) error {
-	out.Allowed = in.Allowed
-	out.Denied = in.Denied
-	out.Reason = in.Reason
-	out.EvaluationError = in.EvaluationError
+	*out = *(*authorization.SubjectAccessReviewStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -491,10 +449,7 @@ func Convert_v1beta1_SubjectAccessReviewStatus_To_authorization_SubjectAccessRev
 }
 
 func autoConvert_authorization_SubjectAccessReviewStatus_To_v1beta1_SubjectAccessReviewStatus(in *authorization.SubjectAccessReviewStatus, out *authorizationv1beta1.SubjectAccessReviewStatus, s conversion.Scope) error {
-	out.Allowed = in.Allowed
-	out.Denied = in.Denied
-	out.Reason = in.Reason
-	out.EvaluationError = in.EvaluationError
+	*out = *(*authorizationv1beta1.SubjectAccessReviewStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -504,10 +459,7 @@ func Convert_authorization_SubjectAccessReviewStatus_To_v1beta1_SubjectAccessRev
 }
 
 func autoConvert_v1beta1_SubjectRulesReviewStatus_To_authorization_SubjectRulesReviewStatus(in *authorizationv1beta1.SubjectRulesReviewStatus, out *authorization.SubjectRulesReviewStatus, s conversion.Scope) error {
-	out.ResourceRules = *(*[]authorization.ResourceRule)(unsafe.Pointer(&in.ResourceRules))
-	out.NonResourceRules = *(*[]authorization.NonResourceRule)(unsafe.Pointer(&in.NonResourceRules))
-	out.Incomplete = in.Incomplete
-	out.EvaluationError = in.EvaluationError
+	*out = *(*authorization.SubjectRulesReviewStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -517,10 +469,7 @@ func Convert_v1beta1_SubjectRulesReviewStatus_To_authorization_SubjectRulesRevie
 }
 
 func autoConvert_authorization_SubjectRulesReviewStatus_To_v1beta1_SubjectRulesReviewStatus(in *authorization.SubjectRulesReviewStatus, out *authorizationv1beta1.SubjectRulesReviewStatus, s conversion.Scope) error {
-	out.ResourceRules = *(*[]authorizationv1beta1.ResourceRule)(unsafe.Pointer(&in.ResourceRules))
-	out.NonResourceRules = *(*[]authorizationv1beta1.NonResourceRule)(unsafe.Pointer(&in.NonResourceRules))
-	out.Incomplete = in.Incomplete
-	out.EvaluationError = in.EvaluationError
+	*out = *(*authorizationv1beta1.SubjectRulesReviewStatus)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/autoscaling/v1/zz_generated.conversion.go
+++ b/pkg/apis/autoscaling/v1/zz_generated.conversion.go
@@ -294,9 +294,7 @@ func autoConvert_autoscaling_ContainerResourceMetricStatus_To_v1_ContainerResour
 }
 
 func autoConvert_v1_CrossVersionObjectReference_To_autoscaling_CrossVersionObjectReference(in *autoscalingv1.CrossVersionObjectReference, out *autoscaling.CrossVersionObjectReference, s conversion.Scope) error {
-	out.Kind = in.Kind
-	out.Name = in.Name
-	out.APIVersion = in.APIVersion
+	*out = *(*autoscaling.CrossVersionObjectReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -306,9 +304,7 @@ func Convert_v1_CrossVersionObjectReference_To_autoscaling_CrossVersionObjectRef
 }
 
 func autoConvert_autoscaling_CrossVersionObjectReference_To_v1_CrossVersionObjectReference(in *autoscaling.CrossVersionObjectReference, out *autoscalingv1.CrossVersionObjectReference, s conversion.Scope) error {
-	out.Kind = in.Kind
-	out.Name = in.Name
-	out.APIVersion = in.APIVersion
+	*out = *(*autoscalingv1.CrossVersionObjectReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -368,12 +364,7 @@ func autoConvert_autoscaling_HorizontalPodAutoscaler_To_v1_HorizontalPodAutoscal
 }
 
 func autoConvert_v1_HorizontalPodAutoscalerCondition_To_autoscaling_HorizontalPodAutoscalerCondition(in *autoscalingv1.HorizontalPodAutoscalerCondition, out *autoscaling.HorizontalPodAutoscalerCondition, s conversion.Scope) error {
-	out.Type = autoscaling.HorizontalPodAutoscalerConditionType(in.Type)
-	out.Status = autoscaling.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
-	out.ObservedGeneration = (*int64)(unsafe.Pointer(in.ObservedGeneration))
+	*out = *(*autoscaling.HorizontalPodAutoscalerCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -383,12 +374,7 @@ func Convert_v1_HorizontalPodAutoscalerCondition_To_autoscaling_HorizontalPodAut
 }
 
 func autoConvert_autoscaling_HorizontalPodAutoscalerCondition_To_v1_HorizontalPodAutoscalerCondition(in *autoscaling.HorizontalPodAutoscalerCondition, out *autoscalingv1.HorizontalPodAutoscalerCondition, s conversion.Scope) error {
-	out.Type = autoscalingv1.HorizontalPodAutoscalerConditionType(in.Type)
-	out.Status = corev1.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
-	out.ObservedGeneration = (*int64)(unsafe.Pointer(in.ObservedGeneration))
+	*out = *(*autoscalingv1.HorizontalPodAutoscalerCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -820,7 +806,7 @@ func Convert_autoscaling_Scale_To_v1_Scale(in *autoscaling.Scale, out *autoscali
 }
 
 func autoConvert_v1_ScaleSpec_To_autoscaling_ScaleSpec(in *autoscalingv1.ScaleSpec, out *autoscaling.ScaleSpec, s conversion.Scope) error {
-	out.Replicas = in.Replicas
+	*out = *(*autoscaling.ScaleSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -830,7 +816,7 @@ func Convert_v1_ScaleSpec_To_autoscaling_ScaleSpec(in *autoscalingv1.ScaleSpec, 
 }
 
 func autoConvert_autoscaling_ScaleSpec_To_v1_ScaleSpec(in *autoscaling.ScaleSpec, out *autoscalingv1.ScaleSpec, s conversion.Scope) error {
-	out.Replicas = in.Replicas
+	*out = *(*autoscalingv1.ScaleSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -840,8 +826,7 @@ func Convert_autoscaling_ScaleSpec_To_v1_ScaleSpec(in *autoscaling.ScaleSpec, ou
 }
 
 func autoConvert_v1_ScaleStatus_To_autoscaling_ScaleStatus(in *autoscalingv1.ScaleStatus, out *autoscaling.ScaleStatus, s conversion.Scope) error {
-	out.Replicas = in.Replicas
-	out.Selector = in.Selector
+	*out = *(*autoscaling.ScaleStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -851,8 +836,7 @@ func Convert_v1_ScaleStatus_To_autoscaling_ScaleStatus(in *autoscalingv1.ScaleSt
 }
 
 func autoConvert_autoscaling_ScaleStatus_To_v1_ScaleStatus(in *autoscaling.ScaleStatus, out *autoscalingv1.ScaleStatus, s conversion.Scope) error {
-	out.Replicas = in.Replicas
-	out.Selector = in.Selector
+	*out = *(*autoscalingv1.ScaleStatus)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/autoscaling/v2/zz_generated.conversion.go
+++ b/pkg/apis/autoscaling/v2/zz_generated.conversion.go
@@ -26,7 +26,6 @@ import (
 
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	v1 "k8s.io/api/core/v1"
-	resource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -341,9 +340,7 @@ func Convert_autoscaling_ContainerResourceMetricStatus_To_v2_ContainerResourceMe
 }
 
 func autoConvert_v2_CrossVersionObjectReference_To_autoscaling_CrossVersionObjectReference(in *autoscalingv2.CrossVersionObjectReference, out *autoscaling.CrossVersionObjectReference, s conversion.Scope) error {
-	out.Kind = in.Kind
-	out.Name = in.Name
-	out.APIVersion = in.APIVersion
+	*out = *(*autoscaling.CrossVersionObjectReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -353,9 +350,7 @@ func Convert_v2_CrossVersionObjectReference_To_autoscaling_CrossVersionObjectRef
 }
 
 func autoConvert_autoscaling_CrossVersionObjectReference_To_v2_CrossVersionObjectReference(in *autoscaling.CrossVersionObjectReference, out *autoscalingv2.CrossVersionObjectReference, s conversion.Scope) error {
-	out.Kind = in.Kind
-	out.Name = in.Name
-	out.APIVersion = in.APIVersion
+	*out = *(*autoscalingv2.CrossVersionObjectReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -365,12 +360,7 @@ func Convert_autoscaling_CrossVersionObjectReference_To_v2_CrossVersionObjectRef
 }
 
 func autoConvert_v2_ExternalMetricSource_To_autoscaling_ExternalMetricSource(in *autoscalingv2.ExternalMetricSource, out *autoscaling.ExternalMetricSource, s conversion.Scope) error {
-	if err := Convert_v2_MetricIdentifier_To_autoscaling_MetricIdentifier(&in.Metric, &out.Metric, s); err != nil {
-		return err
-	}
-	if err := Convert_v2_MetricTarget_To_autoscaling_MetricTarget(&in.Target, &out.Target, s); err != nil {
-		return err
-	}
+	*out = *(*autoscaling.ExternalMetricSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -380,12 +370,7 @@ func Convert_v2_ExternalMetricSource_To_autoscaling_ExternalMetricSource(in *aut
 }
 
 func autoConvert_autoscaling_ExternalMetricSource_To_v2_ExternalMetricSource(in *autoscaling.ExternalMetricSource, out *autoscalingv2.ExternalMetricSource, s conversion.Scope) error {
-	if err := Convert_autoscaling_MetricIdentifier_To_v2_MetricIdentifier(&in.Metric, &out.Metric, s); err != nil {
-		return err
-	}
-	if err := Convert_autoscaling_MetricTarget_To_v2_MetricTarget(&in.Target, &out.Target, s); err != nil {
-		return err
-	}
+	*out = *(*autoscalingv2.ExternalMetricSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -395,12 +380,7 @@ func Convert_autoscaling_ExternalMetricSource_To_v2_ExternalMetricSource(in *aut
 }
 
 func autoConvert_v2_ExternalMetricStatus_To_autoscaling_ExternalMetricStatus(in *autoscalingv2.ExternalMetricStatus, out *autoscaling.ExternalMetricStatus, s conversion.Scope) error {
-	if err := Convert_v2_MetricIdentifier_To_autoscaling_MetricIdentifier(&in.Metric, &out.Metric, s); err != nil {
-		return err
-	}
-	if err := Convert_v2_MetricValueStatus_To_autoscaling_MetricValueStatus(&in.Current, &out.Current, s); err != nil {
-		return err
-	}
+	*out = *(*autoscaling.ExternalMetricStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -410,12 +390,7 @@ func Convert_v2_ExternalMetricStatus_To_autoscaling_ExternalMetricStatus(in *aut
 }
 
 func autoConvert_autoscaling_ExternalMetricStatus_To_v2_ExternalMetricStatus(in *autoscaling.ExternalMetricStatus, out *autoscalingv2.ExternalMetricStatus, s conversion.Scope) error {
-	if err := Convert_autoscaling_MetricIdentifier_To_v2_MetricIdentifier(&in.Metric, &out.Metric, s); err != nil {
-		return err
-	}
-	if err := Convert_autoscaling_MetricValueStatus_To_v2_MetricValueStatus(&in.Current, &out.Current, s); err != nil {
-		return err
-	}
+	*out = *(*autoscalingv2.ExternalMetricStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -425,9 +400,7 @@ func Convert_autoscaling_ExternalMetricStatus_To_v2_ExternalMetricStatus(in *aut
 }
 
 func autoConvert_v2_HPAScalingPolicy_To_autoscaling_HPAScalingPolicy(in *autoscalingv2.HPAScalingPolicy, out *autoscaling.HPAScalingPolicy, s conversion.Scope) error {
-	out.Type = autoscaling.HPAScalingPolicyType(in.Type)
-	out.Value = in.Value
-	out.PeriodSeconds = in.PeriodSeconds
+	*out = *(*autoscaling.HPAScalingPolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -437,9 +410,7 @@ func Convert_v2_HPAScalingPolicy_To_autoscaling_HPAScalingPolicy(in *autoscaling
 }
 
 func autoConvert_autoscaling_HPAScalingPolicy_To_v2_HPAScalingPolicy(in *autoscaling.HPAScalingPolicy, out *autoscalingv2.HPAScalingPolicy, s conversion.Scope) error {
-	out.Type = autoscalingv2.HPAScalingPolicyType(in.Type)
-	out.Value = in.Value
-	out.PeriodSeconds = in.PeriodSeconds
+	*out = *(*autoscalingv2.HPAScalingPolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -449,10 +420,7 @@ func Convert_autoscaling_HPAScalingPolicy_To_v2_HPAScalingPolicy(in *autoscaling
 }
 
 func autoConvert_v2_HPAScalingRules_To_autoscaling_HPAScalingRules(in *autoscalingv2.HPAScalingRules, out *autoscaling.HPAScalingRules, s conversion.Scope) error {
-	out.StabilizationWindowSeconds = (*int32)(unsafe.Pointer(in.StabilizationWindowSeconds))
-	out.SelectPolicy = (*autoscaling.ScalingPolicySelect)(unsafe.Pointer(in.SelectPolicy))
-	out.Policies = *(*[]autoscaling.HPAScalingPolicy)(unsafe.Pointer(&in.Policies))
-	out.Tolerance = (*resource.Quantity)(unsafe.Pointer(in.Tolerance))
+	*out = *(*autoscaling.HPAScalingRules)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -462,10 +430,7 @@ func Convert_v2_HPAScalingRules_To_autoscaling_HPAScalingRules(in *autoscalingv2
 }
 
 func autoConvert_autoscaling_HPAScalingRules_To_v2_HPAScalingRules(in *autoscaling.HPAScalingRules, out *autoscalingv2.HPAScalingRules, s conversion.Scope) error {
-	out.StabilizationWindowSeconds = (*int32)(unsafe.Pointer(in.StabilizationWindowSeconds))
-	out.SelectPolicy = (*autoscalingv2.ScalingPolicySelect)(unsafe.Pointer(in.SelectPolicy))
-	out.Policies = *(*[]autoscalingv2.HPAScalingPolicy)(unsafe.Pointer(&in.Policies))
-	out.Tolerance = (*resource.Quantity)(unsafe.Pointer(in.Tolerance))
+	*out = *(*autoscalingv2.HPAScalingRules)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -497,8 +462,7 @@ func autoConvert_autoscaling_HorizontalPodAutoscaler_To_v2_HorizontalPodAutoscal
 }
 
 func autoConvert_v2_HorizontalPodAutoscalerBehavior_To_autoscaling_HorizontalPodAutoscalerBehavior(in *autoscalingv2.HorizontalPodAutoscalerBehavior, out *autoscaling.HorizontalPodAutoscalerBehavior, s conversion.Scope) error {
-	out.ScaleUp = (*autoscaling.HPAScalingRules)(unsafe.Pointer(in.ScaleUp))
-	out.ScaleDown = (*autoscaling.HPAScalingRules)(unsafe.Pointer(in.ScaleDown))
+	*out = *(*autoscaling.HorizontalPodAutoscalerBehavior)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -508,8 +472,7 @@ func Convert_v2_HorizontalPodAutoscalerBehavior_To_autoscaling_HorizontalPodAuto
 }
 
 func autoConvert_autoscaling_HorizontalPodAutoscalerBehavior_To_v2_HorizontalPodAutoscalerBehavior(in *autoscaling.HorizontalPodAutoscalerBehavior, out *autoscalingv2.HorizontalPodAutoscalerBehavior, s conversion.Scope) error {
-	out.ScaleUp = (*autoscalingv2.HPAScalingRules)(unsafe.Pointer(in.ScaleUp))
-	out.ScaleDown = (*autoscalingv2.HPAScalingRules)(unsafe.Pointer(in.ScaleDown))
+	*out = *(*autoscalingv2.HorizontalPodAutoscalerBehavior)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -519,12 +482,7 @@ func Convert_autoscaling_HorizontalPodAutoscalerBehavior_To_v2_HorizontalPodAuto
 }
 
 func autoConvert_v2_HorizontalPodAutoscalerCondition_To_autoscaling_HorizontalPodAutoscalerCondition(in *autoscalingv2.HorizontalPodAutoscalerCondition, out *autoscaling.HorizontalPodAutoscalerCondition, s conversion.Scope) error {
-	out.Type = autoscaling.HorizontalPodAutoscalerConditionType(in.Type)
-	out.Status = autoscaling.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
-	out.ObservedGeneration = (*int64)(unsafe.Pointer(in.ObservedGeneration))
+	*out = *(*autoscaling.HorizontalPodAutoscalerCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -534,12 +492,7 @@ func Convert_v2_HorizontalPodAutoscalerCondition_To_autoscaling_HorizontalPodAut
 }
 
 func autoConvert_autoscaling_HorizontalPodAutoscalerCondition_To_v2_HorizontalPodAutoscalerCondition(in *autoscaling.HorizontalPodAutoscalerCondition, out *autoscalingv2.HorizontalPodAutoscalerCondition, s conversion.Scope) error {
-	out.Type = autoscalingv2.HorizontalPodAutoscalerConditionType(in.Type)
-	out.Status = v1.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
-	out.ObservedGeneration = (*int64)(unsafe.Pointer(in.ObservedGeneration))
+	*out = *(*autoscalingv2.HorizontalPodAutoscalerCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -693,8 +646,7 @@ func Convert_autoscaling_HorizontalPodAutoscalerStatus_To_v2_HorizontalPodAutosc
 }
 
 func autoConvert_v2_MetricIdentifier_To_autoscaling_MetricIdentifier(in *autoscalingv2.MetricIdentifier, out *autoscaling.MetricIdentifier, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
+	*out = *(*autoscaling.MetricIdentifier)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -704,8 +656,7 @@ func Convert_v2_MetricIdentifier_To_autoscaling_MetricIdentifier(in *autoscaling
 }
 
 func autoConvert_autoscaling_MetricIdentifier_To_v2_MetricIdentifier(in *autoscaling.MetricIdentifier, out *autoscalingv2.MetricIdentifier, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
+	*out = *(*autoscalingv2.MetricIdentifier)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -807,10 +758,7 @@ func Convert_autoscaling_MetricStatus_To_v2_MetricStatus(in *autoscaling.MetricS
 }
 
 func autoConvert_v2_MetricTarget_To_autoscaling_MetricTarget(in *autoscalingv2.MetricTarget, out *autoscaling.MetricTarget, s conversion.Scope) error {
-	out.Type = autoscaling.MetricTargetType(in.Type)
-	out.Value = (*resource.Quantity)(unsafe.Pointer(in.Value))
-	out.AverageValue = (*resource.Quantity)(unsafe.Pointer(in.AverageValue))
-	out.AverageUtilization = (*int32)(unsafe.Pointer(in.AverageUtilization))
+	*out = *(*autoscaling.MetricTarget)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -820,10 +768,7 @@ func Convert_v2_MetricTarget_To_autoscaling_MetricTarget(in *autoscalingv2.Metri
 }
 
 func autoConvert_autoscaling_MetricTarget_To_v2_MetricTarget(in *autoscaling.MetricTarget, out *autoscalingv2.MetricTarget, s conversion.Scope) error {
-	out.Type = autoscalingv2.MetricTargetType(in.Type)
-	out.Value = (*resource.Quantity)(unsafe.Pointer(in.Value))
-	out.AverageValue = (*resource.Quantity)(unsafe.Pointer(in.AverageValue))
-	out.AverageUtilization = (*int32)(unsafe.Pointer(in.AverageUtilization))
+	*out = *(*autoscalingv2.MetricTarget)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -833,9 +778,7 @@ func Convert_autoscaling_MetricTarget_To_v2_MetricTarget(in *autoscaling.MetricT
 }
 
 func autoConvert_v2_MetricValueStatus_To_autoscaling_MetricValueStatus(in *autoscalingv2.MetricValueStatus, out *autoscaling.MetricValueStatus, s conversion.Scope) error {
-	out.Value = (*resource.Quantity)(unsafe.Pointer(in.Value))
-	out.AverageValue = (*resource.Quantity)(unsafe.Pointer(in.AverageValue))
-	out.AverageUtilization = (*int32)(unsafe.Pointer(in.AverageUtilization))
+	*out = *(*autoscaling.MetricValueStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -845,9 +788,7 @@ func Convert_v2_MetricValueStatus_To_autoscaling_MetricValueStatus(in *autoscali
 }
 
 func autoConvert_autoscaling_MetricValueStatus_To_v2_MetricValueStatus(in *autoscaling.MetricValueStatus, out *autoscalingv2.MetricValueStatus, s conversion.Scope) error {
-	out.Value = (*resource.Quantity)(unsafe.Pointer(in.Value))
-	out.AverageValue = (*resource.Quantity)(unsafe.Pointer(in.AverageValue))
-	out.AverageUtilization = (*int32)(unsafe.Pointer(in.AverageUtilization))
+	*out = *(*autoscalingv2.MetricValueStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -857,15 +798,7 @@ func Convert_autoscaling_MetricValueStatus_To_v2_MetricValueStatus(in *autoscali
 }
 
 func autoConvert_v2_ObjectMetricSource_To_autoscaling_ObjectMetricSource(in *autoscalingv2.ObjectMetricSource, out *autoscaling.ObjectMetricSource, s conversion.Scope) error {
-	if err := Convert_v2_CrossVersionObjectReference_To_autoscaling_CrossVersionObjectReference(&in.DescribedObject, &out.DescribedObject, s); err != nil {
-		return err
-	}
-	if err := Convert_v2_MetricTarget_To_autoscaling_MetricTarget(&in.Target, &out.Target, s); err != nil {
-		return err
-	}
-	if err := Convert_v2_MetricIdentifier_To_autoscaling_MetricIdentifier(&in.Metric, &out.Metric, s); err != nil {
-		return err
-	}
+	*out = *(*autoscaling.ObjectMetricSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -875,15 +808,7 @@ func Convert_v2_ObjectMetricSource_To_autoscaling_ObjectMetricSource(in *autosca
 }
 
 func autoConvert_autoscaling_ObjectMetricSource_To_v2_ObjectMetricSource(in *autoscaling.ObjectMetricSource, out *autoscalingv2.ObjectMetricSource, s conversion.Scope) error {
-	if err := Convert_autoscaling_CrossVersionObjectReference_To_v2_CrossVersionObjectReference(&in.DescribedObject, &out.DescribedObject, s); err != nil {
-		return err
-	}
-	if err := Convert_autoscaling_MetricTarget_To_v2_MetricTarget(&in.Target, &out.Target, s); err != nil {
-		return err
-	}
-	if err := Convert_autoscaling_MetricIdentifier_To_v2_MetricIdentifier(&in.Metric, &out.Metric, s); err != nil {
-		return err
-	}
+	*out = *(*autoscalingv2.ObjectMetricSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -893,15 +818,7 @@ func Convert_autoscaling_ObjectMetricSource_To_v2_ObjectMetricSource(in *autosca
 }
 
 func autoConvert_v2_ObjectMetricStatus_To_autoscaling_ObjectMetricStatus(in *autoscalingv2.ObjectMetricStatus, out *autoscaling.ObjectMetricStatus, s conversion.Scope) error {
-	if err := Convert_v2_MetricIdentifier_To_autoscaling_MetricIdentifier(&in.Metric, &out.Metric, s); err != nil {
-		return err
-	}
-	if err := Convert_v2_MetricValueStatus_To_autoscaling_MetricValueStatus(&in.Current, &out.Current, s); err != nil {
-		return err
-	}
-	if err := Convert_v2_CrossVersionObjectReference_To_autoscaling_CrossVersionObjectReference(&in.DescribedObject, &out.DescribedObject, s); err != nil {
-		return err
-	}
+	*out = *(*autoscaling.ObjectMetricStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -911,15 +828,7 @@ func Convert_v2_ObjectMetricStatus_To_autoscaling_ObjectMetricStatus(in *autosca
 }
 
 func autoConvert_autoscaling_ObjectMetricStatus_To_v2_ObjectMetricStatus(in *autoscaling.ObjectMetricStatus, out *autoscalingv2.ObjectMetricStatus, s conversion.Scope) error {
-	if err := Convert_autoscaling_MetricIdentifier_To_v2_MetricIdentifier(&in.Metric, &out.Metric, s); err != nil {
-		return err
-	}
-	if err := Convert_autoscaling_MetricValueStatus_To_v2_MetricValueStatus(&in.Current, &out.Current, s); err != nil {
-		return err
-	}
-	if err := Convert_autoscaling_CrossVersionObjectReference_To_v2_CrossVersionObjectReference(&in.DescribedObject, &out.DescribedObject, s); err != nil {
-		return err
-	}
+	*out = *(*autoscalingv2.ObjectMetricStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -929,12 +838,7 @@ func Convert_autoscaling_ObjectMetricStatus_To_v2_ObjectMetricStatus(in *autosca
 }
 
 func autoConvert_v2_PodsMetricSource_To_autoscaling_PodsMetricSource(in *autoscalingv2.PodsMetricSource, out *autoscaling.PodsMetricSource, s conversion.Scope) error {
-	if err := Convert_v2_MetricIdentifier_To_autoscaling_MetricIdentifier(&in.Metric, &out.Metric, s); err != nil {
-		return err
-	}
-	if err := Convert_v2_MetricTarget_To_autoscaling_MetricTarget(&in.Target, &out.Target, s); err != nil {
-		return err
-	}
+	*out = *(*autoscaling.PodsMetricSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -944,12 +848,7 @@ func Convert_v2_PodsMetricSource_To_autoscaling_PodsMetricSource(in *autoscaling
 }
 
 func autoConvert_autoscaling_PodsMetricSource_To_v2_PodsMetricSource(in *autoscaling.PodsMetricSource, out *autoscalingv2.PodsMetricSource, s conversion.Scope) error {
-	if err := Convert_autoscaling_MetricIdentifier_To_v2_MetricIdentifier(&in.Metric, &out.Metric, s); err != nil {
-		return err
-	}
-	if err := Convert_autoscaling_MetricTarget_To_v2_MetricTarget(&in.Target, &out.Target, s); err != nil {
-		return err
-	}
+	*out = *(*autoscalingv2.PodsMetricSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -959,12 +858,7 @@ func Convert_autoscaling_PodsMetricSource_To_v2_PodsMetricSource(in *autoscaling
 }
 
 func autoConvert_v2_PodsMetricStatus_To_autoscaling_PodsMetricStatus(in *autoscalingv2.PodsMetricStatus, out *autoscaling.PodsMetricStatus, s conversion.Scope) error {
-	if err := Convert_v2_MetricIdentifier_To_autoscaling_MetricIdentifier(&in.Metric, &out.Metric, s); err != nil {
-		return err
-	}
-	if err := Convert_v2_MetricValueStatus_To_autoscaling_MetricValueStatus(&in.Current, &out.Current, s); err != nil {
-		return err
-	}
+	*out = *(*autoscaling.PodsMetricStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -974,12 +868,7 @@ func Convert_v2_PodsMetricStatus_To_autoscaling_PodsMetricStatus(in *autoscaling
 }
 
 func autoConvert_autoscaling_PodsMetricStatus_To_v2_PodsMetricStatus(in *autoscaling.PodsMetricStatus, out *autoscalingv2.PodsMetricStatus, s conversion.Scope) error {
-	if err := Convert_autoscaling_MetricIdentifier_To_v2_MetricIdentifier(&in.Metric, &out.Metric, s); err != nil {
-		return err
-	}
-	if err := Convert_autoscaling_MetricValueStatus_To_v2_MetricValueStatus(&in.Current, &out.Current, s); err != nil {
-		return err
-	}
+	*out = *(*autoscalingv2.PodsMetricStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -989,10 +878,7 @@ func Convert_autoscaling_PodsMetricStatus_To_v2_PodsMetricStatus(in *autoscaling
 }
 
 func autoConvert_v2_ResourceMetricSource_To_autoscaling_ResourceMetricSource(in *autoscalingv2.ResourceMetricSource, out *autoscaling.ResourceMetricSource, s conversion.Scope) error {
-	out.Name = core.ResourceName(in.Name)
-	if err := Convert_v2_MetricTarget_To_autoscaling_MetricTarget(&in.Target, &out.Target, s); err != nil {
-		return err
-	}
+	*out = *(*autoscaling.ResourceMetricSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1002,10 +888,7 @@ func Convert_v2_ResourceMetricSource_To_autoscaling_ResourceMetricSource(in *aut
 }
 
 func autoConvert_autoscaling_ResourceMetricSource_To_v2_ResourceMetricSource(in *autoscaling.ResourceMetricSource, out *autoscalingv2.ResourceMetricSource, s conversion.Scope) error {
-	out.Name = v1.ResourceName(in.Name)
-	if err := Convert_autoscaling_MetricTarget_To_v2_MetricTarget(&in.Target, &out.Target, s); err != nil {
-		return err
-	}
+	*out = *(*autoscalingv2.ResourceMetricSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1015,10 +898,7 @@ func Convert_autoscaling_ResourceMetricSource_To_v2_ResourceMetricSource(in *aut
 }
 
 func autoConvert_v2_ResourceMetricStatus_To_autoscaling_ResourceMetricStatus(in *autoscalingv2.ResourceMetricStatus, out *autoscaling.ResourceMetricStatus, s conversion.Scope) error {
-	out.Name = core.ResourceName(in.Name)
-	if err := Convert_v2_MetricValueStatus_To_autoscaling_MetricValueStatus(&in.Current, &out.Current, s); err != nil {
-		return err
-	}
+	*out = *(*autoscaling.ResourceMetricStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1028,10 +908,7 @@ func Convert_v2_ResourceMetricStatus_To_autoscaling_ResourceMetricStatus(in *aut
 }
 
 func autoConvert_autoscaling_ResourceMetricStatus_To_v2_ResourceMetricStatus(in *autoscaling.ResourceMetricStatus, out *autoscalingv2.ResourceMetricStatus, s conversion.Scope) error {
-	out.Name = v1.ResourceName(in.Name)
-	if err := Convert_autoscaling_MetricValueStatus_To_v2_MetricValueStatus(&in.Current, &out.Current, s); err != nil {
-		return err
-	}
+	*out = *(*autoscalingv2.ResourceMetricStatus)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/batch/v1/zz_generated.conversion.go
+++ b/pkg/apis/batch/v1/zz_generated.conversion.go
@@ -25,14 +25,11 @@ import (
 	unsafe "unsafe"
 
 	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	types "k8s.io/apimachinery/pkg/types"
 	batch "k8s.io/kubernetes/pkg/apis/batch"
-	core "k8s.io/kubernetes/pkg/apis/core"
-	apiscorev1 "k8s.io/kubernetes/pkg/apis/core/v1"
+	corev1 "k8s.io/kubernetes/pkg/apis/core/v1"
 )
 
 func init() {
@@ -328,9 +325,7 @@ func Convert_batch_CronJobSpec_To_v1_CronJobSpec(in *batch.CronJobSpec, out *bat
 }
 
 func autoConvert_v1_CronJobStatus_To_batch_CronJobStatus(in *batchv1.CronJobStatus, out *batch.CronJobStatus, s conversion.Scope) error {
-	out.Active = *(*[]core.ObjectReference)(unsafe.Pointer(&in.Active))
-	out.LastScheduleTime = (*metav1.Time)(unsafe.Pointer(in.LastScheduleTime))
-	out.LastSuccessfulTime = (*metav1.Time)(unsafe.Pointer(in.LastSuccessfulTime))
+	*out = *(*batch.CronJobStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -340,9 +335,7 @@ func Convert_v1_CronJobStatus_To_batch_CronJobStatus(in *batchv1.CronJobStatus, 
 }
 
 func autoConvert_batch_CronJobStatus_To_v1_CronJobStatus(in *batch.CronJobStatus, out *batchv1.CronJobStatus, s conversion.Scope) error {
-	out.Active = *(*[]corev1.ObjectReference)(unsafe.Pointer(&in.Active))
-	out.LastScheduleTime = (*metav1.Time)(unsafe.Pointer(in.LastScheduleTime))
-	out.LastSuccessfulTime = (*metav1.Time)(unsafe.Pointer(in.LastSuccessfulTime))
+	*out = *(*batchv1.CronJobStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -384,12 +377,7 @@ func Convert_batch_Job_To_v1_Job(in *batch.Job, out *batchv1.Job, s conversion.S
 }
 
 func autoConvert_v1_JobCondition_To_batch_JobCondition(in *batchv1.JobCondition, out *batch.JobCondition, s conversion.Scope) error {
-	out.Type = batch.JobConditionType(in.Type)
-	out.Status = core.ConditionStatus(in.Status)
-	out.LastProbeTime = in.LastProbeTime
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*batch.JobCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -399,12 +387,7 @@ func Convert_v1_JobCondition_To_batch_JobCondition(in *batchv1.JobCondition, out
 }
 
 func autoConvert_batch_JobCondition_To_v1_JobCondition(in *batch.JobCondition, out *batchv1.JobCondition, s conversion.Scope) error {
-	out.Type = batchv1.JobConditionType(in.Type)
-	out.Status = corev1.ConditionStatus(in.Status)
-	out.LastProbeTime = in.LastProbeTime
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*batchv1.JobCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -466,7 +449,7 @@ func autoConvert_v1_JobSpec_To_batch_JobSpec(in *batchv1.JobSpec, out *batch.Job
 	out.MaxFailedIndexes = (*int32)(unsafe.Pointer(in.MaxFailedIndexes))
 	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
 	out.ManualSelector = (*bool)(unsafe.Pointer(in.ManualSelector))
-	if err := apiscorev1.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
+	if err := corev1.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
 	out.TTLSecondsAfterFinished = (*int32)(unsafe.Pointer(in.TTLSecondsAfterFinished))
@@ -488,7 +471,7 @@ func autoConvert_batch_JobSpec_To_v1_JobSpec(in *batch.JobSpec, out *batchv1.Job
 	out.MaxFailedIndexes = (*int32)(unsafe.Pointer(in.MaxFailedIndexes))
 	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
 	out.ManualSelector = (*bool)(unsafe.Pointer(in.ManualSelector))
-	if err := apiscorev1.Convert_core_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
+	if err := corev1.Convert_core_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
 	out.TTLSecondsAfterFinished = (*int32)(unsafe.Pointer(in.TTLSecondsAfterFinished))
@@ -566,7 +549,7 @@ func Convert_batch_JobTemplateSpec_To_v1_JobTemplateSpec(in *batch.JobTemplateSp
 }
 
 func autoConvert_v1_PodFailurePolicy_To_batch_PodFailurePolicy(in *batchv1.PodFailurePolicy, out *batch.PodFailurePolicy, s conversion.Scope) error {
-	out.Rules = *(*[]batch.PodFailurePolicyRule)(unsafe.Pointer(&in.Rules))
+	*out = *(*batch.PodFailurePolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -576,7 +559,7 @@ func Convert_v1_PodFailurePolicy_To_batch_PodFailurePolicy(in *batchv1.PodFailur
 }
 
 func autoConvert_batch_PodFailurePolicy_To_v1_PodFailurePolicy(in *batch.PodFailurePolicy, out *batchv1.PodFailurePolicy, s conversion.Scope) error {
-	out.Rules = *(*[]batchv1.PodFailurePolicyRule)(unsafe.Pointer(&in.Rules))
+	*out = *(*batchv1.PodFailurePolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -586,9 +569,7 @@ func Convert_batch_PodFailurePolicy_To_v1_PodFailurePolicy(in *batch.PodFailureP
 }
 
 func autoConvert_v1_PodFailurePolicyOnExitCodesRequirement_To_batch_PodFailurePolicyOnExitCodesRequirement(in *batchv1.PodFailurePolicyOnExitCodesRequirement, out *batch.PodFailurePolicyOnExitCodesRequirement, s conversion.Scope) error {
-	out.ContainerName = (*string)(unsafe.Pointer(in.ContainerName))
-	out.Operator = batch.PodFailurePolicyOnExitCodesOperator(in.Operator)
-	out.Values = *(*[]int32)(unsafe.Pointer(&in.Values))
+	*out = *(*batch.PodFailurePolicyOnExitCodesRequirement)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -598,9 +579,7 @@ func Convert_v1_PodFailurePolicyOnExitCodesRequirement_To_batch_PodFailurePolicy
 }
 
 func autoConvert_batch_PodFailurePolicyOnExitCodesRequirement_To_v1_PodFailurePolicyOnExitCodesRequirement(in *batch.PodFailurePolicyOnExitCodesRequirement, out *batchv1.PodFailurePolicyOnExitCodesRequirement, s conversion.Scope) error {
-	out.ContainerName = (*string)(unsafe.Pointer(in.ContainerName))
-	out.Operator = batchv1.PodFailurePolicyOnExitCodesOperator(in.Operator)
-	out.Values = *(*[]int32)(unsafe.Pointer(&in.Values))
+	*out = *(*batchv1.PodFailurePolicyOnExitCodesRequirement)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -610,8 +589,7 @@ func Convert_batch_PodFailurePolicyOnExitCodesRequirement_To_v1_PodFailurePolicy
 }
 
 func autoConvert_v1_PodFailurePolicyOnPodConditionsPattern_To_batch_PodFailurePolicyOnPodConditionsPattern(in *batchv1.PodFailurePolicyOnPodConditionsPattern, out *batch.PodFailurePolicyOnPodConditionsPattern, s conversion.Scope) error {
-	out.Type = core.PodConditionType(in.Type)
-	out.Status = core.ConditionStatus(in.Status)
+	*out = *(*batch.PodFailurePolicyOnPodConditionsPattern)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -621,8 +599,7 @@ func Convert_v1_PodFailurePolicyOnPodConditionsPattern_To_batch_PodFailurePolicy
 }
 
 func autoConvert_batch_PodFailurePolicyOnPodConditionsPattern_To_v1_PodFailurePolicyOnPodConditionsPattern(in *batch.PodFailurePolicyOnPodConditionsPattern, out *batchv1.PodFailurePolicyOnPodConditionsPattern, s conversion.Scope) error {
-	out.Type = corev1.PodConditionType(in.Type)
-	out.Status = corev1.ConditionStatus(in.Status)
+	*out = *(*batchv1.PodFailurePolicyOnPodConditionsPattern)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -632,9 +609,7 @@ func Convert_batch_PodFailurePolicyOnPodConditionsPattern_To_v1_PodFailurePolicy
 }
 
 func autoConvert_v1_PodFailurePolicyRule_To_batch_PodFailurePolicyRule(in *batchv1.PodFailurePolicyRule, out *batch.PodFailurePolicyRule, s conversion.Scope) error {
-	out.Action = batch.PodFailurePolicyAction(in.Action)
-	out.OnExitCodes = (*batch.PodFailurePolicyOnExitCodesRequirement)(unsafe.Pointer(in.OnExitCodes))
-	out.OnPodConditions = *(*[]batch.PodFailurePolicyOnPodConditionsPattern)(unsafe.Pointer(&in.OnPodConditions))
+	*out = *(*batch.PodFailurePolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -644,9 +619,7 @@ func Convert_v1_PodFailurePolicyRule_To_batch_PodFailurePolicyRule(in *batchv1.P
 }
 
 func autoConvert_batch_PodFailurePolicyRule_To_v1_PodFailurePolicyRule(in *batch.PodFailurePolicyRule, out *batchv1.PodFailurePolicyRule, s conversion.Scope) error {
-	out.Action = batchv1.PodFailurePolicyAction(in.Action)
-	out.OnExitCodes = (*batchv1.PodFailurePolicyOnExitCodesRequirement)(unsafe.Pointer(in.OnExitCodes))
-	out.OnPodConditions = *(*[]batchv1.PodFailurePolicyOnPodConditionsPattern)(unsafe.Pointer(&in.OnPodConditions))
+	*out = *(*batchv1.PodFailurePolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -656,7 +629,7 @@ func Convert_batch_PodFailurePolicyRule_To_v1_PodFailurePolicyRule(in *batch.Pod
 }
 
 func autoConvert_v1_SuccessPolicy_To_batch_SuccessPolicy(in *batchv1.SuccessPolicy, out *batch.SuccessPolicy, s conversion.Scope) error {
-	out.Rules = *(*[]batch.SuccessPolicyRule)(unsafe.Pointer(&in.Rules))
+	*out = *(*batch.SuccessPolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -666,7 +639,7 @@ func Convert_v1_SuccessPolicy_To_batch_SuccessPolicy(in *batchv1.SuccessPolicy, 
 }
 
 func autoConvert_batch_SuccessPolicy_To_v1_SuccessPolicy(in *batch.SuccessPolicy, out *batchv1.SuccessPolicy, s conversion.Scope) error {
-	out.Rules = *(*[]batchv1.SuccessPolicyRule)(unsafe.Pointer(&in.Rules))
+	*out = *(*batchv1.SuccessPolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -676,8 +649,7 @@ func Convert_batch_SuccessPolicy_To_v1_SuccessPolicy(in *batch.SuccessPolicy, ou
 }
 
 func autoConvert_v1_SuccessPolicyRule_To_batch_SuccessPolicyRule(in *batchv1.SuccessPolicyRule, out *batch.SuccessPolicyRule, s conversion.Scope) error {
-	out.SucceededIndexes = (*string)(unsafe.Pointer(in.SucceededIndexes))
-	out.SucceededCount = (*int32)(unsafe.Pointer(in.SucceededCount))
+	*out = *(*batch.SuccessPolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -687,8 +659,7 @@ func Convert_v1_SuccessPolicyRule_To_batch_SuccessPolicyRule(in *batchv1.Success
 }
 
 func autoConvert_batch_SuccessPolicyRule_To_v1_SuccessPolicyRule(in *batch.SuccessPolicyRule, out *batchv1.SuccessPolicyRule, s conversion.Scope) error {
-	out.SucceededIndexes = (*string)(unsafe.Pointer(in.SucceededIndexes))
-	out.SucceededCount = (*int32)(unsafe.Pointer(in.SucceededCount))
+	*out = *(*batchv1.SuccessPolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -698,8 +669,7 @@ func Convert_batch_SuccessPolicyRule_To_v1_SuccessPolicyRule(in *batch.SuccessPo
 }
 
 func autoConvert_v1_UncountedTerminatedPods_To_batch_UncountedTerminatedPods(in *batchv1.UncountedTerminatedPods, out *batch.UncountedTerminatedPods, s conversion.Scope) error {
-	out.Succeeded = *(*[]types.UID)(unsafe.Pointer(&in.Succeeded))
-	out.Failed = *(*[]types.UID)(unsafe.Pointer(&in.Failed))
+	*out = *(*batch.UncountedTerminatedPods)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -709,8 +679,7 @@ func Convert_v1_UncountedTerminatedPods_To_batch_UncountedTerminatedPods(in *bat
 }
 
 func autoConvert_batch_UncountedTerminatedPods_To_v1_UncountedTerminatedPods(in *batch.UncountedTerminatedPods, out *batchv1.UncountedTerminatedPods, s conversion.Scope) error {
-	out.Succeeded = *(*[]types.UID)(unsafe.Pointer(&in.Succeeded))
-	out.Failed = *(*[]types.UID)(unsafe.Pointer(&in.Failed))
+	*out = *(*batchv1.UncountedTerminatedPods)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/batch/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/batch/v1beta1/zz_generated.conversion.go
@@ -25,13 +25,10 @@ import (
 	unsafe "unsafe"
 
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
-	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	batch "k8s.io/kubernetes/pkg/apis/batch"
-	batchv1 "k8s.io/kubernetes/pkg/apis/batch/v1"
-	core "k8s.io/kubernetes/pkg/apis/core"
+	v1 "k8s.io/kubernetes/pkg/apis/batch/v1"
 )
 
 func init() {
@@ -207,9 +204,7 @@ func Convert_batch_CronJobSpec_To_v1beta1_CronJobSpec(in *batch.CronJobSpec, out
 }
 
 func autoConvert_v1beta1_CronJobStatus_To_batch_CronJobStatus(in *batchv1beta1.CronJobStatus, out *batch.CronJobStatus, s conversion.Scope) error {
-	out.Active = *(*[]core.ObjectReference)(unsafe.Pointer(&in.Active))
-	out.LastScheduleTime = (*v1.Time)(unsafe.Pointer(in.LastScheduleTime))
-	out.LastSuccessfulTime = (*v1.Time)(unsafe.Pointer(in.LastSuccessfulTime))
+	*out = *(*batch.CronJobStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -219,9 +214,7 @@ func Convert_v1beta1_CronJobStatus_To_batch_CronJobStatus(in *batchv1beta1.CronJ
 }
 
 func autoConvert_batch_CronJobStatus_To_v1beta1_CronJobStatus(in *batch.CronJobStatus, out *batchv1beta1.CronJobStatus, s conversion.Scope) error {
-	out.Active = *(*[]corev1.ObjectReference)(unsafe.Pointer(&in.Active))
-	out.LastScheduleTime = (*v1.Time)(unsafe.Pointer(in.LastScheduleTime))
-	out.LastSuccessfulTime = (*v1.Time)(unsafe.Pointer(in.LastSuccessfulTime))
+	*out = *(*batchv1beta1.CronJobStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -232,7 +225,7 @@ func Convert_batch_CronJobStatus_To_v1beta1_CronJobStatus(in *batch.CronJobStatu
 
 func autoConvert_v1beta1_JobTemplateSpec_To_batch_JobTemplateSpec(in *batchv1beta1.JobTemplateSpec, out *batch.JobTemplateSpec, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if err := batchv1.Convert_v1_JobSpec_To_batch_JobSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := v1.Convert_v1_JobSpec_To_batch_JobSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
 	return nil
@@ -245,7 +238,7 @@ func Convert_v1beta1_JobTemplateSpec_To_batch_JobTemplateSpec(in *batchv1beta1.J
 
 func autoConvert_batch_JobTemplateSpec_To_v1beta1_JobTemplateSpec(in *batch.JobTemplateSpec, out *batchv1beta1.JobTemplateSpec, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if err := batchv1.Convert_batch_JobSpec_To_v1_JobSpec(&in.Spec, &out.Spec, s); err != nil {
+	if err := v1.Convert_batch_JobSpec_To_v1_JobSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/apis/certificates/v1/zz_generated.conversion.go
+++ b/pkg/apis/certificates/v1/zz_generated.conversion.go
@@ -25,11 +25,9 @@ import (
 	unsafe "unsafe"
 
 	certificatesv1 "k8s.io/api/certificates/v1"
-	corev1 "k8s.io/api/core/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	certificates "k8s.io/kubernetes/pkg/apis/certificates"
-	core "k8s.io/kubernetes/pkg/apis/core"
 )
 
 func init() {
@@ -125,12 +123,7 @@ func Convert_certificates_CertificateSigningRequest_To_v1_CertificateSigningRequ
 }
 
 func autoConvert_v1_CertificateSigningRequestCondition_To_certificates_CertificateSigningRequestCondition(in *certificatesv1.CertificateSigningRequestCondition, out *certificates.CertificateSigningRequestCondition, s conversion.Scope) error {
-	out.Type = certificates.RequestConditionType(in.Type)
-	out.Status = core.ConditionStatus(in.Status)
-	out.Reason = in.Reason
-	out.Message = in.Message
-	out.LastUpdateTime = in.LastUpdateTime
-	out.LastTransitionTime = in.LastTransitionTime
+	*out = *(*certificates.CertificateSigningRequestCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -140,12 +133,7 @@ func Convert_v1_CertificateSigningRequestCondition_To_certificates_CertificateSi
 }
 
 func autoConvert_certificates_CertificateSigningRequestCondition_To_v1_CertificateSigningRequestCondition(in *certificates.CertificateSigningRequestCondition, out *certificatesv1.CertificateSigningRequestCondition, s conversion.Scope) error {
-	out.Type = certificatesv1.RequestConditionType(in.Type)
-	out.Status = corev1.ConditionStatus(in.Status)
-	out.Reason = in.Reason
-	out.Message = in.Message
-	out.LastUpdateTime = in.LastUpdateTime
-	out.LastTransitionTime = in.LastTransitionTime
+	*out = *(*certificatesv1.CertificateSigningRequestCondition)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/certificates/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/certificates/v1alpha1/zz_generated.conversion.go
@@ -119,8 +119,7 @@ func Convert_certificates_ClusterTrustBundleList_To_v1alpha1_ClusterTrustBundleL
 }
 
 func autoConvert_v1alpha1_ClusterTrustBundleSpec_To_certificates_ClusterTrustBundleSpec(in *certificatesv1alpha1.ClusterTrustBundleSpec, out *certificates.ClusterTrustBundleSpec, s conversion.Scope) error {
-	out.SignerName = in.SignerName
-	out.TrustBundle = in.TrustBundle
+	*out = *(*certificates.ClusterTrustBundleSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -130,8 +129,7 @@ func Convert_v1alpha1_ClusterTrustBundleSpec_To_certificates_ClusterTrustBundleS
 }
 
 func autoConvert_certificates_ClusterTrustBundleSpec_To_v1alpha1_ClusterTrustBundleSpec(in *certificates.ClusterTrustBundleSpec, out *certificatesv1alpha1.ClusterTrustBundleSpec, s conversion.Scope) error {
-	out.SignerName = in.SignerName
-	out.TrustBundle = in.TrustBundle
+	*out = *(*certificatesv1alpha1.ClusterTrustBundleSpec)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/certificates/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/certificates/v1beta1/zz_generated.conversion.go
@@ -25,13 +25,11 @@ import (
 	unsafe "unsafe"
 
 	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	types "k8s.io/apimachinery/pkg/types"
 	certificates "k8s.io/kubernetes/pkg/apis/certificates"
-	core "k8s.io/kubernetes/pkg/apis/core"
 )
 
 func init() {
@@ -197,12 +195,7 @@ func Convert_certificates_CertificateSigningRequest_To_v1beta1_CertificateSignin
 }
 
 func autoConvert_v1beta1_CertificateSigningRequestCondition_To_certificates_CertificateSigningRequestCondition(in *certificatesv1beta1.CertificateSigningRequestCondition, out *certificates.CertificateSigningRequestCondition, s conversion.Scope) error {
-	out.Type = certificates.RequestConditionType(in.Type)
-	out.Status = core.ConditionStatus(in.Status)
-	out.Reason = in.Reason
-	out.Message = in.Message
-	out.LastUpdateTime = in.LastUpdateTime
-	out.LastTransitionTime = in.LastTransitionTime
+	*out = *(*certificates.CertificateSigningRequestCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -212,12 +205,7 @@ func Convert_v1beta1_CertificateSigningRequestCondition_To_certificates_Certific
 }
 
 func autoConvert_certificates_CertificateSigningRequestCondition_To_v1beta1_CertificateSigningRequestCondition(in *certificates.CertificateSigningRequestCondition, out *certificatesv1beta1.CertificateSigningRequestCondition, s conversion.Scope) error {
-	out.Type = certificatesv1beta1.RequestConditionType(in.Type)
-	out.Status = v1.ConditionStatus(in.Status)
-	out.Reason = in.Reason
-	out.Message = in.Message
-	out.LastUpdateTime = in.LastUpdateTime
-	out.LastTransitionTime = in.LastTransitionTime
+	*out = *(*certificatesv1beta1.CertificateSigningRequestCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -270,7 +258,7 @@ func Convert_certificates_CertificateSigningRequestList_To_v1beta1_CertificateSi
 
 func autoConvert_v1beta1_CertificateSigningRequestSpec_To_certificates_CertificateSigningRequestSpec(in *certificatesv1beta1.CertificateSigningRequestSpec, out *certificates.CertificateSigningRequestSpec, s conversion.Scope) error {
 	out.Request = *(*[]byte)(unsafe.Pointer(&in.Request))
-	if err := metav1.Convert_Pointer_string_To_string(&in.SignerName, &out.SignerName, s); err != nil {
+	if err := v1.Convert_Pointer_string_To_string(&in.SignerName, &out.SignerName, s); err != nil {
 		return err
 	}
 	out.ExpirationSeconds = (*int32)(unsafe.Pointer(in.ExpirationSeconds))
@@ -289,7 +277,7 @@ func Convert_v1beta1_CertificateSigningRequestSpec_To_certificates_CertificateSi
 
 func autoConvert_certificates_CertificateSigningRequestSpec_To_v1beta1_CertificateSigningRequestSpec(in *certificates.CertificateSigningRequestSpec, out *certificatesv1beta1.CertificateSigningRequestSpec, s conversion.Scope) error {
 	out.Request = *(*[]byte)(unsafe.Pointer(&in.Request))
-	if err := metav1.Convert_string_To_Pointer_string(&in.SignerName, &out.SignerName, s); err != nil {
+	if err := v1.Convert_string_To_Pointer_string(&in.SignerName, &out.SignerName, s); err != nil {
 		return err
 	}
 	out.ExpirationSeconds = (*int32)(unsafe.Pointer(in.ExpirationSeconds))
@@ -377,8 +365,7 @@ func Convert_certificates_ClusterTrustBundleList_To_v1beta1_ClusterTrustBundleLi
 }
 
 func autoConvert_v1beta1_ClusterTrustBundleSpec_To_certificates_ClusterTrustBundleSpec(in *certificatesv1beta1.ClusterTrustBundleSpec, out *certificates.ClusterTrustBundleSpec, s conversion.Scope) error {
-	out.SignerName = in.SignerName
-	out.TrustBundle = in.TrustBundle
+	*out = *(*certificates.ClusterTrustBundleSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -388,8 +375,7 @@ func Convert_v1beta1_ClusterTrustBundleSpec_To_certificates_ClusterTrustBundleSp
 }
 
 func autoConvert_certificates_ClusterTrustBundleSpec_To_v1beta1_ClusterTrustBundleSpec(in *certificates.ClusterTrustBundleSpec, out *certificatesv1beta1.ClusterTrustBundleSpec, s conversion.Scope) error {
-	out.SignerName = in.SignerName
-	out.TrustBundle = in.TrustBundle
+	*out = *(*certificatesv1beta1.ClusterTrustBundleSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -495,11 +481,7 @@ func Convert_certificates_PodCertificateRequestSpec_To_v1beta1_PodCertificateReq
 }
 
 func autoConvert_v1beta1_PodCertificateRequestStatus_To_certificates_PodCertificateRequestStatus(in *certificatesv1beta1.PodCertificateRequestStatus, out *certificates.PodCertificateRequestStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]metav1.Condition)(unsafe.Pointer(&in.Conditions))
-	out.CertificateChain = in.CertificateChain
-	out.NotBefore = (*metav1.Time)(unsafe.Pointer(in.NotBefore))
-	out.BeginRefreshAt = (*metav1.Time)(unsafe.Pointer(in.BeginRefreshAt))
-	out.NotAfter = (*metav1.Time)(unsafe.Pointer(in.NotAfter))
+	*out = *(*certificates.PodCertificateRequestStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -509,11 +491,7 @@ func Convert_v1beta1_PodCertificateRequestStatus_To_certificates_PodCertificateR
 }
 
 func autoConvert_certificates_PodCertificateRequestStatus_To_v1beta1_PodCertificateRequestStatus(in *certificates.PodCertificateRequestStatus, out *certificatesv1beta1.PodCertificateRequestStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]metav1.Condition)(unsafe.Pointer(&in.Conditions))
-	out.CertificateChain = in.CertificateChain
-	out.NotBefore = (*metav1.Time)(unsafe.Pointer(in.NotBefore))
-	out.BeginRefreshAt = (*metav1.Time)(unsafe.Pointer(in.BeginRefreshAt))
-	out.NotAfter = (*metav1.Time)(unsafe.Pointer(in.NotAfter))
+	*out = *(*certificatesv1beta1.PodCertificateRequestStatus)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/coordination/v1/zz_generated.conversion.go
+++ b/pkg/apis/coordination/v1/zz_generated.conversion.go
@@ -25,7 +25,6 @@ import (
 	unsafe "unsafe"
 
 	coordinationv1 "k8s.io/api/coordination/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	coordination "k8s.io/kubernetes/pkg/apis/coordination"
@@ -120,13 +119,7 @@ func Convert_coordination_LeaseList_To_v1_LeaseList(in *coordination.LeaseList, 
 }
 
 func autoConvert_v1_LeaseSpec_To_coordination_LeaseSpec(in *coordinationv1.LeaseSpec, out *coordination.LeaseSpec, s conversion.Scope) error {
-	out.HolderIdentity = (*string)(unsafe.Pointer(in.HolderIdentity))
-	out.LeaseDurationSeconds = (*int32)(unsafe.Pointer(in.LeaseDurationSeconds))
-	out.AcquireTime = (*metav1.MicroTime)(unsafe.Pointer(in.AcquireTime))
-	out.RenewTime = (*metav1.MicroTime)(unsafe.Pointer(in.RenewTime))
-	out.LeaseTransitions = (*int32)(unsafe.Pointer(in.LeaseTransitions))
-	out.Strategy = (*coordination.CoordinatedLeaseStrategy)(unsafe.Pointer(in.Strategy))
-	out.PreferredHolder = (*string)(unsafe.Pointer(in.PreferredHolder))
+	*out = *(*coordination.LeaseSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -136,13 +129,7 @@ func Convert_v1_LeaseSpec_To_coordination_LeaseSpec(in *coordinationv1.LeaseSpec
 }
 
 func autoConvert_coordination_LeaseSpec_To_v1_LeaseSpec(in *coordination.LeaseSpec, out *coordinationv1.LeaseSpec, s conversion.Scope) error {
-	out.HolderIdentity = (*string)(unsafe.Pointer(in.HolderIdentity))
-	out.LeaseDurationSeconds = (*int32)(unsafe.Pointer(in.LeaseDurationSeconds))
-	out.AcquireTime = (*metav1.MicroTime)(unsafe.Pointer(in.AcquireTime))
-	out.RenewTime = (*metav1.MicroTime)(unsafe.Pointer(in.RenewTime))
-	out.LeaseTransitions = (*int32)(unsafe.Pointer(in.LeaseTransitions))
-	out.Strategy = (*coordinationv1.CoordinatedLeaseStrategy)(unsafe.Pointer(in.Strategy))
-	out.PreferredHolder = (*string)(unsafe.Pointer(in.PreferredHolder))
+	*out = *(*coordinationv1.LeaseSpec)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/coordination/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/coordination/v1alpha2/zz_generated.conversion.go
@@ -24,9 +24,7 @@ package v1alpha2
 import (
 	unsafe "unsafe"
 
-	coordinationv1 "k8s.io/api/coordination/v1"
 	coordinationv1alpha2 "k8s.io/api/coordination/v1alpha2"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	coordination "k8s.io/kubernetes/pkg/apis/coordination"
@@ -121,12 +119,7 @@ func Convert_coordination_LeaseCandidateList_To_v1alpha2_LeaseCandidateList(in *
 }
 
 func autoConvert_v1alpha2_LeaseCandidateSpec_To_coordination_LeaseCandidateSpec(in *coordinationv1alpha2.LeaseCandidateSpec, out *coordination.LeaseCandidateSpec, s conversion.Scope) error {
-	out.LeaseName = in.LeaseName
-	out.PingTime = (*v1.MicroTime)(unsafe.Pointer(in.PingTime))
-	out.RenewTime = (*v1.MicroTime)(unsafe.Pointer(in.RenewTime))
-	out.BinaryVersion = in.BinaryVersion
-	out.EmulationVersion = in.EmulationVersion
-	out.Strategy = coordination.CoordinatedLeaseStrategy(in.Strategy)
+	*out = *(*coordination.LeaseCandidateSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -136,12 +129,7 @@ func Convert_v1alpha2_LeaseCandidateSpec_To_coordination_LeaseCandidateSpec(in *
 }
 
 func autoConvert_coordination_LeaseCandidateSpec_To_v1alpha2_LeaseCandidateSpec(in *coordination.LeaseCandidateSpec, out *coordinationv1alpha2.LeaseCandidateSpec, s conversion.Scope) error {
-	out.LeaseName = in.LeaseName
-	out.PingTime = (*v1.MicroTime)(unsafe.Pointer(in.PingTime))
-	out.RenewTime = (*v1.MicroTime)(unsafe.Pointer(in.RenewTime))
-	out.BinaryVersion = in.BinaryVersion
-	out.EmulationVersion = in.EmulationVersion
-	out.Strategy = coordinationv1.CoordinatedLeaseStrategy(in.Strategy)
+	*out = *(*coordinationv1alpha2.LeaseCandidateSpec)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/coordination/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/coordination/v1beta1/zz_generated.conversion.go
@@ -24,9 +24,7 @@ package v1beta1
 import (
 	unsafe "unsafe"
 
-	coordinationv1 "k8s.io/api/coordination/v1"
 	coordinationv1beta1 "k8s.io/api/coordination/v1beta1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	coordination "k8s.io/kubernetes/pkg/apis/coordination"
@@ -177,12 +175,7 @@ func Convert_coordination_LeaseCandidateList_To_v1beta1_LeaseCandidateList(in *c
 }
 
 func autoConvert_v1beta1_LeaseCandidateSpec_To_coordination_LeaseCandidateSpec(in *coordinationv1beta1.LeaseCandidateSpec, out *coordination.LeaseCandidateSpec, s conversion.Scope) error {
-	out.LeaseName = in.LeaseName
-	out.PingTime = (*v1.MicroTime)(unsafe.Pointer(in.PingTime))
-	out.RenewTime = (*v1.MicroTime)(unsafe.Pointer(in.RenewTime))
-	out.BinaryVersion = in.BinaryVersion
-	out.EmulationVersion = in.EmulationVersion
-	out.Strategy = coordination.CoordinatedLeaseStrategy(in.Strategy)
+	*out = *(*coordination.LeaseCandidateSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -192,12 +185,7 @@ func Convert_v1beta1_LeaseCandidateSpec_To_coordination_LeaseCandidateSpec(in *c
 }
 
 func autoConvert_coordination_LeaseCandidateSpec_To_v1beta1_LeaseCandidateSpec(in *coordination.LeaseCandidateSpec, out *coordinationv1beta1.LeaseCandidateSpec, s conversion.Scope) error {
-	out.LeaseName = in.LeaseName
-	out.PingTime = (*v1.MicroTime)(unsafe.Pointer(in.PingTime))
-	out.RenewTime = (*v1.MicroTime)(unsafe.Pointer(in.RenewTime))
-	out.BinaryVersion = in.BinaryVersion
-	out.EmulationVersion = in.EmulationVersion
-	out.Strategy = coordinationv1.CoordinatedLeaseStrategy(in.Strategy)
+	*out = *(*coordinationv1beta1.LeaseCandidateSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -229,13 +217,7 @@ func Convert_coordination_LeaseList_To_v1beta1_LeaseList(in *coordination.LeaseL
 }
 
 func autoConvert_v1beta1_LeaseSpec_To_coordination_LeaseSpec(in *coordinationv1beta1.LeaseSpec, out *coordination.LeaseSpec, s conversion.Scope) error {
-	out.HolderIdentity = (*string)(unsafe.Pointer(in.HolderIdentity))
-	out.LeaseDurationSeconds = (*int32)(unsafe.Pointer(in.LeaseDurationSeconds))
-	out.AcquireTime = (*v1.MicroTime)(unsafe.Pointer(in.AcquireTime))
-	out.RenewTime = (*v1.MicroTime)(unsafe.Pointer(in.RenewTime))
-	out.LeaseTransitions = (*int32)(unsafe.Pointer(in.LeaseTransitions))
-	out.Strategy = (*coordination.CoordinatedLeaseStrategy)(unsafe.Pointer(in.Strategy))
-	out.PreferredHolder = (*string)(unsafe.Pointer(in.PreferredHolder))
+	*out = *(*coordination.LeaseSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -245,13 +227,7 @@ func Convert_v1beta1_LeaseSpec_To_coordination_LeaseSpec(in *coordinationv1beta1
 }
 
 func autoConvert_coordination_LeaseSpec_To_v1beta1_LeaseSpec(in *coordination.LeaseSpec, out *coordinationv1beta1.LeaseSpec, s conversion.Scope) error {
-	out.HolderIdentity = (*string)(unsafe.Pointer(in.HolderIdentity))
-	out.LeaseDurationSeconds = (*int32)(unsafe.Pointer(in.LeaseDurationSeconds))
-	out.AcquireTime = (*v1.MicroTime)(unsafe.Pointer(in.AcquireTime))
-	out.RenewTime = (*v1.MicroTime)(unsafe.Pointer(in.RenewTime))
-	out.LeaseTransitions = (*int32)(unsafe.Pointer(in.LeaseTransitions))
-	out.Strategy = (*coordinationv1.CoordinatedLeaseStrategy)(unsafe.Pointer(in.Strategy))
-	out.PreferredHolder = (*string)(unsafe.Pointer(in.PreferredHolder))
+	*out = *(*coordinationv1beta1.LeaseSpec)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/core/v1/conversion_test.go
+++ b/pkg/apis/core/v1/conversion_test.go
@@ -803,6 +803,10 @@ func assertMemoryIdentical(t *testing.T, path string, a, b reflect.Value) {
 	}
 	switch a.Kind() {
 	case reflect.Struct: // allow for copied structs since conversion copies status/spec today
+		if a.Type().Size() != b.Type().Size() {
+			t.Errorf("%s: unexpected struct size mismatch: %d, %d", path, a.Type().Size(), b.Type().Size())
+			return
+		}
 		if a.NumField() != b.NumField() {
 			t.Errorf("%s: unexpected field count mismatch: %d, %d", path, a.NumField(), b.NumField())
 			return
@@ -812,6 +816,9 @@ func assertMemoryIdentical(t *testing.T, path string, a, b reflect.Value) {
 			bTypeField := b.Type().Field(i)
 			if aTypeField.Name != bTypeField.Name {
 				t.Errorf("%s: unexpected field name mismatch: %s, %s", path, aTypeField.Name, bTypeField.Name)
+			}
+			if aTypeField.Offset != bTypeField.Offset {
+				t.Errorf("%s.%s: unexpected field offset mismatch: %d, %d", path, aTypeField.Name, aTypeField.Offset, bTypeField.Offset)
 			}
 			assertMemoryIdentical(t, path+"."+aTypeField.Name, a.Field(i), b.Field(i))
 		}

--- a/pkg/apis/core/v1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1/zz_generated.conversion.go
@@ -26,11 +26,9 @@ import (
 	unsafe "unsafe"
 
 	corev1 "k8s.io/api/core/v1"
-	resource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	types "k8s.io/apimachinery/pkg/types"
 	apps "k8s.io/kubernetes/pkg/apis/apps"
 	core "k8s.io/kubernetes/pkg/apis/core"
 )
@@ -2521,10 +2519,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1_AWSElasticBlockStoreVolumeSource_To_core_AWSElasticBlockStoreVolumeSource(in *corev1.AWSElasticBlockStoreVolumeSource, out *core.AWSElasticBlockStoreVolumeSource, s conversion.Scope) error {
-	out.VolumeID = in.VolumeID
-	out.FSType = in.FSType
-	out.Partition = in.Partition
-	out.ReadOnly = in.ReadOnly
+	*out = *(*core.AWSElasticBlockStoreVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2534,10 +2529,7 @@ func Convert_v1_AWSElasticBlockStoreVolumeSource_To_core_AWSElasticBlockStoreVol
 }
 
 func autoConvert_core_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource(in *core.AWSElasticBlockStoreVolumeSource, out *corev1.AWSElasticBlockStoreVolumeSource, s conversion.Scope) error {
-	out.VolumeID = in.VolumeID
-	out.FSType = in.FSType
-	out.Partition = in.Partition
-	out.ReadOnly = in.ReadOnly
+	*out = *(*corev1.AWSElasticBlockStoreVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2547,9 +2539,7 @@ func Convert_core_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVol
 }
 
 func autoConvert_v1_Affinity_To_core_Affinity(in *corev1.Affinity, out *core.Affinity, s conversion.Scope) error {
-	out.NodeAffinity = (*core.NodeAffinity)(unsafe.Pointer(in.NodeAffinity))
-	out.PodAffinity = (*core.PodAffinity)(unsafe.Pointer(in.PodAffinity))
-	out.PodAntiAffinity = (*core.PodAntiAffinity)(unsafe.Pointer(in.PodAntiAffinity))
+	*out = *(*core.Affinity)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2559,9 +2549,7 @@ func Convert_v1_Affinity_To_core_Affinity(in *corev1.Affinity, out *core.Affinit
 }
 
 func autoConvert_core_Affinity_To_v1_Affinity(in *core.Affinity, out *corev1.Affinity, s conversion.Scope) error {
-	out.NodeAffinity = (*corev1.NodeAffinity)(unsafe.Pointer(in.NodeAffinity))
-	out.PodAffinity = (*corev1.PodAffinity)(unsafe.Pointer(in.PodAffinity))
-	out.PodAntiAffinity = (*corev1.PodAntiAffinity)(unsafe.Pointer(in.PodAntiAffinity))
+	*out = *(*corev1.Affinity)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2571,8 +2559,7 @@ func Convert_core_Affinity_To_v1_Affinity(in *core.Affinity, out *corev1.Affinit
 }
 
 func autoConvert_v1_AppArmorProfile_To_core_AppArmorProfile(in *corev1.AppArmorProfile, out *core.AppArmorProfile, s conversion.Scope) error {
-	out.Type = core.AppArmorProfileType(in.Type)
-	out.LocalhostProfile = (*string)(unsafe.Pointer(in.LocalhostProfile))
+	*out = *(*core.AppArmorProfile)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2582,8 +2569,7 @@ func Convert_v1_AppArmorProfile_To_core_AppArmorProfile(in *corev1.AppArmorProfi
 }
 
 func autoConvert_core_AppArmorProfile_To_v1_AppArmorProfile(in *core.AppArmorProfile, out *corev1.AppArmorProfile, s conversion.Scope) error {
-	out.Type = corev1.AppArmorProfileType(in.Type)
-	out.LocalhostProfile = (*string)(unsafe.Pointer(in.LocalhostProfile))
+	*out = *(*corev1.AppArmorProfile)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2593,8 +2579,7 @@ func Convert_core_AppArmorProfile_To_v1_AppArmorProfile(in *core.AppArmorProfile
 }
 
 func autoConvert_v1_AttachedVolume_To_core_AttachedVolume(in *corev1.AttachedVolume, out *core.AttachedVolume, s conversion.Scope) error {
-	out.Name = core.UniqueVolumeName(in.Name)
-	out.DevicePath = in.DevicePath
+	*out = *(*core.AttachedVolume)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2604,8 +2589,7 @@ func Convert_v1_AttachedVolume_To_core_AttachedVolume(in *corev1.AttachedVolume,
 }
 
 func autoConvert_core_AttachedVolume_To_v1_AttachedVolume(in *core.AttachedVolume, out *corev1.AttachedVolume, s conversion.Scope) error {
-	out.Name = corev1.UniqueVolumeName(in.Name)
-	out.DevicePath = in.DevicePath
+	*out = *(*corev1.AttachedVolume)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2615,7 +2599,7 @@ func Convert_core_AttachedVolume_To_v1_AttachedVolume(in *core.AttachedVolume, o
 }
 
 func autoConvert_v1_AvoidPods_To_core_AvoidPods(in *corev1.AvoidPods, out *core.AvoidPods, s conversion.Scope) error {
-	out.PreferAvoidPods = *(*[]core.PreferAvoidPodsEntry)(unsafe.Pointer(&in.PreferAvoidPods))
+	*out = *(*core.AvoidPods)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2625,7 +2609,7 @@ func Convert_v1_AvoidPods_To_core_AvoidPods(in *corev1.AvoidPods, out *core.Avoi
 }
 
 func autoConvert_core_AvoidPods_To_v1_AvoidPods(in *core.AvoidPods, out *corev1.AvoidPods, s conversion.Scope) error {
-	out.PreferAvoidPods = *(*[]corev1.PreferAvoidPodsEntry)(unsafe.Pointer(&in.PreferAvoidPods))
+	*out = *(*corev1.AvoidPods)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2635,12 +2619,7 @@ func Convert_core_AvoidPods_To_v1_AvoidPods(in *core.AvoidPods, out *corev1.Avoi
 }
 
 func autoConvert_v1_AzureDiskVolumeSource_To_core_AzureDiskVolumeSource(in *corev1.AzureDiskVolumeSource, out *core.AzureDiskVolumeSource, s conversion.Scope) error {
-	out.DiskName = in.DiskName
-	out.DataDiskURI = in.DataDiskURI
-	out.CachingMode = (*core.AzureDataDiskCachingMode)(unsafe.Pointer(in.CachingMode))
-	out.FSType = (*string)(unsafe.Pointer(in.FSType))
-	out.ReadOnly = (*bool)(unsafe.Pointer(in.ReadOnly))
-	out.Kind = (*core.AzureDataDiskKind)(unsafe.Pointer(in.Kind))
+	*out = *(*core.AzureDiskVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2650,12 +2629,7 @@ func Convert_v1_AzureDiskVolumeSource_To_core_AzureDiskVolumeSource(in *corev1.A
 }
 
 func autoConvert_core_AzureDiskVolumeSource_To_v1_AzureDiskVolumeSource(in *core.AzureDiskVolumeSource, out *corev1.AzureDiskVolumeSource, s conversion.Scope) error {
-	out.DiskName = in.DiskName
-	out.DataDiskURI = in.DataDiskURI
-	out.CachingMode = (*corev1.AzureDataDiskCachingMode)(unsafe.Pointer(in.CachingMode))
-	out.FSType = (*string)(unsafe.Pointer(in.FSType))
-	out.ReadOnly = (*bool)(unsafe.Pointer(in.ReadOnly))
-	out.Kind = (*corev1.AzureDataDiskKind)(unsafe.Pointer(in.Kind))
+	*out = *(*corev1.AzureDiskVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2665,10 +2639,7 @@ func Convert_core_AzureDiskVolumeSource_To_v1_AzureDiskVolumeSource(in *core.Azu
 }
 
 func autoConvert_v1_AzureFilePersistentVolumeSource_To_core_AzureFilePersistentVolumeSource(in *corev1.AzureFilePersistentVolumeSource, out *core.AzureFilePersistentVolumeSource, s conversion.Scope) error {
-	out.SecretName = in.SecretName
-	out.ShareName = in.ShareName
-	out.ReadOnly = in.ReadOnly
-	out.SecretNamespace = (*string)(unsafe.Pointer(in.SecretNamespace))
+	*out = *(*core.AzureFilePersistentVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2678,10 +2649,7 @@ func Convert_v1_AzureFilePersistentVolumeSource_To_core_AzureFilePersistentVolum
 }
 
 func autoConvert_core_AzureFilePersistentVolumeSource_To_v1_AzureFilePersistentVolumeSource(in *core.AzureFilePersistentVolumeSource, out *corev1.AzureFilePersistentVolumeSource, s conversion.Scope) error {
-	out.SecretName = in.SecretName
-	out.ShareName = in.ShareName
-	out.ReadOnly = in.ReadOnly
-	out.SecretNamespace = (*string)(unsafe.Pointer(in.SecretNamespace))
+	*out = *(*corev1.AzureFilePersistentVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2691,9 +2659,7 @@ func Convert_core_AzureFilePersistentVolumeSource_To_v1_AzureFilePersistentVolum
 }
 
 func autoConvert_v1_AzureFileVolumeSource_To_core_AzureFileVolumeSource(in *corev1.AzureFileVolumeSource, out *core.AzureFileVolumeSource, s conversion.Scope) error {
-	out.SecretName = in.SecretName
-	out.ShareName = in.ShareName
-	out.ReadOnly = in.ReadOnly
+	*out = *(*core.AzureFileVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2703,9 +2669,7 @@ func Convert_v1_AzureFileVolumeSource_To_core_AzureFileVolumeSource(in *corev1.A
 }
 
 func autoConvert_core_AzureFileVolumeSource_To_v1_AzureFileVolumeSource(in *core.AzureFileVolumeSource, out *corev1.AzureFileVolumeSource, s conversion.Scope) error {
-	out.SecretName = in.SecretName
-	out.ShareName = in.ShareName
-	out.ReadOnly = in.ReadOnly
+	*out = *(*corev1.AzureFileVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2741,16 +2705,7 @@ func Convert_core_Binding_To_v1_Binding(in *core.Binding, out *corev1.Binding, s
 }
 
 func autoConvert_v1_CSIPersistentVolumeSource_To_core_CSIPersistentVolumeSource(in *corev1.CSIPersistentVolumeSource, out *core.CSIPersistentVolumeSource, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.VolumeHandle = in.VolumeHandle
-	out.ReadOnly = in.ReadOnly
-	out.FSType = in.FSType
-	out.VolumeAttributes = *(*map[string]string)(unsafe.Pointer(&in.VolumeAttributes))
-	out.ControllerPublishSecretRef = (*core.SecretReference)(unsafe.Pointer(in.ControllerPublishSecretRef))
-	out.NodeStageSecretRef = (*core.SecretReference)(unsafe.Pointer(in.NodeStageSecretRef))
-	out.NodePublishSecretRef = (*core.SecretReference)(unsafe.Pointer(in.NodePublishSecretRef))
-	out.ControllerExpandSecretRef = (*core.SecretReference)(unsafe.Pointer(in.ControllerExpandSecretRef))
-	out.NodeExpandSecretRef = (*core.SecretReference)(unsafe.Pointer(in.NodeExpandSecretRef))
+	*out = *(*core.CSIPersistentVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2760,16 +2715,7 @@ func Convert_v1_CSIPersistentVolumeSource_To_core_CSIPersistentVolumeSource(in *
 }
 
 func autoConvert_core_CSIPersistentVolumeSource_To_v1_CSIPersistentVolumeSource(in *core.CSIPersistentVolumeSource, out *corev1.CSIPersistentVolumeSource, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.VolumeHandle = in.VolumeHandle
-	out.ReadOnly = in.ReadOnly
-	out.FSType = in.FSType
-	out.VolumeAttributes = *(*map[string]string)(unsafe.Pointer(&in.VolumeAttributes))
-	out.ControllerPublishSecretRef = (*corev1.SecretReference)(unsafe.Pointer(in.ControllerPublishSecretRef))
-	out.NodeStageSecretRef = (*corev1.SecretReference)(unsafe.Pointer(in.NodeStageSecretRef))
-	out.NodePublishSecretRef = (*corev1.SecretReference)(unsafe.Pointer(in.NodePublishSecretRef))
-	out.ControllerExpandSecretRef = (*corev1.SecretReference)(unsafe.Pointer(in.ControllerExpandSecretRef))
-	out.NodeExpandSecretRef = (*corev1.SecretReference)(unsafe.Pointer(in.NodeExpandSecretRef))
+	*out = *(*corev1.CSIPersistentVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2779,11 +2725,7 @@ func Convert_core_CSIPersistentVolumeSource_To_v1_CSIPersistentVolumeSource(in *
 }
 
 func autoConvert_v1_CSIVolumeSource_To_core_CSIVolumeSource(in *corev1.CSIVolumeSource, out *core.CSIVolumeSource, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.ReadOnly = (*bool)(unsafe.Pointer(in.ReadOnly))
-	out.FSType = (*string)(unsafe.Pointer(in.FSType))
-	out.VolumeAttributes = *(*map[string]string)(unsafe.Pointer(&in.VolumeAttributes))
-	out.NodePublishSecretRef = (*core.LocalObjectReference)(unsafe.Pointer(in.NodePublishSecretRef))
+	*out = *(*core.CSIVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2793,11 +2735,7 @@ func Convert_v1_CSIVolumeSource_To_core_CSIVolumeSource(in *corev1.CSIVolumeSour
 }
 
 func autoConvert_core_CSIVolumeSource_To_v1_CSIVolumeSource(in *core.CSIVolumeSource, out *corev1.CSIVolumeSource, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.ReadOnly = (*bool)(unsafe.Pointer(in.ReadOnly))
-	out.FSType = (*string)(unsafe.Pointer(in.FSType))
-	out.VolumeAttributes = *(*map[string]string)(unsafe.Pointer(&in.VolumeAttributes))
-	out.NodePublishSecretRef = (*corev1.LocalObjectReference)(unsafe.Pointer(in.NodePublishSecretRef))
+	*out = *(*corev1.CSIVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2807,8 +2745,7 @@ func Convert_core_CSIVolumeSource_To_v1_CSIVolumeSource(in *core.CSIVolumeSource
 }
 
 func autoConvert_v1_Capabilities_To_core_Capabilities(in *corev1.Capabilities, out *core.Capabilities, s conversion.Scope) error {
-	out.Add = *(*[]core.Capability)(unsafe.Pointer(&in.Add))
-	out.Drop = *(*[]core.Capability)(unsafe.Pointer(&in.Drop))
+	*out = *(*core.Capabilities)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2818,8 +2755,7 @@ func Convert_v1_Capabilities_To_core_Capabilities(in *corev1.Capabilities, out *
 }
 
 func autoConvert_core_Capabilities_To_v1_Capabilities(in *core.Capabilities, out *corev1.Capabilities, s conversion.Scope) error {
-	out.Add = *(*[]corev1.Capability)(unsafe.Pointer(&in.Add))
-	out.Drop = *(*[]corev1.Capability)(unsafe.Pointer(&in.Drop))
+	*out = *(*corev1.Capabilities)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2829,12 +2765,7 @@ func Convert_core_Capabilities_To_v1_Capabilities(in *core.Capabilities, out *co
 }
 
 func autoConvert_v1_CephFSPersistentVolumeSource_To_core_CephFSPersistentVolumeSource(in *corev1.CephFSPersistentVolumeSource, out *core.CephFSPersistentVolumeSource, s conversion.Scope) error {
-	out.Monitors = *(*[]string)(unsafe.Pointer(&in.Monitors))
-	out.Path = in.Path
-	out.User = in.User
-	out.SecretFile = in.SecretFile
-	out.SecretRef = (*core.SecretReference)(unsafe.Pointer(in.SecretRef))
-	out.ReadOnly = in.ReadOnly
+	*out = *(*core.CephFSPersistentVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2844,12 +2775,7 @@ func Convert_v1_CephFSPersistentVolumeSource_To_core_CephFSPersistentVolumeSourc
 }
 
 func autoConvert_core_CephFSPersistentVolumeSource_To_v1_CephFSPersistentVolumeSource(in *core.CephFSPersistentVolumeSource, out *corev1.CephFSPersistentVolumeSource, s conversion.Scope) error {
-	out.Monitors = *(*[]string)(unsafe.Pointer(&in.Monitors))
-	out.Path = in.Path
-	out.User = in.User
-	out.SecretFile = in.SecretFile
-	out.SecretRef = (*corev1.SecretReference)(unsafe.Pointer(in.SecretRef))
-	out.ReadOnly = in.ReadOnly
+	*out = *(*corev1.CephFSPersistentVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2859,12 +2785,7 @@ func Convert_core_CephFSPersistentVolumeSource_To_v1_CephFSPersistentVolumeSourc
 }
 
 func autoConvert_v1_CephFSVolumeSource_To_core_CephFSVolumeSource(in *corev1.CephFSVolumeSource, out *core.CephFSVolumeSource, s conversion.Scope) error {
-	out.Monitors = *(*[]string)(unsafe.Pointer(&in.Monitors))
-	out.Path = in.Path
-	out.User = in.User
-	out.SecretFile = in.SecretFile
-	out.SecretRef = (*core.LocalObjectReference)(unsafe.Pointer(in.SecretRef))
-	out.ReadOnly = in.ReadOnly
+	*out = *(*core.CephFSVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2874,12 +2795,7 @@ func Convert_v1_CephFSVolumeSource_To_core_CephFSVolumeSource(in *corev1.CephFSV
 }
 
 func autoConvert_core_CephFSVolumeSource_To_v1_CephFSVolumeSource(in *core.CephFSVolumeSource, out *corev1.CephFSVolumeSource, s conversion.Scope) error {
-	out.Monitors = *(*[]string)(unsafe.Pointer(&in.Monitors))
-	out.Path = in.Path
-	out.User = in.User
-	out.SecretFile = in.SecretFile
-	out.SecretRef = (*corev1.LocalObjectReference)(unsafe.Pointer(in.SecretRef))
-	out.ReadOnly = in.ReadOnly
+	*out = *(*corev1.CephFSVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2889,10 +2805,7 @@ func Convert_core_CephFSVolumeSource_To_v1_CephFSVolumeSource(in *core.CephFSVol
 }
 
 func autoConvert_v1_CinderPersistentVolumeSource_To_core_CinderPersistentVolumeSource(in *corev1.CinderPersistentVolumeSource, out *core.CinderPersistentVolumeSource, s conversion.Scope) error {
-	out.VolumeID = in.VolumeID
-	out.FSType = in.FSType
-	out.ReadOnly = in.ReadOnly
-	out.SecretRef = (*core.SecretReference)(unsafe.Pointer(in.SecretRef))
+	*out = *(*core.CinderPersistentVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2902,10 +2815,7 @@ func Convert_v1_CinderPersistentVolumeSource_To_core_CinderPersistentVolumeSourc
 }
 
 func autoConvert_core_CinderPersistentVolumeSource_To_v1_CinderPersistentVolumeSource(in *core.CinderPersistentVolumeSource, out *corev1.CinderPersistentVolumeSource, s conversion.Scope) error {
-	out.VolumeID = in.VolumeID
-	out.FSType = in.FSType
-	out.ReadOnly = in.ReadOnly
-	out.SecretRef = (*corev1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	*out = *(*corev1.CinderPersistentVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2915,10 +2825,7 @@ func Convert_core_CinderPersistentVolumeSource_To_v1_CinderPersistentVolumeSourc
 }
 
 func autoConvert_v1_CinderVolumeSource_To_core_CinderVolumeSource(in *corev1.CinderVolumeSource, out *core.CinderVolumeSource, s conversion.Scope) error {
-	out.VolumeID = in.VolumeID
-	out.FSType = in.FSType
-	out.ReadOnly = in.ReadOnly
-	out.SecretRef = (*core.LocalObjectReference)(unsafe.Pointer(in.SecretRef))
+	*out = *(*core.CinderVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2928,10 +2835,7 @@ func Convert_v1_CinderVolumeSource_To_core_CinderVolumeSource(in *corev1.CinderV
 }
 
 func autoConvert_core_CinderVolumeSource_To_v1_CinderVolumeSource(in *core.CinderVolumeSource, out *corev1.CinderVolumeSource, s conversion.Scope) error {
-	out.VolumeID = in.VolumeID
-	out.FSType = in.FSType
-	out.ReadOnly = in.ReadOnly
-	out.SecretRef = (*corev1.LocalObjectReference)(unsafe.Pointer(in.SecretRef))
+	*out = *(*corev1.CinderVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2941,7 +2845,7 @@ func Convert_core_CinderVolumeSource_To_v1_CinderVolumeSource(in *core.CinderVol
 }
 
 func autoConvert_v1_ClientIPConfig_To_core_ClientIPConfig(in *corev1.ClientIPConfig, out *core.ClientIPConfig, s conversion.Scope) error {
-	out.TimeoutSeconds = (*int32)(unsafe.Pointer(in.TimeoutSeconds))
+	*out = *(*core.ClientIPConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2951,7 +2855,7 @@ func Convert_v1_ClientIPConfig_To_core_ClientIPConfig(in *corev1.ClientIPConfig,
 }
 
 func autoConvert_core_ClientIPConfig_To_v1_ClientIPConfig(in *core.ClientIPConfig, out *corev1.ClientIPConfig, s conversion.Scope) error {
-	out.TimeoutSeconds = (*int32)(unsafe.Pointer(in.TimeoutSeconds))
+	*out = *(*corev1.ClientIPConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2961,11 +2865,7 @@ func Convert_core_ClientIPConfig_To_v1_ClientIPConfig(in *core.ClientIPConfig, o
 }
 
 func autoConvert_v1_ClusterTrustBundleProjection_To_core_ClusterTrustBundleProjection(in *corev1.ClusterTrustBundleProjection, out *core.ClusterTrustBundleProjection, s conversion.Scope) error {
-	out.Name = (*string)(unsafe.Pointer(in.Name))
-	out.SignerName = (*string)(unsafe.Pointer(in.SignerName))
-	out.LabelSelector = (*metav1.LabelSelector)(unsafe.Pointer(in.LabelSelector))
-	out.Optional = (*bool)(unsafe.Pointer(in.Optional))
-	out.Path = in.Path
+	*out = *(*core.ClusterTrustBundleProjection)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2975,11 +2875,7 @@ func Convert_v1_ClusterTrustBundleProjection_To_core_ClusterTrustBundleProjectio
 }
 
 func autoConvert_core_ClusterTrustBundleProjection_To_v1_ClusterTrustBundleProjection(in *core.ClusterTrustBundleProjection, out *corev1.ClusterTrustBundleProjection, s conversion.Scope) error {
-	out.Name = (*string)(unsafe.Pointer(in.Name))
-	out.SignerName = (*string)(unsafe.Pointer(in.SignerName))
-	out.LabelSelector = (*metav1.LabelSelector)(unsafe.Pointer(in.LabelSelector))
-	out.Optional = (*bool)(unsafe.Pointer(in.Optional))
-	out.Path = in.Path
+	*out = *(*corev1.ClusterTrustBundleProjection)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -2989,10 +2885,7 @@ func Convert_core_ClusterTrustBundleProjection_To_v1_ClusterTrustBundleProjectio
 }
 
 func autoConvert_v1_ComponentCondition_To_core_ComponentCondition(in *corev1.ComponentCondition, out *core.ComponentCondition, s conversion.Scope) error {
-	out.Type = core.ComponentConditionType(in.Type)
-	out.Status = core.ConditionStatus(in.Status)
-	out.Message = in.Message
-	out.Error = in.Error
+	*out = *(*core.ComponentCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3002,10 +2895,7 @@ func Convert_v1_ComponentCondition_To_core_ComponentCondition(in *corev1.Compone
 }
 
 func autoConvert_core_ComponentCondition_To_v1_ComponentCondition(in *core.ComponentCondition, out *corev1.ComponentCondition, s conversion.Scope) error {
-	out.Type = corev1.ComponentConditionType(in.Type)
-	out.Status = corev1.ConditionStatus(in.Status)
-	out.Message = in.Message
-	out.Error = in.Error
+	*out = *(*corev1.ComponentCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3085,10 +2975,7 @@ func Convert_core_ConfigMap_To_v1_ConfigMap(in *core.ConfigMap, out *corev1.Conf
 }
 
 func autoConvert_v1_ConfigMapEnvSource_To_core_ConfigMapEnvSource(in *corev1.ConfigMapEnvSource, out *core.ConfigMapEnvSource, s conversion.Scope) error {
-	if err := Convert_v1_LocalObjectReference_To_core_LocalObjectReference(&in.LocalObjectReference, &out.LocalObjectReference, s); err != nil {
-		return err
-	}
-	out.Optional = (*bool)(unsafe.Pointer(in.Optional))
+	*out = *(*core.ConfigMapEnvSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3098,10 +2985,7 @@ func Convert_v1_ConfigMapEnvSource_To_core_ConfigMapEnvSource(in *corev1.ConfigM
 }
 
 func autoConvert_core_ConfigMapEnvSource_To_v1_ConfigMapEnvSource(in *core.ConfigMapEnvSource, out *corev1.ConfigMapEnvSource, s conversion.Scope) error {
-	if err := Convert_core_LocalObjectReference_To_v1_LocalObjectReference(&in.LocalObjectReference, &out.LocalObjectReference, s); err != nil {
-		return err
-	}
-	out.Optional = (*bool)(unsafe.Pointer(in.Optional))
+	*out = *(*corev1.ConfigMapEnvSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3111,11 +2995,7 @@ func Convert_core_ConfigMapEnvSource_To_v1_ConfigMapEnvSource(in *core.ConfigMap
 }
 
 func autoConvert_v1_ConfigMapKeySelector_To_core_ConfigMapKeySelector(in *corev1.ConfigMapKeySelector, out *core.ConfigMapKeySelector, s conversion.Scope) error {
-	if err := Convert_v1_LocalObjectReference_To_core_LocalObjectReference(&in.LocalObjectReference, &out.LocalObjectReference, s); err != nil {
-		return err
-	}
-	out.Key = in.Key
-	out.Optional = (*bool)(unsafe.Pointer(in.Optional))
+	*out = *(*core.ConfigMapKeySelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3125,11 +3005,7 @@ func Convert_v1_ConfigMapKeySelector_To_core_ConfigMapKeySelector(in *corev1.Con
 }
 
 func autoConvert_core_ConfigMapKeySelector_To_v1_ConfigMapKeySelector(in *core.ConfigMapKeySelector, out *corev1.ConfigMapKeySelector, s conversion.Scope) error {
-	if err := Convert_core_LocalObjectReference_To_v1_LocalObjectReference(&in.LocalObjectReference, &out.LocalObjectReference, s); err != nil {
-		return err
-	}
-	out.Key = in.Key
-	out.Optional = (*bool)(unsafe.Pointer(in.Optional))
+	*out = *(*corev1.ConfigMapKeySelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3161,11 +3037,7 @@ func Convert_core_ConfigMapList_To_v1_ConfigMapList(in *core.ConfigMapList, out 
 }
 
 func autoConvert_v1_ConfigMapNodeConfigSource_To_core_ConfigMapNodeConfigSource(in *corev1.ConfigMapNodeConfigSource, out *core.ConfigMapNodeConfigSource, s conversion.Scope) error {
-	out.Namespace = in.Namespace
-	out.Name = in.Name
-	out.UID = types.UID(in.UID)
-	out.ResourceVersion = in.ResourceVersion
-	out.KubeletConfigKey = in.KubeletConfigKey
+	*out = *(*core.ConfigMapNodeConfigSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3175,11 +3047,7 @@ func Convert_v1_ConfigMapNodeConfigSource_To_core_ConfigMapNodeConfigSource(in *
 }
 
 func autoConvert_core_ConfigMapNodeConfigSource_To_v1_ConfigMapNodeConfigSource(in *core.ConfigMapNodeConfigSource, out *corev1.ConfigMapNodeConfigSource, s conversion.Scope) error {
-	out.Namespace = in.Namespace
-	out.Name = in.Name
-	out.UID = types.UID(in.UID)
-	out.ResourceVersion = in.ResourceVersion
-	out.KubeletConfigKey = in.KubeletConfigKey
+	*out = *(*corev1.ConfigMapNodeConfigSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3189,11 +3057,7 @@ func Convert_core_ConfigMapNodeConfigSource_To_v1_ConfigMapNodeConfigSource(in *
 }
 
 func autoConvert_v1_ConfigMapProjection_To_core_ConfigMapProjection(in *corev1.ConfigMapProjection, out *core.ConfigMapProjection, s conversion.Scope) error {
-	if err := Convert_v1_LocalObjectReference_To_core_LocalObjectReference(&in.LocalObjectReference, &out.LocalObjectReference, s); err != nil {
-		return err
-	}
-	out.Items = *(*[]core.KeyToPath)(unsafe.Pointer(&in.Items))
-	out.Optional = (*bool)(unsafe.Pointer(in.Optional))
+	*out = *(*core.ConfigMapProjection)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3203,11 +3067,7 @@ func Convert_v1_ConfigMapProjection_To_core_ConfigMapProjection(in *corev1.Confi
 }
 
 func autoConvert_core_ConfigMapProjection_To_v1_ConfigMapProjection(in *core.ConfigMapProjection, out *corev1.ConfigMapProjection, s conversion.Scope) error {
-	if err := Convert_core_LocalObjectReference_To_v1_LocalObjectReference(&in.LocalObjectReference, &out.LocalObjectReference, s); err != nil {
-		return err
-	}
-	out.Items = *(*[]corev1.KeyToPath)(unsafe.Pointer(&in.Items))
-	out.Optional = (*bool)(unsafe.Pointer(in.Optional))
+	*out = *(*corev1.ConfigMapProjection)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3217,12 +3077,7 @@ func Convert_core_ConfigMapProjection_To_v1_ConfigMapProjection(in *core.ConfigM
 }
 
 func autoConvert_v1_ConfigMapVolumeSource_To_core_ConfigMapVolumeSource(in *corev1.ConfigMapVolumeSource, out *core.ConfigMapVolumeSource, s conversion.Scope) error {
-	if err := Convert_v1_LocalObjectReference_To_core_LocalObjectReference(&in.LocalObjectReference, &out.LocalObjectReference, s); err != nil {
-		return err
-	}
-	out.Items = *(*[]core.KeyToPath)(unsafe.Pointer(&in.Items))
-	out.DefaultMode = (*int32)(unsafe.Pointer(in.DefaultMode))
-	out.Optional = (*bool)(unsafe.Pointer(in.Optional))
+	*out = *(*core.ConfigMapVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3232,12 +3087,7 @@ func Convert_v1_ConfigMapVolumeSource_To_core_ConfigMapVolumeSource(in *corev1.C
 }
 
 func autoConvert_core_ConfigMapVolumeSource_To_v1_ConfigMapVolumeSource(in *core.ConfigMapVolumeSource, out *corev1.ConfigMapVolumeSource, s conversion.Scope) error {
-	if err := Convert_core_LocalObjectReference_To_v1_LocalObjectReference(&in.LocalObjectReference, &out.LocalObjectReference, s); err != nil {
-		return err
-	}
-	out.Items = *(*[]corev1.KeyToPath)(unsafe.Pointer(&in.Items))
-	out.DefaultMode = (*int32)(unsafe.Pointer(in.DefaultMode))
-	out.Optional = (*bool)(unsafe.Pointer(in.Optional))
+	*out = *(*corev1.ConfigMapVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3247,33 +3097,7 @@ func Convert_core_ConfigMapVolumeSource_To_v1_ConfigMapVolumeSource(in *core.Con
 }
 
 func autoConvert_v1_Container_To_core_Container(in *corev1.Container, out *core.Container, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Image = in.Image
-	out.Command = *(*[]string)(unsafe.Pointer(&in.Command))
-	out.Args = *(*[]string)(unsafe.Pointer(&in.Args))
-	out.WorkingDir = in.WorkingDir
-	out.Ports = *(*[]core.ContainerPort)(unsafe.Pointer(&in.Ports))
-	out.EnvFrom = *(*[]core.EnvFromSource)(unsafe.Pointer(&in.EnvFrom))
-	out.Env = *(*[]core.EnvVar)(unsafe.Pointer(&in.Env))
-	if err := Convert_v1_ResourceRequirements_To_core_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
-		return err
-	}
-	out.ResizePolicy = *(*[]core.ContainerResizePolicy)(unsafe.Pointer(&in.ResizePolicy))
-	out.RestartPolicy = (*core.ContainerRestartPolicy)(unsafe.Pointer(in.RestartPolicy))
-	out.RestartPolicyRules = *(*[]core.ContainerRestartRule)(unsafe.Pointer(&in.RestartPolicyRules))
-	out.VolumeMounts = *(*[]core.VolumeMount)(unsafe.Pointer(&in.VolumeMounts))
-	out.VolumeDevices = *(*[]core.VolumeDevice)(unsafe.Pointer(&in.VolumeDevices))
-	out.LivenessProbe = (*core.Probe)(unsafe.Pointer(in.LivenessProbe))
-	out.ReadinessProbe = (*core.Probe)(unsafe.Pointer(in.ReadinessProbe))
-	out.StartupProbe = (*core.Probe)(unsafe.Pointer(in.StartupProbe))
-	out.Lifecycle = (*core.Lifecycle)(unsafe.Pointer(in.Lifecycle))
-	out.TerminationMessagePath = in.TerminationMessagePath
-	out.TerminationMessagePolicy = core.TerminationMessagePolicy(in.TerminationMessagePolicy)
-	out.ImagePullPolicy = core.PullPolicy(in.ImagePullPolicy)
-	out.SecurityContext = (*core.SecurityContext)(unsafe.Pointer(in.SecurityContext))
-	out.Stdin = in.Stdin
-	out.StdinOnce = in.StdinOnce
-	out.TTY = in.TTY
+	*out = *(*core.Container)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3283,33 +3107,7 @@ func Convert_v1_Container_To_core_Container(in *corev1.Container, out *core.Cont
 }
 
 func autoConvert_core_Container_To_v1_Container(in *core.Container, out *corev1.Container, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Image = in.Image
-	out.Command = *(*[]string)(unsafe.Pointer(&in.Command))
-	out.Args = *(*[]string)(unsafe.Pointer(&in.Args))
-	out.WorkingDir = in.WorkingDir
-	out.Ports = *(*[]corev1.ContainerPort)(unsafe.Pointer(&in.Ports))
-	out.EnvFrom = *(*[]corev1.EnvFromSource)(unsafe.Pointer(&in.EnvFrom))
-	out.Env = *(*[]corev1.EnvVar)(unsafe.Pointer(&in.Env))
-	if err := Convert_core_ResourceRequirements_To_v1_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
-		return err
-	}
-	out.ResizePolicy = *(*[]corev1.ContainerResizePolicy)(unsafe.Pointer(&in.ResizePolicy))
-	out.RestartPolicy = (*corev1.ContainerRestartPolicy)(unsafe.Pointer(in.RestartPolicy))
-	out.RestartPolicyRules = *(*[]corev1.ContainerRestartRule)(unsafe.Pointer(&in.RestartPolicyRules))
-	out.VolumeMounts = *(*[]corev1.VolumeMount)(unsafe.Pointer(&in.VolumeMounts))
-	out.VolumeDevices = *(*[]corev1.VolumeDevice)(unsafe.Pointer(&in.VolumeDevices))
-	out.LivenessProbe = (*corev1.Probe)(unsafe.Pointer(in.LivenessProbe))
-	out.ReadinessProbe = (*corev1.Probe)(unsafe.Pointer(in.ReadinessProbe))
-	out.StartupProbe = (*corev1.Probe)(unsafe.Pointer(in.StartupProbe))
-	out.Lifecycle = (*corev1.Lifecycle)(unsafe.Pointer(in.Lifecycle))
-	out.TerminationMessagePath = in.TerminationMessagePath
-	out.TerminationMessagePolicy = corev1.TerminationMessagePolicy(in.TerminationMessagePolicy)
-	out.ImagePullPolicy = corev1.PullPolicy(in.ImagePullPolicy)
-	out.SecurityContext = (*corev1.SecurityContext)(unsafe.Pointer(in.SecurityContext))
-	out.Stdin = in.Stdin
-	out.StdinOnce = in.StdinOnce
-	out.TTY = in.TTY
+	*out = *(*corev1.Container)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3319,9 +3117,7 @@ func Convert_core_Container_To_v1_Container(in *core.Container, out *corev1.Cont
 }
 
 func autoConvert_v1_ContainerExtendedResourceRequest_To_core_ContainerExtendedResourceRequest(in *corev1.ContainerExtendedResourceRequest, out *core.ContainerExtendedResourceRequest, s conversion.Scope) error {
-	out.ContainerName = in.ContainerName
-	out.ResourceName = in.ResourceName
-	out.RequestName = in.RequestName
+	*out = *(*core.ContainerExtendedResourceRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3331,9 +3127,7 @@ func Convert_v1_ContainerExtendedResourceRequest_To_core_ContainerExtendedResour
 }
 
 func autoConvert_core_ContainerExtendedResourceRequest_To_v1_ContainerExtendedResourceRequest(in *core.ContainerExtendedResourceRequest, out *corev1.ContainerExtendedResourceRequest, s conversion.Scope) error {
-	out.ContainerName = in.ContainerName
-	out.ResourceName = in.ResourceName
-	out.RequestName = in.RequestName
+	*out = *(*corev1.ContainerExtendedResourceRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3343,8 +3137,7 @@ func Convert_core_ContainerExtendedResourceRequest_To_v1_ContainerExtendedResour
 }
 
 func autoConvert_v1_ContainerImage_To_core_ContainerImage(in *corev1.ContainerImage, out *core.ContainerImage, s conversion.Scope) error {
-	out.Names = *(*[]string)(unsafe.Pointer(&in.Names))
-	out.SizeBytes = in.SizeBytes
+	*out = *(*core.ContainerImage)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3354,8 +3147,7 @@ func Convert_v1_ContainerImage_To_core_ContainerImage(in *corev1.ContainerImage,
 }
 
 func autoConvert_core_ContainerImage_To_v1_ContainerImage(in *core.ContainerImage, out *corev1.ContainerImage, s conversion.Scope) error {
-	out.Names = *(*[]string)(unsafe.Pointer(&in.Names))
-	out.SizeBytes = in.SizeBytes
+	*out = *(*corev1.ContainerImage)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3365,11 +3157,7 @@ func Convert_core_ContainerImage_To_v1_ContainerImage(in *core.ContainerImage, o
 }
 
 func autoConvert_v1_ContainerPort_To_core_ContainerPort(in *corev1.ContainerPort, out *core.ContainerPort, s conversion.Scope) error {
-	out.Name = in.Name
-	out.HostPort = in.HostPort
-	out.ContainerPort = in.ContainerPort
-	out.Protocol = core.Protocol(in.Protocol)
-	out.HostIP = in.HostIP
+	*out = *(*core.ContainerPort)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3379,11 +3167,7 @@ func Convert_v1_ContainerPort_To_core_ContainerPort(in *corev1.ContainerPort, ou
 }
 
 func autoConvert_core_ContainerPort_To_v1_ContainerPort(in *core.ContainerPort, out *corev1.ContainerPort, s conversion.Scope) error {
-	out.Name = in.Name
-	out.HostPort = in.HostPort
-	out.ContainerPort = in.ContainerPort
-	out.Protocol = corev1.Protocol(in.Protocol)
-	out.HostIP = in.HostIP
+	*out = *(*corev1.ContainerPort)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3393,8 +3177,7 @@ func Convert_core_ContainerPort_To_v1_ContainerPort(in *core.ContainerPort, out 
 }
 
 func autoConvert_v1_ContainerResizePolicy_To_core_ContainerResizePolicy(in *corev1.ContainerResizePolicy, out *core.ContainerResizePolicy, s conversion.Scope) error {
-	out.ResourceName = core.ResourceName(in.ResourceName)
-	out.RestartPolicy = core.ResourceResizeRestartPolicy(in.RestartPolicy)
+	*out = *(*core.ContainerResizePolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3404,8 +3187,7 @@ func Convert_v1_ContainerResizePolicy_To_core_ContainerResizePolicy(in *corev1.C
 }
 
 func autoConvert_core_ContainerResizePolicy_To_v1_ContainerResizePolicy(in *core.ContainerResizePolicy, out *corev1.ContainerResizePolicy, s conversion.Scope) error {
-	out.ResourceName = corev1.ResourceName(in.ResourceName)
-	out.RestartPolicy = corev1.ResourceResizeRestartPolicy(in.RestartPolicy)
+	*out = *(*corev1.ContainerResizePolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3415,8 +3197,7 @@ func Convert_core_ContainerResizePolicy_To_v1_ContainerResizePolicy(in *core.Con
 }
 
 func autoConvert_v1_ContainerRestartRule_To_core_ContainerRestartRule(in *corev1.ContainerRestartRule, out *core.ContainerRestartRule, s conversion.Scope) error {
-	out.Action = core.ContainerRestartRuleAction(in.Action)
-	out.ExitCodes = (*core.ContainerRestartRuleOnExitCodes)(unsafe.Pointer(in.ExitCodes))
+	*out = *(*core.ContainerRestartRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3426,8 +3207,7 @@ func Convert_v1_ContainerRestartRule_To_core_ContainerRestartRule(in *corev1.Con
 }
 
 func autoConvert_core_ContainerRestartRule_To_v1_ContainerRestartRule(in *core.ContainerRestartRule, out *corev1.ContainerRestartRule, s conversion.Scope) error {
-	out.Action = corev1.ContainerRestartRuleAction(in.Action)
-	out.ExitCodes = (*corev1.ContainerRestartRuleOnExitCodes)(unsafe.Pointer(in.ExitCodes))
+	*out = *(*corev1.ContainerRestartRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3437,8 +3217,7 @@ func Convert_core_ContainerRestartRule_To_v1_ContainerRestartRule(in *core.Conta
 }
 
 func autoConvert_v1_ContainerRestartRuleOnExitCodes_To_core_ContainerRestartRuleOnExitCodes(in *corev1.ContainerRestartRuleOnExitCodes, out *core.ContainerRestartRuleOnExitCodes, s conversion.Scope) error {
-	out.Operator = core.ContainerRestartRuleOnExitCodesOperator(in.Operator)
-	out.Values = *(*[]int32)(unsafe.Pointer(&in.Values))
+	*out = *(*core.ContainerRestartRuleOnExitCodes)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3448,8 +3227,7 @@ func Convert_v1_ContainerRestartRuleOnExitCodes_To_core_ContainerRestartRuleOnEx
 }
 
 func autoConvert_core_ContainerRestartRuleOnExitCodes_To_v1_ContainerRestartRuleOnExitCodes(in *core.ContainerRestartRuleOnExitCodes, out *corev1.ContainerRestartRuleOnExitCodes, s conversion.Scope) error {
-	out.Operator = corev1.ContainerRestartRuleOnExitCodesOperator(in.Operator)
-	out.Values = *(*[]int32)(unsafe.Pointer(&in.Values))
+	*out = *(*corev1.ContainerRestartRuleOnExitCodes)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3459,9 +3237,7 @@ func Convert_core_ContainerRestartRuleOnExitCodes_To_v1_ContainerRestartRuleOnEx
 }
 
 func autoConvert_v1_ContainerState_To_core_ContainerState(in *corev1.ContainerState, out *core.ContainerState, s conversion.Scope) error {
-	out.Waiting = (*core.ContainerStateWaiting)(unsafe.Pointer(in.Waiting))
-	out.Running = (*core.ContainerStateRunning)(unsafe.Pointer(in.Running))
-	out.Terminated = (*core.ContainerStateTerminated)(unsafe.Pointer(in.Terminated))
+	*out = *(*core.ContainerState)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3471,9 +3247,7 @@ func Convert_v1_ContainerState_To_core_ContainerState(in *corev1.ContainerState,
 }
 
 func autoConvert_core_ContainerState_To_v1_ContainerState(in *core.ContainerState, out *corev1.ContainerState, s conversion.Scope) error {
-	out.Waiting = (*corev1.ContainerStateWaiting)(unsafe.Pointer(in.Waiting))
-	out.Running = (*corev1.ContainerStateRunning)(unsafe.Pointer(in.Running))
-	out.Terminated = (*corev1.ContainerStateTerminated)(unsafe.Pointer(in.Terminated))
+	*out = *(*corev1.ContainerState)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3483,7 +3257,7 @@ func Convert_core_ContainerState_To_v1_ContainerState(in *core.ContainerState, o
 }
 
 func autoConvert_v1_ContainerStateRunning_To_core_ContainerStateRunning(in *corev1.ContainerStateRunning, out *core.ContainerStateRunning, s conversion.Scope) error {
-	out.StartedAt = in.StartedAt
+	*out = *(*core.ContainerStateRunning)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3493,7 +3267,7 @@ func Convert_v1_ContainerStateRunning_To_core_ContainerStateRunning(in *corev1.C
 }
 
 func autoConvert_core_ContainerStateRunning_To_v1_ContainerStateRunning(in *core.ContainerStateRunning, out *corev1.ContainerStateRunning, s conversion.Scope) error {
-	out.StartedAt = in.StartedAt
+	*out = *(*corev1.ContainerStateRunning)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3503,13 +3277,7 @@ func Convert_core_ContainerStateRunning_To_v1_ContainerStateRunning(in *core.Con
 }
 
 func autoConvert_v1_ContainerStateTerminated_To_core_ContainerStateTerminated(in *corev1.ContainerStateTerminated, out *core.ContainerStateTerminated, s conversion.Scope) error {
-	out.ExitCode = in.ExitCode
-	out.Signal = in.Signal
-	out.Reason = in.Reason
-	out.Message = in.Message
-	out.StartedAt = in.StartedAt
-	out.FinishedAt = in.FinishedAt
-	out.ContainerID = in.ContainerID
+	*out = *(*core.ContainerStateTerminated)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3519,13 +3287,7 @@ func Convert_v1_ContainerStateTerminated_To_core_ContainerStateTerminated(in *co
 }
 
 func autoConvert_core_ContainerStateTerminated_To_v1_ContainerStateTerminated(in *core.ContainerStateTerminated, out *corev1.ContainerStateTerminated, s conversion.Scope) error {
-	out.ExitCode = in.ExitCode
-	out.Signal = in.Signal
-	out.Reason = in.Reason
-	out.Message = in.Message
-	out.StartedAt = in.StartedAt
-	out.FinishedAt = in.FinishedAt
-	out.ContainerID = in.ContainerID
+	*out = *(*corev1.ContainerStateTerminated)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3535,8 +3297,7 @@ func Convert_core_ContainerStateTerminated_To_v1_ContainerStateTerminated(in *co
 }
 
 func autoConvert_v1_ContainerStateWaiting_To_core_ContainerStateWaiting(in *corev1.ContainerStateWaiting, out *core.ContainerStateWaiting, s conversion.Scope) error {
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*core.ContainerStateWaiting)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3546,8 +3307,7 @@ func Convert_v1_ContainerStateWaiting_To_core_ContainerStateWaiting(in *corev1.C
 }
 
 func autoConvert_core_ContainerStateWaiting_To_v1_ContainerStateWaiting(in *core.ContainerStateWaiting, out *corev1.ContainerStateWaiting, s conversion.Scope) error {
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*corev1.ContainerStateWaiting)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3557,25 +3317,7 @@ func Convert_core_ContainerStateWaiting_To_v1_ContainerStateWaiting(in *core.Con
 }
 
 func autoConvert_v1_ContainerStatus_To_core_ContainerStatus(in *corev1.ContainerStatus, out *core.ContainerStatus, s conversion.Scope) error {
-	out.Name = in.Name
-	if err := Convert_v1_ContainerState_To_core_ContainerState(&in.State, &out.State, s); err != nil {
-		return err
-	}
-	if err := Convert_v1_ContainerState_To_core_ContainerState(&in.LastTerminationState, &out.LastTerminationState, s); err != nil {
-		return err
-	}
-	out.Ready = in.Ready
-	out.RestartCount = in.RestartCount
-	out.Image = in.Image
-	out.ImageID = in.ImageID
-	out.ContainerID = in.ContainerID
-	out.Started = (*bool)(unsafe.Pointer(in.Started))
-	out.AllocatedResources = *(*core.ResourceList)(unsafe.Pointer(&in.AllocatedResources))
-	out.Resources = (*core.ResourceRequirements)(unsafe.Pointer(in.Resources))
-	out.VolumeMounts = *(*[]core.VolumeMountStatus)(unsafe.Pointer(&in.VolumeMounts))
-	out.User = (*core.ContainerUser)(unsafe.Pointer(in.User))
-	out.AllocatedResourcesStatus = *(*[]core.ResourceStatus)(unsafe.Pointer(&in.AllocatedResourcesStatus))
-	out.StopSignal = (*core.Signal)(unsafe.Pointer(in.StopSignal))
+	*out = *(*core.ContainerStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3585,25 +3327,7 @@ func Convert_v1_ContainerStatus_To_core_ContainerStatus(in *corev1.ContainerStat
 }
 
 func autoConvert_core_ContainerStatus_To_v1_ContainerStatus(in *core.ContainerStatus, out *corev1.ContainerStatus, s conversion.Scope) error {
-	out.Name = in.Name
-	if err := Convert_core_ContainerState_To_v1_ContainerState(&in.State, &out.State, s); err != nil {
-		return err
-	}
-	if err := Convert_core_ContainerState_To_v1_ContainerState(&in.LastTerminationState, &out.LastTerminationState, s); err != nil {
-		return err
-	}
-	out.Ready = in.Ready
-	out.RestartCount = in.RestartCount
-	out.Image = in.Image
-	out.ImageID = in.ImageID
-	out.ContainerID = in.ContainerID
-	out.Started = (*bool)(unsafe.Pointer(in.Started))
-	out.AllocatedResources = *(*corev1.ResourceList)(unsafe.Pointer(&in.AllocatedResources))
-	out.Resources = (*corev1.ResourceRequirements)(unsafe.Pointer(in.Resources))
-	out.VolumeMounts = *(*[]corev1.VolumeMountStatus)(unsafe.Pointer(&in.VolumeMounts))
-	out.User = (*corev1.ContainerUser)(unsafe.Pointer(in.User))
-	out.AllocatedResourcesStatus = *(*[]corev1.ResourceStatus)(unsafe.Pointer(&in.AllocatedResourcesStatus))
-	out.StopSignal = (*corev1.Signal)(unsafe.Pointer(in.StopSignal))
+	*out = *(*corev1.ContainerStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3613,7 +3337,7 @@ func Convert_core_ContainerStatus_To_v1_ContainerStatus(in *core.ContainerStatus
 }
 
 func autoConvert_v1_ContainerUser_To_core_ContainerUser(in *corev1.ContainerUser, out *core.ContainerUser, s conversion.Scope) error {
-	out.Linux = (*core.LinuxContainerUser)(unsafe.Pointer(in.Linux))
+	*out = *(*core.ContainerUser)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3623,7 +3347,7 @@ func Convert_v1_ContainerUser_To_core_ContainerUser(in *corev1.ContainerUser, ou
 }
 
 func autoConvert_core_ContainerUser_To_v1_ContainerUser(in *core.ContainerUser, out *corev1.ContainerUser, s conversion.Scope) error {
-	out.Linux = (*corev1.LinuxContainerUser)(unsafe.Pointer(in.Linux))
+	*out = *(*corev1.ContainerUser)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3633,7 +3357,7 @@ func Convert_core_ContainerUser_To_v1_ContainerUser(in *core.ContainerUser, out 
 }
 
 func autoConvert_v1_DaemonEndpoint_To_core_DaemonEndpoint(in *corev1.DaemonEndpoint, out *core.DaemonEndpoint, s conversion.Scope) error {
-	out.Port = in.Port
+	*out = *(*core.DaemonEndpoint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3643,7 +3367,7 @@ func Convert_v1_DaemonEndpoint_To_core_DaemonEndpoint(in *corev1.DaemonEndpoint,
 }
 
 func autoConvert_core_DaemonEndpoint_To_v1_DaemonEndpoint(in *core.DaemonEndpoint, out *corev1.DaemonEndpoint, s conversion.Scope) error {
-	out.Port = in.Port
+	*out = *(*corev1.DaemonEndpoint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3653,7 +3377,7 @@ func Convert_core_DaemonEndpoint_To_v1_DaemonEndpoint(in *core.DaemonEndpoint, o
 }
 
 func autoConvert_v1_DownwardAPIProjection_To_core_DownwardAPIProjection(in *corev1.DownwardAPIProjection, out *core.DownwardAPIProjection, s conversion.Scope) error {
-	out.Items = *(*[]core.DownwardAPIVolumeFile)(unsafe.Pointer(&in.Items))
+	*out = *(*core.DownwardAPIProjection)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3663,7 +3387,7 @@ func Convert_v1_DownwardAPIProjection_To_core_DownwardAPIProjection(in *corev1.D
 }
 
 func autoConvert_core_DownwardAPIProjection_To_v1_DownwardAPIProjection(in *core.DownwardAPIProjection, out *corev1.DownwardAPIProjection, s conversion.Scope) error {
-	out.Items = *(*[]corev1.DownwardAPIVolumeFile)(unsafe.Pointer(&in.Items))
+	*out = *(*corev1.DownwardAPIProjection)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3673,10 +3397,7 @@ func Convert_core_DownwardAPIProjection_To_v1_DownwardAPIProjection(in *core.Dow
 }
 
 func autoConvert_v1_DownwardAPIVolumeFile_To_core_DownwardAPIVolumeFile(in *corev1.DownwardAPIVolumeFile, out *core.DownwardAPIVolumeFile, s conversion.Scope) error {
-	out.Path = in.Path
-	out.FieldRef = (*core.ObjectFieldSelector)(unsafe.Pointer(in.FieldRef))
-	out.ResourceFieldRef = (*core.ResourceFieldSelector)(unsafe.Pointer(in.ResourceFieldRef))
-	out.Mode = (*int32)(unsafe.Pointer(in.Mode))
+	*out = *(*core.DownwardAPIVolumeFile)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3686,10 +3407,7 @@ func Convert_v1_DownwardAPIVolumeFile_To_core_DownwardAPIVolumeFile(in *corev1.D
 }
 
 func autoConvert_core_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile(in *core.DownwardAPIVolumeFile, out *corev1.DownwardAPIVolumeFile, s conversion.Scope) error {
-	out.Path = in.Path
-	out.FieldRef = (*corev1.ObjectFieldSelector)(unsafe.Pointer(in.FieldRef))
-	out.ResourceFieldRef = (*corev1.ResourceFieldSelector)(unsafe.Pointer(in.ResourceFieldRef))
-	out.Mode = (*int32)(unsafe.Pointer(in.Mode))
+	*out = *(*corev1.DownwardAPIVolumeFile)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3699,8 +3417,7 @@ func Convert_core_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile(in *core.Dow
 }
 
 func autoConvert_v1_DownwardAPIVolumeSource_To_core_DownwardAPIVolumeSource(in *corev1.DownwardAPIVolumeSource, out *core.DownwardAPIVolumeSource, s conversion.Scope) error {
-	out.Items = *(*[]core.DownwardAPIVolumeFile)(unsafe.Pointer(&in.Items))
-	out.DefaultMode = (*int32)(unsafe.Pointer(in.DefaultMode))
+	*out = *(*core.DownwardAPIVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3710,8 +3427,7 @@ func Convert_v1_DownwardAPIVolumeSource_To_core_DownwardAPIVolumeSource(in *core
 }
 
 func autoConvert_core_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource(in *core.DownwardAPIVolumeSource, out *corev1.DownwardAPIVolumeSource, s conversion.Scope) error {
-	out.Items = *(*[]corev1.DownwardAPIVolumeFile)(unsafe.Pointer(&in.Items))
-	out.DefaultMode = (*int32)(unsafe.Pointer(in.DefaultMode))
+	*out = *(*corev1.DownwardAPIVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3721,8 +3437,7 @@ func Convert_core_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource(in *core
 }
 
 func autoConvert_v1_EmptyDirVolumeSource_To_core_EmptyDirVolumeSource(in *corev1.EmptyDirVolumeSource, out *core.EmptyDirVolumeSource, s conversion.Scope) error {
-	out.Medium = core.StorageMedium(in.Medium)
-	out.SizeLimit = (*resource.Quantity)(unsafe.Pointer(in.SizeLimit))
+	*out = *(*core.EmptyDirVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3732,8 +3447,7 @@ func Convert_v1_EmptyDirVolumeSource_To_core_EmptyDirVolumeSource(in *corev1.Emp
 }
 
 func autoConvert_core_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(in *core.EmptyDirVolumeSource, out *corev1.EmptyDirVolumeSource, s conversion.Scope) error {
-	out.Medium = corev1.StorageMedium(in.Medium)
-	out.SizeLimit = (*resource.Quantity)(unsafe.Pointer(in.SizeLimit))
+	*out = *(*corev1.EmptyDirVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3743,10 +3457,7 @@ func Convert_core_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(in *core.Empty
 }
 
 func autoConvert_v1_EndpointAddress_To_core_EndpointAddress(in *corev1.EndpointAddress, out *core.EndpointAddress, s conversion.Scope) error {
-	out.IP = in.IP
-	out.Hostname = in.Hostname
-	out.NodeName = (*string)(unsafe.Pointer(in.NodeName))
-	out.TargetRef = (*core.ObjectReference)(unsafe.Pointer(in.TargetRef))
+	*out = *(*core.EndpointAddress)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3756,10 +3467,7 @@ func Convert_v1_EndpointAddress_To_core_EndpointAddress(in *corev1.EndpointAddre
 }
 
 func autoConvert_core_EndpointAddress_To_v1_EndpointAddress(in *core.EndpointAddress, out *corev1.EndpointAddress, s conversion.Scope) error {
-	out.IP = in.IP
-	out.Hostname = in.Hostname
-	out.NodeName = (*string)(unsafe.Pointer(in.NodeName))
-	out.TargetRef = (*corev1.ObjectReference)(unsafe.Pointer(in.TargetRef))
+	*out = *(*corev1.EndpointAddress)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3769,10 +3477,7 @@ func Convert_core_EndpointAddress_To_v1_EndpointAddress(in *core.EndpointAddress
 }
 
 func autoConvert_v1_EndpointPort_To_core_EndpointPort(in *corev1.EndpointPort, out *core.EndpointPort, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Port = in.Port
-	out.Protocol = core.Protocol(in.Protocol)
-	out.AppProtocol = (*string)(unsafe.Pointer(in.AppProtocol))
+	*out = *(*core.EndpointPort)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3782,10 +3487,7 @@ func Convert_v1_EndpointPort_To_core_EndpointPort(in *corev1.EndpointPort, out *
 }
 
 func autoConvert_core_EndpointPort_To_v1_EndpointPort(in *core.EndpointPort, out *corev1.EndpointPort, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Port = in.Port
-	out.Protocol = corev1.Protocol(in.Protocol)
-	out.AppProtocol = (*string)(unsafe.Pointer(in.AppProtocol))
+	*out = *(*corev1.EndpointPort)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3795,9 +3497,7 @@ func Convert_core_EndpointPort_To_v1_EndpointPort(in *core.EndpointPort, out *co
 }
 
 func autoConvert_v1_EndpointSubset_To_core_EndpointSubset(in *corev1.EndpointSubset, out *core.EndpointSubset, s conversion.Scope) error {
-	out.Addresses = *(*[]core.EndpointAddress)(unsafe.Pointer(&in.Addresses))
-	out.NotReadyAddresses = *(*[]core.EndpointAddress)(unsafe.Pointer(&in.NotReadyAddresses))
-	out.Ports = *(*[]core.EndpointPort)(unsafe.Pointer(&in.Ports))
+	*out = *(*core.EndpointSubset)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3807,9 +3507,7 @@ func Convert_v1_EndpointSubset_To_core_EndpointSubset(in *corev1.EndpointSubset,
 }
 
 func autoConvert_core_EndpointSubset_To_v1_EndpointSubset(in *core.EndpointSubset, out *corev1.EndpointSubset, s conversion.Scope) error {
-	out.Addresses = *(*[]corev1.EndpointAddress)(unsafe.Pointer(&in.Addresses))
-	out.NotReadyAddresses = *(*[]corev1.EndpointAddress)(unsafe.Pointer(&in.NotReadyAddresses))
-	out.Ports = *(*[]corev1.EndpointPort)(unsafe.Pointer(&in.Ports))
+	*out = *(*corev1.EndpointSubset)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3863,9 +3561,7 @@ func Convert_core_EndpointsList_To_v1_EndpointsList(in *core.EndpointsList, out 
 }
 
 func autoConvert_v1_EnvFromSource_To_core_EnvFromSource(in *corev1.EnvFromSource, out *core.EnvFromSource, s conversion.Scope) error {
-	out.Prefix = in.Prefix
-	out.ConfigMapRef = (*core.ConfigMapEnvSource)(unsafe.Pointer(in.ConfigMapRef))
-	out.SecretRef = (*core.SecretEnvSource)(unsafe.Pointer(in.SecretRef))
+	*out = *(*core.EnvFromSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3875,9 +3571,7 @@ func Convert_v1_EnvFromSource_To_core_EnvFromSource(in *corev1.EnvFromSource, ou
 }
 
 func autoConvert_core_EnvFromSource_To_v1_EnvFromSource(in *core.EnvFromSource, out *corev1.EnvFromSource, s conversion.Scope) error {
-	out.Prefix = in.Prefix
-	out.ConfigMapRef = (*corev1.ConfigMapEnvSource)(unsafe.Pointer(in.ConfigMapRef))
-	out.SecretRef = (*corev1.SecretEnvSource)(unsafe.Pointer(in.SecretRef))
+	*out = *(*corev1.EnvFromSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3887,9 +3581,7 @@ func Convert_core_EnvFromSource_To_v1_EnvFromSource(in *core.EnvFromSource, out 
 }
 
 func autoConvert_v1_EnvVar_To_core_EnvVar(in *corev1.EnvVar, out *core.EnvVar, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Value = in.Value
-	out.ValueFrom = (*core.EnvVarSource)(unsafe.Pointer(in.ValueFrom))
+	*out = *(*core.EnvVar)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3899,9 +3591,7 @@ func Convert_v1_EnvVar_To_core_EnvVar(in *corev1.EnvVar, out *core.EnvVar, s con
 }
 
 func autoConvert_core_EnvVar_To_v1_EnvVar(in *core.EnvVar, out *corev1.EnvVar, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Value = in.Value
-	out.ValueFrom = (*corev1.EnvVarSource)(unsafe.Pointer(in.ValueFrom))
+	*out = *(*corev1.EnvVar)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3911,11 +3601,7 @@ func Convert_core_EnvVar_To_v1_EnvVar(in *core.EnvVar, out *corev1.EnvVar, s con
 }
 
 func autoConvert_v1_EnvVarSource_To_core_EnvVarSource(in *corev1.EnvVarSource, out *core.EnvVarSource, s conversion.Scope) error {
-	out.FieldRef = (*core.ObjectFieldSelector)(unsafe.Pointer(in.FieldRef))
-	out.ResourceFieldRef = (*core.ResourceFieldSelector)(unsafe.Pointer(in.ResourceFieldRef))
-	out.ConfigMapKeyRef = (*core.ConfigMapKeySelector)(unsafe.Pointer(in.ConfigMapKeyRef))
-	out.SecretKeyRef = (*core.SecretKeySelector)(unsafe.Pointer(in.SecretKeyRef))
-	out.FileKeyRef = (*core.FileKeySelector)(unsafe.Pointer(in.FileKeyRef))
+	*out = *(*core.EnvVarSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3925,11 +3611,7 @@ func Convert_v1_EnvVarSource_To_core_EnvVarSource(in *corev1.EnvVarSource, out *
 }
 
 func autoConvert_core_EnvVarSource_To_v1_EnvVarSource(in *core.EnvVarSource, out *corev1.EnvVarSource, s conversion.Scope) error {
-	out.FieldRef = (*corev1.ObjectFieldSelector)(unsafe.Pointer(in.FieldRef))
-	out.ResourceFieldRef = (*corev1.ResourceFieldSelector)(unsafe.Pointer(in.ResourceFieldRef))
-	out.ConfigMapKeyRef = (*corev1.ConfigMapKeySelector)(unsafe.Pointer(in.ConfigMapKeyRef))
-	out.SecretKeyRef = (*corev1.SecretKeySelector)(unsafe.Pointer(in.SecretKeyRef))
-	out.FileKeyRef = (*corev1.FileKeySelector)(unsafe.Pointer(in.FileKeyRef))
+	*out = *(*corev1.EnvVarSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3939,10 +3621,7 @@ func Convert_core_EnvVarSource_To_v1_EnvVarSource(in *core.EnvVarSource, out *co
 }
 
 func autoConvert_v1_EphemeralContainer_To_core_EphemeralContainer(in *corev1.EphemeralContainer, out *core.EphemeralContainer, s conversion.Scope) error {
-	if err := Convert_v1_EphemeralContainerCommon_To_core_EphemeralContainerCommon(&in.EphemeralContainerCommon, &out.EphemeralContainerCommon, s); err != nil {
-		return err
-	}
-	out.TargetContainerName = in.TargetContainerName
+	*out = *(*core.EphemeralContainer)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3952,10 +3631,7 @@ func Convert_v1_EphemeralContainer_To_core_EphemeralContainer(in *corev1.Ephemer
 }
 
 func autoConvert_core_EphemeralContainer_To_v1_EphemeralContainer(in *core.EphemeralContainer, out *corev1.EphemeralContainer, s conversion.Scope) error {
-	if err := Convert_core_EphemeralContainerCommon_To_v1_EphemeralContainerCommon(&in.EphemeralContainerCommon, &out.EphemeralContainerCommon, s); err != nil {
-		return err
-	}
-	out.TargetContainerName = in.TargetContainerName
+	*out = *(*corev1.EphemeralContainer)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -3965,33 +3641,7 @@ func Convert_core_EphemeralContainer_To_v1_EphemeralContainer(in *core.Ephemeral
 }
 
 func autoConvert_v1_EphemeralContainerCommon_To_core_EphemeralContainerCommon(in *corev1.EphemeralContainerCommon, out *core.EphemeralContainerCommon, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Image = in.Image
-	out.Command = *(*[]string)(unsafe.Pointer(&in.Command))
-	out.Args = *(*[]string)(unsafe.Pointer(&in.Args))
-	out.WorkingDir = in.WorkingDir
-	out.Ports = *(*[]core.ContainerPort)(unsafe.Pointer(&in.Ports))
-	out.EnvFrom = *(*[]core.EnvFromSource)(unsafe.Pointer(&in.EnvFrom))
-	out.Env = *(*[]core.EnvVar)(unsafe.Pointer(&in.Env))
-	if err := Convert_v1_ResourceRequirements_To_core_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
-		return err
-	}
-	out.ResizePolicy = *(*[]core.ContainerResizePolicy)(unsafe.Pointer(&in.ResizePolicy))
-	out.RestartPolicy = (*core.ContainerRestartPolicy)(unsafe.Pointer(in.RestartPolicy))
-	out.RestartPolicyRules = *(*[]core.ContainerRestartRule)(unsafe.Pointer(&in.RestartPolicyRules))
-	out.VolumeMounts = *(*[]core.VolumeMount)(unsafe.Pointer(&in.VolumeMounts))
-	out.VolumeDevices = *(*[]core.VolumeDevice)(unsafe.Pointer(&in.VolumeDevices))
-	out.LivenessProbe = (*core.Probe)(unsafe.Pointer(in.LivenessProbe))
-	out.ReadinessProbe = (*core.Probe)(unsafe.Pointer(in.ReadinessProbe))
-	out.StartupProbe = (*core.Probe)(unsafe.Pointer(in.StartupProbe))
-	out.Lifecycle = (*core.Lifecycle)(unsafe.Pointer(in.Lifecycle))
-	out.TerminationMessagePath = in.TerminationMessagePath
-	out.TerminationMessagePolicy = core.TerminationMessagePolicy(in.TerminationMessagePolicy)
-	out.ImagePullPolicy = core.PullPolicy(in.ImagePullPolicy)
-	out.SecurityContext = (*core.SecurityContext)(unsafe.Pointer(in.SecurityContext))
-	out.Stdin = in.Stdin
-	out.StdinOnce = in.StdinOnce
-	out.TTY = in.TTY
+	*out = *(*core.EphemeralContainerCommon)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4001,33 +3651,7 @@ func Convert_v1_EphemeralContainerCommon_To_core_EphemeralContainerCommon(in *co
 }
 
 func autoConvert_core_EphemeralContainerCommon_To_v1_EphemeralContainerCommon(in *core.EphemeralContainerCommon, out *corev1.EphemeralContainerCommon, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Image = in.Image
-	out.Command = *(*[]string)(unsafe.Pointer(&in.Command))
-	out.Args = *(*[]string)(unsafe.Pointer(&in.Args))
-	out.WorkingDir = in.WorkingDir
-	out.Ports = *(*[]corev1.ContainerPort)(unsafe.Pointer(&in.Ports))
-	out.EnvFrom = *(*[]corev1.EnvFromSource)(unsafe.Pointer(&in.EnvFrom))
-	out.Env = *(*[]corev1.EnvVar)(unsafe.Pointer(&in.Env))
-	if err := Convert_core_ResourceRequirements_To_v1_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
-		return err
-	}
-	out.ResizePolicy = *(*[]corev1.ContainerResizePolicy)(unsafe.Pointer(&in.ResizePolicy))
-	out.RestartPolicy = (*corev1.ContainerRestartPolicy)(unsafe.Pointer(in.RestartPolicy))
-	out.RestartPolicyRules = *(*[]corev1.ContainerRestartRule)(unsafe.Pointer(&in.RestartPolicyRules))
-	out.VolumeMounts = *(*[]corev1.VolumeMount)(unsafe.Pointer(&in.VolumeMounts))
-	out.VolumeDevices = *(*[]corev1.VolumeDevice)(unsafe.Pointer(&in.VolumeDevices))
-	out.LivenessProbe = (*corev1.Probe)(unsafe.Pointer(in.LivenessProbe))
-	out.ReadinessProbe = (*corev1.Probe)(unsafe.Pointer(in.ReadinessProbe))
-	out.StartupProbe = (*corev1.Probe)(unsafe.Pointer(in.StartupProbe))
-	out.Lifecycle = (*corev1.Lifecycle)(unsafe.Pointer(in.Lifecycle))
-	out.TerminationMessagePath = in.TerminationMessagePath
-	out.TerminationMessagePolicy = corev1.TerminationMessagePolicy(in.TerminationMessagePolicy)
-	out.ImagePullPolicy = corev1.PullPolicy(in.ImagePullPolicy)
-	out.SecurityContext = (*corev1.SecurityContext)(unsafe.Pointer(in.SecurityContext))
-	out.Stdin = in.Stdin
-	out.StdinOnce = in.StdinOnce
-	out.TTY = in.TTY
+	*out = *(*corev1.EphemeralContainerCommon)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4037,7 +3661,7 @@ func Convert_core_EphemeralContainerCommon_To_v1_EphemeralContainerCommon(in *co
 }
 
 func autoConvert_v1_EphemeralVolumeSource_To_core_EphemeralVolumeSource(in *corev1.EphemeralVolumeSource, out *core.EphemeralVolumeSource, s conversion.Scope) error {
-	out.VolumeClaimTemplate = (*core.PersistentVolumeClaimTemplate)(unsafe.Pointer(in.VolumeClaimTemplate))
+	*out = *(*core.EphemeralVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4047,7 +3671,7 @@ func Convert_v1_EphemeralVolumeSource_To_core_EphemeralVolumeSource(in *corev1.E
 }
 
 func autoConvert_core_EphemeralVolumeSource_To_v1_EphemeralVolumeSource(in *core.EphemeralVolumeSource, out *corev1.EphemeralVolumeSource, s conversion.Scope) error {
-	out.VolumeClaimTemplate = (*corev1.PersistentVolumeClaimTemplate)(unsafe.Pointer(in.VolumeClaimTemplate))
+	*out = *(*corev1.EphemeralVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4135,8 +3759,7 @@ func Convert_core_EventList_To_v1_EventList(in *core.EventList, out *corev1.Even
 }
 
 func autoConvert_v1_EventSeries_To_core_EventSeries(in *corev1.EventSeries, out *core.EventSeries, s conversion.Scope) error {
-	out.Count = in.Count
-	out.LastObservedTime = in.LastObservedTime
+	*out = *(*core.EventSeries)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4146,8 +3769,7 @@ func Convert_v1_EventSeries_To_core_EventSeries(in *corev1.EventSeries, out *cor
 }
 
 func autoConvert_core_EventSeries_To_v1_EventSeries(in *core.EventSeries, out *corev1.EventSeries, s conversion.Scope) error {
-	out.Count = in.Count
-	out.LastObservedTime = in.LastObservedTime
+	*out = *(*corev1.EventSeries)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4157,8 +3779,7 @@ func Convert_core_EventSeries_To_v1_EventSeries(in *core.EventSeries, out *corev
 }
 
 func autoConvert_v1_EventSource_To_core_EventSource(in *corev1.EventSource, out *core.EventSource, s conversion.Scope) error {
-	out.Component = in.Component
-	out.Host = in.Host
+	*out = *(*core.EventSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4168,8 +3789,7 @@ func Convert_v1_EventSource_To_core_EventSource(in *corev1.EventSource, out *cor
 }
 
 func autoConvert_core_EventSource_To_v1_EventSource(in *core.EventSource, out *corev1.EventSource, s conversion.Scope) error {
-	out.Component = in.Component
-	out.Host = in.Host
+	*out = *(*corev1.EventSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4179,7 +3799,7 @@ func Convert_core_EventSource_To_v1_EventSource(in *core.EventSource, out *corev
 }
 
 func autoConvert_v1_ExecAction_To_core_ExecAction(in *corev1.ExecAction, out *core.ExecAction, s conversion.Scope) error {
-	out.Command = *(*[]string)(unsafe.Pointer(&in.Command))
+	*out = *(*core.ExecAction)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4189,7 +3809,7 @@ func Convert_v1_ExecAction_To_core_ExecAction(in *corev1.ExecAction, out *core.E
 }
 
 func autoConvert_core_ExecAction_To_v1_ExecAction(in *core.ExecAction, out *corev1.ExecAction, s conversion.Scope) error {
-	out.Command = *(*[]string)(unsafe.Pointer(&in.Command))
+	*out = *(*corev1.ExecAction)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4199,11 +3819,7 @@ func Convert_core_ExecAction_To_v1_ExecAction(in *core.ExecAction, out *corev1.E
 }
 
 func autoConvert_v1_FCVolumeSource_To_core_FCVolumeSource(in *corev1.FCVolumeSource, out *core.FCVolumeSource, s conversion.Scope) error {
-	out.TargetWWNs = *(*[]string)(unsafe.Pointer(&in.TargetWWNs))
-	out.Lun = (*int32)(unsafe.Pointer(in.Lun))
-	out.FSType = in.FSType
-	out.ReadOnly = in.ReadOnly
-	out.WWIDs = *(*[]string)(unsafe.Pointer(&in.WWIDs))
+	*out = *(*core.FCVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4213,11 +3829,7 @@ func Convert_v1_FCVolumeSource_To_core_FCVolumeSource(in *corev1.FCVolumeSource,
 }
 
 func autoConvert_core_FCVolumeSource_To_v1_FCVolumeSource(in *core.FCVolumeSource, out *corev1.FCVolumeSource, s conversion.Scope) error {
-	out.TargetWWNs = *(*[]string)(unsafe.Pointer(&in.TargetWWNs))
-	out.Lun = (*int32)(unsafe.Pointer(in.Lun))
-	out.FSType = in.FSType
-	out.ReadOnly = in.ReadOnly
-	out.WWIDs = *(*[]string)(unsafe.Pointer(&in.WWIDs))
+	*out = *(*corev1.FCVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4227,10 +3839,7 @@ func Convert_core_FCVolumeSource_To_v1_FCVolumeSource(in *core.FCVolumeSource, o
 }
 
 func autoConvert_v1_FileKeySelector_To_core_FileKeySelector(in *corev1.FileKeySelector, out *core.FileKeySelector, s conversion.Scope) error {
-	out.VolumeName = in.VolumeName
-	out.Path = in.Path
-	out.Key = in.Key
-	out.Optional = (*bool)(unsafe.Pointer(in.Optional))
+	*out = *(*core.FileKeySelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4240,10 +3849,7 @@ func Convert_v1_FileKeySelector_To_core_FileKeySelector(in *corev1.FileKeySelect
 }
 
 func autoConvert_core_FileKeySelector_To_v1_FileKeySelector(in *core.FileKeySelector, out *corev1.FileKeySelector, s conversion.Scope) error {
-	out.VolumeName = in.VolumeName
-	out.Path = in.Path
-	out.Key = in.Key
-	out.Optional = (*bool)(unsafe.Pointer(in.Optional))
+	*out = *(*corev1.FileKeySelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4253,11 +3859,7 @@ func Convert_core_FileKeySelector_To_v1_FileKeySelector(in *core.FileKeySelector
 }
 
 func autoConvert_v1_FlexPersistentVolumeSource_To_core_FlexPersistentVolumeSource(in *corev1.FlexPersistentVolumeSource, out *core.FlexPersistentVolumeSource, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.FSType = in.FSType
-	out.SecretRef = (*core.SecretReference)(unsafe.Pointer(in.SecretRef))
-	out.ReadOnly = in.ReadOnly
-	out.Options = *(*map[string]string)(unsafe.Pointer(&in.Options))
+	*out = *(*core.FlexPersistentVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4267,11 +3869,7 @@ func Convert_v1_FlexPersistentVolumeSource_To_core_FlexPersistentVolumeSource(in
 }
 
 func autoConvert_core_FlexPersistentVolumeSource_To_v1_FlexPersistentVolumeSource(in *core.FlexPersistentVolumeSource, out *corev1.FlexPersistentVolumeSource, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.FSType = in.FSType
-	out.SecretRef = (*corev1.SecretReference)(unsafe.Pointer(in.SecretRef))
-	out.ReadOnly = in.ReadOnly
-	out.Options = *(*map[string]string)(unsafe.Pointer(&in.Options))
+	*out = *(*corev1.FlexPersistentVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4281,11 +3879,7 @@ func Convert_core_FlexPersistentVolumeSource_To_v1_FlexPersistentVolumeSource(in
 }
 
 func autoConvert_v1_FlexVolumeSource_To_core_FlexVolumeSource(in *corev1.FlexVolumeSource, out *core.FlexVolumeSource, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.FSType = in.FSType
-	out.SecretRef = (*core.LocalObjectReference)(unsafe.Pointer(in.SecretRef))
-	out.ReadOnly = in.ReadOnly
-	out.Options = *(*map[string]string)(unsafe.Pointer(&in.Options))
+	*out = *(*core.FlexVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4295,11 +3889,7 @@ func Convert_v1_FlexVolumeSource_To_core_FlexVolumeSource(in *corev1.FlexVolumeS
 }
 
 func autoConvert_core_FlexVolumeSource_To_v1_FlexVolumeSource(in *core.FlexVolumeSource, out *corev1.FlexVolumeSource, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.FSType = in.FSType
-	out.SecretRef = (*corev1.LocalObjectReference)(unsafe.Pointer(in.SecretRef))
-	out.ReadOnly = in.ReadOnly
-	out.Options = *(*map[string]string)(unsafe.Pointer(&in.Options))
+	*out = *(*corev1.FlexVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4309,8 +3899,7 @@ func Convert_core_FlexVolumeSource_To_v1_FlexVolumeSource(in *core.FlexVolumeSou
 }
 
 func autoConvert_v1_FlockerVolumeSource_To_core_FlockerVolumeSource(in *corev1.FlockerVolumeSource, out *core.FlockerVolumeSource, s conversion.Scope) error {
-	out.DatasetName = in.DatasetName
-	out.DatasetUUID = in.DatasetUUID
+	*out = *(*core.FlockerVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4320,8 +3909,7 @@ func Convert_v1_FlockerVolumeSource_To_core_FlockerVolumeSource(in *corev1.Flock
 }
 
 func autoConvert_core_FlockerVolumeSource_To_v1_FlockerVolumeSource(in *core.FlockerVolumeSource, out *corev1.FlockerVolumeSource, s conversion.Scope) error {
-	out.DatasetName = in.DatasetName
-	out.DatasetUUID = in.DatasetUUID
+	*out = *(*corev1.FlockerVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4331,10 +3919,7 @@ func Convert_core_FlockerVolumeSource_To_v1_FlockerVolumeSource(in *core.Flocker
 }
 
 func autoConvert_v1_GCEPersistentDiskVolumeSource_To_core_GCEPersistentDiskVolumeSource(in *corev1.GCEPersistentDiskVolumeSource, out *core.GCEPersistentDiskVolumeSource, s conversion.Scope) error {
-	out.PDName = in.PDName
-	out.FSType = in.FSType
-	out.Partition = in.Partition
-	out.ReadOnly = in.ReadOnly
+	*out = *(*core.GCEPersistentDiskVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4344,10 +3929,7 @@ func Convert_v1_GCEPersistentDiskVolumeSource_To_core_GCEPersistentDiskVolumeSou
 }
 
 func autoConvert_core_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource(in *core.GCEPersistentDiskVolumeSource, out *corev1.GCEPersistentDiskVolumeSource, s conversion.Scope) error {
-	out.PDName = in.PDName
-	out.FSType = in.FSType
-	out.Partition = in.Partition
-	out.ReadOnly = in.ReadOnly
+	*out = *(*corev1.GCEPersistentDiskVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4357,8 +3939,7 @@ func Convert_core_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSou
 }
 
 func autoConvert_v1_GRPCAction_To_core_GRPCAction(in *corev1.GRPCAction, out *core.GRPCAction, s conversion.Scope) error {
-	out.Port = in.Port
-	out.Service = (*string)(unsafe.Pointer(in.Service))
+	*out = *(*core.GRPCAction)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4368,8 +3949,7 @@ func Convert_v1_GRPCAction_To_core_GRPCAction(in *corev1.GRPCAction, out *core.G
 }
 
 func autoConvert_core_GRPCAction_To_v1_GRPCAction(in *core.GRPCAction, out *corev1.GRPCAction, s conversion.Scope) error {
-	out.Port = in.Port
-	out.Service = (*string)(unsafe.Pointer(in.Service))
+	*out = *(*corev1.GRPCAction)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4379,9 +3959,7 @@ func Convert_core_GRPCAction_To_v1_GRPCAction(in *core.GRPCAction, out *corev1.G
 }
 
 func autoConvert_v1_GitRepoVolumeSource_To_core_GitRepoVolumeSource(in *corev1.GitRepoVolumeSource, out *core.GitRepoVolumeSource, s conversion.Scope) error {
-	out.Repository = in.Repository
-	out.Revision = in.Revision
-	out.Directory = in.Directory
+	*out = *(*core.GitRepoVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4391,9 +3969,7 @@ func Convert_v1_GitRepoVolumeSource_To_core_GitRepoVolumeSource(in *corev1.GitRe
 }
 
 func autoConvert_core_GitRepoVolumeSource_To_v1_GitRepoVolumeSource(in *core.GitRepoVolumeSource, out *corev1.GitRepoVolumeSource, s conversion.Scope) error {
-	out.Repository = in.Repository
-	out.Revision = in.Revision
-	out.Directory = in.Directory
+	*out = *(*corev1.GitRepoVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4403,10 +3979,7 @@ func Convert_core_GitRepoVolumeSource_To_v1_GitRepoVolumeSource(in *core.GitRepo
 }
 
 func autoConvert_v1_GlusterfsPersistentVolumeSource_To_core_GlusterfsPersistentVolumeSource(in *corev1.GlusterfsPersistentVolumeSource, out *core.GlusterfsPersistentVolumeSource, s conversion.Scope) error {
-	out.EndpointsName = in.EndpointsName
-	out.Path = in.Path
-	out.ReadOnly = in.ReadOnly
-	out.EndpointsNamespace = (*string)(unsafe.Pointer(in.EndpointsNamespace))
+	*out = *(*core.GlusterfsPersistentVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4416,10 +3989,7 @@ func Convert_v1_GlusterfsPersistentVolumeSource_To_core_GlusterfsPersistentVolum
 }
 
 func autoConvert_core_GlusterfsPersistentVolumeSource_To_v1_GlusterfsPersistentVolumeSource(in *core.GlusterfsPersistentVolumeSource, out *corev1.GlusterfsPersistentVolumeSource, s conversion.Scope) error {
-	out.EndpointsName = in.EndpointsName
-	out.Path = in.Path
-	out.ReadOnly = in.ReadOnly
-	out.EndpointsNamespace = (*string)(unsafe.Pointer(in.EndpointsNamespace))
+	*out = *(*corev1.GlusterfsPersistentVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4429,9 +3999,7 @@ func Convert_core_GlusterfsPersistentVolumeSource_To_v1_GlusterfsPersistentVolum
 }
 
 func autoConvert_v1_GlusterfsVolumeSource_To_core_GlusterfsVolumeSource(in *corev1.GlusterfsVolumeSource, out *core.GlusterfsVolumeSource, s conversion.Scope) error {
-	out.EndpointsName = in.EndpointsName
-	out.Path = in.Path
-	out.ReadOnly = in.ReadOnly
+	*out = *(*core.GlusterfsVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4441,9 +4009,7 @@ func Convert_v1_GlusterfsVolumeSource_To_core_GlusterfsVolumeSource(in *corev1.G
 }
 
 func autoConvert_core_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(in *core.GlusterfsVolumeSource, out *corev1.GlusterfsVolumeSource, s conversion.Scope) error {
-	out.EndpointsName = in.EndpointsName
-	out.Path = in.Path
-	out.ReadOnly = in.ReadOnly
+	*out = *(*corev1.GlusterfsVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4453,11 +4019,7 @@ func Convert_core_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(in *core.Glu
 }
 
 func autoConvert_v1_HTTPGetAction_To_core_HTTPGetAction(in *corev1.HTTPGetAction, out *core.HTTPGetAction, s conversion.Scope) error {
-	out.Path = in.Path
-	out.Port = in.Port
-	out.Host = in.Host
-	out.Scheme = core.URIScheme(in.Scheme)
-	out.HTTPHeaders = *(*[]core.HTTPHeader)(unsafe.Pointer(&in.HTTPHeaders))
+	*out = *(*core.HTTPGetAction)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4467,11 +4029,7 @@ func Convert_v1_HTTPGetAction_To_core_HTTPGetAction(in *corev1.HTTPGetAction, ou
 }
 
 func autoConvert_core_HTTPGetAction_To_v1_HTTPGetAction(in *core.HTTPGetAction, out *corev1.HTTPGetAction, s conversion.Scope) error {
-	out.Path = in.Path
-	out.Port = in.Port
-	out.Host = in.Host
-	out.Scheme = corev1.URIScheme(in.Scheme)
-	out.HTTPHeaders = *(*[]corev1.HTTPHeader)(unsafe.Pointer(&in.HTTPHeaders))
+	*out = *(*corev1.HTTPGetAction)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4481,8 +4039,7 @@ func Convert_core_HTTPGetAction_To_v1_HTTPGetAction(in *core.HTTPGetAction, out 
 }
 
 func autoConvert_v1_HTTPHeader_To_core_HTTPHeader(in *corev1.HTTPHeader, out *core.HTTPHeader, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Value = in.Value
+	*out = *(*core.HTTPHeader)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4492,8 +4049,7 @@ func Convert_v1_HTTPHeader_To_core_HTTPHeader(in *corev1.HTTPHeader, out *core.H
 }
 
 func autoConvert_core_HTTPHeader_To_v1_HTTPHeader(in *core.HTTPHeader, out *corev1.HTTPHeader, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Value = in.Value
+	*out = *(*corev1.HTTPHeader)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4503,8 +4059,7 @@ func Convert_core_HTTPHeader_To_v1_HTTPHeader(in *core.HTTPHeader, out *corev1.H
 }
 
 func autoConvert_v1_HostAlias_To_core_HostAlias(in *corev1.HostAlias, out *core.HostAlias, s conversion.Scope) error {
-	out.IP = in.IP
-	out.Hostnames = *(*[]string)(unsafe.Pointer(&in.Hostnames))
+	*out = *(*core.HostAlias)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4514,8 +4069,7 @@ func Convert_v1_HostAlias_To_core_HostAlias(in *corev1.HostAlias, out *core.Host
 }
 
 func autoConvert_core_HostAlias_To_v1_HostAlias(in *core.HostAlias, out *corev1.HostAlias, s conversion.Scope) error {
-	out.IP = in.IP
-	out.Hostnames = *(*[]string)(unsafe.Pointer(&in.Hostnames))
+	*out = *(*corev1.HostAlias)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4525,7 +4079,7 @@ func Convert_core_HostAlias_To_v1_HostAlias(in *core.HostAlias, out *corev1.Host
 }
 
 func autoConvert_v1_HostIP_To_core_HostIP(in *corev1.HostIP, out *core.HostIP, s conversion.Scope) error {
-	out.IP = in.IP
+	*out = *(*core.HostIP)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4535,7 +4089,7 @@ func Convert_v1_HostIP_To_core_HostIP(in *corev1.HostIP, out *core.HostIP, s con
 }
 
 func autoConvert_core_HostIP_To_v1_HostIP(in *core.HostIP, out *corev1.HostIP, s conversion.Scope) error {
-	out.IP = in.IP
+	*out = *(*corev1.HostIP)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4545,8 +4099,7 @@ func Convert_core_HostIP_To_v1_HostIP(in *core.HostIP, out *corev1.HostIP, s con
 }
 
 func autoConvert_v1_HostPathVolumeSource_To_core_HostPathVolumeSource(in *corev1.HostPathVolumeSource, out *core.HostPathVolumeSource, s conversion.Scope) error {
-	out.Path = in.Path
-	out.Type = (*core.HostPathType)(unsafe.Pointer(in.Type))
+	*out = *(*core.HostPathVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4556,8 +4109,7 @@ func Convert_v1_HostPathVolumeSource_To_core_HostPathVolumeSource(in *corev1.Hos
 }
 
 func autoConvert_core_HostPathVolumeSource_To_v1_HostPathVolumeSource(in *core.HostPathVolumeSource, out *corev1.HostPathVolumeSource, s conversion.Scope) error {
-	out.Path = in.Path
-	out.Type = (*corev1.HostPathType)(unsafe.Pointer(in.Type))
+	*out = *(*corev1.HostPathVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4567,17 +4119,7 @@ func Convert_core_HostPathVolumeSource_To_v1_HostPathVolumeSource(in *core.HostP
 }
 
 func autoConvert_v1_ISCSIPersistentVolumeSource_To_core_ISCSIPersistentVolumeSource(in *corev1.ISCSIPersistentVolumeSource, out *core.ISCSIPersistentVolumeSource, s conversion.Scope) error {
-	out.TargetPortal = in.TargetPortal
-	out.IQN = in.IQN
-	out.Lun = in.Lun
-	out.ISCSIInterface = in.ISCSIInterface
-	out.FSType = in.FSType
-	out.ReadOnly = in.ReadOnly
-	out.Portals = *(*[]string)(unsafe.Pointer(&in.Portals))
-	out.DiscoveryCHAPAuth = in.DiscoveryCHAPAuth
-	out.SessionCHAPAuth = in.SessionCHAPAuth
-	out.SecretRef = (*core.SecretReference)(unsafe.Pointer(in.SecretRef))
-	out.InitiatorName = (*string)(unsafe.Pointer(in.InitiatorName))
+	*out = *(*core.ISCSIPersistentVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4587,17 +4129,7 @@ func Convert_v1_ISCSIPersistentVolumeSource_To_core_ISCSIPersistentVolumeSource(
 }
 
 func autoConvert_core_ISCSIPersistentVolumeSource_To_v1_ISCSIPersistentVolumeSource(in *core.ISCSIPersistentVolumeSource, out *corev1.ISCSIPersistentVolumeSource, s conversion.Scope) error {
-	out.TargetPortal = in.TargetPortal
-	out.IQN = in.IQN
-	out.Lun = in.Lun
-	out.ISCSIInterface = in.ISCSIInterface
-	out.FSType = in.FSType
-	out.ReadOnly = in.ReadOnly
-	out.Portals = *(*[]string)(unsafe.Pointer(&in.Portals))
-	out.DiscoveryCHAPAuth = in.DiscoveryCHAPAuth
-	out.SessionCHAPAuth = in.SessionCHAPAuth
-	out.SecretRef = (*corev1.SecretReference)(unsafe.Pointer(in.SecretRef))
-	out.InitiatorName = (*string)(unsafe.Pointer(in.InitiatorName))
+	*out = *(*corev1.ISCSIPersistentVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4607,17 +4139,7 @@ func Convert_core_ISCSIPersistentVolumeSource_To_v1_ISCSIPersistentVolumeSource(
 }
 
 func autoConvert_v1_ISCSIVolumeSource_To_core_ISCSIVolumeSource(in *corev1.ISCSIVolumeSource, out *core.ISCSIVolumeSource, s conversion.Scope) error {
-	out.TargetPortal = in.TargetPortal
-	out.IQN = in.IQN
-	out.Lun = in.Lun
-	out.ISCSIInterface = in.ISCSIInterface
-	out.FSType = in.FSType
-	out.ReadOnly = in.ReadOnly
-	out.Portals = *(*[]string)(unsafe.Pointer(&in.Portals))
-	out.DiscoveryCHAPAuth = in.DiscoveryCHAPAuth
-	out.SessionCHAPAuth = in.SessionCHAPAuth
-	out.SecretRef = (*core.LocalObjectReference)(unsafe.Pointer(in.SecretRef))
-	out.InitiatorName = (*string)(unsafe.Pointer(in.InitiatorName))
+	*out = *(*core.ISCSIVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4627,17 +4149,7 @@ func Convert_v1_ISCSIVolumeSource_To_core_ISCSIVolumeSource(in *corev1.ISCSIVolu
 }
 
 func autoConvert_core_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in *core.ISCSIVolumeSource, out *corev1.ISCSIVolumeSource, s conversion.Scope) error {
-	out.TargetPortal = in.TargetPortal
-	out.IQN = in.IQN
-	out.Lun = in.Lun
-	out.ISCSIInterface = in.ISCSIInterface
-	out.FSType = in.FSType
-	out.ReadOnly = in.ReadOnly
-	out.Portals = *(*[]string)(unsafe.Pointer(&in.Portals))
-	out.DiscoveryCHAPAuth = in.DiscoveryCHAPAuth
-	out.SessionCHAPAuth = in.SessionCHAPAuth
-	out.SecretRef = (*corev1.LocalObjectReference)(unsafe.Pointer(in.SecretRef))
-	out.InitiatorName = (*string)(unsafe.Pointer(in.InitiatorName))
+	*out = *(*corev1.ISCSIVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4647,8 +4159,7 @@ func Convert_core_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in *core.ISCSIVolume
 }
 
 func autoConvert_v1_ImageVolumeSource_To_core_ImageVolumeSource(in *corev1.ImageVolumeSource, out *core.ImageVolumeSource, s conversion.Scope) error {
-	out.Reference = in.Reference
-	out.PullPolicy = core.PullPolicy(in.PullPolicy)
+	*out = *(*core.ImageVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4658,8 +4169,7 @@ func Convert_v1_ImageVolumeSource_To_core_ImageVolumeSource(in *corev1.ImageVolu
 }
 
 func autoConvert_core_ImageVolumeSource_To_v1_ImageVolumeSource(in *core.ImageVolumeSource, out *corev1.ImageVolumeSource, s conversion.Scope) error {
-	out.Reference = in.Reference
-	out.PullPolicy = corev1.PullPolicy(in.PullPolicy)
+	*out = *(*corev1.ImageVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4669,7 +4179,7 @@ func Convert_core_ImageVolumeSource_To_v1_ImageVolumeSource(in *core.ImageVolume
 }
 
 func autoConvert_v1_ImageVolumeStatus_To_core_ImageVolumeStatus(in *corev1.ImageVolumeStatus, out *core.ImageVolumeStatus, s conversion.Scope) error {
-	out.ImageRef = in.ImageRef
+	*out = *(*core.ImageVolumeStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4679,7 +4189,7 @@ func Convert_v1_ImageVolumeStatus_To_core_ImageVolumeStatus(in *corev1.ImageVolu
 }
 
 func autoConvert_core_ImageVolumeStatus_To_v1_ImageVolumeStatus(in *core.ImageVolumeStatus, out *corev1.ImageVolumeStatus, s conversion.Scope) error {
-	out.ImageRef = in.ImageRef
+	*out = *(*corev1.ImageVolumeStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4689,9 +4199,7 @@ func Convert_core_ImageVolumeStatus_To_v1_ImageVolumeStatus(in *core.ImageVolume
 }
 
 func autoConvert_v1_KeyToPath_To_core_KeyToPath(in *corev1.KeyToPath, out *core.KeyToPath, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Path = in.Path
-	out.Mode = (*int32)(unsafe.Pointer(in.Mode))
+	*out = *(*core.KeyToPath)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4701,9 +4209,7 @@ func Convert_v1_KeyToPath_To_core_KeyToPath(in *corev1.KeyToPath, out *core.KeyT
 }
 
 func autoConvert_core_KeyToPath_To_v1_KeyToPath(in *core.KeyToPath, out *corev1.KeyToPath, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Path = in.Path
-	out.Mode = (*int32)(unsafe.Pointer(in.Mode))
+	*out = *(*corev1.KeyToPath)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4713,9 +4219,7 @@ func Convert_core_KeyToPath_To_v1_KeyToPath(in *core.KeyToPath, out *corev1.KeyT
 }
 
 func autoConvert_v1_Lifecycle_To_core_Lifecycle(in *corev1.Lifecycle, out *core.Lifecycle, s conversion.Scope) error {
-	out.PostStart = (*core.LifecycleHandler)(unsafe.Pointer(in.PostStart))
-	out.PreStop = (*core.LifecycleHandler)(unsafe.Pointer(in.PreStop))
-	out.StopSignal = (*core.Signal)(unsafe.Pointer(in.StopSignal))
+	*out = *(*core.Lifecycle)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4725,9 +4229,7 @@ func Convert_v1_Lifecycle_To_core_Lifecycle(in *corev1.Lifecycle, out *core.Life
 }
 
 func autoConvert_core_Lifecycle_To_v1_Lifecycle(in *core.Lifecycle, out *corev1.Lifecycle, s conversion.Scope) error {
-	out.PostStart = (*corev1.LifecycleHandler)(unsafe.Pointer(in.PostStart))
-	out.PreStop = (*corev1.LifecycleHandler)(unsafe.Pointer(in.PreStop))
-	out.StopSignal = (*corev1.Signal)(unsafe.Pointer(in.StopSignal))
+	*out = *(*corev1.Lifecycle)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4737,10 +4239,7 @@ func Convert_core_Lifecycle_To_v1_Lifecycle(in *core.Lifecycle, out *corev1.Life
 }
 
 func autoConvert_v1_LifecycleHandler_To_core_LifecycleHandler(in *corev1.LifecycleHandler, out *core.LifecycleHandler, s conversion.Scope) error {
-	out.Exec = (*core.ExecAction)(unsafe.Pointer(in.Exec))
-	out.HTTPGet = (*core.HTTPGetAction)(unsafe.Pointer(in.HTTPGet))
-	out.TCPSocket = (*core.TCPSocketAction)(unsafe.Pointer(in.TCPSocket))
-	out.Sleep = (*core.SleepAction)(unsafe.Pointer(in.Sleep))
+	*out = *(*core.LifecycleHandler)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4750,10 +4249,7 @@ func Convert_v1_LifecycleHandler_To_core_LifecycleHandler(in *corev1.LifecycleHa
 }
 
 func autoConvert_core_LifecycleHandler_To_v1_LifecycleHandler(in *core.LifecycleHandler, out *corev1.LifecycleHandler, s conversion.Scope) error {
-	out.Exec = (*corev1.ExecAction)(unsafe.Pointer(in.Exec))
-	out.HTTPGet = (*corev1.HTTPGetAction)(unsafe.Pointer(in.HTTPGet))
-	out.TCPSocket = (*corev1.TCPSocketAction)(unsafe.Pointer(in.TCPSocket))
-	out.Sleep = (*corev1.SleepAction)(unsafe.Pointer(in.Sleep))
+	*out = *(*corev1.LifecycleHandler)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4789,12 +4285,7 @@ func Convert_core_LimitRange_To_v1_LimitRange(in *core.LimitRange, out *corev1.L
 }
 
 func autoConvert_v1_LimitRangeItem_To_core_LimitRangeItem(in *corev1.LimitRangeItem, out *core.LimitRangeItem, s conversion.Scope) error {
-	out.Type = core.LimitType(in.Type)
-	out.Max = *(*core.ResourceList)(unsafe.Pointer(&in.Max))
-	out.Min = *(*core.ResourceList)(unsafe.Pointer(&in.Min))
-	out.Default = *(*core.ResourceList)(unsafe.Pointer(&in.Default))
-	out.DefaultRequest = *(*core.ResourceList)(unsafe.Pointer(&in.DefaultRequest))
-	out.MaxLimitRequestRatio = *(*core.ResourceList)(unsafe.Pointer(&in.MaxLimitRequestRatio))
+	*out = *(*core.LimitRangeItem)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4804,12 +4295,7 @@ func Convert_v1_LimitRangeItem_To_core_LimitRangeItem(in *corev1.LimitRangeItem,
 }
 
 func autoConvert_core_LimitRangeItem_To_v1_LimitRangeItem(in *core.LimitRangeItem, out *corev1.LimitRangeItem, s conversion.Scope) error {
-	out.Type = corev1.LimitType(in.Type)
-	out.Max = *(*corev1.ResourceList)(unsafe.Pointer(&in.Max))
-	out.Min = *(*corev1.ResourceList)(unsafe.Pointer(&in.Min))
-	out.Default = *(*corev1.ResourceList)(unsafe.Pointer(&in.Default))
-	out.DefaultRequest = *(*corev1.ResourceList)(unsafe.Pointer(&in.DefaultRequest))
-	out.MaxLimitRequestRatio = *(*corev1.ResourceList)(unsafe.Pointer(&in.MaxLimitRequestRatio))
+	*out = *(*corev1.LimitRangeItem)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4841,7 +4327,7 @@ func Convert_core_LimitRangeList_To_v1_LimitRangeList(in *core.LimitRangeList, o
 }
 
 func autoConvert_v1_LimitRangeSpec_To_core_LimitRangeSpec(in *corev1.LimitRangeSpec, out *core.LimitRangeSpec, s conversion.Scope) error {
-	out.Limits = *(*[]core.LimitRangeItem)(unsafe.Pointer(&in.Limits))
+	*out = *(*core.LimitRangeSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4851,7 +4337,7 @@ func Convert_v1_LimitRangeSpec_To_core_LimitRangeSpec(in *corev1.LimitRangeSpec,
 }
 
 func autoConvert_core_LimitRangeSpec_To_v1_LimitRangeSpec(in *core.LimitRangeSpec, out *corev1.LimitRangeSpec, s conversion.Scope) error {
-	out.Limits = *(*[]corev1.LimitRangeItem)(unsafe.Pointer(&in.Limits))
+	*out = *(*corev1.LimitRangeSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4861,9 +4347,7 @@ func Convert_core_LimitRangeSpec_To_v1_LimitRangeSpec(in *core.LimitRangeSpec, o
 }
 
 func autoConvert_v1_LinuxContainerUser_To_core_LinuxContainerUser(in *corev1.LinuxContainerUser, out *core.LinuxContainerUser, s conversion.Scope) error {
-	out.UID = in.UID
-	out.GID = in.GID
-	out.SupplementalGroups = *(*[]int64)(unsafe.Pointer(&in.SupplementalGroups))
+	*out = *(*core.LinuxContainerUser)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4873,9 +4357,7 @@ func Convert_v1_LinuxContainerUser_To_core_LinuxContainerUser(in *corev1.LinuxCo
 }
 
 func autoConvert_core_LinuxContainerUser_To_v1_LinuxContainerUser(in *core.LinuxContainerUser, out *corev1.LinuxContainerUser, s conversion.Scope) error {
-	out.UID = in.UID
-	out.GID = in.GID
-	out.SupplementalGroups = *(*[]int64)(unsafe.Pointer(&in.SupplementalGroups))
+	*out = *(*corev1.LinuxContainerUser)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4927,10 +4409,7 @@ func Convert_core_List_To_v1_List(in *core.List, out *corev1.List, s conversion.
 }
 
 func autoConvert_v1_LoadBalancerIngress_To_core_LoadBalancerIngress(in *corev1.LoadBalancerIngress, out *core.LoadBalancerIngress, s conversion.Scope) error {
-	out.IP = in.IP
-	out.Hostname = in.Hostname
-	out.IPMode = (*core.LoadBalancerIPMode)(unsafe.Pointer(in.IPMode))
-	out.Ports = *(*[]core.PortStatus)(unsafe.Pointer(&in.Ports))
+	*out = *(*core.LoadBalancerIngress)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4940,10 +4419,7 @@ func Convert_v1_LoadBalancerIngress_To_core_LoadBalancerIngress(in *corev1.LoadB
 }
 
 func autoConvert_core_LoadBalancerIngress_To_v1_LoadBalancerIngress(in *core.LoadBalancerIngress, out *corev1.LoadBalancerIngress, s conversion.Scope) error {
-	out.IP = in.IP
-	out.Hostname = in.Hostname
-	out.IPMode = (*corev1.LoadBalancerIPMode)(unsafe.Pointer(in.IPMode))
-	out.Ports = *(*[]corev1.PortStatus)(unsafe.Pointer(&in.Ports))
+	*out = *(*corev1.LoadBalancerIngress)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4953,7 +4429,7 @@ func Convert_core_LoadBalancerIngress_To_v1_LoadBalancerIngress(in *core.LoadBal
 }
 
 func autoConvert_v1_LoadBalancerStatus_To_core_LoadBalancerStatus(in *corev1.LoadBalancerStatus, out *core.LoadBalancerStatus, s conversion.Scope) error {
-	out.Ingress = *(*[]core.LoadBalancerIngress)(unsafe.Pointer(&in.Ingress))
+	*out = *(*core.LoadBalancerStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4963,7 +4439,7 @@ func Convert_v1_LoadBalancerStatus_To_core_LoadBalancerStatus(in *corev1.LoadBal
 }
 
 func autoConvert_core_LoadBalancerStatus_To_v1_LoadBalancerStatus(in *core.LoadBalancerStatus, out *corev1.LoadBalancerStatus, s conversion.Scope) error {
-	out.Ingress = *(*[]corev1.LoadBalancerIngress)(unsafe.Pointer(&in.Ingress))
+	*out = *(*corev1.LoadBalancerStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4973,7 +4449,7 @@ func Convert_core_LoadBalancerStatus_To_v1_LoadBalancerStatus(in *core.LoadBalan
 }
 
 func autoConvert_v1_LocalObjectReference_To_core_LocalObjectReference(in *corev1.LocalObjectReference, out *core.LocalObjectReference, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*core.LocalObjectReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4983,7 +4459,7 @@ func Convert_v1_LocalObjectReference_To_core_LocalObjectReference(in *corev1.Loc
 }
 
 func autoConvert_core_LocalObjectReference_To_v1_LocalObjectReference(in *core.LocalObjectReference, out *corev1.LocalObjectReference, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*corev1.LocalObjectReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -4993,8 +4469,7 @@ func Convert_core_LocalObjectReference_To_v1_LocalObjectReference(in *core.Local
 }
 
 func autoConvert_v1_LocalVolumeSource_To_core_LocalVolumeSource(in *corev1.LocalVolumeSource, out *core.LocalVolumeSource, s conversion.Scope) error {
-	out.Path = in.Path
-	out.FSType = (*string)(unsafe.Pointer(in.FSType))
+	*out = *(*core.LocalVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5004,8 +4479,7 @@ func Convert_v1_LocalVolumeSource_To_core_LocalVolumeSource(in *corev1.LocalVolu
 }
 
 func autoConvert_core_LocalVolumeSource_To_v1_LocalVolumeSource(in *core.LocalVolumeSource, out *corev1.LocalVolumeSource, s conversion.Scope) error {
-	out.Path = in.Path
-	out.FSType = (*string)(unsafe.Pointer(in.FSType))
+	*out = *(*corev1.LocalVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5015,8 +4489,7 @@ func Convert_core_LocalVolumeSource_To_v1_LocalVolumeSource(in *core.LocalVolume
 }
 
 func autoConvert_v1_ModifyVolumeStatus_To_core_ModifyVolumeStatus(in *corev1.ModifyVolumeStatus, out *core.ModifyVolumeStatus, s conversion.Scope) error {
-	out.TargetVolumeAttributesClassName = in.TargetVolumeAttributesClassName
-	out.Status = core.PersistentVolumeClaimModifyVolumeStatus(in.Status)
+	*out = *(*core.ModifyVolumeStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5026,8 +4499,7 @@ func Convert_v1_ModifyVolumeStatus_To_core_ModifyVolumeStatus(in *corev1.ModifyV
 }
 
 func autoConvert_core_ModifyVolumeStatus_To_v1_ModifyVolumeStatus(in *core.ModifyVolumeStatus, out *corev1.ModifyVolumeStatus, s conversion.Scope) error {
-	out.TargetVolumeAttributesClassName = in.TargetVolumeAttributesClassName
-	out.Status = corev1.PersistentVolumeClaimModifyVolumeStatus(in.Status)
+	*out = *(*corev1.ModifyVolumeStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5037,9 +4509,7 @@ func Convert_core_ModifyVolumeStatus_To_v1_ModifyVolumeStatus(in *core.ModifyVol
 }
 
 func autoConvert_v1_NFSVolumeSource_To_core_NFSVolumeSource(in *corev1.NFSVolumeSource, out *core.NFSVolumeSource, s conversion.Scope) error {
-	out.Server = in.Server
-	out.Path = in.Path
-	out.ReadOnly = in.ReadOnly
+	*out = *(*core.NFSVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5049,9 +4519,7 @@ func Convert_v1_NFSVolumeSource_To_core_NFSVolumeSource(in *corev1.NFSVolumeSour
 }
 
 func autoConvert_core_NFSVolumeSource_To_v1_NFSVolumeSource(in *core.NFSVolumeSource, out *corev1.NFSVolumeSource, s conversion.Scope) error {
-	out.Server = in.Server
-	out.Path = in.Path
-	out.ReadOnly = in.ReadOnly
+	*out = *(*corev1.NFSVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5093,11 +4561,7 @@ func Convert_core_Namespace_To_v1_Namespace(in *core.Namespace, out *corev1.Name
 }
 
 func autoConvert_v1_NamespaceCondition_To_core_NamespaceCondition(in *corev1.NamespaceCondition, out *core.NamespaceCondition, s conversion.Scope) error {
-	out.Type = core.NamespaceConditionType(in.Type)
-	out.Status = core.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*core.NamespaceCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5107,11 +4571,7 @@ func Convert_v1_NamespaceCondition_To_core_NamespaceCondition(in *corev1.Namespa
 }
 
 func autoConvert_core_NamespaceCondition_To_v1_NamespaceCondition(in *core.NamespaceCondition, out *corev1.NamespaceCondition, s conversion.Scope) error {
-	out.Type = corev1.NamespaceConditionType(in.Type)
-	out.Status = corev1.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*corev1.NamespaceCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5143,7 +4603,7 @@ func Convert_core_NamespaceList_To_v1_NamespaceList(in *core.NamespaceList, out 
 }
 
 func autoConvert_v1_NamespaceSpec_To_core_NamespaceSpec(in *corev1.NamespaceSpec, out *core.NamespaceSpec, s conversion.Scope) error {
-	out.Finalizers = *(*[]core.FinalizerName)(unsafe.Pointer(&in.Finalizers))
+	*out = *(*core.NamespaceSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5153,7 +4613,7 @@ func Convert_v1_NamespaceSpec_To_core_NamespaceSpec(in *corev1.NamespaceSpec, ou
 }
 
 func autoConvert_core_NamespaceSpec_To_v1_NamespaceSpec(in *core.NamespaceSpec, out *corev1.NamespaceSpec, s conversion.Scope) error {
-	out.Finalizers = *(*[]corev1.FinalizerName)(unsafe.Pointer(&in.Finalizers))
+	*out = *(*corev1.NamespaceSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5163,8 +4623,7 @@ func Convert_core_NamespaceSpec_To_v1_NamespaceSpec(in *core.NamespaceSpec, out 
 }
 
 func autoConvert_v1_NamespaceStatus_To_core_NamespaceStatus(in *corev1.NamespaceStatus, out *core.NamespaceStatus, s conversion.Scope) error {
-	out.Phase = core.NamespacePhase(in.Phase)
-	out.Conditions = *(*[]core.NamespaceCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*core.NamespaceStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5174,8 +4633,7 @@ func Convert_v1_NamespaceStatus_To_core_NamespaceStatus(in *corev1.NamespaceStat
 }
 
 func autoConvert_core_NamespaceStatus_To_v1_NamespaceStatus(in *core.NamespaceStatus, out *corev1.NamespaceStatus, s conversion.Scope) error {
-	out.Phase = corev1.NamespacePhase(in.Phase)
-	out.Conditions = *(*[]corev1.NamespaceCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*corev1.NamespaceStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5217,8 +4675,7 @@ func Convert_core_Node_To_v1_Node(in *core.Node, out *corev1.Node, s conversion.
 }
 
 func autoConvert_v1_NodeAddress_To_core_NodeAddress(in *corev1.NodeAddress, out *core.NodeAddress, s conversion.Scope) error {
-	out.Type = core.NodeAddressType(in.Type)
-	out.Address = in.Address
+	*out = *(*core.NodeAddress)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5228,8 +4685,7 @@ func Convert_v1_NodeAddress_To_core_NodeAddress(in *corev1.NodeAddress, out *cor
 }
 
 func autoConvert_core_NodeAddress_To_v1_NodeAddress(in *core.NodeAddress, out *corev1.NodeAddress, s conversion.Scope) error {
-	out.Type = corev1.NodeAddressType(in.Type)
-	out.Address = in.Address
+	*out = *(*corev1.NodeAddress)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5239,8 +4695,7 @@ func Convert_core_NodeAddress_To_v1_NodeAddress(in *core.NodeAddress, out *corev
 }
 
 func autoConvert_v1_NodeAffinity_To_core_NodeAffinity(in *corev1.NodeAffinity, out *core.NodeAffinity, s conversion.Scope) error {
-	out.RequiredDuringSchedulingIgnoredDuringExecution = (*core.NodeSelector)(unsafe.Pointer(in.RequiredDuringSchedulingIgnoredDuringExecution))
-	out.PreferredDuringSchedulingIgnoredDuringExecution = *(*[]core.PreferredSchedulingTerm)(unsafe.Pointer(&in.PreferredDuringSchedulingIgnoredDuringExecution))
+	*out = *(*core.NodeAffinity)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5250,8 +4705,7 @@ func Convert_v1_NodeAffinity_To_core_NodeAffinity(in *corev1.NodeAffinity, out *
 }
 
 func autoConvert_core_NodeAffinity_To_v1_NodeAffinity(in *core.NodeAffinity, out *corev1.NodeAffinity, s conversion.Scope) error {
-	out.RequiredDuringSchedulingIgnoredDuringExecution = (*corev1.NodeSelector)(unsafe.Pointer(in.RequiredDuringSchedulingIgnoredDuringExecution))
-	out.PreferredDuringSchedulingIgnoredDuringExecution = *(*[]corev1.PreferredSchedulingTerm)(unsafe.Pointer(&in.PreferredDuringSchedulingIgnoredDuringExecution))
+	*out = *(*corev1.NodeAffinity)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5261,9 +4715,7 @@ func Convert_core_NodeAffinity_To_v1_NodeAffinity(in *core.NodeAffinity, out *co
 }
 
 func autoConvert_v1_NodeAllocatableResourceClaimStatus_To_core_NodeAllocatableResourceClaimStatus(in *corev1.NodeAllocatableResourceClaimStatus, out *core.NodeAllocatableResourceClaimStatus, s conversion.Scope) error {
-	out.ResourceClaimName = in.ResourceClaimName
-	out.Containers = *(*[]string)(unsafe.Pointer(&in.Containers))
-	out.Resources = *(*map[core.ResourceName]resource.Quantity)(unsafe.Pointer(&in.Resources))
+	*out = *(*core.NodeAllocatableResourceClaimStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5273,9 +4725,7 @@ func Convert_v1_NodeAllocatableResourceClaimStatus_To_core_NodeAllocatableResour
 }
 
 func autoConvert_core_NodeAllocatableResourceClaimStatus_To_v1_NodeAllocatableResourceClaimStatus(in *core.NodeAllocatableResourceClaimStatus, out *corev1.NodeAllocatableResourceClaimStatus, s conversion.Scope) error {
-	out.ResourceClaimName = in.ResourceClaimName
-	out.Containers = *(*[]string)(unsafe.Pointer(&in.Containers))
-	out.Resources = *(*map[corev1.ResourceName]resource.Quantity)(unsafe.Pointer(&in.Resources))
+	*out = *(*corev1.NodeAllocatableResourceClaimStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5285,12 +4735,7 @@ func Convert_core_NodeAllocatableResourceClaimStatus_To_v1_NodeAllocatableResour
 }
 
 func autoConvert_v1_NodeCondition_To_core_NodeCondition(in *corev1.NodeCondition, out *core.NodeCondition, s conversion.Scope) error {
-	out.Type = core.NodeConditionType(in.Type)
-	out.Status = core.ConditionStatus(in.Status)
-	out.LastHeartbeatTime = in.LastHeartbeatTime
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*core.NodeCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5300,12 +4745,7 @@ func Convert_v1_NodeCondition_To_core_NodeCondition(in *corev1.NodeCondition, ou
 }
 
 func autoConvert_core_NodeCondition_To_v1_NodeCondition(in *core.NodeCondition, out *corev1.NodeCondition, s conversion.Scope) error {
-	out.Type = corev1.NodeConditionType(in.Type)
-	out.Status = corev1.ConditionStatus(in.Status)
-	out.LastHeartbeatTime = in.LastHeartbeatTime
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*corev1.NodeCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5315,7 +4755,7 @@ func Convert_core_NodeCondition_To_v1_NodeCondition(in *core.NodeCondition, out 
 }
 
 func autoConvert_v1_NodeConfigSource_To_core_NodeConfigSource(in *corev1.NodeConfigSource, out *core.NodeConfigSource, s conversion.Scope) error {
-	out.ConfigMap = (*core.ConfigMapNodeConfigSource)(unsafe.Pointer(in.ConfigMap))
+	*out = *(*core.NodeConfigSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5325,7 +4765,7 @@ func Convert_v1_NodeConfigSource_To_core_NodeConfigSource(in *corev1.NodeConfigS
 }
 
 func autoConvert_core_NodeConfigSource_To_v1_NodeConfigSource(in *core.NodeConfigSource, out *corev1.NodeConfigSource, s conversion.Scope) error {
-	out.ConfigMap = (*corev1.ConfigMapNodeConfigSource)(unsafe.Pointer(in.ConfigMap))
+	*out = *(*corev1.NodeConfigSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5335,10 +4775,7 @@ func Convert_core_NodeConfigSource_To_v1_NodeConfigSource(in *core.NodeConfigSou
 }
 
 func autoConvert_v1_NodeConfigStatus_To_core_NodeConfigStatus(in *corev1.NodeConfigStatus, out *core.NodeConfigStatus, s conversion.Scope) error {
-	out.Assigned = (*core.NodeConfigSource)(unsafe.Pointer(in.Assigned))
-	out.Active = (*core.NodeConfigSource)(unsafe.Pointer(in.Active))
-	out.LastKnownGood = (*core.NodeConfigSource)(unsafe.Pointer(in.LastKnownGood))
-	out.Error = in.Error
+	*out = *(*core.NodeConfigStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5348,10 +4785,7 @@ func Convert_v1_NodeConfigStatus_To_core_NodeConfigStatus(in *corev1.NodeConfigS
 }
 
 func autoConvert_core_NodeConfigStatus_To_v1_NodeConfigStatus(in *core.NodeConfigStatus, out *corev1.NodeConfigStatus, s conversion.Scope) error {
-	out.Assigned = (*corev1.NodeConfigSource)(unsafe.Pointer(in.Assigned))
-	out.Active = (*corev1.NodeConfigSource)(unsafe.Pointer(in.Active))
-	out.LastKnownGood = (*corev1.NodeConfigSource)(unsafe.Pointer(in.LastKnownGood))
-	out.Error = in.Error
+	*out = *(*corev1.NodeConfigStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5361,9 +4795,7 @@ func Convert_core_NodeConfigStatus_To_v1_NodeConfigStatus(in *core.NodeConfigSta
 }
 
 func autoConvert_v1_NodeDaemonEndpoints_To_core_NodeDaemonEndpoints(in *corev1.NodeDaemonEndpoints, out *core.NodeDaemonEndpoints, s conversion.Scope) error {
-	if err := Convert_v1_DaemonEndpoint_To_core_DaemonEndpoint(&in.KubeletEndpoint, &out.KubeletEndpoint, s); err != nil {
-		return err
-	}
+	*out = *(*core.NodeDaemonEndpoints)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5373,9 +4805,7 @@ func Convert_v1_NodeDaemonEndpoints_To_core_NodeDaemonEndpoints(in *corev1.NodeD
 }
 
 func autoConvert_core_NodeDaemonEndpoints_To_v1_NodeDaemonEndpoints(in *core.NodeDaemonEndpoints, out *corev1.NodeDaemonEndpoints, s conversion.Scope) error {
-	if err := Convert_core_DaemonEndpoint_To_v1_DaemonEndpoint(&in.KubeletEndpoint, &out.KubeletEndpoint, s); err != nil {
-		return err
-	}
+	*out = *(*corev1.NodeDaemonEndpoints)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5385,7 +4815,7 @@ func Convert_core_NodeDaemonEndpoints_To_v1_NodeDaemonEndpoints(in *core.NodeDae
 }
 
 func autoConvert_v1_NodeFeatures_To_core_NodeFeatures(in *corev1.NodeFeatures, out *core.NodeFeatures, s conversion.Scope) error {
-	out.SupplementalGroupsPolicy = (*bool)(unsafe.Pointer(in.SupplementalGroupsPolicy))
+	*out = *(*core.NodeFeatures)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5395,7 +4825,7 @@ func Convert_v1_NodeFeatures_To_core_NodeFeatures(in *corev1.NodeFeatures, out *
 }
 
 func autoConvert_core_NodeFeatures_To_v1_NodeFeatures(in *core.NodeFeatures, out *corev1.NodeFeatures, s conversion.Scope) error {
-	out.SupplementalGroupsPolicy = (*bool)(unsafe.Pointer(in.SupplementalGroupsPolicy))
+	*out = *(*corev1.NodeFeatures)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5485,8 +4915,7 @@ func Convert_url_Values_To_v1_NodeProxyOptions(in *url.Values, out *corev1.NodeP
 }
 
 func autoConvert_v1_NodeRuntimeHandler_To_core_NodeRuntimeHandler(in *corev1.NodeRuntimeHandler, out *core.NodeRuntimeHandler, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Features = (*core.NodeRuntimeHandlerFeatures)(unsafe.Pointer(in.Features))
+	*out = *(*core.NodeRuntimeHandler)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5496,8 +4925,7 @@ func Convert_v1_NodeRuntimeHandler_To_core_NodeRuntimeHandler(in *corev1.NodeRun
 }
 
 func autoConvert_core_NodeRuntimeHandler_To_v1_NodeRuntimeHandler(in *core.NodeRuntimeHandler, out *corev1.NodeRuntimeHandler, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Features = (*corev1.NodeRuntimeHandlerFeatures)(unsafe.Pointer(in.Features))
+	*out = *(*corev1.NodeRuntimeHandler)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5507,8 +4935,7 @@ func Convert_core_NodeRuntimeHandler_To_v1_NodeRuntimeHandler(in *core.NodeRunti
 }
 
 func autoConvert_v1_NodeRuntimeHandlerFeatures_To_core_NodeRuntimeHandlerFeatures(in *corev1.NodeRuntimeHandlerFeatures, out *core.NodeRuntimeHandlerFeatures, s conversion.Scope) error {
-	out.RecursiveReadOnlyMounts = (*bool)(unsafe.Pointer(in.RecursiveReadOnlyMounts))
-	out.UserNamespaces = (*bool)(unsafe.Pointer(in.UserNamespaces))
+	*out = *(*core.NodeRuntimeHandlerFeatures)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5518,8 +4945,7 @@ func Convert_v1_NodeRuntimeHandlerFeatures_To_core_NodeRuntimeHandlerFeatures(in
 }
 
 func autoConvert_core_NodeRuntimeHandlerFeatures_To_v1_NodeRuntimeHandlerFeatures(in *core.NodeRuntimeHandlerFeatures, out *corev1.NodeRuntimeHandlerFeatures, s conversion.Scope) error {
-	out.RecursiveReadOnlyMounts = (*bool)(unsafe.Pointer(in.RecursiveReadOnlyMounts))
-	out.UserNamespaces = (*bool)(unsafe.Pointer(in.UserNamespaces))
+	*out = *(*corev1.NodeRuntimeHandlerFeatures)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5529,7 +4955,7 @@ func Convert_core_NodeRuntimeHandlerFeatures_To_v1_NodeRuntimeHandlerFeatures(in
 }
 
 func autoConvert_v1_NodeSelector_To_core_NodeSelector(in *corev1.NodeSelector, out *core.NodeSelector, s conversion.Scope) error {
-	out.NodeSelectorTerms = *(*[]core.NodeSelectorTerm)(unsafe.Pointer(&in.NodeSelectorTerms))
+	*out = *(*core.NodeSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5539,7 +4965,7 @@ func Convert_v1_NodeSelector_To_core_NodeSelector(in *corev1.NodeSelector, out *
 }
 
 func autoConvert_core_NodeSelector_To_v1_NodeSelector(in *core.NodeSelector, out *corev1.NodeSelector, s conversion.Scope) error {
-	out.NodeSelectorTerms = *(*[]corev1.NodeSelectorTerm)(unsafe.Pointer(&in.NodeSelectorTerms))
+	*out = *(*corev1.NodeSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5549,9 +4975,7 @@ func Convert_core_NodeSelector_To_v1_NodeSelector(in *core.NodeSelector, out *co
 }
 
 func autoConvert_v1_NodeSelectorRequirement_To_core_NodeSelectorRequirement(in *corev1.NodeSelectorRequirement, out *core.NodeSelectorRequirement, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Operator = core.NodeSelectorOperator(in.Operator)
-	out.Values = *(*[]string)(unsafe.Pointer(&in.Values))
+	*out = *(*core.NodeSelectorRequirement)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5561,9 +4985,7 @@ func Convert_v1_NodeSelectorRequirement_To_core_NodeSelectorRequirement(in *core
 }
 
 func autoConvert_core_NodeSelectorRequirement_To_v1_NodeSelectorRequirement(in *core.NodeSelectorRequirement, out *corev1.NodeSelectorRequirement, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Operator = corev1.NodeSelectorOperator(in.Operator)
-	out.Values = *(*[]string)(unsafe.Pointer(&in.Values))
+	*out = *(*corev1.NodeSelectorRequirement)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5573,8 +4995,7 @@ func Convert_core_NodeSelectorRequirement_To_v1_NodeSelectorRequirement(in *core
 }
 
 func autoConvert_v1_NodeSelectorTerm_To_core_NodeSelectorTerm(in *corev1.NodeSelectorTerm, out *core.NodeSelectorTerm, s conversion.Scope) error {
-	out.MatchExpressions = *(*[]core.NodeSelectorRequirement)(unsafe.Pointer(&in.MatchExpressions))
-	out.MatchFields = *(*[]core.NodeSelectorRequirement)(unsafe.Pointer(&in.MatchFields))
+	*out = *(*core.NodeSelectorTerm)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5584,8 +5005,7 @@ func Convert_v1_NodeSelectorTerm_To_core_NodeSelectorTerm(in *corev1.NodeSelecto
 }
 
 func autoConvert_core_NodeSelectorTerm_To_v1_NodeSelectorTerm(in *core.NodeSelectorTerm, out *corev1.NodeSelectorTerm, s conversion.Scope) error {
-	out.MatchExpressions = *(*[]corev1.NodeSelectorRequirement)(unsafe.Pointer(&in.MatchExpressions))
-	out.MatchFields = *(*[]corev1.NodeSelectorRequirement)(unsafe.Pointer(&in.MatchFields))
+	*out = *(*corev1.NodeSelectorTerm)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5616,24 +5036,7 @@ func autoConvert_core_NodeSpec_To_v1_NodeSpec(in *core.NodeSpec, out *corev1.Nod
 }
 
 func autoConvert_v1_NodeStatus_To_core_NodeStatus(in *corev1.NodeStatus, out *core.NodeStatus, s conversion.Scope) error {
-	out.Capacity = *(*core.ResourceList)(unsafe.Pointer(&in.Capacity))
-	out.Allocatable = *(*core.ResourceList)(unsafe.Pointer(&in.Allocatable))
-	out.Phase = core.NodePhase(in.Phase)
-	out.Conditions = *(*[]core.NodeCondition)(unsafe.Pointer(&in.Conditions))
-	out.Addresses = *(*[]core.NodeAddress)(unsafe.Pointer(&in.Addresses))
-	if err := Convert_v1_NodeDaemonEndpoints_To_core_NodeDaemonEndpoints(&in.DaemonEndpoints, &out.DaemonEndpoints, s); err != nil {
-		return err
-	}
-	if err := Convert_v1_NodeSystemInfo_To_core_NodeSystemInfo(&in.NodeInfo, &out.NodeInfo, s); err != nil {
-		return err
-	}
-	out.Images = *(*[]core.ContainerImage)(unsafe.Pointer(&in.Images))
-	out.VolumesInUse = *(*[]core.UniqueVolumeName)(unsafe.Pointer(&in.VolumesInUse))
-	out.VolumesAttached = *(*[]core.AttachedVolume)(unsafe.Pointer(&in.VolumesAttached))
-	out.Config = (*core.NodeConfigStatus)(unsafe.Pointer(in.Config))
-	out.RuntimeHandlers = *(*[]core.NodeRuntimeHandler)(unsafe.Pointer(&in.RuntimeHandlers))
-	out.Features = (*core.NodeFeatures)(unsafe.Pointer(in.Features))
-	out.DeclaredFeatures = *(*[]string)(unsafe.Pointer(&in.DeclaredFeatures))
+	*out = *(*core.NodeStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5643,24 +5046,7 @@ func Convert_v1_NodeStatus_To_core_NodeStatus(in *corev1.NodeStatus, out *core.N
 }
 
 func autoConvert_core_NodeStatus_To_v1_NodeStatus(in *core.NodeStatus, out *corev1.NodeStatus, s conversion.Scope) error {
-	out.Capacity = *(*corev1.ResourceList)(unsafe.Pointer(&in.Capacity))
-	out.Allocatable = *(*corev1.ResourceList)(unsafe.Pointer(&in.Allocatable))
-	out.Phase = corev1.NodePhase(in.Phase)
-	out.Conditions = *(*[]corev1.NodeCondition)(unsafe.Pointer(&in.Conditions))
-	out.Addresses = *(*[]corev1.NodeAddress)(unsafe.Pointer(&in.Addresses))
-	if err := Convert_core_NodeDaemonEndpoints_To_v1_NodeDaemonEndpoints(&in.DaemonEndpoints, &out.DaemonEndpoints, s); err != nil {
-		return err
-	}
-	if err := Convert_core_NodeSystemInfo_To_v1_NodeSystemInfo(&in.NodeInfo, &out.NodeInfo, s); err != nil {
-		return err
-	}
-	out.Images = *(*[]corev1.ContainerImage)(unsafe.Pointer(&in.Images))
-	out.VolumesInUse = *(*[]corev1.UniqueVolumeName)(unsafe.Pointer(&in.VolumesInUse))
-	out.VolumesAttached = *(*[]corev1.AttachedVolume)(unsafe.Pointer(&in.VolumesAttached))
-	out.Config = (*corev1.NodeConfigStatus)(unsafe.Pointer(in.Config))
-	out.RuntimeHandlers = *(*[]corev1.NodeRuntimeHandler)(unsafe.Pointer(&in.RuntimeHandlers))
-	out.Features = (*corev1.NodeFeatures)(unsafe.Pointer(in.Features))
-	out.DeclaredFeatures = *(*[]string)(unsafe.Pointer(&in.DeclaredFeatures))
+	*out = *(*corev1.NodeStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5670,7 +5056,7 @@ func Convert_core_NodeStatus_To_v1_NodeStatus(in *core.NodeStatus, out *corev1.N
 }
 
 func autoConvert_v1_NodeSwapStatus_To_core_NodeSwapStatus(in *corev1.NodeSwapStatus, out *core.NodeSwapStatus, s conversion.Scope) error {
-	out.Capacity = (*int64)(unsafe.Pointer(in.Capacity))
+	*out = *(*core.NodeSwapStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5680,7 +5066,7 @@ func Convert_v1_NodeSwapStatus_To_core_NodeSwapStatus(in *corev1.NodeSwapStatus,
 }
 
 func autoConvert_core_NodeSwapStatus_To_v1_NodeSwapStatus(in *core.NodeSwapStatus, out *corev1.NodeSwapStatus, s conversion.Scope) error {
-	out.Capacity = (*int64)(unsafe.Pointer(in.Capacity))
+	*out = *(*corev1.NodeSwapStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5690,17 +5076,7 @@ func Convert_core_NodeSwapStatus_To_v1_NodeSwapStatus(in *core.NodeSwapStatus, o
 }
 
 func autoConvert_v1_NodeSystemInfo_To_core_NodeSystemInfo(in *corev1.NodeSystemInfo, out *core.NodeSystemInfo, s conversion.Scope) error {
-	out.MachineID = in.MachineID
-	out.SystemUUID = in.SystemUUID
-	out.BootID = in.BootID
-	out.KernelVersion = in.KernelVersion
-	out.OSImage = in.OSImage
-	out.ContainerRuntimeVersion = in.ContainerRuntimeVersion
-	out.KubeletVersion = in.KubeletVersion
-	out.KubeProxyVersion = in.KubeProxyVersion
-	out.OperatingSystem = in.OperatingSystem
-	out.Architecture = in.Architecture
-	out.Swap = (*core.NodeSwapStatus)(unsafe.Pointer(in.Swap))
+	*out = *(*core.NodeSystemInfo)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5710,17 +5086,7 @@ func Convert_v1_NodeSystemInfo_To_core_NodeSystemInfo(in *corev1.NodeSystemInfo,
 }
 
 func autoConvert_core_NodeSystemInfo_To_v1_NodeSystemInfo(in *core.NodeSystemInfo, out *corev1.NodeSystemInfo, s conversion.Scope) error {
-	out.MachineID = in.MachineID
-	out.SystemUUID = in.SystemUUID
-	out.BootID = in.BootID
-	out.KernelVersion = in.KernelVersion
-	out.OSImage = in.OSImage
-	out.ContainerRuntimeVersion = in.ContainerRuntimeVersion
-	out.KubeletVersion = in.KubeletVersion
-	out.KubeProxyVersion = in.KubeProxyVersion
-	out.OperatingSystem = in.OperatingSystem
-	out.Architecture = in.Architecture
-	out.Swap = (*corev1.NodeSwapStatus)(unsafe.Pointer(in.Swap))
+	*out = *(*corev1.NodeSystemInfo)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5730,8 +5096,7 @@ func Convert_core_NodeSystemInfo_To_v1_NodeSystemInfo(in *core.NodeSystemInfo, o
 }
 
 func autoConvert_v1_ObjectFieldSelector_To_core_ObjectFieldSelector(in *corev1.ObjectFieldSelector, out *core.ObjectFieldSelector, s conversion.Scope) error {
-	out.APIVersion = in.APIVersion
-	out.FieldPath = in.FieldPath
+	*out = *(*core.ObjectFieldSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5741,8 +5106,7 @@ func Convert_v1_ObjectFieldSelector_To_core_ObjectFieldSelector(in *corev1.Objec
 }
 
 func autoConvert_core_ObjectFieldSelector_To_v1_ObjectFieldSelector(in *core.ObjectFieldSelector, out *corev1.ObjectFieldSelector, s conversion.Scope) error {
-	out.APIVersion = in.APIVersion
-	out.FieldPath = in.FieldPath
+	*out = *(*corev1.ObjectFieldSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5752,13 +5116,7 @@ func Convert_core_ObjectFieldSelector_To_v1_ObjectFieldSelector(in *core.ObjectF
 }
 
 func autoConvert_v1_ObjectReference_To_core_ObjectReference(in *corev1.ObjectReference, out *core.ObjectReference, s conversion.Scope) error {
-	out.Kind = in.Kind
-	out.Namespace = in.Namespace
-	out.Name = in.Name
-	out.UID = types.UID(in.UID)
-	out.APIVersion = in.APIVersion
-	out.ResourceVersion = in.ResourceVersion
-	out.FieldPath = in.FieldPath
+	*out = *(*core.ObjectReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5768,13 +5126,7 @@ func Convert_v1_ObjectReference_To_core_ObjectReference(in *corev1.ObjectReferen
 }
 
 func autoConvert_core_ObjectReference_To_v1_ObjectReference(in *core.ObjectReference, out *corev1.ObjectReference, s conversion.Scope) error {
-	out.Kind = in.Kind
-	out.Namespace = in.Namespace
-	out.Name = in.Name
-	out.UID = types.UID(in.UID)
-	out.APIVersion = in.APIVersion
-	out.ResourceVersion = in.ResourceVersion
-	out.FieldPath = in.FieldPath
+	*out = *(*corev1.ObjectReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5848,12 +5200,7 @@ func Convert_core_PersistentVolumeClaim_To_v1_PersistentVolumeClaim(in *core.Per
 }
 
 func autoConvert_v1_PersistentVolumeClaimCondition_To_core_PersistentVolumeClaimCondition(in *corev1.PersistentVolumeClaimCondition, out *core.PersistentVolumeClaimCondition, s conversion.Scope) error {
-	out.Type = core.PersistentVolumeClaimConditionType(in.Type)
-	out.Status = core.ConditionStatus(in.Status)
-	out.LastProbeTime = in.LastProbeTime
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*core.PersistentVolumeClaimCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5863,12 +5210,7 @@ func Convert_v1_PersistentVolumeClaimCondition_To_core_PersistentVolumeClaimCond
 }
 
 func autoConvert_core_PersistentVolumeClaimCondition_To_v1_PersistentVolumeClaimCondition(in *core.PersistentVolumeClaimCondition, out *corev1.PersistentVolumeClaimCondition, s conversion.Scope) error {
-	out.Type = corev1.PersistentVolumeClaimConditionType(in.Type)
-	out.Status = corev1.ConditionStatus(in.Status)
-	out.LastProbeTime = in.LastProbeTime
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*corev1.PersistentVolumeClaimCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5900,17 +5242,7 @@ func Convert_core_PersistentVolumeClaimList_To_v1_PersistentVolumeClaimList(in *
 }
 
 func autoConvert_v1_PersistentVolumeClaimSpec_To_core_PersistentVolumeClaimSpec(in *corev1.PersistentVolumeClaimSpec, out *core.PersistentVolumeClaimSpec, s conversion.Scope) error {
-	out.AccessModes = *(*[]core.PersistentVolumeAccessMode)(unsafe.Pointer(&in.AccessModes))
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
-	if err := Convert_v1_VolumeResourceRequirements_To_core_VolumeResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
-		return err
-	}
-	out.VolumeName = in.VolumeName
-	out.StorageClassName = (*string)(unsafe.Pointer(in.StorageClassName))
-	out.VolumeMode = (*core.PersistentVolumeMode)(unsafe.Pointer(in.VolumeMode))
-	out.DataSource = (*core.TypedLocalObjectReference)(unsafe.Pointer(in.DataSource))
-	out.DataSourceRef = (*core.TypedObjectReference)(unsafe.Pointer(in.DataSourceRef))
-	out.VolumeAttributesClassName = (*string)(unsafe.Pointer(in.VolumeAttributesClassName))
+	*out = *(*core.PersistentVolumeClaimSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5920,17 +5252,7 @@ func Convert_v1_PersistentVolumeClaimSpec_To_core_PersistentVolumeClaimSpec(in *
 }
 
 func autoConvert_core_PersistentVolumeClaimSpec_To_v1_PersistentVolumeClaimSpec(in *core.PersistentVolumeClaimSpec, out *corev1.PersistentVolumeClaimSpec, s conversion.Scope) error {
-	out.AccessModes = *(*[]corev1.PersistentVolumeAccessMode)(unsafe.Pointer(&in.AccessModes))
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
-	if err := Convert_core_VolumeResourceRequirements_To_v1_VolumeResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
-		return err
-	}
-	out.VolumeName = in.VolumeName
-	out.StorageClassName = (*string)(unsafe.Pointer(in.StorageClassName))
-	out.VolumeMode = (*corev1.PersistentVolumeMode)(unsafe.Pointer(in.VolumeMode))
-	out.DataSource = (*corev1.TypedLocalObjectReference)(unsafe.Pointer(in.DataSource))
-	out.DataSourceRef = (*corev1.TypedObjectReference)(unsafe.Pointer(in.DataSourceRef))
-	out.VolumeAttributesClassName = (*string)(unsafe.Pointer(in.VolumeAttributesClassName))
+	*out = *(*corev1.PersistentVolumeClaimSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5940,14 +5262,7 @@ func Convert_core_PersistentVolumeClaimSpec_To_v1_PersistentVolumeClaimSpec(in *
 }
 
 func autoConvert_v1_PersistentVolumeClaimStatus_To_core_PersistentVolumeClaimStatus(in *corev1.PersistentVolumeClaimStatus, out *core.PersistentVolumeClaimStatus, s conversion.Scope) error {
-	out.Phase = core.PersistentVolumeClaimPhase(in.Phase)
-	out.AccessModes = *(*[]core.PersistentVolumeAccessMode)(unsafe.Pointer(&in.AccessModes))
-	out.Capacity = *(*core.ResourceList)(unsafe.Pointer(&in.Capacity))
-	out.Conditions = *(*[]core.PersistentVolumeClaimCondition)(unsafe.Pointer(&in.Conditions))
-	out.AllocatedResources = *(*core.ResourceList)(unsafe.Pointer(&in.AllocatedResources))
-	out.AllocatedResourceStatuses = *(*map[core.ResourceName]core.ClaimResourceStatus)(unsafe.Pointer(&in.AllocatedResourceStatuses))
-	out.CurrentVolumeAttributesClassName = (*string)(unsafe.Pointer(in.CurrentVolumeAttributesClassName))
-	out.ModifyVolumeStatus = (*core.ModifyVolumeStatus)(unsafe.Pointer(in.ModifyVolumeStatus))
+	*out = *(*core.PersistentVolumeClaimStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5957,14 +5272,7 @@ func Convert_v1_PersistentVolumeClaimStatus_To_core_PersistentVolumeClaimStatus(
 }
 
 func autoConvert_core_PersistentVolumeClaimStatus_To_v1_PersistentVolumeClaimStatus(in *core.PersistentVolumeClaimStatus, out *corev1.PersistentVolumeClaimStatus, s conversion.Scope) error {
-	out.Phase = corev1.PersistentVolumeClaimPhase(in.Phase)
-	out.AccessModes = *(*[]corev1.PersistentVolumeAccessMode)(unsafe.Pointer(&in.AccessModes))
-	out.Capacity = *(*corev1.ResourceList)(unsafe.Pointer(&in.Capacity))
-	out.Conditions = *(*[]corev1.PersistentVolumeClaimCondition)(unsafe.Pointer(&in.Conditions))
-	out.AllocatedResources = *(*corev1.ResourceList)(unsafe.Pointer(&in.AllocatedResources))
-	out.AllocatedResourceStatuses = *(*map[corev1.ResourceName]corev1.ClaimResourceStatus)(unsafe.Pointer(&in.AllocatedResourceStatuses))
-	out.CurrentVolumeAttributesClassName = (*string)(unsafe.Pointer(in.CurrentVolumeAttributesClassName))
-	out.ModifyVolumeStatus = (*corev1.ModifyVolumeStatus)(unsafe.Pointer(in.ModifyVolumeStatus))
+	*out = *(*corev1.PersistentVolumeClaimStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5974,10 +5282,7 @@ func Convert_core_PersistentVolumeClaimStatus_To_v1_PersistentVolumeClaimStatus(
 }
 
 func autoConvert_v1_PersistentVolumeClaimTemplate_To_core_PersistentVolumeClaimTemplate(in *corev1.PersistentVolumeClaimTemplate, out *core.PersistentVolumeClaimTemplate, s conversion.Scope) error {
-	out.ObjectMeta = in.ObjectMeta
-	if err := Convert_v1_PersistentVolumeClaimSpec_To_core_PersistentVolumeClaimSpec(&in.Spec, &out.Spec, s); err != nil {
-		return err
-	}
+	*out = *(*core.PersistentVolumeClaimTemplate)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -5987,10 +5292,7 @@ func Convert_v1_PersistentVolumeClaimTemplate_To_core_PersistentVolumeClaimTempl
 }
 
 func autoConvert_core_PersistentVolumeClaimTemplate_To_v1_PersistentVolumeClaimTemplate(in *core.PersistentVolumeClaimTemplate, out *corev1.PersistentVolumeClaimTemplate, s conversion.Scope) error {
-	out.ObjectMeta = in.ObjectMeta
-	if err := Convert_core_PersistentVolumeClaimSpec_To_v1_PersistentVolumeClaimSpec(&in.Spec, &out.Spec, s); err != nil {
-		return err
-	}
+	*out = *(*corev1.PersistentVolumeClaimTemplate)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6000,8 +5302,7 @@ func Convert_core_PersistentVolumeClaimTemplate_To_v1_PersistentVolumeClaimTempl
 }
 
 func autoConvert_v1_PersistentVolumeClaimVolumeSource_To_core_PersistentVolumeClaimVolumeSource(in *corev1.PersistentVolumeClaimVolumeSource, out *core.PersistentVolumeClaimVolumeSource, s conversion.Scope) error {
-	out.ClaimName = in.ClaimName
-	out.ReadOnly = in.ReadOnly
+	*out = *(*core.PersistentVolumeClaimVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6011,8 +5312,7 @@ func Convert_v1_PersistentVolumeClaimVolumeSource_To_core_PersistentVolumeClaimV
 }
 
 func autoConvert_core_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource(in *core.PersistentVolumeClaimVolumeSource, out *corev1.PersistentVolumeClaimVolumeSource, s conversion.Scope) error {
-	out.ClaimName = in.ClaimName
-	out.ReadOnly = in.ReadOnly
+	*out = *(*corev1.PersistentVolumeClaimVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6158,10 +5458,7 @@ func autoConvert_core_PersistentVolumeSpec_To_v1_PersistentVolumeSpec(in *core.P
 }
 
 func autoConvert_v1_PersistentVolumeStatus_To_core_PersistentVolumeStatus(in *corev1.PersistentVolumeStatus, out *core.PersistentVolumeStatus, s conversion.Scope) error {
-	out.Phase = core.PersistentVolumePhase(in.Phase)
-	out.Message = in.Message
-	out.Reason = in.Reason
-	out.LastPhaseTransitionTime = (*metav1.Time)(unsafe.Pointer(in.LastPhaseTransitionTime))
+	*out = *(*core.PersistentVolumeStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6171,10 +5468,7 @@ func Convert_v1_PersistentVolumeStatus_To_core_PersistentVolumeStatus(in *corev1
 }
 
 func autoConvert_core_PersistentVolumeStatus_To_v1_PersistentVolumeStatus(in *core.PersistentVolumeStatus, out *corev1.PersistentVolumeStatus, s conversion.Scope) error {
-	out.Phase = corev1.PersistentVolumePhase(in.Phase)
-	out.Message = in.Message
-	out.Reason = in.Reason
-	out.LastPhaseTransitionTime = (*metav1.Time)(unsafe.Pointer(in.LastPhaseTransitionTime))
+	*out = *(*corev1.PersistentVolumeStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6184,8 +5478,7 @@ func Convert_core_PersistentVolumeStatus_To_v1_PersistentVolumeStatus(in *core.P
 }
 
 func autoConvert_v1_PhotonPersistentDiskVolumeSource_To_core_PhotonPersistentDiskVolumeSource(in *corev1.PhotonPersistentDiskVolumeSource, out *core.PhotonPersistentDiskVolumeSource, s conversion.Scope) error {
-	out.PdID = in.PdID
-	out.FSType = in.FSType
+	*out = *(*core.PhotonPersistentDiskVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6195,8 +5488,7 @@ func Convert_v1_PhotonPersistentDiskVolumeSource_To_core_PhotonPersistentDiskVol
 }
 
 func autoConvert_core_PhotonPersistentDiskVolumeSource_To_v1_PhotonPersistentDiskVolumeSource(in *core.PhotonPersistentDiskVolumeSource, out *corev1.PhotonPersistentDiskVolumeSource, s conversion.Scope) error {
-	out.PdID = in.PdID
-	out.FSType = in.FSType
+	*out = *(*corev1.PhotonPersistentDiskVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6238,8 +5530,7 @@ func Convert_core_Pod_To_v1_Pod(in *core.Pod, out *corev1.Pod, s conversion.Scop
 }
 
 func autoConvert_v1_PodAffinity_To_core_PodAffinity(in *corev1.PodAffinity, out *core.PodAffinity, s conversion.Scope) error {
-	out.RequiredDuringSchedulingIgnoredDuringExecution = *(*[]core.PodAffinityTerm)(unsafe.Pointer(&in.RequiredDuringSchedulingIgnoredDuringExecution))
-	out.PreferredDuringSchedulingIgnoredDuringExecution = *(*[]core.WeightedPodAffinityTerm)(unsafe.Pointer(&in.PreferredDuringSchedulingIgnoredDuringExecution))
+	*out = *(*core.PodAffinity)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6249,8 +5540,7 @@ func Convert_v1_PodAffinity_To_core_PodAffinity(in *corev1.PodAffinity, out *cor
 }
 
 func autoConvert_core_PodAffinity_To_v1_PodAffinity(in *core.PodAffinity, out *corev1.PodAffinity, s conversion.Scope) error {
-	out.RequiredDuringSchedulingIgnoredDuringExecution = *(*[]corev1.PodAffinityTerm)(unsafe.Pointer(&in.RequiredDuringSchedulingIgnoredDuringExecution))
-	out.PreferredDuringSchedulingIgnoredDuringExecution = *(*[]corev1.WeightedPodAffinityTerm)(unsafe.Pointer(&in.PreferredDuringSchedulingIgnoredDuringExecution))
+	*out = *(*corev1.PodAffinity)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6260,12 +5550,7 @@ func Convert_core_PodAffinity_To_v1_PodAffinity(in *core.PodAffinity, out *corev
 }
 
 func autoConvert_v1_PodAffinityTerm_To_core_PodAffinityTerm(in *corev1.PodAffinityTerm, out *core.PodAffinityTerm, s conversion.Scope) error {
-	out.LabelSelector = (*metav1.LabelSelector)(unsafe.Pointer(in.LabelSelector))
-	out.Namespaces = *(*[]string)(unsafe.Pointer(&in.Namespaces))
-	out.TopologyKey = in.TopologyKey
-	out.NamespaceSelector = (*metav1.LabelSelector)(unsafe.Pointer(in.NamespaceSelector))
-	out.MatchLabelKeys = *(*[]string)(unsafe.Pointer(&in.MatchLabelKeys))
-	out.MismatchLabelKeys = *(*[]string)(unsafe.Pointer(&in.MismatchLabelKeys))
+	*out = *(*core.PodAffinityTerm)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6275,12 +5560,7 @@ func Convert_v1_PodAffinityTerm_To_core_PodAffinityTerm(in *corev1.PodAffinityTe
 }
 
 func autoConvert_core_PodAffinityTerm_To_v1_PodAffinityTerm(in *core.PodAffinityTerm, out *corev1.PodAffinityTerm, s conversion.Scope) error {
-	out.LabelSelector = (*metav1.LabelSelector)(unsafe.Pointer(in.LabelSelector))
-	out.Namespaces = *(*[]string)(unsafe.Pointer(&in.Namespaces))
-	out.TopologyKey = in.TopologyKey
-	out.NamespaceSelector = (*metav1.LabelSelector)(unsafe.Pointer(in.NamespaceSelector))
-	out.MatchLabelKeys = *(*[]string)(unsafe.Pointer(&in.MatchLabelKeys))
-	out.MismatchLabelKeys = *(*[]string)(unsafe.Pointer(&in.MismatchLabelKeys))
+	*out = *(*corev1.PodAffinityTerm)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6290,8 +5570,7 @@ func Convert_core_PodAffinityTerm_To_v1_PodAffinityTerm(in *core.PodAffinityTerm
 }
 
 func autoConvert_v1_PodAntiAffinity_To_core_PodAntiAffinity(in *corev1.PodAntiAffinity, out *core.PodAntiAffinity, s conversion.Scope) error {
-	out.RequiredDuringSchedulingIgnoredDuringExecution = *(*[]core.PodAffinityTerm)(unsafe.Pointer(&in.RequiredDuringSchedulingIgnoredDuringExecution))
-	out.PreferredDuringSchedulingIgnoredDuringExecution = *(*[]core.WeightedPodAffinityTerm)(unsafe.Pointer(&in.PreferredDuringSchedulingIgnoredDuringExecution))
+	*out = *(*core.PodAntiAffinity)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6301,8 +5580,7 @@ func Convert_v1_PodAntiAffinity_To_core_PodAntiAffinity(in *corev1.PodAntiAffini
 }
 
 func autoConvert_core_PodAntiAffinity_To_v1_PodAntiAffinity(in *core.PodAntiAffinity, out *corev1.PodAntiAffinity, s conversion.Scope) error {
-	out.RequiredDuringSchedulingIgnoredDuringExecution = *(*[]corev1.PodAffinityTerm)(unsafe.Pointer(&in.RequiredDuringSchedulingIgnoredDuringExecution))
-	out.PreferredDuringSchedulingIgnoredDuringExecution = *(*[]corev1.WeightedPodAffinityTerm)(unsafe.Pointer(&in.PreferredDuringSchedulingIgnoredDuringExecution))
+	*out = *(*corev1.PodAntiAffinity)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6386,13 +5664,7 @@ func Convert_url_Values_To_v1_PodAttachOptions(in *url.Values, out *corev1.PodAt
 }
 
 func autoConvert_v1_PodCertificateProjection_To_core_PodCertificateProjection(in *corev1.PodCertificateProjection, out *core.PodCertificateProjection, s conversion.Scope) error {
-	out.SignerName = in.SignerName
-	out.KeyType = in.KeyType
-	out.MaxExpirationSeconds = (*int32)(unsafe.Pointer(in.MaxExpirationSeconds))
-	out.CredentialBundlePath = in.CredentialBundlePath
-	out.KeyPath = in.KeyPath
-	out.CertificateChainPath = in.CertificateChainPath
-	out.UserAnnotations = *(*map[string]string)(unsafe.Pointer(&in.UserAnnotations))
+	*out = *(*core.PodCertificateProjection)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6402,13 +5674,7 @@ func Convert_v1_PodCertificateProjection_To_core_PodCertificateProjection(in *co
 }
 
 func autoConvert_core_PodCertificateProjection_To_v1_PodCertificateProjection(in *core.PodCertificateProjection, out *corev1.PodCertificateProjection, s conversion.Scope) error {
-	out.SignerName = in.SignerName
-	out.KeyType = in.KeyType
-	out.MaxExpirationSeconds = (*int32)(unsafe.Pointer(in.MaxExpirationSeconds))
-	out.CredentialBundlePath = in.CredentialBundlePath
-	out.KeyPath = in.KeyPath
-	out.CertificateChainPath = in.CertificateChainPath
-	out.UserAnnotations = *(*map[string]string)(unsafe.Pointer(&in.UserAnnotations))
+	*out = *(*corev1.PodCertificateProjection)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6418,13 +5684,7 @@ func Convert_core_PodCertificateProjection_To_v1_PodCertificateProjection(in *co
 }
 
 func autoConvert_v1_PodCondition_To_core_PodCondition(in *corev1.PodCondition, out *core.PodCondition, s conversion.Scope) error {
-	out.Type = core.PodConditionType(in.Type)
-	out.ObservedGeneration = in.ObservedGeneration
-	out.Status = core.ConditionStatus(in.Status)
-	out.LastProbeTime = in.LastProbeTime
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*core.PodCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6434,13 +5694,7 @@ func Convert_v1_PodCondition_To_core_PodCondition(in *corev1.PodCondition, out *
 }
 
 func autoConvert_core_PodCondition_To_v1_PodCondition(in *core.PodCondition, out *corev1.PodCondition, s conversion.Scope) error {
-	out.Type = corev1.PodConditionType(in.Type)
-	out.ObservedGeneration = in.ObservedGeneration
-	out.Status = corev1.ConditionStatus(in.Status)
-	out.LastProbeTime = in.LastProbeTime
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*corev1.PodCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6450,9 +5704,7 @@ func Convert_core_PodCondition_To_v1_PodCondition(in *core.PodCondition, out *co
 }
 
 func autoConvert_v1_PodDNSConfig_To_core_PodDNSConfig(in *corev1.PodDNSConfig, out *core.PodDNSConfig, s conversion.Scope) error {
-	out.Nameservers = *(*[]string)(unsafe.Pointer(&in.Nameservers))
-	out.Searches = *(*[]string)(unsafe.Pointer(&in.Searches))
-	out.Options = *(*[]core.PodDNSConfigOption)(unsafe.Pointer(&in.Options))
+	*out = *(*core.PodDNSConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6462,9 +5714,7 @@ func Convert_v1_PodDNSConfig_To_core_PodDNSConfig(in *corev1.PodDNSConfig, out *
 }
 
 func autoConvert_core_PodDNSConfig_To_v1_PodDNSConfig(in *core.PodDNSConfig, out *corev1.PodDNSConfig, s conversion.Scope) error {
-	out.Nameservers = *(*[]string)(unsafe.Pointer(&in.Nameservers))
-	out.Searches = *(*[]string)(unsafe.Pointer(&in.Searches))
-	out.Options = *(*[]corev1.PodDNSConfigOption)(unsafe.Pointer(&in.Options))
+	*out = *(*corev1.PodDNSConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6474,8 +5724,7 @@ func Convert_core_PodDNSConfig_To_v1_PodDNSConfig(in *core.PodDNSConfig, out *co
 }
 
 func autoConvert_v1_PodDNSConfigOption_To_core_PodDNSConfigOption(in *corev1.PodDNSConfigOption, out *core.PodDNSConfigOption, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Value = (*string)(unsafe.Pointer(in.Value))
+	*out = *(*core.PodDNSConfigOption)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6485,8 +5734,7 @@ func Convert_v1_PodDNSConfigOption_To_core_PodDNSConfigOption(in *corev1.PodDNSC
 }
 
 func autoConvert_core_PodDNSConfigOption_To_v1_PodDNSConfigOption(in *core.PodDNSConfigOption, out *corev1.PodDNSConfigOption, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Value = (*string)(unsafe.Pointer(in.Value))
+	*out = *(*corev1.PodDNSConfigOption)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6577,8 +5825,7 @@ func Convert_url_Values_To_v1_PodExecOptions(in *url.Values, out *corev1.PodExec
 }
 
 func autoConvert_v1_PodExtendedResourceClaimStatus_To_core_PodExtendedResourceClaimStatus(in *corev1.PodExtendedResourceClaimStatus, out *core.PodExtendedResourceClaimStatus, s conversion.Scope) error {
-	out.RequestMappings = *(*[]core.ContainerExtendedResourceRequest)(unsafe.Pointer(&in.RequestMappings))
-	out.ResourceClaimName = in.ResourceClaimName
+	*out = *(*core.PodExtendedResourceClaimStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6588,8 +5835,7 @@ func Convert_v1_PodExtendedResourceClaimStatus_To_core_PodExtendedResourceClaimS
 }
 
 func autoConvert_core_PodExtendedResourceClaimStatus_To_v1_PodExtendedResourceClaimStatus(in *core.PodExtendedResourceClaimStatus, out *corev1.PodExtendedResourceClaimStatus, s conversion.Scope) error {
-	out.RequestMappings = *(*[]corev1.ContainerExtendedResourceRequest)(unsafe.Pointer(&in.RequestMappings))
-	out.ResourceClaimName = in.ResourceClaimName
+	*out = *(*corev1.PodExtendedResourceClaimStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6599,7 +5845,7 @@ func Convert_core_PodExtendedResourceClaimStatus_To_v1_PodExtendedResourceClaimS
 }
 
 func autoConvert_v1_PodIP_To_core_PodIP(in *corev1.PodIP, out *core.PodIP, s conversion.Scope) error {
-	out.IP = in.IP
+	*out = *(*core.PodIP)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6609,7 +5855,7 @@ func Convert_v1_PodIP_To_core_PodIP(in *corev1.PodIP, out *core.PodIP, s convers
 }
 
 func autoConvert_core_PodIP_To_v1_PodIP(in *core.PodIP, out *corev1.PodIP, s conversion.Scope) error {
-	out.IP = in.IP
+	*out = *(*corev1.PodIP)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6760,7 +6006,7 @@ func Convert_url_Values_To_v1_PodLogOptions(in *url.Values, out *corev1.PodLogOp
 }
 
 func autoConvert_v1_PodOS_To_core_PodOS(in *corev1.PodOS, out *core.PodOS, s conversion.Scope) error {
-	out.Name = core.OSName(in.Name)
+	*out = *(*core.PodOS)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6770,7 +6016,7 @@ func Convert_v1_PodOS_To_core_PodOS(in *corev1.PodOS, out *core.PodOS, s convers
 }
 
 func autoConvert_core_PodOS_To_v1_PodOS(in *core.PodOS, out *corev1.PodOS, s conversion.Scope) error {
-	out.Name = corev1.OSName(in.Name)
+	*out = *(*corev1.PodOS)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6856,7 +6102,7 @@ func Convert_url_Values_To_v1_PodProxyOptions(in *url.Values, out *corev1.PodPro
 }
 
 func autoConvert_v1_PodReadinessGate_To_core_PodReadinessGate(in *corev1.PodReadinessGate, out *core.PodReadinessGate, s conversion.Scope) error {
-	out.ConditionType = core.PodConditionType(in.ConditionType)
+	*out = *(*core.PodReadinessGate)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6866,7 +6112,7 @@ func Convert_v1_PodReadinessGate_To_core_PodReadinessGate(in *corev1.PodReadines
 }
 
 func autoConvert_core_PodReadinessGate_To_v1_PodReadinessGate(in *core.PodReadinessGate, out *corev1.PodReadinessGate, s conversion.Scope) error {
-	out.ConditionType = corev1.PodConditionType(in.ConditionType)
+	*out = *(*corev1.PodReadinessGate)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6876,9 +6122,7 @@ func Convert_core_PodReadinessGate_To_v1_PodReadinessGate(in *core.PodReadinessG
 }
 
 func autoConvert_v1_PodResourceClaim_To_core_PodResourceClaim(in *corev1.PodResourceClaim, out *core.PodResourceClaim, s conversion.Scope) error {
-	out.Name = in.Name
-	out.ResourceClaimName = (*string)(unsafe.Pointer(in.ResourceClaimName))
-	out.ResourceClaimTemplateName = (*string)(unsafe.Pointer(in.ResourceClaimTemplateName))
+	*out = *(*core.PodResourceClaim)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6888,9 +6132,7 @@ func Convert_v1_PodResourceClaim_To_core_PodResourceClaim(in *corev1.PodResource
 }
 
 func autoConvert_core_PodResourceClaim_To_v1_PodResourceClaim(in *core.PodResourceClaim, out *corev1.PodResourceClaim, s conversion.Scope) error {
-	out.Name = in.Name
-	out.ResourceClaimName = (*string)(unsafe.Pointer(in.ResourceClaimName))
-	out.ResourceClaimTemplateName = (*string)(unsafe.Pointer(in.ResourceClaimTemplateName))
+	*out = *(*corev1.PodResourceClaim)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6900,8 +6142,7 @@ func Convert_core_PodResourceClaim_To_v1_PodResourceClaim(in *core.PodResourceCl
 }
 
 func autoConvert_v1_PodResourceClaimStatus_To_core_PodResourceClaimStatus(in *corev1.PodResourceClaimStatus, out *core.PodResourceClaimStatus, s conversion.Scope) error {
-	out.Name = in.Name
-	out.ResourceClaimName = (*string)(unsafe.Pointer(in.ResourceClaimName))
+	*out = *(*core.PodResourceClaimStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6911,8 +6152,7 @@ func Convert_v1_PodResourceClaimStatus_To_core_PodResourceClaimStatus(in *corev1
 }
 
 func autoConvert_core_PodResourceClaimStatus_To_v1_PodResourceClaimStatus(in *core.PodResourceClaimStatus, out *corev1.PodResourceClaimStatus, s conversion.Scope) error {
-	out.Name = in.Name
-	out.ResourceClaimName = (*string)(unsafe.Pointer(in.ResourceClaimName))
+	*out = *(*corev1.PodResourceClaimStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6922,7 +6162,7 @@ func Convert_core_PodResourceClaimStatus_To_v1_PodResourceClaimStatus(in *core.P
 }
 
 func autoConvert_v1_PodSchedulingGate_To_core_PodSchedulingGate(in *corev1.PodSchedulingGate, out *core.PodSchedulingGate, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*core.PodSchedulingGate)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6932,7 +6172,7 @@ func Convert_v1_PodSchedulingGate_To_core_PodSchedulingGate(in *corev1.PodSchedu
 }
 
 func autoConvert_core_PodSchedulingGate_To_v1_PodSchedulingGate(in *core.PodSchedulingGate, out *corev1.PodSchedulingGate, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*corev1.PodSchedulingGate)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6942,7 +6182,7 @@ func Convert_core_PodSchedulingGate_To_v1_PodSchedulingGate(in *core.PodScheduli
 }
 
 func autoConvert_v1_PodSchedulingGroup_To_core_PodSchedulingGroup(in *corev1.PodSchedulingGroup, out *core.PodSchedulingGroup, s conversion.Scope) error {
-	out.PodGroupName = (*string)(unsafe.Pointer(in.PodGroupName))
+	*out = *(*core.PodSchedulingGroup)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6952,7 +6192,7 @@ func Convert_v1_PodSchedulingGroup_To_core_PodSchedulingGroup(in *corev1.PodSche
 }
 
 func autoConvert_core_PodSchedulingGroup_To_v1_PodSchedulingGroup(in *core.PodSchedulingGroup, out *corev1.PodSchedulingGroup, s conversion.Scope) error {
-	out.PodGroupName = (*string)(unsafe.Pointer(in.PodGroupName))
+	*out = *(*corev1.PodSchedulingGroup)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6962,19 +6202,7 @@ func Convert_core_PodSchedulingGroup_To_v1_PodSchedulingGroup(in *core.PodSchedu
 }
 
 func autoConvert_v1_PodSecurityContext_To_core_PodSecurityContext(in *corev1.PodSecurityContext, out *core.PodSecurityContext, s conversion.Scope) error {
-	out.SELinuxOptions = (*core.SELinuxOptions)(unsafe.Pointer(in.SELinuxOptions))
-	out.WindowsOptions = (*core.WindowsSecurityContextOptions)(unsafe.Pointer(in.WindowsOptions))
-	out.RunAsUser = (*int64)(unsafe.Pointer(in.RunAsUser))
-	out.RunAsGroup = (*int64)(unsafe.Pointer(in.RunAsGroup))
-	out.RunAsNonRoot = (*bool)(unsafe.Pointer(in.RunAsNonRoot))
-	out.SupplementalGroups = *(*[]int64)(unsafe.Pointer(&in.SupplementalGroups))
-	out.SupplementalGroupsPolicy = (*core.SupplementalGroupsPolicy)(unsafe.Pointer(in.SupplementalGroupsPolicy))
-	out.FSGroup = (*int64)(unsafe.Pointer(in.FSGroup))
-	out.Sysctls = *(*[]core.Sysctl)(unsafe.Pointer(&in.Sysctls))
-	out.FSGroupChangePolicy = (*core.PodFSGroupChangePolicy)(unsafe.Pointer(in.FSGroupChangePolicy))
-	out.SeccompProfile = (*core.SeccompProfile)(unsafe.Pointer(in.SeccompProfile))
-	out.AppArmorProfile = (*core.AppArmorProfile)(unsafe.Pointer(in.AppArmorProfile))
-	out.SELinuxChangePolicy = (*core.PodSELinuxChangePolicy)(unsafe.Pointer(in.SELinuxChangePolicy))
+	*out = *(*core.PodSecurityContext)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -6984,19 +6212,7 @@ func Convert_v1_PodSecurityContext_To_core_PodSecurityContext(in *corev1.PodSecu
 }
 
 func autoConvert_core_PodSecurityContext_To_v1_PodSecurityContext(in *core.PodSecurityContext, out *corev1.PodSecurityContext, s conversion.Scope) error {
-	out.SELinuxOptions = (*corev1.SELinuxOptions)(unsafe.Pointer(in.SELinuxOptions))
-	out.WindowsOptions = (*corev1.WindowsSecurityContextOptions)(unsafe.Pointer(in.WindowsOptions))
-	out.RunAsUser = (*int64)(unsafe.Pointer(in.RunAsUser))
-	out.RunAsGroup = (*int64)(unsafe.Pointer(in.RunAsGroup))
-	out.RunAsNonRoot = (*bool)(unsafe.Pointer(in.RunAsNonRoot))
-	out.SupplementalGroups = *(*[]int64)(unsafe.Pointer(&in.SupplementalGroups))
-	out.SupplementalGroupsPolicy = (*corev1.SupplementalGroupsPolicy)(unsafe.Pointer(in.SupplementalGroupsPolicy))
-	out.FSGroup = (*int64)(unsafe.Pointer(in.FSGroup))
-	out.Sysctls = *(*[]corev1.Sysctl)(unsafe.Pointer(&in.Sysctls))
-	out.FSGroupChangePolicy = (*corev1.PodFSGroupChangePolicy)(unsafe.Pointer(in.FSGroupChangePolicy))
-	out.SeccompProfile = (*corev1.SeccompProfile)(unsafe.Pointer(in.SeccompProfile))
-	out.AppArmorProfile = (*corev1.AppArmorProfile)(unsafe.Pointer(in.AppArmorProfile))
-	out.SELinuxChangePolicy = (*corev1.PodSELinuxChangePolicy)(unsafe.Pointer(in.SELinuxChangePolicy))
+	*out = *(*corev1.PodSecurityContext)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7006,7 +6222,7 @@ func Convert_core_PodSecurityContext_To_v1_PodSecurityContext(in *core.PodSecuri
 }
 
 func autoConvert_v1_PodSignature_To_core_PodSignature(in *corev1.PodSignature, out *core.PodSignature, s conversion.Scope) error {
-	out.PodController = (*metav1.OwnerReference)(unsafe.Pointer(in.PodController))
+	*out = *(*core.PodSignature)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7016,7 +6232,7 @@ func Convert_v1_PodSignature_To_core_PodSignature(in *corev1.PodSignature, out *
 }
 
 func autoConvert_core_PodSignature_To_v1_PodSignature(in *core.PodSignature, out *corev1.PodSignature, s conversion.Scope) error {
-	out.PodController = (*metav1.OwnerReference)(unsafe.Pointer(in.PodController))
+	*out = *(*corev1.PodSignature)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7026,48 +6242,7 @@ func Convert_core_PodSignature_To_v1_PodSignature(in *core.PodSignature, out *co
 }
 
 func autoConvert_v1_PodSpec_To_core_PodSpec(in *corev1.PodSpec, out *core.PodSpec, s conversion.Scope) error {
-	out.Volumes = *(*[]core.Volume)(unsafe.Pointer(&in.Volumes))
-	out.InitContainers = *(*[]core.Container)(unsafe.Pointer(&in.InitContainers))
-	out.Containers = *(*[]core.Container)(unsafe.Pointer(&in.Containers))
-	out.EphemeralContainers = *(*[]core.EphemeralContainer)(unsafe.Pointer(&in.EphemeralContainers))
-	out.RestartPolicy = core.RestartPolicy(in.RestartPolicy)
-	out.TerminationGracePeriodSeconds = (*int64)(unsafe.Pointer(in.TerminationGracePeriodSeconds))
-	out.ActiveDeadlineSeconds = (*int64)(unsafe.Pointer(in.ActiveDeadlineSeconds))
-	out.DNSPolicy = core.DNSPolicy(in.DNSPolicy)
-	out.NodeSelector = *(*map[string]string)(unsafe.Pointer(&in.NodeSelector))
-	out.ServiceAccountName = in.ServiceAccountName
-	out.DeprecatedServiceAccount = in.DeprecatedServiceAccount
-	out.AutomountServiceAccountToken = (*bool)(unsafe.Pointer(in.AutomountServiceAccountToken))
-	out.NodeName = in.NodeName
-	out.HostNetwork = in.HostNetwork
-	out.HostPID = in.HostPID
-	out.HostIPC = in.HostIPC
-	out.ShareProcessNamespace = (*bool)(unsafe.Pointer(in.ShareProcessNamespace))
-	out.SecurityContext = (*core.PodSecurityContext)(unsafe.Pointer(in.SecurityContext))
-	out.ImagePullSecrets = *(*[]core.LocalObjectReference)(unsafe.Pointer(&in.ImagePullSecrets))
-	out.Hostname = in.Hostname
-	out.Subdomain = in.Subdomain
-	out.Affinity = (*core.Affinity)(unsafe.Pointer(in.Affinity))
-	out.SchedulerName = in.SchedulerName
-	out.Tolerations = *(*[]core.Toleration)(unsafe.Pointer(&in.Tolerations))
-	out.HostAliases = *(*[]core.HostAlias)(unsafe.Pointer(&in.HostAliases))
-	out.PriorityClassName = in.PriorityClassName
-	out.Priority = (*int32)(unsafe.Pointer(in.Priority))
-	out.DNSConfig = (*core.PodDNSConfig)(unsafe.Pointer(in.DNSConfig))
-	out.ReadinessGates = *(*[]core.PodReadinessGate)(unsafe.Pointer(&in.ReadinessGates))
-	out.RuntimeClassName = (*string)(unsafe.Pointer(in.RuntimeClassName))
-	out.EnableServiceLinks = (*bool)(unsafe.Pointer(in.EnableServiceLinks))
-	out.PreemptionPolicy = (*core.PreemptionPolicy)(unsafe.Pointer(in.PreemptionPolicy))
-	out.Overhead = *(*core.ResourceList)(unsafe.Pointer(&in.Overhead))
-	out.TopologySpreadConstraints = *(*[]core.TopologySpreadConstraint)(unsafe.Pointer(&in.TopologySpreadConstraints))
-	out.SetHostnameAsFQDN = (*bool)(unsafe.Pointer(in.SetHostnameAsFQDN))
-	out.OS = (*core.PodOS)(unsafe.Pointer(in.OS))
-	out.HostUsers = (*bool)(unsafe.Pointer(in.HostUsers))
-	out.SchedulingGates = *(*[]core.PodSchedulingGate)(unsafe.Pointer(&in.SchedulingGates))
-	out.ResourceClaims = *(*[]core.PodResourceClaim)(unsafe.Pointer(&in.ResourceClaims))
-	out.Resources = (*core.ResourceRequirements)(unsafe.Pointer(in.Resources))
-	out.HostnameOverride = (*string)(unsafe.Pointer(in.HostnameOverride))
-	out.SchedulingGroup = (*core.PodSchedulingGroup)(unsafe.Pointer(in.SchedulingGroup))
+	*out = *(*core.PodSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7077,48 +6252,7 @@ func Convert_v1_PodSpec_To_core_PodSpec(in *corev1.PodSpec, out *core.PodSpec, s
 }
 
 func autoConvert_core_PodSpec_To_v1_PodSpec(in *core.PodSpec, out *corev1.PodSpec, s conversion.Scope) error {
-	out.Volumes = *(*[]corev1.Volume)(unsafe.Pointer(&in.Volumes))
-	out.InitContainers = *(*[]corev1.Container)(unsafe.Pointer(&in.InitContainers))
-	out.Containers = *(*[]corev1.Container)(unsafe.Pointer(&in.Containers))
-	out.EphemeralContainers = *(*[]corev1.EphemeralContainer)(unsafe.Pointer(&in.EphemeralContainers))
-	out.RestartPolicy = corev1.RestartPolicy(in.RestartPolicy)
-	out.TerminationGracePeriodSeconds = (*int64)(unsafe.Pointer(in.TerminationGracePeriodSeconds))
-	out.ActiveDeadlineSeconds = (*int64)(unsafe.Pointer(in.ActiveDeadlineSeconds))
-	out.DNSPolicy = corev1.DNSPolicy(in.DNSPolicy)
-	out.NodeSelector = *(*map[string]string)(unsafe.Pointer(&in.NodeSelector))
-	out.ServiceAccountName = in.ServiceAccountName
-	out.DeprecatedServiceAccount = in.DeprecatedServiceAccount
-	out.AutomountServiceAccountToken = (*bool)(unsafe.Pointer(in.AutomountServiceAccountToken))
-	out.NodeName = in.NodeName
-	out.HostNetwork = in.HostNetwork
-	out.HostPID = in.HostPID
-	out.HostIPC = in.HostIPC
-	out.ShareProcessNamespace = (*bool)(unsafe.Pointer(in.ShareProcessNamespace))
-	out.SecurityContext = (*corev1.PodSecurityContext)(unsafe.Pointer(in.SecurityContext))
-	out.ImagePullSecrets = *(*[]corev1.LocalObjectReference)(unsafe.Pointer(&in.ImagePullSecrets))
-	out.Hostname = in.Hostname
-	out.Subdomain = in.Subdomain
-	out.Affinity = (*corev1.Affinity)(unsafe.Pointer(in.Affinity))
-	out.SchedulerName = in.SchedulerName
-	out.Tolerations = *(*[]corev1.Toleration)(unsafe.Pointer(&in.Tolerations))
-	out.HostAliases = *(*[]corev1.HostAlias)(unsafe.Pointer(&in.HostAliases))
-	out.PriorityClassName = in.PriorityClassName
-	out.Priority = (*int32)(unsafe.Pointer(in.Priority))
-	out.DNSConfig = (*corev1.PodDNSConfig)(unsafe.Pointer(in.DNSConfig))
-	out.ReadinessGates = *(*[]corev1.PodReadinessGate)(unsafe.Pointer(&in.ReadinessGates))
-	out.RuntimeClassName = (*string)(unsafe.Pointer(in.RuntimeClassName))
-	out.EnableServiceLinks = (*bool)(unsafe.Pointer(in.EnableServiceLinks))
-	out.PreemptionPolicy = (*corev1.PreemptionPolicy)(unsafe.Pointer(in.PreemptionPolicy))
-	out.Overhead = *(*corev1.ResourceList)(unsafe.Pointer(&in.Overhead))
-	out.TopologySpreadConstraints = *(*[]corev1.TopologySpreadConstraint)(unsafe.Pointer(&in.TopologySpreadConstraints))
-	out.SetHostnameAsFQDN = (*bool)(unsafe.Pointer(in.SetHostnameAsFQDN))
-	out.OS = (*corev1.PodOS)(unsafe.Pointer(in.OS))
-	out.HostUsers = (*bool)(unsafe.Pointer(in.HostUsers))
-	out.SchedulingGates = *(*[]corev1.PodSchedulingGate)(unsafe.Pointer(&in.SchedulingGates))
-	out.ResourceClaims = *(*[]corev1.PodResourceClaim)(unsafe.Pointer(&in.ResourceClaims))
-	out.Resources = (*corev1.ResourceRequirements)(unsafe.Pointer(in.Resources))
-	out.HostnameOverride = (*string)(unsafe.Pointer(in.HostnameOverride))
-	out.SchedulingGroup = (*corev1.PodSchedulingGroup)(unsafe.Pointer(in.SchedulingGroup))
+	*out = *(*corev1.PodSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7128,27 +6262,7 @@ func Convert_core_PodSpec_To_v1_PodSpec(in *core.PodSpec, out *corev1.PodSpec, s
 }
 
 func autoConvert_v1_PodStatus_To_core_PodStatus(in *corev1.PodStatus, out *core.PodStatus, s conversion.Scope) error {
-	out.ObservedGeneration = in.ObservedGeneration
-	out.Phase = core.PodPhase(in.Phase)
-	out.Conditions = *(*[]core.PodCondition)(unsafe.Pointer(&in.Conditions))
-	out.Message = in.Message
-	out.Reason = in.Reason
-	out.NominatedNodeName = in.NominatedNodeName
-	out.HostIP = in.HostIP
-	out.HostIPs = *(*[]core.HostIP)(unsafe.Pointer(&in.HostIPs))
-	out.PodIP = in.PodIP
-	out.PodIPs = *(*[]core.PodIP)(unsafe.Pointer(&in.PodIPs))
-	out.StartTime = (*metav1.Time)(unsafe.Pointer(in.StartTime))
-	out.InitContainerStatuses = *(*[]core.ContainerStatus)(unsafe.Pointer(&in.InitContainerStatuses))
-	out.ContainerStatuses = *(*[]core.ContainerStatus)(unsafe.Pointer(&in.ContainerStatuses))
-	out.QOSClass = core.PodQOSClass(in.QOSClass)
-	out.EphemeralContainerStatuses = *(*[]core.ContainerStatus)(unsafe.Pointer(&in.EphemeralContainerStatuses))
-	out.Resize = core.PodResizeStatus(in.Resize)
-	out.ResourceClaimStatuses = *(*[]core.PodResourceClaimStatus)(unsafe.Pointer(&in.ResourceClaimStatuses))
-	out.ExtendedResourceClaimStatus = (*core.PodExtendedResourceClaimStatus)(unsafe.Pointer(in.ExtendedResourceClaimStatus))
-	out.AllocatedResources = *(*core.ResourceList)(unsafe.Pointer(&in.AllocatedResources))
-	out.Resources = (*core.ResourceRequirements)(unsafe.Pointer(in.Resources))
-	out.NodeAllocatableResourceClaimStatuses = *(*[]core.NodeAllocatableResourceClaimStatus)(unsafe.Pointer(&in.NodeAllocatableResourceClaimStatuses))
+	*out = *(*core.PodStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7158,27 +6272,7 @@ func Convert_v1_PodStatus_To_core_PodStatus(in *corev1.PodStatus, out *core.PodS
 }
 
 func autoConvert_core_PodStatus_To_v1_PodStatus(in *core.PodStatus, out *corev1.PodStatus, s conversion.Scope) error {
-	out.ObservedGeneration = in.ObservedGeneration
-	out.Phase = corev1.PodPhase(in.Phase)
-	out.Conditions = *(*[]corev1.PodCondition)(unsafe.Pointer(&in.Conditions))
-	out.Message = in.Message
-	out.Reason = in.Reason
-	out.NominatedNodeName = in.NominatedNodeName
-	out.HostIP = in.HostIP
-	out.HostIPs = *(*[]corev1.HostIP)(unsafe.Pointer(&in.HostIPs))
-	out.PodIP = in.PodIP
-	out.PodIPs = *(*[]corev1.PodIP)(unsafe.Pointer(&in.PodIPs))
-	out.StartTime = (*metav1.Time)(unsafe.Pointer(in.StartTime))
-	out.InitContainerStatuses = *(*[]corev1.ContainerStatus)(unsafe.Pointer(&in.InitContainerStatuses))
-	out.ContainerStatuses = *(*[]corev1.ContainerStatus)(unsafe.Pointer(&in.ContainerStatuses))
-	out.QOSClass = corev1.PodQOSClass(in.QOSClass)
-	out.EphemeralContainerStatuses = *(*[]corev1.ContainerStatus)(unsafe.Pointer(&in.EphemeralContainerStatuses))
-	out.Resize = corev1.PodResizeStatus(in.Resize)
-	out.ResourceClaimStatuses = *(*[]corev1.PodResourceClaimStatus)(unsafe.Pointer(&in.ResourceClaimStatuses))
-	out.ExtendedResourceClaimStatus = (*corev1.PodExtendedResourceClaimStatus)(unsafe.Pointer(in.ExtendedResourceClaimStatus))
-	out.AllocatedResources = *(*corev1.ResourceList)(unsafe.Pointer(&in.AllocatedResources))
-	out.Resources = (*corev1.ResourceRequirements)(unsafe.Pointer(in.Resources))
-	out.NodeAllocatableResourceClaimStatuses = *(*[]corev1.NodeAllocatableResourceClaimStatus)(unsafe.Pointer(&in.NodeAllocatableResourceClaimStatuses))
+	*out = *(*corev1.PodStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7272,9 +6366,7 @@ func autoConvert_core_PodTemplateSpec_To_v1_PodTemplateSpec(in *core.PodTemplate
 }
 
 func autoConvert_v1_PortStatus_To_core_PortStatus(in *corev1.PortStatus, out *core.PortStatus, s conversion.Scope) error {
-	out.Port = in.Port
-	out.Protocol = core.Protocol(in.Protocol)
-	out.Error = (*string)(unsafe.Pointer(in.Error))
+	*out = *(*core.PortStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7284,9 +6376,7 @@ func Convert_v1_PortStatus_To_core_PortStatus(in *corev1.PortStatus, out *core.P
 }
 
 func autoConvert_core_PortStatus_To_v1_PortStatus(in *core.PortStatus, out *corev1.PortStatus, s conversion.Scope) error {
-	out.Port = in.Port
-	out.Protocol = corev1.Protocol(in.Protocol)
-	out.Error = (*string)(unsafe.Pointer(in.Error))
+	*out = *(*corev1.PortStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7296,9 +6386,7 @@ func Convert_core_PortStatus_To_v1_PortStatus(in *core.PortStatus, out *corev1.P
 }
 
 func autoConvert_v1_PortworxVolumeSource_To_core_PortworxVolumeSource(in *corev1.PortworxVolumeSource, out *core.PortworxVolumeSource, s conversion.Scope) error {
-	out.VolumeID = in.VolumeID
-	out.FSType = in.FSType
-	out.ReadOnly = in.ReadOnly
+	*out = *(*core.PortworxVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7308,9 +6396,7 @@ func Convert_v1_PortworxVolumeSource_To_core_PortworxVolumeSource(in *corev1.Por
 }
 
 func autoConvert_core_PortworxVolumeSource_To_v1_PortworxVolumeSource(in *core.PortworxVolumeSource, out *corev1.PortworxVolumeSource, s conversion.Scope) error {
-	out.VolumeID = in.VolumeID
-	out.FSType = in.FSType
-	out.ReadOnly = in.ReadOnly
+	*out = *(*corev1.PortworxVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7320,7 +6406,7 @@ func Convert_core_PortworxVolumeSource_To_v1_PortworxVolumeSource(in *core.Portw
 }
 
 func autoConvert_v1_Preconditions_To_core_Preconditions(in *corev1.Preconditions, out *core.Preconditions, s conversion.Scope) error {
-	out.UID = (*types.UID)(unsafe.Pointer(in.UID))
+	*out = *(*core.Preconditions)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7330,7 +6416,7 @@ func Convert_v1_Preconditions_To_core_Preconditions(in *corev1.Preconditions, ou
 }
 
 func autoConvert_core_Preconditions_To_v1_Preconditions(in *core.Preconditions, out *corev1.Preconditions, s conversion.Scope) error {
-	out.UID = (*types.UID)(unsafe.Pointer(in.UID))
+	*out = *(*corev1.Preconditions)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7340,12 +6426,7 @@ func Convert_core_Preconditions_To_v1_Preconditions(in *core.Preconditions, out 
 }
 
 func autoConvert_v1_PreferAvoidPodsEntry_To_core_PreferAvoidPodsEntry(in *corev1.PreferAvoidPodsEntry, out *core.PreferAvoidPodsEntry, s conversion.Scope) error {
-	if err := Convert_v1_PodSignature_To_core_PodSignature(&in.PodSignature, &out.PodSignature, s); err != nil {
-		return err
-	}
-	out.EvictionTime = in.EvictionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*core.PreferAvoidPodsEntry)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7355,12 +6436,7 @@ func Convert_v1_PreferAvoidPodsEntry_To_core_PreferAvoidPodsEntry(in *corev1.Pre
 }
 
 func autoConvert_core_PreferAvoidPodsEntry_To_v1_PreferAvoidPodsEntry(in *core.PreferAvoidPodsEntry, out *corev1.PreferAvoidPodsEntry, s conversion.Scope) error {
-	if err := Convert_core_PodSignature_To_v1_PodSignature(&in.PodSignature, &out.PodSignature, s); err != nil {
-		return err
-	}
-	out.EvictionTime = in.EvictionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*corev1.PreferAvoidPodsEntry)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7370,10 +6446,7 @@ func Convert_core_PreferAvoidPodsEntry_To_v1_PreferAvoidPodsEntry(in *core.Prefe
 }
 
 func autoConvert_v1_PreferredSchedulingTerm_To_core_PreferredSchedulingTerm(in *corev1.PreferredSchedulingTerm, out *core.PreferredSchedulingTerm, s conversion.Scope) error {
-	out.Weight = in.Weight
-	if err := Convert_v1_NodeSelectorTerm_To_core_NodeSelectorTerm(&in.Preference, &out.Preference, s); err != nil {
-		return err
-	}
+	*out = *(*core.PreferredSchedulingTerm)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7383,10 +6456,7 @@ func Convert_v1_PreferredSchedulingTerm_To_core_PreferredSchedulingTerm(in *core
 }
 
 func autoConvert_core_PreferredSchedulingTerm_To_v1_PreferredSchedulingTerm(in *core.PreferredSchedulingTerm, out *corev1.PreferredSchedulingTerm, s conversion.Scope) error {
-	out.Weight = in.Weight
-	if err := Convert_core_NodeSelectorTerm_To_v1_NodeSelectorTerm(&in.Preference, &out.Preference, s); err != nil {
-		return err
-	}
+	*out = *(*corev1.PreferredSchedulingTerm)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7396,15 +6466,7 @@ func Convert_core_PreferredSchedulingTerm_To_v1_PreferredSchedulingTerm(in *core
 }
 
 func autoConvert_v1_Probe_To_core_Probe(in *corev1.Probe, out *core.Probe, s conversion.Scope) error {
-	if err := Convert_v1_ProbeHandler_To_core_ProbeHandler(&in.ProbeHandler, &out.ProbeHandler, s); err != nil {
-		return err
-	}
-	out.InitialDelaySeconds = in.InitialDelaySeconds
-	out.TimeoutSeconds = in.TimeoutSeconds
-	out.PeriodSeconds = in.PeriodSeconds
-	out.SuccessThreshold = in.SuccessThreshold
-	out.FailureThreshold = in.FailureThreshold
-	out.TerminationGracePeriodSeconds = (*int64)(unsafe.Pointer(in.TerminationGracePeriodSeconds))
+	*out = *(*core.Probe)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7414,15 +6476,7 @@ func Convert_v1_Probe_To_core_Probe(in *corev1.Probe, out *core.Probe, s convers
 }
 
 func autoConvert_core_Probe_To_v1_Probe(in *core.Probe, out *corev1.Probe, s conversion.Scope) error {
-	if err := Convert_core_ProbeHandler_To_v1_ProbeHandler(&in.ProbeHandler, &out.ProbeHandler, s); err != nil {
-		return err
-	}
-	out.InitialDelaySeconds = in.InitialDelaySeconds
-	out.TimeoutSeconds = in.TimeoutSeconds
-	out.PeriodSeconds = in.PeriodSeconds
-	out.SuccessThreshold = in.SuccessThreshold
-	out.FailureThreshold = in.FailureThreshold
-	out.TerminationGracePeriodSeconds = (*int64)(unsafe.Pointer(in.TerminationGracePeriodSeconds))
+	*out = *(*corev1.Probe)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7432,10 +6486,7 @@ func Convert_core_Probe_To_v1_Probe(in *core.Probe, out *corev1.Probe, s convers
 }
 
 func autoConvert_v1_ProbeHandler_To_core_ProbeHandler(in *corev1.ProbeHandler, out *core.ProbeHandler, s conversion.Scope) error {
-	out.Exec = (*core.ExecAction)(unsafe.Pointer(in.Exec))
-	out.HTTPGet = (*core.HTTPGetAction)(unsafe.Pointer(in.HTTPGet))
-	out.TCPSocket = (*core.TCPSocketAction)(unsafe.Pointer(in.TCPSocket))
-	out.GRPC = (*core.GRPCAction)(unsafe.Pointer(in.GRPC))
+	*out = *(*core.ProbeHandler)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7445,10 +6496,7 @@ func Convert_v1_ProbeHandler_To_core_ProbeHandler(in *corev1.ProbeHandler, out *
 }
 
 func autoConvert_core_ProbeHandler_To_v1_ProbeHandler(in *core.ProbeHandler, out *corev1.ProbeHandler, s conversion.Scope) error {
-	out.Exec = (*corev1.ExecAction)(unsafe.Pointer(in.Exec))
-	out.HTTPGet = (*corev1.HTTPGetAction)(unsafe.Pointer(in.HTTPGet))
-	out.TCPSocket = (*corev1.TCPSocketAction)(unsafe.Pointer(in.TCPSocket))
-	out.GRPC = (*corev1.GRPCAction)(unsafe.Pointer(in.GRPC))
+	*out = *(*corev1.ProbeHandler)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7458,8 +6506,7 @@ func Convert_core_ProbeHandler_To_v1_ProbeHandler(in *core.ProbeHandler, out *co
 }
 
 func autoConvert_v1_ProjectedVolumeSource_To_core_ProjectedVolumeSource(in *corev1.ProjectedVolumeSource, out *core.ProjectedVolumeSource, s conversion.Scope) error {
-	out.Sources = *(*[]core.VolumeProjection)(unsafe.Pointer(&in.Sources))
-	out.DefaultMode = (*int32)(unsafe.Pointer(in.DefaultMode))
+	*out = *(*core.ProjectedVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7469,8 +6516,7 @@ func Convert_v1_ProjectedVolumeSource_To_core_ProjectedVolumeSource(in *corev1.P
 }
 
 func autoConvert_core_ProjectedVolumeSource_To_v1_ProjectedVolumeSource(in *core.ProjectedVolumeSource, out *corev1.ProjectedVolumeSource, s conversion.Scope) error {
-	out.Sources = *(*[]corev1.VolumeProjection)(unsafe.Pointer(&in.Sources))
-	out.DefaultMode = (*int32)(unsafe.Pointer(in.DefaultMode))
+	*out = *(*corev1.ProjectedVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7480,12 +6526,7 @@ func Convert_core_ProjectedVolumeSource_To_v1_ProjectedVolumeSource(in *core.Pro
 }
 
 func autoConvert_v1_QuobyteVolumeSource_To_core_QuobyteVolumeSource(in *corev1.QuobyteVolumeSource, out *core.QuobyteVolumeSource, s conversion.Scope) error {
-	out.Registry = in.Registry
-	out.Volume = in.Volume
-	out.ReadOnly = in.ReadOnly
-	out.User = in.User
-	out.Group = in.Group
-	out.Tenant = in.Tenant
+	*out = *(*core.QuobyteVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7495,12 +6536,7 @@ func Convert_v1_QuobyteVolumeSource_To_core_QuobyteVolumeSource(in *corev1.Quoby
 }
 
 func autoConvert_core_QuobyteVolumeSource_To_v1_QuobyteVolumeSource(in *core.QuobyteVolumeSource, out *corev1.QuobyteVolumeSource, s conversion.Scope) error {
-	out.Registry = in.Registry
-	out.Volume = in.Volume
-	out.ReadOnly = in.ReadOnly
-	out.User = in.User
-	out.Group = in.Group
-	out.Tenant = in.Tenant
+	*out = *(*corev1.QuobyteVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7510,14 +6546,7 @@ func Convert_core_QuobyteVolumeSource_To_v1_QuobyteVolumeSource(in *core.Quobyte
 }
 
 func autoConvert_v1_RBDPersistentVolumeSource_To_core_RBDPersistentVolumeSource(in *corev1.RBDPersistentVolumeSource, out *core.RBDPersistentVolumeSource, s conversion.Scope) error {
-	out.CephMonitors = *(*[]string)(unsafe.Pointer(&in.CephMonitors))
-	out.RBDImage = in.RBDImage
-	out.FSType = in.FSType
-	out.RBDPool = in.RBDPool
-	out.RadosUser = in.RadosUser
-	out.Keyring = in.Keyring
-	out.SecretRef = (*core.SecretReference)(unsafe.Pointer(in.SecretRef))
-	out.ReadOnly = in.ReadOnly
+	*out = *(*core.RBDPersistentVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7527,14 +6556,7 @@ func Convert_v1_RBDPersistentVolumeSource_To_core_RBDPersistentVolumeSource(in *
 }
 
 func autoConvert_core_RBDPersistentVolumeSource_To_v1_RBDPersistentVolumeSource(in *core.RBDPersistentVolumeSource, out *corev1.RBDPersistentVolumeSource, s conversion.Scope) error {
-	out.CephMonitors = *(*[]string)(unsafe.Pointer(&in.CephMonitors))
-	out.RBDImage = in.RBDImage
-	out.FSType = in.FSType
-	out.RBDPool = in.RBDPool
-	out.RadosUser = in.RadosUser
-	out.Keyring = in.Keyring
-	out.SecretRef = (*corev1.SecretReference)(unsafe.Pointer(in.SecretRef))
-	out.ReadOnly = in.ReadOnly
+	*out = *(*corev1.RBDPersistentVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7544,14 +6566,7 @@ func Convert_core_RBDPersistentVolumeSource_To_v1_RBDPersistentVolumeSource(in *
 }
 
 func autoConvert_v1_RBDVolumeSource_To_core_RBDVolumeSource(in *corev1.RBDVolumeSource, out *core.RBDVolumeSource, s conversion.Scope) error {
-	out.CephMonitors = *(*[]string)(unsafe.Pointer(&in.CephMonitors))
-	out.RBDImage = in.RBDImage
-	out.FSType = in.FSType
-	out.RBDPool = in.RBDPool
-	out.RadosUser = in.RadosUser
-	out.Keyring = in.Keyring
-	out.SecretRef = (*core.LocalObjectReference)(unsafe.Pointer(in.SecretRef))
-	out.ReadOnly = in.ReadOnly
+	*out = *(*core.RBDVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7561,14 +6576,7 @@ func Convert_v1_RBDVolumeSource_To_core_RBDVolumeSource(in *corev1.RBDVolumeSour
 }
 
 func autoConvert_core_RBDVolumeSource_To_v1_RBDVolumeSource(in *core.RBDVolumeSource, out *corev1.RBDVolumeSource, s conversion.Scope) error {
-	out.CephMonitors = *(*[]string)(unsafe.Pointer(&in.CephMonitors))
-	out.RBDImage = in.RBDImage
-	out.FSType = in.FSType
-	out.RBDPool = in.RBDPool
-	out.RadosUser = in.RadosUser
-	out.Keyring = in.Keyring
-	out.SecretRef = (*corev1.LocalObjectReference)(unsafe.Pointer(in.SecretRef))
-	out.ReadOnly = in.ReadOnly
+	*out = *(*corev1.RBDVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7634,11 +6642,7 @@ func Convert_core_ReplicationController_To_v1_ReplicationController(in *core.Rep
 }
 
 func autoConvert_v1_ReplicationControllerCondition_To_core_ReplicationControllerCondition(in *corev1.ReplicationControllerCondition, out *core.ReplicationControllerCondition, s conversion.Scope) error {
-	out.Type = core.ReplicationControllerConditionType(in.Type)
-	out.Status = core.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*core.ReplicationControllerCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7648,11 +6652,7 @@ func Convert_v1_ReplicationControllerCondition_To_core_ReplicationControllerCond
 }
 
 func autoConvert_core_ReplicationControllerCondition_To_v1_ReplicationControllerCondition(in *core.ReplicationControllerCondition, out *corev1.ReplicationControllerCondition, s conversion.Scope) error {
-	out.Type = corev1.ReplicationControllerConditionType(in.Type)
-	out.Status = corev1.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*corev1.ReplicationControllerCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7736,12 +6736,7 @@ func autoConvert_core_ReplicationControllerSpec_To_v1_ReplicationControllerSpec(
 }
 
 func autoConvert_v1_ReplicationControllerStatus_To_core_ReplicationControllerStatus(in *corev1.ReplicationControllerStatus, out *core.ReplicationControllerStatus, s conversion.Scope) error {
-	out.Replicas = in.Replicas
-	out.FullyLabeledReplicas = in.FullyLabeledReplicas
-	out.ReadyReplicas = in.ReadyReplicas
-	out.AvailableReplicas = in.AvailableReplicas
-	out.ObservedGeneration = in.ObservedGeneration
-	out.Conditions = *(*[]core.ReplicationControllerCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*core.ReplicationControllerStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7751,12 +6746,7 @@ func Convert_v1_ReplicationControllerStatus_To_core_ReplicationControllerStatus(
 }
 
 func autoConvert_core_ReplicationControllerStatus_To_v1_ReplicationControllerStatus(in *core.ReplicationControllerStatus, out *corev1.ReplicationControllerStatus, s conversion.Scope) error {
-	out.Replicas = in.Replicas
-	out.FullyLabeledReplicas = in.FullyLabeledReplicas
-	out.ReadyReplicas = in.ReadyReplicas
-	out.AvailableReplicas = in.AvailableReplicas
-	out.ObservedGeneration = in.ObservedGeneration
-	out.Conditions = *(*[]corev1.ReplicationControllerCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*corev1.ReplicationControllerStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7766,8 +6756,7 @@ func Convert_core_ReplicationControllerStatus_To_v1_ReplicationControllerStatus(
 }
 
 func autoConvert_v1_ResourceClaim_To_core_ResourceClaim(in *corev1.ResourceClaim, out *core.ResourceClaim, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Request = in.Request
+	*out = *(*core.ResourceClaim)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7777,8 +6766,7 @@ func Convert_v1_ResourceClaim_To_core_ResourceClaim(in *corev1.ResourceClaim, ou
 }
 
 func autoConvert_core_ResourceClaim_To_v1_ResourceClaim(in *core.ResourceClaim, out *corev1.ResourceClaim, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Request = in.Request
+	*out = *(*corev1.ResourceClaim)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7788,9 +6776,7 @@ func Convert_core_ResourceClaim_To_v1_ResourceClaim(in *core.ResourceClaim, out 
 }
 
 func autoConvert_v1_ResourceFieldSelector_To_core_ResourceFieldSelector(in *corev1.ResourceFieldSelector, out *core.ResourceFieldSelector, s conversion.Scope) error {
-	out.ContainerName = in.ContainerName
-	out.Resource = in.Resource
-	out.Divisor = in.Divisor
+	*out = *(*core.ResourceFieldSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7800,9 +6786,7 @@ func Convert_v1_ResourceFieldSelector_To_core_ResourceFieldSelector(in *corev1.R
 }
 
 func autoConvert_core_ResourceFieldSelector_To_v1_ResourceFieldSelector(in *core.ResourceFieldSelector, out *corev1.ResourceFieldSelector, s conversion.Scope) error {
-	out.ContainerName = in.ContainerName
-	out.Resource = in.Resource
-	out.Divisor = in.Divisor
+	*out = *(*corev1.ResourceFieldSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7812,9 +6796,7 @@ func Convert_core_ResourceFieldSelector_To_v1_ResourceFieldSelector(in *core.Res
 }
 
 func autoConvert_v1_ResourceHealth_To_core_ResourceHealth(in *corev1.ResourceHealth, out *core.ResourceHealth, s conversion.Scope) error {
-	out.ResourceID = core.ResourceID(in.ResourceID)
-	out.Health = core.ResourceHealthStatus(in.Health)
-	out.Message = (*string)(unsafe.Pointer(in.Message))
+	*out = *(*core.ResourceHealth)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7824,9 +6806,7 @@ func Convert_v1_ResourceHealth_To_core_ResourceHealth(in *corev1.ResourceHealth,
 }
 
 func autoConvert_core_ResourceHealth_To_v1_ResourceHealth(in *core.ResourceHealth, out *corev1.ResourceHealth, s conversion.Scope) error {
-	out.ResourceID = corev1.ResourceID(in.ResourceID)
-	out.Health = corev1.ResourceHealthStatus(in.Health)
-	out.Message = (*string)(unsafe.Pointer(in.Message))
+	*out = *(*corev1.ResourceHealth)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7890,9 +6870,7 @@ func Convert_core_ResourceQuotaList_To_v1_ResourceQuotaList(in *core.ResourceQuo
 }
 
 func autoConvert_v1_ResourceQuotaSpec_To_core_ResourceQuotaSpec(in *corev1.ResourceQuotaSpec, out *core.ResourceQuotaSpec, s conversion.Scope) error {
-	out.Hard = *(*core.ResourceList)(unsafe.Pointer(&in.Hard))
-	out.Scopes = *(*[]core.ResourceQuotaScope)(unsafe.Pointer(&in.Scopes))
-	out.ScopeSelector = (*core.ScopeSelector)(unsafe.Pointer(in.ScopeSelector))
+	*out = *(*core.ResourceQuotaSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7902,9 +6880,7 @@ func Convert_v1_ResourceQuotaSpec_To_core_ResourceQuotaSpec(in *corev1.ResourceQ
 }
 
 func autoConvert_core_ResourceQuotaSpec_To_v1_ResourceQuotaSpec(in *core.ResourceQuotaSpec, out *corev1.ResourceQuotaSpec, s conversion.Scope) error {
-	out.Hard = *(*corev1.ResourceList)(unsafe.Pointer(&in.Hard))
-	out.Scopes = *(*[]corev1.ResourceQuotaScope)(unsafe.Pointer(&in.Scopes))
-	out.ScopeSelector = (*corev1.ScopeSelector)(unsafe.Pointer(in.ScopeSelector))
+	*out = *(*corev1.ResourceQuotaSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7914,8 +6890,7 @@ func Convert_core_ResourceQuotaSpec_To_v1_ResourceQuotaSpec(in *core.ResourceQuo
 }
 
 func autoConvert_v1_ResourceQuotaStatus_To_core_ResourceQuotaStatus(in *corev1.ResourceQuotaStatus, out *core.ResourceQuotaStatus, s conversion.Scope) error {
-	out.Hard = *(*core.ResourceList)(unsafe.Pointer(&in.Hard))
-	out.Used = *(*core.ResourceList)(unsafe.Pointer(&in.Used))
+	*out = *(*core.ResourceQuotaStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7925,8 +6900,7 @@ func Convert_v1_ResourceQuotaStatus_To_core_ResourceQuotaStatus(in *corev1.Resou
 }
 
 func autoConvert_core_ResourceQuotaStatus_To_v1_ResourceQuotaStatus(in *core.ResourceQuotaStatus, out *corev1.ResourceQuotaStatus, s conversion.Scope) error {
-	out.Hard = *(*corev1.ResourceList)(unsafe.Pointer(&in.Hard))
-	out.Used = *(*corev1.ResourceList)(unsafe.Pointer(&in.Used))
+	*out = *(*corev1.ResourceQuotaStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7936,9 +6910,7 @@ func Convert_core_ResourceQuotaStatus_To_v1_ResourceQuotaStatus(in *core.Resourc
 }
 
 func autoConvert_v1_ResourceRequirements_To_core_ResourceRequirements(in *corev1.ResourceRequirements, out *core.ResourceRequirements, s conversion.Scope) error {
-	out.Limits = *(*core.ResourceList)(unsafe.Pointer(&in.Limits))
-	out.Requests = *(*core.ResourceList)(unsafe.Pointer(&in.Requests))
-	out.Claims = *(*[]core.ResourceClaim)(unsafe.Pointer(&in.Claims))
+	*out = *(*core.ResourceRequirements)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7948,9 +6920,7 @@ func Convert_v1_ResourceRequirements_To_core_ResourceRequirements(in *corev1.Res
 }
 
 func autoConvert_core_ResourceRequirements_To_v1_ResourceRequirements(in *core.ResourceRequirements, out *corev1.ResourceRequirements, s conversion.Scope) error {
-	out.Limits = *(*corev1.ResourceList)(unsafe.Pointer(&in.Limits))
-	out.Requests = *(*corev1.ResourceList)(unsafe.Pointer(&in.Requests))
-	out.Claims = *(*[]corev1.ResourceClaim)(unsafe.Pointer(&in.Claims))
+	*out = *(*corev1.ResourceRequirements)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7960,8 +6930,7 @@ func Convert_core_ResourceRequirements_To_v1_ResourceRequirements(in *core.Resou
 }
 
 func autoConvert_v1_ResourceStatus_To_core_ResourceStatus(in *corev1.ResourceStatus, out *core.ResourceStatus, s conversion.Scope) error {
-	out.Name = core.ResourceName(in.Name)
-	out.Resources = *(*[]core.ResourceHealth)(unsafe.Pointer(&in.Resources))
+	*out = *(*core.ResourceStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7971,8 +6940,7 @@ func Convert_v1_ResourceStatus_To_core_ResourceStatus(in *corev1.ResourceStatus,
 }
 
 func autoConvert_core_ResourceStatus_To_v1_ResourceStatus(in *core.ResourceStatus, out *corev1.ResourceStatus, s conversion.Scope) error {
-	out.Name = corev1.ResourceName(in.Name)
-	out.Resources = *(*[]corev1.ResourceHealth)(unsafe.Pointer(&in.Resources))
+	*out = *(*corev1.ResourceStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7982,10 +6950,7 @@ func Convert_core_ResourceStatus_To_v1_ResourceStatus(in *core.ResourceStatus, o
 }
 
 func autoConvert_v1_SELinuxOptions_To_core_SELinuxOptions(in *corev1.SELinuxOptions, out *core.SELinuxOptions, s conversion.Scope) error {
-	out.User = in.User
-	out.Role = in.Role
-	out.Type = in.Type
-	out.Level = in.Level
+	*out = *(*core.SELinuxOptions)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -7995,10 +6960,7 @@ func Convert_v1_SELinuxOptions_To_core_SELinuxOptions(in *corev1.SELinuxOptions,
 }
 
 func autoConvert_core_SELinuxOptions_To_v1_SELinuxOptions(in *core.SELinuxOptions, out *corev1.SELinuxOptions, s conversion.Scope) error {
-	out.User = in.User
-	out.Role = in.Role
-	out.Type = in.Type
-	out.Level = in.Level
+	*out = *(*corev1.SELinuxOptions)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8008,16 +6970,7 @@ func Convert_core_SELinuxOptions_To_v1_SELinuxOptions(in *core.SELinuxOptions, o
 }
 
 func autoConvert_v1_ScaleIOPersistentVolumeSource_To_core_ScaleIOPersistentVolumeSource(in *corev1.ScaleIOPersistentVolumeSource, out *core.ScaleIOPersistentVolumeSource, s conversion.Scope) error {
-	out.Gateway = in.Gateway
-	out.System = in.System
-	out.SecretRef = (*core.SecretReference)(unsafe.Pointer(in.SecretRef))
-	out.SSLEnabled = in.SSLEnabled
-	out.ProtectionDomain = in.ProtectionDomain
-	out.StoragePool = in.StoragePool
-	out.StorageMode = in.StorageMode
-	out.VolumeName = in.VolumeName
-	out.FSType = in.FSType
-	out.ReadOnly = in.ReadOnly
+	*out = *(*core.ScaleIOPersistentVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8027,16 +6980,7 @@ func Convert_v1_ScaleIOPersistentVolumeSource_To_core_ScaleIOPersistentVolumeSou
 }
 
 func autoConvert_core_ScaleIOPersistentVolumeSource_To_v1_ScaleIOPersistentVolumeSource(in *core.ScaleIOPersistentVolumeSource, out *corev1.ScaleIOPersistentVolumeSource, s conversion.Scope) error {
-	out.Gateway = in.Gateway
-	out.System = in.System
-	out.SecretRef = (*corev1.SecretReference)(unsafe.Pointer(in.SecretRef))
-	out.SSLEnabled = in.SSLEnabled
-	out.ProtectionDomain = in.ProtectionDomain
-	out.StoragePool = in.StoragePool
-	out.StorageMode = in.StorageMode
-	out.VolumeName = in.VolumeName
-	out.FSType = in.FSType
-	out.ReadOnly = in.ReadOnly
+	*out = *(*corev1.ScaleIOPersistentVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8046,16 +6990,7 @@ func Convert_core_ScaleIOPersistentVolumeSource_To_v1_ScaleIOPersistentVolumeSou
 }
 
 func autoConvert_v1_ScaleIOVolumeSource_To_core_ScaleIOVolumeSource(in *corev1.ScaleIOVolumeSource, out *core.ScaleIOVolumeSource, s conversion.Scope) error {
-	out.Gateway = in.Gateway
-	out.System = in.System
-	out.SecretRef = (*core.LocalObjectReference)(unsafe.Pointer(in.SecretRef))
-	out.SSLEnabled = in.SSLEnabled
-	out.ProtectionDomain = in.ProtectionDomain
-	out.StoragePool = in.StoragePool
-	out.StorageMode = in.StorageMode
-	out.VolumeName = in.VolumeName
-	out.FSType = in.FSType
-	out.ReadOnly = in.ReadOnly
+	*out = *(*core.ScaleIOVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8065,16 +7000,7 @@ func Convert_v1_ScaleIOVolumeSource_To_core_ScaleIOVolumeSource(in *corev1.Scale
 }
 
 func autoConvert_core_ScaleIOVolumeSource_To_v1_ScaleIOVolumeSource(in *core.ScaleIOVolumeSource, out *corev1.ScaleIOVolumeSource, s conversion.Scope) error {
-	out.Gateway = in.Gateway
-	out.System = in.System
-	out.SecretRef = (*corev1.LocalObjectReference)(unsafe.Pointer(in.SecretRef))
-	out.SSLEnabled = in.SSLEnabled
-	out.ProtectionDomain = in.ProtectionDomain
-	out.StoragePool = in.StoragePool
-	out.StorageMode = in.StorageMode
-	out.VolumeName = in.VolumeName
-	out.FSType = in.FSType
-	out.ReadOnly = in.ReadOnly
+	*out = *(*corev1.ScaleIOVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8084,7 +7010,7 @@ func Convert_core_ScaleIOVolumeSource_To_v1_ScaleIOVolumeSource(in *core.ScaleIO
 }
 
 func autoConvert_v1_ScopeSelector_To_core_ScopeSelector(in *corev1.ScopeSelector, out *core.ScopeSelector, s conversion.Scope) error {
-	out.MatchExpressions = *(*[]core.ScopedResourceSelectorRequirement)(unsafe.Pointer(&in.MatchExpressions))
+	*out = *(*core.ScopeSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8094,7 +7020,7 @@ func Convert_v1_ScopeSelector_To_core_ScopeSelector(in *corev1.ScopeSelector, ou
 }
 
 func autoConvert_core_ScopeSelector_To_v1_ScopeSelector(in *core.ScopeSelector, out *corev1.ScopeSelector, s conversion.Scope) error {
-	out.MatchExpressions = *(*[]corev1.ScopedResourceSelectorRequirement)(unsafe.Pointer(&in.MatchExpressions))
+	*out = *(*corev1.ScopeSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8104,9 +7030,7 @@ func Convert_core_ScopeSelector_To_v1_ScopeSelector(in *core.ScopeSelector, out 
 }
 
 func autoConvert_v1_ScopedResourceSelectorRequirement_To_core_ScopedResourceSelectorRequirement(in *corev1.ScopedResourceSelectorRequirement, out *core.ScopedResourceSelectorRequirement, s conversion.Scope) error {
-	out.ScopeName = core.ResourceQuotaScope(in.ScopeName)
-	out.Operator = core.ScopeSelectorOperator(in.Operator)
-	out.Values = *(*[]string)(unsafe.Pointer(&in.Values))
+	*out = *(*core.ScopedResourceSelectorRequirement)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8116,9 +7040,7 @@ func Convert_v1_ScopedResourceSelectorRequirement_To_core_ScopedResourceSelector
 }
 
 func autoConvert_core_ScopedResourceSelectorRequirement_To_v1_ScopedResourceSelectorRequirement(in *core.ScopedResourceSelectorRequirement, out *corev1.ScopedResourceSelectorRequirement, s conversion.Scope) error {
-	out.ScopeName = corev1.ResourceQuotaScope(in.ScopeName)
-	out.Operator = corev1.ScopeSelectorOperator(in.Operator)
-	out.Values = *(*[]string)(unsafe.Pointer(&in.Values))
+	*out = *(*corev1.ScopedResourceSelectorRequirement)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8128,8 +7050,7 @@ func Convert_core_ScopedResourceSelectorRequirement_To_v1_ScopedResourceSelector
 }
 
 func autoConvert_v1_SeccompProfile_To_core_SeccompProfile(in *corev1.SeccompProfile, out *core.SeccompProfile, s conversion.Scope) error {
-	out.Type = core.SeccompProfileType(in.Type)
-	out.LocalhostProfile = (*string)(unsafe.Pointer(in.LocalhostProfile))
+	*out = *(*core.SeccompProfile)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8139,8 +7060,7 @@ func Convert_v1_SeccompProfile_To_core_SeccompProfile(in *corev1.SeccompProfile,
 }
 
 func autoConvert_core_SeccompProfile_To_v1_SeccompProfile(in *core.SeccompProfile, out *corev1.SeccompProfile, s conversion.Scope) error {
-	out.Type = corev1.SeccompProfileType(in.Type)
-	out.LocalhostProfile = (*string)(unsafe.Pointer(in.LocalhostProfile))
+	*out = *(*corev1.SeccompProfile)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8172,10 +7092,7 @@ func Convert_core_Secret_To_v1_Secret(in *core.Secret, out *corev1.Secret, s con
 }
 
 func autoConvert_v1_SecretEnvSource_To_core_SecretEnvSource(in *corev1.SecretEnvSource, out *core.SecretEnvSource, s conversion.Scope) error {
-	if err := Convert_v1_LocalObjectReference_To_core_LocalObjectReference(&in.LocalObjectReference, &out.LocalObjectReference, s); err != nil {
-		return err
-	}
-	out.Optional = (*bool)(unsafe.Pointer(in.Optional))
+	*out = *(*core.SecretEnvSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8185,10 +7102,7 @@ func Convert_v1_SecretEnvSource_To_core_SecretEnvSource(in *corev1.SecretEnvSour
 }
 
 func autoConvert_core_SecretEnvSource_To_v1_SecretEnvSource(in *core.SecretEnvSource, out *corev1.SecretEnvSource, s conversion.Scope) error {
-	if err := Convert_core_LocalObjectReference_To_v1_LocalObjectReference(&in.LocalObjectReference, &out.LocalObjectReference, s); err != nil {
-		return err
-	}
-	out.Optional = (*bool)(unsafe.Pointer(in.Optional))
+	*out = *(*corev1.SecretEnvSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8198,11 +7112,7 @@ func Convert_core_SecretEnvSource_To_v1_SecretEnvSource(in *core.SecretEnvSource
 }
 
 func autoConvert_v1_SecretKeySelector_To_core_SecretKeySelector(in *corev1.SecretKeySelector, out *core.SecretKeySelector, s conversion.Scope) error {
-	if err := Convert_v1_LocalObjectReference_To_core_LocalObjectReference(&in.LocalObjectReference, &out.LocalObjectReference, s); err != nil {
-		return err
-	}
-	out.Key = in.Key
-	out.Optional = (*bool)(unsafe.Pointer(in.Optional))
+	*out = *(*core.SecretKeySelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8212,11 +7122,7 @@ func Convert_v1_SecretKeySelector_To_core_SecretKeySelector(in *corev1.SecretKey
 }
 
 func autoConvert_core_SecretKeySelector_To_v1_SecretKeySelector(in *core.SecretKeySelector, out *corev1.SecretKeySelector, s conversion.Scope) error {
-	if err := Convert_core_LocalObjectReference_To_v1_LocalObjectReference(&in.LocalObjectReference, &out.LocalObjectReference, s); err != nil {
-		return err
-	}
-	out.Key = in.Key
-	out.Optional = (*bool)(unsafe.Pointer(in.Optional))
+	*out = *(*corev1.SecretKeySelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8268,11 +7174,7 @@ func Convert_core_SecretList_To_v1_SecretList(in *core.SecretList, out *corev1.S
 }
 
 func autoConvert_v1_SecretProjection_To_core_SecretProjection(in *corev1.SecretProjection, out *core.SecretProjection, s conversion.Scope) error {
-	if err := Convert_v1_LocalObjectReference_To_core_LocalObjectReference(&in.LocalObjectReference, &out.LocalObjectReference, s); err != nil {
-		return err
-	}
-	out.Items = *(*[]core.KeyToPath)(unsafe.Pointer(&in.Items))
-	out.Optional = (*bool)(unsafe.Pointer(in.Optional))
+	*out = *(*core.SecretProjection)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8282,11 +7184,7 @@ func Convert_v1_SecretProjection_To_core_SecretProjection(in *corev1.SecretProje
 }
 
 func autoConvert_core_SecretProjection_To_v1_SecretProjection(in *core.SecretProjection, out *corev1.SecretProjection, s conversion.Scope) error {
-	if err := Convert_core_LocalObjectReference_To_v1_LocalObjectReference(&in.LocalObjectReference, &out.LocalObjectReference, s); err != nil {
-		return err
-	}
-	out.Items = *(*[]corev1.KeyToPath)(unsafe.Pointer(&in.Items))
-	out.Optional = (*bool)(unsafe.Pointer(in.Optional))
+	*out = *(*corev1.SecretProjection)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8296,8 +7194,7 @@ func Convert_core_SecretProjection_To_v1_SecretProjection(in *core.SecretProject
 }
 
 func autoConvert_v1_SecretReference_To_core_SecretReference(in *corev1.SecretReference, out *core.SecretReference, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Namespace = in.Namespace
+	*out = *(*core.SecretReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8307,8 +7204,7 @@ func Convert_v1_SecretReference_To_core_SecretReference(in *corev1.SecretReferen
 }
 
 func autoConvert_core_SecretReference_To_v1_SecretReference(in *core.SecretReference, out *corev1.SecretReference, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Namespace = in.Namespace
+	*out = *(*corev1.SecretReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8318,10 +7214,7 @@ func Convert_core_SecretReference_To_v1_SecretReference(in *core.SecretReference
 }
 
 func autoConvert_v1_SecretVolumeSource_To_core_SecretVolumeSource(in *corev1.SecretVolumeSource, out *core.SecretVolumeSource, s conversion.Scope) error {
-	out.SecretName = in.SecretName
-	out.Items = *(*[]core.KeyToPath)(unsafe.Pointer(&in.Items))
-	out.DefaultMode = (*int32)(unsafe.Pointer(in.DefaultMode))
-	out.Optional = (*bool)(unsafe.Pointer(in.Optional))
+	*out = *(*core.SecretVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8331,10 +7224,7 @@ func Convert_v1_SecretVolumeSource_To_core_SecretVolumeSource(in *corev1.SecretV
 }
 
 func autoConvert_core_SecretVolumeSource_To_v1_SecretVolumeSource(in *core.SecretVolumeSource, out *corev1.SecretVolumeSource, s conversion.Scope) error {
-	out.SecretName = in.SecretName
-	out.Items = *(*[]corev1.KeyToPath)(unsafe.Pointer(&in.Items))
-	out.DefaultMode = (*int32)(unsafe.Pointer(in.DefaultMode))
-	out.Optional = (*bool)(unsafe.Pointer(in.Optional))
+	*out = *(*corev1.SecretVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8344,18 +7234,7 @@ func Convert_core_SecretVolumeSource_To_v1_SecretVolumeSource(in *core.SecretVol
 }
 
 func autoConvert_v1_SecurityContext_To_core_SecurityContext(in *corev1.SecurityContext, out *core.SecurityContext, s conversion.Scope) error {
-	out.Capabilities = (*core.Capabilities)(unsafe.Pointer(in.Capabilities))
-	out.Privileged = (*bool)(unsafe.Pointer(in.Privileged))
-	out.SELinuxOptions = (*core.SELinuxOptions)(unsafe.Pointer(in.SELinuxOptions))
-	out.WindowsOptions = (*core.WindowsSecurityContextOptions)(unsafe.Pointer(in.WindowsOptions))
-	out.RunAsUser = (*int64)(unsafe.Pointer(in.RunAsUser))
-	out.RunAsGroup = (*int64)(unsafe.Pointer(in.RunAsGroup))
-	out.RunAsNonRoot = (*bool)(unsafe.Pointer(in.RunAsNonRoot))
-	out.ReadOnlyRootFilesystem = (*bool)(unsafe.Pointer(in.ReadOnlyRootFilesystem))
-	out.AllowPrivilegeEscalation = (*bool)(unsafe.Pointer(in.AllowPrivilegeEscalation))
-	out.ProcMount = (*core.ProcMountType)(unsafe.Pointer(in.ProcMount))
-	out.SeccompProfile = (*core.SeccompProfile)(unsafe.Pointer(in.SeccompProfile))
-	out.AppArmorProfile = (*core.AppArmorProfile)(unsafe.Pointer(in.AppArmorProfile))
+	*out = *(*core.SecurityContext)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8365,18 +7244,7 @@ func Convert_v1_SecurityContext_To_core_SecurityContext(in *corev1.SecurityConte
 }
 
 func autoConvert_core_SecurityContext_To_v1_SecurityContext(in *core.SecurityContext, out *corev1.SecurityContext, s conversion.Scope) error {
-	out.Capabilities = (*corev1.Capabilities)(unsafe.Pointer(in.Capabilities))
-	out.Privileged = (*bool)(unsafe.Pointer(in.Privileged))
-	out.SELinuxOptions = (*corev1.SELinuxOptions)(unsafe.Pointer(in.SELinuxOptions))
-	out.WindowsOptions = (*corev1.WindowsSecurityContextOptions)(unsafe.Pointer(in.WindowsOptions))
-	out.RunAsUser = (*int64)(unsafe.Pointer(in.RunAsUser))
-	out.RunAsGroup = (*int64)(unsafe.Pointer(in.RunAsGroup))
-	out.RunAsNonRoot = (*bool)(unsafe.Pointer(in.RunAsNonRoot))
-	out.ReadOnlyRootFilesystem = (*bool)(unsafe.Pointer(in.ReadOnlyRootFilesystem))
-	out.AllowPrivilegeEscalation = (*bool)(unsafe.Pointer(in.AllowPrivilegeEscalation))
-	out.ProcMount = (*corev1.ProcMountType)(unsafe.Pointer(in.ProcMount))
-	out.SeccompProfile = (*corev1.SeccompProfile)(unsafe.Pointer(in.SeccompProfile))
-	out.AppArmorProfile = (*corev1.AppArmorProfile)(unsafe.Pointer(in.AppArmorProfile))
+	*out = *(*corev1.SecurityContext)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8490,9 +7358,7 @@ func Convert_core_ServiceAccountList_To_v1_ServiceAccountList(in *core.ServiceAc
 }
 
 func autoConvert_v1_ServiceAccountTokenProjection_To_core_ServiceAccountTokenProjection(in *corev1.ServiceAccountTokenProjection, out *core.ServiceAccountTokenProjection, s conversion.Scope) error {
-	out.Audience = in.Audience
-	out.ExpirationSeconds = (*int64)(unsafe.Pointer(in.ExpirationSeconds))
-	out.Path = in.Path
+	*out = *(*core.ServiceAccountTokenProjection)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8502,9 +7368,7 @@ func Convert_v1_ServiceAccountTokenProjection_To_core_ServiceAccountTokenProject
 }
 
 func autoConvert_core_ServiceAccountTokenProjection_To_v1_ServiceAccountTokenProjection(in *core.ServiceAccountTokenProjection, out *corev1.ServiceAccountTokenProjection, s conversion.Scope) error {
-	out.Audience = in.Audience
-	out.ExpirationSeconds = (*int64)(unsafe.Pointer(in.ExpirationSeconds))
-	out.Path = in.Path
+	*out = *(*corev1.ServiceAccountTokenProjection)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8556,12 +7420,7 @@ func Convert_core_ServiceList_To_v1_ServiceList(in *core.ServiceList, out *corev
 }
 
 func autoConvert_v1_ServicePort_To_core_ServicePort(in *corev1.ServicePort, out *core.ServicePort, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Protocol = core.Protocol(in.Protocol)
-	out.AppProtocol = (*string)(unsafe.Pointer(in.AppProtocol))
-	out.Port = in.Port
-	out.TargetPort = in.TargetPort
-	out.NodePort = in.NodePort
+	*out = *(*core.ServicePort)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8571,12 +7430,7 @@ func Convert_v1_ServicePort_To_core_ServicePort(in *corev1.ServicePort, out *cor
 }
 
 func autoConvert_core_ServicePort_To_v1_ServicePort(in *core.ServicePort, out *corev1.ServicePort, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Protocol = corev1.Protocol(in.Protocol)
-	out.AppProtocol = (*string)(unsafe.Pointer(in.AppProtocol))
-	out.Port = in.Port
-	out.TargetPort = in.TargetPort
-	out.NodePort = in.NodePort
+	*out = *(*corev1.ServicePort)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8682,10 +7536,7 @@ func Convert_core_ServiceSpec_To_v1_ServiceSpec(in *core.ServiceSpec, out *corev
 }
 
 func autoConvert_v1_ServiceStatus_To_core_ServiceStatus(in *corev1.ServiceStatus, out *core.ServiceStatus, s conversion.Scope) error {
-	if err := Convert_v1_LoadBalancerStatus_To_core_LoadBalancerStatus(&in.LoadBalancer, &out.LoadBalancer, s); err != nil {
-		return err
-	}
-	out.Conditions = *(*[]metav1.Condition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*core.ServiceStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8695,10 +7546,7 @@ func Convert_v1_ServiceStatus_To_core_ServiceStatus(in *corev1.ServiceStatus, ou
 }
 
 func autoConvert_core_ServiceStatus_To_v1_ServiceStatus(in *core.ServiceStatus, out *corev1.ServiceStatus, s conversion.Scope) error {
-	if err := Convert_core_LoadBalancerStatus_To_v1_LoadBalancerStatus(&in.LoadBalancer, &out.LoadBalancer, s); err != nil {
-		return err
-	}
-	out.Conditions = *(*[]metav1.Condition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*corev1.ServiceStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8708,7 +7556,7 @@ func Convert_core_ServiceStatus_To_v1_ServiceStatus(in *core.ServiceStatus, out 
 }
 
 func autoConvert_v1_SessionAffinityConfig_To_core_SessionAffinityConfig(in *corev1.SessionAffinityConfig, out *core.SessionAffinityConfig, s conversion.Scope) error {
-	out.ClientIP = (*core.ClientIPConfig)(unsafe.Pointer(in.ClientIP))
+	*out = *(*core.SessionAffinityConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8718,7 +7566,7 @@ func Convert_v1_SessionAffinityConfig_To_core_SessionAffinityConfig(in *corev1.S
 }
 
 func autoConvert_core_SessionAffinityConfig_To_v1_SessionAffinityConfig(in *core.SessionAffinityConfig, out *corev1.SessionAffinityConfig, s conversion.Scope) error {
-	out.ClientIP = (*corev1.ClientIPConfig)(unsafe.Pointer(in.ClientIP))
+	*out = *(*corev1.SessionAffinityConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8728,7 +7576,7 @@ func Convert_core_SessionAffinityConfig_To_v1_SessionAffinityConfig(in *core.Ses
 }
 
 func autoConvert_v1_SleepAction_To_core_SleepAction(in *corev1.SleepAction, out *core.SleepAction, s conversion.Scope) error {
-	out.Seconds = in.Seconds
+	*out = *(*core.SleepAction)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8738,7 +7586,7 @@ func Convert_v1_SleepAction_To_core_SleepAction(in *corev1.SleepAction, out *cor
 }
 
 func autoConvert_core_SleepAction_To_v1_SleepAction(in *core.SleepAction, out *corev1.SleepAction, s conversion.Scope) error {
-	out.Seconds = in.Seconds
+	*out = *(*corev1.SleepAction)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8748,11 +7596,7 @@ func Convert_core_SleepAction_To_v1_SleepAction(in *core.SleepAction, out *corev
 }
 
 func autoConvert_v1_StorageOSPersistentVolumeSource_To_core_StorageOSPersistentVolumeSource(in *corev1.StorageOSPersistentVolumeSource, out *core.StorageOSPersistentVolumeSource, s conversion.Scope) error {
-	out.VolumeName = in.VolumeName
-	out.VolumeNamespace = in.VolumeNamespace
-	out.FSType = in.FSType
-	out.ReadOnly = in.ReadOnly
-	out.SecretRef = (*core.ObjectReference)(unsafe.Pointer(in.SecretRef))
+	*out = *(*core.StorageOSPersistentVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8762,11 +7606,7 @@ func Convert_v1_StorageOSPersistentVolumeSource_To_core_StorageOSPersistentVolum
 }
 
 func autoConvert_core_StorageOSPersistentVolumeSource_To_v1_StorageOSPersistentVolumeSource(in *core.StorageOSPersistentVolumeSource, out *corev1.StorageOSPersistentVolumeSource, s conversion.Scope) error {
-	out.VolumeName = in.VolumeName
-	out.VolumeNamespace = in.VolumeNamespace
-	out.FSType = in.FSType
-	out.ReadOnly = in.ReadOnly
-	out.SecretRef = (*corev1.ObjectReference)(unsafe.Pointer(in.SecretRef))
+	*out = *(*corev1.StorageOSPersistentVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8776,11 +7616,7 @@ func Convert_core_StorageOSPersistentVolumeSource_To_v1_StorageOSPersistentVolum
 }
 
 func autoConvert_v1_StorageOSVolumeSource_To_core_StorageOSVolumeSource(in *corev1.StorageOSVolumeSource, out *core.StorageOSVolumeSource, s conversion.Scope) error {
-	out.VolumeName = in.VolumeName
-	out.VolumeNamespace = in.VolumeNamespace
-	out.FSType = in.FSType
-	out.ReadOnly = in.ReadOnly
-	out.SecretRef = (*core.LocalObjectReference)(unsafe.Pointer(in.SecretRef))
+	*out = *(*core.StorageOSVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8790,11 +7626,7 @@ func Convert_v1_StorageOSVolumeSource_To_core_StorageOSVolumeSource(in *corev1.S
 }
 
 func autoConvert_core_StorageOSVolumeSource_To_v1_StorageOSVolumeSource(in *core.StorageOSVolumeSource, out *corev1.StorageOSVolumeSource, s conversion.Scope) error {
-	out.VolumeName = in.VolumeName
-	out.VolumeNamespace = in.VolumeNamespace
-	out.FSType = in.FSType
-	out.ReadOnly = in.ReadOnly
-	out.SecretRef = (*corev1.LocalObjectReference)(unsafe.Pointer(in.SecretRef))
+	*out = *(*corev1.StorageOSVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8804,8 +7636,7 @@ func Convert_core_StorageOSVolumeSource_To_v1_StorageOSVolumeSource(in *core.Sto
 }
 
 func autoConvert_v1_Sysctl_To_core_Sysctl(in *corev1.Sysctl, out *core.Sysctl, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Value = in.Value
+	*out = *(*core.Sysctl)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8815,8 +7646,7 @@ func Convert_v1_Sysctl_To_core_Sysctl(in *corev1.Sysctl, out *core.Sysctl, s con
 }
 
 func autoConvert_core_Sysctl_To_v1_Sysctl(in *core.Sysctl, out *corev1.Sysctl, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Value = in.Value
+	*out = *(*corev1.Sysctl)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8826,8 +7656,7 @@ func Convert_core_Sysctl_To_v1_Sysctl(in *core.Sysctl, out *corev1.Sysctl, s con
 }
 
 func autoConvert_v1_TCPSocketAction_To_core_TCPSocketAction(in *corev1.TCPSocketAction, out *core.TCPSocketAction, s conversion.Scope) error {
-	out.Port = in.Port
-	out.Host = in.Host
+	*out = *(*core.TCPSocketAction)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8837,8 +7666,7 @@ func Convert_v1_TCPSocketAction_To_core_TCPSocketAction(in *corev1.TCPSocketActi
 }
 
 func autoConvert_core_TCPSocketAction_To_v1_TCPSocketAction(in *core.TCPSocketAction, out *corev1.TCPSocketAction, s conversion.Scope) error {
-	out.Port = in.Port
-	out.Host = in.Host
+	*out = *(*corev1.TCPSocketAction)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8848,10 +7676,7 @@ func Convert_core_TCPSocketAction_To_v1_TCPSocketAction(in *core.TCPSocketAction
 }
 
 func autoConvert_v1_Taint_To_core_Taint(in *corev1.Taint, out *core.Taint, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Value = in.Value
-	out.Effect = core.TaintEffect(in.Effect)
-	out.TimeAdded = (*metav1.Time)(unsafe.Pointer(in.TimeAdded))
+	*out = *(*core.Taint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8861,10 +7686,7 @@ func Convert_v1_Taint_To_core_Taint(in *corev1.Taint, out *core.Taint, s convers
 }
 
 func autoConvert_core_Taint_To_v1_Taint(in *core.Taint, out *corev1.Taint, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Value = in.Value
-	out.Effect = corev1.TaintEffect(in.Effect)
-	out.TimeAdded = (*metav1.Time)(unsafe.Pointer(in.TimeAdded))
+	*out = *(*corev1.Taint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8874,11 +7696,7 @@ func Convert_core_Taint_To_v1_Taint(in *core.Taint, out *corev1.Taint, s convers
 }
 
 func autoConvert_v1_Toleration_To_core_Toleration(in *corev1.Toleration, out *core.Toleration, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Operator = core.TolerationOperator(in.Operator)
-	out.Value = in.Value
-	out.Effect = core.TaintEffect(in.Effect)
-	out.TolerationSeconds = (*int64)(unsafe.Pointer(in.TolerationSeconds))
+	*out = *(*core.Toleration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8888,11 +7706,7 @@ func Convert_v1_Toleration_To_core_Toleration(in *corev1.Toleration, out *core.T
 }
 
 func autoConvert_core_Toleration_To_v1_Toleration(in *core.Toleration, out *corev1.Toleration, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Operator = corev1.TolerationOperator(in.Operator)
-	out.Value = in.Value
-	out.Effect = corev1.TaintEffect(in.Effect)
-	out.TolerationSeconds = (*int64)(unsafe.Pointer(in.TolerationSeconds))
+	*out = *(*corev1.Toleration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8902,8 +7716,7 @@ func Convert_core_Toleration_To_v1_Toleration(in *core.Toleration, out *corev1.T
 }
 
 func autoConvert_v1_TopologySelectorLabelRequirement_To_core_TopologySelectorLabelRequirement(in *corev1.TopologySelectorLabelRequirement, out *core.TopologySelectorLabelRequirement, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Values = *(*[]string)(unsafe.Pointer(&in.Values))
+	*out = *(*core.TopologySelectorLabelRequirement)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8913,8 +7726,7 @@ func Convert_v1_TopologySelectorLabelRequirement_To_core_TopologySelectorLabelRe
 }
 
 func autoConvert_core_TopologySelectorLabelRequirement_To_v1_TopologySelectorLabelRequirement(in *core.TopologySelectorLabelRequirement, out *corev1.TopologySelectorLabelRequirement, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Values = *(*[]string)(unsafe.Pointer(&in.Values))
+	*out = *(*corev1.TopologySelectorLabelRequirement)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8924,7 +7736,7 @@ func Convert_core_TopologySelectorLabelRequirement_To_v1_TopologySelectorLabelRe
 }
 
 func autoConvert_v1_TopologySelectorTerm_To_core_TopologySelectorTerm(in *corev1.TopologySelectorTerm, out *core.TopologySelectorTerm, s conversion.Scope) error {
-	out.MatchLabelExpressions = *(*[]core.TopologySelectorLabelRequirement)(unsafe.Pointer(&in.MatchLabelExpressions))
+	*out = *(*core.TopologySelectorTerm)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8934,7 +7746,7 @@ func Convert_v1_TopologySelectorTerm_To_core_TopologySelectorTerm(in *corev1.Top
 }
 
 func autoConvert_core_TopologySelectorTerm_To_v1_TopologySelectorTerm(in *core.TopologySelectorTerm, out *corev1.TopologySelectorTerm, s conversion.Scope) error {
-	out.MatchLabelExpressions = *(*[]corev1.TopologySelectorLabelRequirement)(unsafe.Pointer(&in.MatchLabelExpressions))
+	*out = *(*corev1.TopologySelectorTerm)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8944,14 +7756,7 @@ func Convert_core_TopologySelectorTerm_To_v1_TopologySelectorTerm(in *core.Topol
 }
 
 func autoConvert_v1_TopologySpreadConstraint_To_core_TopologySpreadConstraint(in *corev1.TopologySpreadConstraint, out *core.TopologySpreadConstraint, s conversion.Scope) error {
-	out.MaxSkew = in.MaxSkew
-	out.TopologyKey = in.TopologyKey
-	out.WhenUnsatisfiable = core.UnsatisfiableConstraintAction(in.WhenUnsatisfiable)
-	out.LabelSelector = (*metav1.LabelSelector)(unsafe.Pointer(in.LabelSelector))
-	out.MinDomains = (*int32)(unsafe.Pointer(in.MinDomains))
-	out.NodeAffinityPolicy = (*core.NodeInclusionPolicy)(unsafe.Pointer(in.NodeAffinityPolicy))
-	out.NodeTaintsPolicy = (*core.NodeInclusionPolicy)(unsafe.Pointer(in.NodeTaintsPolicy))
-	out.MatchLabelKeys = *(*[]string)(unsafe.Pointer(&in.MatchLabelKeys))
+	*out = *(*core.TopologySpreadConstraint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8961,14 +7766,7 @@ func Convert_v1_TopologySpreadConstraint_To_core_TopologySpreadConstraint(in *co
 }
 
 func autoConvert_core_TopologySpreadConstraint_To_v1_TopologySpreadConstraint(in *core.TopologySpreadConstraint, out *corev1.TopologySpreadConstraint, s conversion.Scope) error {
-	out.MaxSkew = in.MaxSkew
-	out.TopologyKey = in.TopologyKey
-	out.WhenUnsatisfiable = corev1.UnsatisfiableConstraintAction(in.WhenUnsatisfiable)
-	out.LabelSelector = (*metav1.LabelSelector)(unsafe.Pointer(in.LabelSelector))
-	out.MinDomains = (*int32)(unsafe.Pointer(in.MinDomains))
-	out.NodeAffinityPolicy = (*corev1.NodeInclusionPolicy)(unsafe.Pointer(in.NodeAffinityPolicy))
-	out.NodeTaintsPolicy = (*corev1.NodeInclusionPolicy)(unsafe.Pointer(in.NodeTaintsPolicy))
-	out.MatchLabelKeys = *(*[]string)(unsafe.Pointer(&in.MatchLabelKeys))
+	*out = *(*corev1.TopologySpreadConstraint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8978,9 +7776,7 @@ func Convert_core_TopologySpreadConstraint_To_v1_TopologySpreadConstraint(in *co
 }
 
 func autoConvert_v1_TypedLocalObjectReference_To_core_TypedLocalObjectReference(in *corev1.TypedLocalObjectReference, out *core.TypedLocalObjectReference, s conversion.Scope) error {
-	out.APIGroup = (*string)(unsafe.Pointer(in.APIGroup))
-	out.Kind = in.Kind
-	out.Name = in.Name
+	*out = *(*core.TypedLocalObjectReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -8990,9 +7786,7 @@ func Convert_v1_TypedLocalObjectReference_To_core_TypedLocalObjectReference(in *
 }
 
 func autoConvert_core_TypedLocalObjectReference_To_v1_TypedLocalObjectReference(in *core.TypedLocalObjectReference, out *corev1.TypedLocalObjectReference, s conversion.Scope) error {
-	out.APIGroup = (*string)(unsafe.Pointer(in.APIGroup))
-	out.Kind = in.Kind
-	out.Name = in.Name
+	*out = *(*corev1.TypedLocalObjectReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -9002,10 +7796,7 @@ func Convert_core_TypedLocalObjectReference_To_v1_TypedLocalObjectReference(in *
 }
 
 func autoConvert_v1_TypedObjectReference_To_core_TypedObjectReference(in *corev1.TypedObjectReference, out *core.TypedObjectReference, s conversion.Scope) error {
-	out.APIGroup = (*string)(unsafe.Pointer(in.APIGroup))
-	out.Kind = in.Kind
-	out.Name = in.Name
-	out.Namespace = (*string)(unsafe.Pointer(in.Namespace))
+	*out = *(*core.TypedObjectReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -9015,10 +7806,7 @@ func Convert_v1_TypedObjectReference_To_core_TypedObjectReference(in *corev1.Typ
 }
 
 func autoConvert_core_TypedObjectReference_To_v1_TypedObjectReference(in *core.TypedObjectReference, out *corev1.TypedObjectReference, s conversion.Scope) error {
-	out.APIGroup = (*string)(unsafe.Pointer(in.APIGroup))
-	out.Kind = in.Kind
-	out.Name = in.Name
-	out.Namespace = (*string)(unsafe.Pointer(in.Namespace))
+	*out = *(*corev1.TypedObjectReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -9028,10 +7816,7 @@ func Convert_core_TypedObjectReference_To_v1_TypedObjectReference(in *core.Typed
 }
 
 func autoConvert_v1_Volume_To_core_Volume(in *corev1.Volume, out *core.Volume, s conversion.Scope) error {
-	out.Name = in.Name
-	if err := Convert_v1_VolumeSource_To_core_VolumeSource(&in.VolumeSource, &out.VolumeSource, s); err != nil {
-		return err
-	}
+	*out = *(*core.Volume)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -9041,10 +7826,7 @@ func Convert_v1_Volume_To_core_Volume(in *corev1.Volume, out *core.Volume, s con
 }
 
 func autoConvert_core_Volume_To_v1_Volume(in *core.Volume, out *corev1.Volume, s conversion.Scope) error {
-	out.Name = in.Name
-	if err := Convert_core_VolumeSource_To_v1_VolumeSource(&in.VolumeSource, &out.VolumeSource, s); err != nil {
-		return err
-	}
+	*out = *(*corev1.Volume)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -9054,8 +7836,7 @@ func Convert_core_Volume_To_v1_Volume(in *core.Volume, out *corev1.Volume, s con
 }
 
 func autoConvert_v1_VolumeDevice_To_core_VolumeDevice(in *corev1.VolumeDevice, out *core.VolumeDevice, s conversion.Scope) error {
-	out.Name = in.Name
-	out.DevicePath = in.DevicePath
+	*out = *(*core.VolumeDevice)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -9065,8 +7846,7 @@ func Convert_v1_VolumeDevice_To_core_VolumeDevice(in *corev1.VolumeDevice, out *
 }
 
 func autoConvert_core_VolumeDevice_To_v1_VolumeDevice(in *core.VolumeDevice, out *corev1.VolumeDevice, s conversion.Scope) error {
-	out.Name = in.Name
-	out.DevicePath = in.DevicePath
+	*out = *(*corev1.VolumeDevice)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -9076,13 +7856,7 @@ func Convert_core_VolumeDevice_To_v1_VolumeDevice(in *core.VolumeDevice, out *co
 }
 
 func autoConvert_v1_VolumeMount_To_core_VolumeMount(in *corev1.VolumeMount, out *core.VolumeMount, s conversion.Scope) error {
-	out.Name = in.Name
-	out.ReadOnly = in.ReadOnly
-	out.RecursiveReadOnly = (*core.RecursiveReadOnlyMode)(unsafe.Pointer(in.RecursiveReadOnly))
-	out.MountPath = in.MountPath
-	out.SubPath = in.SubPath
-	out.MountPropagation = (*core.MountPropagationMode)(unsafe.Pointer(in.MountPropagation))
-	out.SubPathExpr = in.SubPathExpr
+	*out = *(*core.VolumeMount)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -9092,13 +7866,7 @@ func Convert_v1_VolumeMount_To_core_VolumeMount(in *corev1.VolumeMount, out *cor
 }
 
 func autoConvert_core_VolumeMount_To_v1_VolumeMount(in *core.VolumeMount, out *corev1.VolumeMount, s conversion.Scope) error {
-	out.Name = in.Name
-	out.ReadOnly = in.ReadOnly
-	out.RecursiveReadOnly = (*corev1.RecursiveReadOnlyMode)(unsafe.Pointer(in.RecursiveReadOnly))
-	out.MountPath = in.MountPath
-	out.SubPath = in.SubPath
-	out.MountPropagation = (*corev1.MountPropagationMode)(unsafe.Pointer(in.MountPropagation))
-	out.SubPathExpr = in.SubPathExpr
+	*out = *(*corev1.VolumeMount)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -9108,11 +7876,7 @@ func Convert_core_VolumeMount_To_v1_VolumeMount(in *core.VolumeMount, out *corev
 }
 
 func autoConvert_v1_VolumeMountStatus_To_core_VolumeMountStatus(in *corev1.VolumeMountStatus, out *core.VolumeMountStatus, s conversion.Scope) error {
-	out.Name = in.Name
-	out.MountPath = in.MountPath
-	out.ReadOnly = in.ReadOnly
-	out.RecursiveReadOnly = (*core.RecursiveReadOnlyMode)(unsafe.Pointer(in.RecursiveReadOnly))
-	out.VolumeStatus = (*core.VolumeStatus)(unsafe.Pointer(in.VolumeStatus))
+	*out = *(*core.VolumeMountStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -9122,11 +7886,7 @@ func Convert_v1_VolumeMountStatus_To_core_VolumeMountStatus(in *corev1.VolumeMou
 }
 
 func autoConvert_core_VolumeMountStatus_To_v1_VolumeMountStatus(in *core.VolumeMountStatus, out *corev1.VolumeMountStatus, s conversion.Scope) error {
-	out.Name = in.Name
-	out.MountPath = in.MountPath
-	out.ReadOnly = in.ReadOnly
-	out.RecursiveReadOnly = (*corev1.RecursiveReadOnlyMode)(unsafe.Pointer(in.RecursiveReadOnly))
-	out.VolumeStatus = (*corev1.VolumeStatus)(unsafe.Pointer(in.VolumeStatus))
+	*out = *(*corev1.VolumeMountStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -9136,7 +7896,7 @@ func Convert_core_VolumeMountStatus_To_v1_VolumeMountStatus(in *core.VolumeMount
 }
 
 func autoConvert_v1_VolumeNodeAffinity_To_core_VolumeNodeAffinity(in *corev1.VolumeNodeAffinity, out *core.VolumeNodeAffinity, s conversion.Scope) error {
-	out.Required = (*core.NodeSelector)(unsafe.Pointer(in.Required))
+	*out = *(*core.VolumeNodeAffinity)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -9146,7 +7906,7 @@ func Convert_v1_VolumeNodeAffinity_To_core_VolumeNodeAffinity(in *corev1.VolumeN
 }
 
 func autoConvert_core_VolumeNodeAffinity_To_v1_VolumeNodeAffinity(in *core.VolumeNodeAffinity, out *corev1.VolumeNodeAffinity, s conversion.Scope) error {
-	out.Required = (*corev1.NodeSelector)(unsafe.Pointer(in.Required))
+	*out = *(*corev1.VolumeNodeAffinity)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -9156,12 +7916,7 @@ func Convert_core_VolumeNodeAffinity_To_v1_VolumeNodeAffinity(in *core.VolumeNod
 }
 
 func autoConvert_v1_VolumeProjection_To_core_VolumeProjection(in *corev1.VolumeProjection, out *core.VolumeProjection, s conversion.Scope) error {
-	out.Secret = (*core.SecretProjection)(unsafe.Pointer(in.Secret))
-	out.DownwardAPI = (*core.DownwardAPIProjection)(unsafe.Pointer(in.DownwardAPI))
-	out.ConfigMap = (*core.ConfigMapProjection)(unsafe.Pointer(in.ConfigMap))
-	out.ServiceAccountToken = (*core.ServiceAccountTokenProjection)(unsafe.Pointer(in.ServiceAccountToken))
-	out.ClusterTrustBundle = (*core.ClusterTrustBundleProjection)(unsafe.Pointer(in.ClusterTrustBundle))
-	out.PodCertificate = (*core.PodCertificateProjection)(unsafe.Pointer(in.PodCertificate))
+	*out = *(*core.VolumeProjection)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -9171,12 +7926,7 @@ func Convert_v1_VolumeProjection_To_core_VolumeProjection(in *corev1.VolumeProje
 }
 
 func autoConvert_core_VolumeProjection_To_v1_VolumeProjection(in *core.VolumeProjection, out *corev1.VolumeProjection, s conversion.Scope) error {
-	out.Secret = (*corev1.SecretProjection)(unsafe.Pointer(in.Secret))
-	out.DownwardAPI = (*corev1.DownwardAPIProjection)(unsafe.Pointer(in.DownwardAPI))
-	out.ConfigMap = (*corev1.ConfigMapProjection)(unsafe.Pointer(in.ConfigMap))
-	out.ServiceAccountToken = (*corev1.ServiceAccountTokenProjection)(unsafe.Pointer(in.ServiceAccountToken))
-	out.ClusterTrustBundle = (*corev1.ClusterTrustBundleProjection)(unsafe.Pointer(in.ClusterTrustBundle))
-	out.PodCertificate = (*corev1.PodCertificateProjection)(unsafe.Pointer(in.PodCertificate))
+	*out = *(*corev1.VolumeProjection)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -9186,8 +7936,7 @@ func Convert_core_VolumeProjection_To_v1_VolumeProjection(in *core.VolumeProject
 }
 
 func autoConvert_v1_VolumeResourceRequirements_To_core_VolumeResourceRequirements(in *corev1.VolumeResourceRequirements, out *core.VolumeResourceRequirements, s conversion.Scope) error {
-	out.Limits = *(*core.ResourceList)(unsafe.Pointer(&in.Limits))
-	out.Requests = *(*core.ResourceList)(unsafe.Pointer(&in.Requests))
+	*out = *(*core.VolumeResourceRequirements)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -9197,8 +7946,7 @@ func Convert_v1_VolumeResourceRequirements_To_core_VolumeResourceRequirements(in
 }
 
 func autoConvert_core_VolumeResourceRequirements_To_v1_VolumeResourceRequirements(in *core.VolumeResourceRequirements, out *corev1.VolumeResourceRequirements, s conversion.Scope) error {
-	out.Limits = *(*corev1.ResourceList)(unsafe.Pointer(&in.Limits))
-	out.Requests = *(*corev1.ResourceList)(unsafe.Pointer(&in.Requests))
+	*out = *(*corev1.VolumeResourceRequirements)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -9208,36 +7956,7 @@ func Convert_core_VolumeResourceRequirements_To_v1_VolumeResourceRequirements(in
 }
 
 func autoConvert_v1_VolumeSource_To_core_VolumeSource(in *corev1.VolumeSource, out *core.VolumeSource, s conversion.Scope) error {
-	out.HostPath = (*core.HostPathVolumeSource)(unsafe.Pointer(in.HostPath))
-	out.EmptyDir = (*core.EmptyDirVolumeSource)(unsafe.Pointer(in.EmptyDir))
-	out.GCEPersistentDisk = (*core.GCEPersistentDiskVolumeSource)(unsafe.Pointer(in.GCEPersistentDisk))
-	out.AWSElasticBlockStore = (*core.AWSElasticBlockStoreVolumeSource)(unsafe.Pointer(in.AWSElasticBlockStore))
-	out.GitRepo = (*core.GitRepoVolumeSource)(unsafe.Pointer(in.GitRepo))
-	out.Secret = (*core.SecretVolumeSource)(unsafe.Pointer(in.Secret))
-	out.NFS = (*core.NFSVolumeSource)(unsafe.Pointer(in.NFS))
-	out.ISCSI = (*core.ISCSIVolumeSource)(unsafe.Pointer(in.ISCSI))
-	out.Glusterfs = (*core.GlusterfsVolumeSource)(unsafe.Pointer(in.Glusterfs))
-	out.PersistentVolumeClaim = (*core.PersistentVolumeClaimVolumeSource)(unsafe.Pointer(in.PersistentVolumeClaim))
-	out.RBD = (*core.RBDVolumeSource)(unsafe.Pointer(in.RBD))
-	out.FlexVolume = (*core.FlexVolumeSource)(unsafe.Pointer(in.FlexVolume))
-	out.Cinder = (*core.CinderVolumeSource)(unsafe.Pointer(in.Cinder))
-	out.CephFS = (*core.CephFSVolumeSource)(unsafe.Pointer(in.CephFS))
-	out.Flocker = (*core.FlockerVolumeSource)(unsafe.Pointer(in.Flocker))
-	out.DownwardAPI = (*core.DownwardAPIVolumeSource)(unsafe.Pointer(in.DownwardAPI))
-	out.FC = (*core.FCVolumeSource)(unsafe.Pointer(in.FC))
-	out.AzureFile = (*core.AzureFileVolumeSource)(unsafe.Pointer(in.AzureFile))
-	out.ConfigMap = (*core.ConfigMapVolumeSource)(unsafe.Pointer(in.ConfigMap))
-	out.VsphereVolume = (*core.VsphereVirtualDiskVolumeSource)(unsafe.Pointer(in.VsphereVolume))
-	out.Quobyte = (*core.QuobyteVolumeSource)(unsafe.Pointer(in.Quobyte))
-	out.AzureDisk = (*core.AzureDiskVolumeSource)(unsafe.Pointer(in.AzureDisk))
-	out.PhotonPersistentDisk = (*core.PhotonPersistentDiskVolumeSource)(unsafe.Pointer(in.PhotonPersistentDisk))
-	out.Projected = (*core.ProjectedVolumeSource)(unsafe.Pointer(in.Projected))
-	out.PortworxVolume = (*core.PortworxVolumeSource)(unsafe.Pointer(in.PortworxVolume))
-	out.ScaleIO = (*core.ScaleIOVolumeSource)(unsafe.Pointer(in.ScaleIO))
-	out.StorageOS = (*core.StorageOSVolumeSource)(unsafe.Pointer(in.StorageOS))
-	out.CSI = (*core.CSIVolumeSource)(unsafe.Pointer(in.CSI))
-	out.Ephemeral = (*core.EphemeralVolumeSource)(unsafe.Pointer(in.Ephemeral))
-	out.Image = (*core.ImageVolumeSource)(unsafe.Pointer(in.Image))
+	*out = *(*core.VolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -9247,36 +7966,7 @@ func Convert_v1_VolumeSource_To_core_VolumeSource(in *corev1.VolumeSource, out *
 }
 
 func autoConvert_core_VolumeSource_To_v1_VolumeSource(in *core.VolumeSource, out *corev1.VolumeSource, s conversion.Scope) error {
-	out.HostPath = (*corev1.HostPathVolumeSource)(unsafe.Pointer(in.HostPath))
-	out.EmptyDir = (*corev1.EmptyDirVolumeSource)(unsafe.Pointer(in.EmptyDir))
-	out.GCEPersistentDisk = (*corev1.GCEPersistentDiskVolumeSource)(unsafe.Pointer(in.GCEPersistentDisk))
-	out.AWSElasticBlockStore = (*corev1.AWSElasticBlockStoreVolumeSource)(unsafe.Pointer(in.AWSElasticBlockStore))
-	out.GitRepo = (*corev1.GitRepoVolumeSource)(unsafe.Pointer(in.GitRepo))
-	out.Secret = (*corev1.SecretVolumeSource)(unsafe.Pointer(in.Secret))
-	out.NFS = (*corev1.NFSVolumeSource)(unsafe.Pointer(in.NFS))
-	out.ISCSI = (*corev1.ISCSIVolumeSource)(unsafe.Pointer(in.ISCSI))
-	out.Glusterfs = (*corev1.GlusterfsVolumeSource)(unsafe.Pointer(in.Glusterfs))
-	out.PersistentVolumeClaim = (*corev1.PersistentVolumeClaimVolumeSource)(unsafe.Pointer(in.PersistentVolumeClaim))
-	out.RBD = (*corev1.RBDVolumeSource)(unsafe.Pointer(in.RBD))
-	out.FlexVolume = (*corev1.FlexVolumeSource)(unsafe.Pointer(in.FlexVolume))
-	out.Cinder = (*corev1.CinderVolumeSource)(unsafe.Pointer(in.Cinder))
-	out.CephFS = (*corev1.CephFSVolumeSource)(unsafe.Pointer(in.CephFS))
-	out.Flocker = (*corev1.FlockerVolumeSource)(unsafe.Pointer(in.Flocker))
-	out.DownwardAPI = (*corev1.DownwardAPIVolumeSource)(unsafe.Pointer(in.DownwardAPI))
-	out.FC = (*corev1.FCVolumeSource)(unsafe.Pointer(in.FC))
-	out.AzureFile = (*corev1.AzureFileVolumeSource)(unsafe.Pointer(in.AzureFile))
-	out.ConfigMap = (*corev1.ConfigMapVolumeSource)(unsafe.Pointer(in.ConfigMap))
-	out.VsphereVolume = (*corev1.VsphereVirtualDiskVolumeSource)(unsafe.Pointer(in.VsphereVolume))
-	out.Quobyte = (*corev1.QuobyteVolumeSource)(unsafe.Pointer(in.Quobyte))
-	out.AzureDisk = (*corev1.AzureDiskVolumeSource)(unsafe.Pointer(in.AzureDisk))
-	out.PhotonPersistentDisk = (*corev1.PhotonPersistentDiskVolumeSource)(unsafe.Pointer(in.PhotonPersistentDisk))
-	out.Projected = (*corev1.ProjectedVolumeSource)(unsafe.Pointer(in.Projected))
-	out.PortworxVolume = (*corev1.PortworxVolumeSource)(unsafe.Pointer(in.PortworxVolume))
-	out.ScaleIO = (*corev1.ScaleIOVolumeSource)(unsafe.Pointer(in.ScaleIO))
-	out.StorageOS = (*corev1.StorageOSVolumeSource)(unsafe.Pointer(in.StorageOS))
-	out.CSI = (*corev1.CSIVolumeSource)(unsafe.Pointer(in.CSI))
-	out.Ephemeral = (*corev1.EphemeralVolumeSource)(unsafe.Pointer(in.Ephemeral))
-	out.Image = (*corev1.ImageVolumeSource)(unsafe.Pointer(in.Image))
+	*out = *(*corev1.VolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -9286,7 +7976,7 @@ func Convert_core_VolumeSource_To_v1_VolumeSource(in *core.VolumeSource, out *co
 }
 
 func autoConvert_v1_VolumeStatus_To_core_VolumeStatus(in *corev1.VolumeStatus, out *core.VolumeStatus, s conversion.Scope) error {
-	out.Image = (*core.ImageVolumeStatus)(unsafe.Pointer(in.Image))
+	*out = *(*core.VolumeStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -9296,7 +7986,7 @@ func Convert_v1_VolumeStatus_To_core_VolumeStatus(in *corev1.VolumeStatus, out *
 }
 
 func autoConvert_core_VolumeStatus_To_v1_VolumeStatus(in *core.VolumeStatus, out *corev1.VolumeStatus, s conversion.Scope) error {
-	out.Image = (*corev1.ImageVolumeStatus)(unsafe.Pointer(in.Image))
+	*out = *(*corev1.VolumeStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -9306,10 +7996,7 @@ func Convert_core_VolumeStatus_To_v1_VolumeStatus(in *core.VolumeStatus, out *co
 }
 
 func autoConvert_v1_VsphereVirtualDiskVolumeSource_To_core_VsphereVirtualDiskVolumeSource(in *corev1.VsphereVirtualDiskVolumeSource, out *core.VsphereVirtualDiskVolumeSource, s conversion.Scope) error {
-	out.VolumePath = in.VolumePath
-	out.FSType = in.FSType
-	out.StoragePolicyName = in.StoragePolicyName
-	out.StoragePolicyID = in.StoragePolicyID
+	*out = *(*core.VsphereVirtualDiskVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -9319,10 +8006,7 @@ func Convert_v1_VsphereVirtualDiskVolumeSource_To_core_VsphereVirtualDiskVolumeS
 }
 
 func autoConvert_core_VsphereVirtualDiskVolumeSource_To_v1_VsphereVirtualDiskVolumeSource(in *core.VsphereVirtualDiskVolumeSource, out *corev1.VsphereVirtualDiskVolumeSource, s conversion.Scope) error {
-	out.VolumePath = in.VolumePath
-	out.FSType = in.FSType
-	out.StoragePolicyName = in.StoragePolicyName
-	out.StoragePolicyID = in.StoragePolicyID
+	*out = *(*corev1.VsphereVirtualDiskVolumeSource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -9332,10 +8016,7 @@ func Convert_core_VsphereVirtualDiskVolumeSource_To_v1_VsphereVirtualDiskVolumeS
 }
 
 func autoConvert_v1_WeightedPodAffinityTerm_To_core_WeightedPodAffinityTerm(in *corev1.WeightedPodAffinityTerm, out *core.WeightedPodAffinityTerm, s conversion.Scope) error {
-	out.Weight = in.Weight
-	if err := Convert_v1_PodAffinityTerm_To_core_PodAffinityTerm(&in.PodAffinityTerm, &out.PodAffinityTerm, s); err != nil {
-		return err
-	}
+	*out = *(*core.WeightedPodAffinityTerm)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -9345,10 +8026,7 @@ func Convert_v1_WeightedPodAffinityTerm_To_core_WeightedPodAffinityTerm(in *core
 }
 
 func autoConvert_core_WeightedPodAffinityTerm_To_v1_WeightedPodAffinityTerm(in *core.WeightedPodAffinityTerm, out *corev1.WeightedPodAffinityTerm, s conversion.Scope) error {
-	out.Weight = in.Weight
-	if err := Convert_core_PodAffinityTerm_To_v1_PodAffinityTerm(&in.PodAffinityTerm, &out.PodAffinityTerm, s); err != nil {
-		return err
-	}
+	*out = *(*corev1.WeightedPodAffinityTerm)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -9358,10 +8036,7 @@ func Convert_core_WeightedPodAffinityTerm_To_v1_WeightedPodAffinityTerm(in *core
 }
 
 func autoConvert_v1_WindowsSecurityContextOptions_To_core_WindowsSecurityContextOptions(in *corev1.WindowsSecurityContextOptions, out *core.WindowsSecurityContextOptions, s conversion.Scope) error {
-	out.GMSACredentialSpecName = (*string)(unsafe.Pointer(in.GMSACredentialSpecName))
-	out.GMSACredentialSpec = (*string)(unsafe.Pointer(in.GMSACredentialSpec))
-	out.RunAsUserName = (*string)(unsafe.Pointer(in.RunAsUserName))
-	out.HostProcess = (*bool)(unsafe.Pointer(in.HostProcess))
+	*out = *(*core.WindowsSecurityContextOptions)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -9371,10 +8046,7 @@ func Convert_v1_WindowsSecurityContextOptions_To_core_WindowsSecurityContextOpti
 }
 
 func autoConvert_core_WindowsSecurityContextOptions_To_v1_WindowsSecurityContextOptions(in *core.WindowsSecurityContextOptions, out *corev1.WindowsSecurityContextOptions, s conversion.Scope) error {
-	out.GMSACredentialSpecName = (*string)(unsafe.Pointer(in.GMSACredentialSpecName))
-	out.GMSACredentialSpec = (*string)(unsafe.Pointer(in.GMSACredentialSpec))
-	out.RunAsUserName = (*string)(unsafe.Pointer(in.RunAsUserName))
-	out.HostProcess = (*bool)(unsafe.Pointer(in.HostProcess))
+	*out = *(*corev1.WindowsSecurityContextOptions)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/discovery/v1/zz_generated.conversion.go
+++ b/pkg/apis/discovery/v1/zz_generated.conversion.go
@@ -24,11 +24,9 @@ package v1
 import (
 	unsafe "unsafe"
 
-	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	core "k8s.io/kubernetes/pkg/apis/core"
 	discovery "k8s.io/kubernetes/pkg/apis/discovery"
 )
 
@@ -123,16 +121,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1_Endpoint_To_discovery_Endpoint(in *discoveryv1.Endpoint, out *discovery.Endpoint, s conversion.Scope) error {
-	out.Addresses = *(*[]string)(unsafe.Pointer(&in.Addresses))
-	if err := Convert_v1_EndpointConditions_To_discovery_EndpointConditions(&in.Conditions, &out.Conditions, s); err != nil {
-		return err
-	}
-	out.Hostname = (*string)(unsafe.Pointer(in.Hostname))
-	out.TargetRef = (*core.ObjectReference)(unsafe.Pointer(in.TargetRef))
-	out.DeprecatedTopology = *(*map[string]string)(unsafe.Pointer(&in.DeprecatedTopology))
-	out.NodeName = (*string)(unsafe.Pointer(in.NodeName))
-	out.Zone = (*string)(unsafe.Pointer(in.Zone))
-	out.Hints = (*discovery.EndpointHints)(unsafe.Pointer(in.Hints))
+	*out = *(*discovery.Endpoint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -142,16 +131,7 @@ func Convert_v1_Endpoint_To_discovery_Endpoint(in *discoveryv1.Endpoint, out *di
 }
 
 func autoConvert_discovery_Endpoint_To_v1_Endpoint(in *discovery.Endpoint, out *discoveryv1.Endpoint, s conversion.Scope) error {
-	out.Addresses = *(*[]string)(unsafe.Pointer(&in.Addresses))
-	if err := Convert_discovery_EndpointConditions_To_v1_EndpointConditions(&in.Conditions, &out.Conditions, s); err != nil {
-		return err
-	}
-	out.Hostname = (*string)(unsafe.Pointer(in.Hostname))
-	out.TargetRef = (*corev1.ObjectReference)(unsafe.Pointer(in.TargetRef))
-	out.DeprecatedTopology = *(*map[string]string)(unsafe.Pointer(&in.DeprecatedTopology))
-	out.NodeName = (*string)(unsafe.Pointer(in.NodeName))
-	out.Zone = (*string)(unsafe.Pointer(in.Zone))
-	out.Hints = (*discoveryv1.EndpointHints)(unsafe.Pointer(in.Hints))
+	*out = *(*discoveryv1.Endpoint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -161,9 +141,7 @@ func Convert_discovery_Endpoint_To_v1_Endpoint(in *discovery.Endpoint, out *disc
 }
 
 func autoConvert_v1_EndpointConditions_To_discovery_EndpointConditions(in *discoveryv1.EndpointConditions, out *discovery.EndpointConditions, s conversion.Scope) error {
-	out.Ready = (*bool)(unsafe.Pointer(in.Ready))
-	out.Serving = (*bool)(unsafe.Pointer(in.Serving))
-	out.Terminating = (*bool)(unsafe.Pointer(in.Terminating))
+	*out = *(*discovery.EndpointConditions)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -173,9 +151,7 @@ func Convert_v1_EndpointConditions_To_discovery_EndpointConditions(in *discovery
 }
 
 func autoConvert_discovery_EndpointConditions_To_v1_EndpointConditions(in *discovery.EndpointConditions, out *discoveryv1.EndpointConditions, s conversion.Scope) error {
-	out.Ready = (*bool)(unsafe.Pointer(in.Ready))
-	out.Serving = (*bool)(unsafe.Pointer(in.Serving))
-	out.Terminating = (*bool)(unsafe.Pointer(in.Terminating))
+	*out = *(*discoveryv1.EndpointConditions)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -185,8 +161,7 @@ func Convert_discovery_EndpointConditions_To_v1_EndpointConditions(in *discovery
 }
 
 func autoConvert_v1_EndpointHints_To_discovery_EndpointHints(in *discoveryv1.EndpointHints, out *discovery.EndpointHints, s conversion.Scope) error {
-	out.ForZones = *(*[]discovery.ForZone)(unsafe.Pointer(&in.ForZones))
-	out.ForNodes = *(*[]discovery.ForNode)(unsafe.Pointer(&in.ForNodes))
+	*out = *(*discovery.EndpointHints)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -196,8 +171,7 @@ func Convert_v1_EndpointHints_To_discovery_EndpointHints(in *discoveryv1.Endpoin
 }
 
 func autoConvert_discovery_EndpointHints_To_v1_EndpointHints(in *discovery.EndpointHints, out *discoveryv1.EndpointHints, s conversion.Scope) error {
-	out.ForZones = *(*[]discoveryv1.ForZone)(unsafe.Pointer(&in.ForZones))
-	out.ForNodes = *(*[]discoveryv1.ForNode)(unsafe.Pointer(&in.ForNodes))
+	*out = *(*discoveryv1.EndpointHints)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -207,10 +181,7 @@ func Convert_discovery_EndpointHints_To_v1_EndpointHints(in *discovery.EndpointH
 }
 
 func autoConvert_v1_EndpointPort_To_discovery_EndpointPort(in *discoveryv1.EndpointPort, out *discovery.EndpointPort, s conversion.Scope) error {
-	out.Name = (*string)(unsafe.Pointer(in.Name))
-	out.Protocol = (*core.Protocol)(unsafe.Pointer(in.Protocol))
-	out.Port = (*int32)(unsafe.Pointer(in.Port))
-	out.AppProtocol = (*string)(unsafe.Pointer(in.AppProtocol))
+	*out = *(*discovery.EndpointPort)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -220,10 +191,7 @@ func Convert_v1_EndpointPort_To_discovery_EndpointPort(in *discoveryv1.EndpointP
 }
 
 func autoConvert_discovery_EndpointPort_To_v1_EndpointPort(in *discovery.EndpointPort, out *discoveryv1.EndpointPort, s conversion.Scope) error {
-	out.Name = (*string)(unsafe.Pointer(in.Name))
-	out.Protocol = (*corev1.Protocol)(unsafe.Pointer(in.Protocol))
-	out.Port = (*int32)(unsafe.Pointer(in.Port))
-	out.AppProtocol = (*string)(unsafe.Pointer(in.AppProtocol))
+	*out = *(*discoveryv1.EndpointPort)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -281,7 +249,7 @@ func Convert_discovery_EndpointSliceList_To_v1_EndpointSliceList(in *discovery.E
 }
 
 func autoConvert_v1_ForNode_To_discovery_ForNode(in *discoveryv1.ForNode, out *discovery.ForNode, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*discovery.ForNode)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -291,7 +259,7 @@ func Convert_v1_ForNode_To_discovery_ForNode(in *discoveryv1.ForNode, out *disco
 }
 
 func autoConvert_discovery_ForNode_To_v1_ForNode(in *discovery.ForNode, out *discoveryv1.ForNode, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*discoveryv1.ForNode)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -301,7 +269,7 @@ func Convert_discovery_ForNode_To_v1_ForNode(in *discovery.ForNode, out *discove
 }
 
 func autoConvert_v1_ForZone_To_discovery_ForZone(in *discoveryv1.ForZone, out *discovery.ForZone, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*discovery.ForZone)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -311,7 +279,7 @@ func Convert_v1_ForZone_To_discovery_ForZone(in *discoveryv1.ForZone, out *disco
 }
 
 func autoConvert_discovery_ForZone_To_v1_ForZone(in *discovery.ForZone, out *discoveryv1.ForZone, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*discoveryv1.ForZone)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/discovery/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/discovery/v1beta1/zz_generated.conversion.go
@@ -150,9 +150,7 @@ func autoConvert_discovery_Endpoint_To_v1beta1_Endpoint(in *discovery.Endpoint, 
 }
 
 func autoConvert_v1beta1_EndpointConditions_To_discovery_EndpointConditions(in *discoveryv1beta1.EndpointConditions, out *discovery.EndpointConditions, s conversion.Scope) error {
-	out.Ready = (*bool)(unsafe.Pointer(in.Ready))
-	out.Serving = (*bool)(unsafe.Pointer(in.Serving))
-	out.Terminating = (*bool)(unsafe.Pointer(in.Terminating))
+	*out = *(*discovery.EndpointConditions)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -162,9 +160,7 @@ func Convert_v1beta1_EndpointConditions_To_discovery_EndpointConditions(in *disc
 }
 
 func autoConvert_discovery_EndpointConditions_To_v1beta1_EndpointConditions(in *discovery.EndpointConditions, out *discoveryv1beta1.EndpointConditions, s conversion.Scope) error {
-	out.Ready = (*bool)(unsafe.Pointer(in.Ready))
-	out.Serving = (*bool)(unsafe.Pointer(in.Serving))
-	out.Terminating = (*bool)(unsafe.Pointer(in.Terminating))
+	*out = *(*discoveryv1beta1.EndpointConditions)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -174,8 +170,7 @@ func Convert_discovery_EndpointConditions_To_v1beta1_EndpointConditions(in *disc
 }
 
 func autoConvert_v1beta1_EndpointHints_To_discovery_EndpointHints(in *discoveryv1beta1.EndpointHints, out *discovery.EndpointHints, s conversion.Scope) error {
-	out.ForZones = *(*[]discovery.ForZone)(unsafe.Pointer(&in.ForZones))
-	out.ForNodes = *(*[]discovery.ForNode)(unsafe.Pointer(&in.ForNodes))
+	*out = *(*discovery.EndpointHints)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -185,8 +180,7 @@ func Convert_v1beta1_EndpointHints_To_discovery_EndpointHints(in *discoveryv1bet
 }
 
 func autoConvert_discovery_EndpointHints_To_v1beta1_EndpointHints(in *discovery.EndpointHints, out *discoveryv1beta1.EndpointHints, s conversion.Scope) error {
-	out.ForZones = *(*[]discoveryv1beta1.ForZone)(unsafe.Pointer(&in.ForZones))
-	out.ForNodes = *(*[]discoveryv1beta1.ForNode)(unsafe.Pointer(&in.ForNodes))
+	*out = *(*discoveryv1beta1.EndpointHints)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -196,10 +190,7 @@ func Convert_discovery_EndpointHints_To_v1beta1_EndpointHints(in *discovery.Endp
 }
 
 func autoConvert_v1beta1_EndpointPort_To_discovery_EndpointPort(in *discoveryv1beta1.EndpointPort, out *discovery.EndpointPort, s conversion.Scope) error {
-	out.Name = (*string)(unsafe.Pointer(in.Name))
-	out.Protocol = (*core.Protocol)(unsafe.Pointer(in.Protocol))
-	out.Port = (*int32)(unsafe.Pointer(in.Port))
-	out.AppProtocol = (*string)(unsafe.Pointer(in.AppProtocol))
+	*out = *(*discovery.EndpointPort)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -209,10 +200,7 @@ func Convert_v1beta1_EndpointPort_To_discovery_EndpointPort(in *discoveryv1beta1
 }
 
 func autoConvert_discovery_EndpointPort_To_v1beta1_EndpointPort(in *discovery.EndpointPort, out *discoveryv1beta1.EndpointPort, s conversion.Scope) error {
-	out.Name = (*string)(unsafe.Pointer(in.Name))
-	out.Protocol = (*v1.Protocol)(unsafe.Pointer(in.Protocol))
-	out.Port = (*int32)(unsafe.Pointer(in.Port))
-	out.AppProtocol = (*string)(unsafe.Pointer(in.AppProtocol))
+	*out = *(*discoveryv1beta1.EndpointPort)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -310,7 +298,7 @@ func Convert_discovery_EndpointSliceList_To_v1beta1_EndpointSliceList(in *discov
 }
 
 func autoConvert_v1beta1_ForNode_To_discovery_ForNode(in *discoveryv1beta1.ForNode, out *discovery.ForNode, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*discovery.ForNode)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -320,7 +308,7 @@ func Convert_v1beta1_ForNode_To_discovery_ForNode(in *discoveryv1beta1.ForNode, 
 }
 
 func autoConvert_discovery_ForNode_To_v1beta1_ForNode(in *discovery.ForNode, out *discoveryv1beta1.ForNode, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*discoveryv1beta1.ForNode)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -330,7 +318,7 @@ func Convert_discovery_ForNode_To_v1beta1_ForNode(in *discovery.ForNode, out *di
 }
 
 func autoConvert_v1beta1_ForZone_To_discovery_ForZone(in *discoveryv1beta1.ForZone, out *discovery.ForZone, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*discovery.ForZone)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -340,7 +328,7 @@ func Convert_v1beta1_ForZone_To_discovery_ForZone(in *discoveryv1beta1.ForZone, 
 }
 
 func autoConvert_discovery_ForZone_To_v1beta1_ForZone(in *discovery.ForZone, out *discoveryv1beta1.ForZone, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*discoveryv1beta1.ForZone)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/events/v1/zz_generated.conversion.go
+++ b/pkg/apis/events/v1/zz_generated.conversion.go
@@ -152,8 +152,7 @@ func Convert_core_EventList_To_v1_EventList(in *core.EventList, out *eventsv1.Ev
 }
 
 func autoConvert_v1_EventSeries_To_core_EventSeries(in *eventsv1.EventSeries, out *core.EventSeries, s conversion.Scope) error {
-	out.Count = in.Count
-	out.LastObservedTime = in.LastObservedTime
+	*out = *(*core.EventSeries)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -163,8 +162,7 @@ func Convert_v1_EventSeries_To_core_EventSeries(in *eventsv1.EventSeries, out *c
 }
 
 func autoConvert_core_EventSeries_To_v1_EventSeries(in *core.EventSeries, out *eventsv1.EventSeries, s conversion.Scope) error {
-	out.Count = in.Count
-	out.LastObservedTime = in.LastObservedTime
+	*out = *(*eventsv1.EventSeries)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/events/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/events/v1beta1/zz_generated.conversion.go
@@ -152,8 +152,7 @@ func Convert_core_EventList_To_v1beta1_EventList(in *core.EventList, out *events
 }
 
 func autoConvert_v1beta1_EventSeries_To_core_EventSeries(in *eventsv1beta1.EventSeries, out *core.EventSeries, s conversion.Scope) error {
-	out.Count = in.Count
-	out.LastObservedTime = in.LastObservedTime
+	*out = *(*core.EventSeries)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -163,8 +162,7 @@ func Convert_v1beta1_EventSeries_To_core_EventSeries(in *eventsv1beta1.EventSeri
 }
 
 func autoConvert_core_EventSeries_To_v1beta1_EventSeries(in *core.EventSeries, out *eventsv1beta1.EventSeries, s conversion.Scope) error {
-	out.Count = in.Count
-	out.LastObservedTime = in.LastObservedTime
+	*out = *(*eventsv1beta1.EventSeries)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/extensions/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/extensions/v1beta1/zz_generated.conversion.go
@@ -24,12 +24,11 @@ package v1beta1
 import (
 	unsafe "unsafe"
 
-	v1 "k8s.io/api/core/v1"
+	apicorev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	intstr "k8s.io/apimachinery/pkg/util/intstr"
 	apps "k8s.io/kubernetes/pkg/apis/apps"
 	autoscaling "k8s.io/kubernetes/pkg/apis/autoscaling"
 	core "k8s.io/kubernetes/pkg/apis/core"
@@ -530,11 +529,7 @@ func Convert_apps_DaemonSet_To_v1beta1_DaemonSet(in *apps.DaemonSet, out *extens
 }
 
 func autoConvert_v1beta1_DaemonSetCondition_To_apps_DaemonSetCondition(in *extensionsv1beta1.DaemonSetCondition, out *apps.DaemonSetCondition, s conversion.Scope) error {
-	out.Type = apps.DaemonSetConditionType(in.Type)
-	out.Status = core.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*apps.DaemonSetCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -544,11 +539,7 @@ func Convert_v1beta1_DaemonSetCondition_To_apps_DaemonSetCondition(in *extension
 }
 
 func autoConvert_apps_DaemonSetCondition_To_v1beta1_DaemonSetCondition(in *apps.DaemonSetCondition, out *extensionsv1beta1.DaemonSetCondition, s conversion.Scope) error {
-	out.Type = extensionsv1beta1.DaemonSetConditionType(in.Type)
-	out.Status = v1.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*extensionsv1beta1.DaemonSetCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -600,7 +591,7 @@ func Convert_apps_DaemonSetList_To_v1beta1_DaemonSetList(in *apps.DaemonSetList,
 }
 
 func autoConvert_v1beta1_DaemonSetSpec_To_apps_DaemonSetSpec(in *extensionsv1beta1.DaemonSetSpec, out *apps.DaemonSetSpec, s conversion.Scope) error {
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
+	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
 	if err := corev1.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -619,7 +610,7 @@ func Convert_v1beta1_DaemonSetSpec_To_apps_DaemonSetSpec(in *extensionsv1beta1.D
 }
 
 func autoConvert_apps_DaemonSetSpec_To_v1beta1_DaemonSetSpec(in *apps.DaemonSetSpec, out *extensionsv1beta1.DaemonSetSpec, s conversion.Scope) error {
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
+	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
 	if err := corev1.Convert_core_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -638,16 +629,7 @@ func Convert_apps_DaemonSetSpec_To_v1beta1_DaemonSetSpec(in *apps.DaemonSetSpec,
 }
 
 func autoConvert_v1beta1_DaemonSetStatus_To_apps_DaemonSetStatus(in *extensionsv1beta1.DaemonSetStatus, out *apps.DaemonSetStatus, s conversion.Scope) error {
-	out.CurrentNumberScheduled = in.CurrentNumberScheduled
-	out.NumberMisscheduled = in.NumberMisscheduled
-	out.DesiredNumberScheduled = in.DesiredNumberScheduled
-	out.NumberReady = in.NumberReady
-	out.ObservedGeneration = in.ObservedGeneration
-	out.UpdatedNumberScheduled = in.UpdatedNumberScheduled
-	out.NumberAvailable = in.NumberAvailable
-	out.NumberUnavailable = in.NumberUnavailable
-	out.CollisionCount = (*int32)(unsafe.Pointer(in.CollisionCount))
-	out.Conditions = *(*[]apps.DaemonSetCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*apps.DaemonSetStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -657,16 +639,7 @@ func Convert_v1beta1_DaemonSetStatus_To_apps_DaemonSetStatus(in *extensionsv1bet
 }
 
 func autoConvert_apps_DaemonSetStatus_To_v1beta1_DaemonSetStatus(in *apps.DaemonSetStatus, out *extensionsv1beta1.DaemonSetStatus, s conversion.Scope) error {
-	out.CurrentNumberScheduled = in.CurrentNumberScheduled
-	out.NumberMisscheduled = in.NumberMisscheduled
-	out.DesiredNumberScheduled = in.DesiredNumberScheduled
-	out.NumberReady = in.NumberReady
-	out.ObservedGeneration = in.ObservedGeneration
-	out.UpdatedNumberScheduled = in.UpdatedNumberScheduled
-	out.NumberAvailable = in.NumberAvailable
-	out.NumberUnavailable = in.NumberUnavailable
-	out.CollisionCount = (*int32)(unsafe.Pointer(in.CollisionCount))
-	out.Conditions = *(*[]extensionsv1beta1.DaemonSetCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*extensionsv1beta1.DaemonSetStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -746,12 +719,7 @@ func Convert_apps_Deployment_To_v1beta1_Deployment(in *apps.Deployment, out *ext
 }
 
 func autoConvert_v1beta1_DeploymentCondition_To_apps_DeploymentCondition(in *extensionsv1beta1.DeploymentCondition, out *apps.DeploymentCondition, s conversion.Scope) error {
-	out.Type = apps.DeploymentConditionType(in.Type)
-	out.Status = core.ConditionStatus(in.Status)
-	out.LastUpdateTime = in.LastUpdateTime
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*apps.DeploymentCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -761,12 +729,7 @@ func Convert_v1beta1_DeploymentCondition_To_apps_DeploymentCondition(in *extensi
 }
 
 func autoConvert_apps_DeploymentCondition_To_v1beta1_DeploymentCondition(in *apps.DeploymentCondition, out *extensionsv1beta1.DeploymentCondition, s conversion.Scope) error {
-	out.Type = extensionsv1beta1.DeploymentConditionType(in.Type)
-	out.Status = v1.ConditionStatus(in.Status)
-	out.LastUpdateTime = in.LastUpdateTime
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*extensionsv1beta1.DeploymentCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -846,10 +809,10 @@ func Convert_apps_DeploymentRollback_To_v1beta1_DeploymentRollback(in *apps.Depl
 }
 
 func autoConvert_v1beta1_DeploymentSpec_To_apps_DeploymentSpec(in *extensionsv1beta1.DeploymentSpec, out *apps.DeploymentSpec, s conversion.Scope) error {
-	if err := metav1.Convert_Pointer_int32_To_int32(&in.Replicas, &out.Replicas, s); err != nil {
+	if err := v1.Convert_Pointer_int32_To_int32(&in.Replicas, &out.Replicas, s); err != nil {
 		return err
 	}
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
+	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
 	if err := corev1.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -870,10 +833,10 @@ func Convert_v1beta1_DeploymentSpec_To_apps_DeploymentSpec(in *extensionsv1beta1
 }
 
 func autoConvert_apps_DeploymentSpec_To_v1beta1_DeploymentSpec(in *apps.DeploymentSpec, out *extensionsv1beta1.DeploymentSpec, s conversion.Scope) error {
-	if err := metav1.Convert_int32_To_Pointer_int32(&in.Replicas, &out.Replicas, s); err != nil {
+	if err := v1.Convert_int32_To_Pointer_int32(&in.Replicas, &out.Replicas, s); err != nil {
 		return err
 	}
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
+	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
 	if err := corev1.Convert_core_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -894,15 +857,7 @@ func Convert_apps_DeploymentSpec_To_v1beta1_DeploymentSpec(in *apps.DeploymentSp
 }
 
 func autoConvert_v1beta1_DeploymentStatus_To_apps_DeploymentStatus(in *extensionsv1beta1.DeploymentStatus, out *apps.DeploymentStatus, s conversion.Scope) error {
-	out.ObservedGeneration = in.ObservedGeneration
-	out.Replicas = in.Replicas
-	out.UpdatedReplicas = in.UpdatedReplicas
-	out.ReadyReplicas = in.ReadyReplicas
-	out.AvailableReplicas = in.AvailableReplicas
-	out.UnavailableReplicas = in.UnavailableReplicas
-	out.TerminatingReplicas = (*int32)(unsafe.Pointer(in.TerminatingReplicas))
-	out.Conditions = *(*[]apps.DeploymentCondition)(unsafe.Pointer(&in.Conditions))
-	out.CollisionCount = (*int32)(unsafe.Pointer(in.CollisionCount))
+	*out = *(*apps.DeploymentStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -912,15 +867,7 @@ func Convert_v1beta1_DeploymentStatus_To_apps_DeploymentStatus(in *extensionsv1b
 }
 
 func autoConvert_apps_DeploymentStatus_To_v1beta1_DeploymentStatus(in *apps.DeploymentStatus, out *extensionsv1beta1.DeploymentStatus, s conversion.Scope) error {
-	out.ObservedGeneration = in.ObservedGeneration
-	out.Replicas = in.Replicas
-	out.UpdatedReplicas = in.UpdatedReplicas
-	out.ReadyReplicas = in.ReadyReplicas
-	out.AvailableReplicas = in.AvailableReplicas
-	out.UnavailableReplicas = in.UnavailableReplicas
-	out.TerminatingReplicas = (*int32)(unsafe.Pointer(in.TerminatingReplicas))
-	out.Conditions = *(*[]extensionsv1beta1.DeploymentCondition)(unsafe.Pointer(&in.Conditions))
-	out.CollisionCount = (*int32)(unsafe.Pointer(in.CollisionCount))
+	*out = *(*extensionsv1beta1.DeploymentStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1088,7 +1035,7 @@ func autoConvert_v1beta1_IngressBackend_To_networking_IngressBackend(in *extensi
 
 func autoConvert_networking_IngressBackend_To_v1beta1_IngressBackend(in *networking.IngressBackend, out *extensionsv1beta1.IngressBackend, s conversion.Scope) error {
 	// WARNING: in.Service requires manual conversion: does not exist in peer-type
-	out.Resource = (*v1.TypedLocalObjectReference)(unsafe.Pointer(in.Resource))
+	out.Resource = (*apicorev1.TypedLocalObjectReference)(unsafe.Pointer(in.Resource))
 	return nil
 }
 
@@ -1135,9 +1082,7 @@ func Convert_networking_IngressList_To_v1beta1_IngressList(in *networking.Ingres
 }
 
 func autoConvert_v1beta1_IngressLoadBalancerIngress_To_networking_IngressLoadBalancerIngress(in *extensionsv1beta1.IngressLoadBalancerIngress, out *networking.IngressLoadBalancerIngress, s conversion.Scope) error {
-	out.IP = in.IP
-	out.Hostname = in.Hostname
-	out.Ports = *(*[]networking.IngressPortStatus)(unsafe.Pointer(&in.Ports))
+	*out = *(*networking.IngressLoadBalancerIngress)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1147,9 +1092,7 @@ func Convert_v1beta1_IngressLoadBalancerIngress_To_networking_IngressLoadBalance
 }
 
 func autoConvert_networking_IngressLoadBalancerIngress_To_v1beta1_IngressLoadBalancerIngress(in *networking.IngressLoadBalancerIngress, out *extensionsv1beta1.IngressLoadBalancerIngress, s conversion.Scope) error {
-	out.IP = in.IP
-	out.Hostname = in.Hostname
-	out.Ports = *(*[]extensionsv1beta1.IngressPortStatus)(unsafe.Pointer(&in.Ports))
+	*out = *(*extensionsv1beta1.IngressLoadBalancerIngress)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1159,7 +1102,7 @@ func Convert_networking_IngressLoadBalancerIngress_To_v1beta1_IngressLoadBalance
 }
 
 func autoConvert_v1beta1_IngressLoadBalancerStatus_To_networking_IngressLoadBalancerStatus(in *extensionsv1beta1.IngressLoadBalancerStatus, out *networking.IngressLoadBalancerStatus, s conversion.Scope) error {
-	out.Ingress = *(*[]networking.IngressLoadBalancerIngress)(unsafe.Pointer(&in.Ingress))
+	*out = *(*networking.IngressLoadBalancerStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1169,7 +1112,7 @@ func Convert_v1beta1_IngressLoadBalancerStatus_To_networking_IngressLoadBalancer
 }
 
 func autoConvert_networking_IngressLoadBalancerStatus_To_v1beta1_IngressLoadBalancerStatus(in *networking.IngressLoadBalancerStatus, out *extensionsv1beta1.IngressLoadBalancerStatus, s conversion.Scope) error {
-	out.Ingress = *(*[]extensionsv1beta1.IngressLoadBalancerIngress)(unsafe.Pointer(&in.Ingress))
+	*out = *(*extensionsv1beta1.IngressLoadBalancerStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1179,9 +1122,7 @@ func Convert_networking_IngressLoadBalancerStatus_To_v1beta1_IngressLoadBalancer
 }
 
 func autoConvert_v1beta1_IngressPortStatus_To_networking_IngressPortStatus(in *extensionsv1beta1.IngressPortStatus, out *networking.IngressPortStatus, s conversion.Scope) error {
-	out.Port = in.Port
-	out.Protocol = core.Protocol(in.Protocol)
-	out.Error = (*string)(unsafe.Pointer(in.Error))
+	*out = *(*networking.IngressPortStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1191,9 +1132,7 @@ func Convert_v1beta1_IngressPortStatus_To_networking_IngressPortStatus(in *exten
 }
 
 func autoConvert_networking_IngressPortStatus_To_v1beta1_IngressPortStatus(in *networking.IngressPortStatus, out *extensionsv1beta1.IngressPortStatus, s conversion.Scope) error {
-	out.Port = in.Port
-	out.Protocol = v1.Protocol(in.Protocol)
-	out.Error = (*string)(unsafe.Pointer(in.Error))
+	*out = *(*extensionsv1beta1.IngressPortStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1301,9 +1240,7 @@ func autoConvert_networking_IngressSpec_To_v1beta1_IngressSpec(in *networking.In
 }
 
 func autoConvert_v1beta1_IngressStatus_To_networking_IngressStatus(in *extensionsv1beta1.IngressStatus, out *networking.IngressStatus, s conversion.Scope) error {
-	if err := Convert_v1beta1_IngressLoadBalancerStatus_To_networking_IngressLoadBalancerStatus(&in.LoadBalancer, &out.LoadBalancer, s); err != nil {
-		return err
-	}
+	*out = *(*networking.IngressStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1313,9 +1250,7 @@ func Convert_v1beta1_IngressStatus_To_networking_IngressStatus(in *extensionsv1b
 }
 
 func autoConvert_networking_IngressStatus_To_v1beta1_IngressStatus(in *networking.IngressStatus, out *extensionsv1beta1.IngressStatus, s conversion.Scope) error {
-	if err := Convert_networking_IngressLoadBalancerStatus_To_v1beta1_IngressLoadBalancerStatus(&in.LoadBalancer, &out.LoadBalancer, s); err != nil {
-		return err
-	}
+	*out = *(*extensionsv1beta1.IngressStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1325,8 +1260,7 @@ func Convert_networking_IngressStatus_To_v1beta1_IngressStatus(in *networking.In
 }
 
 func autoConvert_v1beta1_IngressTLS_To_networking_IngressTLS(in *extensionsv1beta1.IngressTLS, out *networking.IngressTLS, s conversion.Scope) error {
-	out.Hosts = *(*[]string)(unsafe.Pointer(&in.Hosts))
-	out.SecretName = in.SecretName
+	*out = *(*networking.IngressTLS)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1336,8 +1270,7 @@ func Convert_v1beta1_IngressTLS_To_networking_IngressTLS(in *extensionsv1beta1.I
 }
 
 func autoConvert_networking_IngressTLS_To_v1beta1_IngressTLS(in *networking.IngressTLS, out *extensionsv1beta1.IngressTLS, s conversion.Scope) error {
-	out.Hosts = *(*[]string)(unsafe.Pointer(&in.Hosts))
-	out.SecretName = in.SecretName
+	*out = *(*extensionsv1beta1.IngressTLS)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1479,8 +1412,8 @@ func Convert_networking_NetworkPolicyList_To_v1beta1_NetworkPolicyList(in *netwo
 }
 
 func autoConvert_v1beta1_NetworkPolicyPeer_To_networking_NetworkPolicyPeer(in *extensionsv1beta1.NetworkPolicyPeer, out *networking.NetworkPolicyPeer, s conversion.Scope) error {
-	out.PodSelector = (*metav1.LabelSelector)(unsafe.Pointer(in.PodSelector))
-	out.NamespaceSelector = (*metav1.LabelSelector)(unsafe.Pointer(in.NamespaceSelector))
+	out.PodSelector = (*v1.LabelSelector)(unsafe.Pointer(in.PodSelector))
+	out.NamespaceSelector = (*v1.LabelSelector)(unsafe.Pointer(in.NamespaceSelector))
 	if in.IPBlock != nil {
 		in, out := &in.IPBlock, &out.IPBlock
 		*out = new(networking.IPBlock)
@@ -1499,8 +1432,8 @@ func Convert_v1beta1_NetworkPolicyPeer_To_networking_NetworkPolicyPeer(in *exten
 }
 
 func autoConvert_networking_NetworkPolicyPeer_To_v1beta1_NetworkPolicyPeer(in *networking.NetworkPolicyPeer, out *extensionsv1beta1.NetworkPolicyPeer, s conversion.Scope) error {
-	out.PodSelector = (*metav1.LabelSelector)(unsafe.Pointer(in.PodSelector))
-	out.NamespaceSelector = (*metav1.LabelSelector)(unsafe.Pointer(in.NamespaceSelector))
+	out.PodSelector = (*v1.LabelSelector)(unsafe.Pointer(in.PodSelector))
+	out.NamespaceSelector = (*v1.LabelSelector)(unsafe.Pointer(in.NamespaceSelector))
 	if in.IPBlock != nil {
 		in, out := &in.IPBlock, &out.IPBlock
 		*out = new(extensionsv1beta1.IPBlock)
@@ -1519,9 +1452,7 @@ func Convert_networking_NetworkPolicyPeer_To_v1beta1_NetworkPolicyPeer(in *netwo
 }
 
 func autoConvert_v1beta1_NetworkPolicyPort_To_networking_NetworkPolicyPort(in *extensionsv1beta1.NetworkPolicyPort, out *networking.NetworkPolicyPort, s conversion.Scope) error {
-	out.Protocol = (*core.Protocol)(unsafe.Pointer(in.Protocol))
-	out.Port = (*intstr.IntOrString)(unsafe.Pointer(in.Port))
-	out.EndPort = (*int32)(unsafe.Pointer(in.EndPort))
+	*out = *(*networking.NetworkPolicyPort)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1531,9 +1462,7 @@ func Convert_v1beta1_NetworkPolicyPort_To_networking_NetworkPolicyPort(in *exten
 }
 
 func autoConvert_networking_NetworkPolicyPort_To_v1beta1_NetworkPolicyPort(in *networking.NetworkPolicyPort, out *extensionsv1beta1.NetworkPolicyPort, s conversion.Scope) error {
-	out.Protocol = (*v1.Protocol)(unsafe.Pointer(in.Protocol))
-	out.Port = (*intstr.IntOrString)(unsafe.Pointer(in.Port))
-	out.EndPort = (*int32)(unsafe.Pointer(in.EndPort))
+	*out = *(*extensionsv1beta1.NetworkPolicyPort)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1631,11 +1560,7 @@ func Convert_apps_ReplicaSet_To_v1beta1_ReplicaSet(in *apps.ReplicaSet, out *ext
 }
 
 func autoConvert_v1beta1_ReplicaSetCondition_To_apps_ReplicaSetCondition(in *extensionsv1beta1.ReplicaSetCondition, out *apps.ReplicaSetCondition, s conversion.Scope) error {
-	out.Type = apps.ReplicaSetConditionType(in.Type)
-	out.Status = core.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*apps.ReplicaSetCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1645,11 +1570,7 @@ func Convert_v1beta1_ReplicaSetCondition_To_apps_ReplicaSetCondition(in *extensi
 }
 
 func autoConvert_apps_ReplicaSetCondition_To_v1beta1_ReplicaSetCondition(in *apps.ReplicaSetCondition, out *extensionsv1beta1.ReplicaSetCondition, s conversion.Scope) error {
-	out.Type = extensionsv1beta1.ReplicaSetConditionType(in.Type)
-	out.Status = v1.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*extensionsv1beta1.ReplicaSetCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1701,11 +1622,11 @@ func Convert_apps_ReplicaSetList_To_v1beta1_ReplicaSetList(in *apps.ReplicaSetLi
 }
 
 func autoConvert_v1beta1_ReplicaSetSpec_To_apps_ReplicaSetSpec(in *extensionsv1beta1.ReplicaSetSpec, out *apps.ReplicaSetSpec, s conversion.Scope) error {
-	if err := metav1.Convert_Pointer_int32_To_int32(&in.Replicas, &out.Replicas, s); err != nil {
+	if err := v1.Convert_Pointer_int32_To_int32(&in.Replicas, &out.Replicas, s); err != nil {
 		return err
 	}
 	out.MinReadySeconds = in.MinReadySeconds
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
+	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
 	if err := corev1.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -1718,11 +1639,11 @@ func Convert_v1beta1_ReplicaSetSpec_To_apps_ReplicaSetSpec(in *extensionsv1beta1
 }
 
 func autoConvert_apps_ReplicaSetSpec_To_v1beta1_ReplicaSetSpec(in *apps.ReplicaSetSpec, out *extensionsv1beta1.ReplicaSetSpec, s conversion.Scope) error {
-	if err := metav1.Convert_int32_To_Pointer_int32(&in.Replicas, &out.Replicas, s); err != nil {
+	if err := v1.Convert_int32_To_Pointer_int32(&in.Replicas, &out.Replicas, s); err != nil {
 		return err
 	}
 	out.MinReadySeconds = in.MinReadySeconds
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
+	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
 	if err := corev1.Convert_core_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -1735,13 +1656,7 @@ func Convert_apps_ReplicaSetSpec_To_v1beta1_ReplicaSetSpec(in *apps.ReplicaSetSp
 }
 
 func autoConvert_v1beta1_ReplicaSetStatus_To_apps_ReplicaSetStatus(in *extensionsv1beta1.ReplicaSetStatus, out *apps.ReplicaSetStatus, s conversion.Scope) error {
-	out.Replicas = in.Replicas
-	out.FullyLabeledReplicas = in.FullyLabeledReplicas
-	out.ReadyReplicas = in.ReadyReplicas
-	out.AvailableReplicas = in.AvailableReplicas
-	out.TerminatingReplicas = (*int32)(unsafe.Pointer(in.TerminatingReplicas))
-	out.ObservedGeneration = in.ObservedGeneration
-	out.Conditions = *(*[]apps.ReplicaSetCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*apps.ReplicaSetStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1751,13 +1666,7 @@ func Convert_v1beta1_ReplicaSetStatus_To_apps_ReplicaSetStatus(in *extensionsv1b
 }
 
 func autoConvert_apps_ReplicaSetStatus_To_v1beta1_ReplicaSetStatus(in *apps.ReplicaSetStatus, out *extensionsv1beta1.ReplicaSetStatus, s conversion.Scope) error {
-	out.Replicas = in.Replicas
-	out.FullyLabeledReplicas = in.FullyLabeledReplicas
-	out.ReadyReplicas = in.ReadyReplicas
-	out.AvailableReplicas = in.AvailableReplicas
-	out.TerminatingReplicas = (*int32)(unsafe.Pointer(in.TerminatingReplicas))
-	out.ObservedGeneration = in.ObservedGeneration
-	out.Conditions = *(*[]extensionsv1beta1.ReplicaSetCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*extensionsv1beta1.ReplicaSetStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1767,7 +1676,7 @@ func Convert_apps_ReplicaSetStatus_To_v1beta1_ReplicaSetStatus(in *apps.ReplicaS
 }
 
 func autoConvert_v1beta1_RollbackConfig_To_apps_RollbackConfig(in *extensionsv1beta1.RollbackConfig, out *apps.RollbackConfig, s conversion.Scope) error {
-	out.Revision = in.Revision
+	*out = *(*apps.RollbackConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1777,7 +1686,7 @@ func Convert_v1beta1_RollbackConfig_To_apps_RollbackConfig(in *extensionsv1beta1
 }
 
 func autoConvert_apps_RollbackConfig_To_v1beta1_RollbackConfig(in *apps.RollbackConfig, out *extensionsv1beta1.RollbackConfig, s conversion.Scope) error {
-	out.Revision = in.Revision
+	*out = *(*extensionsv1beta1.RollbackConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1787,10 +1696,10 @@ func Convert_apps_RollbackConfig_To_v1beta1_RollbackConfig(in *apps.RollbackConf
 }
 
 func autoConvert_v1beta1_RollingUpdateDaemonSet_To_apps_RollingUpdateDaemonSet(in *extensionsv1beta1.RollingUpdateDaemonSet, out *apps.RollingUpdateDaemonSet, s conversion.Scope) error {
-	if err := metav1.Convert_Pointer_intstr_IntOrString_To_intstr_IntOrString(&in.MaxUnavailable, &out.MaxUnavailable, s); err != nil {
+	if err := v1.Convert_Pointer_intstr_IntOrString_To_intstr_IntOrString(&in.MaxUnavailable, &out.MaxUnavailable, s); err != nil {
 		return err
 	}
-	if err := metav1.Convert_Pointer_intstr_IntOrString_To_intstr_IntOrString(&in.MaxSurge, &out.MaxSurge, s); err != nil {
+	if err := v1.Convert_Pointer_intstr_IntOrString_To_intstr_IntOrString(&in.MaxSurge, &out.MaxSurge, s); err != nil {
 		return err
 	}
 	return nil
@@ -1802,10 +1711,10 @@ func Convert_v1beta1_RollingUpdateDaemonSet_To_apps_RollingUpdateDaemonSet(in *e
 }
 
 func autoConvert_apps_RollingUpdateDaemonSet_To_v1beta1_RollingUpdateDaemonSet(in *apps.RollingUpdateDaemonSet, out *extensionsv1beta1.RollingUpdateDaemonSet, s conversion.Scope) error {
-	if err := metav1.Convert_intstr_IntOrString_To_Pointer_intstr_IntOrString(&in.MaxUnavailable, &out.MaxUnavailable, s); err != nil {
+	if err := v1.Convert_intstr_IntOrString_To_Pointer_intstr_IntOrString(&in.MaxUnavailable, &out.MaxUnavailable, s); err != nil {
 		return err
 	}
-	if err := metav1.Convert_intstr_IntOrString_To_Pointer_intstr_IntOrString(&in.MaxSurge, &out.MaxSurge, s); err != nil {
+	if err := v1.Convert_intstr_IntOrString_To_Pointer_intstr_IntOrString(&in.MaxSurge, &out.MaxSurge, s); err != nil {
 		return err
 	}
 	return nil
@@ -1817,10 +1726,10 @@ func Convert_apps_RollingUpdateDaemonSet_To_v1beta1_RollingUpdateDaemonSet(in *a
 }
 
 func autoConvert_v1beta1_RollingUpdateDeployment_To_apps_RollingUpdateDeployment(in *extensionsv1beta1.RollingUpdateDeployment, out *apps.RollingUpdateDeployment, s conversion.Scope) error {
-	if err := metav1.Convert_Pointer_intstr_IntOrString_To_intstr_IntOrString(&in.MaxUnavailable, &out.MaxUnavailable, s); err != nil {
+	if err := v1.Convert_Pointer_intstr_IntOrString_To_intstr_IntOrString(&in.MaxUnavailable, &out.MaxUnavailable, s); err != nil {
 		return err
 	}
-	if err := metav1.Convert_Pointer_intstr_IntOrString_To_intstr_IntOrString(&in.MaxSurge, &out.MaxSurge, s); err != nil {
+	if err := v1.Convert_Pointer_intstr_IntOrString_To_intstr_IntOrString(&in.MaxSurge, &out.MaxSurge, s); err != nil {
 		return err
 	}
 	return nil
@@ -1832,10 +1741,10 @@ func Convert_v1beta1_RollingUpdateDeployment_To_apps_RollingUpdateDeployment(in 
 }
 
 func autoConvert_apps_RollingUpdateDeployment_To_v1beta1_RollingUpdateDeployment(in *apps.RollingUpdateDeployment, out *extensionsv1beta1.RollingUpdateDeployment, s conversion.Scope) error {
-	if err := metav1.Convert_intstr_IntOrString_To_Pointer_intstr_IntOrString(&in.MaxUnavailable, &out.MaxUnavailable, s); err != nil {
+	if err := v1.Convert_intstr_IntOrString_To_Pointer_intstr_IntOrString(&in.MaxUnavailable, &out.MaxUnavailable, s); err != nil {
 		return err
 	}
-	if err := metav1.Convert_intstr_IntOrString_To_Pointer_intstr_IntOrString(&in.MaxSurge, &out.MaxSurge, s); err != nil {
+	if err := v1.Convert_intstr_IntOrString_To_Pointer_intstr_IntOrString(&in.MaxSurge, &out.MaxSurge, s); err != nil {
 		return err
 	}
 	return nil
@@ -1879,7 +1788,7 @@ func Convert_autoscaling_Scale_To_v1beta1_Scale(in *autoscaling.Scale, out *exte
 }
 
 func autoConvert_v1beta1_ScaleSpec_To_autoscaling_ScaleSpec(in *extensionsv1beta1.ScaleSpec, out *autoscaling.ScaleSpec, s conversion.Scope) error {
-	out.Replicas = in.Replicas
+	*out = *(*autoscaling.ScaleSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1889,7 +1798,7 @@ func Convert_v1beta1_ScaleSpec_To_autoscaling_ScaleSpec(in *extensionsv1beta1.Sc
 }
 
 func autoConvert_autoscaling_ScaleSpec_To_v1beta1_ScaleSpec(in *autoscaling.ScaleSpec, out *extensionsv1beta1.ScaleSpec, s conversion.Scope) error {
-	out.Replicas = in.Replicas
+	*out = *(*extensionsv1beta1.ScaleSpec)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/flowcontrol/v1/zz_generated.conversion.go
+++ b/pkg/apis/flowcontrol/v1/zz_generated.conversion.go
@@ -272,8 +272,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1_ExemptPriorityLevelConfiguration_To_flowcontrol_ExemptPriorityLevelConfiguration(in *flowcontrolv1.ExemptPriorityLevelConfiguration, out *flowcontrol.ExemptPriorityLevelConfiguration, s conversion.Scope) error {
-	out.NominalConcurrencyShares = (*int32)(unsafe.Pointer(in.NominalConcurrencyShares))
-	out.LendablePercent = (*int32)(unsafe.Pointer(in.LendablePercent))
+	*out = *(*flowcontrol.ExemptPriorityLevelConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -283,8 +282,7 @@ func Convert_v1_ExemptPriorityLevelConfiguration_To_flowcontrol_ExemptPriorityLe
 }
 
 func autoConvert_flowcontrol_ExemptPriorityLevelConfiguration_To_v1_ExemptPriorityLevelConfiguration(in *flowcontrol.ExemptPriorityLevelConfiguration, out *flowcontrolv1.ExemptPriorityLevelConfiguration, s conversion.Scope) error {
-	out.NominalConcurrencyShares = (*int32)(unsafe.Pointer(in.NominalConcurrencyShares))
-	out.LendablePercent = (*int32)(unsafe.Pointer(in.LendablePercent))
+	*out = *(*flowcontrolv1.ExemptPriorityLevelConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -294,7 +292,7 @@ func Convert_flowcontrol_ExemptPriorityLevelConfiguration_To_v1_ExemptPriorityLe
 }
 
 func autoConvert_v1_FlowDistinguisherMethod_To_flowcontrol_FlowDistinguisherMethod(in *flowcontrolv1.FlowDistinguisherMethod, out *flowcontrol.FlowDistinguisherMethod, s conversion.Scope) error {
-	out.Type = flowcontrol.FlowDistinguisherMethodType(in.Type)
+	*out = *(*flowcontrol.FlowDistinguisherMethod)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -304,7 +302,7 @@ func Convert_v1_FlowDistinguisherMethod_To_flowcontrol_FlowDistinguisherMethod(i
 }
 
 func autoConvert_flowcontrol_FlowDistinguisherMethod_To_v1_FlowDistinguisherMethod(in *flowcontrol.FlowDistinguisherMethod, out *flowcontrolv1.FlowDistinguisherMethod, s conversion.Scope) error {
-	out.Type = flowcontrolv1.FlowDistinguisherMethodType(in.Type)
+	*out = *(*flowcontrolv1.FlowDistinguisherMethod)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -346,11 +344,7 @@ func Convert_flowcontrol_FlowSchema_To_v1_FlowSchema(in *flowcontrol.FlowSchema,
 }
 
 func autoConvert_v1_FlowSchemaCondition_To_flowcontrol_FlowSchemaCondition(in *flowcontrolv1.FlowSchemaCondition, out *flowcontrol.FlowSchemaCondition, s conversion.Scope) error {
-	out.Type = flowcontrol.FlowSchemaConditionType(in.Type)
-	out.Status = flowcontrol.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*flowcontrol.FlowSchemaCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -360,11 +354,7 @@ func Convert_v1_FlowSchemaCondition_To_flowcontrol_FlowSchemaCondition(in *flowc
 }
 
 func autoConvert_flowcontrol_FlowSchemaCondition_To_v1_FlowSchemaCondition(in *flowcontrol.FlowSchemaCondition, out *flowcontrolv1.FlowSchemaCondition, s conversion.Scope) error {
-	out.Type = flowcontrolv1.FlowSchemaConditionType(in.Type)
-	out.Status = flowcontrolv1.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*flowcontrolv1.FlowSchemaCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -396,12 +386,7 @@ func Convert_flowcontrol_FlowSchemaList_To_v1_FlowSchemaList(in *flowcontrol.Flo
 }
 
 func autoConvert_v1_FlowSchemaSpec_To_flowcontrol_FlowSchemaSpec(in *flowcontrolv1.FlowSchemaSpec, out *flowcontrol.FlowSchemaSpec, s conversion.Scope) error {
-	if err := Convert_v1_PriorityLevelConfigurationReference_To_flowcontrol_PriorityLevelConfigurationReference(&in.PriorityLevelConfiguration, &out.PriorityLevelConfiguration, s); err != nil {
-		return err
-	}
-	out.MatchingPrecedence = in.MatchingPrecedence
-	out.DistinguisherMethod = (*flowcontrol.FlowDistinguisherMethod)(unsafe.Pointer(in.DistinguisherMethod))
-	out.Rules = *(*[]flowcontrol.PolicyRulesWithSubjects)(unsafe.Pointer(&in.Rules))
+	*out = *(*flowcontrol.FlowSchemaSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -411,12 +396,7 @@ func Convert_v1_FlowSchemaSpec_To_flowcontrol_FlowSchemaSpec(in *flowcontrolv1.F
 }
 
 func autoConvert_flowcontrol_FlowSchemaSpec_To_v1_FlowSchemaSpec(in *flowcontrol.FlowSchemaSpec, out *flowcontrolv1.FlowSchemaSpec, s conversion.Scope) error {
-	if err := Convert_flowcontrol_PriorityLevelConfigurationReference_To_v1_PriorityLevelConfigurationReference(&in.PriorityLevelConfiguration, &out.PriorityLevelConfiguration, s); err != nil {
-		return err
-	}
-	out.MatchingPrecedence = in.MatchingPrecedence
-	out.DistinguisherMethod = (*flowcontrolv1.FlowDistinguisherMethod)(unsafe.Pointer(in.DistinguisherMethod))
-	out.Rules = *(*[]flowcontrolv1.PolicyRulesWithSubjects)(unsafe.Pointer(&in.Rules))
+	*out = *(*flowcontrolv1.FlowSchemaSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -426,7 +406,7 @@ func Convert_flowcontrol_FlowSchemaSpec_To_v1_FlowSchemaSpec(in *flowcontrol.Flo
 }
 
 func autoConvert_v1_FlowSchemaStatus_To_flowcontrol_FlowSchemaStatus(in *flowcontrolv1.FlowSchemaStatus, out *flowcontrol.FlowSchemaStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]flowcontrol.FlowSchemaCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*flowcontrol.FlowSchemaStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -436,7 +416,7 @@ func Convert_v1_FlowSchemaStatus_To_flowcontrol_FlowSchemaStatus(in *flowcontrol
 }
 
 func autoConvert_flowcontrol_FlowSchemaStatus_To_v1_FlowSchemaStatus(in *flowcontrol.FlowSchemaStatus, out *flowcontrolv1.FlowSchemaStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]flowcontrolv1.FlowSchemaCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*flowcontrolv1.FlowSchemaStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -446,7 +426,7 @@ func Convert_flowcontrol_FlowSchemaStatus_To_v1_FlowSchemaStatus(in *flowcontrol
 }
 
 func autoConvert_v1_GroupSubject_To_flowcontrol_GroupSubject(in *flowcontrolv1.GroupSubject, out *flowcontrol.GroupSubject, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*flowcontrol.GroupSubject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -456,7 +436,7 @@ func Convert_v1_GroupSubject_To_flowcontrol_GroupSubject(in *flowcontrolv1.Group
 }
 
 func autoConvert_flowcontrol_GroupSubject_To_v1_GroupSubject(in *flowcontrol.GroupSubject, out *flowcontrolv1.GroupSubject, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*flowcontrolv1.GroupSubject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -466,8 +446,7 @@ func Convert_flowcontrol_GroupSubject_To_v1_GroupSubject(in *flowcontrol.GroupSu
 }
 
 func autoConvert_v1_LimitResponse_To_flowcontrol_LimitResponse(in *flowcontrolv1.LimitResponse, out *flowcontrol.LimitResponse, s conversion.Scope) error {
-	out.Type = flowcontrol.LimitResponseType(in.Type)
-	out.Queuing = (*flowcontrol.QueuingConfiguration)(unsafe.Pointer(in.Queuing))
+	*out = *(*flowcontrol.LimitResponse)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -477,8 +456,7 @@ func Convert_v1_LimitResponse_To_flowcontrol_LimitResponse(in *flowcontrolv1.Lim
 }
 
 func autoConvert_flowcontrol_LimitResponse_To_v1_LimitResponse(in *flowcontrol.LimitResponse, out *flowcontrolv1.LimitResponse, s conversion.Scope) error {
-	out.Type = flowcontrolv1.LimitResponseType(in.Type)
-	out.Queuing = (*flowcontrolv1.QueuingConfiguration)(unsafe.Pointer(in.Queuing))
+	*out = *(*flowcontrolv1.LimitResponse)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -522,8 +500,7 @@ func Convert_flowcontrol_LimitedPriorityLevelConfiguration_To_v1_LimitedPriority
 }
 
 func autoConvert_v1_NonResourcePolicyRule_To_flowcontrol_NonResourcePolicyRule(in *flowcontrolv1.NonResourcePolicyRule, out *flowcontrol.NonResourcePolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.NonResourceURLs = *(*[]string)(unsafe.Pointer(&in.NonResourceURLs))
+	*out = *(*flowcontrol.NonResourcePolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -533,8 +510,7 @@ func Convert_v1_NonResourcePolicyRule_To_flowcontrol_NonResourcePolicyRule(in *f
 }
 
 func autoConvert_flowcontrol_NonResourcePolicyRule_To_v1_NonResourcePolicyRule(in *flowcontrol.NonResourcePolicyRule, out *flowcontrolv1.NonResourcePolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.NonResourceURLs = *(*[]string)(unsafe.Pointer(&in.NonResourceURLs))
+	*out = *(*flowcontrolv1.NonResourcePolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -544,9 +520,7 @@ func Convert_flowcontrol_NonResourcePolicyRule_To_v1_NonResourcePolicyRule(in *f
 }
 
 func autoConvert_v1_PolicyRulesWithSubjects_To_flowcontrol_PolicyRulesWithSubjects(in *flowcontrolv1.PolicyRulesWithSubjects, out *flowcontrol.PolicyRulesWithSubjects, s conversion.Scope) error {
-	out.Subjects = *(*[]flowcontrol.Subject)(unsafe.Pointer(&in.Subjects))
-	out.ResourceRules = *(*[]flowcontrol.ResourcePolicyRule)(unsafe.Pointer(&in.ResourceRules))
-	out.NonResourceRules = *(*[]flowcontrol.NonResourcePolicyRule)(unsafe.Pointer(&in.NonResourceRules))
+	*out = *(*flowcontrol.PolicyRulesWithSubjects)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -556,9 +530,7 @@ func Convert_v1_PolicyRulesWithSubjects_To_flowcontrol_PolicyRulesWithSubjects(i
 }
 
 func autoConvert_flowcontrol_PolicyRulesWithSubjects_To_v1_PolicyRulesWithSubjects(in *flowcontrol.PolicyRulesWithSubjects, out *flowcontrolv1.PolicyRulesWithSubjects, s conversion.Scope) error {
-	out.Subjects = *(*[]flowcontrolv1.Subject)(unsafe.Pointer(&in.Subjects))
-	out.ResourceRules = *(*[]flowcontrolv1.ResourcePolicyRule)(unsafe.Pointer(&in.ResourceRules))
-	out.NonResourceRules = *(*[]flowcontrolv1.NonResourcePolicyRule)(unsafe.Pointer(&in.NonResourceRules))
+	*out = *(*flowcontrolv1.PolicyRulesWithSubjects)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -600,11 +572,7 @@ func Convert_flowcontrol_PriorityLevelConfiguration_To_v1_PriorityLevelConfigura
 }
 
 func autoConvert_v1_PriorityLevelConfigurationCondition_To_flowcontrol_PriorityLevelConfigurationCondition(in *flowcontrolv1.PriorityLevelConfigurationCondition, out *flowcontrol.PriorityLevelConfigurationCondition, s conversion.Scope) error {
-	out.Type = flowcontrol.PriorityLevelConfigurationConditionType(in.Type)
-	out.Status = flowcontrol.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*flowcontrol.PriorityLevelConfigurationCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -614,11 +582,7 @@ func Convert_v1_PriorityLevelConfigurationCondition_To_flowcontrol_PriorityLevel
 }
 
 func autoConvert_flowcontrol_PriorityLevelConfigurationCondition_To_v1_PriorityLevelConfigurationCondition(in *flowcontrol.PriorityLevelConfigurationCondition, out *flowcontrolv1.PriorityLevelConfigurationCondition, s conversion.Scope) error {
-	out.Type = flowcontrolv1.PriorityLevelConfigurationConditionType(in.Type)
-	out.Status = flowcontrolv1.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*flowcontrolv1.PriorityLevelConfigurationCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -670,7 +634,7 @@ func Convert_flowcontrol_PriorityLevelConfigurationList_To_v1_PriorityLevelConfi
 }
 
 func autoConvert_v1_PriorityLevelConfigurationReference_To_flowcontrol_PriorityLevelConfigurationReference(in *flowcontrolv1.PriorityLevelConfigurationReference, out *flowcontrol.PriorityLevelConfigurationReference, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*flowcontrol.PriorityLevelConfigurationReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -680,7 +644,7 @@ func Convert_v1_PriorityLevelConfigurationReference_To_flowcontrol_PriorityLevel
 }
 
 func autoConvert_flowcontrol_PriorityLevelConfigurationReference_To_v1_PriorityLevelConfigurationReference(in *flowcontrol.PriorityLevelConfigurationReference, out *flowcontrolv1.PriorityLevelConfigurationReference, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*flowcontrolv1.PriorityLevelConfigurationReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -730,7 +694,7 @@ func Convert_flowcontrol_PriorityLevelConfigurationSpec_To_v1_PriorityLevelConfi
 }
 
 func autoConvert_v1_PriorityLevelConfigurationStatus_To_flowcontrol_PriorityLevelConfigurationStatus(in *flowcontrolv1.PriorityLevelConfigurationStatus, out *flowcontrol.PriorityLevelConfigurationStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]flowcontrol.PriorityLevelConfigurationCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*flowcontrol.PriorityLevelConfigurationStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -740,7 +704,7 @@ func Convert_v1_PriorityLevelConfigurationStatus_To_flowcontrol_PriorityLevelCon
 }
 
 func autoConvert_flowcontrol_PriorityLevelConfigurationStatus_To_v1_PriorityLevelConfigurationStatus(in *flowcontrol.PriorityLevelConfigurationStatus, out *flowcontrolv1.PriorityLevelConfigurationStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]flowcontrolv1.PriorityLevelConfigurationCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*flowcontrolv1.PriorityLevelConfigurationStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -750,9 +714,7 @@ func Convert_flowcontrol_PriorityLevelConfigurationStatus_To_v1_PriorityLevelCon
 }
 
 func autoConvert_v1_QueuingConfiguration_To_flowcontrol_QueuingConfiguration(in *flowcontrolv1.QueuingConfiguration, out *flowcontrol.QueuingConfiguration, s conversion.Scope) error {
-	out.Queues = in.Queues
-	out.HandSize = in.HandSize
-	out.QueueLengthLimit = in.QueueLengthLimit
+	*out = *(*flowcontrol.QueuingConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -762,9 +724,7 @@ func Convert_v1_QueuingConfiguration_To_flowcontrol_QueuingConfiguration(in *flo
 }
 
 func autoConvert_flowcontrol_QueuingConfiguration_To_v1_QueuingConfiguration(in *flowcontrol.QueuingConfiguration, out *flowcontrolv1.QueuingConfiguration, s conversion.Scope) error {
-	out.Queues = in.Queues
-	out.HandSize = in.HandSize
-	out.QueueLengthLimit = in.QueueLengthLimit
+	*out = *(*flowcontrolv1.QueuingConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -774,11 +734,7 @@ func Convert_flowcontrol_QueuingConfiguration_To_v1_QueuingConfiguration(in *flo
 }
 
 func autoConvert_v1_ResourcePolicyRule_To_flowcontrol_ResourcePolicyRule(in *flowcontrolv1.ResourcePolicyRule, out *flowcontrol.ResourcePolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
-	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
-	out.ClusterScope = in.ClusterScope
-	out.Namespaces = *(*[]string)(unsafe.Pointer(&in.Namespaces))
+	*out = *(*flowcontrol.ResourcePolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -788,11 +744,7 @@ func Convert_v1_ResourcePolicyRule_To_flowcontrol_ResourcePolicyRule(in *flowcon
 }
 
 func autoConvert_flowcontrol_ResourcePolicyRule_To_v1_ResourcePolicyRule(in *flowcontrol.ResourcePolicyRule, out *flowcontrolv1.ResourcePolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
-	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
-	out.ClusterScope = in.ClusterScope
-	out.Namespaces = *(*[]string)(unsafe.Pointer(&in.Namespaces))
+	*out = *(*flowcontrolv1.ResourcePolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -802,8 +754,7 @@ func Convert_flowcontrol_ResourcePolicyRule_To_v1_ResourcePolicyRule(in *flowcon
 }
 
 func autoConvert_v1_ServiceAccountSubject_To_flowcontrol_ServiceAccountSubject(in *flowcontrolv1.ServiceAccountSubject, out *flowcontrol.ServiceAccountSubject, s conversion.Scope) error {
-	out.Namespace = in.Namespace
-	out.Name = in.Name
+	*out = *(*flowcontrol.ServiceAccountSubject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -813,8 +764,7 @@ func Convert_v1_ServiceAccountSubject_To_flowcontrol_ServiceAccountSubject(in *f
 }
 
 func autoConvert_flowcontrol_ServiceAccountSubject_To_v1_ServiceAccountSubject(in *flowcontrol.ServiceAccountSubject, out *flowcontrolv1.ServiceAccountSubject, s conversion.Scope) error {
-	out.Namespace = in.Namespace
-	out.Name = in.Name
+	*out = *(*flowcontrolv1.ServiceAccountSubject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -824,10 +774,7 @@ func Convert_flowcontrol_ServiceAccountSubject_To_v1_ServiceAccountSubject(in *f
 }
 
 func autoConvert_v1_Subject_To_flowcontrol_Subject(in *flowcontrolv1.Subject, out *flowcontrol.Subject, s conversion.Scope) error {
-	out.Kind = flowcontrol.SubjectKind(in.Kind)
-	out.User = (*flowcontrol.UserSubject)(unsafe.Pointer(in.User))
-	out.Group = (*flowcontrol.GroupSubject)(unsafe.Pointer(in.Group))
-	out.ServiceAccount = (*flowcontrol.ServiceAccountSubject)(unsafe.Pointer(in.ServiceAccount))
+	*out = *(*flowcontrol.Subject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -837,10 +784,7 @@ func Convert_v1_Subject_To_flowcontrol_Subject(in *flowcontrolv1.Subject, out *f
 }
 
 func autoConvert_flowcontrol_Subject_To_v1_Subject(in *flowcontrol.Subject, out *flowcontrolv1.Subject, s conversion.Scope) error {
-	out.Kind = flowcontrolv1.SubjectKind(in.Kind)
-	out.User = (*flowcontrolv1.UserSubject)(unsafe.Pointer(in.User))
-	out.Group = (*flowcontrolv1.GroupSubject)(unsafe.Pointer(in.Group))
-	out.ServiceAccount = (*flowcontrolv1.ServiceAccountSubject)(unsafe.Pointer(in.ServiceAccount))
+	*out = *(*flowcontrolv1.Subject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -850,7 +794,7 @@ func Convert_flowcontrol_Subject_To_v1_Subject(in *flowcontrol.Subject, out *flo
 }
 
 func autoConvert_v1_UserSubject_To_flowcontrol_UserSubject(in *flowcontrolv1.UserSubject, out *flowcontrol.UserSubject, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*flowcontrol.UserSubject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -860,7 +804,7 @@ func Convert_v1_UserSubject_To_flowcontrol_UserSubject(in *flowcontrolv1.UserSub
 }
 
 func autoConvert_flowcontrol_UserSubject_To_v1_UserSubject(in *flowcontrol.UserSubject, out *flowcontrolv1.UserSubject, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*flowcontrolv1.UserSubject)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/flowcontrol/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/flowcontrol/v1beta1/zz_generated.conversion.go
@@ -271,8 +271,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1beta1_ExemptPriorityLevelConfiguration_To_flowcontrol_ExemptPriorityLevelConfiguration(in *flowcontrolv1beta1.ExemptPriorityLevelConfiguration, out *flowcontrol.ExemptPriorityLevelConfiguration, s conversion.Scope) error {
-	out.NominalConcurrencyShares = (*int32)(unsafe.Pointer(in.NominalConcurrencyShares))
-	out.LendablePercent = (*int32)(unsafe.Pointer(in.LendablePercent))
+	*out = *(*flowcontrol.ExemptPriorityLevelConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -282,8 +281,7 @@ func Convert_v1beta1_ExemptPriorityLevelConfiguration_To_flowcontrol_ExemptPrior
 }
 
 func autoConvert_flowcontrol_ExemptPriorityLevelConfiguration_To_v1beta1_ExemptPriorityLevelConfiguration(in *flowcontrol.ExemptPriorityLevelConfiguration, out *flowcontrolv1beta1.ExemptPriorityLevelConfiguration, s conversion.Scope) error {
-	out.NominalConcurrencyShares = (*int32)(unsafe.Pointer(in.NominalConcurrencyShares))
-	out.LendablePercent = (*int32)(unsafe.Pointer(in.LendablePercent))
+	*out = *(*flowcontrolv1beta1.ExemptPriorityLevelConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -293,7 +291,7 @@ func Convert_flowcontrol_ExemptPriorityLevelConfiguration_To_v1beta1_ExemptPrior
 }
 
 func autoConvert_v1beta1_FlowDistinguisherMethod_To_flowcontrol_FlowDistinguisherMethod(in *flowcontrolv1beta1.FlowDistinguisherMethod, out *flowcontrol.FlowDistinguisherMethod, s conversion.Scope) error {
-	out.Type = flowcontrol.FlowDistinguisherMethodType(in.Type)
+	*out = *(*flowcontrol.FlowDistinguisherMethod)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -303,7 +301,7 @@ func Convert_v1beta1_FlowDistinguisherMethod_To_flowcontrol_FlowDistinguisherMet
 }
 
 func autoConvert_flowcontrol_FlowDistinguisherMethod_To_v1beta1_FlowDistinguisherMethod(in *flowcontrol.FlowDistinguisherMethod, out *flowcontrolv1beta1.FlowDistinguisherMethod, s conversion.Scope) error {
-	out.Type = flowcontrolv1beta1.FlowDistinguisherMethodType(in.Type)
+	*out = *(*flowcontrolv1beta1.FlowDistinguisherMethod)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -345,11 +343,7 @@ func Convert_flowcontrol_FlowSchema_To_v1beta1_FlowSchema(in *flowcontrol.FlowSc
 }
 
 func autoConvert_v1beta1_FlowSchemaCondition_To_flowcontrol_FlowSchemaCondition(in *flowcontrolv1beta1.FlowSchemaCondition, out *flowcontrol.FlowSchemaCondition, s conversion.Scope) error {
-	out.Type = flowcontrol.FlowSchemaConditionType(in.Type)
-	out.Status = flowcontrol.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*flowcontrol.FlowSchemaCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -359,11 +353,7 @@ func Convert_v1beta1_FlowSchemaCondition_To_flowcontrol_FlowSchemaCondition(in *
 }
 
 func autoConvert_flowcontrol_FlowSchemaCondition_To_v1beta1_FlowSchemaCondition(in *flowcontrol.FlowSchemaCondition, out *flowcontrolv1beta1.FlowSchemaCondition, s conversion.Scope) error {
-	out.Type = flowcontrolv1beta1.FlowSchemaConditionType(in.Type)
-	out.Status = flowcontrolv1beta1.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*flowcontrolv1beta1.FlowSchemaCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -395,12 +385,7 @@ func Convert_flowcontrol_FlowSchemaList_To_v1beta1_FlowSchemaList(in *flowcontro
 }
 
 func autoConvert_v1beta1_FlowSchemaSpec_To_flowcontrol_FlowSchemaSpec(in *flowcontrolv1beta1.FlowSchemaSpec, out *flowcontrol.FlowSchemaSpec, s conversion.Scope) error {
-	if err := Convert_v1beta1_PriorityLevelConfigurationReference_To_flowcontrol_PriorityLevelConfigurationReference(&in.PriorityLevelConfiguration, &out.PriorityLevelConfiguration, s); err != nil {
-		return err
-	}
-	out.MatchingPrecedence = in.MatchingPrecedence
-	out.DistinguisherMethod = (*flowcontrol.FlowDistinguisherMethod)(unsafe.Pointer(in.DistinguisherMethod))
-	out.Rules = *(*[]flowcontrol.PolicyRulesWithSubjects)(unsafe.Pointer(&in.Rules))
+	*out = *(*flowcontrol.FlowSchemaSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -410,12 +395,7 @@ func Convert_v1beta1_FlowSchemaSpec_To_flowcontrol_FlowSchemaSpec(in *flowcontro
 }
 
 func autoConvert_flowcontrol_FlowSchemaSpec_To_v1beta1_FlowSchemaSpec(in *flowcontrol.FlowSchemaSpec, out *flowcontrolv1beta1.FlowSchemaSpec, s conversion.Scope) error {
-	if err := Convert_flowcontrol_PriorityLevelConfigurationReference_To_v1beta1_PriorityLevelConfigurationReference(&in.PriorityLevelConfiguration, &out.PriorityLevelConfiguration, s); err != nil {
-		return err
-	}
-	out.MatchingPrecedence = in.MatchingPrecedence
-	out.DistinguisherMethod = (*flowcontrolv1beta1.FlowDistinguisherMethod)(unsafe.Pointer(in.DistinguisherMethod))
-	out.Rules = *(*[]flowcontrolv1beta1.PolicyRulesWithSubjects)(unsafe.Pointer(&in.Rules))
+	*out = *(*flowcontrolv1beta1.FlowSchemaSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -425,7 +405,7 @@ func Convert_flowcontrol_FlowSchemaSpec_To_v1beta1_FlowSchemaSpec(in *flowcontro
 }
 
 func autoConvert_v1beta1_FlowSchemaStatus_To_flowcontrol_FlowSchemaStatus(in *flowcontrolv1beta1.FlowSchemaStatus, out *flowcontrol.FlowSchemaStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]flowcontrol.FlowSchemaCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*flowcontrol.FlowSchemaStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -435,7 +415,7 @@ func Convert_v1beta1_FlowSchemaStatus_To_flowcontrol_FlowSchemaStatus(in *flowco
 }
 
 func autoConvert_flowcontrol_FlowSchemaStatus_To_v1beta1_FlowSchemaStatus(in *flowcontrol.FlowSchemaStatus, out *flowcontrolv1beta1.FlowSchemaStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]flowcontrolv1beta1.FlowSchemaCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*flowcontrolv1beta1.FlowSchemaStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -445,7 +425,7 @@ func Convert_flowcontrol_FlowSchemaStatus_To_v1beta1_FlowSchemaStatus(in *flowco
 }
 
 func autoConvert_v1beta1_GroupSubject_To_flowcontrol_GroupSubject(in *flowcontrolv1beta1.GroupSubject, out *flowcontrol.GroupSubject, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*flowcontrol.GroupSubject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -455,7 +435,7 @@ func Convert_v1beta1_GroupSubject_To_flowcontrol_GroupSubject(in *flowcontrolv1b
 }
 
 func autoConvert_flowcontrol_GroupSubject_To_v1beta1_GroupSubject(in *flowcontrol.GroupSubject, out *flowcontrolv1beta1.GroupSubject, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*flowcontrolv1beta1.GroupSubject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -465,8 +445,7 @@ func Convert_flowcontrol_GroupSubject_To_v1beta1_GroupSubject(in *flowcontrol.Gr
 }
 
 func autoConvert_v1beta1_LimitResponse_To_flowcontrol_LimitResponse(in *flowcontrolv1beta1.LimitResponse, out *flowcontrol.LimitResponse, s conversion.Scope) error {
-	out.Type = flowcontrol.LimitResponseType(in.Type)
-	out.Queuing = (*flowcontrol.QueuingConfiguration)(unsafe.Pointer(in.Queuing))
+	*out = *(*flowcontrol.LimitResponse)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -476,8 +455,7 @@ func Convert_v1beta1_LimitResponse_To_flowcontrol_LimitResponse(in *flowcontrolv
 }
 
 func autoConvert_flowcontrol_LimitResponse_To_v1beta1_LimitResponse(in *flowcontrol.LimitResponse, out *flowcontrolv1beta1.LimitResponse, s conversion.Scope) error {
-	out.Type = flowcontrolv1beta1.LimitResponseType(in.Type)
-	out.Queuing = (*flowcontrolv1beta1.QueuingConfiguration)(unsafe.Pointer(in.Queuing))
+	*out = *(*flowcontrolv1beta1.LimitResponse)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -507,8 +485,7 @@ func autoConvert_flowcontrol_LimitedPriorityLevelConfiguration_To_v1beta1_Limite
 }
 
 func autoConvert_v1beta1_NonResourcePolicyRule_To_flowcontrol_NonResourcePolicyRule(in *flowcontrolv1beta1.NonResourcePolicyRule, out *flowcontrol.NonResourcePolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.NonResourceURLs = *(*[]string)(unsafe.Pointer(&in.NonResourceURLs))
+	*out = *(*flowcontrol.NonResourcePolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -518,8 +495,7 @@ func Convert_v1beta1_NonResourcePolicyRule_To_flowcontrol_NonResourcePolicyRule(
 }
 
 func autoConvert_flowcontrol_NonResourcePolicyRule_To_v1beta1_NonResourcePolicyRule(in *flowcontrol.NonResourcePolicyRule, out *flowcontrolv1beta1.NonResourcePolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.NonResourceURLs = *(*[]string)(unsafe.Pointer(&in.NonResourceURLs))
+	*out = *(*flowcontrolv1beta1.NonResourcePolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -529,9 +505,7 @@ func Convert_flowcontrol_NonResourcePolicyRule_To_v1beta1_NonResourcePolicyRule(
 }
 
 func autoConvert_v1beta1_PolicyRulesWithSubjects_To_flowcontrol_PolicyRulesWithSubjects(in *flowcontrolv1beta1.PolicyRulesWithSubjects, out *flowcontrol.PolicyRulesWithSubjects, s conversion.Scope) error {
-	out.Subjects = *(*[]flowcontrol.Subject)(unsafe.Pointer(&in.Subjects))
-	out.ResourceRules = *(*[]flowcontrol.ResourcePolicyRule)(unsafe.Pointer(&in.ResourceRules))
-	out.NonResourceRules = *(*[]flowcontrol.NonResourcePolicyRule)(unsafe.Pointer(&in.NonResourceRules))
+	*out = *(*flowcontrol.PolicyRulesWithSubjects)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -541,9 +515,7 @@ func Convert_v1beta1_PolicyRulesWithSubjects_To_flowcontrol_PolicyRulesWithSubje
 }
 
 func autoConvert_flowcontrol_PolicyRulesWithSubjects_To_v1beta1_PolicyRulesWithSubjects(in *flowcontrol.PolicyRulesWithSubjects, out *flowcontrolv1beta1.PolicyRulesWithSubjects, s conversion.Scope) error {
-	out.Subjects = *(*[]flowcontrolv1beta1.Subject)(unsafe.Pointer(&in.Subjects))
-	out.ResourceRules = *(*[]flowcontrolv1beta1.ResourcePolicyRule)(unsafe.Pointer(&in.ResourceRules))
-	out.NonResourceRules = *(*[]flowcontrolv1beta1.NonResourcePolicyRule)(unsafe.Pointer(&in.NonResourceRules))
+	*out = *(*flowcontrolv1beta1.PolicyRulesWithSubjects)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -585,11 +557,7 @@ func Convert_flowcontrol_PriorityLevelConfiguration_To_v1beta1_PriorityLevelConf
 }
 
 func autoConvert_v1beta1_PriorityLevelConfigurationCondition_To_flowcontrol_PriorityLevelConfigurationCondition(in *flowcontrolv1beta1.PriorityLevelConfigurationCondition, out *flowcontrol.PriorityLevelConfigurationCondition, s conversion.Scope) error {
-	out.Type = flowcontrol.PriorityLevelConfigurationConditionType(in.Type)
-	out.Status = flowcontrol.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*flowcontrol.PriorityLevelConfigurationCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -599,11 +567,7 @@ func Convert_v1beta1_PriorityLevelConfigurationCondition_To_flowcontrol_Priority
 }
 
 func autoConvert_flowcontrol_PriorityLevelConfigurationCondition_To_v1beta1_PriorityLevelConfigurationCondition(in *flowcontrol.PriorityLevelConfigurationCondition, out *flowcontrolv1beta1.PriorityLevelConfigurationCondition, s conversion.Scope) error {
-	out.Type = flowcontrolv1beta1.PriorityLevelConfigurationConditionType(in.Type)
-	out.Status = flowcontrolv1beta1.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*flowcontrolv1beta1.PriorityLevelConfigurationCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -655,7 +619,7 @@ func Convert_flowcontrol_PriorityLevelConfigurationList_To_v1beta1_PriorityLevel
 }
 
 func autoConvert_v1beta1_PriorityLevelConfigurationReference_To_flowcontrol_PriorityLevelConfigurationReference(in *flowcontrolv1beta1.PriorityLevelConfigurationReference, out *flowcontrol.PriorityLevelConfigurationReference, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*flowcontrol.PriorityLevelConfigurationReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -665,7 +629,7 @@ func Convert_v1beta1_PriorityLevelConfigurationReference_To_flowcontrol_Priority
 }
 
 func autoConvert_flowcontrol_PriorityLevelConfigurationReference_To_v1beta1_PriorityLevelConfigurationReference(in *flowcontrol.PriorityLevelConfigurationReference, out *flowcontrolv1beta1.PriorityLevelConfigurationReference, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*flowcontrolv1beta1.PriorityLevelConfigurationReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -715,7 +679,7 @@ func Convert_flowcontrol_PriorityLevelConfigurationSpec_To_v1beta1_PriorityLevel
 }
 
 func autoConvert_v1beta1_PriorityLevelConfigurationStatus_To_flowcontrol_PriorityLevelConfigurationStatus(in *flowcontrolv1beta1.PriorityLevelConfigurationStatus, out *flowcontrol.PriorityLevelConfigurationStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]flowcontrol.PriorityLevelConfigurationCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*flowcontrol.PriorityLevelConfigurationStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -725,7 +689,7 @@ func Convert_v1beta1_PriorityLevelConfigurationStatus_To_flowcontrol_PriorityLev
 }
 
 func autoConvert_flowcontrol_PriorityLevelConfigurationStatus_To_v1beta1_PriorityLevelConfigurationStatus(in *flowcontrol.PriorityLevelConfigurationStatus, out *flowcontrolv1beta1.PriorityLevelConfigurationStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]flowcontrolv1beta1.PriorityLevelConfigurationCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*flowcontrolv1beta1.PriorityLevelConfigurationStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -735,9 +699,7 @@ func Convert_flowcontrol_PriorityLevelConfigurationStatus_To_v1beta1_PriorityLev
 }
 
 func autoConvert_v1beta1_QueuingConfiguration_To_flowcontrol_QueuingConfiguration(in *flowcontrolv1beta1.QueuingConfiguration, out *flowcontrol.QueuingConfiguration, s conversion.Scope) error {
-	out.Queues = in.Queues
-	out.HandSize = in.HandSize
-	out.QueueLengthLimit = in.QueueLengthLimit
+	*out = *(*flowcontrol.QueuingConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -747,9 +709,7 @@ func Convert_v1beta1_QueuingConfiguration_To_flowcontrol_QueuingConfiguration(in
 }
 
 func autoConvert_flowcontrol_QueuingConfiguration_To_v1beta1_QueuingConfiguration(in *flowcontrol.QueuingConfiguration, out *flowcontrolv1beta1.QueuingConfiguration, s conversion.Scope) error {
-	out.Queues = in.Queues
-	out.HandSize = in.HandSize
-	out.QueueLengthLimit = in.QueueLengthLimit
+	*out = *(*flowcontrolv1beta1.QueuingConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -759,11 +719,7 @@ func Convert_flowcontrol_QueuingConfiguration_To_v1beta1_QueuingConfiguration(in
 }
 
 func autoConvert_v1beta1_ResourcePolicyRule_To_flowcontrol_ResourcePolicyRule(in *flowcontrolv1beta1.ResourcePolicyRule, out *flowcontrol.ResourcePolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
-	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
-	out.ClusterScope = in.ClusterScope
-	out.Namespaces = *(*[]string)(unsafe.Pointer(&in.Namespaces))
+	*out = *(*flowcontrol.ResourcePolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -773,11 +729,7 @@ func Convert_v1beta1_ResourcePolicyRule_To_flowcontrol_ResourcePolicyRule(in *fl
 }
 
 func autoConvert_flowcontrol_ResourcePolicyRule_To_v1beta1_ResourcePolicyRule(in *flowcontrol.ResourcePolicyRule, out *flowcontrolv1beta1.ResourcePolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
-	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
-	out.ClusterScope = in.ClusterScope
-	out.Namespaces = *(*[]string)(unsafe.Pointer(&in.Namespaces))
+	*out = *(*flowcontrolv1beta1.ResourcePolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -787,8 +739,7 @@ func Convert_flowcontrol_ResourcePolicyRule_To_v1beta1_ResourcePolicyRule(in *fl
 }
 
 func autoConvert_v1beta1_ServiceAccountSubject_To_flowcontrol_ServiceAccountSubject(in *flowcontrolv1beta1.ServiceAccountSubject, out *flowcontrol.ServiceAccountSubject, s conversion.Scope) error {
-	out.Namespace = in.Namespace
-	out.Name = in.Name
+	*out = *(*flowcontrol.ServiceAccountSubject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -798,8 +749,7 @@ func Convert_v1beta1_ServiceAccountSubject_To_flowcontrol_ServiceAccountSubject(
 }
 
 func autoConvert_flowcontrol_ServiceAccountSubject_To_v1beta1_ServiceAccountSubject(in *flowcontrol.ServiceAccountSubject, out *flowcontrolv1beta1.ServiceAccountSubject, s conversion.Scope) error {
-	out.Namespace = in.Namespace
-	out.Name = in.Name
+	*out = *(*flowcontrolv1beta1.ServiceAccountSubject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -809,10 +759,7 @@ func Convert_flowcontrol_ServiceAccountSubject_To_v1beta1_ServiceAccountSubject(
 }
 
 func autoConvert_v1beta1_Subject_To_flowcontrol_Subject(in *flowcontrolv1beta1.Subject, out *flowcontrol.Subject, s conversion.Scope) error {
-	out.Kind = flowcontrol.SubjectKind(in.Kind)
-	out.User = (*flowcontrol.UserSubject)(unsafe.Pointer(in.User))
-	out.Group = (*flowcontrol.GroupSubject)(unsafe.Pointer(in.Group))
-	out.ServiceAccount = (*flowcontrol.ServiceAccountSubject)(unsafe.Pointer(in.ServiceAccount))
+	*out = *(*flowcontrol.Subject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -822,10 +769,7 @@ func Convert_v1beta1_Subject_To_flowcontrol_Subject(in *flowcontrolv1beta1.Subje
 }
 
 func autoConvert_flowcontrol_Subject_To_v1beta1_Subject(in *flowcontrol.Subject, out *flowcontrolv1beta1.Subject, s conversion.Scope) error {
-	out.Kind = flowcontrolv1beta1.SubjectKind(in.Kind)
-	out.User = (*flowcontrolv1beta1.UserSubject)(unsafe.Pointer(in.User))
-	out.Group = (*flowcontrolv1beta1.GroupSubject)(unsafe.Pointer(in.Group))
-	out.ServiceAccount = (*flowcontrolv1beta1.ServiceAccountSubject)(unsafe.Pointer(in.ServiceAccount))
+	*out = *(*flowcontrolv1beta1.Subject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -835,7 +779,7 @@ func Convert_flowcontrol_Subject_To_v1beta1_Subject(in *flowcontrol.Subject, out
 }
 
 func autoConvert_v1beta1_UserSubject_To_flowcontrol_UserSubject(in *flowcontrolv1beta1.UserSubject, out *flowcontrol.UserSubject, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*flowcontrol.UserSubject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -845,7 +789,7 @@ func Convert_v1beta1_UserSubject_To_flowcontrol_UserSubject(in *flowcontrolv1bet
 }
 
 func autoConvert_flowcontrol_UserSubject_To_v1beta1_UserSubject(in *flowcontrol.UserSubject, out *flowcontrolv1beta1.UserSubject, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*flowcontrolv1beta1.UserSubject)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/flowcontrol/v1beta2/zz_generated.conversion.go
+++ b/pkg/apis/flowcontrol/v1beta2/zz_generated.conversion.go
@@ -271,8 +271,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1beta2_ExemptPriorityLevelConfiguration_To_flowcontrol_ExemptPriorityLevelConfiguration(in *flowcontrolv1beta2.ExemptPriorityLevelConfiguration, out *flowcontrol.ExemptPriorityLevelConfiguration, s conversion.Scope) error {
-	out.NominalConcurrencyShares = (*int32)(unsafe.Pointer(in.NominalConcurrencyShares))
-	out.LendablePercent = (*int32)(unsafe.Pointer(in.LendablePercent))
+	*out = *(*flowcontrol.ExemptPriorityLevelConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -282,8 +281,7 @@ func Convert_v1beta2_ExemptPriorityLevelConfiguration_To_flowcontrol_ExemptPrior
 }
 
 func autoConvert_flowcontrol_ExemptPriorityLevelConfiguration_To_v1beta2_ExemptPriorityLevelConfiguration(in *flowcontrol.ExemptPriorityLevelConfiguration, out *flowcontrolv1beta2.ExemptPriorityLevelConfiguration, s conversion.Scope) error {
-	out.NominalConcurrencyShares = (*int32)(unsafe.Pointer(in.NominalConcurrencyShares))
-	out.LendablePercent = (*int32)(unsafe.Pointer(in.LendablePercent))
+	*out = *(*flowcontrolv1beta2.ExemptPriorityLevelConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -293,7 +291,7 @@ func Convert_flowcontrol_ExemptPriorityLevelConfiguration_To_v1beta2_ExemptPrior
 }
 
 func autoConvert_v1beta2_FlowDistinguisherMethod_To_flowcontrol_FlowDistinguisherMethod(in *flowcontrolv1beta2.FlowDistinguisherMethod, out *flowcontrol.FlowDistinguisherMethod, s conversion.Scope) error {
-	out.Type = flowcontrol.FlowDistinguisherMethodType(in.Type)
+	*out = *(*flowcontrol.FlowDistinguisherMethod)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -303,7 +301,7 @@ func Convert_v1beta2_FlowDistinguisherMethod_To_flowcontrol_FlowDistinguisherMet
 }
 
 func autoConvert_flowcontrol_FlowDistinguisherMethod_To_v1beta2_FlowDistinguisherMethod(in *flowcontrol.FlowDistinguisherMethod, out *flowcontrolv1beta2.FlowDistinguisherMethod, s conversion.Scope) error {
-	out.Type = flowcontrolv1beta2.FlowDistinguisherMethodType(in.Type)
+	*out = *(*flowcontrolv1beta2.FlowDistinguisherMethod)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -345,11 +343,7 @@ func Convert_flowcontrol_FlowSchema_To_v1beta2_FlowSchema(in *flowcontrol.FlowSc
 }
 
 func autoConvert_v1beta2_FlowSchemaCondition_To_flowcontrol_FlowSchemaCondition(in *flowcontrolv1beta2.FlowSchemaCondition, out *flowcontrol.FlowSchemaCondition, s conversion.Scope) error {
-	out.Type = flowcontrol.FlowSchemaConditionType(in.Type)
-	out.Status = flowcontrol.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*flowcontrol.FlowSchemaCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -359,11 +353,7 @@ func Convert_v1beta2_FlowSchemaCondition_To_flowcontrol_FlowSchemaCondition(in *
 }
 
 func autoConvert_flowcontrol_FlowSchemaCondition_To_v1beta2_FlowSchemaCondition(in *flowcontrol.FlowSchemaCondition, out *flowcontrolv1beta2.FlowSchemaCondition, s conversion.Scope) error {
-	out.Type = flowcontrolv1beta2.FlowSchemaConditionType(in.Type)
-	out.Status = flowcontrolv1beta2.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*flowcontrolv1beta2.FlowSchemaCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -395,12 +385,7 @@ func Convert_flowcontrol_FlowSchemaList_To_v1beta2_FlowSchemaList(in *flowcontro
 }
 
 func autoConvert_v1beta2_FlowSchemaSpec_To_flowcontrol_FlowSchemaSpec(in *flowcontrolv1beta2.FlowSchemaSpec, out *flowcontrol.FlowSchemaSpec, s conversion.Scope) error {
-	if err := Convert_v1beta2_PriorityLevelConfigurationReference_To_flowcontrol_PriorityLevelConfigurationReference(&in.PriorityLevelConfiguration, &out.PriorityLevelConfiguration, s); err != nil {
-		return err
-	}
-	out.MatchingPrecedence = in.MatchingPrecedence
-	out.DistinguisherMethod = (*flowcontrol.FlowDistinguisherMethod)(unsafe.Pointer(in.DistinguisherMethod))
-	out.Rules = *(*[]flowcontrol.PolicyRulesWithSubjects)(unsafe.Pointer(&in.Rules))
+	*out = *(*flowcontrol.FlowSchemaSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -410,12 +395,7 @@ func Convert_v1beta2_FlowSchemaSpec_To_flowcontrol_FlowSchemaSpec(in *flowcontro
 }
 
 func autoConvert_flowcontrol_FlowSchemaSpec_To_v1beta2_FlowSchemaSpec(in *flowcontrol.FlowSchemaSpec, out *flowcontrolv1beta2.FlowSchemaSpec, s conversion.Scope) error {
-	if err := Convert_flowcontrol_PriorityLevelConfigurationReference_To_v1beta2_PriorityLevelConfigurationReference(&in.PriorityLevelConfiguration, &out.PriorityLevelConfiguration, s); err != nil {
-		return err
-	}
-	out.MatchingPrecedence = in.MatchingPrecedence
-	out.DistinguisherMethod = (*flowcontrolv1beta2.FlowDistinguisherMethod)(unsafe.Pointer(in.DistinguisherMethod))
-	out.Rules = *(*[]flowcontrolv1beta2.PolicyRulesWithSubjects)(unsafe.Pointer(&in.Rules))
+	*out = *(*flowcontrolv1beta2.FlowSchemaSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -425,7 +405,7 @@ func Convert_flowcontrol_FlowSchemaSpec_To_v1beta2_FlowSchemaSpec(in *flowcontro
 }
 
 func autoConvert_v1beta2_FlowSchemaStatus_To_flowcontrol_FlowSchemaStatus(in *flowcontrolv1beta2.FlowSchemaStatus, out *flowcontrol.FlowSchemaStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]flowcontrol.FlowSchemaCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*flowcontrol.FlowSchemaStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -435,7 +415,7 @@ func Convert_v1beta2_FlowSchemaStatus_To_flowcontrol_FlowSchemaStatus(in *flowco
 }
 
 func autoConvert_flowcontrol_FlowSchemaStatus_To_v1beta2_FlowSchemaStatus(in *flowcontrol.FlowSchemaStatus, out *flowcontrolv1beta2.FlowSchemaStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]flowcontrolv1beta2.FlowSchemaCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*flowcontrolv1beta2.FlowSchemaStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -445,7 +425,7 @@ func Convert_flowcontrol_FlowSchemaStatus_To_v1beta2_FlowSchemaStatus(in *flowco
 }
 
 func autoConvert_v1beta2_GroupSubject_To_flowcontrol_GroupSubject(in *flowcontrolv1beta2.GroupSubject, out *flowcontrol.GroupSubject, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*flowcontrol.GroupSubject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -455,7 +435,7 @@ func Convert_v1beta2_GroupSubject_To_flowcontrol_GroupSubject(in *flowcontrolv1b
 }
 
 func autoConvert_flowcontrol_GroupSubject_To_v1beta2_GroupSubject(in *flowcontrol.GroupSubject, out *flowcontrolv1beta2.GroupSubject, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*flowcontrolv1beta2.GroupSubject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -465,8 +445,7 @@ func Convert_flowcontrol_GroupSubject_To_v1beta2_GroupSubject(in *flowcontrol.Gr
 }
 
 func autoConvert_v1beta2_LimitResponse_To_flowcontrol_LimitResponse(in *flowcontrolv1beta2.LimitResponse, out *flowcontrol.LimitResponse, s conversion.Scope) error {
-	out.Type = flowcontrol.LimitResponseType(in.Type)
-	out.Queuing = (*flowcontrol.QueuingConfiguration)(unsafe.Pointer(in.Queuing))
+	*out = *(*flowcontrol.LimitResponse)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -476,8 +455,7 @@ func Convert_v1beta2_LimitResponse_To_flowcontrol_LimitResponse(in *flowcontrolv
 }
 
 func autoConvert_flowcontrol_LimitResponse_To_v1beta2_LimitResponse(in *flowcontrol.LimitResponse, out *flowcontrolv1beta2.LimitResponse, s conversion.Scope) error {
-	out.Type = flowcontrolv1beta2.LimitResponseType(in.Type)
-	out.Queuing = (*flowcontrolv1beta2.QueuingConfiguration)(unsafe.Pointer(in.Queuing))
+	*out = *(*flowcontrolv1beta2.LimitResponse)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -507,8 +485,7 @@ func autoConvert_flowcontrol_LimitedPriorityLevelConfiguration_To_v1beta2_Limite
 }
 
 func autoConvert_v1beta2_NonResourcePolicyRule_To_flowcontrol_NonResourcePolicyRule(in *flowcontrolv1beta2.NonResourcePolicyRule, out *flowcontrol.NonResourcePolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.NonResourceURLs = *(*[]string)(unsafe.Pointer(&in.NonResourceURLs))
+	*out = *(*flowcontrol.NonResourcePolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -518,8 +495,7 @@ func Convert_v1beta2_NonResourcePolicyRule_To_flowcontrol_NonResourcePolicyRule(
 }
 
 func autoConvert_flowcontrol_NonResourcePolicyRule_To_v1beta2_NonResourcePolicyRule(in *flowcontrol.NonResourcePolicyRule, out *flowcontrolv1beta2.NonResourcePolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.NonResourceURLs = *(*[]string)(unsafe.Pointer(&in.NonResourceURLs))
+	*out = *(*flowcontrolv1beta2.NonResourcePolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -529,9 +505,7 @@ func Convert_flowcontrol_NonResourcePolicyRule_To_v1beta2_NonResourcePolicyRule(
 }
 
 func autoConvert_v1beta2_PolicyRulesWithSubjects_To_flowcontrol_PolicyRulesWithSubjects(in *flowcontrolv1beta2.PolicyRulesWithSubjects, out *flowcontrol.PolicyRulesWithSubjects, s conversion.Scope) error {
-	out.Subjects = *(*[]flowcontrol.Subject)(unsafe.Pointer(&in.Subjects))
-	out.ResourceRules = *(*[]flowcontrol.ResourcePolicyRule)(unsafe.Pointer(&in.ResourceRules))
-	out.NonResourceRules = *(*[]flowcontrol.NonResourcePolicyRule)(unsafe.Pointer(&in.NonResourceRules))
+	*out = *(*flowcontrol.PolicyRulesWithSubjects)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -541,9 +515,7 @@ func Convert_v1beta2_PolicyRulesWithSubjects_To_flowcontrol_PolicyRulesWithSubje
 }
 
 func autoConvert_flowcontrol_PolicyRulesWithSubjects_To_v1beta2_PolicyRulesWithSubjects(in *flowcontrol.PolicyRulesWithSubjects, out *flowcontrolv1beta2.PolicyRulesWithSubjects, s conversion.Scope) error {
-	out.Subjects = *(*[]flowcontrolv1beta2.Subject)(unsafe.Pointer(&in.Subjects))
-	out.ResourceRules = *(*[]flowcontrolv1beta2.ResourcePolicyRule)(unsafe.Pointer(&in.ResourceRules))
-	out.NonResourceRules = *(*[]flowcontrolv1beta2.NonResourcePolicyRule)(unsafe.Pointer(&in.NonResourceRules))
+	*out = *(*flowcontrolv1beta2.PolicyRulesWithSubjects)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -585,11 +557,7 @@ func Convert_flowcontrol_PriorityLevelConfiguration_To_v1beta2_PriorityLevelConf
 }
 
 func autoConvert_v1beta2_PriorityLevelConfigurationCondition_To_flowcontrol_PriorityLevelConfigurationCondition(in *flowcontrolv1beta2.PriorityLevelConfigurationCondition, out *flowcontrol.PriorityLevelConfigurationCondition, s conversion.Scope) error {
-	out.Type = flowcontrol.PriorityLevelConfigurationConditionType(in.Type)
-	out.Status = flowcontrol.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*flowcontrol.PriorityLevelConfigurationCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -599,11 +567,7 @@ func Convert_v1beta2_PriorityLevelConfigurationCondition_To_flowcontrol_Priority
 }
 
 func autoConvert_flowcontrol_PriorityLevelConfigurationCondition_To_v1beta2_PriorityLevelConfigurationCondition(in *flowcontrol.PriorityLevelConfigurationCondition, out *flowcontrolv1beta2.PriorityLevelConfigurationCondition, s conversion.Scope) error {
-	out.Type = flowcontrolv1beta2.PriorityLevelConfigurationConditionType(in.Type)
-	out.Status = flowcontrolv1beta2.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*flowcontrolv1beta2.PriorityLevelConfigurationCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -655,7 +619,7 @@ func Convert_flowcontrol_PriorityLevelConfigurationList_To_v1beta2_PriorityLevel
 }
 
 func autoConvert_v1beta2_PriorityLevelConfigurationReference_To_flowcontrol_PriorityLevelConfigurationReference(in *flowcontrolv1beta2.PriorityLevelConfigurationReference, out *flowcontrol.PriorityLevelConfigurationReference, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*flowcontrol.PriorityLevelConfigurationReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -665,7 +629,7 @@ func Convert_v1beta2_PriorityLevelConfigurationReference_To_flowcontrol_Priority
 }
 
 func autoConvert_flowcontrol_PriorityLevelConfigurationReference_To_v1beta2_PriorityLevelConfigurationReference(in *flowcontrol.PriorityLevelConfigurationReference, out *flowcontrolv1beta2.PriorityLevelConfigurationReference, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*flowcontrolv1beta2.PriorityLevelConfigurationReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -715,7 +679,7 @@ func Convert_flowcontrol_PriorityLevelConfigurationSpec_To_v1beta2_PriorityLevel
 }
 
 func autoConvert_v1beta2_PriorityLevelConfigurationStatus_To_flowcontrol_PriorityLevelConfigurationStatus(in *flowcontrolv1beta2.PriorityLevelConfigurationStatus, out *flowcontrol.PriorityLevelConfigurationStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]flowcontrol.PriorityLevelConfigurationCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*flowcontrol.PriorityLevelConfigurationStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -725,7 +689,7 @@ func Convert_v1beta2_PriorityLevelConfigurationStatus_To_flowcontrol_PriorityLev
 }
 
 func autoConvert_flowcontrol_PriorityLevelConfigurationStatus_To_v1beta2_PriorityLevelConfigurationStatus(in *flowcontrol.PriorityLevelConfigurationStatus, out *flowcontrolv1beta2.PriorityLevelConfigurationStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]flowcontrolv1beta2.PriorityLevelConfigurationCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*flowcontrolv1beta2.PriorityLevelConfigurationStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -735,9 +699,7 @@ func Convert_flowcontrol_PriorityLevelConfigurationStatus_To_v1beta2_PriorityLev
 }
 
 func autoConvert_v1beta2_QueuingConfiguration_To_flowcontrol_QueuingConfiguration(in *flowcontrolv1beta2.QueuingConfiguration, out *flowcontrol.QueuingConfiguration, s conversion.Scope) error {
-	out.Queues = in.Queues
-	out.HandSize = in.HandSize
-	out.QueueLengthLimit = in.QueueLengthLimit
+	*out = *(*flowcontrol.QueuingConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -747,9 +709,7 @@ func Convert_v1beta2_QueuingConfiguration_To_flowcontrol_QueuingConfiguration(in
 }
 
 func autoConvert_flowcontrol_QueuingConfiguration_To_v1beta2_QueuingConfiguration(in *flowcontrol.QueuingConfiguration, out *flowcontrolv1beta2.QueuingConfiguration, s conversion.Scope) error {
-	out.Queues = in.Queues
-	out.HandSize = in.HandSize
-	out.QueueLengthLimit = in.QueueLengthLimit
+	*out = *(*flowcontrolv1beta2.QueuingConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -759,11 +719,7 @@ func Convert_flowcontrol_QueuingConfiguration_To_v1beta2_QueuingConfiguration(in
 }
 
 func autoConvert_v1beta2_ResourcePolicyRule_To_flowcontrol_ResourcePolicyRule(in *flowcontrolv1beta2.ResourcePolicyRule, out *flowcontrol.ResourcePolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
-	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
-	out.ClusterScope = in.ClusterScope
-	out.Namespaces = *(*[]string)(unsafe.Pointer(&in.Namespaces))
+	*out = *(*flowcontrol.ResourcePolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -773,11 +729,7 @@ func Convert_v1beta2_ResourcePolicyRule_To_flowcontrol_ResourcePolicyRule(in *fl
 }
 
 func autoConvert_flowcontrol_ResourcePolicyRule_To_v1beta2_ResourcePolicyRule(in *flowcontrol.ResourcePolicyRule, out *flowcontrolv1beta2.ResourcePolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
-	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
-	out.ClusterScope = in.ClusterScope
-	out.Namespaces = *(*[]string)(unsafe.Pointer(&in.Namespaces))
+	*out = *(*flowcontrolv1beta2.ResourcePolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -787,8 +739,7 @@ func Convert_flowcontrol_ResourcePolicyRule_To_v1beta2_ResourcePolicyRule(in *fl
 }
 
 func autoConvert_v1beta2_ServiceAccountSubject_To_flowcontrol_ServiceAccountSubject(in *flowcontrolv1beta2.ServiceAccountSubject, out *flowcontrol.ServiceAccountSubject, s conversion.Scope) error {
-	out.Namespace = in.Namespace
-	out.Name = in.Name
+	*out = *(*flowcontrol.ServiceAccountSubject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -798,8 +749,7 @@ func Convert_v1beta2_ServiceAccountSubject_To_flowcontrol_ServiceAccountSubject(
 }
 
 func autoConvert_flowcontrol_ServiceAccountSubject_To_v1beta2_ServiceAccountSubject(in *flowcontrol.ServiceAccountSubject, out *flowcontrolv1beta2.ServiceAccountSubject, s conversion.Scope) error {
-	out.Namespace = in.Namespace
-	out.Name = in.Name
+	*out = *(*flowcontrolv1beta2.ServiceAccountSubject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -809,10 +759,7 @@ func Convert_flowcontrol_ServiceAccountSubject_To_v1beta2_ServiceAccountSubject(
 }
 
 func autoConvert_v1beta2_Subject_To_flowcontrol_Subject(in *flowcontrolv1beta2.Subject, out *flowcontrol.Subject, s conversion.Scope) error {
-	out.Kind = flowcontrol.SubjectKind(in.Kind)
-	out.User = (*flowcontrol.UserSubject)(unsafe.Pointer(in.User))
-	out.Group = (*flowcontrol.GroupSubject)(unsafe.Pointer(in.Group))
-	out.ServiceAccount = (*flowcontrol.ServiceAccountSubject)(unsafe.Pointer(in.ServiceAccount))
+	*out = *(*flowcontrol.Subject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -822,10 +769,7 @@ func Convert_v1beta2_Subject_To_flowcontrol_Subject(in *flowcontrolv1beta2.Subje
 }
 
 func autoConvert_flowcontrol_Subject_To_v1beta2_Subject(in *flowcontrol.Subject, out *flowcontrolv1beta2.Subject, s conversion.Scope) error {
-	out.Kind = flowcontrolv1beta2.SubjectKind(in.Kind)
-	out.User = (*flowcontrolv1beta2.UserSubject)(unsafe.Pointer(in.User))
-	out.Group = (*flowcontrolv1beta2.GroupSubject)(unsafe.Pointer(in.Group))
-	out.ServiceAccount = (*flowcontrolv1beta2.ServiceAccountSubject)(unsafe.Pointer(in.ServiceAccount))
+	*out = *(*flowcontrolv1beta2.Subject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -835,7 +779,7 @@ func Convert_flowcontrol_Subject_To_v1beta2_Subject(in *flowcontrol.Subject, out
 }
 
 func autoConvert_v1beta2_UserSubject_To_flowcontrol_UserSubject(in *flowcontrolv1beta2.UserSubject, out *flowcontrol.UserSubject, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*flowcontrol.UserSubject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -845,7 +789,7 @@ func Convert_v1beta2_UserSubject_To_flowcontrol_UserSubject(in *flowcontrolv1bet
 }
 
 func autoConvert_flowcontrol_UserSubject_To_v1beta2_UserSubject(in *flowcontrol.UserSubject, out *flowcontrolv1beta2.UserSubject, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*flowcontrolv1beta2.UserSubject)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/flowcontrol/v1beta3/zz_generated.conversion.go
+++ b/pkg/apis/flowcontrol/v1beta3/zz_generated.conversion.go
@@ -271,8 +271,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1beta3_ExemptPriorityLevelConfiguration_To_flowcontrol_ExemptPriorityLevelConfiguration(in *flowcontrolv1beta3.ExemptPriorityLevelConfiguration, out *flowcontrol.ExemptPriorityLevelConfiguration, s conversion.Scope) error {
-	out.NominalConcurrencyShares = (*int32)(unsafe.Pointer(in.NominalConcurrencyShares))
-	out.LendablePercent = (*int32)(unsafe.Pointer(in.LendablePercent))
+	*out = *(*flowcontrol.ExemptPriorityLevelConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -282,8 +281,7 @@ func Convert_v1beta3_ExemptPriorityLevelConfiguration_To_flowcontrol_ExemptPrior
 }
 
 func autoConvert_flowcontrol_ExemptPriorityLevelConfiguration_To_v1beta3_ExemptPriorityLevelConfiguration(in *flowcontrol.ExemptPriorityLevelConfiguration, out *flowcontrolv1beta3.ExemptPriorityLevelConfiguration, s conversion.Scope) error {
-	out.NominalConcurrencyShares = (*int32)(unsafe.Pointer(in.NominalConcurrencyShares))
-	out.LendablePercent = (*int32)(unsafe.Pointer(in.LendablePercent))
+	*out = *(*flowcontrolv1beta3.ExemptPriorityLevelConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -293,7 +291,7 @@ func Convert_flowcontrol_ExemptPriorityLevelConfiguration_To_v1beta3_ExemptPrior
 }
 
 func autoConvert_v1beta3_FlowDistinguisherMethod_To_flowcontrol_FlowDistinguisherMethod(in *flowcontrolv1beta3.FlowDistinguisherMethod, out *flowcontrol.FlowDistinguisherMethod, s conversion.Scope) error {
-	out.Type = flowcontrol.FlowDistinguisherMethodType(in.Type)
+	*out = *(*flowcontrol.FlowDistinguisherMethod)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -303,7 +301,7 @@ func Convert_v1beta3_FlowDistinguisherMethod_To_flowcontrol_FlowDistinguisherMet
 }
 
 func autoConvert_flowcontrol_FlowDistinguisherMethod_To_v1beta3_FlowDistinguisherMethod(in *flowcontrol.FlowDistinguisherMethod, out *flowcontrolv1beta3.FlowDistinguisherMethod, s conversion.Scope) error {
-	out.Type = flowcontrolv1beta3.FlowDistinguisherMethodType(in.Type)
+	*out = *(*flowcontrolv1beta3.FlowDistinguisherMethod)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -345,11 +343,7 @@ func Convert_flowcontrol_FlowSchema_To_v1beta3_FlowSchema(in *flowcontrol.FlowSc
 }
 
 func autoConvert_v1beta3_FlowSchemaCondition_To_flowcontrol_FlowSchemaCondition(in *flowcontrolv1beta3.FlowSchemaCondition, out *flowcontrol.FlowSchemaCondition, s conversion.Scope) error {
-	out.Type = flowcontrol.FlowSchemaConditionType(in.Type)
-	out.Status = flowcontrol.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*flowcontrol.FlowSchemaCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -359,11 +353,7 @@ func Convert_v1beta3_FlowSchemaCondition_To_flowcontrol_FlowSchemaCondition(in *
 }
 
 func autoConvert_flowcontrol_FlowSchemaCondition_To_v1beta3_FlowSchemaCondition(in *flowcontrol.FlowSchemaCondition, out *flowcontrolv1beta3.FlowSchemaCondition, s conversion.Scope) error {
-	out.Type = flowcontrolv1beta3.FlowSchemaConditionType(in.Type)
-	out.Status = flowcontrolv1beta3.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*flowcontrolv1beta3.FlowSchemaCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -395,12 +385,7 @@ func Convert_flowcontrol_FlowSchemaList_To_v1beta3_FlowSchemaList(in *flowcontro
 }
 
 func autoConvert_v1beta3_FlowSchemaSpec_To_flowcontrol_FlowSchemaSpec(in *flowcontrolv1beta3.FlowSchemaSpec, out *flowcontrol.FlowSchemaSpec, s conversion.Scope) error {
-	if err := Convert_v1beta3_PriorityLevelConfigurationReference_To_flowcontrol_PriorityLevelConfigurationReference(&in.PriorityLevelConfiguration, &out.PriorityLevelConfiguration, s); err != nil {
-		return err
-	}
-	out.MatchingPrecedence = in.MatchingPrecedence
-	out.DistinguisherMethod = (*flowcontrol.FlowDistinguisherMethod)(unsafe.Pointer(in.DistinguisherMethod))
-	out.Rules = *(*[]flowcontrol.PolicyRulesWithSubjects)(unsafe.Pointer(&in.Rules))
+	*out = *(*flowcontrol.FlowSchemaSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -410,12 +395,7 @@ func Convert_v1beta3_FlowSchemaSpec_To_flowcontrol_FlowSchemaSpec(in *flowcontro
 }
 
 func autoConvert_flowcontrol_FlowSchemaSpec_To_v1beta3_FlowSchemaSpec(in *flowcontrol.FlowSchemaSpec, out *flowcontrolv1beta3.FlowSchemaSpec, s conversion.Scope) error {
-	if err := Convert_flowcontrol_PriorityLevelConfigurationReference_To_v1beta3_PriorityLevelConfigurationReference(&in.PriorityLevelConfiguration, &out.PriorityLevelConfiguration, s); err != nil {
-		return err
-	}
-	out.MatchingPrecedence = in.MatchingPrecedence
-	out.DistinguisherMethod = (*flowcontrolv1beta3.FlowDistinguisherMethod)(unsafe.Pointer(in.DistinguisherMethod))
-	out.Rules = *(*[]flowcontrolv1beta3.PolicyRulesWithSubjects)(unsafe.Pointer(&in.Rules))
+	*out = *(*flowcontrolv1beta3.FlowSchemaSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -425,7 +405,7 @@ func Convert_flowcontrol_FlowSchemaSpec_To_v1beta3_FlowSchemaSpec(in *flowcontro
 }
 
 func autoConvert_v1beta3_FlowSchemaStatus_To_flowcontrol_FlowSchemaStatus(in *flowcontrolv1beta3.FlowSchemaStatus, out *flowcontrol.FlowSchemaStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]flowcontrol.FlowSchemaCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*flowcontrol.FlowSchemaStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -435,7 +415,7 @@ func Convert_v1beta3_FlowSchemaStatus_To_flowcontrol_FlowSchemaStatus(in *flowco
 }
 
 func autoConvert_flowcontrol_FlowSchemaStatus_To_v1beta3_FlowSchemaStatus(in *flowcontrol.FlowSchemaStatus, out *flowcontrolv1beta3.FlowSchemaStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]flowcontrolv1beta3.FlowSchemaCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*flowcontrolv1beta3.FlowSchemaStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -445,7 +425,7 @@ func Convert_flowcontrol_FlowSchemaStatus_To_v1beta3_FlowSchemaStatus(in *flowco
 }
 
 func autoConvert_v1beta3_GroupSubject_To_flowcontrol_GroupSubject(in *flowcontrolv1beta3.GroupSubject, out *flowcontrol.GroupSubject, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*flowcontrol.GroupSubject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -455,7 +435,7 @@ func Convert_v1beta3_GroupSubject_To_flowcontrol_GroupSubject(in *flowcontrolv1b
 }
 
 func autoConvert_flowcontrol_GroupSubject_To_v1beta3_GroupSubject(in *flowcontrol.GroupSubject, out *flowcontrolv1beta3.GroupSubject, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*flowcontrolv1beta3.GroupSubject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -465,8 +445,7 @@ func Convert_flowcontrol_GroupSubject_To_v1beta3_GroupSubject(in *flowcontrol.Gr
 }
 
 func autoConvert_v1beta3_LimitResponse_To_flowcontrol_LimitResponse(in *flowcontrolv1beta3.LimitResponse, out *flowcontrol.LimitResponse, s conversion.Scope) error {
-	out.Type = flowcontrol.LimitResponseType(in.Type)
-	out.Queuing = (*flowcontrol.QueuingConfiguration)(unsafe.Pointer(in.Queuing))
+	*out = *(*flowcontrol.LimitResponse)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -476,8 +455,7 @@ func Convert_v1beta3_LimitResponse_To_flowcontrol_LimitResponse(in *flowcontrolv
 }
 
 func autoConvert_flowcontrol_LimitResponse_To_v1beta3_LimitResponse(in *flowcontrol.LimitResponse, out *flowcontrolv1beta3.LimitResponse, s conversion.Scope) error {
-	out.Type = flowcontrolv1beta3.LimitResponseType(in.Type)
-	out.Queuing = (*flowcontrolv1beta3.QueuingConfiguration)(unsafe.Pointer(in.Queuing))
+	*out = *(*flowcontrolv1beta3.LimitResponse)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -487,12 +465,7 @@ func Convert_flowcontrol_LimitResponse_To_v1beta3_LimitResponse(in *flowcontrol.
 }
 
 func autoConvert_v1beta3_LimitedPriorityLevelConfiguration_To_flowcontrol_LimitedPriorityLevelConfiguration(in *flowcontrolv1beta3.LimitedPriorityLevelConfiguration, out *flowcontrol.LimitedPriorityLevelConfiguration, s conversion.Scope) error {
-	out.NominalConcurrencyShares = in.NominalConcurrencyShares
-	if err := Convert_v1beta3_LimitResponse_To_flowcontrol_LimitResponse(&in.LimitResponse, &out.LimitResponse, s); err != nil {
-		return err
-	}
-	out.LendablePercent = (*int32)(unsafe.Pointer(in.LendablePercent))
-	out.BorrowingLimitPercent = (*int32)(unsafe.Pointer(in.BorrowingLimitPercent))
+	*out = *(*flowcontrol.LimitedPriorityLevelConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -502,12 +475,7 @@ func Convert_v1beta3_LimitedPriorityLevelConfiguration_To_flowcontrol_LimitedPri
 }
 
 func autoConvert_flowcontrol_LimitedPriorityLevelConfiguration_To_v1beta3_LimitedPriorityLevelConfiguration(in *flowcontrol.LimitedPriorityLevelConfiguration, out *flowcontrolv1beta3.LimitedPriorityLevelConfiguration, s conversion.Scope) error {
-	out.NominalConcurrencyShares = in.NominalConcurrencyShares
-	if err := Convert_flowcontrol_LimitResponse_To_v1beta3_LimitResponse(&in.LimitResponse, &out.LimitResponse, s); err != nil {
-		return err
-	}
-	out.LendablePercent = (*int32)(unsafe.Pointer(in.LendablePercent))
-	out.BorrowingLimitPercent = (*int32)(unsafe.Pointer(in.BorrowingLimitPercent))
+	*out = *(*flowcontrolv1beta3.LimitedPriorityLevelConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -517,8 +485,7 @@ func Convert_flowcontrol_LimitedPriorityLevelConfiguration_To_v1beta3_LimitedPri
 }
 
 func autoConvert_v1beta3_NonResourcePolicyRule_To_flowcontrol_NonResourcePolicyRule(in *flowcontrolv1beta3.NonResourcePolicyRule, out *flowcontrol.NonResourcePolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.NonResourceURLs = *(*[]string)(unsafe.Pointer(&in.NonResourceURLs))
+	*out = *(*flowcontrol.NonResourcePolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -528,8 +495,7 @@ func Convert_v1beta3_NonResourcePolicyRule_To_flowcontrol_NonResourcePolicyRule(
 }
 
 func autoConvert_flowcontrol_NonResourcePolicyRule_To_v1beta3_NonResourcePolicyRule(in *flowcontrol.NonResourcePolicyRule, out *flowcontrolv1beta3.NonResourcePolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.NonResourceURLs = *(*[]string)(unsafe.Pointer(&in.NonResourceURLs))
+	*out = *(*flowcontrolv1beta3.NonResourcePolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -539,9 +505,7 @@ func Convert_flowcontrol_NonResourcePolicyRule_To_v1beta3_NonResourcePolicyRule(
 }
 
 func autoConvert_v1beta3_PolicyRulesWithSubjects_To_flowcontrol_PolicyRulesWithSubjects(in *flowcontrolv1beta3.PolicyRulesWithSubjects, out *flowcontrol.PolicyRulesWithSubjects, s conversion.Scope) error {
-	out.Subjects = *(*[]flowcontrol.Subject)(unsafe.Pointer(&in.Subjects))
-	out.ResourceRules = *(*[]flowcontrol.ResourcePolicyRule)(unsafe.Pointer(&in.ResourceRules))
-	out.NonResourceRules = *(*[]flowcontrol.NonResourcePolicyRule)(unsafe.Pointer(&in.NonResourceRules))
+	*out = *(*flowcontrol.PolicyRulesWithSubjects)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -551,9 +515,7 @@ func Convert_v1beta3_PolicyRulesWithSubjects_To_flowcontrol_PolicyRulesWithSubje
 }
 
 func autoConvert_flowcontrol_PolicyRulesWithSubjects_To_v1beta3_PolicyRulesWithSubjects(in *flowcontrol.PolicyRulesWithSubjects, out *flowcontrolv1beta3.PolicyRulesWithSubjects, s conversion.Scope) error {
-	out.Subjects = *(*[]flowcontrolv1beta3.Subject)(unsafe.Pointer(&in.Subjects))
-	out.ResourceRules = *(*[]flowcontrolv1beta3.ResourcePolicyRule)(unsafe.Pointer(&in.ResourceRules))
-	out.NonResourceRules = *(*[]flowcontrolv1beta3.NonResourcePolicyRule)(unsafe.Pointer(&in.NonResourceRules))
+	*out = *(*flowcontrolv1beta3.PolicyRulesWithSubjects)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -585,11 +547,7 @@ func autoConvert_flowcontrol_PriorityLevelConfiguration_To_v1beta3_PriorityLevel
 }
 
 func autoConvert_v1beta3_PriorityLevelConfigurationCondition_To_flowcontrol_PriorityLevelConfigurationCondition(in *flowcontrolv1beta3.PriorityLevelConfigurationCondition, out *flowcontrol.PriorityLevelConfigurationCondition, s conversion.Scope) error {
-	out.Type = flowcontrol.PriorityLevelConfigurationConditionType(in.Type)
-	out.Status = flowcontrol.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*flowcontrol.PriorityLevelConfigurationCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -599,11 +557,7 @@ func Convert_v1beta3_PriorityLevelConfigurationCondition_To_flowcontrol_Priority
 }
 
 func autoConvert_flowcontrol_PriorityLevelConfigurationCondition_To_v1beta3_PriorityLevelConfigurationCondition(in *flowcontrol.PriorityLevelConfigurationCondition, out *flowcontrolv1beta3.PriorityLevelConfigurationCondition, s conversion.Scope) error {
-	out.Type = flowcontrolv1beta3.PriorityLevelConfigurationConditionType(in.Type)
-	out.Status = flowcontrolv1beta3.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*flowcontrolv1beta3.PriorityLevelConfigurationCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -655,7 +609,7 @@ func Convert_flowcontrol_PriorityLevelConfigurationList_To_v1beta3_PriorityLevel
 }
 
 func autoConvert_v1beta3_PriorityLevelConfigurationReference_To_flowcontrol_PriorityLevelConfigurationReference(in *flowcontrolv1beta3.PriorityLevelConfigurationReference, out *flowcontrol.PriorityLevelConfigurationReference, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*flowcontrol.PriorityLevelConfigurationReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -665,7 +619,7 @@ func Convert_v1beta3_PriorityLevelConfigurationReference_To_flowcontrol_Priority
 }
 
 func autoConvert_flowcontrol_PriorityLevelConfigurationReference_To_v1beta3_PriorityLevelConfigurationReference(in *flowcontrol.PriorityLevelConfigurationReference, out *flowcontrolv1beta3.PriorityLevelConfigurationReference, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*flowcontrolv1beta3.PriorityLevelConfigurationReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -675,9 +629,7 @@ func Convert_flowcontrol_PriorityLevelConfigurationReference_To_v1beta3_Priority
 }
 
 func autoConvert_v1beta3_PriorityLevelConfigurationSpec_To_flowcontrol_PriorityLevelConfigurationSpec(in *flowcontrolv1beta3.PriorityLevelConfigurationSpec, out *flowcontrol.PriorityLevelConfigurationSpec, s conversion.Scope) error {
-	out.Type = flowcontrol.PriorityLevelEnablement(in.Type)
-	out.Limited = (*flowcontrol.LimitedPriorityLevelConfiguration)(unsafe.Pointer(in.Limited))
-	out.Exempt = (*flowcontrol.ExemptPriorityLevelConfiguration)(unsafe.Pointer(in.Exempt))
+	*out = *(*flowcontrol.PriorityLevelConfigurationSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -687,9 +639,7 @@ func Convert_v1beta3_PriorityLevelConfigurationSpec_To_flowcontrol_PriorityLevel
 }
 
 func autoConvert_flowcontrol_PriorityLevelConfigurationSpec_To_v1beta3_PriorityLevelConfigurationSpec(in *flowcontrol.PriorityLevelConfigurationSpec, out *flowcontrolv1beta3.PriorityLevelConfigurationSpec, s conversion.Scope) error {
-	out.Type = flowcontrolv1beta3.PriorityLevelEnablement(in.Type)
-	out.Limited = (*flowcontrolv1beta3.LimitedPriorityLevelConfiguration)(unsafe.Pointer(in.Limited))
-	out.Exempt = (*flowcontrolv1beta3.ExemptPriorityLevelConfiguration)(unsafe.Pointer(in.Exempt))
+	*out = *(*flowcontrolv1beta3.PriorityLevelConfigurationSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -699,7 +649,7 @@ func Convert_flowcontrol_PriorityLevelConfigurationSpec_To_v1beta3_PriorityLevel
 }
 
 func autoConvert_v1beta3_PriorityLevelConfigurationStatus_To_flowcontrol_PriorityLevelConfigurationStatus(in *flowcontrolv1beta3.PriorityLevelConfigurationStatus, out *flowcontrol.PriorityLevelConfigurationStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]flowcontrol.PriorityLevelConfigurationCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*flowcontrol.PriorityLevelConfigurationStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -709,7 +659,7 @@ func Convert_v1beta3_PriorityLevelConfigurationStatus_To_flowcontrol_PriorityLev
 }
 
 func autoConvert_flowcontrol_PriorityLevelConfigurationStatus_To_v1beta3_PriorityLevelConfigurationStatus(in *flowcontrol.PriorityLevelConfigurationStatus, out *flowcontrolv1beta3.PriorityLevelConfigurationStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]flowcontrolv1beta3.PriorityLevelConfigurationCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*flowcontrolv1beta3.PriorityLevelConfigurationStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -719,9 +669,7 @@ func Convert_flowcontrol_PriorityLevelConfigurationStatus_To_v1beta3_PriorityLev
 }
 
 func autoConvert_v1beta3_QueuingConfiguration_To_flowcontrol_QueuingConfiguration(in *flowcontrolv1beta3.QueuingConfiguration, out *flowcontrol.QueuingConfiguration, s conversion.Scope) error {
-	out.Queues = in.Queues
-	out.HandSize = in.HandSize
-	out.QueueLengthLimit = in.QueueLengthLimit
+	*out = *(*flowcontrol.QueuingConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -731,9 +679,7 @@ func Convert_v1beta3_QueuingConfiguration_To_flowcontrol_QueuingConfiguration(in
 }
 
 func autoConvert_flowcontrol_QueuingConfiguration_To_v1beta3_QueuingConfiguration(in *flowcontrol.QueuingConfiguration, out *flowcontrolv1beta3.QueuingConfiguration, s conversion.Scope) error {
-	out.Queues = in.Queues
-	out.HandSize = in.HandSize
-	out.QueueLengthLimit = in.QueueLengthLimit
+	*out = *(*flowcontrolv1beta3.QueuingConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -743,11 +689,7 @@ func Convert_flowcontrol_QueuingConfiguration_To_v1beta3_QueuingConfiguration(in
 }
 
 func autoConvert_v1beta3_ResourcePolicyRule_To_flowcontrol_ResourcePolicyRule(in *flowcontrolv1beta3.ResourcePolicyRule, out *flowcontrol.ResourcePolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
-	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
-	out.ClusterScope = in.ClusterScope
-	out.Namespaces = *(*[]string)(unsafe.Pointer(&in.Namespaces))
+	*out = *(*flowcontrol.ResourcePolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -757,11 +699,7 @@ func Convert_v1beta3_ResourcePolicyRule_To_flowcontrol_ResourcePolicyRule(in *fl
 }
 
 func autoConvert_flowcontrol_ResourcePolicyRule_To_v1beta3_ResourcePolicyRule(in *flowcontrol.ResourcePolicyRule, out *flowcontrolv1beta3.ResourcePolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
-	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
-	out.ClusterScope = in.ClusterScope
-	out.Namespaces = *(*[]string)(unsafe.Pointer(&in.Namespaces))
+	*out = *(*flowcontrolv1beta3.ResourcePolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -771,8 +709,7 @@ func Convert_flowcontrol_ResourcePolicyRule_To_v1beta3_ResourcePolicyRule(in *fl
 }
 
 func autoConvert_v1beta3_ServiceAccountSubject_To_flowcontrol_ServiceAccountSubject(in *flowcontrolv1beta3.ServiceAccountSubject, out *flowcontrol.ServiceAccountSubject, s conversion.Scope) error {
-	out.Namespace = in.Namespace
-	out.Name = in.Name
+	*out = *(*flowcontrol.ServiceAccountSubject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -782,8 +719,7 @@ func Convert_v1beta3_ServiceAccountSubject_To_flowcontrol_ServiceAccountSubject(
 }
 
 func autoConvert_flowcontrol_ServiceAccountSubject_To_v1beta3_ServiceAccountSubject(in *flowcontrol.ServiceAccountSubject, out *flowcontrolv1beta3.ServiceAccountSubject, s conversion.Scope) error {
-	out.Namespace = in.Namespace
-	out.Name = in.Name
+	*out = *(*flowcontrolv1beta3.ServiceAccountSubject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -793,10 +729,7 @@ func Convert_flowcontrol_ServiceAccountSubject_To_v1beta3_ServiceAccountSubject(
 }
 
 func autoConvert_v1beta3_Subject_To_flowcontrol_Subject(in *flowcontrolv1beta3.Subject, out *flowcontrol.Subject, s conversion.Scope) error {
-	out.Kind = flowcontrol.SubjectKind(in.Kind)
-	out.User = (*flowcontrol.UserSubject)(unsafe.Pointer(in.User))
-	out.Group = (*flowcontrol.GroupSubject)(unsafe.Pointer(in.Group))
-	out.ServiceAccount = (*flowcontrol.ServiceAccountSubject)(unsafe.Pointer(in.ServiceAccount))
+	*out = *(*flowcontrol.Subject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -806,10 +739,7 @@ func Convert_v1beta3_Subject_To_flowcontrol_Subject(in *flowcontrolv1beta3.Subje
 }
 
 func autoConvert_flowcontrol_Subject_To_v1beta3_Subject(in *flowcontrol.Subject, out *flowcontrolv1beta3.Subject, s conversion.Scope) error {
-	out.Kind = flowcontrolv1beta3.SubjectKind(in.Kind)
-	out.User = (*flowcontrolv1beta3.UserSubject)(unsafe.Pointer(in.User))
-	out.Group = (*flowcontrolv1beta3.GroupSubject)(unsafe.Pointer(in.Group))
-	out.ServiceAccount = (*flowcontrolv1beta3.ServiceAccountSubject)(unsafe.Pointer(in.ServiceAccount))
+	*out = *(*flowcontrolv1beta3.Subject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -819,7 +749,7 @@ func Convert_flowcontrol_Subject_To_v1beta3_Subject(in *flowcontrol.Subject, out
 }
 
 func autoConvert_v1beta3_UserSubject_To_flowcontrol_UserSubject(in *flowcontrolv1beta3.UserSubject, out *flowcontrol.UserSubject, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*flowcontrol.UserSubject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -829,7 +759,7 @@ func Convert_v1beta3_UserSubject_To_flowcontrol_UserSubject(in *flowcontrolv1bet
 }
 
 func autoConvert_flowcontrol_UserSubject_To_v1beta3_UserSubject(in *flowcontrol.UserSubject, out *flowcontrolv1beta3.UserSubject, s conversion.Scope) error {
-	out.Name = in.Name
+	*out = *(*flowcontrolv1beta3.UserSubject)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/imagepolicy/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/imagepolicy/v1alpha1/zz_generated.conversion.go
@@ -113,7 +113,7 @@ func Convert_imagepolicy_ImageReview_To_v1alpha1_ImageReview(in *imagepolicy.Ima
 }
 
 func autoConvert_v1alpha1_ImageReviewContainerSpec_To_imagepolicy_ImageReviewContainerSpec(in *imagepolicyv1alpha1.ImageReviewContainerSpec, out *imagepolicy.ImageReviewContainerSpec, s conversion.Scope) error {
-	out.Image = in.Image
+	*out = *(*imagepolicy.ImageReviewContainerSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -123,7 +123,7 @@ func Convert_v1alpha1_ImageReviewContainerSpec_To_imagepolicy_ImageReviewContain
 }
 
 func autoConvert_imagepolicy_ImageReviewContainerSpec_To_v1alpha1_ImageReviewContainerSpec(in *imagepolicy.ImageReviewContainerSpec, out *imagepolicyv1alpha1.ImageReviewContainerSpec, s conversion.Scope) error {
-	out.Image = in.Image
+	*out = *(*imagepolicyv1alpha1.ImageReviewContainerSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -133,9 +133,7 @@ func Convert_imagepolicy_ImageReviewContainerSpec_To_v1alpha1_ImageReviewContain
 }
 
 func autoConvert_v1alpha1_ImageReviewSpec_To_imagepolicy_ImageReviewSpec(in *imagepolicyv1alpha1.ImageReviewSpec, out *imagepolicy.ImageReviewSpec, s conversion.Scope) error {
-	out.Containers = *(*[]imagepolicy.ImageReviewContainerSpec)(unsafe.Pointer(&in.Containers))
-	out.Annotations = *(*map[string]string)(unsafe.Pointer(&in.Annotations))
-	out.Namespace = in.Namespace
+	*out = *(*imagepolicy.ImageReviewSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -145,9 +143,7 @@ func Convert_v1alpha1_ImageReviewSpec_To_imagepolicy_ImageReviewSpec(in *imagepo
 }
 
 func autoConvert_imagepolicy_ImageReviewSpec_To_v1alpha1_ImageReviewSpec(in *imagepolicy.ImageReviewSpec, out *imagepolicyv1alpha1.ImageReviewSpec, s conversion.Scope) error {
-	out.Containers = *(*[]imagepolicyv1alpha1.ImageReviewContainerSpec)(unsafe.Pointer(&in.Containers))
-	out.Annotations = *(*map[string]string)(unsafe.Pointer(&in.Annotations))
-	out.Namespace = in.Namespace
+	*out = *(*imagepolicyv1alpha1.ImageReviewSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -157,9 +153,7 @@ func Convert_imagepolicy_ImageReviewSpec_To_v1alpha1_ImageReviewSpec(in *imagepo
 }
 
 func autoConvert_v1alpha1_ImageReviewStatus_To_imagepolicy_ImageReviewStatus(in *imagepolicyv1alpha1.ImageReviewStatus, out *imagepolicy.ImageReviewStatus, s conversion.Scope) error {
-	out.Allowed = in.Allowed
-	out.Reason = in.Reason
-	out.AuditAnnotations = *(*map[string]string)(unsafe.Pointer(&in.AuditAnnotations))
+	*out = *(*imagepolicy.ImageReviewStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -169,9 +163,7 @@ func Convert_v1alpha1_ImageReviewStatus_To_imagepolicy_ImageReviewStatus(in *ima
 }
 
 func autoConvert_imagepolicy_ImageReviewStatus_To_v1alpha1_ImageReviewStatus(in *imagepolicy.ImageReviewStatus, out *imagepolicyv1alpha1.ImageReviewStatus, s conversion.Scope) error {
-	out.Allowed = in.Allowed
-	out.Reason = in.Reason
-	out.AuditAnnotations = *(*map[string]string)(unsafe.Pointer(&in.AuditAnnotations))
+	*out = *(*imagepolicyv1alpha1.ImageReviewStatus)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/networking/v1/zz_generated.conversion.go
+++ b/pkg/apis/networking/v1/zz_generated.conversion.go
@@ -24,13 +24,9 @@ package v1
 import (
 	unsafe "unsafe"
 
-	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	intstr "k8s.io/apimachinery/pkg/util/intstr"
-	core "k8s.io/kubernetes/pkg/apis/core"
 	networking "k8s.io/kubernetes/pkg/apis/networking"
 )
 
@@ -395,11 +391,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1_HTTPIngressPath_To_networking_HTTPIngressPath(in *networkingv1.HTTPIngressPath, out *networking.HTTPIngressPath, s conversion.Scope) error {
-	out.Path = in.Path
-	out.PathType = (*networking.PathType)(unsafe.Pointer(in.PathType))
-	if err := Convert_v1_IngressBackend_To_networking_IngressBackend(&in.Backend, &out.Backend, s); err != nil {
-		return err
-	}
+	*out = *(*networking.HTTPIngressPath)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -409,11 +401,7 @@ func Convert_v1_HTTPIngressPath_To_networking_HTTPIngressPath(in *networkingv1.H
 }
 
 func autoConvert_networking_HTTPIngressPath_To_v1_HTTPIngressPath(in *networking.HTTPIngressPath, out *networkingv1.HTTPIngressPath, s conversion.Scope) error {
-	out.Path = in.Path
-	out.PathType = (*networkingv1.PathType)(unsafe.Pointer(in.PathType))
-	if err := Convert_networking_IngressBackend_To_v1_IngressBackend(&in.Backend, &out.Backend, s); err != nil {
-		return err
-	}
+	*out = *(*networkingv1.HTTPIngressPath)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -423,7 +411,7 @@ func Convert_networking_HTTPIngressPath_To_v1_HTTPIngressPath(in *networking.HTT
 }
 
 func autoConvert_v1_HTTPIngressRuleValue_To_networking_HTTPIngressRuleValue(in *networkingv1.HTTPIngressRuleValue, out *networking.HTTPIngressRuleValue, s conversion.Scope) error {
-	out.Paths = *(*[]networking.HTTPIngressPath)(unsafe.Pointer(&in.Paths))
+	*out = *(*networking.HTTPIngressRuleValue)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -433,7 +421,7 @@ func Convert_v1_HTTPIngressRuleValue_To_networking_HTTPIngressRuleValue(in *netw
 }
 
 func autoConvert_networking_HTTPIngressRuleValue_To_v1_HTTPIngressRuleValue(in *networking.HTTPIngressRuleValue, out *networkingv1.HTTPIngressRuleValue, s conversion.Scope) error {
-	out.Paths = *(*[]networkingv1.HTTPIngressPath)(unsafe.Pointer(&in.Paths))
+	*out = *(*networkingv1.HTTPIngressRuleValue)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -491,7 +479,7 @@ func Convert_networking_IPAddressList_To_v1_IPAddressList(in *networking.IPAddre
 }
 
 func autoConvert_v1_IPAddressSpec_To_networking_IPAddressSpec(in *networkingv1.IPAddressSpec, out *networking.IPAddressSpec, s conversion.Scope) error {
-	out.ParentRef = (*networking.ParentReference)(unsafe.Pointer(in.ParentRef))
+	*out = *(*networking.IPAddressSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -501,7 +489,7 @@ func Convert_v1_IPAddressSpec_To_networking_IPAddressSpec(in *networkingv1.IPAdd
 }
 
 func autoConvert_networking_IPAddressSpec_To_v1_IPAddressSpec(in *networking.IPAddressSpec, out *networkingv1.IPAddressSpec, s conversion.Scope) error {
-	out.ParentRef = (*networkingv1.ParentReference)(unsafe.Pointer(in.ParentRef))
+	*out = *(*networkingv1.IPAddressSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -511,8 +499,7 @@ func Convert_networking_IPAddressSpec_To_v1_IPAddressSpec(in *networking.IPAddre
 }
 
 func autoConvert_v1_IPBlock_To_networking_IPBlock(in *networkingv1.IPBlock, out *networking.IPBlock, s conversion.Scope) error {
-	out.CIDR = in.CIDR
-	out.Except = *(*[]string)(unsafe.Pointer(&in.Except))
+	*out = *(*networking.IPBlock)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -522,8 +509,7 @@ func Convert_v1_IPBlock_To_networking_IPBlock(in *networkingv1.IPBlock, out *net
 }
 
 func autoConvert_networking_IPBlock_To_v1_IPBlock(in *networking.IPBlock, out *networkingv1.IPBlock, s conversion.Scope) error {
-	out.CIDR = in.CIDR
-	out.Except = *(*[]string)(unsafe.Pointer(&in.Except))
+	*out = *(*networkingv1.IPBlock)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -565,8 +551,7 @@ func Convert_networking_Ingress_To_v1_Ingress(in *networking.Ingress, out *netwo
 }
 
 func autoConvert_v1_IngressBackend_To_networking_IngressBackend(in *networkingv1.IngressBackend, out *networking.IngressBackend, s conversion.Scope) error {
-	out.Service = (*networking.IngressServiceBackend)(unsafe.Pointer(in.Service))
-	out.Resource = (*core.TypedLocalObjectReference)(unsafe.Pointer(in.Resource))
+	*out = *(*networking.IngressBackend)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -576,8 +561,7 @@ func Convert_v1_IngressBackend_To_networking_IngressBackend(in *networkingv1.Ing
 }
 
 func autoConvert_networking_IngressBackend_To_v1_IngressBackend(in *networking.IngressBackend, out *networkingv1.IngressBackend, s conversion.Scope) error {
-	out.Service = (*networkingv1.IngressServiceBackend)(unsafe.Pointer(in.Service))
-	out.Resource = (*corev1.TypedLocalObjectReference)(unsafe.Pointer(in.Resource))
+	*out = *(*networkingv1.IngressBackend)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -635,11 +619,7 @@ func Convert_networking_IngressClassList_To_v1_IngressClassList(in *networking.I
 }
 
 func autoConvert_v1_IngressClassParametersReference_To_networking_IngressClassParametersReference(in *networkingv1.IngressClassParametersReference, out *networking.IngressClassParametersReference, s conversion.Scope) error {
-	out.APIGroup = (*string)(unsafe.Pointer(in.APIGroup))
-	out.Kind = in.Kind
-	out.Name = in.Name
-	out.Scope = (*string)(unsafe.Pointer(in.Scope))
-	out.Namespace = (*string)(unsafe.Pointer(in.Namespace))
+	*out = *(*networking.IngressClassParametersReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -649,11 +629,7 @@ func Convert_v1_IngressClassParametersReference_To_networking_IngressClassParame
 }
 
 func autoConvert_networking_IngressClassParametersReference_To_v1_IngressClassParametersReference(in *networking.IngressClassParametersReference, out *networkingv1.IngressClassParametersReference, s conversion.Scope) error {
-	out.APIGroup = (*string)(unsafe.Pointer(in.APIGroup))
-	out.Kind = in.Kind
-	out.Name = in.Name
-	out.Scope = (*string)(unsafe.Pointer(in.Scope))
-	out.Namespace = (*string)(unsafe.Pointer(in.Namespace))
+	*out = *(*networkingv1.IngressClassParametersReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -663,8 +639,7 @@ func Convert_networking_IngressClassParametersReference_To_v1_IngressClassParame
 }
 
 func autoConvert_v1_IngressClassSpec_To_networking_IngressClassSpec(in *networkingv1.IngressClassSpec, out *networking.IngressClassSpec, s conversion.Scope) error {
-	out.Controller = in.Controller
-	out.Parameters = (*networking.IngressClassParametersReference)(unsafe.Pointer(in.Parameters))
+	*out = *(*networking.IngressClassSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -674,8 +649,7 @@ func Convert_v1_IngressClassSpec_To_networking_IngressClassSpec(in *networkingv1
 }
 
 func autoConvert_networking_IngressClassSpec_To_v1_IngressClassSpec(in *networking.IngressClassSpec, out *networkingv1.IngressClassSpec, s conversion.Scope) error {
-	out.Controller = in.Controller
-	out.Parameters = (*networkingv1.IngressClassParametersReference)(unsafe.Pointer(in.Parameters))
+	*out = *(*networkingv1.IngressClassSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -707,9 +681,7 @@ func Convert_networking_IngressList_To_v1_IngressList(in *networking.IngressList
 }
 
 func autoConvert_v1_IngressLoadBalancerIngress_To_networking_IngressLoadBalancerIngress(in *networkingv1.IngressLoadBalancerIngress, out *networking.IngressLoadBalancerIngress, s conversion.Scope) error {
-	out.IP = in.IP
-	out.Hostname = in.Hostname
-	out.Ports = *(*[]networking.IngressPortStatus)(unsafe.Pointer(&in.Ports))
+	*out = *(*networking.IngressLoadBalancerIngress)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -719,9 +691,7 @@ func Convert_v1_IngressLoadBalancerIngress_To_networking_IngressLoadBalancerIngr
 }
 
 func autoConvert_networking_IngressLoadBalancerIngress_To_v1_IngressLoadBalancerIngress(in *networking.IngressLoadBalancerIngress, out *networkingv1.IngressLoadBalancerIngress, s conversion.Scope) error {
-	out.IP = in.IP
-	out.Hostname = in.Hostname
-	out.Ports = *(*[]networkingv1.IngressPortStatus)(unsafe.Pointer(&in.Ports))
+	*out = *(*networkingv1.IngressLoadBalancerIngress)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -731,7 +701,7 @@ func Convert_networking_IngressLoadBalancerIngress_To_v1_IngressLoadBalancerIngr
 }
 
 func autoConvert_v1_IngressLoadBalancerStatus_To_networking_IngressLoadBalancerStatus(in *networkingv1.IngressLoadBalancerStatus, out *networking.IngressLoadBalancerStatus, s conversion.Scope) error {
-	out.Ingress = *(*[]networking.IngressLoadBalancerIngress)(unsafe.Pointer(&in.Ingress))
+	*out = *(*networking.IngressLoadBalancerStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -741,7 +711,7 @@ func Convert_v1_IngressLoadBalancerStatus_To_networking_IngressLoadBalancerStatu
 }
 
 func autoConvert_networking_IngressLoadBalancerStatus_To_v1_IngressLoadBalancerStatus(in *networking.IngressLoadBalancerStatus, out *networkingv1.IngressLoadBalancerStatus, s conversion.Scope) error {
-	out.Ingress = *(*[]networkingv1.IngressLoadBalancerIngress)(unsafe.Pointer(&in.Ingress))
+	*out = *(*networkingv1.IngressLoadBalancerStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -751,9 +721,7 @@ func Convert_networking_IngressLoadBalancerStatus_To_v1_IngressLoadBalancerStatu
 }
 
 func autoConvert_v1_IngressPortStatus_To_networking_IngressPortStatus(in *networkingv1.IngressPortStatus, out *networking.IngressPortStatus, s conversion.Scope) error {
-	out.Port = in.Port
-	out.Protocol = core.Protocol(in.Protocol)
-	out.Error = (*string)(unsafe.Pointer(in.Error))
+	*out = *(*networking.IngressPortStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -763,9 +731,7 @@ func Convert_v1_IngressPortStatus_To_networking_IngressPortStatus(in *networking
 }
 
 func autoConvert_networking_IngressPortStatus_To_v1_IngressPortStatus(in *networking.IngressPortStatus, out *networkingv1.IngressPortStatus, s conversion.Scope) error {
-	out.Port = in.Port
-	out.Protocol = corev1.Protocol(in.Protocol)
-	out.Error = (*string)(unsafe.Pointer(in.Error))
+	*out = *(*networkingv1.IngressPortStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -775,10 +741,7 @@ func Convert_networking_IngressPortStatus_To_v1_IngressPortStatus(in *networking
 }
 
 func autoConvert_v1_IngressRule_To_networking_IngressRule(in *networkingv1.IngressRule, out *networking.IngressRule, s conversion.Scope) error {
-	out.Host = in.Host
-	if err := Convert_v1_IngressRuleValue_To_networking_IngressRuleValue(&in.IngressRuleValue, &out.IngressRuleValue, s); err != nil {
-		return err
-	}
+	*out = *(*networking.IngressRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -788,10 +751,7 @@ func Convert_v1_IngressRule_To_networking_IngressRule(in *networkingv1.IngressRu
 }
 
 func autoConvert_networking_IngressRule_To_v1_IngressRule(in *networking.IngressRule, out *networkingv1.IngressRule, s conversion.Scope) error {
-	out.Host = in.Host
-	if err := Convert_networking_IngressRuleValue_To_v1_IngressRuleValue(&in.IngressRuleValue, &out.IngressRuleValue, s); err != nil {
-		return err
-	}
+	*out = *(*networkingv1.IngressRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -801,7 +761,7 @@ func Convert_networking_IngressRule_To_v1_IngressRule(in *networking.IngressRule
 }
 
 func autoConvert_v1_IngressRuleValue_To_networking_IngressRuleValue(in *networkingv1.IngressRuleValue, out *networking.IngressRuleValue, s conversion.Scope) error {
-	out.HTTP = (*networking.HTTPIngressRuleValue)(unsafe.Pointer(in.HTTP))
+	*out = *(*networking.IngressRuleValue)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -811,7 +771,7 @@ func Convert_v1_IngressRuleValue_To_networking_IngressRuleValue(in *networkingv1
 }
 
 func autoConvert_networking_IngressRuleValue_To_v1_IngressRuleValue(in *networking.IngressRuleValue, out *networkingv1.IngressRuleValue, s conversion.Scope) error {
-	out.HTTP = (*networkingv1.HTTPIngressRuleValue)(unsafe.Pointer(in.HTTP))
+	*out = *(*networkingv1.IngressRuleValue)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -821,10 +781,7 @@ func Convert_networking_IngressRuleValue_To_v1_IngressRuleValue(in *networking.I
 }
 
 func autoConvert_v1_IngressServiceBackend_To_networking_IngressServiceBackend(in *networkingv1.IngressServiceBackend, out *networking.IngressServiceBackend, s conversion.Scope) error {
-	out.Name = in.Name
-	if err := Convert_v1_ServiceBackendPort_To_networking_ServiceBackendPort(&in.Port, &out.Port, s); err != nil {
-		return err
-	}
+	*out = *(*networking.IngressServiceBackend)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -834,10 +791,7 @@ func Convert_v1_IngressServiceBackend_To_networking_IngressServiceBackend(in *ne
 }
 
 func autoConvert_networking_IngressServiceBackend_To_v1_IngressServiceBackend(in *networking.IngressServiceBackend, out *networkingv1.IngressServiceBackend, s conversion.Scope) error {
-	out.Name = in.Name
-	if err := Convert_networking_ServiceBackendPort_To_v1_ServiceBackendPort(&in.Port, &out.Port, s); err != nil {
-		return err
-	}
+	*out = *(*networkingv1.IngressServiceBackend)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -847,10 +801,7 @@ func Convert_networking_IngressServiceBackend_To_v1_IngressServiceBackend(in *ne
 }
 
 func autoConvert_v1_IngressSpec_To_networking_IngressSpec(in *networkingv1.IngressSpec, out *networking.IngressSpec, s conversion.Scope) error {
-	out.IngressClassName = (*string)(unsafe.Pointer(in.IngressClassName))
-	out.DefaultBackend = (*networking.IngressBackend)(unsafe.Pointer(in.DefaultBackend))
-	out.TLS = *(*[]networking.IngressTLS)(unsafe.Pointer(&in.TLS))
-	out.Rules = *(*[]networking.IngressRule)(unsafe.Pointer(&in.Rules))
+	*out = *(*networking.IngressSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -860,10 +811,7 @@ func Convert_v1_IngressSpec_To_networking_IngressSpec(in *networkingv1.IngressSp
 }
 
 func autoConvert_networking_IngressSpec_To_v1_IngressSpec(in *networking.IngressSpec, out *networkingv1.IngressSpec, s conversion.Scope) error {
-	out.IngressClassName = (*string)(unsafe.Pointer(in.IngressClassName))
-	out.DefaultBackend = (*networkingv1.IngressBackend)(unsafe.Pointer(in.DefaultBackend))
-	out.TLS = *(*[]networkingv1.IngressTLS)(unsafe.Pointer(&in.TLS))
-	out.Rules = *(*[]networkingv1.IngressRule)(unsafe.Pointer(&in.Rules))
+	*out = *(*networkingv1.IngressSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -873,9 +821,7 @@ func Convert_networking_IngressSpec_To_v1_IngressSpec(in *networking.IngressSpec
 }
 
 func autoConvert_v1_IngressStatus_To_networking_IngressStatus(in *networkingv1.IngressStatus, out *networking.IngressStatus, s conversion.Scope) error {
-	if err := Convert_v1_IngressLoadBalancerStatus_To_networking_IngressLoadBalancerStatus(&in.LoadBalancer, &out.LoadBalancer, s); err != nil {
-		return err
-	}
+	*out = *(*networking.IngressStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -885,9 +831,7 @@ func Convert_v1_IngressStatus_To_networking_IngressStatus(in *networkingv1.Ingre
 }
 
 func autoConvert_networking_IngressStatus_To_v1_IngressStatus(in *networking.IngressStatus, out *networkingv1.IngressStatus, s conversion.Scope) error {
-	if err := Convert_networking_IngressLoadBalancerStatus_To_v1_IngressLoadBalancerStatus(&in.LoadBalancer, &out.LoadBalancer, s); err != nil {
-		return err
-	}
+	*out = *(*networkingv1.IngressStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -897,8 +841,7 @@ func Convert_networking_IngressStatus_To_v1_IngressStatus(in *networking.Ingress
 }
 
 func autoConvert_v1_IngressTLS_To_networking_IngressTLS(in *networkingv1.IngressTLS, out *networking.IngressTLS, s conversion.Scope) error {
-	out.Hosts = *(*[]string)(unsafe.Pointer(&in.Hosts))
-	out.SecretName = in.SecretName
+	*out = *(*networking.IngressTLS)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -908,8 +851,7 @@ func Convert_v1_IngressTLS_To_networking_IngressTLS(in *networkingv1.IngressTLS,
 }
 
 func autoConvert_networking_IngressTLS_To_v1_IngressTLS(in *networking.IngressTLS, out *networkingv1.IngressTLS, s conversion.Scope) error {
-	out.Hosts = *(*[]string)(unsafe.Pointer(&in.Hosts))
-	out.SecretName = in.SecretName
+	*out = *(*networkingv1.IngressTLS)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -945,8 +887,7 @@ func Convert_networking_NetworkPolicy_To_v1_NetworkPolicy(in *networking.Network
 }
 
 func autoConvert_v1_NetworkPolicyEgressRule_To_networking_NetworkPolicyEgressRule(in *networkingv1.NetworkPolicyEgressRule, out *networking.NetworkPolicyEgressRule, s conversion.Scope) error {
-	out.Ports = *(*[]networking.NetworkPolicyPort)(unsafe.Pointer(&in.Ports))
-	out.To = *(*[]networking.NetworkPolicyPeer)(unsafe.Pointer(&in.To))
+	*out = *(*networking.NetworkPolicyEgressRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -956,8 +897,7 @@ func Convert_v1_NetworkPolicyEgressRule_To_networking_NetworkPolicyEgressRule(in
 }
 
 func autoConvert_networking_NetworkPolicyEgressRule_To_v1_NetworkPolicyEgressRule(in *networking.NetworkPolicyEgressRule, out *networkingv1.NetworkPolicyEgressRule, s conversion.Scope) error {
-	out.Ports = *(*[]networkingv1.NetworkPolicyPort)(unsafe.Pointer(&in.Ports))
-	out.To = *(*[]networkingv1.NetworkPolicyPeer)(unsafe.Pointer(&in.To))
+	*out = *(*networkingv1.NetworkPolicyEgressRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -967,8 +907,7 @@ func Convert_networking_NetworkPolicyEgressRule_To_v1_NetworkPolicyEgressRule(in
 }
 
 func autoConvert_v1_NetworkPolicyIngressRule_To_networking_NetworkPolicyIngressRule(in *networkingv1.NetworkPolicyIngressRule, out *networking.NetworkPolicyIngressRule, s conversion.Scope) error {
-	out.Ports = *(*[]networking.NetworkPolicyPort)(unsafe.Pointer(&in.Ports))
-	out.From = *(*[]networking.NetworkPolicyPeer)(unsafe.Pointer(&in.From))
+	*out = *(*networking.NetworkPolicyIngressRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -978,8 +917,7 @@ func Convert_v1_NetworkPolicyIngressRule_To_networking_NetworkPolicyIngressRule(
 }
 
 func autoConvert_networking_NetworkPolicyIngressRule_To_v1_NetworkPolicyIngressRule(in *networking.NetworkPolicyIngressRule, out *networkingv1.NetworkPolicyIngressRule, s conversion.Scope) error {
-	out.Ports = *(*[]networkingv1.NetworkPolicyPort)(unsafe.Pointer(&in.Ports))
-	out.From = *(*[]networkingv1.NetworkPolicyPeer)(unsafe.Pointer(&in.From))
+	*out = *(*networkingv1.NetworkPolicyIngressRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1011,9 +949,7 @@ func Convert_networking_NetworkPolicyList_To_v1_NetworkPolicyList(in *networking
 }
 
 func autoConvert_v1_NetworkPolicyPeer_To_networking_NetworkPolicyPeer(in *networkingv1.NetworkPolicyPeer, out *networking.NetworkPolicyPeer, s conversion.Scope) error {
-	out.PodSelector = (*metav1.LabelSelector)(unsafe.Pointer(in.PodSelector))
-	out.NamespaceSelector = (*metav1.LabelSelector)(unsafe.Pointer(in.NamespaceSelector))
-	out.IPBlock = (*networking.IPBlock)(unsafe.Pointer(in.IPBlock))
+	*out = *(*networking.NetworkPolicyPeer)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1023,9 +959,7 @@ func Convert_v1_NetworkPolicyPeer_To_networking_NetworkPolicyPeer(in *networking
 }
 
 func autoConvert_networking_NetworkPolicyPeer_To_v1_NetworkPolicyPeer(in *networking.NetworkPolicyPeer, out *networkingv1.NetworkPolicyPeer, s conversion.Scope) error {
-	out.PodSelector = (*metav1.LabelSelector)(unsafe.Pointer(in.PodSelector))
-	out.NamespaceSelector = (*metav1.LabelSelector)(unsafe.Pointer(in.NamespaceSelector))
-	out.IPBlock = (*networkingv1.IPBlock)(unsafe.Pointer(in.IPBlock))
+	*out = *(*networkingv1.NetworkPolicyPeer)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1035,9 +969,7 @@ func Convert_networking_NetworkPolicyPeer_To_v1_NetworkPolicyPeer(in *networking
 }
 
 func autoConvert_v1_NetworkPolicyPort_To_networking_NetworkPolicyPort(in *networkingv1.NetworkPolicyPort, out *networking.NetworkPolicyPort, s conversion.Scope) error {
-	out.Protocol = (*core.Protocol)(unsafe.Pointer(in.Protocol))
-	out.Port = (*intstr.IntOrString)(unsafe.Pointer(in.Port))
-	out.EndPort = (*int32)(unsafe.Pointer(in.EndPort))
+	*out = *(*networking.NetworkPolicyPort)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1047,9 +979,7 @@ func Convert_v1_NetworkPolicyPort_To_networking_NetworkPolicyPort(in *networking
 }
 
 func autoConvert_networking_NetworkPolicyPort_To_v1_NetworkPolicyPort(in *networking.NetworkPolicyPort, out *networkingv1.NetworkPolicyPort, s conversion.Scope) error {
-	out.Protocol = (*corev1.Protocol)(unsafe.Pointer(in.Protocol))
-	out.Port = (*intstr.IntOrString)(unsafe.Pointer(in.Port))
-	out.EndPort = (*int32)(unsafe.Pointer(in.EndPort))
+	*out = *(*networkingv1.NetworkPolicyPort)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1059,10 +989,7 @@ func Convert_networking_NetworkPolicyPort_To_v1_NetworkPolicyPort(in *networking
 }
 
 func autoConvert_v1_NetworkPolicySpec_To_networking_NetworkPolicySpec(in *networkingv1.NetworkPolicySpec, out *networking.NetworkPolicySpec, s conversion.Scope) error {
-	out.PodSelector = in.PodSelector
-	out.Ingress = *(*[]networking.NetworkPolicyIngressRule)(unsafe.Pointer(&in.Ingress))
-	out.Egress = *(*[]networking.NetworkPolicyEgressRule)(unsafe.Pointer(&in.Egress))
-	out.PolicyTypes = *(*[]networking.PolicyType)(unsafe.Pointer(&in.PolicyTypes))
+	*out = *(*networking.NetworkPolicySpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1072,10 +999,7 @@ func Convert_v1_NetworkPolicySpec_To_networking_NetworkPolicySpec(in *networking
 }
 
 func autoConvert_networking_NetworkPolicySpec_To_v1_NetworkPolicySpec(in *networking.NetworkPolicySpec, out *networkingv1.NetworkPolicySpec, s conversion.Scope) error {
-	out.PodSelector = in.PodSelector
-	out.Ingress = *(*[]networkingv1.NetworkPolicyIngressRule)(unsafe.Pointer(&in.Ingress))
-	out.Egress = *(*[]networkingv1.NetworkPolicyEgressRule)(unsafe.Pointer(&in.Egress))
-	out.PolicyTypes = *(*[]networkingv1.PolicyType)(unsafe.Pointer(&in.PolicyTypes))
+	*out = *(*networkingv1.NetworkPolicySpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1085,10 +1009,7 @@ func Convert_networking_NetworkPolicySpec_To_v1_NetworkPolicySpec(in *networking
 }
 
 func autoConvert_v1_ParentReference_To_networking_ParentReference(in *networkingv1.ParentReference, out *networking.ParentReference, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
-	out.Namespace = in.Namespace
-	out.Name = in.Name
+	*out = *(*networking.ParentReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1098,10 +1019,7 @@ func Convert_v1_ParentReference_To_networking_ParentReference(in *networkingv1.P
 }
 
 func autoConvert_networking_ParentReference_To_v1_ParentReference(in *networking.ParentReference, out *networkingv1.ParentReference, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
-	out.Namespace = in.Namespace
-	out.Name = in.Name
+	*out = *(*networkingv1.ParentReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1111,8 +1029,7 @@ func Convert_networking_ParentReference_To_v1_ParentReference(in *networking.Par
 }
 
 func autoConvert_v1_ServiceBackendPort_To_networking_ServiceBackendPort(in *networkingv1.ServiceBackendPort, out *networking.ServiceBackendPort, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Number = in.Number
+	*out = *(*networking.ServiceBackendPort)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1122,8 +1039,7 @@ func Convert_v1_ServiceBackendPort_To_networking_ServiceBackendPort(in *networki
 }
 
 func autoConvert_networking_ServiceBackendPort_To_v1_ServiceBackendPort(in *networking.ServiceBackendPort, out *networkingv1.ServiceBackendPort, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Number = in.Number
+	*out = *(*networkingv1.ServiceBackendPort)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1187,7 +1103,7 @@ func Convert_networking_ServiceCIDRList_To_v1_ServiceCIDRList(in *networking.Ser
 }
 
 func autoConvert_v1_ServiceCIDRSpec_To_networking_ServiceCIDRSpec(in *networkingv1.ServiceCIDRSpec, out *networking.ServiceCIDRSpec, s conversion.Scope) error {
-	out.CIDRs = *(*[]string)(unsafe.Pointer(&in.CIDRs))
+	*out = *(*networking.ServiceCIDRSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1197,7 +1113,7 @@ func Convert_v1_ServiceCIDRSpec_To_networking_ServiceCIDRSpec(in *networkingv1.S
 }
 
 func autoConvert_networking_ServiceCIDRSpec_To_v1_ServiceCIDRSpec(in *networking.ServiceCIDRSpec, out *networkingv1.ServiceCIDRSpec, s conversion.Scope) error {
-	out.CIDRs = *(*[]string)(unsafe.Pointer(&in.CIDRs))
+	*out = *(*networkingv1.ServiceCIDRSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1207,7 +1123,7 @@ func Convert_networking_ServiceCIDRSpec_To_v1_ServiceCIDRSpec(in *networking.Ser
 }
 
 func autoConvert_v1_ServiceCIDRStatus_To_networking_ServiceCIDRStatus(in *networkingv1.ServiceCIDRStatus, out *networking.ServiceCIDRStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]metav1.Condition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*networking.ServiceCIDRStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1217,7 +1133,7 @@ func Convert_v1_ServiceCIDRStatus_To_networking_ServiceCIDRStatus(in *networking
 }
 
 func autoConvert_networking_ServiceCIDRStatus_To_v1_ServiceCIDRStatus(in *networking.ServiceCIDRStatus, out *networkingv1.ServiceCIDRStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]metav1.Condition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*networkingv1.ServiceCIDRStatus)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/networking/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/networking/v1beta1/zz_generated.conversion.go
@@ -26,7 +26,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	core "k8s.io/kubernetes/pkg/apis/core"
@@ -410,7 +409,7 @@ func Convert_networking_IPAddressList_To_v1beta1_IPAddressList(in *networking.IP
 }
 
 func autoConvert_v1beta1_IPAddressSpec_To_networking_IPAddressSpec(in *networkingv1beta1.IPAddressSpec, out *networking.IPAddressSpec, s conversion.Scope) error {
-	out.ParentRef = (*networking.ParentReference)(unsafe.Pointer(in.ParentRef))
+	*out = *(*networking.IPAddressSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -420,7 +419,7 @@ func Convert_v1beta1_IPAddressSpec_To_networking_IPAddressSpec(in *networkingv1b
 }
 
 func autoConvert_networking_IPAddressSpec_To_v1beta1_IPAddressSpec(in *networking.IPAddressSpec, out *networkingv1beta1.IPAddressSpec, s conversion.Scope) error {
-	out.ParentRef = (*networkingv1beta1.ParentReference)(unsafe.Pointer(in.ParentRef))
+	*out = *(*networkingv1beta1.IPAddressSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -523,11 +522,7 @@ func Convert_networking_IngressClassList_To_v1beta1_IngressClassList(in *network
 }
 
 func autoConvert_v1beta1_IngressClassParametersReference_To_networking_IngressClassParametersReference(in *networkingv1beta1.IngressClassParametersReference, out *networking.IngressClassParametersReference, s conversion.Scope) error {
-	out.APIGroup = (*string)(unsafe.Pointer(in.APIGroup))
-	out.Kind = in.Kind
-	out.Name = in.Name
-	out.Scope = (*string)(unsafe.Pointer(in.Scope))
-	out.Namespace = (*string)(unsafe.Pointer(in.Namespace))
+	*out = *(*networking.IngressClassParametersReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -537,11 +532,7 @@ func Convert_v1beta1_IngressClassParametersReference_To_networking_IngressClassP
 }
 
 func autoConvert_networking_IngressClassParametersReference_To_v1beta1_IngressClassParametersReference(in *networking.IngressClassParametersReference, out *networkingv1beta1.IngressClassParametersReference, s conversion.Scope) error {
-	out.APIGroup = (*string)(unsafe.Pointer(in.APIGroup))
-	out.Kind = in.Kind
-	out.Name = in.Name
-	out.Scope = (*string)(unsafe.Pointer(in.Scope))
-	out.Namespace = (*string)(unsafe.Pointer(in.Namespace))
+	*out = *(*networkingv1beta1.IngressClassParametersReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -551,8 +542,7 @@ func Convert_networking_IngressClassParametersReference_To_v1beta1_IngressClassP
 }
 
 func autoConvert_v1beta1_IngressClassSpec_To_networking_IngressClassSpec(in *networkingv1beta1.IngressClassSpec, out *networking.IngressClassSpec, s conversion.Scope) error {
-	out.Controller = in.Controller
-	out.Parameters = (*networking.IngressClassParametersReference)(unsafe.Pointer(in.Parameters))
+	*out = *(*networking.IngressClassSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -562,8 +552,7 @@ func Convert_v1beta1_IngressClassSpec_To_networking_IngressClassSpec(in *network
 }
 
 func autoConvert_networking_IngressClassSpec_To_v1beta1_IngressClassSpec(in *networking.IngressClassSpec, out *networkingv1beta1.IngressClassSpec, s conversion.Scope) error {
-	out.Controller = in.Controller
-	out.Parameters = (*networkingv1beta1.IngressClassParametersReference)(unsafe.Pointer(in.Parameters))
+	*out = *(*networkingv1beta1.IngressClassSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -615,9 +604,7 @@ func Convert_networking_IngressList_To_v1beta1_IngressList(in *networking.Ingres
 }
 
 func autoConvert_v1beta1_IngressLoadBalancerIngress_To_networking_IngressLoadBalancerIngress(in *networkingv1beta1.IngressLoadBalancerIngress, out *networking.IngressLoadBalancerIngress, s conversion.Scope) error {
-	out.IP = in.IP
-	out.Hostname = in.Hostname
-	out.Ports = *(*[]networking.IngressPortStatus)(unsafe.Pointer(&in.Ports))
+	*out = *(*networking.IngressLoadBalancerIngress)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -627,9 +614,7 @@ func Convert_v1beta1_IngressLoadBalancerIngress_To_networking_IngressLoadBalance
 }
 
 func autoConvert_networking_IngressLoadBalancerIngress_To_v1beta1_IngressLoadBalancerIngress(in *networking.IngressLoadBalancerIngress, out *networkingv1beta1.IngressLoadBalancerIngress, s conversion.Scope) error {
-	out.IP = in.IP
-	out.Hostname = in.Hostname
-	out.Ports = *(*[]networkingv1beta1.IngressPortStatus)(unsafe.Pointer(&in.Ports))
+	*out = *(*networkingv1beta1.IngressLoadBalancerIngress)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -639,7 +624,7 @@ func Convert_networking_IngressLoadBalancerIngress_To_v1beta1_IngressLoadBalance
 }
 
 func autoConvert_v1beta1_IngressLoadBalancerStatus_To_networking_IngressLoadBalancerStatus(in *networkingv1beta1.IngressLoadBalancerStatus, out *networking.IngressLoadBalancerStatus, s conversion.Scope) error {
-	out.Ingress = *(*[]networking.IngressLoadBalancerIngress)(unsafe.Pointer(&in.Ingress))
+	*out = *(*networking.IngressLoadBalancerStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -649,7 +634,7 @@ func Convert_v1beta1_IngressLoadBalancerStatus_To_networking_IngressLoadBalancer
 }
 
 func autoConvert_networking_IngressLoadBalancerStatus_To_v1beta1_IngressLoadBalancerStatus(in *networking.IngressLoadBalancerStatus, out *networkingv1beta1.IngressLoadBalancerStatus, s conversion.Scope) error {
-	out.Ingress = *(*[]networkingv1beta1.IngressLoadBalancerIngress)(unsafe.Pointer(&in.Ingress))
+	*out = *(*networkingv1beta1.IngressLoadBalancerStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -659,9 +644,7 @@ func Convert_networking_IngressLoadBalancerStatus_To_v1beta1_IngressLoadBalancer
 }
 
 func autoConvert_v1beta1_IngressPortStatus_To_networking_IngressPortStatus(in *networkingv1beta1.IngressPortStatus, out *networking.IngressPortStatus, s conversion.Scope) error {
-	out.Port = in.Port
-	out.Protocol = core.Protocol(in.Protocol)
-	out.Error = (*string)(unsafe.Pointer(in.Error))
+	*out = *(*networking.IngressPortStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -671,9 +654,7 @@ func Convert_v1beta1_IngressPortStatus_To_networking_IngressPortStatus(in *netwo
 }
 
 func autoConvert_networking_IngressPortStatus_To_v1beta1_IngressPortStatus(in *networking.IngressPortStatus, out *networkingv1beta1.IngressPortStatus, s conversion.Scope) error {
-	out.Port = in.Port
-	out.Protocol = v1.Protocol(in.Protocol)
-	out.Error = (*string)(unsafe.Pointer(in.Error))
+	*out = *(*networkingv1beta1.IngressPortStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -781,9 +762,7 @@ func autoConvert_networking_IngressSpec_To_v1beta1_IngressSpec(in *networking.In
 }
 
 func autoConvert_v1beta1_IngressStatus_To_networking_IngressStatus(in *networkingv1beta1.IngressStatus, out *networking.IngressStatus, s conversion.Scope) error {
-	if err := Convert_v1beta1_IngressLoadBalancerStatus_To_networking_IngressLoadBalancerStatus(&in.LoadBalancer, &out.LoadBalancer, s); err != nil {
-		return err
-	}
+	*out = *(*networking.IngressStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -793,9 +772,7 @@ func Convert_v1beta1_IngressStatus_To_networking_IngressStatus(in *networkingv1b
 }
 
 func autoConvert_networking_IngressStatus_To_v1beta1_IngressStatus(in *networking.IngressStatus, out *networkingv1beta1.IngressStatus, s conversion.Scope) error {
-	if err := Convert_networking_IngressLoadBalancerStatus_To_v1beta1_IngressLoadBalancerStatus(&in.LoadBalancer, &out.LoadBalancer, s); err != nil {
-		return err
-	}
+	*out = *(*networkingv1beta1.IngressStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -805,8 +782,7 @@ func Convert_networking_IngressStatus_To_v1beta1_IngressStatus(in *networking.In
 }
 
 func autoConvert_v1beta1_IngressTLS_To_networking_IngressTLS(in *networkingv1beta1.IngressTLS, out *networking.IngressTLS, s conversion.Scope) error {
-	out.Hosts = *(*[]string)(unsafe.Pointer(&in.Hosts))
-	out.SecretName = in.SecretName
+	*out = *(*networking.IngressTLS)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -816,8 +792,7 @@ func Convert_v1beta1_IngressTLS_To_networking_IngressTLS(in *networkingv1beta1.I
 }
 
 func autoConvert_networking_IngressTLS_To_v1beta1_IngressTLS(in *networking.IngressTLS, out *networkingv1beta1.IngressTLS, s conversion.Scope) error {
-	out.Hosts = *(*[]string)(unsafe.Pointer(&in.Hosts))
-	out.SecretName = in.SecretName
+	*out = *(*networkingv1beta1.IngressTLS)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -827,10 +802,7 @@ func Convert_networking_IngressTLS_To_v1beta1_IngressTLS(in *networking.IngressT
 }
 
 func autoConvert_v1beta1_ParentReference_To_networking_ParentReference(in *networkingv1beta1.ParentReference, out *networking.ParentReference, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
-	out.Namespace = in.Namespace
-	out.Name = in.Name
+	*out = *(*networking.ParentReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -840,10 +812,7 @@ func Convert_v1beta1_ParentReference_To_networking_ParentReference(in *networkin
 }
 
 func autoConvert_networking_ParentReference_To_v1beta1_ParentReference(in *networking.ParentReference, out *networkingv1beta1.ParentReference, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
-	out.Namespace = in.Namespace
-	out.Name = in.Name
+	*out = *(*networkingv1beta1.ParentReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -907,7 +876,7 @@ func Convert_networking_ServiceCIDRList_To_v1beta1_ServiceCIDRList(in *networkin
 }
 
 func autoConvert_v1beta1_ServiceCIDRSpec_To_networking_ServiceCIDRSpec(in *networkingv1beta1.ServiceCIDRSpec, out *networking.ServiceCIDRSpec, s conversion.Scope) error {
-	out.CIDRs = *(*[]string)(unsafe.Pointer(&in.CIDRs))
+	*out = *(*networking.ServiceCIDRSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -917,7 +886,7 @@ func Convert_v1beta1_ServiceCIDRSpec_To_networking_ServiceCIDRSpec(in *networkin
 }
 
 func autoConvert_networking_ServiceCIDRSpec_To_v1beta1_ServiceCIDRSpec(in *networking.ServiceCIDRSpec, out *networkingv1beta1.ServiceCIDRSpec, s conversion.Scope) error {
-	out.CIDRs = *(*[]string)(unsafe.Pointer(&in.CIDRs))
+	*out = *(*networkingv1beta1.ServiceCIDRSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -927,7 +896,7 @@ func Convert_networking_ServiceCIDRSpec_To_v1beta1_ServiceCIDRSpec(in *networkin
 }
 
 func autoConvert_v1beta1_ServiceCIDRStatus_To_networking_ServiceCIDRStatus(in *networkingv1beta1.ServiceCIDRStatus, out *networking.ServiceCIDRStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]metav1.Condition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*networking.ServiceCIDRStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -937,7 +906,7 @@ func Convert_v1beta1_ServiceCIDRStatus_To_networking_ServiceCIDRStatus(in *netwo
 }
 
 func autoConvert_networking_ServiceCIDRStatus_To_v1beta1_ServiceCIDRStatus(in *networking.ServiceCIDRStatus, out *networkingv1beta1.ServiceCIDRStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]metav1.Condition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*networkingv1beta1.ServiceCIDRStatus)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/node/v1/zz_generated.conversion.go
+++ b/pkg/apis/node/v1/zz_generated.conversion.go
@@ -24,11 +24,9 @@ package v1
 import (
 	unsafe "unsafe"
 
-	corev1 "k8s.io/api/core/v1"
 	nodev1 "k8s.io/api/node/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	core "k8s.io/kubernetes/pkg/apis/core"
 	node "k8s.io/kubernetes/pkg/apis/node"
 )
 
@@ -83,7 +81,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1_Overhead_To_node_Overhead(in *nodev1.Overhead, out *node.Overhead, s conversion.Scope) error {
-	out.PodFixed = *(*core.ResourceList)(unsafe.Pointer(&in.PodFixed))
+	*out = *(*node.Overhead)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -93,7 +91,7 @@ func Convert_v1_Overhead_To_node_Overhead(in *nodev1.Overhead, out *node.Overhea
 }
 
 func autoConvert_node_Overhead_To_v1_Overhead(in *node.Overhead, out *nodev1.Overhead, s conversion.Scope) error {
-	out.PodFixed = *(*corev1.ResourceList)(unsafe.Pointer(&in.PodFixed))
+	*out = *(*nodev1.Overhead)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -151,8 +149,7 @@ func Convert_node_RuntimeClassList_To_v1_RuntimeClassList(in *node.RuntimeClassL
 }
 
 func autoConvert_v1_Scheduling_To_node_Scheduling(in *nodev1.Scheduling, out *node.Scheduling, s conversion.Scope) error {
-	out.NodeSelector = *(*map[string]string)(unsafe.Pointer(&in.NodeSelector))
-	out.Tolerations = *(*[]core.Toleration)(unsafe.Pointer(&in.Tolerations))
+	*out = *(*node.Scheduling)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -162,8 +159,7 @@ func Convert_v1_Scheduling_To_node_Scheduling(in *nodev1.Scheduling, out *node.S
 }
 
 func autoConvert_node_Scheduling_To_v1_Scheduling(in *node.Scheduling, out *nodev1.Scheduling, s conversion.Scope) error {
-	out.NodeSelector = *(*map[string]string)(unsafe.Pointer(&in.NodeSelector))
-	out.Tolerations = *(*[]corev1.Toleration)(unsafe.Pointer(&in.Tolerations))
+	*out = *(*nodev1.Scheduling)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/node/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/node/v1alpha1/zz_generated.conversion.go
@@ -24,11 +24,9 @@ package v1alpha1
 import (
 	unsafe "unsafe"
 
-	v1 "k8s.io/api/core/v1"
 	nodev1alpha1 "k8s.io/api/node/v1alpha1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	core "k8s.io/kubernetes/pkg/apis/core"
 	node "k8s.io/kubernetes/pkg/apis/node"
 )
 
@@ -83,7 +81,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_Overhead_To_node_Overhead(in *nodev1alpha1.Overhead, out *node.Overhead, s conversion.Scope) error {
-	out.PodFixed = *(*core.ResourceList)(unsafe.Pointer(&in.PodFixed))
+	*out = *(*node.Overhead)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -93,7 +91,7 @@ func Convert_v1alpha1_Overhead_To_node_Overhead(in *nodev1alpha1.Overhead, out *
 }
 
 func autoConvert_node_Overhead_To_v1alpha1_Overhead(in *node.Overhead, out *nodev1alpha1.Overhead, s conversion.Scope) error {
-	out.PodFixed = *(*v1.ResourceList)(unsafe.Pointer(&in.PodFixed))
+	*out = *(*nodev1alpha1.Overhead)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -159,8 +157,7 @@ func Convert_node_RuntimeClassList_To_v1alpha1_RuntimeClassList(in *node.Runtime
 }
 
 func autoConvert_v1alpha1_Scheduling_To_node_Scheduling(in *nodev1alpha1.Scheduling, out *node.Scheduling, s conversion.Scope) error {
-	out.NodeSelector = *(*map[string]string)(unsafe.Pointer(&in.NodeSelector))
-	out.Tolerations = *(*[]core.Toleration)(unsafe.Pointer(&in.Tolerations))
+	*out = *(*node.Scheduling)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -170,8 +167,7 @@ func Convert_v1alpha1_Scheduling_To_node_Scheduling(in *nodev1alpha1.Scheduling,
 }
 
 func autoConvert_node_Scheduling_To_v1alpha1_Scheduling(in *node.Scheduling, out *nodev1alpha1.Scheduling, s conversion.Scope) error {
-	out.NodeSelector = *(*map[string]string)(unsafe.Pointer(&in.NodeSelector))
-	out.Tolerations = *(*[]v1.Toleration)(unsafe.Pointer(&in.Tolerations))
+	*out = *(*nodev1alpha1.Scheduling)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/node/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/node/v1beta1/zz_generated.conversion.go
@@ -24,11 +24,9 @@ package v1beta1
 import (
 	unsafe "unsafe"
 
-	v1 "k8s.io/api/core/v1"
 	nodev1beta1 "k8s.io/api/node/v1beta1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	core "k8s.io/kubernetes/pkg/apis/core"
 	node "k8s.io/kubernetes/pkg/apis/node"
 )
 
@@ -83,7 +81,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1beta1_Overhead_To_node_Overhead(in *nodev1beta1.Overhead, out *node.Overhead, s conversion.Scope) error {
-	out.PodFixed = *(*core.ResourceList)(unsafe.Pointer(&in.PodFixed))
+	*out = *(*node.Overhead)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -93,7 +91,7 @@ func Convert_v1beta1_Overhead_To_node_Overhead(in *nodev1beta1.Overhead, out *no
 }
 
 func autoConvert_node_Overhead_To_v1beta1_Overhead(in *node.Overhead, out *nodev1beta1.Overhead, s conversion.Scope) error {
-	out.PodFixed = *(*v1.ResourceList)(unsafe.Pointer(&in.PodFixed))
+	*out = *(*nodev1beta1.Overhead)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -151,8 +149,7 @@ func Convert_node_RuntimeClassList_To_v1beta1_RuntimeClassList(in *node.RuntimeC
 }
 
 func autoConvert_v1beta1_Scheduling_To_node_Scheduling(in *nodev1beta1.Scheduling, out *node.Scheduling, s conversion.Scope) error {
-	out.NodeSelector = *(*map[string]string)(unsafe.Pointer(&in.NodeSelector))
-	out.Tolerations = *(*[]core.Toleration)(unsafe.Pointer(&in.Tolerations))
+	*out = *(*node.Scheduling)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -162,8 +159,7 @@ func Convert_v1beta1_Scheduling_To_node_Scheduling(in *nodev1beta1.Scheduling, o
 }
 
 func autoConvert_node_Scheduling_To_v1beta1_Scheduling(in *node.Scheduling, out *nodev1beta1.Scheduling, s conversion.Scope) error {
-	out.NodeSelector = *(*map[string]string)(unsafe.Pointer(&in.NodeSelector))
-	out.Tolerations = *(*[]v1.Toleration)(unsafe.Pointer(&in.Tolerations))
+	*out = *(*nodev1beta1.Scheduling)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/policy/v1/zz_generated.conversion.go
+++ b/pkg/apis/policy/v1/zz_generated.conversion.go
@@ -28,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	intstr "k8s.io/apimachinery/pkg/util/intstr"
 	policy "k8s.io/kubernetes/pkg/apis/policy"
 )
 
@@ -184,10 +183,7 @@ func Convert_policy_PodDisruptionBudgetList_To_v1_PodDisruptionBudgetList(in *po
 }
 
 func autoConvert_v1_PodDisruptionBudgetSpec_To_policy_PodDisruptionBudgetSpec(in *policyv1.PodDisruptionBudgetSpec, out *policy.PodDisruptionBudgetSpec, s conversion.Scope) error {
-	out.MinAvailable = (*intstr.IntOrString)(unsafe.Pointer(in.MinAvailable))
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
-	out.MaxUnavailable = (*intstr.IntOrString)(unsafe.Pointer(in.MaxUnavailable))
-	out.UnhealthyPodEvictionPolicy = (*policy.UnhealthyPodEvictionPolicyType)(unsafe.Pointer(in.UnhealthyPodEvictionPolicy))
+	*out = *(*policy.PodDisruptionBudgetSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -197,10 +193,7 @@ func Convert_v1_PodDisruptionBudgetSpec_To_policy_PodDisruptionBudgetSpec(in *po
 }
 
 func autoConvert_policy_PodDisruptionBudgetSpec_To_v1_PodDisruptionBudgetSpec(in *policy.PodDisruptionBudgetSpec, out *policyv1.PodDisruptionBudgetSpec, s conversion.Scope) error {
-	out.MinAvailable = (*intstr.IntOrString)(unsafe.Pointer(in.MinAvailable))
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
-	out.MaxUnavailable = (*intstr.IntOrString)(unsafe.Pointer(in.MaxUnavailable))
-	out.UnhealthyPodEvictionPolicy = (*policyv1.UnhealthyPodEvictionPolicyType)(unsafe.Pointer(in.UnhealthyPodEvictionPolicy))
+	*out = *(*policyv1.PodDisruptionBudgetSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -210,13 +203,7 @@ func Convert_policy_PodDisruptionBudgetSpec_To_v1_PodDisruptionBudgetSpec(in *po
 }
 
 func autoConvert_v1_PodDisruptionBudgetStatus_To_policy_PodDisruptionBudgetStatus(in *policyv1.PodDisruptionBudgetStatus, out *policy.PodDisruptionBudgetStatus, s conversion.Scope) error {
-	out.ObservedGeneration = in.ObservedGeneration
-	out.DisruptedPods = *(*map[string]metav1.Time)(unsafe.Pointer(&in.DisruptedPods))
-	out.DisruptionsAllowed = in.DisruptionsAllowed
-	out.CurrentHealthy = in.CurrentHealthy
-	out.DesiredHealthy = in.DesiredHealthy
-	out.ExpectedPods = in.ExpectedPods
-	out.Conditions = *(*[]metav1.Condition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*policy.PodDisruptionBudgetStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -226,13 +213,7 @@ func Convert_v1_PodDisruptionBudgetStatus_To_policy_PodDisruptionBudgetStatus(in
 }
 
 func autoConvert_policy_PodDisruptionBudgetStatus_To_v1_PodDisruptionBudgetStatus(in *policy.PodDisruptionBudgetStatus, out *policyv1.PodDisruptionBudgetStatus, s conversion.Scope) error {
-	out.ObservedGeneration = in.ObservedGeneration
-	out.DisruptedPods = *(*map[string]metav1.Time)(unsafe.Pointer(&in.DisruptedPods))
-	out.DisruptionsAllowed = in.DisruptionsAllowed
-	out.CurrentHealthy = in.CurrentHealthy
-	out.DesiredHealthy = in.DesiredHealthy
-	out.ExpectedPods = in.ExpectedPods
-	out.Conditions = *(*[]metav1.Condition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*policyv1.PodDisruptionBudgetStatus)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/policy/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/policy/v1beta1/zz_generated.conversion.go
@@ -28,7 +28,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	intstr "k8s.io/apimachinery/pkg/util/intstr"
 	policy "k8s.io/kubernetes/pkg/apis/policy"
 )
 
@@ -179,10 +178,7 @@ func Convert_policy_PodDisruptionBudgetList_To_v1beta1_PodDisruptionBudgetList(i
 }
 
 func autoConvert_v1beta1_PodDisruptionBudgetSpec_To_policy_PodDisruptionBudgetSpec(in *policyv1beta1.PodDisruptionBudgetSpec, out *policy.PodDisruptionBudgetSpec, s conversion.Scope) error {
-	out.MinAvailable = (*intstr.IntOrString)(unsafe.Pointer(in.MinAvailable))
-	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
-	out.MaxUnavailable = (*intstr.IntOrString)(unsafe.Pointer(in.MaxUnavailable))
-	out.UnhealthyPodEvictionPolicy = (*policy.UnhealthyPodEvictionPolicyType)(unsafe.Pointer(in.UnhealthyPodEvictionPolicy))
+	*out = *(*policy.PodDisruptionBudgetSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -192,10 +188,7 @@ func Convert_v1beta1_PodDisruptionBudgetSpec_To_policy_PodDisruptionBudgetSpec(i
 }
 
 func autoConvert_policy_PodDisruptionBudgetSpec_To_v1beta1_PodDisruptionBudgetSpec(in *policy.PodDisruptionBudgetSpec, out *policyv1beta1.PodDisruptionBudgetSpec, s conversion.Scope) error {
-	out.MinAvailable = (*intstr.IntOrString)(unsafe.Pointer(in.MinAvailable))
-	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
-	out.MaxUnavailable = (*intstr.IntOrString)(unsafe.Pointer(in.MaxUnavailable))
-	out.UnhealthyPodEvictionPolicy = (*policyv1beta1.UnhealthyPodEvictionPolicyType)(unsafe.Pointer(in.UnhealthyPodEvictionPolicy))
+	*out = *(*policyv1beta1.PodDisruptionBudgetSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -205,13 +198,7 @@ func Convert_policy_PodDisruptionBudgetSpec_To_v1beta1_PodDisruptionBudgetSpec(i
 }
 
 func autoConvert_v1beta1_PodDisruptionBudgetStatus_To_policy_PodDisruptionBudgetStatus(in *policyv1beta1.PodDisruptionBudgetStatus, out *policy.PodDisruptionBudgetStatus, s conversion.Scope) error {
-	out.ObservedGeneration = in.ObservedGeneration
-	out.DisruptedPods = *(*map[string]v1.Time)(unsafe.Pointer(&in.DisruptedPods))
-	out.DisruptionsAllowed = in.DisruptionsAllowed
-	out.CurrentHealthy = in.CurrentHealthy
-	out.DesiredHealthy = in.DesiredHealthy
-	out.ExpectedPods = in.ExpectedPods
-	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*policy.PodDisruptionBudgetStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -221,13 +208,7 @@ func Convert_v1beta1_PodDisruptionBudgetStatus_To_policy_PodDisruptionBudgetStat
 }
 
 func autoConvert_policy_PodDisruptionBudgetStatus_To_v1beta1_PodDisruptionBudgetStatus(in *policy.PodDisruptionBudgetStatus, out *policyv1beta1.PodDisruptionBudgetStatus, s conversion.Scope) error {
-	out.ObservedGeneration = in.ObservedGeneration
-	out.DisruptedPods = *(*map[string]v1.Time)(unsafe.Pointer(&in.DisruptedPods))
-	out.DisruptionsAllowed = in.DisruptionsAllowed
-	out.CurrentHealthy = in.CurrentHealthy
-	out.DesiredHealthy = in.DesiredHealthy
-	out.ExpectedPods = in.ExpectedPods
-	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*policyv1beta1.PodDisruptionBudgetStatus)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/rbac/v1/zz_generated.conversion.go
+++ b/pkg/apis/rbac/v1/zz_generated.conversion.go
@@ -25,7 +25,6 @@ import (
 	unsafe "unsafe"
 
 	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	rbac "k8s.io/kubernetes/pkg/apis/rbac"
@@ -162,7 +161,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1_AggregationRule_To_rbac_AggregationRule(in *rbacv1.AggregationRule, out *rbac.AggregationRule, s conversion.Scope) error {
-	out.ClusterRoleSelectors = *(*[]metav1.LabelSelector)(unsafe.Pointer(&in.ClusterRoleSelectors))
+	*out = *(*rbac.AggregationRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -172,7 +171,7 @@ func Convert_v1_AggregationRule_To_rbac_AggregationRule(in *rbacv1.AggregationRu
 }
 
 func autoConvert_rbac_AggregationRule_To_v1_AggregationRule(in *rbac.AggregationRule, out *rbacv1.AggregationRule, s conversion.Scope) error {
-	out.ClusterRoleSelectors = *(*[]metav1.LabelSelector)(unsafe.Pointer(&in.ClusterRoleSelectors))
+	*out = *(*rbacv1.AggregationRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -278,11 +277,7 @@ func Convert_rbac_ClusterRoleList_To_v1_ClusterRoleList(in *rbac.ClusterRoleList
 }
 
 func autoConvert_v1_PolicyRule_To_rbac_PolicyRule(in *rbacv1.PolicyRule, out *rbac.PolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
-	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
-	out.ResourceNames = *(*[]string)(unsafe.Pointer(&in.ResourceNames))
-	out.NonResourceURLs = *(*[]string)(unsafe.Pointer(&in.NonResourceURLs))
+	*out = *(*rbac.PolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -292,11 +287,7 @@ func Convert_v1_PolicyRule_To_rbac_PolicyRule(in *rbacv1.PolicyRule, out *rbac.P
 }
 
 func autoConvert_rbac_PolicyRule_To_v1_PolicyRule(in *rbac.PolicyRule, out *rbacv1.PolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
-	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
-	out.ResourceNames = *(*[]string)(unsafe.Pointer(&in.ResourceNames))
-	out.NonResourceURLs = *(*[]string)(unsafe.Pointer(&in.NonResourceURLs))
+	*out = *(*rbacv1.PolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -400,9 +391,7 @@ func Convert_rbac_RoleList_To_v1_RoleList(in *rbac.RoleList, out *rbacv1.RoleLis
 }
 
 func autoConvert_v1_RoleRef_To_rbac_RoleRef(in *rbacv1.RoleRef, out *rbac.RoleRef, s conversion.Scope) error {
-	out.APIGroup = in.APIGroup
-	out.Kind = in.Kind
-	out.Name = in.Name
+	*out = *(*rbac.RoleRef)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -412,9 +401,7 @@ func Convert_v1_RoleRef_To_rbac_RoleRef(in *rbacv1.RoleRef, out *rbac.RoleRef, s
 }
 
 func autoConvert_rbac_RoleRef_To_v1_RoleRef(in *rbac.RoleRef, out *rbacv1.RoleRef, s conversion.Scope) error {
-	out.APIGroup = in.APIGroup
-	out.Kind = in.Kind
-	out.Name = in.Name
+	*out = *(*rbacv1.RoleRef)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -424,10 +411,7 @@ func Convert_rbac_RoleRef_To_v1_RoleRef(in *rbac.RoleRef, out *rbacv1.RoleRef, s
 }
 
 func autoConvert_v1_Subject_To_rbac_Subject(in *rbacv1.Subject, out *rbac.Subject, s conversion.Scope) error {
-	out.Kind = in.Kind
-	out.APIGroup = in.APIGroup
-	out.Name = in.Name
-	out.Namespace = in.Namespace
+	*out = *(*rbac.Subject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -437,10 +421,7 @@ func Convert_v1_Subject_To_rbac_Subject(in *rbacv1.Subject, out *rbac.Subject, s
 }
 
 func autoConvert_rbac_Subject_To_v1_Subject(in *rbac.Subject, out *rbacv1.Subject, s conversion.Scope) error {
-	out.Kind = in.Kind
-	out.APIGroup = in.APIGroup
-	out.Name = in.Name
-	out.Namespace = in.Namespace
+	*out = *(*rbacv1.Subject)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/rbac/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/rbac/v1alpha1/zz_generated.conversion.go
@@ -25,7 +25,6 @@ import (
 	unsafe "unsafe"
 
 	rbacv1alpha1 "k8s.io/api/rbac/v1alpha1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	rbac "k8s.io/kubernetes/pkg/apis/rbac"
@@ -162,7 +161,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_AggregationRule_To_rbac_AggregationRule(in *rbacv1alpha1.AggregationRule, out *rbac.AggregationRule, s conversion.Scope) error {
-	out.ClusterRoleSelectors = *(*[]v1.LabelSelector)(unsafe.Pointer(&in.ClusterRoleSelectors))
+	*out = *(*rbac.AggregationRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -172,7 +171,7 @@ func Convert_v1alpha1_AggregationRule_To_rbac_AggregationRule(in *rbacv1alpha1.A
 }
 
 func autoConvert_rbac_AggregationRule_To_v1alpha1_AggregationRule(in *rbac.AggregationRule, out *rbacv1alpha1.AggregationRule, s conversion.Scope) error {
-	out.ClusterRoleSelectors = *(*[]v1.LabelSelector)(unsafe.Pointer(&in.ClusterRoleSelectors))
+	*out = *(*rbacv1alpha1.AggregationRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -318,11 +317,7 @@ func Convert_rbac_ClusterRoleList_To_v1alpha1_ClusterRoleList(in *rbac.ClusterRo
 }
 
 func autoConvert_v1alpha1_PolicyRule_To_rbac_PolicyRule(in *rbacv1alpha1.PolicyRule, out *rbac.PolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
-	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
-	out.ResourceNames = *(*[]string)(unsafe.Pointer(&in.ResourceNames))
-	out.NonResourceURLs = *(*[]string)(unsafe.Pointer(&in.NonResourceURLs))
+	*out = *(*rbac.PolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -332,11 +327,7 @@ func Convert_v1alpha1_PolicyRule_To_rbac_PolicyRule(in *rbacv1alpha1.PolicyRule,
 }
 
 func autoConvert_rbac_PolicyRule_To_v1alpha1_PolicyRule(in *rbac.PolicyRule, out *rbacv1alpha1.PolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
-	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
-	out.ResourceNames = *(*[]string)(unsafe.Pointer(&in.ResourceNames))
-	out.NonResourceURLs = *(*[]string)(unsafe.Pointer(&in.NonResourceURLs))
+	*out = *(*rbacv1alpha1.PolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -480,9 +471,7 @@ func Convert_rbac_RoleList_To_v1alpha1_RoleList(in *rbac.RoleList, out *rbacv1al
 }
 
 func autoConvert_v1alpha1_RoleRef_To_rbac_RoleRef(in *rbacv1alpha1.RoleRef, out *rbac.RoleRef, s conversion.Scope) error {
-	out.APIGroup = in.APIGroup
-	out.Kind = in.Kind
-	out.Name = in.Name
+	*out = *(*rbac.RoleRef)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -492,9 +481,7 @@ func Convert_v1alpha1_RoleRef_To_rbac_RoleRef(in *rbacv1alpha1.RoleRef, out *rba
 }
 
 func autoConvert_rbac_RoleRef_To_v1alpha1_RoleRef(in *rbac.RoleRef, out *rbacv1alpha1.RoleRef, s conversion.Scope) error {
-	out.APIGroup = in.APIGroup
-	out.Kind = in.Kind
-	out.Name = in.Name
+	*out = *(*rbacv1alpha1.RoleRef)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/rbac/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/rbac/v1beta1/zz_generated.conversion.go
@@ -25,7 +25,6 @@ import (
 	unsafe "unsafe"
 
 	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	rbac "k8s.io/kubernetes/pkg/apis/rbac"
@@ -162,7 +161,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1beta1_AggregationRule_To_rbac_AggregationRule(in *rbacv1beta1.AggregationRule, out *rbac.AggregationRule, s conversion.Scope) error {
-	out.ClusterRoleSelectors = *(*[]v1.LabelSelector)(unsafe.Pointer(&in.ClusterRoleSelectors))
+	*out = *(*rbac.AggregationRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -172,7 +171,7 @@ func Convert_v1beta1_AggregationRule_To_rbac_AggregationRule(in *rbacv1beta1.Agg
 }
 
 func autoConvert_rbac_AggregationRule_To_v1beta1_AggregationRule(in *rbac.AggregationRule, out *rbacv1beta1.AggregationRule, s conversion.Scope) error {
-	out.ClusterRoleSelectors = *(*[]v1.LabelSelector)(unsafe.Pointer(&in.ClusterRoleSelectors))
+	*out = *(*rbacv1beta1.AggregationRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -278,11 +277,7 @@ func Convert_rbac_ClusterRoleList_To_v1beta1_ClusterRoleList(in *rbac.ClusterRol
 }
 
 func autoConvert_v1beta1_PolicyRule_To_rbac_PolicyRule(in *rbacv1beta1.PolicyRule, out *rbac.PolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
-	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
-	out.ResourceNames = *(*[]string)(unsafe.Pointer(&in.ResourceNames))
-	out.NonResourceURLs = *(*[]string)(unsafe.Pointer(&in.NonResourceURLs))
+	*out = *(*rbac.PolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -292,11 +287,7 @@ func Convert_v1beta1_PolicyRule_To_rbac_PolicyRule(in *rbacv1beta1.PolicyRule, o
 }
 
 func autoConvert_rbac_PolicyRule_To_v1beta1_PolicyRule(in *rbac.PolicyRule, out *rbacv1beta1.PolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
-	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
-	out.ResourceNames = *(*[]string)(unsafe.Pointer(&in.ResourceNames))
-	out.NonResourceURLs = *(*[]string)(unsafe.Pointer(&in.NonResourceURLs))
+	*out = *(*rbacv1beta1.PolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -400,9 +391,7 @@ func Convert_rbac_RoleList_To_v1beta1_RoleList(in *rbac.RoleList, out *rbacv1bet
 }
 
 func autoConvert_v1beta1_RoleRef_To_rbac_RoleRef(in *rbacv1beta1.RoleRef, out *rbac.RoleRef, s conversion.Scope) error {
-	out.APIGroup = in.APIGroup
-	out.Kind = in.Kind
-	out.Name = in.Name
+	*out = *(*rbac.RoleRef)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -412,9 +401,7 @@ func Convert_v1beta1_RoleRef_To_rbac_RoleRef(in *rbacv1beta1.RoleRef, out *rbac.
 }
 
 func autoConvert_rbac_RoleRef_To_v1beta1_RoleRef(in *rbac.RoleRef, out *rbacv1beta1.RoleRef, s conversion.Scope) error {
-	out.APIGroup = in.APIGroup
-	out.Kind = in.Kind
-	out.Name = in.Name
+	*out = *(*rbacv1beta1.RoleRef)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -424,10 +411,7 @@ func Convert_rbac_RoleRef_To_v1beta1_RoleRef(in *rbac.RoleRef, out *rbacv1beta1.
 }
 
 func autoConvert_v1beta1_Subject_To_rbac_Subject(in *rbacv1beta1.Subject, out *rbac.Subject, s conversion.Scope) error {
-	out.Kind = in.Kind
-	out.APIGroup = in.APIGroup
-	out.Name = in.Name
-	out.Namespace = in.Namespace
+	*out = *(*rbac.Subject)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -437,10 +421,7 @@ func Convert_v1beta1_Subject_To_rbac_Subject(in *rbacv1beta1.Subject, out *rbac.
 }
 
 func autoConvert_rbac_Subject_To_v1beta1_Subject(in *rbac.Subject, out *rbacv1beta1.Subject, s conversion.Scope) error {
-	out.Kind = in.Kind
-	out.APIGroup = in.APIGroup
-	out.Name = in.Name
-	out.Namespace = in.Namespace
+	*out = *(*rbacv1beta1.Subject)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/resource/v1/zz_generated.conversion.go
+++ b/pkg/apis/resource/v1/zz_generated.conversion.go
@@ -24,14 +24,9 @@ package v1
 import (
 	unsafe "unsafe"
 
-	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
-	apiresource "k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	types "k8s.io/apimachinery/pkg/types"
-	core "k8s.io/kubernetes/pkg/apis/core"
 	resource "k8s.io/kubernetes/pkg/apis/resource"
 )
 
@@ -486,13 +481,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1_AllocatedDeviceStatus_To_resource_AllocatedDeviceStatus(in *resourcev1.AllocatedDeviceStatus, out *resource.AllocatedDeviceStatus, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.Pool = in.Pool
-	out.Device = in.Device
-	out.ShareID = (*string)(unsafe.Pointer(in.ShareID))
-	out.Conditions = *(*[]metav1.Condition)(unsafe.Pointer(&in.Conditions))
-	out.Data = (*runtime.RawExtension)(unsafe.Pointer(in.Data))
-	out.NetworkData = (*resource.NetworkDeviceData)(unsafe.Pointer(in.NetworkData))
+	*out = *(*resource.AllocatedDeviceStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -502,13 +491,7 @@ func Convert_v1_AllocatedDeviceStatus_To_resource_AllocatedDeviceStatus(in *reso
 }
 
 func autoConvert_resource_AllocatedDeviceStatus_To_v1_AllocatedDeviceStatus(in *resource.AllocatedDeviceStatus, out *resourcev1.AllocatedDeviceStatus, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.Pool = in.Pool
-	out.Device = in.Device
-	out.ShareID = (*string)(unsafe.Pointer(in.ShareID))
-	out.Conditions = *(*[]metav1.Condition)(unsafe.Pointer(&in.Conditions))
-	out.Data = (*runtime.RawExtension)(unsafe.Pointer(in.Data))
-	out.NetworkData = (*resourcev1.NetworkDeviceData)(unsafe.Pointer(in.NetworkData))
+	*out = *(*resourcev1.AllocatedDeviceStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -518,11 +501,7 @@ func Convert_resource_AllocatedDeviceStatus_To_v1_AllocatedDeviceStatus(in *reso
 }
 
 func autoConvert_v1_AllocationResult_To_resource_AllocationResult(in *resourcev1.AllocationResult, out *resource.AllocationResult, s conversion.Scope) error {
-	if err := Convert_v1_DeviceAllocationResult_To_resource_DeviceAllocationResult(&in.Devices, &out.Devices, s); err != nil {
-		return err
-	}
-	out.NodeSelector = (*core.NodeSelector)(unsafe.Pointer(in.NodeSelector))
-	out.AllocationTimestamp = (*metav1.Time)(unsafe.Pointer(in.AllocationTimestamp))
+	*out = *(*resource.AllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -532,11 +511,7 @@ func Convert_v1_AllocationResult_To_resource_AllocationResult(in *resourcev1.All
 }
 
 func autoConvert_resource_AllocationResult_To_v1_AllocationResult(in *resource.AllocationResult, out *resourcev1.AllocationResult, s conversion.Scope) error {
-	if err := Convert_resource_DeviceAllocationResult_To_v1_DeviceAllocationResult(&in.Devices, &out.Devices, s); err != nil {
-		return err
-	}
-	out.NodeSelector = (*corev1.NodeSelector)(unsafe.Pointer(in.NodeSelector))
-	out.AllocationTimestamp = (*metav1.Time)(unsafe.Pointer(in.AllocationTimestamp))
+	*out = *(*resourcev1.AllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -546,7 +521,7 @@ func Convert_resource_AllocationResult_To_v1_AllocationResult(in *resource.Alloc
 }
 
 func autoConvert_v1_CELDeviceSelector_To_resource_CELDeviceSelector(in *resourcev1.CELDeviceSelector, out *resource.CELDeviceSelector, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*resource.CELDeviceSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -556,7 +531,7 @@ func Convert_v1_CELDeviceSelector_To_resource_CELDeviceSelector(in *resourcev1.C
 }
 
 func autoConvert_resource_CELDeviceSelector_To_v1_CELDeviceSelector(in *resource.CELDeviceSelector, out *resourcev1.CELDeviceSelector, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*resourcev1.CELDeviceSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -566,9 +541,7 @@ func Convert_resource_CELDeviceSelector_To_v1_CELDeviceSelector(in *resource.CEL
 }
 
 func autoConvert_v1_CapacityRequestPolicy_To_resource_CapacityRequestPolicy(in *resourcev1.CapacityRequestPolicy, out *resource.CapacityRequestPolicy, s conversion.Scope) error {
-	out.Default = (*apiresource.Quantity)(unsafe.Pointer(in.Default))
-	out.ValidValues = *(*[]apiresource.Quantity)(unsafe.Pointer(&in.ValidValues))
-	out.ValidRange = (*resource.CapacityRequestPolicyRange)(unsafe.Pointer(in.ValidRange))
+	*out = *(*resource.CapacityRequestPolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -578,9 +551,7 @@ func Convert_v1_CapacityRequestPolicy_To_resource_CapacityRequestPolicy(in *reso
 }
 
 func autoConvert_resource_CapacityRequestPolicy_To_v1_CapacityRequestPolicy(in *resource.CapacityRequestPolicy, out *resourcev1.CapacityRequestPolicy, s conversion.Scope) error {
-	out.Default = (*apiresource.Quantity)(unsafe.Pointer(in.Default))
-	out.ValidValues = *(*[]apiresource.Quantity)(unsafe.Pointer(&in.ValidValues))
-	out.ValidRange = (*resourcev1.CapacityRequestPolicyRange)(unsafe.Pointer(in.ValidRange))
+	*out = *(*resourcev1.CapacityRequestPolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -590,9 +561,7 @@ func Convert_resource_CapacityRequestPolicy_To_v1_CapacityRequestPolicy(in *reso
 }
 
 func autoConvert_v1_CapacityRequestPolicyRange_To_resource_CapacityRequestPolicyRange(in *resourcev1.CapacityRequestPolicyRange, out *resource.CapacityRequestPolicyRange, s conversion.Scope) error {
-	out.Min = (*apiresource.Quantity)(unsafe.Pointer(in.Min))
-	out.Max = (*apiresource.Quantity)(unsafe.Pointer(in.Max))
-	out.Step = (*apiresource.Quantity)(unsafe.Pointer(in.Step))
+	*out = *(*resource.CapacityRequestPolicyRange)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -602,9 +571,7 @@ func Convert_v1_CapacityRequestPolicyRange_To_resource_CapacityRequestPolicyRang
 }
 
 func autoConvert_resource_CapacityRequestPolicyRange_To_v1_CapacityRequestPolicyRange(in *resource.CapacityRequestPolicyRange, out *resourcev1.CapacityRequestPolicyRange, s conversion.Scope) error {
-	out.Min = (*apiresource.Quantity)(unsafe.Pointer(in.Min))
-	out.Max = (*apiresource.Quantity)(unsafe.Pointer(in.Max))
-	out.Step = (*apiresource.Quantity)(unsafe.Pointer(in.Step))
+	*out = *(*resourcev1.CapacityRequestPolicyRange)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -614,7 +581,7 @@ func Convert_resource_CapacityRequestPolicyRange_To_v1_CapacityRequestPolicyRang
 }
 
 func autoConvert_v1_CapacityRequirements_To_resource_CapacityRequirements(in *resourcev1.CapacityRequirements, out *resource.CapacityRequirements, s conversion.Scope) error {
-	out.Requests = *(*map[resource.QualifiedName]apiresource.Quantity)(unsafe.Pointer(&in.Requests))
+	*out = *(*resource.CapacityRequirements)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -624,7 +591,7 @@ func Convert_v1_CapacityRequirements_To_resource_CapacityRequirements(in *resour
 }
 
 func autoConvert_resource_CapacityRequirements_To_v1_CapacityRequirements(in *resource.CapacityRequirements, out *resourcev1.CapacityRequirements, s conversion.Scope) error {
-	out.Requests = *(*map[resourcev1.QualifiedName]apiresource.Quantity)(unsafe.Pointer(&in.Requests))
+	*out = *(*resourcev1.CapacityRequirements)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -634,7 +601,7 @@ func Convert_resource_CapacityRequirements_To_v1_CapacityRequirements(in *resour
 }
 
 func autoConvert_v1_Counter_To_resource_Counter(in *resourcev1.Counter, out *resource.Counter, s conversion.Scope) error {
-	out.Value = in.Value
+	*out = *(*resource.Counter)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -644,7 +611,7 @@ func Convert_v1_Counter_To_resource_Counter(in *resourcev1.Counter, out *resourc
 }
 
 func autoConvert_resource_Counter_To_v1_Counter(in *resource.Counter, out *resourcev1.Counter, s conversion.Scope) error {
-	out.Value = in.Value
+	*out = *(*resourcev1.Counter)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -654,8 +621,7 @@ func Convert_resource_Counter_To_v1_Counter(in *resource.Counter, out *resourcev
 }
 
 func autoConvert_v1_CounterSet_To_resource_CounterSet(in *resourcev1.CounterSet, out *resource.CounterSet, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Counters = *(*map[string]resource.Counter)(unsafe.Pointer(&in.Counters))
+	*out = *(*resource.CounterSet)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -665,8 +631,7 @@ func Convert_v1_CounterSet_To_resource_CounterSet(in *resourcev1.CounterSet, out
 }
 
 func autoConvert_resource_CounterSet_To_v1_CounterSet(in *resource.CounterSet, out *resourcev1.CounterSet, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Counters = *(*map[string]resourcev1.Counter)(unsafe.Pointer(&in.Counters))
+	*out = *(*resourcev1.CounterSet)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -676,19 +641,7 @@ func Convert_resource_CounterSet_To_v1_CounterSet(in *resource.CounterSet, out *
 }
 
 func autoConvert_v1_Device_To_resource_Device(in *resourcev1.Device, out *resource.Device, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Attributes = *(*map[resource.QualifiedName]resource.DeviceAttribute)(unsafe.Pointer(&in.Attributes))
-	out.Capacity = *(*map[resource.QualifiedName]resource.DeviceCapacity)(unsafe.Pointer(&in.Capacity))
-	out.ConsumesCounters = *(*[]resource.DeviceCounterConsumption)(unsafe.Pointer(&in.ConsumesCounters))
-	out.NodeName = (*string)(unsafe.Pointer(in.NodeName))
-	out.NodeSelector = (*core.NodeSelector)(unsafe.Pointer(in.NodeSelector))
-	out.AllNodes = (*bool)(unsafe.Pointer(in.AllNodes))
-	out.Taints = *(*[]resource.DeviceTaint)(unsafe.Pointer(&in.Taints))
-	out.BindsToNode = (*bool)(unsafe.Pointer(in.BindsToNode))
-	out.BindingConditions = *(*[]string)(unsafe.Pointer(&in.BindingConditions))
-	out.BindingFailureConditions = *(*[]string)(unsafe.Pointer(&in.BindingFailureConditions))
-	out.AllowMultipleAllocations = (*bool)(unsafe.Pointer(in.AllowMultipleAllocations))
-	out.NodeAllocatableResourceMappings = *(*map[corev1.ResourceName]resource.NodeAllocatableResourceMapping)(unsafe.Pointer(&in.NodeAllocatableResourceMappings))
+	*out = *(*resource.Device)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -698,19 +651,7 @@ func Convert_v1_Device_To_resource_Device(in *resourcev1.Device, out *resource.D
 }
 
 func autoConvert_resource_Device_To_v1_Device(in *resource.Device, out *resourcev1.Device, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Attributes = *(*map[resourcev1.QualifiedName]resourcev1.DeviceAttribute)(unsafe.Pointer(&in.Attributes))
-	out.Capacity = *(*map[resourcev1.QualifiedName]resourcev1.DeviceCapacity)(unsafe.Pointer(&in.Capacity))
-	out.ConsumesCounters = *(*[]resourcev1.DeviceCounterConsumption)(unsafe.Pointer(&in.ConsumesCounters))
-	out.NodeName = (*string)(unsafe.Pointer(in.NodeName))
-	out.NodeSelector = (*corev1.NodeSelector)(unsafe.Pointer(in.NodeSelector))
-	out.AllNodes = (*bool)(unsafe.Pointer(in.AllNodes))
-	out.Taints = *(*[]resourcev1.DeviceTaint)(unsafe.Pointer(&in.Taints))
-	out.BindsToNode = (*bool)(unsafe.Pointer(in.BindsToNode))
-	out.BindingConditions = *(*[]string)(unsafe.Pointer(&in.BindingConditions))
-	out.BindingFailureConditions = *(*[]string)(unsafe.Pointer(&in.BindingFailureConditions))
-	out.AllowMultipleAllocations = (*bool)(unsafe.Pointer(in.AllowMultipleAllocations))
-	out.NodeAllocatableResourceMappings = *(*map[corev1.ResourceName]resourcev1.NodeAllocatableResourceMapping)(unsafe.Pointer(&in.NodeAllocatableResourceMappings))
+	*out = *(*resourcev1.Device)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -720,11 +661,7 @@ func Convert_resource_Device_To_v1_Device(in *resource.Device, out *resourcev1.D
 }
 
 func autoConvert_v1_DeviceAllocationConfiguration_To_resource_DeviceAllocationConfiguration(in *resourcev1.DeviceAllocationConfiguration, out *resource.DeviceAllocationConfiguration, s conversion.Scope) error {
-	out.Source = resource.AllocationConfigSource(in.Source)
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	if err := Convert_v1_DeviceConfiguration_To_resource_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*resource.DeviceAllocationConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -734,11 +671,7 @@ func Convert_v1_DeviceAllocationConfiguration_To_resource_DeviceAllocationConfig
 }
 
 func autoConvert_resource_DeviceAllocationConfiguration_To_v1_DeviceAllocationConfiguration(in *resource.DeviceAllocationConfiguration, out *resourcev1.DeviceAllocationConfiguration, s conversion.Scope) error {
-	out.Source = resourcev1.AllocationConfigSource(in.Source)
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	if err := Convert_resource_DeviceConfiguration_To_v1_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*resourcev1.DeviceAllocationConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -748,8 +681,7 @@ func Convert_resource_DeviceAllocationConfiguration_To_v1_DeviceAllocationConfig
 }
 
 func autoConvert_v1_DeviceAllocationResult_To_resource_DeviceAllocationResult(in *resourcev1.DeviceAllocationResult, out *resource.DeviceAllocationResult, s conversion.Scope) error {
-	out.Results = *(*[]resource.DeviceRequestAllocationResult)(unsafe.Pointer(&in.Results))
-	out.Config = *(*[]resource.DeviceAllocationConfiguration)(unsafe.Pointer(&in.Config))
+	*out = *(*resource.DeviceAllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -759,8 +691,7 @@ func Convert_v1_DeviceAllocationResult_To_resource_DeviceAllocationResult(in *re
 }
 
 func autoConvert_resource_DeviceAllocationResult_To_v1_DeviceAllocationResult(in *resource.DeviceAllocationResult, out *resourcev1.DeviceAllocationResult, s conversion.Scope) error {
-	out.Results = *(*[]resourcev1.DeviceRequestAllocationResult)(unsafe.Pointer(&in.Results))
-	out.Config = *(*[]resourcev1.DeviceAllocationConfiguration)(unsafe.Pointer(&in.Config))
+	*out = *(*resourcev1.DeviceAllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -770,14 +701,7 @@ func Convert_resource_DeviceAllocationResult_To_v1_DeviceAllocationResult(in *re
 }
 
 func autoConvert_v1_DeviceAttribute_To_resource_DeviceAttribute(in *resourcev1.DeviceAttribute, out *resource.DeviceAttribute, s conversion.Scope) error {
-	out.IntValue = (*int64)(unsafe.Pointer(in.IntValue))
-	out.BoolValue = (*bool)(unsafe.Pointer(in.BoolValue))
-	out.StringValue = (*string)(unsafe.Pointer(in.StringValue))
-	out.VersionValue = (*string)(unsafe.Pointer(in.VersionValue))
-	out.IntValues = *(*[]int64)(unsafe.Pointer(&in.IntValues))
-	out.BoolValues = *(*[]bool)(unsafe.Pointer(&in.BoolValues))
-	out.StringValues = *(*[]string)(unsafe.Pointer(&in.StringValues))
-	out.VersionValues = *(*[]string)(unsafe.Pointer(&in.VersionValues))
+	*out = *(*resource.DeviceAttribute)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -787,14 +711,7 @@ func Convert_v1_DeviceAttribute_To_resource_DeviceAttribute(in *resourcev1.Devic
 }
 
 func autoConvert_resource_DeviceAttribute_To_v1_DeviceAttribute(in *resource.DeviceAttribute, out *resourcev1.DeviceAttribute, s conversion.Scope) error {
-	out.IntValue = (*int64)(unsafe.Pointer(in.IntValue))
-	out.BoolValue = (*bool)(unsafe.Pointer(in.BoolValue))
-	out.StringValue = (*string)(unsafe.Pointer(in.StringValue))
-	out.VersionValue = (*string)(unsafe.Pointer(in.VersionValue))
-	out.IntValues = *(*[]int64)(unsafe.Pointer(&in.IntValues))
-	out.BoolValues = *(*[]bool)(unsafe.Pointer(&in.BoolValues))
-	out.StringValues = *(*[]string)(unsafe.Pointer(&in.StringValues))
-	out.VersionValues = *(*[]string)(unsafe.Pointer(&in.VersionValues))
+	*out = *(*resourcev1.DeviceAttribute)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -804,8 +721,7 @@ func Convert_resource_DeviceAttribute_To_v1_DeviceAttribute(in *resource.DeviceA
 }
 
 func autoConvert_v1_DeviceCapacity_To_resource_DeviceCapacity(in *resourcev1.DeviceCapacity, out *resource.DeviceCapacity, s conversion.Scope) error {
-	out.Value = in.Value
-	out.RequestPolicy = (*resource.CapacityRequestPolicy)(unsafe.Pointer(in.RequestPolicy))
+	*out = *(*resource.DeviceCapacity)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -815,8 +731,7 @@ func Convert_v1_DeviceCapacity_To_resource_DeviceCapacity(in *resourcev1.DeviceC
 }
 
 func autoConvert_resource_DeviceCapacity_To_v1_DeviceCapacity(in *resource.DeviceCapacity, out *resourcev1.DeviceCapacity, s conversion.Scope) error {
-	out.Value = in.Value
-	out.RequestPolicy = (*resourcev1.CapacityRequestPolicy)(unsafe.Pointer(in.RequestPolicy))
+	*out = *(*resourcev1.DeviceCapacity)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -826,9 +741,7 @@ func Convert_resource_DeviceCapacity_To_v1_DeviceCapacity(in *resource.DeviceCap
 }
 
 func autoConvert_v1_DeviceClaim_To_resource_DeviceClaim(in *resourcev1.DeviceClaim, out *resource.DeviceClaim, s conversion.Scope) error {
-	out.Requests = *(*[]resource.DeviceRequest)(unsafe.Pointer(&in.Requests))
-	out.Constraints = *(*[]resource.DeviceConstraint)(unsafe.Pointer(&in.Constraints))
-	out.Config = *(*[]resource.DeviceClaimConfiguration)(unsafe.Pointer(&in.Config))
+	*out = *(*resource.DeviceClaim)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -838,9 +751,7 @@ func Convert_v1_DeviceClaim_To_resource_DeviceClaim(in *resourcev1.DeviceClaim, 
 }
 
 func autoConvert_resource_DeviceClaim_To_v1_DeviceClaim(in *resource.DeviceClaim, out *resourcev1.DeviceClaim, s conversion.Scope) error {
-	out.Requests = *(*[]resourcev1.DeviceRequest)(unsafe.Pointer(&in.Requests))
-	out.Constraints = *(*[]resourcev1.DeviceConstraint)(unsafe.Pointer(&in.Constraints))
-	out.Config = *(*[]resourcev1.DeviceClaimConfiguration)(unsafe.Pointer(&in.Config))
+	*out = *(*resourcev1.DeviceClaim)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -850,10 +761,7 @@ func Convert_resource_DeviceClaim_To_v1_DeviceClaim(in *resource.DeviceClaim, ou
 }
 
 func autoConvert_v1_DeviceClaimConfiguration_To_resource_DeviceClaimConfiguration(in *resourcev1.DeviceClaimConfiguration, out *resource.DeviceClaimConfiguration, s conversion.Scope) error {
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	if err := Convert_v1_DeviceConfiguration_To_resource_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*resource.DeviceClaimConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -863,10 +771,7 @@ func Convert_v1_DeviceClaimConfiguration_To_resource_DeviceClaimConfiguration(in
 }
 
 func autoConvert_resource_DeviceClaimConfiguration_To_v1_DeviceClaimConfiguration(in *resource.DeviceClaimConfiguration, out *resourcev1.DeviceClaimConfiguration, s conversion.Scope) error {
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	if err := Convert_resource_DeviceConfiguration_To_v1_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*resourcev1.DeviceClaimConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -902,9 +807,7 @@ func Convert_resource_DeviceClass_To_v1_DeviceClass(in *resource.DeviceClass, ou
 }
 
 func autoConvert_v1_DeviceClassConfiguration_To_resource_DeviceClassConfiguration(in *resourcev1.DeviceClassConfiguration, out *resource.DeviceClassConfiguration, s conversion.Scope) error {
-	if err := Convert_v1_DeviceConfiguration_To_resource_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*resource.DeviceClassConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -914,9 +817,7 @@ func Convert_v1_DeviceClassConfiguration_To_resource_DeviceClassConfiguration(in
 }
 
 func autoConvert_resource_DeviceClassConfiguration_To_v1_DeviceClassConfiguration(in *resource.DeviceClassConfiguration, out *resourcev1.DeviceClassConfiguration, s conversion.Scope) error {
-	if err := Convert_resource_DeviceConfiguration_To_v1_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*resourcev1.DeviceClassConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -948,9 +849,7 @@ func Convert_resource_DeviceClassList_To_v1_DeviceClassList(in *resource.DeviceC
 }
 
 func autoConvert_v1_DeviceClassSpec_To_resource_DeviceClassSpec(in *resourcev1.DeviceClassSpec, out *resource.DeviceClassSpec, s conversion.Scope) error {
-	out.Selectors = *(*[]resource.DeviceSelector)(unsafe.Pointer(&in.Selectors))
-	out.Config = *(*[]resource.DeviceClassConfiguration)(unsafe.Pointer(&in.Config))
-	out.ExtendedResourceName = (*string)(unsafe.Pointer(in.ExtendedResourceName))
+	*out = *(*resource.DeviceClassSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -960,9 +859,7 @@ func Convert_v1_DeviceClassSpec_To_resource_DeviceClassSpec(in *resourcev1.Devic
 }
 
 func autoConvert_resource_DeviceClassSpec_To_v1_DeviceClassSpec(in *resource.DeviceClassSpec, out *resourcev1.DeviceClassSpec, s conversion.Scope) error {
-	out.Selectors = *(*[]resourcev1.DeviceSelector)(unsafe.Pointer(&in.Selectors))
-	out.Config = *(*[]resourcev1.DeviceClassConfiguration)(unsafe.Pointer(&in.Config))
-	out.ExtendedResourceName = (*string)(unsafe.Pointer(in.ExtendedResourceName))
+	*out = *(*resourcev1.DeviceClassSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -972,7 +869,7 @@ func Convert_resource_DeviceClassSpec_To_v1_DeviceClassSpec(in *resource.DeviceC
 }
 
 func autoConvert_v1_DeviceConfiguration_To_resource_DeviceConfiguration(in *resourcev1.DeviceConfiguration, out *resource.DeviceConfiguration, s conversion.Scope) error {
-	out.Opaque = (*resource.OpaqueDeviceConfiguration)(unsafe.Pointer(in.Opaque))
+	*out = *(*resource.DeviceConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -982,7 +879,7 @@ func Convert_v1_DeviceConfiguration_To_resource_DeviceConfiguration(in *resource
 }
 
 func autoConvert_resource_DeviceConfiguration_To_v1_DeviceConfiguration(in *resource.DeviceConfiguration, out *resourcev1.DeviceConfiguration, s conversion.Scope) error {
-	out.Opaque = (*resourcev1.OpaqueDeviceConfiguration)(unsafe.Pointer(in.Opaque))
+	*out = *(*resourcev1.DeviceConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -992,9 +889,7 @@ func Convert_resource_DeviceConfiguration_To_v1_DeviceConfiguration(in *resource
 }
 
 func autoConvert_v1_DeviceConstraint_To_resource_DeviceConstraint(in *resourcev1.DeviceConstraint, out *resource.DeviceConstraint, s conversion.Scope) error {
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	out.MatchAttribute = (*resource.FullyQualifiedName)(unsafe.Pointer(in.MatchAttribute))
-	out.DistinctAttribute = (*resource.FullyQualifiedName)(unsafe.Pointer(in.DistinctAttribute))
+	*out = *(*resource.DeviceConstraint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1004,9 +899,7 @@ func Convert_v1_DeviceConstraint_To_resource_DeviceConstraint(in *resourcev1.Dev
 }
 
 func autoConvert_resource_DeviceConstraint_To_v1_DeviceConstraint(in *resource.DeviceConstraint, out *resourcev1.DeviceConstraint, s conversion.Scope) error {
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	out.MatchAttribute = (*resourcev1.FullyQualifiedName)(unsafe.Pointer(in.MatchAttribute))
-	out.DistinctAttribute = (*resourcev1.FullyQualifiedName)(unsafe.Pointer(in.DistinctAttribute))
+	*out = *(*resourcev1.DeviceConstraint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1016,8 +909,7 @@ func Convert_resource_DeviceConstraint_To_v1_DeviceConstraint(in *resource.Devic
 }
 
 func autoConvert_v1_DeviceCounterConsumption_To_resource_DeviceCounterConsumption(in *resourcev1.DeviceCounterConsumption, out *resource.DeviceCounterConsumption, s conversion.Scope) error {
-	out.CounterSet = in.CounterSet
-	out.Counters = *(*map[string]resource.Counter)(unsafe.Pointer(&in.Counters))
+	*out = *(*resource.DeviceCounterConsumption)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1027,8 +919,7 @@ func Convert_v1_DeviceCounterConsumption_To_resource_DeviceCounterConsumption(in
 }
 
 func autoConvert_resource_DeviceCounterConsumption_To_v1_DeviceCounterConsumption(in *resource.DeviceCounterConsumption, out *resourcev1.DeviceCounterConsumption, s conversion.Scope) error {
-	out.CounterSet = in.CounterSet
-	out.Counters = *(*map[string]resourcev1.Counter)(unsafe.Pointer(&in.Counters))
+	*out = *(*resourcev1.DeviceCounterConsumption)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1038,9 +929,7 @@ func Convert_resource_DeviceCounterConsumption_To_v1_DeviceCounterConsumption(in
 }
 
 func autoConvert_v1_DeviceRequest_To_resource_DeviceRequest(in *resourcev1.DeviceRequest, out *resource.DeviceRequest, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Exactly = (*resource.ExactDeviceRequest)(unsafe.Pointer(in.Exactly))
-	out.FirstAvailable = *(*[]resource.DeviceSubRequest)(unsafe.Pointer(&in.FirstAvailable))
+	*out = *(*resource.DeviceRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1050,9 +939,7 @@ func Convert_v1_DeviceRequest_To_resource_DeviceRequest(in *resourcev1.DeviceReq
 }
 
 func autoConvert_resource_DeviceRequest_To_v1_DeviceRequest(in *resource.DeviceRequest, out *resourcev1.DeviceRequest, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Exactly = (*resourcev1.ExactDeviceRequest)(unsafe.Pointer(in.Exactly))
-	out.FirstAvailable = *(*[]resourcev1.DeviceSubRequest)(unsafe.Pointer(&in.FirstAvailable))
+	*out = *(*resourcev1.DeviceRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1062,16 +949,7 @@ func Convert_resource_DeviceRequest_To_v1_DeviceRequest(in *resource.DeviceReque
 }
 
 func autoConvert_v1_DeviceRequestAllocationResult_To_resource_DeviceRequestAllocationResult(in *resourcev1.DeviceRequestAllocationResult, out *resource.DeviceRequestAllocationResult, s conversion.Scope) error {
-	out.Request = in.Request
-	out.Driver = in.Driver
-	out.Pool = in.Pool
-	out.Device = in.Device
-	out.AdminAccess = (*bool)(unsafe.Pointer(in.AdminAccess))
-	out.Tolerations = *(*[]resource.DeviceToleration)(unsafe.Pointer(&in.Tolerations))
-	out.BindingConditions = *(*[]string)(unsafe.Pointer(&in.BindingConditions))
-	out.BindingFailureConditions = *(*[]string)(unsafe.Pointer(&in.BindingFailureConditions))
-	out.ShareID = (*types.UID)(unsafe.Pointer(in.ShareID))
-	out.ConsumedCapacity = *(*map[resource.QualifiedName]apiresource.Quantity)(unsafe.Pointer(&in.ConsumedCapacity))
+	*out = *(*resource.DeviceRequestAllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1081,16 +959,7 @@ func Convert_v1_DeviceRequestAllocationResult_To_resource_DeviceRequestAllocatio
 }
 
 func autoConvert_resource_DeviceRequestAllocationResult_To_v1_DeviceRequestAllocationResult(in *resource.DeviceRequestAllocationResult, out *resourcev1.DeviceRequestAllocationResult, s conversion.Scope) error {
-	out.Request = in.Request
-	out.Driver = in.Driver
-	out.Pool = in.Pool
-	out.Device = in.Device
-	out.AdminAccess = (*bool)(unsafe.Pointer(in.AdminAccess))
-	out.Tolerations = *(*[]resourcev1.DeviceToleration)(unsafe.Pointer(&in.Tolerations))
-	out.BindingConditions = *(*[]string)(unsafe.Pointer(&in.BindingConditions))
-	out.BindingFailureConditions = *(*[]string)(unsafe.Pointer(&in.BindingFailureConditions))
-	out.ShareID = (*types.UID)(unsafe.Pointer(in.ShareID))
-	out.ConsumedCapacity = *(*map[resourcev1.QualifiedName]apiresource.Quantity)(unsafe.Pointer(&in.ConsumedCapacity))
+	*out = *(*resourcev1.DeviceRequestAllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1100,7 +969,7 @@ func Convert_resource_DeviceRequestAllocationResult_To_v1_DeviceRequestAllocatio
 }
 
 func autoConvert_v1_DeviceSelector_To_resource_DeviceSelector(in *resourcev1.DeviceSelector, out *resource.DeviceSelector, s conversion.Scope) error {
-	out.CEL = (*resource.CELDeviceSelector)(unsafe.Pointer(in.CEL))
+	*out = *(*resource.DeviceSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1110,7 +979,7 @@ func Convert_v1_DeviceSelector_To_resource_DeviceSelector(in *resourcev1.DeviceS
 }
 
 func autoConvert_resource_DeviceSelector_To_v1_DeviceSelector(in *resource.DeviceSelector, out *resourcev1.DeviceSelector, s conversion.Scope) error {
-	out.CEL = (*resourcev1.CELDeviceSelector)(unsafe.Pointer(in.CEL))
+	*out = *(*resourcev1.DeviceSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1120,13 +989,7 @@ func Convert_resource_DeviceSelector_To_v1_DeviceSelector(in *resource.DeviceSel
 }
 
 func autoConvert_v1_DeviceSubRequest_To_resource_DeviceSubRequest(in *resourcev1.DeviceSubRequest, out *resource.DeviceSubRequest, s conversion.Scope) error {
-	out.Name = in.Name
-	out.DeviceClassName = in.DeviceClassName
-	out.Selectors = *(*[]resource.DeviceSelector)(unsafe.Pointer(&in.Selectors))
-	out.AllocationMode = resource.DeviceAllocationMode(in.AllocationMode)
-	out.Count = in.Count
-	out.Tolerations = *(*[]resource.DeviceToleration)(unsafe.Pointer(&in.Tolerations))
-	out.Capacity = (*resource.CapacityRequirements)(unsafe.Pointer(in.Capacity))
+	*out = *(*resource.DeviceSubRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1136,13 +999,7 @@ func Convert_v1_DeviceSubRequest_To_resource_DeviceSubRequest(in *resourcev1.Dev
 }
 
 func autoConvert_resource_DeviceSubRequest_To_v1_DeviceSubRequest(in *resource.DeviceSubRequest, out *resourcev1.DeviceSubRequest, s conversion.Scope) error {
-	out.Name = in.Name
-	out.DeviceClassName = in.DeviceClassName
-	out.Selectors = *(*[]resourcev1.DeviceSelector)(unsafe.Pointer(&in.Selectors))
-	out.AllocationMode = resourcev1.DeviceAllocationMode(in.AllocationMode)
-	out.Count = in.Count
-	out.Tolerations = *(*[]resourcev1.DeviceToleration)(unsafe.Pointer(&in.Tolerations))
-	out.Capacity = (*resourcev1.CapacityRequirements)(unsafe.Pointer(in.Capacity))
+	*out = *(*resourcev1.DeviceSubRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1152,10 +1009,7 @@ func Convert_resource_DeviceSubRequest_To_v1_DeviceSubRequest(in *resource.Devic
 }
 
 func autoConvert_v1_DeviceTaint_To_resource_DeviceTaint(in *resourcev1.DeviceTaint, out *resource.DeviceTaint, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Value = in.Value
-	out.Effect = resource.DeviceTaintEffect(in.Effect)
-	out.TimeAdded = (*metav1.Time)(unsafe.Pointer(in.TimeAdded))
+	*out = *(*resource.DeviceTaint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1165,10 +1019,7 @@ func Convert_v1_DeviceTaint_To_resource_DeviceTaint(in *resourcev1.DeviceTaint, 
 }
 
 func autoConvert_resource_DeviceTaint_To_v1_DeviceTaint(in *resource.DeviceTaint, out *resourcev1.DeviceTaint, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Value = in.Value
-	out.Effect = resourcev1.DeviceTaintEffect(in.Effect)
-	out.TimeAdded = (*metav1.Time)(unsafe.Pointer(in.TimeAdded))
+	*out = *(*resourcev1.DeviceTaint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1178,11 +1029,7 @@ func Convert_resource_DeviceTaint_To_v1_DeviceTaint(in *resource.DeviceTaint, ou
 }
 
 func autoConvert_v1_DeviceToleration_To_resource_DeviceToleration(in *resourcev1.DeviceToleration, out *resource.DeviceToleration, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Operator = resource.DeviceTolerationOperator(in.Operator)
-	out.Value = in.Value
-	out.Effect = resource.DeviceTaintEffect(in.Effect)
-	out.TolerationSeconds = (*int64)(unsafe.Pointer(in.TolerationSeconds))
+	*out = *(*resource.DeviceToleration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1192,11 +1039,7 @@ func Convert_v1_DeviceToleration_To_resource_DeviceToleration(in *resourcev1.Dev
 }
 
 func autoConvert_resource_DeviceToleration_To_v1_DeviceToleration(in *resource.DeviceToleration, out *resourcev1.DeviceToleration, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Operator = resourcev1.DeviceTolerationOperator(in.Operator)
-	out.Value = in.Value
-	out.Effect = resourcev1.DeviceTaintEffect(in.Effect)
-	out.TolerationSeconds = (*int64)(unsafe.Pointer(in.TolerationSeconds))
+	*out = *(*resourcev1.DeviceToleration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1206,13 +1049,7 @@ func Convert_resource_DeviceToleration_To_v1_DeviceToleration(in *resource.Devic
 }
 
 func autoConvert_v1_ExactDeviceRequest_To_resource_ExactDeviceRequest(in *resourcev1.ExactDeviceRequest, out *resource.ExactDeviceRequest, s conversion.Scope) error {
-	out.DeviceClassName = in.DeviceClassName
-	out.Selectors = *(*[]resource.DeviceSelector)(unsafe.Pointer(&in.Selectors))
-	out.AllocationMode = resource.DeviceAllocationMode(in.AllocationMode)
-	out.Count = in.Count
-	out.AdminAccess = (*bool)(unsafe.Pointer(in.AdminAccess))
-	out.Tolerations = *(*[]resource.DeviceToleration)(unsafe.Pointer(&in.Tolerations))
-	out.Capacity = (*resource.CapacityRequirements)(unsafe.Pointer(in.Capacity))
+	*out = *(*resource.ExactDeviceRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1222,13 +1059,7 @@ func Convert_v1_ExactDeviceRequest_To_resource_ExactDeviceRequest(in *resourcev1
 }
 
 func autoConvert_resource_ExactDeviceRequest_To_v1_ExactDeviceRequest(in *resource.ExactDeviceRequest, out *resourcev1.ExactDeviceRequest, s conversion.Scope) error {
-	out.DeviceClassName = in.DeviceClassName
-	out.Selectors = *(*[]resourcev1.DeviceSelector)(unsafe.Pointer(&in.Selectors))
-	out.AllocationMode = resourcev1.DeviceAllocationMode(in.AllocationMode)
-	out.Count = in.Count
-	out.AdminAccess = (*bool)(unsafe.Pointer(in.AdminAccess))
-	out.Tolerations = *(*[]resourcev1.DeviceToleration)(unsafe.Pointer(&in.Tolerations))
-	out.Capacity = (*resourcev1.CapacityRequirements)(unsafe.Pointer(in.Capacity))
+	*out = *(*resourcev1.ExactDeviceRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1238,9 +1069,7 @@ func Convert_resource_ExactDeviceRequest_To_v1_ExactDeviceRequest(in *resource.E
 }
 
 func autoConvert_v1_NetworkDeviceData_To_resource_NetworkDeviceData(in *resourcev1.NetworkDeviceData, out *resource.NetworkDeviceData, s conversion.Scope) error {
-	out.InterfaceName = in.InterfaceName
-	out.IPs = *(*[]string)(unsafe.Pointer(&in.IPs))
-	out.HardwareAddress = in.HardwareAddress
+	*out = *(*resource.NetworkDeviceData)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1250,9 +1079,7 @@ func Convert_v1_NetworkDeviceData_To_resource_NetworkDeviceData(in *resourcev1.N
 }
 
 func autoConvert_resource_NetworkDeviceData_To_v1_NetworkDeviceData(in *resource.NetworkDeviceData, out *resourcev1.NetworkDeviceData, s conversion.Scope) error {
-	out.InterfaceName = in.InterfaceName
-	out.IPs = *(*[]string)(unsafe.Pointer(&in.IPs))
-	out.HardwareAddress = in.HardwareAddress
+	*out = *(*resourcev1.NetworkDeviceData)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1262,8 +1089,7 @@ func Convert_resource_NetworkDeviceData_To_v1_NetworkDeviceData(in *resource.Net
 }
 
 func autoConvert_v1_NodeAllocatableResourceMapping_To_resource_NodeAllocatableResourceMapping(in *resourcev1.NodeAllocatableResourceMapping, out *resource.NodeAllocatableResourceMapping, s conversion.Scope) error {
-	out.CapacityKey = (*resource.QualifiedName)(unsafe.Pointer(in.CapacityKey))
-	out.AllocationMultiplier = (*apiresource.Quantity)(unsafe.Pointer(in.AllocationMultiplier))
+	*out = *(*resource.NodeAllocatableResourceMapping)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1273,8 +1099,7 @@ func Convert_v1_NodeAllocatableResourceMapping_To_resource_NodeAllocatableResour
 }
 
 func autoConvert_resource_NodeAllocatableResourceMapping_To_v1_NodeAllocatableResourceMapping(in *resource.NodeAllocatableResourceMapping, out *resourcev1.NodeAllocatableResourceMapping, s conversion.Scope) error {
-	out.CapacityKey = (*resourcev1.QualifiedName)(unsafe.Pointer(in.CapacityKey))
-	out.AllocationMultiplier = (*apiresource.Quantity)(unsafe.Pointer(in.AllocationMultiplier))
+	*out = *(*resourcev1.NodeAllocatableResourceMapping)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1284,8 +1109,7 @@ func Convert_resource_NodeAllocatableResourceMapping_To_v1_NodeAllocatableResour
 }
 
 func autoConvert_v1_OpaqueDeviceConfiguration_To_resource_OpaqueDeviceConfiguration(in *resourcev1.OpaqueDeviceConfiguration, out *resource.OpaqueDeviceConfiguration, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.Parameters = in.Parameters
+	*out = *(*resource.OpaqueDeviceConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1295,8 +1119,7 @@ func Convert_v1_OpaqueDeviceConfiguration_To_resource_OpaqueDeviceConfiguration(
 }
 
 func autoConvert_resource_OpaqueDeviceConfiguration_To_v1_OpaqueDeviceConfiguration(in *resource.OpaqueDeviceConfiguration, out *resourcev1.OpaqueDeviceConfiguration, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.Parameters = in.Parameters
+	*out = *(*resourcev1.OpaqueDeviceConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1338,10 +1161,7 @@ func Convert_resource_ResourceClaim_To_v1_ResourceClaim(in *resource.ResourceCla
 }
 
 func autoConvert_v1_ResourceClaimConsumerReference_To_resource_ResourceClaimConsumerReference(in *resourcev1.ResourceClaimConsumerReference, out *resource.ResourceClaimConsumerReference, s conversion.Scope) error {
-	out.APIGroup = in.APIGroup
-	out.Resource = in.Resource
-	out.Name = in.Name
-	out.UID = types.UID(in.UID)
+	*out = *(*resource.ResourceClaimConsumerReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1351,10 +1171,7 @@ func Convert_v1_ResourceClaimConsumerReference_To_resource_ResourceClaimConsumer
 }
 
 func autoConvert_resource_ResourceClaimConsumerReference_To_v1_ResourceClaimConsumerReference(in *resource.ResourceClaimConsumerReference, out *resourcev1.ResourceClaimConsumerReference, s conversion.Scope) error {
-	out.APIGroup = in.APIGroup
-	out.Resource = in.Resource
-	out.Name = in.Name
-	out.UID = types.UID(in.UID)
+	*out = *(*resourcev1.ResourceClaimConsumerReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1386,9 +1203,7 @@ func Convert_resource_ResourceClaimList_To_v1_ResourceClaimList(in *resource.Res
 }
 
 func autoConvert_v1_ResourceClaimSpec_To_resource_ResourceClaimSpec(in *resourcev1.ResourceClaimSpec, out *resource.ResourceClaimSpec, s conversion.Scope) error {
-	if err := Convert_v1_DeviceClaim_To_resource_DeviceClaim(&in.Devices, &out.Devices, s); err != nil {
-		return err
-	}
+	*out = *(*resource.ResourceClaimSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1398,9 +1213,7 @@ func Convert_v1_ResourceClaimSpec_To_resource_ResourceClaimSpec(in *resourcev1.R
 }
 
 func autoConvert_resource_ResourceClaimSpec_To_v1_ResourceClaimSpec(in *resource.ResourceClaimSpec, out *resourcev1.ResourceClaimSpec, s conversion.Scope) error {
-	if err := Convert_resource_DeviceClaim_To_v1_DeviceClaim(&in.Devices, &out.Devices, s); err != nil {
-		return err
-	}
+	*out = *(*resourcev1.ResourceClaimSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1410,9 +1223,7 @@ func Convert_resource_ResourceClaimSpec_To_v1_ResourceClaimSpec(in *resource.Res
 }
 
 func autoConvert_v1_ResourceClaimStatus_To_resource_ResourceClaimStatus(in *resourcev1.ResourceClaimStatus, out *resource.ResourceClaimStatus, s conversion.Scope) error {
-	out.Allocation = (*resource.AllocationResult)(unsafe.Pointer(in.Allocation))
-	out.ReservedFor = *(*[]resource.ResourceClaimConsumerReference)(unsafe.Pointer(&in.ReservedFor))
-	out.Devices = *(*[]resource.AllocatedDeviceStatus)(unsafe.Pointer(&in.Devices))
+	*out = *(*resource.ResourceClaimStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1422,9 +1233,7 @@ func Convert_v1_ResourceClaimStatus_To_resource_ResourceClaimStatus(in *resource
 }
 
 func autoConvert_resource_ResourceClaimStatus_To_v1_ResourceClaimStatus(in *resource.ResourceClaimStatus, out *resourcev1.ResourceClaimStatus, s conversion.Scope) error {
-	out.Allocation = (*resourcev1.AllocationResult)(unsafe.Pointer(in.Allocation))
-	out.ReservedFor = *(*[]resourcev1.ResourceClaimConsumerReference)(unsafe.Pointer(&in.ReservedFor))
-	out.Devices = *(*[]resourcev1.AllocatedDeviceStatus)(unsafe.Pointer(&in.Devices))
+	*out = *(*resourcev1.ResourceClaimStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1482,10 +1291,7 @@ func Convert_resource_ResourceClaimTemplateList_To_v1_ResourceClaimTemplateList(
 }
 
 func autoConvert_v1_ResourceClaimTemplateSpec_To_resource_ResourceClaimTemplateSpec(in *resourcev1.ResourceClaimTemplateSpec, out *resource.ResourceClaimTemplateSpec, s conversion.Scope) error {
-	out.ObjectMeta = in.ObjectMeta
-	if err := Convert_v1_ResourceClaimSpec_To_resource_ResourceClaimSpec(&in.Spec, &out.Spec, s); err != nil {
-		return err
-	}
+	*out = *(*resource.ResourceClaimTemplateSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1495,10 +1301,7 @@ func Convert_v1_ResourceClaimTemplateSpec_To_resource_ResourceClaimTemplateSpec(
 }
 
 func autoConvert_resource_ResourceClaimTemplateSpec_To_v1_ResourceClaimTemplateSpec(in *resource.ResourceClaimTemplateSpec, out *resourcev1.ResourceClaimTemplateSpec, s conversion.Scope) error {
-	out.ObjectMeta = in.ObjectMeta
-	if err := Convert_resource_ResourceClaimSpec_To_v1_ResourceClaimSpec(&in.Spec, &out.Spec, s); err != nil {
-		return err
-	}
+	*out = *(*resourcev1.ResourceClaimTemplateSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1508,9 +1311,7 @@ func Convert_resource_ResourceClaimTemplateSpec_To_v1_ResourceClaimTemplateSpec(
 }
 
 func autoConvert_v1_ResourcePool_To_resource_ResourcePool(in *resourcev1.ResourcePool, out *resource.ResourcePool, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Generation = in.Generation
-	out.ResourceSliceCount = in.ResourceSliceCount
+	*out = *(*resource.ResourcePool)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1520,9 +1321,7 @@ func Convert_v1_ResourcePool_To_resource_ResourcePool(in *resourcev1.ResourcePoo
 }
 
 func autoConvert_resource_ResourcePool_To_v1_ResourcePool(in *resource.ResourcePool, out *resourcev1.ResourcePool, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Generation = in.Generation
-	out.ResourceSliceCount = in.ResourceSliceCount
+	*out = *(*resourcev1.ResourcePool)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1580,16 +1379,7 @@ func Convert_resource_ResourceSliceList_To_v1_ResourceSliceList(in *resource.Res
 }
 
 func autoConvert_v1_ResourceSliceSpec_To_resource_ResourceSliceSpec(in *resourcev1.ResourceSliceSpec, out *resource.ResourceSliceSpec, s conversion.Scope) error {
-	out.Driver = in.Driver
-	if err := Convert_v1_ResourcePool_To_resource_ResourcePool(&in.Pool, &out.Pool, s); err != nil {
-		return err
-	}
-	out.NodeName = (*string)(unsafe.Pointer(in.NodeName))
-	out.NodeSelector = (*core.NodeSelector)(unsafe.Pointer(in.NodeSelector))
-	out.AllNodes = (*bool)(unsafe.Pointer(in.AllNodes))
-	out.Devices = *(*[]resource.Device)(unsafe.Pointer(&in.Devices))
-	out.PerDeviceNodeSelection = (*bool)(unsafe.Pointer(in.PerDeviceNodeSelection))
-	out.SharedCounters = *(*[]resource.CounterSet)(unsafe.Pointer(&in.SharedCounters))
+	*out = *(*resource.ResourceSliceSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1599,16 +1389,7 @@ func Convert_v1_ResourceSliceSpec_To_resource_ResourceSliceSpec(in *resourcev1.R
 }
 
 func autoConvert_resource_ResourceSliceSpec_To_v1_ResourceSliceSpec(in *resource.ResourceSliceSpec, out *resourcev1.ResourceSliceSpec, s conversion.Scope) error {
-	out.Driver = in.Driver
-	if err := Convert_resource_ResourcePool_To_v1_ResourcePool(&in.Pool, &out.Pool, s); err != nil {
-		return err
-	}
-	out.NodeName = (*string)(unsafe.Pointer(in.NodeName))
-	out.NodeSelector = (*corev1.NodeSelector)(unsafe.Pointer(in.NodeSelector))
-	out.AllNodes = (*bool)(unsafe.Pointer(in.AllNodes))
-	out.Devices = *(*[]resourcev1.Device)(unsafe.Pointer(&in.Devices))
-	out.PerDeviceNodeSelection = (*bool)(unsafe.Pointer(in.PerDeviceNodeSelection))
-	out.SharedCounters = *(*[]resourcev1.CounterSet)(unsafe.Pointer(&in.SharedCounters))
+	*out = *(*resourcev1.ResourceSliceSpec)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/resource/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/resource/v1alpha3/zz_generated.conversion.go
@@ -25,7 +25,6 @@ import (
 	unsafe "unsafe"
 
 	resourcev1alpha3 "k8s.io/api/resource/v1alpha3"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	resource "k8s.io/kubernetes/pkg/apis/resource"
@@ -172,7 +171,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha3_CELDeviceSelector_To_resource_CELDeviceSelector(in *resourcev1alpha3.CELDeviceSelector, out *resource.CELDeviceSelector, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*resource.CELDeviceSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -182,7 +181,7 @@ func Convert_v1alpha3_CELDeviceSelector_To_resource_CELDeviceSelector(in *resour
 }
 
 func autoConvert_resource_CELDeviceSelector_To_v1alpha3_CELDeviceSelector(in *resource.CELDeviceSelector, out *resourcev1alpha3.CELDeviceSelector, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*resourcev1alpha3.CELDeviceSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -192,7 +191,7 @@ func Convert_resource_CELDeviceSelector_To_v1alpha3_CELDeviceSelector(in *resour
 }
 
 func autoConvert_v1alpha3_DeviceSelector_To_resource_DeviceSelector(in *resourcev1alpha3.DeviceSelector, out *resource.DeviceSelector, s conversion.Scope) error {
-	out.CEL = (*resource.CELDeviceSelector)(unsafe.Pointer(in.CEL))
+	*out = *(*resource.DeviceSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -202,7 +201,7 @@ func Convert_v1alpha3_DeviceSelector_To_resource_DeviceSelector(in *resourcev1al
 }
 
 func autoConvert_resource_DeviceSelector_To_v1alpha3_DeviceSelector(in *resource.DeviceSelector, out *resourcev1alpha3.DeviceSelector, s conversion.Scope) error {
-	out.CEL = (*resourcev1alpha3.CELDeviceSelector)(unsafe.Pointer(in.CEL))
+	*out = *(*resourcev1alpha3.DeviceSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -212,10 +211,7 @@ func Convert_resource_DeviceSelector_To_v1alpha3_DeviceSelector(in *resource.Dev
 }
 
 func autoConvert_v1alpha3_DeviceTaint_To_resource_DeviceTaint(in *resourcev1alpha3.DeviceTaint, out *resource.DeviceTaint, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Value = in.Value
-	out.Effect = resource.DeviceTaintEffect(in.Effect)
-	out.TimeAdded = (*v1.Time)(unsafe.Pointer(in.TimeAdded))
+	*out = *(*resource.DeviceTaint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -225,10 +221,7 @@ func Convert_v1alpha3_DeviceTaint_To_resource_DeviceTaint(in *resourcev1alpha3.D
 }
 
 func autoConvert_resource_DeviceTaint_To_v1alpha3_DeviceTaint(in *resource.DeviceTaint, out *resourcev1alpha3.DeviceTaint, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Value = in.Value
-	out.Effect = resourcev1alpha3.DeviceTaintEffect(in.Effect)
-	out.TimeAdded = (*v1.Time)(unsafe.Pointer(in.TimeAdded))
+	*out = *(*resourcev1alpha3.DeviceTaint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -292,10 +285,7 @@ func Convert_resource_DeviceTaintRuleList_To_v1alpha3_DeviceTaintRuleList(in *re
 }
 
 func autoConvert_v1alpha3_DeviceTaintRuleSpec_To_resource_DeviceTaintRuleSpec(in *resourcev1alpha3.DeviceTaintRuleSpec, out *resource.DeviceTaintRuleSpec, s conversion.Scope) error {
-	out.DeviceSelector = (*resource.DeviceTaintSelector)(unsafe.Pointer(in.DeviceSelector))
-	if err := Convert_v1alpha3_DeviceTaint_To_resource_DeviceTaint(&in.Taint, &out.Taint, s); err != nil {
-		return err
-	}
+	*out = *(*resource.DeviceTaintRuleSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -305,10 +295,7 @@ func Convert_v1alpha3_DeviceTaintRuleSpec_To_resource_DeviceTaintRuleSpec(in *re
 }
 
 func autoConvert_resource_DeviceTaintRuleSpec_To_v1alpha3_DeviceTaintRuleSpec(in *resource.DeviceTaintRuleSpec, out *resourcev1alpha3.DeviceTaintRuleSpec, s conversion.Scope) error {
-	out.DeviceSelector = (*resourcev1alpha3.DeviceTaintSelector)(unsafe.Pointer(in.DeviceSelector))
-	if err := Convert_resource_DeviceTaint_To_v1alpha3_DeviceTaint(&in.Taint, &out.Taint, s); err != nil {
-		return err
-	}
+	*out = *(*resourcev1alpha3.DeviceTaintRuleSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -318,7 +305,7 @@ func Convert_resource_DeviceTaintRuleSpec_To_v1alpha3_DeviceTaintRuleSpec(in *re
 }
 
 func autoConvert_v1alpha3_DeviceTaintRuleStatus_To_resource_DeviceTaintRuleStatus(in *resourcev1alpha3.DeviceTaintRuleStatus, out *resource.DeviceTaintRuleStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*resource.DeviceTaintRuleStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -328,7 +315,7 @@ func Convert_v1alpha3_DeviceTaintRuleStatus_To_resource_DeviceTaintRuleStatus(in
 }
 
 func autoConvert_resource_DeviceTaintRuleStatus_To_v1alpha3_DeviceTaintRuleStatus(in *resource.DeviceTaintRuleStatus, out *resourcev1alpha3.DeviceTaintRuleStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*resourcev1alpha3.DeviceTaintRuleStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -338,9 +325,7 @@ func Convert_resource_DeviceTaintRuleStatus_To_v1alpha3_DeviceTaintRuleStatus(in
 }
 
 func autoConvert_v1alpha3_DeviceTaintSelector_To_resource_DeviceTaintSelector(in *resourcev1alpha3.DeviceTaintSelector, out *resource.DeviceTaintSelector, s conversion.Scope) error {
-	out.Driver = (*string)(unsafe.Pointer(in.Driver))
-	out.Pool = (*string)(unsafe.Pointer(in.Pool))
-	out.Device = (*string)(unsafe.Pointer(in.Device))
+	*out = *(*resource.DeviceTaintSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -350,9 +335,7 @@ func Convert_v1alpha3_DeviceTaintSelector_To_resource_DeviceTaintSelector(in *re
 }
 
 func autoConvert_resource_DeviceTaintSelector_To_v1alpha3_DeviceTaintSelector(in *resource.DeviceTaintSelector, out *resourcev1alpha3.DeviceTaintSelector, s conversion.Scope) error {
-	out.Driver = (*string)(unsafe.Pointer(in.Driver))
-	out.Pool = (*string)(unsafe.Pointer(in.Pool))
-	out.Device = (*string)(unsafe.Pointer(in.Device))
+	*out = *(*resourcev1alpha3.DeviceTaintSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -362,16 +345,7 @@ func Convert_resource_DeviceTaintSelector_To_v1alpha3_DeviceTaintSelector(in *re
 }
 
 func autoConvert_v1alpha3_PoolStatus_To_resource_PoolStatus(in *resourcev1alpha3.PoolStatus, out *resource.PoolStatus, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.PoolName = in.PoolName
-	out.Generation = in.Generation
-	out.ResourceSliceCount = (*int32)(unsafe.Pointer(in.ResourceSliceCount))
-	out.TotalDevices = (*int32)(unsafe.Pointer(in.TotalDevices))
-	out.AllocatedDevices = (*int32)(unsafe.Pointer(in.AllocatedDevices))
-	out.AvailableDevices = (*int32)(unsafe.Pointer(in.AvailableDevices))
-	out.UnavailableDevices = (*int32)(unsafe.Pointer(in.UnavailableDevices))
-	out.NodeName = (*string)(unsafe.Pointer(in.NodeName))
-	out.ValidationError = (*string)(unsafe.Pointer(in.ValidationError))
+	*out = *(*resource.PoolStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -381,16 +355,7 @@ func Convert_v1alpha3_PoolStatus_To_resource_PoolStatus(in *resourcev1alpha3.Poo
 }
 
 func autoConvert_resource_PoolStatus_To_v1alpha3_PoolStatus(in *resource.PoolStatus, out *resourcev1alpha3.PoolStatus, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.PoolName = in.PoolName
-	out.Generation = in.Generation
-	out.ResourceSliceCount = (*int32)(unsafe.Pointer(in.ResourceSliceCount))
-	out.TotalDevices = (*int32)(unsafe.Pointer(in.TotalDevices))
-	out.AllocatedDevices = (*int32)(unsafe.Pointer(in.AllocatedDevices))
-	out.AvailableDevices = (*int32)(unsafe.Pointer(in.AvailableDevices))
-	out.UnavailableDevices = (*int32)(unsafe.Pointer(in.UnavailableDevices))
-	out.NodeName = (*string)(unsafe.Pointer(in.NodeName))
-	out.ValidationError = (*string)(unsafe.Pointer(in.ValidationError))
+	*out = *(*resourcev1alpha3.PoolStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -450,9 +415,7 @@ func Convert_resource_ResourcePoolStatusRequestList_To_v1alpha3_ResourcePoolStat
 }
 
 func autoConvert_v1alpha3_ResourcePoolStatusRequestSpec_To_resource_ResourcePoolStatusRequestSpec(in *resourcev1alpha3.ResourcePoolStatusRequestSpec, out *resource.ResourcePoolStatusRequestSpec, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.PoolName = (*string)(unsafe.Pointer(in.PoolName))
-	out.Limit = (*int32)(unsafe.Pointer(in.Limit))
+	*out = *(*resource.ResourcePoolStatusRequestSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -462,9 +425,7 @@ func Convert_v1alpha3_ResourcePoolStatusRequestSpec_To_resource_ResourcePoolStat
 }
 
 func autoConvert_resource_ResourcePoolStatusRequestSpec_To_v1alpha3_ResourcePoolStatusRequestSpec(in *resource.ResourcePoolStatusRequestSpec, out *resourcev1alpha3.ResourcePoolStatusRequestSpec, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.PoolName = (*string)(unsafe.Pointer(in.PoolName))
-	out.Limit = (*int32)(unsafe.Pointer(in.Limit))
+	*out = *(*resourcev1alpha3.ResourcePoolStatusRequestSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -474,9 +435,7 @@ func Convert_resource_ResourcePoolStatusRequestSpec_To_v1alpha3_ResourcePoolStat
 }
 
 func autoConvert_v1alpha3_ResourcePoolStatusRequestStatus_To_resource_ResourcePoolStatusRequestStatus(in *resourcev1alpha3.ResourcePoolStatusRequestStatus, out *resource.ResourcePoolStatusRequestStatus, s conversion.Scope) error {
-	out.PoolCount = (*int32)(unsafe.Pointer(in.PoolCount))
-	out.Pools = *(*[]resource.PoolStatus)(unsafe.Pointer(&in.Pools))
-	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*resource.ResourcePoolStatusRequestStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -486,9 +445,7 @@ func Convert_v1alpha3_ResourcePoolStatusRequestStatus_To_resource_ResourcePoolSt
 }
 
 func autoConvert_resource_ResourcePoolStatusRequestStatus_To_v1alpha3_ResourcePoolStatusRequestStatus(in *resource.ResourcePoolStatusRequestStatus, out *resourcev1alpha3.ResourcePoolStatusRequestStatus, s conversion.Scope) error {
-	out.PoolCount = (*int32)(unsafe.Pointer(in.PoolCount))
-	out.Pools = *(*[]resourcev1alpha3.PoolStatus)(unsafe.Pointer(&in.Pools))
-	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*resourcev1alpha3.ResourcePoolStatusRequestStatus)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/resource/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/resource/v1beta1/zz_generated.conversion.go
@@ -26,11 +26,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	resourcev1beta1 "k8s.io/api/resource/v1beta1"
-	apiresource "k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	types "k8s.io/apimachinery/pkg/types"
 	core "k8s.io/kubernetes/pkg/apis/core"
 	resource "k8s.io/kubernetes/pkg/apis/resource"
 )
@@ -476,13 +474,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1beta1_AllocatedDeviceStatus_To_resource_AllocatedDeviceStatus(in *resourcev1beta1.AllocatedDeviceStatus, out *resource.AllocatedDeviceStatus, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.Pool = in.Pool
-	out.Device = in.Device
-	out.ShareID = (*string)(unsafe.Pointer(in.ShareID))
-	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
-	out.Data = (*runtime.RawExtension)(unsafe.Pointer(in.Data))
-	out.NetworkData = (*resource.NetworkDeviceData)(unsafe.Pointer(in.NetworkData))
+	*out = *(*resource.AllocatedDeviceStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -492,13 +484,7 @@ func Convert_v1beta1_AllocatedDeviceStatus_To_resource_AllocatedDeviceStatus(in 
 }
 
 func autoConvert_resource_AllocatedDeviceStatus_To_v1beta1_AllocatedDeviceStatus(in *resource.AllocatedDeviceStatus, out *resourcev1beta1.AllocatedDeviceStatus, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.Pool = in.Pool
-	out.Device = in.Device
-	out.ShareID = (*string)(unsafe.Pointer(in.ShareID))
-	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
-	out.Data = (*runtime.RawExtension)(unsafe.Pointer(in.Data))
-	out.NetworkData = (*resourcev1beta1.NetworkDeviceData)(unsafe.Pointer(in.NetworkData))
+	*out = *(*resourcev1beta1.AllocatedDeviceStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -508,11 +494,7 @@ func Convert_resource_AllocatedDeviceStatus_To_v1beta1_AllocatedDeviceStatus(in 
 }
 
 func autoConvert_v1beta1_AllocationResult_To_resource_AllocationResult(in *resourcev1beta1.AllocationResult, out *resource.AllocationResult, s conversion.Scope) error {
-	if err := Convert_v1beta1_DeviceAllocationResult_To_resource_DeviceAllocationResult(&in.Devices, &out.Devices, s); err != nil {
-		return err
-	}
-	out.NodeSelector = (*core.NodeSelector)(unsafe.Pointer(in.NodeSelector))
-	out.AllocationTimestamp = (*v1.Time)(unsafe.Pointer(in.AllocationTimestamp))
+	*out = *(*resource.AllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -522,11 +504,7 @@ func Convert_v1beta1_AllocationResult_To_resource_AllocationResult(in *resourcev
 }
 
 func autoConvert_resource_AllocationResult_To_v1beta1_AllocationResult(in *resource.AllocationResult, out *resourcev1beta1.AllocationResult, s conversion.Scope) error {
-	if err := Convert_resource_DeviceAllocationResult_To_v1beta1_DeviceAllocationResult(&in.Devices, &out.Devices, s); err != nil {
-		return err
-	}
-	out.NodeSelector = (*corev1.NodeSelector)(unsafe.Pointer(in.NodeSelector))
-	out.AllocationTimestamp = (*v1.Time)(unsafe.Pointer(in.AllocationTimestamp))
+	*out = *(*resourcev1beta1.AllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -536,7 +514,7 @@ func Convert_resource_AllocationResult_To_v1beta1_AllocationResult(in *resource.
 }
 
 func autoConvert_v1beta1_CELDeviceSelector_To_resource_CELDeviceSelector(in *resourcev1beta1.CELDeviceSelector, out *resource.CELDeviceSelector, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*resource.CELDeviceSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -546,7 +524,7 @@ func Convert_v1beta1_CELDeviceSelector_To_resource_CELDeviceSelector(in *resourc
 }
 
 func autoConvert_resource_CELDeviceSelector_To_v1beta1_CELDeviceSelector(in *resource.CELDeviceSelector, out *resourcev1beta1.CELDeviceSelector, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*resourcev1beta1.CELDeviceSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -556,9 +534,7 @@ func Convert_resource_CELDeviceSelector_To_v1beta1_CELDeviceSelector(in *resourc
 }
 
 func autoConvert_v1beta1_CapacityRequestPolicy_To_resource_CapacityRequestPolicy(in *resourcev1beta1.CapacityRequestPolicy, out *resource.CapacityRequestPolicy, s conversion.Scope) error {
-	out.Default = (*apiresource.Quantity)(unsafe.Pointer(in.Default))
-	out.ValidValues = *(*[]apiresource.Quantity)(unsafe.Pointer(&in.ValidValues))
-	out.ValidRange = (*resource.CapacityRequestPolicyRange)(unsafe.Pointer(in.ValidRange))
+	*out = *(*resource.CapacityRequestPolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -568,9 +544,7 @@ func Convert_v1beta1_CapacityRequestPolicy_To_resource_CapacityRequestPolicy(in 
 }
 
 func autoConvert_resource_CapacityRequestPolicy_To_v1beta1_CapacityRequestPolicy(in *resource.CapacityRequestPolicy, out *resourcev1beta1.CapacityRequestPolicy, s conversion.Scope) error {
-	out.Default = (*apiresource.Quantity)(unsafe.Pointer(in.Default))
-	out.ValidValues = *(*[]apiresource.Quantity)(unsafe.Pointer(&in.ValidValues))
-	out.ValidRange = (*resourcev1beta1.CapacityRequestPolicyRange)(unsafe.Pointer(in.ValidRange))
+	*out = *(*resourcev1beta1.CapacityRequestPolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -580,9 +554,7 @@ func Convert_resource_CapacityRequestPolicy_To_v1beta1_CapacityRequestPolicy(in 
 }
 
 func autoConvert_v1beta1_CapacityRequestPolicyRange_To_resource_CapacityRequestPolicyRange(in *resourcev1beta1.CapacityRequestPolicyRange, out *resource.CapacityRequestPolicyRange, s conversion.Scope) error {
-	out.Min = (*apiresource.Quantity)(unsafe.Pointer(in.Min))
-	out.Max = (*apiresource.Quantity)(unsafe.Pointer(in.Max))
-	out.Step = (*apiresource.Quantity)(unsafe.Pointer(in.Step))
+	*out = *(*resource.CapacityRequestPolicyRange)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -592,9 +564,7 @@ func Convert_v1beta1_CapacityRequestPolicyRange_To_resource_CapacityRequestPolic
 }
 
 func autoConvert_resource_CapacityRequestPolicyRange_To_v1beta1_CapacityRequestPolicyRange(in *resource.CapacityRequestPolicyRange, out *resourcev1beta1.CapacityRequestPolicyRange, s conversion.Scope) error {
-	out.Min = (*apiresource.Quantity)(unsafe.Pointer(in.Min))
-	out.Max = (*apiresource.Quantity)(unsafe.Pointer(in.Max))
-	out.Step = (*apiresource.Quantity)(unsafe.Pointer(in.Step))
+	*out = *(*resourcev1beta1.CapacityRequestPolicyRange)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -604,7 +574,7 @@ func Convert_resource_CapacityRequestPolicyRange_To_v1beta1_CapacityRequestPolic
 }
 
 func autoConvert_v1beta1_CapacityRequirements_To_resource_CapacityRequirements(in *resourcev1beta1.CapacityRequirements, out *resource.CapacityRequirements, s conversion.Scope) error {
-	out.Requests = *(*map[resource.QualifiedName]apiresource.Quantity)(unsafe.Pointer(&in.Requests))
+	*out = *(*resource.CapacityRequirements)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -614,7 +584,7 @@ func Convert_v1beta1_CapacityRequirements_To_resource_CapacityRequirements(in *r
 }
 
 func autoConvert_resource_CapacityRequirements_To_v1beta1_CapacityRequirements(in *resource.CapacityRequirements, out *resourcev1beta1.CapacityRequirements, s conversion.Scope) error {
-	out.Requests = *(*map[resourcev1beta1.QualifiedName]apiresource.Quantity)(unsafe.Pointer(&in.Requests))
+	*out = *(*resourcev1beta1.CapacityRequirements)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -624,7 +594,7 @@ func Convert_resource_CapacityRequirements_To_v1beta1_CapacityRequirements(in *r
 }
 
 func autoConvert_v1beta1_Counter_To_resource_Counter(in *resourcev1beta1.Counter, out *resource.Counter, s conversion.Scope) error {
-	out.Value = in.Value
+	*out = *(*resource.Counter)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -634,7 +604,7 @@ func Convert_v1beta1_Counter_To_resource_Counter(in *resourcev1beta1.Counter, ou
 }
 
 func autoConvert_resource_Counter_To_v1beta1_Counter(in *resource.Counter, out *resourcev1beta1.Counter, s conversion.Scope) error {
-	out.Value = in.Value
+	*out = *(*resourcev1beta1.Counter)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -644,8 +614,7 @@ func Convert_resource_Counter_To_v1beta1_Counter(in *resource.Counter, out *reso
 }
 
 func autoConvert_v1beta1_CounterSet_To_resource_CounterSet(in *resourcev1beta1.CounterSet, out *resource.CounterSet, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Counters = *(*map[string]resource.Counter)(unsafe.Pointer(&in.Counters))
+	*out = *(*resource.CounterSet)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -655,8 +624,7 @@ func Convert_v1beta1_CounterSet_To_resource_CounterSet(in *resourcev1beta1.Count
 }
 
 func autoConvert_resource_CounterSet_To_v1beta1_CounterSet(in *resource.CounterSet, out *resourcev1beta1.CounterSet, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Counters = *(*map[string]resourcev1beta1.Counter)(unsafe.Pointer(&in.Counters))
+	*out = *(*resourcev1beta1.CounterSet)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -689,11 +657,7 @@ func autoConvert_resource_Device_To_v1beta1_Device(in *resource.Device, out *res
 }
 
 func autoConvert_v1beta1_DeviceAllocationConfiguration_To_resource_DeviceAllocationConfiguration(in *resourcev1beta1.DeviceAllocationConfiguration, out *resource.DeviceAllocationConfiguration, s conversion.Scope) error {
-	out.Source = resource.AllocationConfigSource(in.Source)
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	if err := Convert_v1beta1_DeviceConfiguration_To_resource_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*resource.DeviceAllocationConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -703,11 +667,7 @@ func Convert_v1beta1_DeviceAllocationConfiguration_To_resource_DeviceAllocationC
 }
 
 func autoConvert_resource_DeviceAllocationConfiguration_To_v1beta1_DeviceAllocationConfiguration(in *resource.DeviceAllocationConfiguration, out *resourcev1beta1.DeviceAllocationConfiguration, s conversion.Scope) error {
-	out.Source = resourcev1beta1.AllocationConfigSource(in.Source)
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	if err := Convert_resource_DeviceConfiguration_To_v1beta1_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*resourcev1beta1.DeviceAllocationConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -717,8 +677,7 @@ func Convert_resource_DeviceAllocationConfiguration_To_v1beta1_DeviceAllocationC
 }
 
 func autoConvert_v1beta1_DeviceAllocationResult_To_resource_DeviceAllocationResult(in *resourcev1beta1.DeviceAllocationResult, out *resource.DeviceAllocationResult, s conversion.Scope) error {
-	out.Results = *(*[]resource.DeviceRequestAllocationResult)(unsafe.Pointer(&in.Results))
-	out.Config = *(*[]resource.DeviceAllocationConfiguration)(unsafe.Pointer(&in.Config))
+	*out = *(*resource.DeviceAllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -728,8 +687,7 @@ func Convert_v1beta1_DeviceAllocationResult_To_resource_DeviceAllocationResult(i
 }
 
 func autoConvert_resource_DeviceAllocationResult_To_v1beta1_DeviceAllocationResult(in *resource.DeviceAllocationResult, out *resourcev1beta1.DeviceAllocationResult, s conversion.Scope) error {
-	out.Results = *(*[]resourcev1beta1.DeviceRequestAllocationResult)(unsafe.Pointer(&in.Results))
-	out.Config = *(*[]resourcev1beta1.DeviceAllocationConfiguration)(unsafe.Pointer(&in.Config))
+	*out = *(*resourcev1beta1.DeviceAllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -739,14 +697,7 @@ func Convert_resource_DeviceAllocationResult_To_v1beta1_DeviceAllocationResult(i
 }
 
 func autoConvert_v1beta1_DeviceAttribute_To_resource_DeviceAttribute(in *resourcev1beta1.DeviceAttribute, out *resource.DeviceAttribute, s conversion.Scope) error {
-	out.IntValue = (*int64)(unsafe.Pointer(in.IntValue))
-	out.BoolValue = (*bool)(unsafe.Pointer(in.BoolValue))
-	out.StringValue = (*string)(unsafe.Pointer(in.StringValue))
-	out.VersionValue = (*string)(unsafe.Pointer(in.VersionValue))
-	out.IntValues = *(*[]int64)(unsafe.Pointer(&in.IntValues))
-	out.BoolValues = *(*[]bool)(unsafe.Pointer(&in.BoolValues))
-	out.StringValues = *(*[]string)(unsafe.Pointer(&in.StringValues))
-	out.VersionValues = *(*[]string)(unsafe.Pointer(&in.VersionValues))
+	*out = *(*resource.DeviceAttribute)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -756,14 +707,7 @@ func Convert_v1beta1_DeviceAttribute_To_resource_DeviceAttribute(in *resourcev1b
 }
 
 func autoConvert_resource_DeviceAttribute_To_v1beta1_DeviceAttribute(in *resource.DeviceAttribute, out *resourcev1beta1.DeviceAttribute, s conversion.Scope) error {
-	out.IntValue = (*int64)(unsafe.Pointer(in.IntValue))
-	out.BoolValue = (*bool)(unsafe.Pointer(in.BoolValue))
-	out.StringValue = (*string)(unsafe.Pointer(in.StringValue))
-	out.VersionValue = (*string)(unsafe.Pointer(in.VersionValue))
-	out.IntValues = *(*[]int64)(unsafe.Pointer(&in.IntValues))
-	out.BoolValues = *(*[]bool)(unsafe.Pointer(&in.BoolValues))
-	out.StringValues = *(*[]string)(unsafe.Pointer(&in.StringValues))
-	out.VersionValues = *(*[]string)(unsafe.Pointer(&in.VersionValues))
+	*out = *(*resourcev1beta1.DeviceAttribute)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -773,8 +717,7 @@ func Convert_resource_DeviceAttribute_To_v1beta1_DeviceAttribute(in *resource.De
 }
 
 func autoConvert_v1beta1_DeviceCapacity_To_resource_DeviceCapacity(in *resourcev1beta1.DeviceCapacity, out *resource.DeviceCapacity, s conversion.Scope) error {
-	out.Value = in.Value
-	out.RequestPolicy = (*resource.CapacityRequestPolicy)(unsafe.Pointer(in.RequestPolicy))
+	*out = *(*resource.DeviceCapacity)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -784,8 +727,7 @@ func Convert_v1beta1_DeviceCapacity_To_resource_DeviceCapacity(in *resourcev1bet
 }
 
 func autoConvert_resource_DeviceCapacity_To_v1beta1_DeviceCapacity(in *resource.DeviceCapacity, out *resourcev1beta1.DeviceCapacity, s conversion.Scope) error {
-	out.Value = in.Value
-	out.RequestPolicy = (*resourcev1beta1.CapacityRequestPolicy)(unsafe.Pointer(in.RequestPolicy))
+	*out = *(*resourcev1beta1.DeviceCapacity)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -839,10 +781,7 @@ func Convert_resource_DeviceClaim_To_v1beta1_DeviceClaim(in *resource.DeviceClai
 }
 
 func autoConvert_v1beta1_DeviceClaimConfiguration_To_resource_DeviceClaimConfiguration(in *resourcev1beta1.DeviceClaimConfiguration, out *resource.DeviceClaimConfiguration, s conversion.Scope) error {
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	if err := Convert_v1beta1_DeviceConfiguration_To_resource_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*resource.DeviceClaimConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -852,10 +791,7 @@ func Convert_v1beta1_DeviceClaimConfiguration_To_resource_DeviceClaimConfigurati
 }
 
 func autoConvert_resource_DeviceClaimConfiguration_To_v1beta1_DeviceClaimConfiguration(in *resource.DeviceClaimConfiguration, out *resourcev1beta1.DeviceClaimConfiguration, s conversion.Scope) error {
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	if err := Convert_resource_DeviceConfiguration_To_v1beta1_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*resourcev1beta1.DeviceClaimConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -891,9 +827,7 @@ func Convert_resource_DeviceClass_To_v1beta1_DeviceClass(in *resource.DeviceClas
 }
 
 func autoConvert_v1beta1_DeviceClassConfiguration_To_resource_DeviceClassConfiguration(in *resourcev1beta1.DeviceClassConfiguration, out *resource.DeviceClassConfiguration, s conversion.Scope) error {
-	if err := Convert_v1beta1_DeviceConfiguration_To_resource_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*resource.DeviceClassConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -903,9 +837,7 @@ func Convert_v1beta1_DeviceClassConfiguration_To_resource_DeviceClassConfigurati
 }
 
 func autoConvert_resource_DeviceClassConfiguration_To_v1beta1_DeviceClassConfiguration(in *resource.DeviceClassConfiguration, out *resourcev1beta1.DeviceClassConfiguration, s conversion.Scope) error {
-	if err := Convert_resource_DeviceConfiguration_To_v1beta1_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*resourcev1beta1.DeviceClassConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -937,9 +869,7 @@ func Convert_resource_DeviceClassList_To_v1beta1_DeviceClassList(in *resource.De
 }
 
 func autoConvert_v1beta1_DeviceClassSpec_To_resource_DeviceClassSpec(in *resourcev1beta1.DeviceClassSpec, out *resource.DeviceClassSpec, s conversion.Scope) error {
-	out.Selectors = *(*[]resource.DeviceSelector)(unsafe.Pointer(&in.Selectors))
-	out.Config = *(*[]resource.DeviceClassConfiguration)(unsafe.Pointer(&in.Config))
-	out.ExtendedResourceName = (*string)(unsafe.Pointer(in.ExtendedResourceName))
+	*out = *(*resource.DeviceClassSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -949,9 +879,7 @@ func Convert_v1beta1_DeviceClassSpec_To_resource_DeviceClassSpec(in *resourcev1b
 }
 
 func autoConvert_resource_DeviceClassSpec_To_v1beta1_DeviceClassSpec(in *resource.DeviceClassSpec, out *resourcev1beta1.DeviceClassSpec, s conversion.Scope) error {
-	out.Selectors = *(*[]resourcev1beta1.DeviceSelector)(unsafe.Pointer(&in.Selectors))
-	out.Config = *(*[]resourcev1beta1.DeviceClassConfiguration)(unsafe.Pointer(&in.Config))
-	out.ExtendedResourceName = (*string)(unsafe.Pointer(in.ExtendedResourceName))
+	*out = *(*resourcev1beta1.DeviceClassSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -961,7 +889,7 @@ func Convert_resource_DeviceClassSpec_To_v1beta1_DeviceClassSpec(in *resource.De
 }
 
 func autoConvert_v1beta1_DeviceConfiguration_To_resource_DeviceConfiguration(in *resourcev1beta1.DeviceConfiguration, out *resource.DeviceConfiguration, s conversion.Scope) error {
-	out.Opaque = (*resource.OpaqueDeviceConfiguration)(unsafe.Pointer(in.Opaque))
+	*out = *(*resource.DeviceConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -971,7 +899,7 @@ func Convert_v1beta1_DeviceConfiguration_To_resource_DeviceConfiguration(in *res
 }
 
 func autoConvert_resource_DeviceConfiguration_To_v1beta1_DeviceConfiguration(in *resource.DeviceConfiguration, out *resourcev1beta1.DeviceConfiguration, s conversion.Scope) error {
-	out.Opaque = (*resourcev1beta1.OpaqueDeviceConfiguration)(unsafe.Pointer(in.Opaque))
+	*out = *(*resourcev1beta1.DeviceConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -981,9 +909,7 @@ func Convert_resource_DeviceConfiguration_To_v1beta1_DeviceConfiguration(in *res
 }
 
 func autoConvert_v1beta1_DeviceConstraint_To_resource_DeviceConstraint(in *resourcev1beta1.DeviceConstraint, out *resource.DeviceConstraint, s conversion.Scope) error {
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	out.MatchAttribute = (*resource.FullyQualifiedName)(unsafe.Pointer(in.MatchAttribute))
-	out.DistinctAttribute = (*resource.FullyQualifiedName)(unsafe.Pointer(in.DistinctAttribute))
+	*out = *(*resource.DeviceConstraint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -993,9 +919,7 @@ func Convert_v1beta1_DeviceConstraint_To_resource_DeviceConstraint(in *resourcev
 }
 
 func autoConvert_resource_DeviceConstraint_To_v1beta1_DeviceConstraint(in *resource.DeviceConstraint, out *resourcev1beta1.DeviceConstraint, s conversion.Scope) error {
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	out.MatchAttribute = (*resourcev1beta1.FullyQualifiedName)(unsafe.Pointer(in.MatchAttribute))
-	out.DistinctAttribute = (*resourcev1beta1.FullyQualifiedName)(unsafe.Pointer(in.DistinctAttribute))
+	*out = *(*resourcev1beta1.DeviceConstraint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1005,8 +929,7 @@ func Convert_resource_DeviceConstraint_To_v1beta1_DeviceConstraint(in *resource.
 }
 
 func autoConvert_v1beta1_DeviceCounterConsumption_To_resource_DeviceCounterConsumption(in *resourcev1beta1.DeviceCounterConsumption, out *resource.DeviceCounterConsumption, s conversion.Scope) error {
-	out.CounterSet = in.CounterSet
-	out.Counters = *(*map[string]resource.Counter)(unsafe.Pointer(&in.Counters))
+	*out = *(*resource.DeviceCounterConsumption)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1016,8 +939,7 @@ func Convert_v1beta1_DeviceCounterConsumption_To_resource_DeviceCounterConsumpti
 }
 
 func autoConvert_resource_DeviceCounterConsumption_To_v1beta1_DeviceCounterConsumption(in *resource.DeviceCounterConsumption, out *resourcev1beta1.DeviceCounterConsumption, s conversion.Scope) error {
-	out.CounterSet = in.CounterSet
-	out.Counters = *(*map[string]resourcev1beta1.Counter)(unsafe.Pointer(&in.Counters))
+	*out = *(*resourcev1beta1.DeviceCounterConsumption)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1047,16 +969,7 @@ func autoConvert_resource_DeviceRequest_To_v1beta1_DeviceRequest(in *resource.De
 }
 
 func autoConvert_v1beta1_DeviceRequestAllocationResult_To_resource_DeviceRequestAllocationResult(in *resourcev1beta1.DeviceRequestAllocationResult, out *resource.DeviceRequestAllocationResult, s conversion.Scope) error {
-	out.Request = in.Request
-	out.Driver = in.Driver
-	out.Pool = in.Pool
-	out.Device = in.Device
-	out.AdminAccess = (*bool)(unsafe.Pointer(in.AdminAccess))
-	out.Tolerations = *(*[]resource.DeviceToleration)(unsafe.Pointer(&in.Tolerations))
-	out.BindingConditions = *(*[]string)(unsafe.Pointer(&in.BindingConditions))
-	out.BindingFailureConditions = *(*[]string)(unsafe.Pointer(&in.BindingFailureConditions))
-	out.ShareID = (*types.UID)(unsafe.Pointer(in.ShareID))
-	out.ConsumedCapacity = *(*map[resource.QualifiedName]apiresource.Quantity)(unsafe.Pointer(&in.ConsumedCapacity))
+	*out = *(*resource.DeviceRequestAllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1066,16 +979,7 @@ func Convert_v1beta1_DeviceRequestAllocationResult_To_resource_DeviceRequestAllo
 }
 
 func autoConvert_resource_DeviceRequestAllocationResult_To_v1beta1_DeviceRequestAllocationResult(in *resource.DeviceRequestAllocationResult, out *resourcev1beta1.DeviceRequestAllocationResult, s conversion.Scope) error {
-	out.Request = in.Request
-	out.Driver = in.Driver
-	out.Pool = in.Pool
-	out.Device = in.Device
-	out.AdminAccess = (*bool)(unsafe.Pointer(in.AdminAccess))
-	out.Tolerations = *(*[]resourcev1beta1.DeviceToleration)(unsafe.Pointer(&in.Tolerations))
-	out.BindingConditions = *(*[]string)(unsafe.Pointer(&in.BindingConditions))
-	out.BindingFailureConditions = *(*[]string)(unsafe.Pointer(&in.BindingFailureConditions))
-	out.ShareID = (*types.UID)(unsafe.Pointer(in.ShareID))
-	out.ConsumedCapacity = *(*map[resourcev1beta1.QualifiedName]apiresource.Quantity)(unsafe.Pointer(&in.ConsumedCapacity))
+	*out = *(*resourcev1beta1.DeviceRequestAllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1085,7 +989,7 @@ func Convert_resource_DeviceRequestAllocationResult_To_v1beta1_DeviceRequestAllo
 }
 
 func autoConvert_v1beta1_DeviceSelector_To_resource_DeviceSelector(in *resourcev1beta1.DeviceSelector, out *resource.DeviceSelector, s conversion.Scope) error {
-	out.CEL = (*resource.CELDeviceSelector)(unsafe.Pointer(in.CEL))
+	*out = *(*resource.DeviceSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1095,7 +999,7 @@ func Convert_v1beta1_DeviceSelector_To_resource_DeviceSelector(in *resourcev1bet
 }
 
 func autoConvert_resource_DeviceSelector_To_v1beta1_DeviceSelector(in *resource.DeviceSelector, out *resourcev1beta1.DeviceSelector, s conversion.Scope) error {
-	out.CEL = (*resourcev1beta1.CELDeviceSelector)(unsafe.Pointer(in.CEL))
+	*out = *(*resourcev1beta1.DeviceSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1105,13 +1009,7 @@ func Convert_resource_DeviceSelector_To_v1beta1_DeviceSelector(in *resource.Devi
 }
 
 func autoConvert_v1beta1_DeviceSubRequest_To_resource_DeviceSubRequest(in *resourcev1beta1.DeviceSubRequest, out *resource.DeviceSubRequest, s conversion.Scope) error {
-	out.Name = in.Name
-	out.DeviceClassName = in.DeviceClassName
-	out.Selectors = *(*[]resource.DeviceSelector)(unsafe.Pointer(&in.Selectors))
-	out.AllocationMode = resource.DeviceAllocationMode(in.AllocationMode)
-	out.Count = in.Count
-	out.Tolerations = *(*[]resource.DeviceToleration)(unsafe.Pointer(&in.Tolerations))
-	out.Capacity = (*resource.CapacityRequirements)(unsafe.Pointer(in.Capacity))
+	*out = *(*resource.DeviceSubRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1121,13 +1019,7 @@ func Convert_v1beta1_DeviceSubRequest_To_resource_DeviceSubRequest(in *resourcev
 }
 
 func autoConvert_resource_DeviceSubRequest_To_v1beta1_DeviceSubRequest(in *resource.DeviceSubRequest, out *resourcev1beta1.DeviceSubRequest, s conversion.Scope) error {
-	out.Name = in.Name
-	out.DeviceClassName = in.DeviceClassName
-	out.Selectors = *(*[]resourcev1beta1.DeviceSelector)(unsafe.Pointer(&in.Selectors))
-	out.AllocationMode = resourcev1beta1.DeviceAllocationMode(in.AllocationMode)
-	out.Count = in.Count
-	out.Tolerations = *(*[]resourcev1beta1.DeviceToleration)(unsafe.Pointer(&in.Tolerations))
-	out.Capacity = (*resourcev1beta1.CapacityRequirements)(unsafe.Pointer(in.Capacity))
+	*out = *(*resourcev1beta1.DeviceSubRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1137,10 +1029,7 @@ func Convert_resource_DeviceSubRequest_To_v1beta1_DeviceSubRequest(in *resource.
 }
 
 func autoConvert_v1beta1_DeviceTaint_To_resource_DeviceTaint(in *resourcev1beta1.DeviceTaint, out *resource.DeviceTaint, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Value = in.Value
-	out.Effect = resource.DeviceTaintEffect(in.Effect)
-	out.TimeAdded = (*v1.Time)(unsafe.Pointer(in.TimeAdded))
+	*out = *(*resource.DeviceTaint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1150,10 +1039,7 @@ func Convert_v1beta1_DeviceTaint_To_resource_DeviceTaint(in *resourcev1beta1.Dev
 }
 
 func autoConvert_resource_DeviceTaint_To_v1beta1_DeviceTaint(in *resource.DeviceTaint, out *resourcev1beta1.DeviceTaint, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Value = in.Value
-	out.Effect = resourcev1beta1.DeviceTaintEffect(in.Effect)
-	out.TimeAdded = (*v1.Time)(unsafe.Pointer(in.TimeAdded))
+	*out = *(*resourcev1beta1.DeviceTaint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1163,11 +1049,7 @@ func Convert_resource_DeviceTaint_To_v1beta1_DeviceTaint(in *resource.DeviceTain
 }
 
 func autoConvert_v1beta1_DeviceToleration_To_resource_DeviceToleration(in *resourcev1beta1.DeviceToleration, out *resource.DeviceToleration, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Operator = resource.DeviceTolerationOperator(in.Operator)
-	out.Value = in.Value
-	out.Effect = resource.DeviceTaintEffect(in.Effect)
-	out.TolerationSeconds = (*int64)(unsafe.Pointer(in.TolerationSeconds))
+	*out = *(*resource.DeviceToleration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1177,11 +1059,7 @@ func Convert_v1beta1_DeviceToleration_To_resource_DeviceToleration(in *resourcev
 }
 
 func autoConvert_resource_DeviceToleration_To_v1beta1_DeviceToleration(in *resource.DeviceToleration, out *resourcev1beta1.DeviceToleration, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Operator = resourcev1beta1.DeviceTolerationOperator(in.Operator)
-	out.Value = in.Value
-	out.Effect = resourcev1beta1.DeviceTaintEffect(in.Effect)
-	out.TolerationSeconds = (*int64)(unsafe.Pointer(in.TolerationSeconds))
+	*out = *(*resourcev1beta1.DeviceToleration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1191,9 +1069,7 @@ func Convert_resource_DeviceToleration_To_v1beta1_DeviceToleration(in *resource.
 }
 
 func autoConvert_v1beta1_NetworkDeviceData_To_resource_NetworkDeviceData(in *resourcev1beta1.NetworkDeviceData, out *resource.NetworkDeviceData, s conversion.Scope) error {
-	out.InterfaceName = in.InterfaceName
-	out.IPs = *(*[]string)(unsafe.Pointer(&in.IPs))
-	out.HardwareAddress = in.HardwareAddress
+	*out = *(*resource.NetworkDeviceData)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1203,9 +1079,7 @@ func Convert_v1beta1_NetworkDeviceData_To_resource_NetworkDeviceData(in *resourc
 }
 
 func autoConvert_resource_NetworkDeviceData_To_v1beta1_NetworkDeviceData(in *resource.NetworkDeviceData, out *resourcev1beta1.NetworkDeviceData, s conversion.Scope) error {
-	out.InterfaceName = in.InterfaceName
-	out.IPs = *(*[]string)(unsafe.Pointer(&in.IPs))
-	out.HardwareAddress = in.HardwareAddress
+	*out = *(*resourcev1beta1.NetworkDeviceData)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1215,8 +1089,7 @@ func Convert_resource_NetworkDeviceData_To_v1beta1_NetworkDeviceData(in *resourc
 }
 
 func autoConvert_v1beta1_NodeAllocatableResourceMapping_To_resource_NodeAllocatableResourceMapping(in *resourcev1beta1.NodeAllocatableResourceMapping, out *resource.NodeAllocatableResourceMapping, s conversion.Scope) error {
-	out.CapacityKey = (*resource.QualifiedName)(unsafe.Pointer(in.CapacityKey))
-	out.AllocationMultiplier = (*apiresource.Quantity)(unsafe.Pointer(in.AllocationMultiplier))
+	*out = *(*resource.NodeAllocatableResourceMapping)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1226,8 +1099,7 @@ func Convert_v1beta1_NodeAllocatableResourceMapping_To_resource_NodeAllocatableR
 }
 
 func autoConvert_resource_NodeAllocatableResourceMapping_To_v1beta1_NodeAllocatableResourceMapping(in *resource.NodeAllocatableResourceMapping, out *resourcev1beta1.NodeAllocatableResourceMapping, s conversion.Scope) error {
-	out.CapacityKey = (*resourcev1beta1.QualifiedName)(unsafe.Pointer(in.CapacityKey))
-	out.AllocationMultiplier = (*apiresource.Quantity)(unsafe.Pointer(in.AllocationMultiplier))
+	*out = *(*resourcev1beta1.NodeAllocatableResourceMapping)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1237,8 +1109,7 @@ func Convert_resource_NodeAllocatableResourceMapping_To_v1beta1_NodeAllocatableR
 }
 
 func autoConvert_v1beta1_OpaqueDeviceConfiguration_To_resource_OpaqueDeviceConfiguration(in *resourcev1beta1.OpaqueDeviceConfiguration, out *resource.OpaqueDeviceConfiguration, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.Parameters = in.Parameters
+	*out = *(*resource.OpaqueDeviceConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1248,8 +1119,7 @@ func Convert_v1beta1_OpaqueDeviceConfiguration_To_resource_OpaqueDeviceConfigura
 }
 
 func autoConvert_resource_OpaqueDeviceConfiguration_To_v1beta1_OpaqueDeviceConfiguration(in *resource.OpaqueDeviceConfiguration, out *resourcev1beta1.OpaqueDeviceConfiguration, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.Parameters = in.Parameters
+	*out = *(*resourcev1beta1.OpaqueDeviceConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1291,10 +1161,7 @@ func Convert_resource_ResourceClaim_To_v1beta1_ResourceClaim(in *resource.Resour
 }
 
 func autoConvert_v1beta1_ResourceClaimConsumerReference_To_resource_ResourceClaimConsumerReference(in *resourcev1beta1.ResourceClaimConsumerReference, out *resource.ResourceClaimConsumerReference, s conversion.Scope) error {
-	out.APIGroup = in.APIGroup
-	out.Resource = in.Resource
-	out.Name = in.Name
-	out.UID = types.UID(in.UID)
+	*out = *(*resource.ResourceClaimConsumerReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1304,10 +1171,7 @@ func Convert_v1beta1_ResourceClaimConsumerReference_To_resource_ResourceClaimCon
 }
 
 func autoConvert_resource_ResourceClaimConsumerReference_To_v1beta1_ResourceClaimConsumerReference(in *resource.ResourceClaimConsumerReference, out *resourcev1beta1.ResourceClaimConsumerReference, s conversion.Scope) error {
-	out.APIGroup = in.APIGroup
-	out.Resource = in.Resource
-	out.Name = in.Name
-	out.UID = types.UID(in.UID)
+	*out = *(*resourcev1beta1.ResourceClaimConsumerReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1383,9 +1247,7 @@ func Convert_resource_ResourceClaimSpec_To_v1beta1_ResourceClaimSpec(in *resourc
 }
 
 func autoConvert_v1beta1_ResourceClaimStatus_To_resource_ResourceClaimStatus(in *resourcev1beta1.ResourceClaimStatus, out *resource.ResourceClaimStatus, s conversion.Scope) error {
-	out.Allocation = (*resource.AllocationResult)(unsafe.Pointer(in.Allocation))
-	out.ReservedFor = *(*[]resource.ResourceClaimConsumerReference)(unsafe.Pointer(&in.ReservedFor))
-	out.Devices = *(*[]resource.AllocatedDeviceStatus)(unsafe.Pointer(&in.Devices))
+	*out = *(*resource.ResourceClaimStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1395,9 +1257,7 @@ func Convert_v1beta1_ResourceClaimStatus_To_resource_ResourceClaimStatus(in *res
 }
 
 func autoConvert_resource_ResourceClaimStatus_To_v1beta1_ResourceClaimStatus(in *resource.ResourceClaimStatus, out *resourcev1beta1.ResourceClaimStatus, s conversion.Scope) error {
-	out.Allocation = (*resourcev1beta1.AllocationResult)(unsafe.Pointer(in.Allocation))
-	out.ReservedFor = *(*[]resourcev1beta1.ResourceClaimConsumerReference)(unsafe.Pointer(&in.ReservedFor))
-	out.Devices = *(*[]resourcev1beta1.AllocatedDeviceStatus)(unsafe.Pointer(&in.Devices))
+	*out = *(*resourcev1beta1.ResourceClaimStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1501,9 +1361,7 @@ func Convert_resource_ResourceClaimTemplateSpec_To_v1beta1_ResourceClaimTemplate
 }
 
 func autoConvert_v1beta1_ResourcePool_To_resource_ResourcePool(in *resourcev1beta1.ResourcePool, out *resource.ResourcePool, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Generation = in.Generation
-	out.ResourceSliceCount = in.ResourceSliceCount
+	*out = *(*resource.ResourcePool)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1513,9 +1371,7 @@ func Convert_v1beta1_ResourcePool_To_resource_ResourcePool(in *resourcev1beta1.R
 }
 
 func autoConvert_resource_ResourcePool_To_v1beta1_ResourcePool(in *resource.ResourcePool, out *resourcev1beta1.ResourcePool, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Generation = in.Generation
-	out.ResourceSliceCount = in.ResourceSliceCount
+	*out = *(*resourcev1beta1.ResourcePool)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/resource/v1beta2/zz_generated.conversion.go
+++ b/pkg/apis/resource/v1beta2/zz_generated.conversion.go
@@ -24,14 +24,9 @@ package v1beta2
 import (
 	unsafe "unsafe"
 
-	corev1 "k8s.io/api/core/v1"
 	resourcev1beta2 "k8s.io/api/resource/v1beta2"
-	apiresource "k8s.io/apimachinery/pkg/api/resource"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	types "k8s.io/apimachinery/pkg/types"
-	core "k8s.io/kubernetes/pkg/apis/core"
 	resource "k8s.io/kubernetes/pkg/apis/resource"
 )
 
@@ -536,13 +531,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1beta2_AllocatedDeviceStatus_To_resource_AllocatedDeviceStatus(in *resourcev1beta2.AllocatedDeviceStatus, out *resource.AllocatedDeviceStatus, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.Pool = in.Pool
-	out.Device = in.Device
-	out.ShareID = (*string)(unsafe.Pointer(in.ShareID))
-	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
-	out.Data = (*runtime.RawExtension)(unsafe.Pointer(in.Data))
-	out.NetworkData = (*resource.NetworkDeviceData)(unsafe.Pointer(in.NetworkData))
+	*out = *(*resource.AllocatedDeviceStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -552,13 +541,7 @@ func Convert_v1beta2_AllocatedDeviceStatus_To_resource_AllocatedDeviceStatus(in 
 }
 
 func autoConvert_resource_AllocatedDeviceStatus_To_v1beta2_AllocatedDeviceStatus(in *resource.AllocatedDeviceStatus, out *resourcev1beta2.AllocatedDeviceStatus, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.Pool = in.Pool
-	out.Device = in.Device
-	out.ShareID = (*string)(unsafe.Pointer(in.ShareID))
-	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
-	out.Data = (*runtime.RawExtension)(unsafe.Pointer(in.Data))
-	out.NetworkData = (*resourcev1beta2.NetworkDeviceData)(unsafe.Pointer(in.NetworkData))
+	*out = *(*resourcev1beta2.AllocatedDeviceStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -568,11 +551,7 @@ func Convert_resource_AllocatedDeviceStatus_To_v1beta2_AllocatedDeviceStatus(in 
 }
 
 func autoConvert_v1beta2_AllocationResult_To_resource_AllocationResult(in *resourcev1beta2.AllocationResult, out *resource.AllocationResult, s conversion.Scope) error {
-	if err := Convert_v1beta2_DeviceAllocationResult_To_resource_DeviceAllocationResult(&in.Devices, &out.Devices, s); err != nil {
-		return err
-	}
-	out.NodeSelector = (*core.NodeSelector)(unsafe.Pointer(in.NodeSelector))
-	out.AllocationTimestamp = (*v1.Time)(unsafe.Pointer(in.AllocationTimestamp))
+	*out = *(*resource.AllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -582,11 +561,7 @@ func Convert_v1beta2_AllocationResult_To_resource_AllocationResult(in *resourcev
 }
 
 func autoConvert_resource_AllocationResult_To_v1beta2_AllocationResult(in *resource.AllocationResult, out *resourcev1beta2.AllocationResult, s conversion.Scope) error {
-	if err := Convert_resource_DeviceAllocationResult_To_v1beta2_DeviceAllocationResult(&in.Devices, &out.Devices, s); err != nil {
-		return err
-	}
-	out.NodeSelector = (*corev1.NodeSelector)(unsafe.Pointer(in.NodeSelector))
-	out.AllocationTimestamp = (*v1.Time)(unsafe.Pointer(in.AllocationTimestamp))
+	*out = *(*resourcev1beta2.AllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -596,7 +571,7 @@ func Convert_resource_AllocationResult_To_v1beta2_AllocationResult(in *resource.
 }
 
 func autoConvert_v1beta2_CELDeviceSelector_To_resource_CELDeviceSelector(in *resourcev1beta2.CELDeviceSelector, out *resource.CELDeviceSelector, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*resource.CELDeviceSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -606,7 +581,7 @@ func Convert_v1beta2_CELDeviceSelector_To_resource_CELDeviceSelector(in *resourc
 }
 
 func autoConvert_resource_CELDeviceSelector_To_v1beta2_CELDeviceSelector(in *resource.CELDeviceSelector, out *resourcev1beta2.CELDeviceSelector, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*resourcev1beta2.CELDeviceSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -616,9 +591,7 @@ func Convert_resource_CELDeviceSelector_To_v1beta2_CELDeviceSelector(in *resourc
 }
 
 func autoConvert_v1beta2_CapacityRequestPolicy_To_resource_CapacityRequestPolicy(in *resourcev1beta2.CapacityRequestPolicy, out *resource.CapacityRequestPolicy, s conversion.Scope) error {
-	out.Default = (*apiresource.Quantity)(unsafe.Pointer(in.Default))
-	out.ValidValues = *(*[]apiresource.Quantity)(unsafe.Pointer(&in.ValidValues))
-	out.ValidRange = (*resource.CapacityRequestPolicyRange)(unsafe.Pointer(in.ValidRange))
+	*out = *(*resource.CapacityRequestPolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -628,9 +601,7 @@ func Convert_v1beta2_CapacityRequestPolicy_To_resource_CapacityRequestPolicy(in 
 }
 
 func autoConvert_resource_CapacityRequestPolicy_To_v1beta2_CapacityRequestPolicy(in *resource.CapacityRequestPolicy, out *resourcev1beta2.CapacityRequestPolicy, s conversion.Scope) error {
-	out.Default = (*apiresource.Quantity)(unsafe.Pointer(in.Default))
-	out.ValidValues = *(*[]apiresource.Quantity)(unsafe.Pointer(&in.ValidValues))
-	out.ValidRange = (*resourcev1beta2.CapacityRequestPolicyRange)(unsafe.Pointer(in.ValidRange))
+	*out = *(*resourcev1beta2.CapacityRequestPolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -640,9 +611,7 @@ func Convert_resource_CapacityRequestPolicy_To_v1beta2_CapacityRequestPolicy(in 
 }
 
 func autoConvert_v1beta2_CapacityRequestPolicyRange_To_resource_CapacityRequestPolicyRange(in *resourcev1beta2.CapacityRequestPolicyRange, out *resource.CapacityRequestPolicyRange, s conversion.Scope) error {
-	out.Min = (*apiresource.Quantity)(unsafe.Pointer(in.Min))
-	out.Max = (*apiresource.Quantity)(unsafe.Pointer(in.Max))
-	out.Step = (*apiresource.Quantity)(unsafe.Pointer(in.Step))
+	*out = *(*resource.CapacityRequestPolicyRange)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -652,9 +621,7 @@ func Convert_v1beta2_CapacityRequestPolicyRange_To_resource_CapacityRequestPolic
 }
 
 func autoConvert_resource_CapacityRequestPolicyRange_To_v1beta2_CapacityRequestPolicyRange(in *resource.CapacityRequestPolicyRange, out *resourcev1beta2.CapacityRequestPolicyRange, s conversion.Scope) error {
-	out.Min = (*apiresource.Quantity)(unsafe.Pointer(in.Min))
-	out.Max = (*apiresource.Quantity)(unsafe.Pointer(in.Max))
-	out.Step = (*apiresource.Quantity)(unsafe.Pointer(in.Step))
+	*out = *(*resourcev1beta2.CapacityRequestPolicyRange)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -664,7 +631,7 @@ func Convert_resource_CapacityRequestPolicyRange_To_v1beta2_CapacityRequestPolic
 }
 
 func autoConvert_v1beta2_CapacityRequirements_To_resource_CapacityRequirements(in *resourcev1beta2.CapacityRequirements, out *resource.CapacityRequirements, s conversion.Scope) error {
-	out.Requests = *(*map[resource.QualifiedName]apiresource.Quantity)(unsafe.Pointer(&in.Requests))
+	*out = *(*resource.CapacityRequirements)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -674,7 +641,7 @@ func Convert_v1beta2_CapacityRequirements_To_resource_CapacityRequirements(in *r
 }
 
 func autoConvert_resource_CapacityRequirements_To_v1beta2_CapacityRequirements(in *resource.CapacityRequirements, out *resourcev1beta2.CapacityRequirements, s conversion.Scope) error {
-	out.Requests = *(*map[resourcev1beta2.QualifiedName]apiresource.Quantity)(unsafe.Pointer(&in.Requests))
+	*out = *(*resourcev1beta2.CapacityRequirements)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -684,7 +651,7 @@ func Convert_resource_CapacityRequirements_To_v1beta2_CapacityRequirements(in *r
 }
 
 func autoConvert_v1beta2_Counter_To_resource_Counter(in *resourcev1beta2.Counter, out *resource.Counter, s conversion.Scope) error {
-	out.Value = in.Value
+	*out = *(*resource.Counter)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -694,7 +661,7 @@ func Convert_v1beta2_Counter_To_resource_Counter(in *resourcev1beta2.Counter, ou
 }
 
 func autoConvert_resource_Counter_To_v1beta2_Counter(in *resource.Counter, out *resourcev1beta2.Counter, s conversion.Scope) error {
-	out.Value = in.Value
+	*out = *(*resourcev1beta2.Counter)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -704,8 +671,7 @@ func Convert_resource_Counter_To_v1beta2_Counter(in *resource.Counter, out *reso
 }
 
 func autoConvert_v1beta2_CounterSet_To_resource_CounterSet(in *resourcev1beta2.CounterSet, out *resource.CounterSet, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Counters = *(*map[string]resource.Counter)(unsafe.Pointer(&in.Counters))
+	*out = *(*resource.CounterSet)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -715,8 +681,7 @@ func Convert_v1beta2_CounterSet_To_resource_CounterSet(in *resourcev1beta2.Count
 }
 
 func autoConvert_resource_CounterSet_To_v1beta2_CounterSet(in *resource.CounterSet, out *resourcev1beta2.CounterSet, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Counters = *(*map[string]resourcev1beta2.Counter)(unsafe.Pointer(&in.Counters))
+	*out = *(*resourcev1beta2.CounterSet)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -726,19 +691,7 @@ func Convert_resource_CounterSet_To_v1beta2_CounterSet(in *resource.CounterSet, 
 }
 
 func autoConvert_v1beta2_Device_To_resource_Device(in *resourcev1beta2.Device, out *resource.Device, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Attributes = *(*map[resource.QualifiedName]resource.DeviceAttribute)(unsafe.Pointer(&in.Attributes))
-	out.Capacity = *(*map[resource.QualifiedName]resource.DeviceCapacity)(unsafe.Pointer(&in.Capacity))
-	out.ConsumesCounters = *(*[]resource.DeviceCounterConsumption)(unsafe.Pointer(&in.ConsumesCounters))
-	out.NodeName = (*string)(unsafe.Pointer(in.NodeName))
-	out.NodeSelector = (*core.NodeSelector)(unsafe.Pointer(in.NodeSelector))
-	out.AllNodes = (*bool)(unsafe.Pointer(in.AllNodes))
-	out.Taints = *(*[]resource.DeviceTaint)(unsafe.Pointer(&in.Taints))
-	out.BindsToNode = (*bool)(unsafe.Pointer(in.BindsToNode))
-	out.BindingConditions = *(*[]string)(unsafe.Pointer(&in.BindingConditions))
-	out.BindingFailureConditions = *(*[]string)(unsafe.Pointer(&in.BindingFailureConditions))
-	out.AllowMultipleAllocations = (*bool)(unsafe.Pointer(in.AllowMultipleAllocations))
-	out.NodeAllocatableResourceMappings = *(*map[corev1.ResourceName]resource.NodeAllocatableResourceMapping)(unsafe.Pointer(&in.NodeAllocatableResourceMappings))
+	*out = *(*resource.Device)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -748,19 +701,7 @@ func Convert_v1beta2_Device_To_resource_Device(in *resourcev1beta2.Device, out *
 }
 
 func autoConvert_resource_Device_To_v1beta2_Device(in *resource.Device, out *resourcev1beta2.Device, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Attributes = *(*map[resourcev1beta2.QualifiedName]resourcev1beta2.DeviceAttribute)(unsafe.Pointer(&in.Attributes))
-	out.Capacity = *(*map[resourcev1beta2.QualifiedName]resourcev1beta2.DeviceCapacity)(unsafe.Pointer(&in.Capacity))
-	out.ConsumesCounters = *(*[]resourcev1beta2.DeviceCounterConsumption)(unsafe.Pointer(&in.ConsumesCounters))
-	out.NodeName = (*string)(unsafe.Pointer(in.NodeName))
-	out.NodeSelector = (*corev1.NodeSelector)(unsafe.Pointer(in.NodeSelector))
-	out.AllNodes = (*bool)(unsafe.Pointer(in.AllNodes))
-	out.Taints = *(*[]resourcev1beta2.DeviceTaint)(unsafe.Pointer(&in.Taints))
-	out.BindsToNode = (*bool)(unsafe.Pointer(in.BindsToNode))
-	out.BindingConditions = *(*[]string)(unsafe.Pointer(&in.BindingConditions))
-	out.BindingFailureConditions = *(*[]string)(unsafe.Pointer(&in.BindingFailureConditions))
-	out.AllowMultipleAllocations = (*bool)(unsafe.Pointer(in.AllowMultipleAllocations))
-	out.NodeAllocatableResourceMappings = *(*map[corev1.ResourceName]resourcev1beta2.NodeAllocatableResourceMapping)(unsafe.Pointer(&in.NodeAllocatableResourceMappings))
+	*out = *(*resourcev1beta2.Device)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -770,11 +711,7 @@ func Convert_resource_Device_To_v1beta2_Device(in *resource.Device, out *resourc
 }
 
 func autoConvert_v1beta2_DeviceAllocationConfiguration_To_resource_DeviceAllocationConfiguration(in *resourcev1beta2.DeviceAllocationConfiguration, out *resource.DeviceAllocationConfiguration, s conversion.Scope) error {
-	out.Source = resource.AllocationConfigSource(in.Source)
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	if err := Convert_v1beta2_DeviceConfiguration_To_resource_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*resource.DeviceAllocationConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -784,11 +721,7 @@ func Convert_v1beta2_DeviceAllocationConfiguration_To_resource_DeviceAllocationC
 }
 
 func autoConvert_resource_DeviceAllocationConfiguration_To_v1beta2_DeviceAllocationConfiguration(in *resource.DeviceAllocationConfiguration, out *resourcev1beta2.DeviceAllocationConfiguration, s conversion.Scope) error {
-	out.Source = resourcev1beta2.AllocationConfigSource(in.Source)
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	if err := Convert_resource_DeviceConfiguration_To_v1beta2_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*resourcev1beta2.DeviceAllocationConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -798,8 +731,7 @@ func Convert_resource_DeviceAllocationConfiguration_To_v1beta2_DeviceAllocationC
 }
 
 func autoConvert_v1beta2_DeviceAllocationResult_To_resource_DeviceAllocationResult(in *resourcev1beta2.DeviceAllocationResult, out *resource.DeviceAllocationResult, s conversion.Scope) error {
-	out.Results = *(*[]resource.DeviceRequestAllocationResult)(unsafe.Pointer(&in.Results))
-	out.Config = *(*[]resource.DeviceAllocationConfiguration)(unsafe.Pointer(&in.Config))
+	*out = *(*resource.DeviceAllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -809,8 +741,7 @@ func Convert_v1beta2_DeviceAllocationResult_To_resource_DeviceAllocationResult(i
 }
 
 func autoConvert_resource_DeviceAllocationResult_To_v1beta2_DeviceAllocationResult(in *resource.DeviceAllocationResult, out *resourcev1beta2.DeviceAllocationResult, s conversion.Scope) error {
-	out.Results = *(*[]resourcev1beta2.DeviceRequestAllocationResult)(unsafe.Pointer(&in.Results))
-	out.Config = *(*[]resourcev1beta2.DeviceAllocationConfiguration)(unsafe.Pointer(&in.Config))
+	*out = *(*resourcev1beta2.DeviceAllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -820,14 +751,7 @@ func Convert_resource_DeviceAllocationResult_To_v1beta2_DeviceAllocationResult(i
 }
 
 func autoConvert_v1beta2_DeviceAttribute_To_resource_DeviceAttribute(in *resourcev1beta2.DeviceAttribute, out *resource.DeviceAttribute, s conversion.Scope) error {
-	out.IntValue = (*int64)(unsafe.Pointer(in.IntValue))
-	out.BoolValue = (*bool)(unsafe.Pointer(in.BoolValue))
-	out.StringValue = (*string)(unsafe.Pointer(in.StringValue))
-	out.VersionValue = (*string)(unsafe.Pointer(in.VersionValue))
-	out.IntValues = *(*[]int64)(unsafe.Pointer(&in.IntValues))
-	out.BoolValues = *(*[]bool)(unsafe.Pointer(&in.BoolValues))
-	out.StringValues = *(*[]string)(unsafe.Pointer(&in.StringValues))
-	out.VersionValues = *(*[]string)(unsafe.Pointer(&in.VersionValues))
+	*out = *(*resource.DeviceAttribute)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -837,14 +761,7 @@ func Convert_v1beta2_DeviceAttribute_To_resource_DeviceAttribute(in *resourcev1b
 }
 
 func autoConvert_resource_DeviceAttribute_To_v1beta2_DeviceAttribute(in *resource.DeviceAttribute, out *resourcev1beta2.DeviceAttribute, s conversion.Scope) error {
-	out.IntValue = (*int64)(unsafe.Pointer(in.IntValue))
-	out.BoolValue = (*bool)(unsafe.Pointer(in.BoolValue))
-	out.StringValue = (*string)(unsafe.Pointer(in.StringValue))
-	out.VersionValue = (*string)(unsafe.Pointer(in.VersionValue))
-	out.IntValues = *(*[]int64)(unsafe.Pointer(&in.IntValues))
-	out.BoolValues = *(*[]bool)(unsafe.Pointer(&in.BoolValues))
-	out.StringValues = *(*[]string)(unsafe.Pointer(&in.StringValues))
-	out.VersionValues = *(*[]string)(unsafe.Pointer(&in.VersionValues))
+	*out = *(*resourcev1beta2.DeviceAttribute)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -854,8 +771,7 @@ func Convert_resource_DeviceAttribute_To_v1beta2_DeviceAttribute(in *resource.De
 }
 
 func autoConvert_v1beta2_DeviceCapacity_To_resource_DeviceCapacity(in *resourcev1beta2.DeviceCapacity, out *resource.DeviceCapacity, s conversion.Scope) error {
-	out.Value = in.Value
-	out.RequestPolicy = (*resource.CapacityRequestPolicy)(unsafe.Pointer(in.RequestPolicy))
+	*out = *(*resource.DeviceCapacity)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -865,8 +781,7 @@ func Convert_v1beta2_DeviceCapacity_To_resource_DeviceCapacity(in *resourcev1bet
 }
 
 func autoConvert_resource_DeviceCapacity_To_v1beta2_DeviceCapacity(in *resource.DeviceCapacity, out *resourcev1beta2.DeviceCapacity, s conversion.Scope) error {
-	out.Value = in.Value
-	out.RequestPolicy = (*resourcev1beta2.CapacityRequestPolicy)(unsafe.Pointer(in.RequestPolicy))
+	*out = *(*resourcev1beta2.DeviceCapacity)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -876,9 +791,7 @@ func Convert_resource_DeviceCapacity_To_v1beta2_DeviceCapacity(in *resource.Devi
 }
 
 func autoConvert_v1beta2_DeviceClaim_To_resource_DeviceClaim(in *resourcev1beta2.DeviceClaim, out *resource.DeviceClaim, s conversion.Scope) error {
-	out.Requests = *(*[]resource.DeviceRequest)(unsafe.Pointer(&in.Requests))
-	out.Constraints = *(*[]resource.DeviceConstraint)(unsafe.Pointer(&in.Constraints))
-	out.Config = *(*[]resource.DeviceClaimConfiguration)(unsafe.Pointer(&in.Config))
+	*out = *(*resource.DeviceClaim)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -888,9 +801,7 @@ func Convert_v1beta2_DeviceClaim_To_resource_DeviceClaim(in *resourcev1beta2.Dev
 }
 
 func autoConvert_resource_DeviceClaim_To_v1beta2_DeviceClaim(in *resource.DeviceClaim, out *resourcev1beta2.DeviceClaim, s conversion.Scope) error {
-	out.Requests = *(*[]resourcev1beta2.DeviceRequest)(unsafe.Pointer(&in.Requests))
-	out.Constraints = *(*[]resourcev1beta2.DeviceConstraint)(unsafe.Pointer(&in.Constraints))
-	out.Config = *(*[]resourcev1beta2.DeviceClaimConfiguration)(unsafe.Pointer(&in.Config))
+	*out = *(*resourcev1beta2.DeviceClaim)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -900,10 +811,7 @@ func Convert_resource_DeviceClaim_To_v1beta2_DeviceClaim(in *resource.DeviceClai
 }
 
 func autoConvert_v1beta2_DeviceClaimConfiguration_To_resource_DeviceClaimConfiguration(in *resourcev1beta2.DeviceClaimConfiguration, out *resource.DeviceClaimConfiguration, s conversion.Scope) error {
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	if err := Convert_v1beta2_DeviceConfiguration_To_resource_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*resource.DeviceClaimConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -913,10 +821,7 @@ func Convert_v1beta2_DeviceClaimConfiguration_To_resource_DeviceClaimConfigurati
 }
 
 func autoConvert_resource_DeviceClaimConfiguration_To_v1beta2_DeviceClaimConfiguration(in *resource.DeviceClaimConfiguration, out *resourcev1beta2.DeviceClaimConfiguration, s conversion.Scope) error {
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	if err := Convert_resource_DeviceConfiguration_To_v1beta2_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*resourcev1beta2.DeviceClaimConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -952,9 +857,7 @@ func Convert_resource_DeviceClass_To_v1beta2_DeviceClass(in *resource.DeviceClas
 }
 
 func autoConvert_v1beta2_DeviceClassConfiguration_To_resource_DeviceClassConfiguration(in *resourcev1beta2.DeviceClassConfiguration, out *resource.DeviceClassConfiguration, s conversion.Scope) error {
-	if err := Convert_v1beta2_DeviceConfiguration_To_resource_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*resource.DeviceClassConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -964,9 +867,7 @@ func Convert_v1beta2_DeviceClassConfiguration_To_resource_DeviceClassConfigurati
 }
 
 func autoConvert_resource_DeviceClassConfiguration_To_v1beta2_DeviceClassConfiguration(in *resource.DeviceClassConfiguration, out *resourcev1beta2.DeviceClassConfiguration, s conversion.Scope) error {
-	if err := Convert_resource_DeviceConfiguration_To_v1beta2_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*resourcev1beta2.DeviceClassConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -998,9 +899,7 @@ func Convert_resource_DeviceClassList_To_v1beta2_DeviceClassList(in *resource.De
 }
 
 func autoConvert_v1beta2_DeviceClassSpec_To_resource_DeviceClassSpec(in *resourcev1beta2.DeviceClassSpec, out *resource.DeviceClassSpec, s conversion.Scope) error {
-	out.Selectors = *(*[]resource.DeviceSelector)(unsafe.Pointer(&in.Selectors))
-	out.Config = *(*[]resource.DeviceClassConfiguration)(unsafe.Pointer(&in.Config))
-	out.ExtendedResourceName = (*string)(unsafe.Pointer(in.ExtendedResourceName))
+	*out = *(*resource.DeviceClassSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1010,9 +909,7 @@ func Convert_v1beta2_DeviceClassSpec_To_resource_DeviceClassSpec(in *resourcev1b
 }
 
 func autoConvert_resource_DeviceClassSpec_To_v1beta2_DeviceClassSpec(in *resource.DeviceClassSpec, out *resourcev1beta2.DeviceClassSpec, s conversion.Scope) error {
-	out.Selectors = *(*[]resourcev1beta2.DeviceSelector)(unsafe.Pointer(&in.Selectors))
-	out.Config = *(*[]resourcev1beta2.DeviceClassConfiguration)(unsafe.Pointer(&in.Config))
-	out.ExtendedResourceName = (*string)(unsafe.Pointer(in.ExtendedResourceName))
+	*out = *(*resourcev1beta2.DeviceClassSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1022,7 +919,7 @@ func Convert_resource_DeviceClassSpec_To_v1beta2_DeviceClassSpec(in *resource.De
 }
 
 func autoConvert_v1beta2_DeviceConfiguration_To_resource_DeviceConfiguration(in *resourcev1beta2.DeviceConfiguration, out *resource.DeviceConfiguration, s conversion.Scope) error {
-	out.Opaque = (*resource.OpaqueDeviceConfiguration)(unsafe.Pointer(in.Opaque))
+	*out = *(*resource.DeviceConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1032,7 +929,7 @@ func Convert_v1beta2_DeviceConfiguration_To_resource_DeviceConfiguration(in *res
 }
 
 func autoConvert_resource_DeviceConfiguration_To_v1beta2_DeviceConfiguration(in *resource.DeviceConfiguration, out *resourcev1beta2.DeviceConfiguration, s conversion.Scope) error {
-	out.Opaque = (*resourcev1beta2.OpaqueDeviceConfiguration)(unsafe.Pointer(in.Opaque))
+	*out = *(*resourcev1beta2.DeviceConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1042,9 +939,7 @@ func Convert_resource_DeviceConfiguration_To_v1beta2_DeviceConfiguration(in *res
 }
 
 func autoConvert_v1beta2_DeviceConstraint_To_resource_DeviceConstraint(in *resourcev1beta2.DeviceConstraint, out *resource.DeviceConstraint, s conversion.Scope) error {
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	out.MatchAttribute = (*resource.FullyQualifiedName)(unsafe.Pointer(in.MatchAttribute))
-	out.DistinctAttribute = (*resource.FullyQualifiedName)(unsafe.Pointer(in.DistinctAttribute))
+	*out = *(*resource.DeviceConstraint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1054,9 +949,7 @@ func Convert_v1beta2_DeviceConstraint_To_resource_DeviceConstraint(in *resourcev
 }
 
 func autoConvert_resource_DeviceConstraint_To_v1beta2_DeviceConstraint(in *resource.DeviceConstraint, out *resourcev1beta2.DeviceConstraint, s conversion.Scope) error {
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	out.MatchAttribute = (*resourcev1beta2.FullyQualifiedName)(unsafe.Pointer(in.MatchAttribute))
-	out.DistinctAttribute = (*resourcev1beta2.FullyQualifiedName)(unsafe.Pointer(in.DistinctAttribute))
+	*out = *(*resourcev1beta2.DeviceConstraint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1066,8 +959,7 @@ func Convert_resource_DeviceConstraint_To_v1beta2_DeviceConstraint(in *resource.
 }
 
 func autoConvert_v1beta2_DeviceCounterConsumption_To_resource_DeviceCounterConsumption(in *resourcev1beta2.DeviceCounterConsumption, out *resource.DeviceCounterConsumption, s conversion.Scope) error {
-	out.CounterSet = in.CounterSet
-	out.Counters = *(*map[string]resource.Counter)(unsafe.Pointer(&in.Counters))
+	*out = *(*resource.DeviceCounterConsumption)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1077,8 +969,7 @@ func Convert_v1beta2_DeviceCounterConsumption_To_resource_DeviceCounterConsumpti
 }
 
 func autoConvert_resource_DeviceCounterConsumption_To_v1beta2_DeviceCounterConsumption(in *resource.DeviceCounterConsumption, out *resourcev1beta2.DeviceCounterConsumption, s conversion.Scope) error {
-	out.CounterSet = in.CounterSet
-	out.Counters = *(*map[string]resourcev1beta2.Counter)(unsafe.Pointer(&in.Counters))
+	*out = *(*resourcev1beta2.DeviceCounterConsumption)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1088,9 +979,7 @@ func Convert_resource_DeviceCounterConsumption_To_v1beta2_DeviceCounterConsumpti
 }
 
 func autoConvert_v1beta2_DeviceRequest_To_resource_DeviceRequest(in *resourcev1beta2.DeviceRequest, out *resource.DeviceRequest, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Exactly = (*resource.ExactDeviceRequest)(unsafe.Pointer(in.Exactly))
-	out.FirstAvailable = *(*[]resource.DeviceSubRequest)(unsafe.Pointer(&in.FirstAvailable))
+	*out = *(*resource.DeviceRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1100,9 +989,7 @@ func Convert_v1beta2_DeviceRequest_To_resource_DeviceRequest(in *resourcev1beta2
 }
 
 func autoConvert_resource_DeviceRequest_To_v1beta2_DeviceRequest(in *resource.DeviceRequest, out *resourcev1beta2.DeviceRequest, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Exactly = (*resourcev1beta2.ExactDeviceRequest)(unsafe.Pointer(in.Exactly))
-	out.FirstAvailable = *(*[]resourcev1beta2.DeviceSubRequest)(unsafe.Pointer(&in.FirstAvailable))
+	*out = *(*resourcev1beta2.DeviceRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1112,16 +999,7 @@ func Convert_resource_DeviceRequest_To_v1beta2_DeviceRequest(in *resource.Device
 }
 
 func autoConvert_v1beta2_DeviceRequestAllocationResult_To_resource_DeviceRequestAllocationResult(in *resourcev1beta2.DeviceRequestAllocationResult, out *resource.DeviceRequestAllocationResult, s conversion.Scope) error {
-	out.Request = in.Request
-	out.Driver = in.Driver
-	out.Pool = in.Pool
-	out.Device = in.Device
-	out.AdminAccess = (*bool)(unsafe.Pointer(in.AdminAccess))
-	out.Tolerations = *(*[]resource.DeviceToleration)(unsafe.Pointer(&in.Tolerations))
-	out.BindingConditions = *(*[]string)(unsafe.Pointer(&in.BindingConditions))
-	out.BindingFailureConditions = *(*[]string)(unsafe.Pointer(&in.BindingFailureConditions))
-	out.ShareID = (*types.UID)(unsafe.Pointer(in.ShareID))
-	out.ConsumedCapacity = *(*map[resource.QualifiedName]apiresource.Quantity)(unsafe.Pointer(&in.ConsumedCapacity))
+	*out = *(*resource.DeviceRequestAllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1131,16 +1009,7 @@ func Convert_v1beta2_DeviceRequestAllocationResult_To_resource_DeviceRequestAllo
 }
 
 func autoConvert_resource_DeviceRequestAllocationResult_To_v1beta2_DeviceRequestAllocationResult(in *resource.DeviceRequestAllocationResult, out *resourcev1beta2.DeviceRequestAllocationResult, s conversion.Scope) error {
-	out.Request = in.Request
-	out.Driver = in.Driver
-	out.Pool = in.Pool
-	out.Device = in.Device
-	out.AdminAccess = (*bool)(unsafe.Pointer(in.AdminAccess))
-	out.Tolerations = *(*[]resourcev1beta2.DeviceToleration)(unsafe.Pointer(&in.Tolerations))
-	out.BindingConditions = *(*[]string)(unsafe.Pointer(&in.BindingConditions))
-	out.BindingFailureConditions = *(*[]string)(unsafe.Pointer(&in.BindingFailureConditions))
-	out.ShareID = (*types.UID)(unsafe.Pointer(in.ShareID))
-	out.ConsumedCapacity = *(*map[resourcev1beta2.QualifiedName]apiresource.Quantity)(unsafe.Pointer(&in.ConsumedCapacity))
+	*out = *(*resourcev1beta2.DeviceRequestAllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1150,7 +1019,7 @@ func Convert_resource_DeviceRequestAllocationResult_To_v1beta2_DeviceRequestAllo
 }
 
 func autoConvert_v1beta2_DeviceSelector_To_resource_DeviceSelector(in *resourcev1beta2.DeviceSelector, out *resource.DeviceSelector, s conversion.Scope) error {
-	out.CEL = (*resource.CELDeviceSelector)(unsafe.Pointer(in.CEL))
+	*out = *(*resource.DeviceSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1160,7 +1029,7 @@ func Convert_v1beta2_DeviceSelector_To_resource_DeviceSelector(in *resourcev1bet
 }
 
 func autoConvert_resource_DeviceSelector_To_v1beta2_DeviceSelector(in *resource.DeviceSelector, out *resourcev1beta2.DeviceSelector, s conversion.Scope) error {
-	out.CEL = (*resourcev1beta2.CELDeviceSelector)(unsafe.Pointer(in.CEL))
+	*out = *(*resourcev1beta2.DeviceSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1170,13 +1039,7 @@ func Convert_resource_DeviceSelector_To_v1beta2_DeviceSelector(in *resource.Devi
 }
 
 func autoConvert_v1beta2_DeviceSubRequest_To_resource_DeviceSubRequest(in *resourcev1beta2.DeviceSubRequest, out *resource.DeviceSubRequest, s conversion.Scope) error {
-	out.Name = in.Name
-	out.DeviceClassName = in.DeviceClassName
-	out.Selectors = *(*[]resource.DeviceSelector)(unsafe.Pointer(&in.Selectors))
-	out.AllocationMode = resource.DeviceAllocationMode(in.AllocationMode)
-	out.Count = in.Count
-	out.Tolerations = *(*[]resource.DeviceToleration)(unsafe.Pointer(&in.Tolerations))
-	out.Capacity = (*resource.CapacityRequirements)(unsafe.Pointer(in.Capacity))
+	*out = *(*resource.DeviceSubRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1186,13 +1049,7 @@ func Convert_v1beta2_DeviceSubRequest_To_resource_DeviceSubRequest(in *resourcev
 }
 
 func autoConvert_resource_DeviceSubRequest_To_v1beta2_DeviceSubRequest(in *resource.DeviceSubRequest, out *resourcev1beta2.DeviceSubRequest, s conversion.Scope) error {
-	out.Name = in.Name
-	out.DeviceClassName = in.DeviceClassName
-	out.Selectors = *(*[]resourcev1beta2.DeviceSelector)(unsafe.Pointer(&in.Selectors))
-	out.AllocationMode = resourcev1beta2.DeviceAllocationMode(in.AllocationMode)
-	out.Count = in.Count
-	out.Tolerations = *(*[]resourcev1beta2.DeviceToleration)(unsafe.Pointer(&in.Tolerations))
-	out.Capacity = (*resourcev1beta2.CapacityRequirements)(unsafe.Pointer(in.Capacity))
+	*out = *(*resourcev1beta2.DeviceSubRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1202,10 +1059,7 @@ func Convert_resource_DeviceSubRequest_To_v1beta2_DeviceSubRequest(in *resource.
 }
 
 func autoConvert_v1beta2_DeviceTaint_To_resource_DeviceTaint(in *resourcev1beta2.DeviceTaint, out *resource.DeviceTaint, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Value = in.Value
-	out.Effect = resource.DeviceTaintEffect(in.Effect)
-	out.TimeAdded = (*v1.Time)(unsafe.Pointer(in.TimeAdded))
+	*out = *(*resource.DeviceTaint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1215,10 +1069,7 @@ func Convert_v1beta2_DeviceTaint_To_resource_DeviceTaint(in *resourcev1beta2.Dev
 }
 
 func autoConvert_resource_DeviceTaint_To_v1beta2_DeviceTaint(in *resource.DeviceTaint, out *resourcev1beta2.DeviceTaint, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Value = in.Value
-	out.Effect = resourcev1beta2.DeviceTaintEffect(in.Effect)
-	out.TimeAdded = (*v1.Time)(unsafe.Pointer(in.TimeAdded))
+	*out = *(*resourcev1beta2.DeviceTaint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1282,10 +1133,7 @@ func Convert_resource_DeviceTaintRuleList_To_v1beta2_DeviceTaintRuleList(in *res
 }
 
 func autoConvert_v1beta2_DeviceTaintRuleSpec_To_resource_DeviceTaintRuleSpec(in *resourcev1beta2.DeviceTaintRuleSpec, out *resource.DeviceTaintRuleSpec, s conversion.Scope) error {
-	out.DeviceSelector = (*resource.DeviceTaintSelector)(unsafe.Pointer(in.DeviceSelector))
-	if err := Convert_v1beta2_DeviceTaint_To_resource_DeviceTaint(&in.Taint, &out.Taint, s); err != nil {
-		return err
-	}
+	*out = *(*resource.DeviceTaintRuleSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1295,10 +1143,7 @@ func Convert_v1beta2_DeviceTaintRuleSpec_To_resource_DeviceTaintRuleSpec(in *res
 }
 
 func autoConvert_resource_DeviceTaintRuleSpec_To_v1beta2_DeviceTaintRuleSpec(in *resource.DeviceTaintRuleSpec, out *resourcev1beta2.DeviceTaintRuleSpec, s conversion.Scope) error {
-	out.DeviceSelector = (*resourcev1beta2.DeviceTaintSelector)(unsafe.Pointer(in.DeviceSelector))
-	if err := Convert_resource_DeviceTaint_To_v1beta2_DeviceTaint(&in.Taint, &out.Taint, s); err != nil {
-		return err
-	}
+	*out = *(*resourcev1beta2.DeviceTaintRuleSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1308,7 +1153,7 @@ func Convert_resource_DeviceTaintRuleSpec_To_v1beta2_DeviceTaintRuleSpec(in *res
 }
 
 func autoConvert_v1beta2_DeviceTaintRuleStatus_To_resource_DeviceTaintRuleStatus(in *resourcev1beta2.DeviceTaintRuleStatus, out *resource.DeviceTaintRuleStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*resource.DeviceTaintRuleStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1318,7 +1163,7 @@ func Convert_v1beta2_DeviceTaintRuleStatus_To_resource_DeviceTaintRuleStatus(in 
 }
 
 func autoConvert_resource_DeviceTaintRuleStatus_To_v1beta2_DeviceTaintRuleStatus(in *resource.DeviceTaintRuleStatus, out *resourcev1beta2.DeviceTaintRuleStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*resourcev1beta2.DeviceTaintRuleStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1328,9 +1173,7 @@ func Convert_resource_DeviceTaintRuleStatus_To_v1beta2_DeviceTaintRuleStatus(in 
 }
 
 func autoConvert_v1beta2_DeviceTaintSelector_To_resource_DeviceTaintSelector(in *resourcev1beta2.DeviceTaintSelector, out *resource.DeviceTaintSelector, s conversion.Scope) error {
-	out.Driver = (*string)(unsafe.Pointer(in.Driver))
-	out.Pool = (*string)(unsafe.Pointer(in.Pool))
-	out.Device = (*string)(unsafe.Pointer(in.Device))
+	*out = *(*resource.DeviceTaintSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1340,9 +1183,7 @@ func Convert_v1beta2_DeviceTaintSelector_To_resource_DeviceTaintSelector(in *res
 }
 
 func autoConvert_resource_DeviceTaintSelector_To_v1beta2_DeviceTaintSelector(in *resource.DeviceTaintSelector, out *resourcev1beta2.DeviceTaintSelector, s conversion.Scope) error {
-	out.Driver = (*string)(unsafe.Pointer(in.Driver))
-	out.Pool = (*string)(unsafe.Pointer(in.Pool))
-	out.Device = (*string)(unsafe.Pointer(in.Device))
+	*out = *(*resourcev1beta2.DeviceTaintSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1352,11 +1193,7 @@ func Convert_resource_DeviceTaintSelector_To_v1beta2_DeviceTaintSelector(in *res
 }
 
 func autoConvert_v1beta2_DeviceToleration_To_resource_DeviceToleration(in *resourcev1beta2.DeviceToleration, out *resource.DeviceToleration, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Operator = resource.DeviceTolerationOperator(in.Operator)
-	out.Value = in.Value
-	out.Effect = resource.DeviceTaintEffect(in.Effect)
-	out.TolerationSeconds = (*int64)(unsafe.Pointer(in.TolerationSeconds))
+	*out = *(*resource.DeviceToleration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1366,11 +1203,7 @@ func Convert_v1beta2_DeviceToleration_To_resource_DeviceToleration(in *resourcev
 }
 
 func autoConvert_resource_DeviceToleration_To_v1beta2_DeviceToleration(in *resource.DeviceToleration, out *resourcev1beta2.DeviceToleration, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Operator = resourcev1beta2.DeviceTolerationOperator(in.Operator)
-	out.Value = in.Value
-	out.Effect = resourcev1beta2.DeviceTaintEffect(in.Effect)
-	out.TolerationSeconds = (*int64)(unsafe.Pointer(in.TolerationSeconds))
+	*out = *(*resourcev1beta2.DeviceToleration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1380,13 +1213,7 @@ func Convert_resource_DeviceToleration_To_v1beta2_DeviceToleration(in *resource.
 }
 
 func autoConvert_v1beta2_ExactDeviceRequest_To_resource_ExactDeviceRequest(in *resourcev1beta2.ExactDeviceRequest, out *resource.ExactDeviceRequest, s conversion.Scope) error {
-	out.DeviceClassName = in.DeviceClassName
-	out.Selectors = *(*[]resource.DeviceSelector)(unsafe.Pointer(&in.Selectors))
-	out.AllocationMode = resource.DeviceAllocationMode(in.AllocationMode)
-	out.Count = in.Count
-	out.AdminAccess = (*bool)(unsafe.Pointer(in.AdminAccess))
-	out.Tolerations = *(*[]resource.DeviceToleration)(unsafe.Pointer(&in.Tolerations))
-	out.Capacity = (*resource.CapacityRequirements)(unsafe.Pointer(in.Capacity))
+	*out = *(*resource.ExactDeviceRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1396,13 +1223,7 @@ func Convert_v1beta2_ExactDeviceRequest_To_resource_ExactDeviceRequest(in *resou
 }
 
 func autoConvert_resource_ExactDeviceRequest_To_v1beta2_ExactDeviceRequest(in *resource.ExactDeviceRequest, out *resourcev1beta2.ExactDeviceRequest, s conversion.Scope) error {
-	out.DeviceClassName = in.DeviceClassName
-	out.Selectors = *(*[]resourcev1beta2.DeviceSelector)(unsafe.Pointer(&in.Selectors))
-	out.AllocationMode = resourcev1beta2.DeviceAllocationMode(in.AllocationMode)
-	out.Count = in.Count
-	out.AdminAccess = (*bool)(unsafe.Pointer(in.AdminAccess))
-	out.Tolerations = *(*[]resourcev1beta2.DeviceToleration)(unsafe.Pointer(&in.Tolerations))
-	out.Capacity = (*resourcev1beta2.CapacityRequirements)(unsafe.Pointer(in.Capacity))
+	*out = *(*resourcev1beta2.ExactDeviceRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1412,9 +1233,7 @@ func Convert_resource_ExactDeviceRequest_To_v1beta2_ExactDeviceRequest(in *resou
 }
 
 func autoConvert_v1beta2_NetworkDeviceData_To_resource_NetworkDeviceData(in *resourcev1beta2.NetworkDeviceData, out *resource.NetworkDeviceData, s conversion.Scope) error {
-	out.InterfaceName = in.InterfaceName
-	out.IPs = *(*[]string)(unsafe.Pointer(&in.IPs))
-	out.HardwareAddress = in.HardwareAddress
+	*out = *(*resource.NetworkDeviceData)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1424,9 +1243,7 @@ func Convert_v1beta2_NetworkDeviceData_To_resource_NetworkDeviceData(in *resourc
 }
 
 func autoConvert_resource_NetworkDeviceData_To_v1beta2_NetworkDeviceData(in *resource.NetworkDeviceData, out *resourcev1beta2.NetworkDeviceData, s conversion.Scope) error {
-	out.InterfaceName = in.InterfaceName
-	out.IPs = *(*[]string)(unsafe.Pointer(&in.IPs))
-	out.HardwareAddress = in.HardwareAddress
+	*out = *(*resourcev1beta2.NetworkDeviceData)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1436,8 +1253,7 @@ func Convert_resource_NetworkDeviceData_To_v1beta2_NetworkDeviceData(in *resourc
 }
 
 func autoConvert_v1beta2_NodeAllocatableResourceMapping_To_resource_NodeAllocatableResourceMapping(in *resourcev1beta2.NodeAllocatableResourceMapping, out *resource.NodeAllocatableResourceMapping, s conversion.Scope) error {
-	out.CapacityKey = (*resource.QualifiedName)(unsafe.Pointer(in.CapacityKey))
-	out.AllocationMultiplier = (*apiresource.Quantity)(unsafe.Pointer(in.AllocationMultiplier))
+	*out = *(*resource.NodeAllocatableResourceMapping)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1447,8 +1263,7 @@ func Convert_v1beta2_NodeAllocatableResourceMapping_To_resource_NodeAllocatableR
 }
 
 func autoConvert_resource_NodeAllocatableResourceMapping_To_v1beta2_NodeAllocatableResourceMapping(in *resource.NodeAllocatableResourceMapping, out *resourcev1beta2.NodeAllocatableResourceMapping, s conversion.Scope) error {
-	out.CapacityKey = (*resourcev1beta2.QualifiedName)(unsafe.Pointer(in.CapacityKey))
-	out.AllocationMultiplier = (*apiresource.Quantity)(unsafe.Pointer(in.AllocationMultiplier))
+	*out = *(*resourcev1beta2.NodeAllocatableResourceMapping)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1458,8 +1273,7 @@ func Convert_resource_NodeAllocatableResourceMapping_To_v1beta2_NodeAllocatableR
 }
 
 func autoConvert_v1beta2_OpaqueDeviceConfiguration_To_resource_OpaqueDeviceConfiguration(in *resourcev1beta2.OpaqueDeviceConfiguration, out *resource.OpaqueDeviceConfiguration, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.Parameters = in.Parameters
+	*out = *(*resource.OpaqueDeviceConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1469,8 +1283,7 @@ func Convert_v1beta2_OpaqueDeviceConfiguration_To_resource_OpaqueDeviceConfigura
 }
 
 func autoConvert_resource_OpaqueDeviceConfiguration_To_v1beta2_OpaqueDeviceConfiguration(in *resource.OpaqueDeviceConfiguration, out *resourcev1beta2.OpaqueDeviceConfiguration, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.Parameters = in.Parameters
+	*out = *(*resourcev1beta2.OpaqueDeviceConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1512,10 +1325,7 @@ func Convert_resource_ResourceClaim_To_v1beta2_ResourceClaim(in *resource.Resour
 }
 
 func autoConvert_v1beta2_ResourceClaimConsumerReference_To_resource_ResourceClaimConsumerReference(in *resourcev1beta2.ResourceClaimConsumerReference, out *resource.ResourceClaimConsumerReference, s conversion.Scope) error {
-	out.APIGroup = in.APIGroup
-	out.Resource = in.Resource
-	out.Name = in.Name
-	out.UID = types.UID(in.UID)
+	*out = *(*resource.ResourceClaimConsumerReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1525,10 +1335,7 @@ func Convert_v1beta2_ResourceClaimConsumerReference_To_resource_ResourceClaimCon
 }
 
 func autoConvert_resource_ResourceClaimConsumerReference_To_v1beta2_ResourceClaimConsumerReference(in *resource.ResourceClaimConsumerReference, out *resourcev1beta2.ResourceClaimConsumerReference, s conversion.Scope) error {
-	out.APIGroup = in.APIGroup
-	out.Resource = in.Resource
-	out.Name = in.Name
-	out.UID = types.UID(in.UID)
+	*out = *(*resourcev1beta2.ResourceClaimConsumerReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1560,9 +1367,7 @@ func Convert_resource_ResourceClaimList_To_v1beta2_ResourceClaimList(in *resourc
 }
 
 func autoConvert_v1beta2_ResourceClaimSpec_To_resource_ResourceClaimSpec(in *resourcev1beta2.ResourceClaimSpec, out *resource.ResourceClaimSpec, s conversion.Scope) error {
-	if err := Convert_v1beta2_DeviceClaim_To_resource_DeviceClaim(&in.Devices, &out.Devices, s); err != nil {
-		return err
-	}
+	*out = *(*resource.ResourceClaimSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1572,9 +1377,7 @@ func Convert_v1beta2_ResourceClaimSpec_To_resource_ResourceClaimSpec(in *resourc
 }
 
 func autoConvert_resource_ResourceClaimSpec_To_v1beta2_ResourceClaimSpec(in *resource.ResourceClaimSpec, out *resourcev1beta2.ResourceClaimSpec, s conversion.Scope) error {
-	if err := Convert_resource_DeviceClaim_To_v1beta2_DeviceClaim(&in.Devices, &out.Devices, s); err != nil {
-		return err
-	}
+	*out = *(*resourcev1beta2.ResourceClaimSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1584,9 +1387,7 @@ func Convert_resource_ResourceClaimSpec_To_v1beta2_ResourceClaimSpec(in *resourc
 }
 
 func autoConvert_v1beta2_ResourceClaimStatus_To_resource_ResourceClaimStatus(in *resourcev1beta2.ResourceClaimStatus, out *resource.ResourceClaimStatus, s conversion.Scope) error {
-	out.Allocation = (*resource.AllocationResult)(unsafe.Pointer(in.Allocation))
-	out.ReservedFor = *(*[]resource.ResourceClaimConsumerReference)(unsafe.Pointer(&in.ReservedFor))
-	out.Devices = *(*[]resource.AllocatedDeviceStatus)(unsafe.Pointer(&in.Devices))
+	*out = *(*resource.ResourceClaimStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1596,9 +1397,7 @@ func Convert_v1beta2_ResourceClaimStatus_To_resource_ResourceClaimStatus(in *res
 }
 
 func autoConvert_resource_ResourceClaimStatus_To_v1beta2_ResourceClaimStatus(in *resource.ResourceClaimStatus, out *resourcev1beta2.ResourceClaimStatus, s conversion.Scope) error {
-	out.Allocation = (*resourcev1beta2.AllocationResult)(unsafe.Pointer(in.Allocation))
-	out.ReservedFor = *(*[]resourcev1beta2.ResourceClaimConsumerReference)(unsafe.Pointer(&in.ReservedFor))
-	out.Devices = *(*[]resourcev1beta2.AllocatedDeviceStatus)(unsafe.Pointer(&in.Devices))
+	*out = *(*resourcev1beta2.ResourceClaimStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1656,10 +1455,7 @@ func Convert_resource_ResourceClaimTemplateList_To_v1beta2_ResourceClaimTemplate
 }
 
 func autoConvert_v1beta2_ResourceClaimTemplateSpec_To_resource_ResourceClaimTemplateSpec(in *resourcev1beta2.ResourceClaimTemplateSpec, out *resource.ResourceClaimTemplateSpec, s conversion.Scope) error {
-	out.ObjectMeta = in.ObjectMeta
-	if err := Convert_v1beta2_ResourceClaimSpec_To_resource_ResourceClaimSpec(&in.Spec, &out.Spec, s); err != nil {
-		return err
-	}
+	*out = *(*resource.ResourceClaimTemplateSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1669,10 +1465,7 @@ func Convert_v1beta2_ResourceClaimTemplateSpec_To_resource_ResourceClaimTemplate
 }
 
 func autoConvert_resource_ResourceClaimTemplateSpec_To_v1beta2_ResourceClaimTemplateSpec(in *resource.ResourceClaimTemplateSpec, out *resourcev1beta2.ResourceClaimTemplateSpec, s conversion.Scope) error {
-	out.ObjectMeta = in.ObjectMeta
-	if err := Convert_resource_ResourceClaimSpec_To_v1beta2_ResourceClaimSpec(&in.Spec, &out.Spec, s); err != nil {
-		return err
-	}
+	*out = *(*resourcev1beta2.ResourceClaimTemplateSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1682,9 +1475,7 @@ func Convert_resource_ResourceClaimTemplateSpec_To_v1beta2_ResourceClaimTemplate
 }
 
 func autoConvert_v1beta2_ResourcePool_To_resource_ResourcePool(in *resourcev1beta2.ResourcePool, out *resource.ResourcePool, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Generation = in.Generation
-	out.ResourceSliceCount = in.ResourceSliceCount
+	*out = *(*resource.ResourcePool)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1694,9 +1485,7 @@ func Convert_v1beta2_ResourcePool_To_resource_ResourcePool(in *resourcev1beta2.R
 }
 
 func autoConvert_resource_ResourcePool_To_v1beta2_ResourcePool(in *resource.ResourcePool, out *resourcev1beta2.ResourcePool, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Generation = in.Generation
-	out.ResourceSliceCount = in.ResourceSliceCount
+	*out = *(*resourcev1beta2.ResourcePool)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1754,16 +1543,7 @@ func Convert_resource_ResourceSliceList_To_v1beta2_ResourceSliceList(in *resourc
 }
 
 func autoConvert_v1beta2_ResourceSliceSpec_To_resource_ResourceSliceSpec(in *resourcev1beta2.ResourceSliceSpec, out *resource.ResourceSliceSpec, s conversion.Scope) error {
-	out.Driver = in.Driver
-	if err := Convert_v1beta2_ResourcePool_To_resource_ResourcePool(&in.Pool, &out.Pool, s); err != nil {
-		return err
-	}
-	out.NodeName = (*string)(unsafe.Pointer(in.NodeName))
-	out.NodeSelector = (*core.NodeSelector)(unsafe.Pointer(in.NodeSelector))
-	out.AllNodes = (*bool)(unsafe.Pointer(in.AllNodes))
-	out.Devices = *(*[]resource.Device)(unsafe.Pointer(&in.Devices))
-	out.PerDeviceNodeSelection = (*bool)(unsafe.Pointer(in.PerDeviceNodeSelection))
-	out.SharedCounters = *(*[]resource.CounterSet)(unsafe.Pointer(&in.SharedCounters))
+	*out = *(*resource.ResourceSliceSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1773,16 +1553,7 @@ func Convert_v1beta2_ResourceSliceSpec_To_resource_ResourceSliceSpec(in *resourc
 }
 
 func autoConvert_resource_ResourceSliceSpec_To_v1beta2_ResourceSliceSpec(in *resource.ResourceSliceSpec, out *resourcev1beta2.ResourceSliceSpec, s conversion.Scope) error {
-	out.Driver = in.Driver
-	if err := Convert_resource_ResourcePool_To_v1beta2_ResourcePool(&in.Pool, &out.Pool, s); err != nil {
-		return err
-	}
-	out.NodeName = (*string)(unsafe.Pointer(in.NodeName))
-	out.NodeSelector = (*corev1.NodeSelector)(unsafe.Pointer(in.NodeSelector))
-	out.AllNodes = (*bool)(unsafe.Pointer(in.AllNodes))
-	out.Devices = *(*[]resourcev1beta2.Device)(unsafe.Pointer(&in.Devices))
-	out.PerDeviceNodeSelection = (*bool)(unsafe.Pointer(in.PerDeviceNodeSelection))
-	out.SharedCounters = *(*[]resourcev1beta2.CounterSet)(unsafe.Pointer(&in.SharedCounters))
+	*out = *(*resourcev1beta2.ResourceSliceSpec)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/scheduling/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/scheduling/v1alpha3/zz_generated.conversion.go
@@ -25,7 +25,6 @@ import (
 	unsafe "unsafe"
 
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	scheduling "k8s.io/kubernetes/pkg/apis/scheduling"
@@ -252,6 +251,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha3_AllDisruptionMode_To_scheduling_AllDisruptionMode(in *schedulingv1alpha3.AllDisruptionMode, out *scheduling.AllDisruptionMode, s conversion.Scope) error {
+	*out = *(*scheduling.AllDisruptionMode)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -261,6 +261,7 @@ func Convert_v1alpha3_AllDisruptionMode_To_scheduling_AllDisruptionMode(in *sche
 }
 
 func autoConvert_scheduling_AllDisruptionMode_To_v1alpha3_AllDisruptionMode(in *scheduling.AllDisruptionMode, out *schedulingv1alpha3.AllDisruptionMode, s conversion.Scope) error {
+	*out = *(*schedulingv1alpha3.AllDisruptionMode)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -270,6 +271,7 @@ func Convert_scheduling_AllDisruptionMode_To_v1alpha3_AllDisruptionMode(in *sche
 }
 
 func autoConvert_v1alpha3_BasicSchedulingPolicy_To_scheduling_BasicSchedulingPolicy(in *schedulingv1alpha3.BasicSchedulingPolicy, out *scheduling.BasicSchedulingPolicy, s conversion.Scope) error {
+	*out = *(*scheduling.BasicSchedulingPolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -279,6 +281,7 @@ func Convert_v1alpha3_BasicSchedulingPolicy_To_scheduling_BasicSchedulingPolicy(
 }
 
 func autoConvert_scheduling_BasicSchedulingPolicy_To_v1alpha3_BasicSchedulingPolicy(in *scheduling.BasicSchedulingPolicy, out *schedulingv1alpha3.BasicSchedulingPolicy, s conversion.Scope) error {
+	*out = *(*schedulingv1alpha3.BasicSchedulingPolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -288,8 +291,7 @@ func Convert_scheduling_BasicSchedulingPolicy_To_v1alpha3_BasicSchedulingPolicy(
 }
 
 func autoConvert_v1alpha3_DisruptionMode_To_scheduling_DisruptionMode(in *schedulingv1alpha3.DisruptionMode, out *scheduling.DisruptionMode, s conversion.Scope) error {
-	out.Single = (*scheduling.SingleDisruptionMode)(unsafe.Pointer(in.Single))
-	out.All = (*scheduling.AllDisruptionMode)(unsafe.Pointer(in.All))
+	*out = *(*scheduling.DisruptionMode)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -299,8 +301,7 @@ func Convert_v1alpha3_DisruptionMode_To_scheduling_DisruptionMode(in *scheduling
 }
 
 func autoConvert_scheduling_DisruptionMode_To_v1alpha3_DisruptionMode(in *scheduling.DisruptionMode, out *schedulingv1alpha3.DisruptionMode, s conversion.Scope) error {
-	out.Single = (*schedulingv1alpha3.SingleDisruptionMode)(unsafe.Pointer(in.Single))
-	out.All = (*schedulingv1alpha3.AllDisruptionMode)(unsafe.Pointer(in.All))
+	*out = *(*schedulingv1alpha3.DisruptionMode)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -310,7 +311,7 @@ func Convert_scheduling_DisruptionMode_To_v1alpha3_DisruptionMode(in *scheduling
 }
 
 func autoConvert_v1alpha3_GangSchedulingPolicy_To_scheduling_GangSchedulingPolicy(in *schedulingv1alpha3.GangSchedulingPolicy, out *scheduling.GangSchedulingPolicy, s conversion.Scope) error {
-	out.MinCount = in.MinCount
+	*out = *(*scheduling.GangSchedulingPolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -320,7 +321,7 @@ func Convert_v1alpha3_GangSchedulingPolicy_To_scheduling_GangSchedulingPolicy(in
 }
 
 func autoConvert_scheduling_GangSchedulingPolicy_To_v1alpha3_GangSchedulingPolicy(in *scheduling.GangSchedulingPolicy, out *schedulingv1alpha3.GangSchedulingPolicy, s conversion.Scope) error {
-	out.MinCount = in.MinCount
+	*out = *(*schedulingv1alpha3.GangSchedulingPolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -384,9 +385,7 @@ func Convert_scheduling_PodGroupList_To_v1alpha3_PodGroupList(in *scheduling.Pod
 }
 
 func autoConvert_v1alpha3_PodGroupResourceClaim_To_scheduling_PodGroupResourceClaim(in *schedulingv1alpha3.PodGroupResourceClaim, out *scheduling.PodGroupResourceClaim, s conversion.Scope) error {
-	out.Name = in.Name
-	out.ResourceClaimName = (*string)(unsafe.Pointer(in.ResourceClaimName))
-	out.ResourceClaimTemplateName = (*string)(unsafe.Pointer(in.ResourceClaimTemplateName))
+	*out = *(*scheduling.PodGroupResourceClaim)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -396,9 +395,7 @@ func Convert_v1alpha3_PodGroupResourceClaim_To_scheduling_PodGroupResourceClaim(
 }
 
 func autoConvert_scheduling_PodGroupResourceClaim_To_v1alpha3_PodGroupResourceClaim(in *scheduling.PodGroupResourceClaim, out *schedulingv1alpha3.PodGroupResourceClaim, s conversion.Scope) error {
-	out.Name = in.Name
-	out.ResourceClaimName = (*string)(unsafe.Pointer(in.ResourceClaimName))
-	out.ResourceClaimTemplateName = (*string)(unsafe.Pointer(in.ResourceClaimTemplateName))
+	*out = *(*schedulingv1alpha3.PodGroupResourceClaim)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -408,8 +405,7 @@ func Convert_scheduling_PodGroupResourceClaim_To_v1alpha3_PodGroupResourceClaim(
 }
 
 func autoConvert_v1alpha3_PodGroupResourceClaimStatus_To_scheduling_PodGroupResourceClaimStatus(in *schedulingv1alpha3.PodGroupResourceClaimStatus, out *scheduling.PodGroupResourceClaimStatus, s conversion.Scope) error {
-	out.Name = in.Name
-	out.ResourceClaimName = (*string)(unsafe.Pointer(in.ResourceClaimName))
+	*out = *(*scheduling.PodGroupResourceClaimStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -419,8 +415,7 @@ func Convert_v1alpha3_PodGroupResourceClaimStatus_To_scheduling_PodGroupResource
 }
 
 func autoConvert_scheduling_PodGroupResourceClaimStatus_To_v1alpha3_PodGroupResourceClaimStatus(in *scheduling.PodGroupResourceClaimStatus, out *schedulingv1alpha3.PodGroupResourceClaimStatus, s conversion.Scope) error {
-	out.Name = in.Name
-	out.ResourceClaimName = (*string)(unsafe.Pointer(in.ResourceClaimName))
+	*out = *(*schedulingv1alpha3.PodGroupResourceClaimStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -430,7 +425,7 @@ func Convert_scheduling_PodGroupResourceClaimStatus_To_v1alpha3_PodGroupResource
 }
 
 func autoConvert_v1alpha3_PodGroupSchedulingConstraints_To_scheduling_PodGroupSchedulingConstraints(in *schedulingv1alpha3.PodGroupSchedulingConstraints, out *scheduling.PodGroupSchedulingConstraints, s conversion.Scope) error {
-	out.Topology = *(*[]scheduling.TopologyConstraint)(unsafe.Pointer(&in.Topology))
+	*out = *(*scheduling.PodGroupSchedulingConstraints)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -440,7 +435,7 @@ func Convert_v1alpha3_PodGroupSchedulingConstraints_To_scheduling_PodGroupSchedu
 }
 
 func autoConvert_scheduling_PodGroupSchedulingConstraints_To_v1alpha3_PodGroupSchedulingConstraints(in *scheduling.PodGroupSchedulingConstraints, out *schedulingv1alpha3.PodGroupSchedulingConstraints, s conversion.Scope) error {
-	out.Topology = *(*[]schedulingv1alpha3.TopologyConstraint)(unsafe.Pointer(&in.Topology))
+	*out = *(*schedulingv1alpha3.PodGroupSchedulingConstraints)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -450,8 +445,7 @@ func Convert_scheduling_PodGroupSchedulingConstraints_To_v1alpha3_PodGroupSchedu
 }
 
 func autoConvert_v1alpha3_PodGroupSchedulingPolicy_To_scheduling_PodGroupSchedulingPolicy(in *schedulingv1alpha3.PodGroupSchedulingPolicy, out *scheduling.PodGroupSchedulingPolicy, s conversion.Scope) error {
-	out.Basic = (*scheduling.BasicSchedulingPolicy)(unsafe.Pointer(in.Basic))
-	out.Gang = (*scheduling.GangSchedulingPolicy)(unsafe.Pointer(in.Gang))
+	*out = *(*scheduling.PodGroupSchedulingPolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -461,8 +455,7 @@ func Convert_v1alpha3_PodGroupSchedulingPolicy_To_scheduling_PodGroupSchedulingP
 }
 
 func autoConvert_scheduling_PodGroupSchedulingPolicy_To_v1alpha3_PodGroupSchedulingPolicy(in *scheduling.PodGroupSchedulingPolicy, out *schedulingv1alpha3.PodGroupSchedulingPolicy, s conversion.Scope) error {
-	out.Basic = (*schedulingv1alpha3.BasicSchedulingPolicy)(unsafe.Pointer(in.Basic))
-	out.Gang = (*schedulingv1alpha3.GangSchedulingPolicy)(unsafe.Pointer(in.Gang))
+	*out = *(*schedulingv1alpha3.PodGroupSchedulingPolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -472,16 +465,7 @@ func Convert_scheduling_PodGroupSchedulingPolicy_To_v1alpha3_PodGroupSchedulingP
 }
 
 func autoConvert_v1alpha3_PodGroupSpec_To_scheduling_PodGroupSpec(in *schedulingv1alpha3.PodGroupSpec, out *scheduling.PodGroupSpec, s conversion.Scope) error {
-	out.PodGroupTemplateRef = (*scheduling.PodGroupTemplateReference)(unsafe.Pointer(in.PodGroupTemplateRef))
-	if err := Convert_v1alpha3_PodGroupSchedulingPolicy_To_scheduling_PodGroupSchedulingPolicy(&in.SchedulingPolicy, &out.SchedulingPolicy, s); err != nil {
-		return err
-	}
-	out.SchedulingConstraints = (*scheduling.PodGroupSchedulingConstraints)(unsafe.Pointer(in.SchedulingConstraints))
-	out.ResourceClaims = *(*[]scheduling.PodGroupResourceClaim)(unsafe.Pointer(&in.ResourceClaims))
-	out.DisruptionMode = (*scheduling.DisruptionMode)(unsafe.Pointer(in.DisruptionMode))
-	out.PriorityClassName = in.PriorityClassName
-	out.Priority = (*int32)(unsafe.Pointer(in.Priority))
-	out.PreemptionPolicy = (*scheduling.PreemptionPolicy)(unsafe.Pointer(in.PreemptionPolicy))
+	*out = *(*scheduling.PodGroupSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -491,16 +475,7 @@ func Convert_v1alpha3_PodGroupSpec_To_scheduling_PodGroupSpec(in *schedulingv1al
 }
 
 func autoConvert_scheduling_PodGroupSpec_To_v1alpha3_PodGroupSpec(in *scheduling.PodGroupSpec, out *schedulingv1alpha3.PodGroupSpec, s conversion.Scope) error {
-	out.PodGroupTemplateRef = (*schedulingv1alpha3.PodGroupTemplateReference)(unsafe.Pointer(in.PodGroupTemplateRef))
-	if err := Convert_scheduling_PodGroupSchedulingPolicy_To_v1alpha3_PodGroupSchedulingPolicy(&in.SchedulingPolicy, &out.SchedulingPolicy, s); err != nil {
-		return err
-	}
-	out.SchedulingConstraints = (*schedulingv1alpha3.PodGroupSchedulingConstraints)(unsafe.Pointer(in.SchedulingConstraints))
-	out.ResourceClaims = *(*[]schedulingv1alpha3.PodGroupResourceClaim)(unsafe.Pointer(&in.ResourceClaims))
-	out.DisruptionMode = (*schedulingv1alpha3.DisruptionMode)(unsafe.Pointer(in.DisruptionMode))
-	out.PriorityClassName = in.PriorityClassName
-	out.Priority = (*int32)(unsafe.Pointer(in.Priority))
-	out.PreemptionPolicy = (*schedulingv1alpha3.PreemptionPolicy)(unsafe.Pointer(in.PreemptionPolicy))
+	*out = *(*schedulingv1alpha3.PodGroupSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -510,8 +485,7 @@ func Convert_scheduling_PodGroupSpec_To_v1alpha3_PodGroupSpec(in *scheduling.Pod
 }
 
 func autoConvert_v1alpha3_PodGroupStatus_To_scheduling_PodGroupStatus(in *schedulingv1alpha3.PodGroupStatus, out *scheduling.PodGroupStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
-	out.ResourceClaimStatuses = *(*[]scheduling.PodGroupResourceClaimStatus)(unsafe.Pointer(&in.ResourceClaimStatuses))
+	*out = *(*scheduling.PodGroupStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -521,8 +495,7 @@ func Convert_v1alpha3_PodGroupStatus_To_scheduling_PodGroupStatus(in *scheduling
 }
 
 func autoConvert_scheduling_PodGroupStatus_To_v1alpha3_PodGroupStatus(in *scheduling.PodGroupStatus, out *schedulingv1alpha3.PodGroupStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
-	out.ResourceClaimStatuses = *(*[]schedulingv1alpha3.PodGroupResourceClaimStatus)(unsafe.Pointer(&in.ResourceClaimStatuses))
+	*out = *(*schedulingv1alpha3.PodGroupStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -532,15 +505,7 @@ func Convert_scheduling_PodGroupStatus_To_v1alpha3_PodGroupStatus(in *scheduling
 }
 
 func autoConvert_v1alpha3_PodGroupTemplate_To_scheduling_PodGroupTemplate(in *schedulingv1alpha3.PodGroupTemplate, out *scheduling.PodGroupTemplate, s conversion.Scope) error {
-	out.Name = in.Name
-	if err := Convert_v1alpha3_PodGroupSchedulingPolicy_To_scheduling_PodGroupSchedulingPolicy(&in.SchedulingPolicy, &out.SchedulingPolicy, s); err != nil {
-		return err
-	}
-	out.SchedulingConstraints = (*scheduling.PodGroupSchedulingConstraints)(unsafe.Pointer(in.SchedulingConstraints))
-	out.ResourceClaims = *(*[]scheduling.PodGroupResourceClaim)(unsafe.Pointer(&in.ResourceClaims))
-	out.DisruptionMode = (*scheduling.DisruptionMode)(unsafe.Pointer(in.DisruptionMode))
-	out.PriorityClassName = in.PriorityClassName
-	out.Priority = (*int32)(unsafe.Pointer(in.Priority))
+	*out = *(*scheduling.PodGroupTemplate)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -550,15 +515,7 @@ func Convert_v1alpha3_PodGroupTemplate_To_scheduling_PodGroupTemplate(in *schedu
 }
 
 func autoConvert_scheduling_PodGroupTemplate_To_v1alpha3_PodGroupTemplate(in *scheduling.PodGroupTemplate, out *schedulingv1alpha3.PodGroupTemplate, s conversion.Scope) error {
-	out.Name = in.Name
-	if err := Convert_scheduling_PodGroupSchedulingPolicy_To_v1alpha3_PodGroupSchedulingPolicy(&in.SchedulingPolicy, &out.SchedulingPolicy, s); err != nil {
-		return err
-	}
-	out.SchedulingConstraints = (*schedulingv1alpha3.PodGroupSchedulingConstraints)(unsafe.Pointer(in.SchedulingConstraints))
-	out.ResourceClaims = *(*[]schedulingv1alpha3.PodGroupResourceClaim)(unsafe.Pointer(&in.ResourceClaims))
-	out.DisruptionMode = (*schedulingv1alpha3.DisruptionMode)(unsafe.Pointer(in.DisruptionMode))
-	out.PriorityClassName = in.PriorityClassName
-	out.Priority = (*int32)(unsafe.Pointer(in.Priority))
+	*out = *(*schedulingv1alpha3.PodGroupTemplate)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -568,7 +525,7 @@ func Convert_scheduling_PodGroupTemplate_To_v1alpha3_PodGroupTemplate(in *schedu
 }
 
 func autoConvert_v1alpha3_PodGroupTemplateReference_To_scheduling_PodGroupTemplateReference(in *schedulingv1alpha3.PodGroupTemplateReference, out *scheduling.PodGroupTemplateReference, s conversion.Scope) error {
-	out.Workload = (*scheduling.WorkloadPodGroupTemplateReference)(unsafe.Pointer(in.Workload))
+	*out = *(*scheduling.PodGroupTemplateReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -578,7 +535,7 @@ func Convert_v1alpha3_PodGroupTemplateReference_To_scheduling_PodGroupTemplateRe
 }
 
 func autoConvert_scheduling_PodGroupTemplateReference_To_v1alpha3_PodGroupTemplateReference(in *scheduling.PodGroupTemplateReference, out *schedulingv1alpha3.PodGroupTemplateReference, s conversion.Scope) error {
-	out.Workload = (*schedulingv1alpha3.WorkloadPodGroupTemplateReference)(unsafe.Pointer(in.Workload))
+	*out = *(*schedulingv1alpha3.PodGroupTemplateReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -588,6 +545,7 @@ func Convert_scheduling_PodGroupTemplateReference_To_v1alpha3_PodGroupTemplateRe
 }
 
 func autoConvert_v1alpha3_SingleDisruptionMode_To_scheduling_SingleDisruptionMode(in *schedulingv1alpha3.SingleDisruptionMode, out *scheduling.SingleDisruptionMode, s conversion.Scope) error {
+	*out = *(*scheduling.SingleDisruptionMode)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -597,6 +555,7 @@ func Convert_v1alpha3_SingleDisruptionMode_To_scheduling_SingleDisruptionMode(in
 }
 
 func autoConvert_scheduling_SingleDisruptionMode_To_v1alpha3_SingleDisruptionMode(in *scheduling.SingleDisruptionMode, out *schedulingv1alpha3.SingleDisruptionMode, s conversion.Scope) error {
+	*out = *(*schedulingv1alpha3.SingleDisruptionMode)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -606,7 +565,7 @@ func Convert_scheduling_SingleDisruptionMode_To_v1alpha3_SingleDisruptionMode(in
 }
 
 func autoConvert_v1alpha3_TopologyConstraint_To_scheduling_TopologyConstraint(in *schedulingv1alpha3.TopologyConstraint, out *scheduling.TopologyConstraint, s conversion.Scope) error {
-	out.Key = in.Key
+	*out = *(*scheduling.TopologyConstraint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -616,7 +575,7 @@ func Convert_v1alpha3_TopologyConstraint_To_scheduling_TopologyConstraint(in *sc
 }
 
 func autoConvert_scheduling_TopologyConstraint_To_v1alpha3_TopologyConstraint(in *scheduling.TopologyConstraint, out *schedulingv1alpha3.TopologyConstraint, s conversion.Scope) error {
-	out.Key = in.Key
+	*out = *(*schedulingv1alpha3.TopologyConstraint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -626,9 +585,7 @@ func Convert_scheduling_TopologyConstraint_To_v1alpha3_TopologyConstraint(in *sc
 }
 
 func autoConvert_v1alpha3_TypedLocalObjectReference_To_scheduling_TypedLocalObjectReference(in *schedulingv1alpha3.TypedLocalObjectReference, out *scheduling.TypedLocalObjectReference, s conversion.Scope) error {
-	out.APIGroup = in.APIGroup
-	out.Kind = in.Kind
-	out.Name = in.Name
+	*out = *(*scheduling.TypedLocalObjectReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -638,9 +595,7 @@ func Convert_v1alpha3_TypedLocalObjectReference_To_scheduling_TypedLocalObjectRe
 }
 
 func autoConvert_scheduling_TypedLocalObjectReference_To_v1alpha3_TypedLocalObjectReference(in *scheduling.TypedLocalObjectReference, out *schedulingv1alpha3.TypedLocalObjectReference, s conversion.Scope) error {
-	out.APIGroup = in.APIGroup
-	out.Kind = in.Kind
-	out.Name = in.Name
+	*out = *(*schedulingv1alpha3.TypedLocalObjectReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -698,8 +653,7 @@ func Convert_scheduling_WorkloadList_To_v1alpha3_WorkloadList(in *scheduling.Wor
 }
 
 func autoConvert_v1alpha3_WorkloadPodGroupTemplateReference_To_scheduling_WorkloadPodGroupTemplateReference(in *schedulingv1alpha3.WorkloadPodGroupTemplateReference, out *scheduling.WorkloadPodGroupTemplateReference, s conversion.Scope) error {
-	out.WorkloadName = in.WorkloadName
-	out.PodGroupTemplateName = in.PodGroupTemplateName
+	*out = *(*scheduling.WorkloadPodGroupTemplateReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -709,8 +663,7 @@ func Convert_v1alpha3_WorkloadPodGroupTemplateReference_To_scheduling_WorkloadPo
 }
 
 func autoConvert_scheduling_WorkloadPodGroupTemplateReference_To_v1alpha3_WorkloadPodGroupTemplateReference(in *scheduling.WorkloadPodGroupTemplateReference, out *schedulingv1alpha3.WorkloadPodGroupTemplateReference, s conversion.Scope) error {
-	out.WorkloadName = in.WorkloadName
-	out.PodGroupTemplateName = in.PodGroupTemplateName
+	*out = *(*schedulingv1alpha3.WorkloadPodGroupTemplateReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -720,8 +673,7 @@ func Convert_scheduling_WorkloadPodGroupTemplateReference_To_v1alpha3_WorkloadPo
 }
 
 func autoConvert_v1alpha3_WorkloadSpec_To_scheduling_WorkloadSpec(in *schedulingv1alpha3.WorkloadSpec, out *scheduling.WorkloadSpec, s conversion.Scope) error {
-	out.ControllerRef = (*scheduling.TypedLocalObjectReference)(unsafe.Pointer(in.ControllerRef))
-	out.PodGroupTemplates = *(*[]scheduling.PodGroupTemplate)(unsafe.Pointer(&in.PodGroupTemplates))
+	*out = *(*scheduling.WorkloadSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -731,8 +683,7 @@ func Convert_v1alpha3_WorkloadSpec_To_scheduling_WorkloadSpec(in *schedulingv1al
 }
 
 func autoConvert_scheduling_WorkloadSpec_To_v1alpha3_WorkloadSpec(in *scheduling.WorkloadSpec, out *schedulingv1alpha3.WorkloadSpec, s conversion.Scope) error {
-	out.ControllerRef = (*schedulingv1alpha3.TypedLocalObjectReference)(unsafe.Pointer(in.ControllerRef))
-	out.PodGroupTemplates = *(*[]schedulingv1alpha3.PodGroupTemplate)(unsafe.Pointer(&in.PodGroupTemplates))
+	*out = *(*schedulingv1alpha3.WorkloadSpec)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/storage/v1/zz_generated.conversion.go
+++ b/pkg/apis/storage/v1/zz_generated.conversion.go
@@ -390,10 +390,7 @@ func Convert_storage_CSINode_To_v1_CSINode(in *storage.CSINode, out *storagev1.C
 }
 
 func autoConvert_v1_CSINodeDriver_To_storage_CSINodeDriver(in *storagev1.CSINodeDriver, out *storage.CSINodeDriver, s conversion.Scope) error {
-	out.Name = in.Name
-	out.NodeID = in.NodeID
-	out.TopologyKeys = *(*[]string)(unsafe.Pointer(&in.TopologyKeys))
-	out.Allocatable = (*storage.VolumeNodeResources)(unsafe.Pointer(in.Allocatable))
+	*out = *(*storage.CSINodeDriver)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -403,10 +400,7 @@ func Convert_v1_CSINodeDriver_To_storage_CSINodeDriver(in *storagev1.CSINodeDriv
 }
 
 func autoConvert_storage_CSINodeDriver_To_v1_CSINodeDriver(in *storage.CSINodeDriver, out *storagev1.CSINodeDriver, s conversion.Scope) error {
-	out.Name = in.Name
-	out.NodeID = in.NodeID
-	out.TopologyKeys = *(*[]string)(unsafe.Pointer(&in.TopologyKeys))
-	out.Allocatable = (*storagev1.VolumeNodeResources)(unsafe.Pointer(in.Allocatable))
+	*out = *(*storagev1.CSINodeDriver)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -438,7 +432,7 @@ func Convert_storage_CSINodeList_To_v1_CSINodeList(in *storage.CSINodeList, out 
 }
 
 func autoConvert_v1_CSINodeSpec_To_storage_CSINodeSpec(in *storagev1.CSINodeSpec, out *storage.CSINodeSpec, s conversion.Scope) error {
-	out.Drivers = *(*[]storage.CSINodeDriver)(unsafe.Pointer(&in.Drivers))
+	*out = *(*storage.CSINodeSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -448,7 +442,7 @@ func Convert_v1_CSINodeSpec_To_storage_CSINodeSpec(in *storagev1.CSINodeSpec, ou
 }
 
 func autoConvert_storage_CSINodeSpec_To_v1_CSINodeSpec(in *storage.CSINodeSpec, out *storagev1.CSINodeSpec, s conversion.Scope) error {
-	out.Drivers = *(*[]storagev1.CSINodeDriver)(unsafe.Pointer(&in.Drivers))
+	*out = *(*storagev1.CSINodeSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -564,8 +558,7 @@ func Convert_storage_StorageClassList_To_v1_StorageClassList(in *storage.Storage
 }
 
 func autoConvert_v1_TokenRequest_To_storage_TokenRequest(in *storagev1.TokenRequest, out *storage.TokenRequest, s conversion.Scope) error {
-	out.Audience = in.Audience
-	out.ExpirationSeconds = (*int64)(unsafe.Pointer(in.ExpirationSeconds))
+	*out = *(*storage.TokenRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -575,8 +568,7 @@ func Convert_v1_TokenRequest_To_storage_TokenRequest(in *storagev1.TokenRequest,
 }
 
 func autoConvert_storage_TokenRequest_To_v1_TokenRequest(in *storage.TokenRequest, out *storagev1.TokenRequest, s conversion.Scope) error {
-	out.Audience = in.Audience
-	out.ExpirationSeconds = (*int64)(unsafe.Pointer(in.ExpirationSeconds))
+	*out = *(*storagev1.TokenRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -726,10 +718,7 @@ func Convert_storage_VolumeAttachmentSpec_To_v1_VolumeAttachmentSpec(in *storage
 }
 
 func autoConvert_v1_VolumeAttachmentStatus_To_storage_VolumeAttachmentStatus(in *storagev1.VolumeAttachmentStatus, out *storage.VolumeAttachmentStatus, s conversion.Scope) error {
-	out.Attached = in.Attached
-	out.AttachmentMetadata = *(*map[string]string)(unsafe.Pointer(&in.AttachmentMetadata))
-	out.AttachError = (*storage.VolumeError)(unsafe.Pointer(in.AttachError))
-	out.DetachError = (*storage.VolumeError)(unsafe.Pointer(in.DetachError))
+	*out = *(*storage.VolumeAttachmentStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -739,10 +728,7 @@ func Convert_v1_VolumeAttachmentStatus_To_storage_VolumeAttachmentStatus(in *sto
 }
 
 func autoConvert_storage_VolumeAttachmentStatus_To_v1_VolumeAttachmentStatus(in *storage.VolumeAttachmentStatus, out *storagev1.VolumeAttachmentStatus, s conversion.Scope) error {
-	out.Attached = in.Attached
-	out.AttachmentMetadata = *(*map[string]string)(unsafe.Pointer(&in.AttachmentMetadata))
-	out.AttachError = (*storagev1.VolumeError)(unsafe.Pointer(in.AttachError))
-	out.DetachError = (*storagev1.VolumeError)(unsafe.Pointer(in.DetachError))
+	*out = *(*storagev1.VolumeAttachmentStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -798,9 +784,7 @@ func Convert_storage_VolumeAttributesClassList_To_v1_VolumeAttributesClassList(i
 }
 
 func autoConvert_v1_VolumeError_To_storage_VolumeError(in *storagev1.VolumeError, out *storage.VolumeError, s conversion.Scope) error {
-	out.Time = in.Time
-	out.Message = in.Message
-	out.ErrorCode = (*int32)(unsafe.Pointer(in.ErrorCode))
+	*out = *(*storage.VolumeError)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -810,9 +794,7 @@ func Convert_v1_VolumeError_To_storage_VolumeError(in *storagev1.VolumeError, ou
 }
 
 func autoConvert_storage_VolumeError_To_v1_VolumeError(in *storage.VolumeError, out *storagev1.VolumeError, s conversion.Scope) error {
-	out.Time = in.Time
-	out.Message = in.Message
-	out.ErrorCode = (*int32)(unsafe.Pointer(in.ErrorCode))
+	*out = *(*storagev1.VolumeError)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -822,7 +804,7 @@ func Convert_storage_VolumeError_To_v1_VolumeError(in *storage.VolumeError, out 
 }
 
 func autoConvert_v1_VolumeNodeResources_To_storage_VolumeNodeResources(in *storagev1.VolumeNodeResources, out *storage.VolumeNodeResources, s conversion.Scope) error {
-	out.Count = (*int32)(unsafe.Pointer(in.Count))
+	*out = *(*storage.VolumeNodeResources)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -832,7 +814,7 @@ func Convert_v1_VolumeNodeResources_To_storage_VolumeNodeResources(in *storagev1
 }
 
 func autoConvert_storage_VolumeNodeResources_To_v1_VolumeNodeResources(in *storage.VolumeNodeResources, out *storagev1.VolumeNodeResources, s conversion.Scope) error {
-	out.Count = (*int32)(unsafe.Pointer(in.Count))
+	*out = *(*storagev1.VolumeNodeResources)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/storage/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/storage/v1alpha1/zz_generated.conversion.go
@@ -336,10 +336,7 @@ func Convert_storage_VolumeAttachmentSpec_To_v1alpha1_VolumeAttachmentSpec(in *s
 }
 
 func autoConvert_v1alpha1_VolumeAttachmentStatus_To_storage_VolumeAttachmentStatus(in *storagev1alpha1.VolumeAttachmentStatus, out *storage.VolumeAttachmentStatus, s conversion.Scope) error {
-	out.Attached = in.Attached
-	out.AttachmentMetadata = *(*map[string]string)(unsafe.Pointer(&in.AttachmentMetadata))
-	out.AttachError = (*storage.VolumeError)(unsafe.Pointer(in.AttachError))
-	out.DetachError = (*storage.VolumeError)(unsafe.Pointer(in.DetachError))
+	*out = *(*storage.VolumeAttachmentStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -349,10 +346,7 @@ func Convert_v1alpha1_VolumeAttachmentStatus_To_storage_VolumeAttachmentStatus(i
 }
 
 func autoConvert_storage_VolumeAttachmentStatus_To_v1alpha1_VolumeAttachmentStatus(in *storage.VolumeAttachmentStatus, out *storagev1alpha1.VolumeAttachmentStatus, s conversion.Scope) error {
-	out.Attached = in.Attached
-	out.AttachmentMetadata = *(*map[string]string)(unsafe.Pointer(&in.AttachmentMetadata))
-	out.AttachError = (*storagev1alpha1.VolumeError)(unsafe.Pointer(in.AttachError))
-	out.DetachError = (*storagev1alpha1.VolumeError)(unsafe.Pointer(in.DetachError))
+	*out = *(*storagev1alpha1.VolumeAttachmentStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -408,9 +402,7 @@ func Convert_storage_VolumeAttributesClassList_To_v1alpha1_VolumeAttributesClass
 }
 
 func autoConvert_v1alpha1_VolumeError_To_storage_VolumeError(in *storagev1alpha1.VolumeError, out *storage.VolumeError, s conversion.Scope) error {
-	out.Time = in.Time
-	out.Message = in.Message
-	out.ErrorCode = (*int32)(unsafe.Pointer(in.ErrorCode))
+	*out = *(*storage.VolumeError)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -420,9 +412,7 @@ func Convert_v1alpha1_VolumeError_To_storage_VolumeError(in *storagev1alpha1.Vol
 }
 
 func autoConvert_storage_VolumeError_To_v1alpha1_VolumeError(in *storage.VolumeError, out *storagev1alpha1.VolumeError, s conversion.Scope) error {
-	out.Time = in.Time
-	out.Message = in.Message
-	out.ErrorCode = (*int32)(unsafe.Pointer(in.ErrorCode))
+	*out = *(*storagev1alpha1.VolumeError)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/storage/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/storage/v1beta1/zz_generated.conversion.go
@@ -390,10 +390,7 @@ func Convert_storage_CSINode_To_v1beta1_CSINode(in *storage.CSINode, out *storag
 }
 
 func autoConvert_v1beta1_CSINodeDriver_To_storage_CSINodeDriver(in *storagev1beta1.CSINodeDriver, out *storage.CSINodeDriver, s conversion.Scope) error {
-	out.Name = in.Name
-	out.NodeID = in.NodeID
-	out.TopologyKeys = *(*[]string)(unsafe.Pointer(&in.TopologyKeys))
-	out.Allocatable = (*storage.VolumeNodeResources)(unsafe.Pointer(in.Allocatable))
+	*out = *(*storage.CSINodeDriver)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -403,10 +400,7 @@ func Convert_v1beta1_CSINodeDriver_To_storage_CSINodeDriver(in *storagev1beta1.C
 }
 
 func autoConvert_storage_CSINodeDriver_To_v1beta1_CSINodeDriver(in *storage.CSINodeDriver, out *storagev1beta1.CSINodeDriver, s conversion.Scope) error {
-	out.Name = in.Name
-	out.NodeID = in.NodeID
-	out.TopologyKeys = *(*[]string)(unsafe.Pointer(&in.TopologyKeys))
-	out.Allocatable = (*storagev1beta1.VolumeNodeResources)(unsafe.Pointer(in.Allocatable))
+	*out = *(*storagev1beta1.CSINodeDriver)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -438,7 +432,7 @@ func Convert_storage_CSINodeList_To_v1beta1_CSINodeList(in *storage.CSINodeList,
 }
 
 func autoConvert_v1beta1_CSINodeSpec_To_storage_CSINodeSpec(in *storagev1beta1.CSINodeSpec, out *storage.CSINodeSpec, s conversion.Scope) error {
-	out.Drivers = *(*[]storage.CSINodeDriver)(unsafe.Pointer(&in.Drivers))
+	*out = *(*storage.CSINodeSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -448,7 +442,7 @@ func Convert_v1beta1_CSINodeSpec_To_storage_CSINodeSpec(in *storagev1beta1.CSINo
 }
 
 func autoConvert_storage_CSINodeSpec_To_v1beta1_CSINodeSpec(in *storage.CSINodeSpec, out *storagev1beta1.CSINodeSpec, s conversion.Scope) error {
-	out.Drivers = *(*[]storagev1beta1.CSINodeDriver)(unsafe.Pointer(&in.Drivers))
+	*out = *(*storagev1beta1.CSINodeSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -564,8 +558,7 @@ func Convert_storage_StorageClassList_To_v1beta1_StorageClassList(in *storage.St
 }
 
 func autoConvert_v1beta1_TokenRequest_To_storage_TokenRequest(in *storagev1beta1.TokenRequest, out *storage.TokenRequest, s conversion.Scope) error {
-	out.Audience = in.Audience
-	out.ExpirationSeconds = (*int64)(unsafe.Pointer(in.ExpirationSeconds))
+	*out = *(*storage.TokenRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -575,8 +568,7 @@ func Convert_v1beta1_TokenRequest_To_storage_TokenRequest(in *storagev1beta1.Tok
 }
 
 func autoConvert_storage_TokenRequest_To_v1beta1_TokenRequest(in *storage.TokenRequest, out *storagev1beta1.TokenRequest, s conversion.Scope) error {
-	out.Audience = in.Audience
-	out.ExpirationSeconds = (*int64)(unsafe.Pointer(in.ExpirationSeconds))
+	*out = *(*storagev1beta1.TokenRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -726,10 +718,7 @@ func Convert_storage_VolumeAttachmentSpec_To_v1beta1_VolumeAttachmentSpec(in *st
 }
 
 func autoConvert_v1beta1_VolumeAttachmentStatus_To_storage_VolumeAttachmentStatus(in *storagev1beta1.VolumeAttachmentStatus, out *storage.VolumeAttachmentStatus, s conversion.Scope) error {
-	out.Attached = in.Attached
-	out.AttachmentMetadata = *(*map[string]string)(unsafe.Pointer(&in.AttachmentMetadata))
-	out.AttachError = (*storage.VolumeError)(unsafe.Pointer(in.AttachError))
-	out.DetachError = (*storage.VolumeError)(unsafe.Pointer(in.DetachError))
+	*out = *(*storage.VolumeAttachmentStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -739,10 +728,7 @@ func Convert_v1beta1_VolumeAttachmentStatus_To_storage_VolumeAttachmentStatus(in
 }
 
 func autoConvert_storage_VolumeAttachmentStatus_To_v1beta1_VolumeAttachmentStatus(in *storage.VolumeAttachmentStatus, out *storagev1beta1.VolumeAttachmentStatus, s conversion.Scope) error {
-	out.Attached = in.Attached
-	out.AttachmentMetadata = *(*map[string]string)(unsafe.Pointer(&in.AttachmentMetadata))
-	out.AttachError = (*storagev1beta1.VolumeError)(unsafe.Pointer(in.AttachError))
-	out.DetachError = (*storagev1beta1.VolumeError)(unsafe.Pointer(in.DetachError))
+	*out = *(*storagev1beta1.VolumeAttachmentStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -798,9 +784,7 @@ func Convert_storage_VolumeAttributesClassList_To_v1beta1_VolumeAttributesClassL
 }
 
 func autoConvert_v1beta1_VolumeError_To_storage_VolumeError(in *storagev1beta1.VolumeError, out *storage.VolumeError, s conversion.Scope) error {
-	out.Time = in.Time
-	out.Message = in.Message
-	out.ErrorCode = (*int32)(unsafe.Pointer(in.ErrorCode))
+	*out = *(*storage.VolumeError)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -810,9 +794,7 @@ func Convert_v1beta1_VolumeError_To_storage_VolumeError(in *storagev1beta1.Volum
 }
 
 func autoConvert_storage_VolumeError_To_v1beta1_VolumeError(in *storage.VolumeError, out *storagev1beta1.VolumeError, s conversion.Scope) error {
-	out.Time = in.Time
-	out.Message = in.Message
-	out.ErrorCode = (*int32)(unsafe.Pointer(in.ErrorCode))
+	*out = *(*storagev1beta1.VolumeError)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -822,7 +804,7 @@ func Convert_storage_VolumeError_To_v1beta1_VolumeError(in *storage.VolumeError,
 }
 
 func autoConvert_v1beta1_VolumeNodeResources_To_storage_VolumeNodeResources(in *storagev1beta1.VolumeNodeResources, out *storage.VolumeNodeResources, s conversion.Scope) error {
-	out.Count = (*int32)(unsafe.Pointer(in.Count))
+	*out = *(*storage.VolumeNodeResources)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -832,7 +814,7 @@ func Convert_v1beta1_VolumeNodeResources_To_storage_VolumeNodeResources(in *stor
 }
 
 func autoConvert_storage_VolumeNodeResources_To_v1beta1_VolumeNodeResources(in *storage.VolumeNodeResources, out *storagev1beta1.VolumeNodeResources, s conversion.Scope) error {
-	out.Count = (*int32)(unsafe.Pointer(in.Count))
+	*out = *(*storagev1beta1.VolumeNodeResources)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/storagemigration/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/storagemigration/v1beta1/zz_generated.conversion.go
@@ -25,7 +25,6 @@ import (
 	unsafe "unsafe"
 
 	storagemigrationv1beta1 "k8s.io/api/storagemigration/v1beta1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	storagemigration "k8s.io/kubernetes/pkg/apis/storagemigration"
@@ -136,7 +135,7 @@ func Convert_storagemigration_StorageVersionMigrationList_To_v1beta1_StorageVers
 }
 
 func autoConvert_v1beta1_StorageVersionMigrationSpec_To_storagemigration_StorageVersionMigrationSpec(in *storagemigrationv1beta1.StorageVersionMigrationSpec, out *storagemigration.StorageVersionMigrationSpec, s conversion.Scope) error {
-	out.Resource = in.Resource
+	*out = *(*storagemigration.StorageVersionMigrationSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -146,7 +145,7 @@ func Convert_v1beta1_StorageVersionMigrationSpec_To_storagemigration_StorageVers
 }
 
 func autoConvert_storagemigration_StorageVersionMigrationSpec_To_v1beta1_StorageVersionMigrationSpec(in *storagemigration.StorageVersionMigrationSpec, out *storagemigrationv1beta1.StorageVersionMigrationSpec, s conversion.Scope) error {
-	out.Resource = in.Resource
+	*out = *(*storagemigrationv1beta1.StorageVersionMigrationSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -156,8 +155,7 @@ func Convert_storagemigration_StorageVersionMigrationSpec_To_v1beta1_StorageVers
 }
 
 func autoConvert_v1beta1_StorageVersionMigrationStatus_To_storagemigration_StorageVersionMigrationStatus(in *storagemigrationv1beta1.StorageVersionMigrationStatus, out *storagemigration.StorageVersionMigrationStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
-	out.ResourceVersion = in.ResourceVersion
+	*out = *(*storagemigration.StorageVersionMigrationStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -167,8 +165,7 @@ func Convert_v1beta1_StorageVersionMigrationStatus_To_storagemigration_StorageVe
 }
 
 func autoConvert_storagemigration_StorageVersionMigrationStatus_To_v1beta1_StorageVersionMigrationStatus(in *storagemigration.StorageVersionMigrationStatus, out *storagemigrationv1beta1.StorageVersionMigrationStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
-	out.ResourceVersion = in.ResourceVersion
+	*out = *(*storagemigrationv1beta1.StorageVersionMigrationStatus)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/apis/config/v1alpha1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -99,6 +101,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_DeprecatedControllerConfiguration_To_config_DeprecatedControllerConfiguration(in *configv1alpha1.DeprecatedControllerConfiguration, out *config.DeprecatedControllerConfiguration, s conversion.Scope) error {
+	*out = *(*config.DeprecatedControllerConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -108,6 +111,7 @@ func Convert_v1alpha1_DeprecatedControllerConfiguration_To_config_DeprecatedCont
 }
 
 func autoConvert_config_DeprecatedControllerConfiguration_To_v1alpha1_DeprecatedControllerConfiguration(in *config.DeprecatedControllerConfiguration, out *configv1alpha1.DeprecatedControllerConfiguration, s conversion.Scope) error {
+	*out = *(*configv1alpha1.DeprecatedControllerConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -117,8 +121,7 @@ func Convert_config_DeprecatedControllerConfiguration_To_v1alpha1_DeprecatedCont
 }
 
 func autoConvert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.GroupResource, out *v1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*v1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -128,8 +131,7 @@ func Convert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.Group
 }
 
 func autoConvert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/certificates/signer/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/certificates/signer/config/v1alpha1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -70,8 +72,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_CSRSigningConfiguration_To_config_CSRSigningConfiguration(in *configv1alpha1.CSRSigningConfiguration, out *config.CSRSigningConfiguration, s conversion.Scope) error {
-	out.CertFile = in.CertFile
-	out.KeyFile = in.KeyFile
+	*out = *(*config.CSRSigningConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -81,8 +82,7 @@ func Convert_v1alpha1_CSRSigningConfiguration_To_config_CSRSigningConfiguration(
 }
 
 func autoConvert_config_CSRSigningConfiguration_To_v1alpha1_CSRSigningConfiguration(in *config.CSRSigningConfiguration, out *configv1alpha1.CSRSigningConfiguration, s conversion.Scope) error {
-	out.CertFile = in.CertFile
-	out.KeyFile = in.KeyFile
+	*out = *(*configv1alpha1.CSRSigningConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -130,8 +130,7 @@ func autoConvert_config_CSRSigningControllerConfiguration_To_v1alpha1_CSRSigning
 }
 
 func autoConvert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.GroupResource, out *v1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*v1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -141,8 +140,7 @@ func Convert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.Group
 }
 
 func autoConvert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/cronjob/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/cronjob/config/v1alpha1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -70,8 +72,7 @@ func autoConvert_config_CronJobControllerConfiguration_To_v1alpha1_CronJobContro
 }
 
 func autoConvert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.GroupResource, out *v1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*v1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -81,8 +82,7 @@ func Convert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.Group
 }
 
 func autoConvert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/daemon/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/daemon/config/v1alpha1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -70,8 +72,7 @@ func autoConvert_config_DaemonSetControllerConfiguration_To_v1alpha1_DaemonSetCo
 }
 
 func autoConvert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.GroupResource, out *v1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*v1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -81,8 +82,7 @@ func Convert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.Group
 }
 
 func autoConvert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/deployment/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/deployment/config/v1alpha1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -70,8 +72,7 @@ func autoConvert_config_DeploymentControllerConfiguration_To_v1alpha1_Deployment
 }
 
 func autoConvert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.GroupResource, out *v1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*v1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -81,8 +82,7 @@ func Convert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.Group
 }
 
 func autoConvert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/devicetainteviction/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/devicetainteviction/config/v1alpha1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -70,8 +72,7 @@ func autoConvert_config_DeviceTaintEvictionControllerConfiguration_To_v1alpha1_D
 }
 
 func autoConvert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.GroupResource, out *v1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*v1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -81,8 +82,7 @@ func Convert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.Group
 }
 
 func autoConvert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/endpoint/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/endpoint/config/v1alpha1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -72,8 +74,7 @@ func autoConvert_config_EndpointControllerConfiguration_To_v1alpha1_EndpointCont
 }
 
 func autoConvert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.GroupResource, out *v1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*v1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -83,8 +84,7 @@ func Convert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.Group
 }
 
 func autoConvert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/endpointslice/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/endpointslice/config/v1alpha1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -74,8 +76,7 @@ func autoConvert_config_EndpointSliceControllerConfiguration_To_v1alpha1_Endpoin
 }
 
 func autoConvert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.GroupResource, out *v1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*v1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -85,8 +86,7 @@ func Convert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.Group
 }
 
 func autoConvert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/endpointslicemirroring/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/endpointslicemirroring/config/v1alpha1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -74,8 +76,7 @@ func autoConvert_config_EndpointSliceMirroringControllerConfiguration_To_v1alpha
 }
 
 func autoConvert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.GroupResource, out *v1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*v1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -85,8 +86,7 @@ func Convert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.Group
 }
 
 func autoConvert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/garbagecollector/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/garbagecollector/config/v1alpha1/zz_generated.conversion.go
@@ -80,8 +80,7 @@ func autoConvert_config_GarbageCollectorControllerConfiguration_To_v1alpha1_Garb
 }
 
 func autoConvert_v1alpha1_GroupResource_To_config_GroupResource(in *configv1alpha1.GroupResource, out *config.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*config.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -91,8 +90,7 @@ func Convert_v1alpha1_GroupResource_To_config_GroupResource(in *configv1alpha1.G
 }
 
 func autoConvert_config_GroupResource_To_v1alpha1_GroupResource(in *config.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/job/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/job/config/v1alpha1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -60,8 +62,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.GroupResource, out *v1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*v1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -71,8 +72,7 @@ func Convert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.Group
 }
 
 func autoConvert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/namespace/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/namespace/config/v1alpha1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -60,8 +62,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.GroupResource, out *v1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*v1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -71,8 +72,7 @@ func Convert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.Group
 }
 
 func autoConvert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/nodeipam/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/nodeipam/config/v1alpha1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -60,8 +62,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.GroupResource, out *v1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*v1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -71,8 +72,7 @@ func Convert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.Group
 }
 
 func autoConvert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/nodelifecycle/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/nodelifecycle/config/v1alpha1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -60,8 +62,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.GroupResource, out *v1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*v1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -71,8 +72,7 @@ func Convert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.Group
 }
 
 func autoConvert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/podautoscaler/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/podautoscaler/config/v1alpha1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -60,8 +62,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.GroupResource, out *v1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*v1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -71,8 +72,7 @@ func Convert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.Group
 }
 
 func autoConvert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/podgc/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/podgc/config/v1alpha1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -60,8 +62,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.GroupResource, out *v1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*v1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -71,8 +72,7 @@ func Convert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.Group
 }
 
 func autoConvert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/replicaset/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/replicaset/config/v1alpha1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -60,8 +62,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.GroupResource, out *v1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*v1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -71,8 +72,7 @@ func Convert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.Group
 }
 
 func autoConvert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/replication/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/replication/config/v1alpha1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -60,8 +62,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.GroupResource, out *v1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*v1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -71,8 +72,7 @@ func Convert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.Group
 }
 
 func autoConvert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/resourceclaim/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/resourceclaim/config/v1alpha1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -60,8 +62,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.GroupResource, out *v1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*v1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -71,8 +72,7 @@ func Convert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.Group
 }
 
 func autoConvert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/resourcequota/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/resourcequota/config/v1alpha1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -60,8 +62,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.GroupResource, out *v1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*v1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -71,8 +72,7 @@ func Convert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.Group
 }
 
 func autoConvert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/serviceaccount/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/serviceaccount/config/v1alpha1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -70,8 +72,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.GroupResource, out *v1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*v1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -81,8 +82,7 @@ func Convert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.Group
 }
 
 func autoConvert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/statefulset/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/statefulset/config/v1alpha1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -60,8 +62,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.GroupResource, out *v1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*v1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -71,8 +72,7 @@ func Convert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.Group
 }
 
 func autoConvert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/ttlafterfinished/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/ttlafterfinished/config/v1alpha1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -60,8 +62,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.GroupResource, out *v1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*v1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -71,8 +72,7 @@ func Convert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.Group
 }
 
 func autoConvert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/validatingadmissionpolicystatus/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/validatingadmissionpolicystatus/config/v1alpha1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -60,8 +62,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.GroupResource, out *v1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*v1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -71,8 +72,7 @@ func Convert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.Group
 }
 
 func autoConvert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/volume/attachdetach/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/volume/attachdetach/config/v1alpha1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -74,8 +76,7 @@ func autoConvert_config_AttachDetachControllerConfiguration_To_v1alpha1_AttachDe
 }
 
 func autoConvert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.GroupResource, out *v1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*v1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -85,8 +86,7 @@ func Convert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.Group
 }
 
 func autoConvert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/volume/ephemeral/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/volume/ephemeral/config/v1alpha1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -70,8 +72,7 @@ func autoConvert_config_EphemeralVolumeControllerConfiguration_To_v1alpha1_Ephem
 }
 
 func autoConvert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.GroupResource, out *v1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*v1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -81,8 +82,7 @@ func Convert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.Group
 }
 
 func autoConvert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/controller/volume/persistentvolume/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/volume/persistentvolume/config/v1alpha1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -80,8 +82,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.GroupResource, out *v1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*v1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -91,8 +92,7 @@ func Convert_v1alpha1_GroupResource_To_v1_GroupResource(in *configv1alpha1.Group
 }
 
 func autoConvert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, out *configv1alpha1.GroupResource, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resource = in.Resource
+	*out = *(*configv1alpha1.GroupResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -118,13 +118,7 @@ func autoConvert_config_PersistentVolumeBinderControllerConfiguration_To_v1alpha
 }
 
 func autoConvert_v1alpha1_PersistentVolumeRecyclerConfiguration_To_config_PersistentVolumeRecyclerConfiguration(in *configv1alpha1.PersistentVolumeRecyclerConfiguration, out *config.PersistentVolumeRecyclerConfiguration, s conversion.Scope) error {
-	out.MaximumRetry = in.MaximumRetry
-	out.MinimumTimeoutNFS = in.MinimumTimeoutNFS
-	out.PodTemplateFilePathNFS = in.PodTemplateFilePathNFS
-	out.IncrementTimeoutNFS = in.IncrementTimeoutNFS
-	out.PodTemplateFilePathHostPath = in.PodTemplateFilePathHostPath
-	out.MinimumTimeoutHostPath = in.MinimumTimeoutHostPath
-	out.IncrementTimeoutHostPath = in.IncrementTimeoutHostPath
+	*out = *(*config.PersistentVolumeRecyclerConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -134,13 +128,7 @@ func Convert_v1alpha1_PersistentVolumeRecyclerConfiguration_To_config_Persistent
 }
 
 func autoConvert_config_PersistentVolumeRecyclerConfiguration_To_v1alpha1_PersistentVolumeRecyclerConfiguration(in *config.PersistentVolumeRecyclerConfiguration, out *configv1alpha1.PersistentVolumeRecyclerConfiguration, s conversion.Scope) error {
-	out.MaximumRetry = in.MaximumRetry
-	out.MinimumTimeoutNFS = in.MinimumTimeoutNFS
-	out.PodTemplateFilePathNFS = in.PodTemplateFilePathNFS
-	out.IncrementTimeoutNFS = in.IncrementTimeoutNFS
-	out.PodTemplateFilePathHostPath = in.PodTemplateFilePathHostPath
-	out.MinimumTimeoutHostPath = in.MinimumTimeoutHostPath
-	out.IncrementTimeoutHostPath = in.IncrementTimeoutHostPath
+	*out = *(*configv1alpha1.PersistentVolumeRecyclerConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/kubelet/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/config/v1/zz_generated.conversion.go
@@ -24,7 +24,6 @@ package v1
 import (
 	unsafe "unsafe"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	configv1 "k8s.io/kubelet/config/v1"
@@ -82,13 +81,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1_CredentialProvider_To_config_CredentialProvider(in *configv1.CredentialProvider, out *config.CredentialProvider, s conversion.Scope) error {
-	out.Name = in.Name
-	out.MatchImages = *(*[]string)(unsafe.Pointer(&in.MatchImages))
-	out.DefaultCacheDuration = (*metav1.Duration)(unsafe.Pointer(in.DefaultCacheDuration))
-	out.APIVersion = in.APIVersion
-	out.Args = *(*[]string)(unsafe.Pointer(&in.Args))
-	out.Env = *(*[]config.ExecEnvVar)(unsafe.Pointer(&in.Env))
-	out.TokenAttributes = (*config.ServiceAccountTokenAttributes)(unsafe.Pointer(in.TokenAttributes))
+	*out = *(*config.CredentialProvider)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -98,13 +91,7 @@ func Convert_v1_CredentialProvider_To_config_CredentialProvider(in *configv1.Cre
 }
 
 func autoConvert_config_CredentialProvider_To_v1_CredentialProvider(in *config.CredentialProvider, out *configv1.CredentialProvider, s conversion.Scope) error {
-	out.Name = in.Name
-	out.MatchImages = *(*[]string)(unsafe.Pointer(&in.MatchImages))
-	out.DefaultCacheDuration = (*metav1.Duration)(unsafe.Pointer(in.DefaultCacheDuration))
-	out.APIVersion = in.APIVersion
-	out.Args = *(*[]string)(unsafe.Pointer(&in.Args))
-	out.Env = *(*[]configv1.ExecEnvVar)(unsafe.Pointer(&in.Env))
-	out.TokenAttributes = (*configv1.ServiceAccountTokenAttributes)(unsafe.Pointer(in.TokenAttributes))
+	*out = *(*configv1.CredentialProvider)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -134,8 +121,7 @@ func Convert_config_CredentialProviderConfig_To_v1_CredentialProviderConfig(in *
 }
 
 func autoConvert_v1_ExecEnvVar_To_config_ExecEnvVar(in *configv1.ExecEnvVar, out *config.ExecEnvVar, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Value = in.Value
+	*out = *(*config.ExecEnvVar)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -145,8 +131,7 @@ func Convert_v1_ExecEnvVar_To_config_ExecEnvVar(in *configv1.ExecEnvVar, out *co
 }
 
 func autoConvert_config_ExecEnvVar_To_v1_ExecEnvVar(in *config.ExecEnvVar, out *configv1.ExecEnvVar, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Value = in.Value
+	*out = *(*configv1.ExecEnvVar)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -156,11 +141,7 @@ func Convert_config_ExecEnvVar_To_v1_ExecEnvVar(in *config.ExecEnvVar, out *conf
 }
 
 func autoConvert_v1_ServiceAccountTokenAttributes_To_config_ServiceAccountTokenAttributes(in *configv1.ServiceAccountTokenAttributes, out *config.ServiceAccountTokenAttributes, s conversion.Scope) error {
-	out.ServiceAccountTokenAudience = in.ServiceAccountTokenAudience
-	out.CacheType = config.ServiceAccountTokenCacheType(in.CacheType)
-	out.RequireServiceAccount = (*bool)(unsafe.Pointer(in.RequireServiceAccount))
-	out.RequiredServiceAccountAnnotationKeys = *(*[]string)(unsafe.Pointer(&in.RequiredServiceAccountAnnotationKeys))
-	out.OptionalServiceAccountAnnotationKeys = *(*[]string)(unsafe.Pointer(&in.OptionalServiceAccountAnnotationKeys))
+	*out = *(*config.ServiceAccountTokenAttributes)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -170,11 +151,7 @@ func Convert_v1_ServiceAccountTokenAttributes_To_config_ServiceAccountTokenAttri
 }
 
 func autoConvert_config_ServiceAccountTokenAttributes_To_v1_ServiceAccountTokenAttributes(in *config.ServiceAccountTokenAttributes, out *configv1.ServiceAccountTokenAttributes, s conversion.Scope) error {
-	out.ServiceAccountTokenAudience = in.ServiceAccountTokenAudience
-	out.CacheType = configv1.ServiceAccountTokenCacheType(in.CacheType)
-	out.RequireServiceAccount = (*bool)(unsafe.Pointer(in.RequireServiceAccount))
-	out.RequiredServiceAccountAnnotationKeys = *(*[]string)(unsafe.Pointer(&in.RequiredServiceAccountAnnotationKeys))
-	out.OptionalServiceAccountAnnotationKeys = *(*[]string)(unsafe.Pointer(&in.OptionalServiceAccountAnnotationKeys))
+	*out = *(*configv1.ServiceAccountTokenAttributes)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/kubelet/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/config/v1alpha1/zz_generated.conversion.go
@@ -188,8 +188,7 @@ func Convert_config_CredentialProviderConfig_To_v1alpha1_CredentialProviderConfi
 }
 
 func autoConvert_v1alpha1_ExecEnvVar_To_config_ExecEnvVar(in *configv1alpha1.ExecEnvVar, out *config.ExecEnvVar, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Value = in.Value
+	*out = *(*config.ExecEnvVar)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -199,8 +198,7 @@ func Convert_v1alpha1_ExecEnvVar_To_config_ExecEnvVar(in *configv1alpha1.ExecEnv
 }
 
 func autoConvert_config_ExecEnvVar_To_v1alpha1_ExecEnvVar(in *config.ExecEnvVar, out *configv1alpha1.ExecEnvVar, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Value = in.Value
+	*out = *(*configv1alpha1.ExecEnvVar)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -210,9 +208,7 @@ func Convert_config_ExecEnvVar_To_v1alpha1_ExecEnvVar(in *config.ExecEnvVar, out
 }
 
 func autoConvert_v1alpha1_ImagePullCredentials_To_config_ImagePullCredentials(in *configv1alpha1.ImagePullCredentials, out *config.ImagePullCredentials, s conversion.Scope) error {
-	out.KubernetesSecrets = *(*[]config.ImagePullSecret)(unsafe.Pointer(&in.KubernetesSecrets))
-	out.KubernetesServiceAccounts = *(*[]config.ImagePullServiceAccount)(unsafe.Pointer(&in.KubernetesServiceAccounts))
-	out.NodePodsAccessible = in.NodePodsAccessible
+	*out = *(*config.ImagePullCredentials)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -222,9 +218,7 @@ func Convert_v1alpha1_ImagePullCredentials_To_config_ImagePullCredentials(in *co
 }
 
 func autoConvert_config_ImagePullCredentials_To_v1alpha1_ImagePullCredentials(in *config.ImagePullCredentials, out *configv1alpha1.ImagePullCredentials, s conversion.Scope) error {
-	out.KubernetesSecrets = *(*[]configv1alpha1.ImagePullSecret)(unsafe.Pointer(&in.KubernetesSecrets))
-	out.KubernetesServiceAccounts = *(*[]configv1alpha1.ImagePullServiceAccount)(unsafe.Pointer(&in.KubernetesServiceAccounts))
-	out.NodePodsAccessible = in.NodePodsAccessible
+	*out = *(*configv1alpha1.ImagePullCredentials)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -254,10 +248,7 @@ func Convert_config_ImagePullIntent_To_v1alpha1_ImagePullIntent(in *config.Image
 }
 
 func autoConvert_v1alpha1_ImagePullSecret_To_config_ImagePullSecret(in *configv1alpha1.ImagePullSecret, out *config.ImagePullSecret, s conversion.Scope) error {
-	out.UID = in.UID
-	out.Namespace = in.Namespace
-	out.Name = in.Name
-	out.CredentialHash = in.CredentialHash
+	*out = *(*config.ImagePullSecret)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -267,10 +258,7 @@ func Convert_v1alpha1_ImagePullSecret_To_config_ImagePullSecret(in *configv1alph
 }
 
 func autoConvert_config_ImagePullSecret_To_v1alpha1_ImagePullSecret(in *config.ImagePullSecret, out *configv1alpha1.ImagePullSecret, s conversion.Scope) error {
-	out.UID = in.UID
-	out.Namespace = in.Namespace
-	out.Name = in.Name
-	out.CredentialHash = in.CredentialHash
+	*out = *(*configv1alpha1.ImagePullSecret)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -280,9 +268,7 @@ func Convert_config_ImagePullSecret_To_v1alpha1_ImagePullSecret(in *config.Image
 }
 
 func autoConvert_v1alpha1_ImagePullServiceAccount_To_config_ImagePullServiceAccount(in *configv1alpha1.ImagePullServiceAccount, out *config.ImagePullServiceAccount, s conversion.Scope) error {
-	out.UID = in.UID
-	out.Namespace = in.Namespace
-	out.Name = in.Name
+	*out = *(*config.ImagePullServiceAccount)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -292,9 +278,7 @@ func Convert_v1alpha1_ImagePullServiceAccount_To_config_ImagePullServiceAccount(
 }
 
 func autoConvert_config_ImagePullServiceAccount_To_v1alpha1_ImagePullServiceAccount(in *config.ImagePullServiceAccount, out *configv1alpha1.ImagePullServiceAccount, s conversion.Scope) error {
-	out.UID = in.UID
-	out.Namespace = in.Namespace
-	out.Name = in.Name
+	*out = *(*configv1alpha1.ImagePullServiceAccount)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
@@ -254,7 +254,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1beta1_CrashLoopBackOffConfig_To_config_CrashLoopBackOffConfig(in *configv1beta1.CrashLoopBackOffConfig, out *config.CrashLoopBackOffConfig, s conversion.Scope) error {
-	out.MaxContainerRestartPeriod = (*v1.Duration)(unsafe.Pointer(in.MaxContainerRestartPeriod))
+	*out = *(*config.CrashLoopBackOffConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -264,7 +264,7 @@ func Convert_v1beta1_CrashLoopBackOffConfig_To_config_CrashLoopBackOffConfig(in 
 }
 
 func autoConvert_config_CrashLoopBackOffConfig_To_v1beta1_CrashLoopBackOffConfig(in *config.CrashLoopBackOffConfig, out *configv1beta1.CrashLoopBackOffConfig, s conversion.Scope) error {
-	out.MaxContainerRestartPeriod = (*v1.Duration)(unsafe.Pointer(in.MaxContainerRestartPeriod))
+	*out = *(*configv1beta1.CrashLoopBackOffConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -340,8 +340,7 @@ func Convert_config_CredentialProviderConfig_To_v1beta1_CredentialProviderConfig
 }
 
 func autoConvert_v1beta1_ExecEnvVar_To_config_ExecEnvVar(in *configv1beta1.ExecEnvVar, out *config.ExecEnvVar, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Value = in.Value
+	*out = *(*config.ExecEnvVar)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -351,8 +350,7 @@ func Convert_v1beta1_ExecEnvVar_To_config_ExecEnvVar(in *configv1beta1.ExecEnvVa
 }
 
 func autoConvert_config_ExecEnvVar_To_v1beta1_ExecEnvVar(in *config.ExecEnvVar, out *configv1beta1.ExecEnvVar, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Value = in.Value
+	*out = *(*configv1beta1.ExecEnvVar)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -362,9 +360,7 @@ func Convert_config_ExecEnvVar_To_v1beta1_ExecEnvVar(in *config.ExecEnvVar, out 
 }
 
 func autoConvert_v1beta1_ImagePullCredentials_To_config_ImagePullCredentials(in *configv1beta1.ImagePullCredentials, out *config.ImagePullCredentials, s conversion.Scope) error {
-	out.KubernetesSecrets = *(*[]config.ImagePullSecret)(unsafe.Pointer(&in.KubernetesSecrets))
-	out.KubernetesServiceAccounts = *(*[]config.ImagePullServiceAccount)(unsafe.Pointer(&in.KubernetesServiceAccounts))
-	out.NodePodsAccessible = in.NodePodsAccessible
+	*out = *(*config.ImagePullCredentials)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -374,9 +370,7 @@ func Convert_v1beta1_ImagePullCredentials_To_config_ImagePullCredentials(in *con
 }
 
 func autoConvert_config_ImagePullCredentials_To_v1beta1_ImagePullCredentials(in *config.ImagePullCredentials, out *configv1beta1.ImagePullCredentials, s conversion.Scope) error {
-	out.KubernetesSecrets = *(*[]configv1beta1.ImagePullSecret)(unsafe.Pointer(&in.KubernetesSecrets))
-	out.KubernetesServiceAccounts = *(*[]configv1beta1.ImagePullServiceAccount)(unsafe.Pointer(&in.KubernetesServiceAccounts))
-	out.NodePodsAccessible = in.NodePodsAccessible
+	*out = *(*configv1beta1.ImagePullCredentials)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -406,10 +400,7 @@ func Convert_config_ImagePullIntent_To_v1beta1_ImagePullIntent(in *config.ImageP
 }
 
 func autoConvert_v1beta1_ImagePullSecret_To_config_ImagePullSecret(in *configv1beta1.ImagePullSecret, out *config.ImagePullSecret, s conversion.Scope) error {
-	out.UID = in.UID
-	out.Namespace = in.Namespace
-	out.Name = in.Name
-	out.CredentialHash = in.CredentialHash
+	*out = *(*config.ImagePullSecret)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -419,10 +410,7 @@ func Convert_v1beta1_ImagePullSecret_To_config_ImagePullSecret(in *configv1beta1
 }
 
 func autoConvert_config_ImagePullSecret_To_v1beta1_ImagePullSecret(in *config.ImagePullSecret, out *configv1beta1.ImagePullSecret, s conversion.Scope) error {
-	out.UID = in.UID
-	out.Namespace = in.Namespace
-	out.Name = in.Name
-	out.CredentialHash = in.CredentialHash
+	*out = *(*configv1beta1.ImagePullSecret)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -432,9 +420,7 @@ func Convert_config_ImagePullSecret_To_v1beta1_ImagePullSecret(in *config.ImageP
 }
 
 func autoConvert_v1beta1_ImagePullServiceAccount_To_config_ImagePullServiceAccount(in *configv1beta1.ImagePullServiceAccount, out *config.ImagePullServiceAccount, s conversion.Scope) error {
-	out.UID = in.UID
-	out.Namespace = in.Namespace
-	out.Name = in.Name
+	*out = *(*config.ImagePullServiceAccount)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -444,9 +430,7 @@ func Convert_v1beta1_ImagePullServiceAccount_To_config_ImagePullServiceAccount(i
 }
 
 func autoConvert_config_ImagePullServiceAccount_To_v1beta1_ImagePullServiceAccount(in *config.ImagePullServiceAccount, out *configv1beta1.ImagePullServiceAccount, s conversion.Scope) error {
-	out.UID = in.UID
-	out.Namespace = in.Namespace
-	out.Name = in.Name
+	*out = *(*configv1beta1.ImagePullServiceAccount)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -540,10 +524,7 @@ func Convert_config_KubeletAuthentication_To_v1beta1_KubeletAuthentication(in *c
 }
 
 func autoConvert_v1beta1_KubeletAuthorization_To_config_KubeletAuthorization(in *configv1beta1.KubeletAuthorization, out *config.KubeletAuthorization, s conversion.Scope) error {
-	out.Mode = config.KubeletAuthorizationMode(in.Mode)
-	if err := Convert_v1beta1_KubeletWebhookAuthorization_To_config_KubeletWebhookAuthorization(&in.Webhook, &out.Webhook, s); err != nil {
-		return err
-	}
+	*out = *(*config.KubeletAuthorization)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -553,10 +534,7 @@ func Convert_v1beta1_KubeletAuthorization_To_config_KubeletAuthorization(in *con
 }
 
 func autoConvert_config_KubeletAuthorization_To_v1beta1_KubeletAuthorization(in *config.KubeletAuthorization, out *configv1beta1.KubeletAuthorization, s conversion.Scope) error {
-	out.Mode = configv1beta1.KubeletAuthorizationMode(in.Mode)
-	if err := Convert_config_KubeletWebhookAuthorization_To_v1beta1_KubeletWebhookAuthorization(&in.Webhook, &out.Webhook, s); err != nil {
-		return err
-	}
+	*out = *(*configv1beta1.KubeletAuthorization)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1008,8 +986,7 @@ func Convert_config_KubeletWebhookAuthentication_To_v1beta1_KubeletWebhookAuthen
 }
 
 func autoConvert_v1beta1_KubeletWebhookAuthorization_To_config_KubeletWebhookAuthorization(in *configv1beta1.KubeletWebhookAuthorization, out *config.KubeletWebhookAuthorization, s conversion.Scope) error {
-	out.CacheAuthorizedTTL = in.CacheAuthorizedTTL
-	out.CacheUnauthorizedTTL = in.CacheUnauthorizedTTL
+	*out = *(*config.KubeletWebhookAuthorization)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1019,8 +996,7 @@ func Convert_v1beta1_KubeletWebhookAuthorization_To_config_KubeletWebhookAuthori
 }
 
 func autoConvert_config_KubeletWebhookAuthorization_To_v1beta1_KubeletWebhookAuthorization(in *config.KubeletWebhookAuthorization, out *configv1beta1.KubeletWebhookAuthorization, s conversion.Scope) error {
-	out.CacheAuthorizedTTL = in.CacheAuthorizedTTL
-	out.CacheUnauthorizedTTL = in.CacheUnauthorizedTTL
+	*out = *(*configv1beta1.KubeletWebhookAuthorization)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1030,7 +1006,7 @@ func Convert_config_KubeletWebhookAuthorization_To_v1beta1_KubeletWebhookAuthori
 }
 
 func autoConvert_v1beta1_KubeletX509Authentication_To_config_KubeletX509Authentication(in *configv1beta1.KubeletX509Authentication, out *config.KubeletX509Authentication, s conversion.Scope) error {
-	out.ClientCAFile = in.ClientCAFile
+	*out = *(*config.KubeletX509Authentication)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1040,7 +1016,7 @@ func Convert_v1beta1_KubeletX509Authentication_To_config_KubeletX509Authenticati
 }
 
 func autoConvert_config_KubeletX509Authentication_To_v1beta1_KubeletX509Authentication(in *config.KubeletX509Authentication, out *configv1beta1.KubeletX509Authentication, s conversion.Scope) error {
-	out.ClientCAFile = in.ClientCAFile
+	*out = *(*configv1beta1.KubeletX509Authentication)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1050,8 +1026,7 @@ func Convert_config_KubeletX509Authentication_To_v1beta1_KubeletX509Authenticati
 }
 
 func autoConvert_v1beta1_MemoryReservation_To_config_MemoryReservation(in *configv1beta1.MemoryReservation, out *config.MemoryReservation, s conversion.Scope) error {
-	out.NumaNode = in.NumaNode
-	out.Limits = *(*corev1.ResourceList)(unsafe.Pointer(&in.Limits))
+	*out = *(*config.MemoryReservation)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1061,8 +1036,7 @@ func Convert_v1beta1_MemoryReservation_To_config_MemoryReservation(in *configv1b
 }
 
 func autoConvert_config_MemoryReservation_To_v1beta1_MemoryReservation(in *config.MemoryReservation, out *configv1beta1.MemoryReservation, s conversion.Scope) error {
-	out.NumaNode = in.NumaNode
-	out.Limits = *(*corev1.ResourceList)(unsafe.Pointer(&in.Limits))
+	*out = *(*configv1beta1.MemoryReservation)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1072,7 +1046,7 @@ func Convert_config_MemoryReservation_To_v1beta1_MemoryReservation(in *config.Me
 }
 
 func autoConvert_v1beta1_MemorySwapConfiguration_To_config_MemorySwapConfiguration(in *configv1beta1.MemorySwapConfiguration, out *config.MemorySwapConfiguration, s conversion.Scope) error {
-	out.SwapBehavior = in.SwapBehavior
+	*out = *(*config.MemorySwapConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1082,7 +1056,7 @@ func Convert_v1beta1_MemorySwapConfiguration_To_config_MemorySwapConfiguration(i
 }
 
 func autoConvert_config_MemorySwapConfiguration_To_v1beta1_MemorySwapConfiguration(in *config.MemorySwapConfiguration, out *configv1beta1.MemorySwapConfiguration, s conversion.Scope) error {
-	out.SwapBehavior = in.SwapBehavior
+	*out = *(*configv1beta1.MemorySwapConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1112,8 +1086,7 @@ func Convert_config_SerializedNodeConfigSource_To_v1beta1_SerializedNodeConfigSo
 }
 
 func autoConvert_v1beta1_ShutdownGracePeriodByPodPriority_To_config_ShutdownGracePeriodByPodPriority(in *configv1beta1.ShutdownGracePeriodByPodPriority, out *config.ShutdownGracePeriodByPodPriority, s conversion.Scope) error {
-	out.Priority = in.Priority
-	out.ShutdownGracePeriodSeconds = in.ShutdownGracePeriodSeconds
+	*out = *(*config.ShutdownGracePeriodByPodPriority)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1123,8 +1096,7 @@ func Convert_v1beta1_ShutdownGracePeriodByPodPriority_To_config_ShutdownGracePer
 }
 
 func autoConvert_config_ShutdownGracePeriodByPodPriority_To_v1beta1_ShutdownGracePeriodByPodPriority(in *config.ShutdownGracePeriodByPodPriority, out *configv1beta1.ShutdownGracePeriodByPodPriority, s conversion.Scope) error {
-	out.Priority = in.Priority
-	out.ShutdownGracePeriodSeconds = in.ShutdownGracePeriodSeconds
+	*out = *(*configv1beta1.ShutdownGracePeriodByPodPriority)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1134,7 +1106,7 @@ func Convert_config_ShutdownGracePeriodByPodPriority_To_v1beta1_ShutdownGracePer
 }
 
 func autoConvert_v1beta1_UserNamespaces_To_config_UserNamespaces(in *configv1beta1.UserNamespaces, out *config.UserNamespaces, s conversion.Scope) error {
-	out.IDsPerPod = (*int64)(unsafe.Pointer(in.IDsPerPod))
+	*out = *(*config.UserNamespaces)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1144,7 +1116,7 @@ func Convert_v1beta1_UserNamespaces_To_config_UserNamespaces(in *configv1beta1.U
 }
 
 func autoConvert_config_UserNamespaces_To_v1beta1_UserNamespaces(in *config.UserNamespaces, out *configv1beta1.UserNamespaces, s conversion.Scope) error {
-	out.IDsPerPod = (*int64)(unsafe.Pointer(in.IDsPerPod))
+	*out = *(*configv1beta1.UserNamespaces)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/proxy/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/proxy/apis/config/v1alpha1/zz_generated.conversion.go
@@ -24,7 +24,6 @@ package v1alpha1
 import (
 	unsafe "unsafe"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
@@ -210,13 +209,7 @@ func autoConvert_config_KubeProxyConfiguration_To_v1alpha1_KubeProxyConfiguratio
 }
 
 func autoConvert_v1alpha1_KubeProxyConntrackConfiguration_To_config_KubeProxyConntrackConfiguration(in *configv1alpha1.KubeProxyConntrackConfiguration, out *config.KubeProxyConntrackConfiguration, s conversion.Scope) error {
-	out.MaxPerCore = (*int32)(unsafe.Pointer(in.MaxPerCore))
-	out.Min = (*int32)(unsafe.Pointer(in.Min))
-	out.TCPEstablishedTimeout = (*v1.Duration)(unsafe.Pointer(in.TCPEstablishedTimeout))
-	out.TCPCloseWaitTimeout = (*v1.Duration)(unsafe.Pointer(in.TCPCloseWaitTimeout))
-	out.TCPBeLiberal = in.TCPBeLiberal
-	out.UDPTimeout = in.UDPTimeout
-	out.UDPStreamTimeout = in.UDPStreamTimeout
+	*out = *(*config.KubeProxyConntrackConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -226,13 +219,7 @@ func Convert_v1alpha1_KubeProxyConntrackConfiguration_To_config_KubeProxyConntra
 }
 
 func autoConvert_config_KubeProxyConntrackConfiguration_To_v1alpha1_KubeProxyConntrackConfiguration(in *config.KubeProxyConntrackConfiguration, out *configv1alpha1.KubeProxyConntrackConfiguration, s conversion.Scope) error {
-	out.MaxPerCore = (*int32)(unsafe.Pointer(in.MaxPerCore))
-	out.Min = (*int32)(unsafe.Pointer(in.Min))
-	out.TCPEstablishedTimeout = (*v1.Duration)(unsafe.Pointer(in.TCPEstablishedTimeout))
-	out.TCPCloseWaitTimeout = (*v1.Duration)(unsafe.Pointer(in.TCPCloseWaitTimeout))
-	out.TCPBeLiberal = in.TCPBeLiberal
-	out.UDPTimeout = in.UDPTimeout
-	out.UDPStreamTimeout = in.UDPStreamTimeout
+	*out = *(*configv1alpha1.KubeProxyConntrackConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -307,11 +294,7 @@ func Convert_config_KubeProxyNFTablesConfiguration_To_v1alpha1_KubeProxyNFTables
 }
 
 func autoConvert_v1alpha1_KubeProxyWinkernelConfiguration_To_config_KubeProxyWinkernelConfiguration(in *configv1alpha1.KubeProxyWinkernelConfiguration, out *config.KubeProxyWinkernelConfiguration, s conversion.Scope) error {
-	out.NetworkName = in.NetworkName
-	out.SourceVip = in.SourceVip
-	out.EnableDSR = in.EnableDSR
-	out.RootHnsEndpointName = in.RootHnsEndpointName
-	out.ForwardHealthCheckVip = in.ForwardHealthCheckVip
+	*out = *(*config.KubeProxyWinkernelConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -321,11 +304,7 @@ func Convert_v1alpha1_KubeProxyWinkernelConfiguration_To_config_KubeProxyWinkern
 }
 
 func autoConvert_config_KubeProxyWinkernelConfiguration_To_v1alpha1_KubeProxyWinkernelConfiguration(in *config.KubeProxyWinkernelConfiguration, out *configv1alpha1.KubeProxyWinkernelConfiguration, s conversion.Scope) error {
-	out.NetworkName = in.NetworkName
-	out.SourceVip = in.SourceVip
-	out.EnableDSR = in.EnableDSR
-	out.RootHnsEndpointName = in.RootHnsEndpointName
-	out.ForwardHealthCheckVip = in.ForwardHealthCheckVip
+	*out = *(*configv1alpha1.KubeProxyWinkernelConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
@@ -306,18 +306,7 @@ func Convert_config_DynamicResourcesArgs_To_v1_DynamicResourcesArgs(in *config.D
 }
 
 func autoConvert_v1_Extender_To_config_Extender(in *configv1.Extender, out *config.Extender, s conversion.Scope) error {
-	out.URLPrefix = in.URLPrefix
-	out.FilterVerb = in.FilterVerb
-	out.PreemptVerb = in.PreemptVerb
-	out.PrioritizeVerb = in.PrioritizeVerb
-	out.Weight = in.Weight
-	out.BindVerb = in.BindVerb
-	out.EnableHTTPS = in.EnableHTTPS
-	out.TLSConfig = (*config.ExtenderTLSConfig)(unsafe.Pointer(in.TLSConfig))
-	out.HTTPTimeout = in.HTTPTimeout
-	out.NodeCacheCapable = in.NodeCacheCapable
-	out.ManagedResources = *(*[]config.ExtenderManagedResource)(unsafe.Pointer(&in.ManagedResources))
-	out.Ignorable = in.Ignorable
+	*out = *(*config.Extender)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -327,18 +316,7 @@ func Convert_v1_Extender_To_config_Extender(in *configv1.Extender, out *config.E
 }
 
 func autoConvert_config_Extender_To_v1_Extender(in *config.Extender, out *configv1.Extender, s conversion.Scope) error {
-	out.URLPrefix = in.URLPrefix
-	out.FilterVerb = in.FilterVerb
-	out.PreemptVerb = in.PreemptVerb
-	out.PrioritizeVerb = in.PrioritizeVerb
-	out.Weight = in.Weight
-	out.BindVerb = in.BindVerb
-	out.EnableHTTPS = in.EnableHTTPS
-	out.TLSConfig = (*configv1.ExtenderTLSConfig)(unsafe.Pointer(in.TLSConfig))
-	out.HTTPTimeout = in.HTTPTimeout
-	out.NodeCacheCapable = in.NodeCacheCapable
-	out.ManagedResources = *(*[]configv1.ExtenderManagedResource)(unsafe.Pointer(&in.ManagedResources))
-	out.Ignorable = in.Ignorable
+	*out = *(*configv1.Extender)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -348,8 +326,7 @@ func Convert_config_Extender_To_v1_Extender(in *config.Extender, out *configv1.E
 }
 
 func autoConvert_v1_ExtenderManagedResource_To_config_ExtenderManagedResource(in *configv1.ExtenderManagedResource, out *config.ExtenderManagedResource, s conversion.Scope) error {
-	out.Name = in.Name
-	out.IgnoredByScheduler = in.IgnoredByScheduler
+	*out = *(*config.ExtenderManagedResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -359,8 +336,7 @@ func Convert_v1_ExtenderManagedResource_To_config_ExtenderManagedResource(in *co
 }
 
 func autoConvert_config_ExtenderManagedResource_To_v1_ExtenderManagedResource(in *config.ExtenderManagedResource, out *configv1.ExtenderManagedResource, s conversion.Scope) error {
-	out.Name = in.Name
-	out.IgnoredByScheduler = in.IgnoredByScheduler
+	*out = *(*configv1.ExtenderManagedResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -876,7 +852,7 @@ func Convert_config_PodTopologySpreadArgs_To_v1_PodTopologySpreadArgs(in *config
 }
 
 func autoConvert_v1_RequestedToCapacityRatioParam_To_config_RequestedToCapacityRatioParam(in *configv1.RequestedToCapacityRatioParam, out *config.RequestedToCapacityRatioParam, s conversion.Scope) error {
-	out.Shape = *(*[]config.UtilizationShapePoint)(unsafe.Pointer(&in.Shape))
+	*out = *(*config.RequestedToCapacityRatioParam)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -886,7 +862,7 @@ func Convert_v1_RequestedToCapacityRatioParam_To_config_RequestedToCapacityRatio
 }
 
 func autoConvert_config_RequestedToCapacityRatioParam_To_v1_RequestedToCapacityRatioParam(in *config.RequestedToCapacityRatioParam, out *configv1.RequestedToCapacityRatioParam, s conversion.Scope) error {
-	out.Shape = *(*[]configv1.UtilizationShapePoint)(unsafe.Pointer(&in.Shape))
+	*out = *(*configv1.RequestedToCapacityRatioParam)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -896,8 +872,7 @@ func Convert_config_RequestedToCapacityRatioParam_To_v1_RequestedToCapacityRatio
 }
 
 func autoConvert_v1_ResourceSpec_To_config_ResourceSpec(in *configv1.ResourceSpec, out *config.ResourceSpec, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Weight = in.Weight
+	*out = *(*config.ResourceSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -907,8 +882,7 @@ func Convert_v1_ResourceSpec_To_config_ResourceSpec(in *configv1.ResourceSpec, o
 }
 
 func autoConvert_config_ResourceSpec_To_v1_ResourceSpec(in *config.ResourceSpec, out *configv1.ResourceSpec, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Weight = in.Weight
+	*out = *(*configv1.ResourceSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -918,9 +892,7 @@ func Convert_config_ResourceSpec_To_v1_ResourceSpec(in *config.ResourceSpec, out
 }
 
 func autoConvert_v1_ScoringStrategy_To_config_ScoringStrategy(in *configv1.ScoringStrategy, out *config.ScoringStrategy, s conversion.Scope) error {
-	out.Type = config.ScoringStrategyType(in.Type)
-	out.Resources = *(*[]config.ResourceSpec)(unsafe.Pointer(&in.Resources))
-	out.RequestedToCapacityRatio = (*config.RequestedToCapacityRatioParam)(unsafe.Pointer(in.RequestedToCapacityRatio))
+	*out = *(*config.ScoringStrategy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -930,9 +902,7 @@ func Convert_v1_ScoringStrategy_To_config_ScoringStrategy(in *configv1.ScoringSt
 }
 
 func autoConvert_config_ScoringStrategy_To_v1_ScoringStrategy(in *config.ScoringStrategy, out *configv1.ScoringStrategy, s conversion.Scope) error {
-	out.Type = configv1.ScoringStrategyType(in.Type)
-	out.Resources = *(*[]configv1.ResourceSpec)(unsafe.Pointer(&in.Resources))
-	out.RequestedToCapacityRatio = (*configv1.RequestedToCapacityRatioParam)(unsafe.Pointer(in.RequestedToCapacityRatio))
+	*out = *(*configv1.ScoringStrategy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -942,8 +912,7 @@ func Convert_config_ScoringStrategy_To_v1_ScoringStrategy(in *config.ScoringStra
 }
 
 func autoConvert_v1_UtilizationShapePoint_To_config_UtilizationShapePoint(in *configv1.UtilizationShapePoint, out *config.UtilizationShapePoint, s conversion.Scope) error {
-	out.Utilization = in.Utilization
-	out.Score = in.Score
+	*out = *(*config.UtilizationShapePoint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -953,8 +922,7 @@ func Convert_v1_UtilizationShapePoint_To_config_UtilizationShapePoint(in *config
 }
 
 func autoConvert_config_UtilizationShapePoint_To_v1_UtilizationShapePoint(in *config.UtilizationShapePoint, out *configv1.UtilizationShapePoint, s conversion.Scope) error {
-	out.Utilization = in.Utilization
-	out.Score = in.Score
+	*out = *(*configv1.UtilizationShapePoint)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/plugin/pkg/admission/eventratelimit/apis/eventratelimit/v1alpha1/zz_generated.conversion.go
+++ b/plugin/pkg/admission/eventratelimit/apis/eventratelimit/v1alpha1/zz_generated.conversion.go
@@ -80,10 +80,7 @@ func Convert_eventratelimit_Configuration_To_v1alpha1_Configuration(in *eventrat
 }
 
 func autoConvert_v1alpha1_Limit_To_eventratelimit_Limit(in *Limit, out *eventratelimit.Limit, s conversion.Scope) error {
-	out.Type = eventratelimit.LimitType(in.Type)
-	out.QPS = in.QPS
-	out.Burst = in.Burst
-	out.CacheSize = in.CacheSize
+	*out = *(*eventratelimit.Limit)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -93,10 +90,7 @@ func Convert_v1alpha1_Limit_To_eventratelimit_Limit(in *Limit, out *eventratelim
 }
 
 func autoConvert_eventratelimit_Limit_To_v1alpha1_Limit(in *eventratelimit.Limit, out *Limit, s conversion.Scope) error {
-	out.Type = LimitType(in.Type)
-	out.QPS = in.QPS
-	out.Burst = in.Burst
-	out.CacheSize = in.CacheSize
+	*out = *(*Limit)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/zz_generated.conversion.go
@@ -276,12 +276,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1_CustomResourceColumnDefinition_To_apiextensions_CustomResourceColumnDefinition(in *CustomResourceColumnDefinition, out *apiextensions.CustomResourceColumnDefinition, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Type = in.Type
-	out.Format = in.Format
-	out.Description = in.Description
-	out.Priority = in.Priority
-	out.JSONPath = in.JSONPath
+	*out = *(*apiextensions.CustomResourceColumnDefinition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -291,12 +286,7 @@ func Convert_v1_CustomResourceColumnDefinition_To_apiextensions_CustomResourceCo
 }
 
 func autoConvert_apiextensions_CustomResourceColumnDefinition_To_v1_CustomResourceColumnDefinition(in *apiextensions.CustomResourceColumnDefinition, out *CustomResourceColumnDefinition, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Type = in.Type
-	out.Format = in.Format
-	out.Description = in.Description
-	out.Priority = in.Priority
-	out.JSONPath = in.JSONPath
+	*out = *(*CustomResourceColumnDefinition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -351,12 +341,7 @@ func Convert_apiextensions_CustomResourceDefinition_To_v1_CustomResourceDefiniti
 }
 
 func autoConvert_v1_CustomResourceDefinitionCondition_To_apiextensions_CustomResourceDefinitionCondition(in *CustomResourceDefinitionCondition, out *apiextensions.CustomResourceDefinitionCondition, s conversion.Scope) error {
-	out.Type = apiextensions.CustomResourceDefinitionConditionType(in.Type)
-	out.Status = apiextensions.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
-	out.ObservedGeneration = in.ObservedGeneration
+	*out = *(*apiextensions.CustomResourceDefinitionCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -366,12 +351,7 @@ func Convert_v1_CustomResourceDefinitionCondition_To_apiextensions_CustomResourc
 }
 
 func autoConvert_apiextensions_CustomResourceDefinitionCondition_To_v1_CustomResourceDefinitionCondition(in *apiextensions.CustomResourceDefinitionCondition, out *CustomResourceDefinitionCondition, s conversion.Scope) error {
-	out.Type = CustomResourceDefinitionConditionType(in.Type)
-	out.Status = ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
-	out.ObservedGeneration = in.ObservedGeneration
+	*out = *(*CustomResourceDefinitionCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -423,12 +403,7 @@ func Convert_apiextensions_CustomResourceDefinitionList_To_v1_CustomResourceDefi
 }
 
 func autoConvert_v1_CustomResourceDefinitionNames_To_apiextensions_CustomResourceDefinitionNames(in *CustomResourceDefinitionNames, out *apiextensions.CustomResourceDefinitionNames, s conversion.Scope) error {
-	out.Plural = in.Plural
-	out.Singular = in.Singular
-	out.ShortNames = *(*[]string)(unsafe.Pointer(&in.ShortNames))
-	out.Kind = in.Kind
-	out.ListKind = in.ListKind
-	out.Categories = *(*[]string)(unsafe.Pointer(&in.Categories))
+	*out = *(*apiextensions.CustomResourceDefinitionNames)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -438,12 +413,7 @@ func Convert_v1_CustomResourceDefinitionNames_To_apiextensions_CustomResourceDef
 }
 
 func autoConvert_apiextensions_CustomResourceDefinitionNames_To_v1_CustomResourceDefinitionNames(in *apiextensions.CustomResourceDefinitionNames, out *CustomResourceDefinitionNames, s conversion.Scope) error {
-	out.Plural = in.Plural
-	out.Singular = in.Singular
-	out.ShortNames = *(*[]string)(unsafe.Pointer(&in.ShortNames))
-	out.Kind = in.Kind
-	out.ListKind = in.ListKind
-	out.Categories = *(*[]string)(unsafe.Pointer(&in.Categories))
+	*out = *(*CustomResourceDefinitionNames)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -522,12 +492,7 @@ func autoConvert_apiextensions_CustomResourceDefinitionSpec_To_v1_CustomResource
 }
 
 func autoConvert_v1_CustomResourceDefinitionStatus_To_apiextensions_CustomResourceDefinitionStatus(in *CustomResourceDefinitionStatus, out *apiextensions.CustomResourceDefinitionStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]apiextensions.CustomResourceDefinitionCondition)(unsafe.Pointer(&in.Conditions))
-	if err := Convert_v1_CustomResourceDefinitionNames_To_apiextensions_CustomResourceDefinitionNames(&in.AcceptedNames, &out.AcceptedNames, s); err != nil {
-		return err
-	}
-	out.StoredVersions = *(*[]string)(unsafe.Pointer(&in.StoredVersions))
-	out.ObservedGeneration = in.ObservedGeneration
+	*out = *(*apiextensions.CustomResourceDefinitionStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -537,12 +502,7 @@ func Convert_v1_CustomResourceDefinitionStatus_To_apiextensions_CustomResourceDe
 }
 
 func autoConvert_apiextensions_CustomResourceDefinitionStatus_To_v1_CustomResourceDefinitionStatus(in *apiextensions.CustomResourceDefinitionStatus, out *CustomResourceDefinitionStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]CustomResourceDefinitionCondition)(unsafe.Pointer(&in.Conditions))
-	if err := Convert_apiextensions_CustomResourceDefinitionNames_To_v1_CustomResourceDefinitionNames(&in.AcceptedNames, &out.AcceptedNames, s); err != nil {
-		return err
-	}
-	out.StoredVersions = *(*[]string)(unsafe.Pointer(&in.StoredVersions))
-	out.ObservedGeneration = in.ObservedGeneration
+	*out = *(*CustomResourceDefinitionStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -604,9 +564,7 @@ func Convert_apiextensions_CustomResourceDefinitionVersion_To_v1_CustomResourceD
 }
 
 func autoConvert_v1_CustomResourceSubresourceScale_To_apiextensions_CustomResourceSubresourceScale(in *CustomResourceSubresourceScale, out *apiextensions.CustomResourceSubresourceScale, s conversion.Scope) error {
-	out.SpecReplicasPath = in.SpecReplicasPath
-	out.StatusReplicasPath = in.StatusReplicasPath
-	out.LabelSelectorPath = (*string)(unsafe.Pointer(in.LabelSelectorPath))
+	*out = *(*apiextensions.CustomResourceSubresourceScale)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -616,9 +574,7 @@ func Convert_v1_CustomResourceSubresourceScale_To_apiextensions_CustomResourceSu
 }
 
 func autoConvert_apiextensions_CustomResourceSubresourceScale_To_v1_CustomResourceSubresourceScale(in *apiextensions.CustomResourceSubresourceScale, out *CustomResourceSubresourceScale, s conversion.Scope) error {
-	out.SpecReplicasPath = in.SpecReplicasPath
-	out.StatusReplicasPath = in.StatusReplicasPath
-	out.LabelSelectorPath = (*string)(unsafe.Pointer(in.LabelSelectorPath))
+	*out = *(*CustomResourceSubresourceScale)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -628,6 +584,7 @@ func Convert_apiextensions_CustomResourceSubresourceScale_To_v1_CustomResourceSu
 }
 
 func autoConvert_v1_CustomResourceSubresourceStatus_To_apiextensions_CustomResourceSubresourceStatus(in *CustomResourceSubresourceStatus, out *apiextensions.CustomResourceSubresourceStatus, s conversion.Scope) error {
+	*out = *(*apiextensions.CustomResourceSubresourceStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -637,6 +594,7 @@ func Convert_v1_CustomResourceSubresourceStatus_To_apiextensions_CustomResourceS
 }
 
 func autoConvert_apiextensions_CustomResourceSubresourceStatus_To_v1_CustomResourceSubresourceStatus(in *apiextensions.CustomResourceSubresourceStatus, out *CustomResourceSubresourceStatus, s conversion.Scope) error {
+	*out = *(*CustomResourceSubresourceStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -646,8 +604,7 @@ func Convert_apiextensions_CustomResourceSubresourceStatus_To_v1_CustomResourceS
 }
 
 func autoConvert_v1_CustomResourceSubresources_To_apiextensions_CustomResourceSubresources(in *CustomResourceSubresources, out *apiextensions.CustomResourceSubresources, s conversion.Scope) error {
-	out.Status = (*apiextensions.CustomResourceSubresourceStatus)(unsafe.Pointer(in.Status))
-	out.Scale = (*apiextensions.CustomResourceSubresourceScale)(unsafe.Pointer(in.Scale))
+	*out = *(*apiextensions.CustomResourceSubresources)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -657,8 +614,7 @@ func Convert_v1_CustomResourceSubresources_To_apiextensions_CustomResourceSubres
 }
 
 func autoConvert_apiextensions_CustomResourceSubresources_To_v1_CustomResourceSubresources(in *apiextensions.CustomResourceSubresources, out *CustomResourceSubresources, s conversion.Scope) error {
-	out.Status = (*CustomResourceSubresourceStatus)(unsafe.Pointer(in.Status))
-	out.Scale = (*CustomResourceSubresourceScale)(unsafe.Pointer(in.Scale))
+	*out = *(*CustomResourceSubresources)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -704,8 +660,7 @@ func Convert_apiextensions_CustomResourceValidation_To_v1_CustomResourceValidati
 }
 
 func autoConvert_v1_ExternalDocumentation_To_apiextensions_ExternalDocumentation(in *ExternalDocumentation, out *apiextensions.ExternalDocumentation, s conversion.Scope) error {
-	out.Description = in.Description
-	out.URL = in.URL
+	*out = *(*apiextensions.ExternalDocumentation)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -715,8 +670,7 @@ func Convert_v1_ExternalDocumentation_To_apiextensions_ExternalDocumentation(in 
 }
 
 func autoConvert_apiextensions_ExternalDocumentation_To_v1_ExternalDocumentation(in *apiextensions.ExternalDocumentation, out *ExternalDocumentation, s conversion.Scope) error {
-	out.Description = in.Description
-	out.URL = in.URL
+	*out = *(*ExternalDocumentation)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1243,7 +1197,7 @@ func Convert_apiextensions_JSONSchemaPropsOrStringArray_To_v1_JSONSchemaPropsOrS
 }
 
 func autoConvert_v1_SelectableField_To_apiextensions_SelectableField(in *SelectableField, out *apiextensions.SelectableField, s conversion.Scope) error {
-	out.JSONPath = in.JSONPath
+	*out = *(*apiextensions.SelectableField)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1253,7 +1207,7 @@ func Convert_v1_SelectableField_To_apiextensions_SelectableField(in *SelectableF
 }
 
 func autoConvert_apiextensions_SelectableField_To_v1_SelectableField(in *apiextensions.SelectableField, out *SelectableField, s conversion.Scope) error {
-	out.JSONPath = in.JSONPath
+	*out = *(*SelectableField)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1293,12 +1247,7 @@ func Convert_apiextensions_ServiceReference_To_v1_ServiceReference(in *apiextens
 }
 
 func autoConvert_v1_ValidationRule_To_apiextensions_ValidationRule(in *ValidationRule, out *apiextensions.ValidationRule, s conversion.Scope) error {
-	out.Rule = in.Rule
-	out.Message = in.Message
-	out.MessageExpression = in.MessageExpression
-	out.Reason = (*apiextensions.FieldValueErrorReason)(unsafe.Pointer(in.Reason))
-	out.FieldPath = in.FieldPath
-	out.OptionalOldSelf = (*bool)(unsafe.Pointer(in.OptionalOldSelf))
+	*out = *(*apiextensions.ValidationRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1308,12 +1257,7 @@ func Convert_v1_ValidationRule_To_apiextensions_ValidationRule(in *ValidationRul
 }
 
 func autoConvert_apiextensions_ValidationRule_To_v1_ValidationRule(in *apiextensions.ValidationRule, out *ValidationRule, s conversion.Scope) error {
-	out.Rule = in.Rule
-	out.Message = in.Message
-	out.MessageExpression = in.MessageExpression
-	out.Reason = (*FieldValueErrorReason)(unsafe.Pointer(in.Reason))
-	out.FieldPath = in.FieldPath
-	out.OptionalOldSelf = (*bool)(unsafe.Pointer(in.OptionalOldSelf))
+	*out = *(*ValidationRule)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/zz_generated.conversion.go
@@ -271,12 +271,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1beta1_CustomResourceColumnDefinition_To_apiextensions_CustomResourceColumnDefinition(in *CustomResourceColumnDefinition, out *apiextensions.CustomResourceColumnDefinition, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Type = in.Type
-	out.Format = in.Format
-	out.Description = in.Description
-	out.Priority = in.Priority
-	out.JSONPath = in.JSONPath
+	*out = *(*apiextensions.CustomResourceColumnDefinition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -286,12 +281,7 @@ func Convert_v1beta1_CustomResourceColumnDefinition_To_apiextensions_CustomResou
 }
 
 func autoConvert_apiextensions_CustomResourceColumnDefinition_To_v1beta1_CustomResourceColumnDefinition(in *apiextensions.CustomResourceColumnDefinition, out *CustomResourceColumnDefinition, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Type = in.Type
-	out.Format = in.Format
-	out.Description = in.Description
-	out.Priority = in.Priority
-	out.JSONPath = in.JSONPath
+	*out = *(*CustomResourceColumnDefinition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -373,12 +363,7 @@ func Convert_apiextensions_CustomResourceDefinition_To_v1beta1_CustomResourceDef
 }
 
 func autoConvert_v1beta1_CustomResourceDefinitionCondition_To_apiextensions_CustomResourceDefinitionCondition(in *CustomResourceDefinitionCondition, out *apiextensions.CustomResourceDefinitionCondition, s conversion.Scope) error {
-	out.Type = apiextensions.CustomResourceDefinitionConditionType(in.Type)
-	out.Status = apiextensions.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
-	out.ObservedGeneration = in.ObservedGeneration
+	*out = *(*apiextensions.CustomResourceDefinitionCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -388,12 +373,7 @@ func Convert_v1beta1_CustomResourceDefinitionCondition_To_apiextensions_CustomRe
 }
 
 func autoConvert_apiextensions_CustomResourceDefinitionCondition_To_v1beta1_CustomResourceDefinitionCondition(in *apiextensions.CustomResourceDefinitionCondition, out *CustomResourceDefinitionCondition, s conversion.Scope) error {
-	out.Type = CustomResourceDefinitionConditionType(in.Type)
-	out.Status = ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
-	out.ObservedGeneration = in.ObservedGeneration
+	*out = *(*CustomResourceDefinitionCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -445,12 +425,7 @@ func Convert_apiextensions_CustomResourceDefinitionList_To_v1beta1_CustomResourc
 }
 
 func autoConvert_v1beta1_CustomResourceDefinitionNames_To_apiextensions_CustomResourceDefinitionNames(in *CustomResourceDefinitionNames, out *apiextensions.CustomResourceDefinitionNames, s conversion.Scope) error {
-	out.Plural = in.Plural
-	out.Singular = in.Singular
-	out.ShortNames = *(*[]string)(unsafe.Pointer(&in.ShortNames))
-	out.Kind = in.Kind
-	out.ListKind = in.ListKind
-	out.Categories = *(*[]string)(unsafe.Pointer(&in.Categories))
+	*out = *(*apiextensions.CustomResourceDefinitionNames)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -460,12 +435,7 @@ func Convert_v1beta1_CustomResourceDefinitionNames_To_apiextensions_CustomResour
 }
 
 func autoConvert_apiextensions_CustomResourceDefinitionNames_To_v1beta1_CustomResourceDefinitionNames(in *apiextensions.CustomResourceDefinitionNames, out *CustomResourceDefinitionNames, s conversion.Scope) error {
-	out.Plural = in.Plural
-	out.Singular = in.Singular
-	out.ShortNames = *(*[]string)(unsafe.Pointer(&in.ShortNames))
-	out.Kind = in.Kind
-	out.ListKind = in.ListKind
-	out.Categories = *(*[]string)(unsafe.Pointer(&in.Categories))
+	*out = *(*CustomResourceDefinitionNames)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -571,12 +541,7 @@ func Convert_apiextensions_CustomResourceDefinitionSpec_To_v1beta1_CustomResourc
 }
 
 func autoConvert_v1beta1_CustomResourceDefinitionStatus_To_apiextensions_CustomResourceDefinitionStatus(in *CustomResourceDefinitionStatus, out *apiextensions.CustomResourceDefinitionStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]apiextensions.CustomResourceDefinitionCondition)(unsafe.Pointer(&in.Conditions))
-	if err := Convert_v1beta1_CustomResourceDefinitionNames_To_apiextensions_CustomResourceDefinitionNames(&in.AcceptedNames, &out.AcceptedNames, s); err != nil {
-		return err
-	}
-	out.StoredVersions = *(*[]string)(unsafe.Pointer(&in.StoredVersions))
-	out.ObservedGeneration = in.ObservedGeneration
+	*out = *(*apiextensions.CustomResourceDefinitionStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -586,12 +551,7 @@ func Convert_v1beta1_CustomResourceDefinitionStatus_To_apiextensions_CustomResou
 }
 
 func autoConvert_apiextensions_CustomResourceDefinitionStatus_To_v1beta1_CustomResourceDefinitionStatus(in *apiextensions.CustomResourceDefinitionStatus, out *CustomResourceDefinitionStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]CustomResourceDefinitionCondition)(unsafe.Pointer(&in.Conditions))
-	if err := Convert_apiextensions_CustomResourceDefinitionNames_To_v1beta1_CustomResourceDefinitionNames(&in.AcceptedNames, &out.AcceptedNames, s); err != nil {
-		return err
-	}
-	out.StoredVersions = *(*[]string)(unsafe.Pointer(&in.StoredVersions))
-	out.ObservedGeneration = in.ObservedGeneration
+	*out = *(*CustomResourceDefinitionStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -653,9 +613,7 @@ func Convert_apiextensions_CustomResourceDefinitionVersion_To_v1beta1_CustomReso
 }
 
 func autoConvert_v1beta1_CustomResourceSubresourceScale_To_apiextensions_CustomResourceSubresourceScale(in *CustomResourceSubresourceScale, out *apiextensions.CustomResourceSubresourceScale, s conversion.Scope) error {
-	out.SpecReplicasPath = in.SpecReplicasPath
-	out.StatusReplicasPath = in.StatusReplicasPath
-	out.LabelSelectorPath = (*string)(unsafe.Pointer(in.LabelSelectorPath))
+	*out = *(*apiextensions.CustomResourceSubresourceScale)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -665,9 +623,7 @@ func Convert_v1beta1_CustomResourceSubresourceScale_To_apiextensions_CustomResou
 }
 
 func autoConvert_apiextensions_CustomResourceSubresourceScale_To_v1beta1_CustomResourceSubresourceScale(in *apiextensions.CustomResourceSubresourceScale, out *CustomResourceSubresourceScale, s conversion.Scope) error {
-	out.SpecReplicasPath = in.SpecReplicasPath
-	out.StatusReplicasPath = in.StatusReplicasPath
-	out.LabelSelectorPath = (*string)(unsafe.Pointer(in.LabelSelectorPath))
+	*out = *(*CustomResourceSubresourceScale)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -677,6 +633,7 @@ func Convert_apiextensions_CustomResourceSubresourceScale_To_v1beta1_CustomResou
 }
 
 func autoConvert_v1beta1_CustomResourceSubresourceStatus_To_apiextensions_CustomResourceSubresourceStatus(in *CustomResourceSubresourceStatus, out *apiextensions.CustomResourceSubresourceStatus, s conversion.Scope) error {
+	*out = *(*apiextensions.CustomResourceSubresourceStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -686,6 +643,7 @@ func Convert_v1beta1_CustomResourceSubresourceStatus_To_apiextensions_CustomReso
 }
 
 func autoConvert_apiextensions_CustomResourceSubresourceStatus_To_v1beta1_CustomResourceSubresourceStatus(in *apiextensions.CustomResourceSubresourceStatus, out *CustomResourceSubresourceStatus, s conversion.Scope) error {
+	*out = *(*CustomResourceSubresourceStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -695,8 +653,7 @@ func Convert_apiextensions_CustomResourceSubresourceStatus_To_v1beta1_CustomReso
 }
 
 func autoConvert_v1beta1_CustomResourceSubresources_To_apiextensions_CustomResourceSubresources(in *CustomResourceSubresources, out *apiextensions.CustomResourceSubresources, s conversion.Scope) error {
-	out.Status = (*apiextensions.CustomResourceSubresourceStatus)(unsafe.Pointer(in.Status))
-	out.Scale = (*apiextensions.CustomResourceSubresourceScale)(unsafe.Pointer(in.Scale))
+	*out = *(*apiextensions.CustomResourceSubresources)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -706,8 +663,7 @@ func Convert_v1beta1_CustomResourceSubresources_To_apiextensions_CustomResourceS
 }
 
 func autoConvert_apiextensions_CustomResourceSubresources_To_v1beta1_CustomResourceSubresources(in *apiextensions.CustomResourceSubresources, out *CustomResourceSubresources, s conversion.Scope) error {
-	out.Status = (*CustomResourceSubresourceStatus)(unsafe.Pointer(in.Status))
-	out.Scale = (*CustomResourceSubresourceScale)(unsafe.Pointer(in.Scale))
+	*out = *(*CustomResourceSubresources)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -753,8 +709,7 @@ func Convert_apiextensions_CustomResourceValidation_To_v1beta1_CustomResourceVal
 }
 
 func autoConvert_v1beta1_ExternalDocumentation_To_apiextensions_ExternalDocumentation(in *ExternalDocumentation, out *apiextensions.ExternalDocumentation, s conversion.Scope) error {
-	out.Description = in.Description
-	out.URL = in.URL
+	*out = *(*apiextensions.ExternalDocumentation)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -764,8 +719,7 @@ func Convert_v1beta1_ExternalDocumentation_To_apiextensions_ExternalDocumentatio
 }
 
 func autoConvert_apiextensions_ExternalDocumentation_To_v1beta1_ExternalDocumentation(in *apiextensions.ExternalDocumentation, out *ExternalDocumentation, s conversion.Scope) error {
-	out.Description = in.Description
-	out.URL = in.URL
+	*out = *(*ExternalDocumentation)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1292,7 +1246,7 @@ func Convert_apiextensions_JSONSchemaPropsOrStringArray_To_v1beta1_JSONSchemaPro
 }
 
 func autoConvert_v1beta1_SelectableField_To_apiextensions_SelectableField(in *SelectableField, out *apiextensions.SelectableField, s conversion.Scope) error {
-	out.JSONPath = in.JSONPath
+	*out = *(*apiextensions.SelectableField)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1302,7 +1256,7 @@ func Convert_v1beta1_SelectableField_To_apiextensions_SelectableField(in *Select
 }
 
 func autoConvert_apiextensions_SelectableField_To_v1beta1_SelectableField(in *apiextensions.SelectableField, out *SelectableField, s conversion.Scope) error {
-	out.JSONPath = in.JSONPath
+	*out = *(*SelectableField)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1342,12 +1296,7 @@ func Convert_apiextensions_ServiceReference_To_v1beta1_ServiceReference(in *apie
 }
 
 func autoConvert_v1beta1_ValidationRule_To_apiextensions_ValidationRule(in *ValidationRule, out *apiextensions.ValidationRule, s conversion.Scope) error {
-	out.Rule = in.Rule
-	out.Message = in.Message
-	out.MessageExpression = in.MessageExpression
-	out.Reason = (*apiextensions.FieldValueErrorReason)(unsafe.Pointer(in.Reason))
-	out.FieldPath = in.FieldPath
-	out.OptionalOldSelf = (*bool)(unsafe.Pointer(in.OptionalOldSelf))
+	*out = *(*apiextensions.ValidationRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1357,12 +1306,7 @@ func Convert_v1beta1_ValidationRule_To_apiextensions_ValidationRule(in *Validati
 }
 
 func autoConvert_apiextensions_ValidationRule_To_v1beta1_ValidationRule(in *apiextensions.ValidationRule, out *ValidationRule, s conversion.Scope) error {
-	out.Rule = in.Rule
-	out.Message = in.Message
-	out.MessageExpression = in.MessageExpression
-	out.Reason = (*FieldValueErrorReason)(unsafe.Pointer(in.Reason))
-	out.FieldPath = in.FieldPath
-	out.OptionalOldSelf = (*bool)(unsafe.Pointer(in.OptionalOldSelf))
+	*out = *(*ValidationRule)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/v1/zz_generated.conversion.go
@@ -24,7 +24,6 @@ package v1
 import (
 	unsafe "unsafe"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testapigroup "k8s.io/apimachinery/pkg/apis/testapigroup"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -133,12 +132,7 @@ func Convert_testapigroup_Carp_To_v1_Carp(in *testapigroup.Carp, out *Carp, s co
 }
 
 func autoConvert_v1_CarpCondition_To_testapigroup_CarpCondition(in *CarpCondition, out *testapigroup.CarpCondition, s conversion.Scope) error {
-	out.Type = testapigroup.CarpConditionType(in.Type)
-	out.Status = testapigroup.ConditionStatus(in.Status)
-	out.LastProbeTime = in.LastProbeTime
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*testapigroup.CarpCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -148,12 +142,7 @@ func Convert_v1_CarpCondition_To_testapigroup_CarpCondition(in *CarpCondition, o
 }
 
 func autoConvert_testapigroup_CarpCondition_To_v1_CarpCondition(in *testapigroup.CarpCondition, out *CarpCondition, s conversion.Scope) error {
-	out.Type = CarpConditionType(in.Type)
-	out.Status = ConditionStatus(in.Status)
-	out.LastProbeTime = in.LastProbeTime
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*CarpCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -163,10 +152,7 @@ func Convert_testapigroup_CarpCondition_To_v1_CarpCondition(in *testapigroup.Car
 }
 
 func autoConvert_v1_CarpInfo_To_testapigroup_CarpInfo(in *CarpInfo, out *testapigroup.CarpInfo, s conversion.Scope) error {
-	out.A = in.A
-	out.B = in.B
-	out.C = (*string)(unsafe.Pointer(in.C))
-	out.Data = in.Data
+	*out = *(*testapigroup.CarpInfo)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -176,10 +162,7 @@ func Convert_v1_CarpInfo_To_testapigroup_CarpInfo(in *CarpInfo, out *testapigrou
 }
 
 func autoConvert_testapigroup_CarpInfo_To_v1_CarpInfo(in *testapigroup.CarpInfo, out *CarpInfo, s conversion.Scope) error {
-	out.A = in.A
-	out.B = in.B
-	out.C = (*string)(unsafe.Pointer(in.C))
-	out.Data = in.Data
+	*out = *(*CarpInfo)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -271,14 +254,7 @@ func Convert_testapigroup_CarpSpec_To_v1_CarpSpec(in *testapigroup.CarpSpec, out
 }
 
 func autoConvert_v1_CarpStatus_To_testapigroup_CarpStatus(in *CarpStatus, out *testapigroup.CarpStatus, s conversion.Scope) error {
-	out.Phase = testapigroup.CarpPhase(in.Phase)
-	out.Conditions = *(*[]testapigroup.CarpCondition)(unsafe.Pointer(&in.Conditions))
-	out.Message = in.Message
-	out.Reason = in.Reason
-	out.HostIP = in.HostIP
-	out.CarpIP = in.CarpIP
-	out.StartTime = (*metav1.Time)(unsafe.Pointer(in.StartTime))
-	out.Infos = *(*[]testapigroup.CarpInfo)(unsafe.Pointer(&in.Infos))
+	*out = *(*testapigroup.CarpStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -288,14 +264,7 @@ func Convert_v1_CarpStatus_To_testapigroup_CarpStatus(in *CarpStatus, out *testa
 }
 
 func autoConvert_testapigroup_CarpStatus_To_v1_CarpStatus(in *testapigroup.CarpStatus, out *CarpStatus, s conversion.Scope) error {
-	out.Phase = CarpPhase(in.Phase)
-	out.Conditions = *(*[]CarpCondition)(unsafe.Pointer(&in.Conditions))
-	out.Message = in.Message
-	out.Reason = in.Reason
-	out.HostIP = in.HostIP
-	out.CarpIP = in.CarpIP
-	out.StartTime = (*metav1.Time)(unsafe.Pointer(in.StartTime))
-	out.Infos = *(*[]CarpInfo)(unsafe.Pointer(&in.Infos))
+	*out = *(*CarpStatus)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/apis/resourcequota/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/apis/resourcequota/v1/zz_generated.conversion.go
@@ -24,7 +24,6 @@ package v1
 import (
 	unsafe "unsafe"
 
-	corev1 "k8s.io/api/core/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	resourcequota "k8s.io/apiserver/pkg/admission/plugin/resourcequota/apis/resourcequota"
@@ -81,10 +80,7 @@ func Convert_resourcequota_Configuration_To_v1_Configuration(in *resourcequota.C
 }
 
 func autoConvert_v1_LimitedResource_To_resourcequota_LimitedResource(in *LimitedResource, out *resourcequota.LimitedResource, s conversion.Scope) error {
-	out.APIGroup = in.APIGroup
-	out.Resource = in.Resource
-	out.MatchContains = *(*[]string)(unsafe.Pointer(&in.MatchContains))
-	out.MatchScopes = *(*[]corev1.ScopedResourceSelectorRequirement)(unsafe.Pointer(&in.MatchScopes))
+	*out = *(*resourcequota.LimitedResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -94,10 +90,7 @@ func Convert_v1_LimitedResource_To_resourcequota_LimitedResource(in *LimitedReso
 }
 
 func autoConvert_resourcequota_LimitedResource_To_v1_LimitedResource(in *resourcequota.LimitedResource, out *LimitedResource, s conversion.Scope) error {
-	out.APIGroup = in.APIGroup
-	out.Resource = in.Resource
-	out.MatchContains = *(*[]string)(unsafe.Pointer(&in.MatchContains))
-	out.MatchScopes = *(*[]corev1.ScopedResourceSelectorRequirement)(unsafe.Pointer(&in.MatchScopes))
+	*out = *(*LimitedResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/apis/resourcequota/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/apis/resourcequota/v1alpha1/zz_generated.conversion.go
@@ -24,7 +24,6 @@ package v1alpha1
 import (
 	unsafe "unsafe"
 
-	v1 "k8s.io/api/core/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	resourcequota "k8s.io/apiserver/pkg/admission/plugin/resourcequota/apis/resourcequota"
@@ -81,10 +80,7 @@ func Convert_resourcequota_Configuration_To_v1alpha1_Configuration(in *resourceq
 }
 
 func autoConvert_v1alpha1_LimitedResource_To_resourcequota_LimitedResource(in *LimitedResource, out *resourcequota.LimitedResource, s conversion.Scope) error {
-	out.APIGroup = in.APIGroup
-	out.Resource = in.Resource
-	out.MatchContains = *(*[]string)(unsafe.Pointer(&in.MatchContains))
-	out.MatchScopes = *(*[]v1.ScopedResourceSelectorRequirement)(unsafe.Pointer(&in.MatchScopes))
+	*out = *(*resourcequota.LimitedResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -94,10 +90,7 @@ func Convert_v1alpha1_LimitedResource_To_resourcequota_LimitedResource(in *Limit
 }
 
 func autoConvert_resourcequota_LimitedResource_To_v1alpha1_LimitedResource(in *resourcequota.LimitedResource, out *LimitedResource, s conversion.Scope) error {
-	out.APIGroup = in.APIGroup
-	out.Resource = in.Resource
-	out.MatchContains = *(*[]string)(unsafe.Pointer(&in.MatchContains))
-	out.MatchScopes = *(*[]v1.ScopedResourceSelectorRequirement)(unsafe.Pointer(&in.MatchScopes))
+	*out = *(*LimitedResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/apis/resourcequota/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/apis/resourcequota/v1beta1/zz_generated.conversion.go
@@ -24,7 +24,6 @@ package v1beta1
 import (
 	unsafe "unsafe"
 
-	v1 "k8s.io/api/core/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	resourcequota "k8s.io/apiserver/pkg/admission/plugin/resourcequota/apis/resourcequota"
@@ -81,10 +80,7 @@ func Convert_resourcequota_Configuration_To_v1beta1_Configuration(in *resourcequ
 }
 
 func autoConvert_v1beta1_LimitedResource_To_resourcequota_LimitedResource(in *LimitedResource, out *resourcequota.LimitedResource, s conversion.Scope) error {
-	out.APIGroup = in.APIGroup
-	out.Resource = in.Resource
-	out.MatchContains = *(*[]string)(unsafe.Pointer(&in.MatchContains))
-	out.MatchScopes = *(*[]v1.ScopedResourceSelectorRequirement)(unsafe.Pointer(&in.MatchScopes))
+	*out = *(*resourcequota.LimitedResource)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -94,10 +90,7 @@ func Convert_v1beta1_LimitedResource_To_resourcequota_LimitedResource(in *Limite
 }
 
 func autoConvert_resourcequota_LimitedResource_To_v1beta1_LimitedResource(in *resourcequota.LimitedResource, out *LimitedResource, s conversion.Scope) error {
-	out.APIGroup = in.APIGroup
-	out.Resource = in.Resource
-	out.MatchContains = *(*[]string)(unsafe.Pointer(&in.MatchContains))
-	out.MatchScopes = *(*[]v1.ScopedResourceSelectorRequirement)(unsafe.Pointer(&in.MatchScopes))
+	*out = *(*LimitedResource)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1/zz_generated.conversion.go
@@ -311,7 +311,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1_AESConfiguration_To_apiserver_AESConfiguration(in *AESConfiguration, out *apiserver.AESConfiguration, s conversion.Scope) error {
-	out.Keys = *(*[]apiserver.Key)(unsafe.Pointer(&in.Keys))
+	*out = *(*apiserver.AESConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -321,7 +321,7 @@ func Convert_v1_AESConfiguration_To_apiserver_AESConfiguration(in *AESConfigurat
 }
 
 func autoConvert_apiserver_AESConfiguration_To_v1_AESConfiguration(in *apiserver.AESConfiguration, out *AESConfiguration, s conversion.Scope) error {
-	out.Keys = *(*[]Key)(unsafe.Pointer(&in.Keys))
+	*out = *(*AESConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -351,9 +351,7 @@ func Convert_apiserver_AdmissionConfiguration_To_v1_AdmissionConfiguration(in *a
 }
 
 func autoConvert_v1_AdmissionPluginConfiguration_To_apiserver_AdmissionPluginConfiguration(in *AdmissionPluginConfiguration, out *apiserver.AdmissionPluginConfiguration, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Path = in.Path
-	out.Configuration = (*runtime.Unknown)(unsafe.Pointer(in.Configuration))
+	*out = *(*apiserver.AdmissionPluginConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -363,9 +361,7 @@ func Convert_v1_AdmissionPluginConfiguration_To_apiserver_AdmissionPluginConfigu
 }
 
 func autoConvert_apiserver_AdmissionPluginConfiguration_To_v1_AdmissionPluginConfiguration(in *apiserver.AdmissionPluginConfiguration, out *AdmissionPluginConfiguration, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Path = in.Path
-	out.Configuration = (*runtime.Unknown)(unsafe.Pointer(in.Configuration))
+	*out = *(*AdmissionPluginConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -375,7 +371,7 @@ func Convert_apiserver_AdmissionPluginConfiguration_To_v1_AdmissionPluginConfigu
 }
 
 func autoConvert_v1_AnonymousAuthCondition_To_apiserver_AnonymousAuthCondition(in *AnonymousAuthCondition, out *apiserver.AnonymousAuthCondition, s conversion.Scope) error {
-	out.Path = in.Path
+	*out = *(*apiserver.AnonymousAuthCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -385,7 +381,7 @@ func Convert_v1_AnonymousAuthCondition_To_apiserver_AnonymousAuthCondition(in *A
 }
 
 func autoConvert_apiserver_AnonymousAuthCondition_To_v1_AnonymousAuthCondition(in *apiserver.AnonymousAuthCondition, out *AnonymousAuthCondition, s conversion.Scope) error {
-	out.Path = in.Path
+	*out = *(*AnonymousAuthCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -395,8 +391,7 @@ func Convert_apiserver_AnonymousAuthCondition_To_v1_AnonymousAuthCondition(in *a
 }
 
 func autoConvert_v1_AnonymousAuthConfig_To_apiserver_AnonymousAuthConfig(in *AnonymousAuthConfig, out *apiserver.AnonymousAuthConfig, s conversion.Scope) error {
-	out.Enabled = in.Enabled
-	out.Conditions = *(*[]apiserver.AnonymousAuthCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*apiserver.AnonymousAuthConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -406,8 +401,7 @@ func Convert_v1_AnonymousAuthConfig_To_apiserver_AnonymousAuthConfig(in *Anonymo
 }
 
 func autoConvert_apiserver_AnonymousAuthConfig_To_v1_AnonymousAuthConfig(in *apiserver.AnonymousAuthConfig, out *AnonymousAuthConfig, s conversion.Scope) error {
-	out.Enabled = in.Enabled
-	out.Conditions = *(*[]AnonymousAuthCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*AnonymousAuthConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -539,16 +533,7 @@ func Convert_apiserver_AuthorizerConfiguration_To_v1_AuthorizerConfiguration(in 
 }
 
 func autoConvert_v1_ClaimMappings_To_apiserver_ClaimMappings(in *ClaimMappings, out *apiserver.ClaimMappings, s conversion.Scope) error {
-	if err := Convert_v1_PrefixedClaimOrExpression_To_apiserver_PrefixedClaimOrExpression(&in.Username, &out.Username, s); err != nil {
-		return err
-	}
-	if err := Convert_v1_PrefixedClaimOrExpression_To_apiserver_PrefixedClaimOrExpression(&in.Groups, &out.Groups, s); err != nil {
-		return err
-	}
-	if err := Convert_v1_ClaimOrExpression_To_apiserver_ClaimOrExpression(&in.UID, &out.UID, s); err != nil {
-		return err
-	}
-	out.Extra = *(*[]apiserver.ExtraMapping)(unsafe.Pointer(&in.Extra))
+	*out = *(*apiserver.ClaimMappings)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -558,16 +543,7 @@ func Convert_v1_ClaimMappings_To_apiserver_ClaimMappings(in *ClaimMappings, out 
 }
 
 func autoConvert_apiserver_ClaimMappings_To_v1_ClaimMappings(in *apiserver.ClaimMappings, out *ClaimMappings, s conversion.Scope) error {
-	if err := Convert_apiserver_PrefixedClaimOrExpression_To_v1_PrefixedClaimOrExpression(&in.Username, &out.Username, s); err != nil {
-		return err
-	}
-	if err := Convert_apiserver_PrefixedClaimOrExpression_To_v1_PrefixedClaimOrExpression(&in.Groups, &out.Groups, s); err != nil {
-		return err
-	}
-	if err := Convert_apiserver_ClaimOrExpression_To_v1_ClaimOrExpression(&in.UID, &out.UID, s); err != nil {
-		return err
-	}
-	out.Extra = *(*[]ExtraMapping)(unsafe.Pointer(&in.Extra))
+	*out = *(*ClaimMappings)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -577,8 +553,7 @@ func Convert_apiserver_ClaimMappings_To_v1_ClaimMappings(in *apiserver.ClaimMapp
 }
 
 func autoConvert_v1_ClaimOrExpression_To_apiserver_ClaimOrExpression(in *ClaimOrExpression, out *apiserver.ClaimOrExpression, s conversion.Scope) error {
-	out.Claim = in.Claim
-	out.Expression = in.Expression
+	*out = *(*apiserver.ClaimOrExpression)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -588,8 +563,7 @@ func Convert_v1_ClaimOrExpression_To_apiserver_ClaimOrExpression(in *ClaimOrExpr
 }
 
 func autoConvert_apiserver_ClaimOrExpression_To_v1_ClaimOrExpression(in *apiserver.ClaimOrExpression, out *ClaimOrExpression, s conversion.Scope) error {
-	out.Claim = in.Claim
-	out.Expression = in.Expression
+	*out = *(*ClaimOrExpression)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -599,10 +573,7 @@ func Convert_apiserver_ClaimOrExpression_To_v1_ClaimOrExpression(in *apiserver.C
 }
 
 func autoConvert_v1_ClaimValidationRule_To_apiserver_ClaimValidationRule(in *ClaimValidationRule, out *apiserver.ClaimValidationRule, s conversion.Scope) error {
-	out.Claim = in.Claim
-	out.RequiredValue = in.RequiredValue
-	out.Expression = in.Expression
-	out.Message = in.Message
+	*out = *(*apiserver.ClaimValidationRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -612,10 +583,7 @@ func Convert_v1_ClaimValidationRule_To_apiserver_ClaimValidationRule(in *ClaimVa
 }
 
 func autoConvert_apiserver_ClaimValidationRule_To_v1_ClaimValidationRule(in *apiserver.ClaimValidationRule, out *ClaimValidationRule, s conversion.Scope) error {
-	out.Claim = in.Claim
-	out.RequiredValue = in.RequiredValue
-	out.Expression = in.Expression
-	out.Message = in.Message
+	*out = *(*ClaimValidationRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -645,8 +613,7 @@ func Convert_apiserver_EncryptionConfiguration_To_v1_EncryptionConfiguration(in 
 }
 
 func autoConvert_v1_ExtraMapping_To_apiserver_ExtraMapping(in *ExtraMapping, out *apiserver.ExtraMapping, s conversion.Scope) error {
-	out.Key = in.Key
-	out.ValueExpression = in.ValueExpression
+	*out = *(*apiserver.ExtraMapping)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -656,8 +623,7 @@ func Convert_v1_ExtraMapping_To_apiserver_ExtraMapping(in *ExtraMapping, out *ap
 }
 
 func autoConvert_apiserver_ExtraMapping_To_v1_ExtraMapping(in *apiserver.ExtraMapping, out *ExtraMapping, s conversion.Scope) error {
-	out.Key = in.Key
-	out.ValueExpression = in.ValueExpression
+	*out = *(*ExtraMapping)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -667,6 +633,7 @@ func Convert_apiserver_ExtraMapping_To_v1_ExtraMapping(in *apiserver.ExtraMappin
 }
 
 func autoConvert_v1_IdentityConfiguration_To_apiserver_IdentityConfiguration(in *IdentityConfiguration, out *apiserver.IdentityConfiguration, s conversion.Scope) error {
+	*out = *(*apiserver.IdentityConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -676,6 +643,7 @@ func Convert_v1_IdentityConfiguration_To_apiserver_IdentityConfiguration(in *Ide
 }
 
 func autoConvert_apiserver_IdentityConfiguration_To_v1_IdentityConfiguration(in *apiserver.IdentityConfiguration, out *IdentityConfiguration, s conversion.Scope) error {
+	*out = *(*IdentityConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -753,11 +721,7 @@ func Convert_apiserver_JWTAuthenticator_To_v1_JWTAuthenticator(in *apiserver.JWT
 }
 
 func autoConvert_v1_KMSConfiguration_To_apiserver_KMSConfiguration(in *KMSConfiguration, out *apiserver.KMSConfiguration, s conversion.Scope) error {
-	out.APIVersion = in.APIVersion
-	out.Name = in.Name
-	out.CacheSize = (*int32)(unsafe.Pointer(in.CacheSize))
-	out.Endpoint = in.Endpoint
-	out.Timeout = (*metav1.Duration)(unsafe.Pointer(in.Timeout))
+	*out = *(*apiserver.KMSConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -767,11 +731,7 @@ func Convert_v1_KMSConfiguration_To_apiserver_KMSConfiguration(in *KMSConfigurat
 }
 
 func autoConvert_apiserver_KMSConfiguration_To_v1_KMSConfiguration(in *apiserver.KMSConfiguration, out *KMSConfiguration, s conversion.Scope) error {
-	out.APIVersion = in.APIVersion
-	out.Name = in.Name
-	out.CacheSize = (*int32)(unsafe.Pointer(in.CacheSize))
-	out.Endpoint = in.Endpoint
-	out.Timeout = (*metav1.Duration)(unsafe.Pointer(in.Timeout))
+	*out = *(*KMSConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -781,8 +741,7 @@ func Convert_apiserver_KMSConfiguration_To_v1_KMSConfiguration(in *apiserver.KMS
 }
 
 func autoConvert_v1_Key_To_apiserver_Key(in *Key, out *apiserver.Key, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Secret = in.Secret
+	*out = *(*apiserver.Key)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -792,8 +751,7 @@ func Convert_v1_Key_To_apiserver_Key(in *Key, out *apiserver.Key, s conversion.S
 }
 
 func autoConvert_apiserver_Key_To_v1_Key(in *apiserver.Key, out *Key, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Secret = in.Secret
+	*out = *(*Key)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -803,9 +761,7 @@ func Convert_apiserver_Key_To_v1_Key(in *apiserver.Key, out *Key, s conversion.S
 }
 
 func autoConvert_v1_PrefixedClaimOrExpression_To_apiserver_PrefixedClaimOrExpression(in *PrefixedClaimOrExpression, out *apiserver.PrefixedClaimOrExpression, s conversion.Scope) error {
-	out.Claim = in.Claim
-	out.Prefix = (*string)(unsafe.Pointer(in.Prefix))
-	out.Expression = in.Expression
+	*out = *(*apiserver.PrefixedClaimOrExpression)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -815,9 +771,7 @@ func Convert_v1_PrefixedClaimOrExpression_To_apiserver_PrefixedClaimOrExpression
 }
 
 func autoConvert_apiserver_PrefixedClaimOrExpression_To_v1_PrefixedClaimOrExpression(in *apiserver.PrefixedClaimOrExpression, out *PrefixedClaimOrExpression, s conversion.Scope) error {
-	out.Claim = in.Claim
-	out.Prefix = (*string)(unsafe.Pointer(in.Prefix))
-	out.Expression = in.Expression
+	*out = *(*PrefixedClaimOrExpression)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -827,11 +781,7 @@ func Convert_apiserver_PrefixedClaimOrExpression_To_v1_PrefixedClaimOrExpression
 }
 
 func autoConvert_v1_ProviderConfiguration_To_apiserver_ProviderConfiguration(in *ProviderConfiguration, out *apiserver.ProviderConfiguration, s conversion.Scope) error {
-	out.AESGCM = (*apiserver.AESConfiguration)(unsafe.Pointer(in.AESGCM))
-	out.AESCBC = (*apiserver.AESConfiguration)(unsafe.Pointer(in.AESCBC))
-	out.Secretbox = (*apiserver.SecretboxConfiguration)(unsafe.Pointer(in.Secretbox))
-	out.Identity = (*apiserver.IdentityConfiguration)(unsafe.Pointer(in.Identity))
-	out.KMS = (*apiserver.KMSConfiguration)(unsafe.Pointer(in.KMS))
+	*out = *(*apiserver.ProviderConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -841,11 +791,7 @@ func Convert_v1_ProviderConfiguration_To_apiserver_ProviderConfiguration(in *Pro
 }
 
 func autoConvert_apiserver_ProviderConfiguration_To_v1_ProviderConfiguration(in *apiserver.ProviderConfiguration, out *ProviderConfiguration, s conversion.Scope) error {
-	out.AESGCM = (*AESConfiguration)(unsafe.Pointer(in.AESGCM))
-	out.AESCBC = (*AESConfiguration)(unsafe.Pointer(in.AESCBC))
-	out.Secretbox = (*SecretboxConfiguration)(unsafe.Pointer(in.Secretbox))
-	out.Identity = (*IdentityConfiguration)(unsafe.Pointer(in.Identity))
-	out.KMS = (*KMSConfiguration)(unsafe.Pointer(in.KMS))
+	*out = *(*ProviderConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -855,8 +801,7 @@ func Convert_apiserver_ProviderConfiguration_To_v1_ProviderConfiguration(in *api
 }
 
 func autoConvert_v1_ResourceConfiguration_To_apiserver_ResourceConfiguration(in *ResourceConfiguration, out *apiserver.ResourceConfiguration, s conversion.Scope) error {
-	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
-	out.Providers = *(*[]apiserver.ProviderConfiguration)(unsafe.Pointer(&in.Providers))
+	*out = *(*apiserver.ResourceConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -866,8 +811,7 @@ func Convert_v1_ResourceConfiguration_To_apiserver_ResourceConfiguration(in *Res
 }
 
 func autoConvert_apiserver_ResourceConfiguration_To_v1_ResourceConfiguration(in *apiserver.ResourceConfiguration, out *ResourceConfiguration, s conversion.Scope) error {
-	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
-	out.Providers = *(*[]ProviderConfiguration)(unsafe.Pointer(&in.Providers))
+	*out = *(*ResourceConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -877,7 +821,7 @@ func Convert_apiserver_ResourceConfiguration_To_v1_ResourceConfiguration(in *api
 }
 
 func autoConvert_v1_SecretboxConfiguration_To_apiserver_SecretboxConfiguration(in *SecretboxConfiguration, out *apiserver.SecretboxConfiguration, s conversion.Scope) error {
-	out.Keys = *(*[]apiserver.Key)(unsafe.Pointer(&in.Keys))
+	*out = *(*apiserver.SecretboxConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -887,7 +831,7 @@ func Convert_v1_SecretboxConfiguration_To_apiserver_SecretboxConfiguration(in *S
 }
 
 func autoConvert_apiserver_SecretboxConfiguration_To_v1_SecretboxConfiguration(in *apiserver.SecretboxConfiguration, out *SecretboxConfiguration, s conversion.Scope) error {
-	out.Keys = *(*[]Key)(unsafe.Pointer(&in.Keys))
+	*out = *(*SecretboxConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -917,8 +861,7 @@ func Convert_apiserver_TracingConfiguration_To_v1_TracingConfiguration(in *apise
 }
 
 func autoConvert_v1_UserValidationRule_To_apiserver_UserValidationRule(in *UserValidationRule, out *apiserver.UserValidationRule, s conversion.Scope) error {
-	out.Expression = in.Expression
-	out.Message = in.Message
+	*out = *(*apiserver.UserValidationRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -928,8 +871,7 @@ func Convert_v1_UserValidationRule_To_apiserver_UserValidationRule(in *UserValid
 }
 
 func autoConvert_apiserver_UserValidationRule_To_v1_UserValidationRule(in *apiserver.UserValidationRule, out *UserValidationRule, s conversion.Scope) error {
-	out.Expression = in.Expression
-	out.Message = in.Message
+	*out = *(*UserValidationRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -989,8 +931,7 @@ func Convert_apiserver_WebhookConfiguration_To_v1_WebhookConfiguration(in *apise
 }
 
 func autoConvert_v1_WebhookConnectionInfo_To_apiserver_WebhookConnectionInfo(in *WebhookConnectionInfo, out *apiserver.WebhookConnectionInfo, s conversion.Scope) error {
-	out.Type = in.Type
-	out.KubeConfigFile = (*string)(unsafe.Pointer(in.KubeConfigFile))
+	*out = *(*apiserver.WebhookConnectionInfo)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1000,8 +941,7 @@ func Convert_v1_WebhookConnectionInfo_To_apiserver_WebhookConnectionInfo(in *Web
 }
 
 func autoConvert_apiserver_WebhookConnectionInfo_To_v1_WebhookConnectionInfo(in *apiserver.WebhookConnectionInfo, out *WebhookConnectionInfo, s conversion.Scope) error {
-	out.Type = in.Type
-	out.KubeConfigFile = (*string)(unsafe.Pointer(in.KubeConfigFile))
+	*out = *(*WebhookConnectionInfo)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1011,7 +951,7 @@ func Convert_apiserver_WebhookConnectionInfo_To_v1_WebhookConnectionInfo(in *api
 }
 
 func autoConvert_v1_WebhookMatchCondition_To_apiserver_WebhookMatchCondition(in *WebhookMatchCondition, out *apiserver.WebhookMatchCondition, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*apiserver.WebhookMatchCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1021,7 +961,7 @@ func Convert_v1_WebhookMatchCondition_To_apiserver_WebhookMatchCondition(in *Web
 }
 
 func autoConvert_apiserver_WebhookMatchCondition_To_v1_WebhookMatchCondition(in *apiserver.WebhookMatchCondition, out *WebhookMatchCondition, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*WebhookMatchCondition)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.conversion.go
@@ -321,9 +321,7 @@ func Convert_apiserver_AdmissionConfiguration_To_v1alpha1_AdmissionConfiguration
 }
 
 func autoConvert_v1alpha1_AdmissionPluginConfiguration_To_apiserver_AdmissionPluginConfiguration(in *AdmissionPluginConfiguration, out *apiserver.AdmissionPluginConfiguration, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Path = in.Path
-	out.Configuration = (*runtime.Unknown)(unsafe.Pointer(in.Configuration))
+	*out = *(*apiserver.AdmissionPluginConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -333,9 +331,7 @@ func Convert_v1alpha1_AdmissionPluginConfiguration_To_apiserver_AdmissionPluginC
 }
 
 func autoConvert_apiserver_AdmissionPluginConfiguration_To_v1alpha1_AdmissionPluginConfiguration(in *apiserver.AdmissionPluginConfiguration, out *AdmissionPluginConfiguration, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Path = in.Path
-	out.Configuration = (*runtime.Unknown)(unsafe.Pointer(in.Configuration))
+	*out = *(*AdmissionPluginConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -345,7 +341,7 @@ func Convert_apiserver_AdmissionPluginConfiguration_To_v1alpha1_AdmissionPluginC
 }
 
 func autoConvert_v1alpha1_AnonymousAuthCondition_To_apiserver_AnonymousAuthCondition(in *AnonymousAuthCondition, out *apiserver.AnonymousAuthCondition, s conversion.Scope) error {
-	out.Path = in.Path
+	*out = *(*apiserver.AnonymousAuthCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -355,7 +351,7 @@ func Convert_v1alpha1_AnonymousAuthCondition_To_apiserver_AnonymousAuthCondition
 }
 
 func autoConvert_apiserver_AnonymousAuthCondition_To_v1alpha1_AnonymousAuthCondition(in *apiserver.AnonymousAuthCondition, out *AnonymousAuthCondition, s conversion.Scope) error {
-	out.Path = in.Path
+	*out = *(*AnonymousAuthCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -365,8 +361,7 @@ func Convert_apiserver_AnonymousAuthCondition_To_v1alpha1_AnonymousAuthCondition
 }
 
 func autoConvert_v1alpha1_AnonymousAuthConfig_To_apiserver_AnonymousAuthConfig(in *AnonymousAuthConfig, out *apiserver.AnonymousAuthConfig, s conversion.Scope) error {
-	out.Enabled = in.Enabled
-	out.Conditions = *(*[]apiserver.AnonymousAuthCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*apiserver.AnonymousAuthConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -376,8 +371,7 @@ func Convert_v1alpha1_AnonymousAuthConfig_To_apiserver_AnonymousAuthConfig(in *A
 }
 
 func autoConvert_apiserver_AnonymousAuthConfig_To_v1alpha1_AnonymousAuthConfig(in *apiserver.AnonymousAuthConfig, out *AnonymousAuthConfig, s conversion.Scope) error {
-	out.Enabled = in.Enabled
-	out.Conditions = *(*[]AnonymousAuthCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*AnonymousAuthConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -509,16 +503,7 @@ func Convert_apiserver_AuthorizerConfiguration_To_v1alpha1_AuthorizerConfigurati
 }
 
 func autoConvert_v1alpha1_ClaimMappings_To_apiserver_ClaimMappings(in *ClaimMappings, out *apiserver.ClaimMappings, s conversion.Scope) error {
-	if err := Convert_v1alpha1_PrefixedClaimOrExpression_To_apiserver_PrefixedClaimOrExpression(&in.Username, &out.Username, s); err != nil {
-		return err
-	}
-	if err := Convert_v1alpha1_PrefixedClaimOrExpression_To_apiserver_PrefixedClaimOrExpression(&in.Groups, &out.Groups, s); err != nil {
-		return err
-	}
-	if err := Convert_v1alpha1_ClaimOrExpression_To_apiserver_ClaimOrExpression(&in.UID, &out.UID, s); err != nil {
-		return err
-	}
-	out.Extra = *(*[]apiserver.ExtraMapping)(unsafe.Pointer(&in.Extra))
+	*out = *(*apiserver.ClaimMappings)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -528,16 +513,7 @@ func Convert_v1alpha1_ClaimMappings_To_apiserver_ClaimMappings(in *ClaimMappings
 }
 
 func autoConvert_apiserver_ClaimMappings_To_v1alpha1_ClaimMappings(in *apiserver.ClaimMappings, out *ClaimMappings, s conversion.Scope) error {
-	if err := Convert_apiserver_PrefixedClaimOrExpression_To_v1alpha1_PrefixedClaimOrExpression(&in.Username, &out.Username, s); err != nil {
-		return err
-	}
-	if err := Convert_apiserver_PrefixedClaimOrExpression_To_v1alpha1_PrefixedClaimOrExpression(&in.Groups, &out.Groups, s); err != nil {
-		return err
-	}
-	if err := Convert_apiserver_ClaimOrExpression_To_v1alpha1_ClaimOrExpression(&in.UID, &out.UID, s); err != nil {
-		return err
-	}
-	out.Extra = *(*[]ExtraMapping)(unsafe.Pointer(&in.Extra))
+	*out = *(*ClaimMappings)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -547,8 +523,7 @@ func Convert_apiserver_ClaimMappings_To_v1alpha1_ClaimMappings(in *apiserver.Cla
 }
 
 func autoConvert_v1alpha1_ClaimOrExpression_To_apiserver_ClaimOrExpression(in *ClaimOrExpression, out *apiserver.ClaimOrExpression, s conversion.Scope) error {
-	out.Claim = in.Claim
-	out.Expression = in.Expression
+	*out = *(*apiserver.ClaimOrExpression)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -558,8 +533,7 @@ func Convert_v1alpha1_ClaimOrExpression_To_apiserver_ClaimOrExpression(in *Claim
 }
 
 func autoConvert_apiserver_ClaimOrExpression_To_v1alpha1_ClaimOrExpression(in *apiserver.ClaimOrExpression, out *ClaimOrExpression, s conversion.Scope) error {
-	out.Claim = in.Claim
-	out.Expression = in.Expression
+	*out = *(*ClaimOrExpression)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -569,10 +543,7 @@ func Convert_apiserver_ClaimOrExpression_To_v1alpha1_ClaimOrExpression(in *apise
 }
 
 func autoConvert_v1alpha1_ClaimValidationRule_To_apiserver_ClaimValidationRule(in *ClaimValidationRule, out *apiserver.ClaimValidationRule, s conversion.Scope) error {
-	out.Claim = in.Claim
-	out.RequiredValue = in.RequiredValue
-	out.Expression = in.Expression
-	out.Message = in.Message
+	*out = *(*apiserver.ClaimValidationRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -582,10 +553,7 @@ func Convert_v1alpha1_ClaimValidationRule_To_apiserver_ClaimValidationRule(in *C
 }
 
 func autoConvert_apiserver_ClaimValidationRule_To_v1alpha1_ClaimValidationRule(in *apiserver.ClaimValidationRule, out *ClaimValidationRule, s conversion.Scope) error {
-	out.Claim = in.Claim
-	out.RequiredValue = in.RequiredValue
-	out.Expression = in.Expression
-	out.Message = in.Message
+	*out = *(*ClaimValidationRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -595,8 +563,7 @@ func Convert_apiserver_ClaimValidationRule_To_v1alpha1_ClaimValidationRule(in *a
 }
 
 func autoConvert_v1alpha1_Connection_To_apiserver_Connection(in *Connection, out *apiserver.Connection, s conversion.Scope) error {
-	out.ProxyProtocol = apiserver.ProtocolType(in.ProxyProtocol)
-	out.Transport = (*apiserver.Transport)(unsafe.Pointer(in.Transport))
+	*out = *(*apiserver.Connection)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -606,8 +573,7 @@ func Convert_v1alpha1_Connection_To_apiserver_Connection(in *Connection, out *ap
 }
 
 func autoConvert_apiserver_Connection_To_v1alpha1_Connection(in *apiserver.Connection, out *Connection, s conversion.Scope) error {
-	out.ProxyProtocol = ProtocolType(in.ProxyProtocol)
-	out.Transport = (*Transport)(unsafe.Pointer(in.Transport))
+	*out = *(*Connection)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -678,8 +644,7 @@ func Convert_apiserver_EgressSelectorConfiguration_To_v1alpha1_EgressSelectorCon
 }
 
 func autoConvert_v1alpha1_ExtraMapping_To_apiserver_ExtraMapping(in *ExtraMapping, out *apiserver.ExtraMapping, s conversion.Scope) error {
-	out.Key = in.Key
-	out.ValueExpression = in.ValueExpression
+	*out = *(*apiserver.ExtraMapping)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -689,8 +654,7 @@ func Convert_v1alpha1_ExtraMapping_To_apiserver_ExtraMapping(in *ExtraMapping, o
 }
 
 func autoConvert_apiserver_ExtraMapping_To_v1alpha1_ExtraMapping(in *apiserver.ExtraMapping, out *ExtraMapping, s conversion.Scope) error {
-	out.Key = in.Key
-	out.ValueExpression = in.ValueExpression
+	*out = *(*ExtraMapping)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -768,9 +732,7 @@ func Convert_apiserver_JWTAuthenticator_To_v1alpha1_JWTAuthenticator(in *apiserv
 }
 
 func autoConvert_v1alpha1_PrefixedClaimOrExpression_To_apiserver_PrefixedClaimOrExpression(in *PrefixedClaimOrExpression, out *apiserver.PrefixedClaimOrExpression, s conversion.Scope) error {
-	out.Claim = in.Claim
-	out.Prefix = (*string)(unsafe.Pointer(in.Prefix))
-	out.Expression = in.Expression
+	*out = *(*apiserver.PrefixedClaimOrExpression)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -780,9 +742,7 @@ func Convert_v1alpha1_PrefixedClaimOrExpression_To_apiserver_PrefixedClaimOrExpr
 }
 
 func autoConvert_apiserver_PrefixedClaimOrExpression_To_v1alpha1_PrefixedClaimOrExpression(in *apiserver.PrefixedClaimOrExpression, out *PrefixedClaimOrExpression, s conversion.Scope) error {
-	out.Claim = in.Claim
-	out.Prefix = (*string)(unsafe.Pointer(in.Prefix))
-	out.Expression = in.Expression
+	*out = *(*PrefixedClaimOrExpression)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -792,8 +752,7 @@ func Convert_apiserver_PrefixedClaimOrExpression_To_v1alpha1_PrefixedClaimOrExpr
 }
 
 func autoConvert_v1alpha1_TCPTransport_To_apiserver_TCPTransport(in *TCPTransport, out *apiserver.TCPTransport, s conversion.Scope) error {
-	out.URL = in.URL
-	out.TLSConfig = (*apiserver.TLSConfig)(unsafe.Pointer(in.TLSConfig))
+	*out = *(*apiserver.TCPTransport)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -803,8 +762,7 @@ func Convert_v1alpha1_TCPTransport_To_apiserver_TCPTransport(in *TCPTransport, o
 }
 
 func autoConvert_apiserver_TCPTransport_To_v1alpha1_TCPTransport(in *apiserver.TCPTransport, out *TCPTransport, s conversion.Scope) error {
-	out.URL = in.URL
-	out.TLSConfig = (*TLSConfig)(unsafe.Pointer(in.TLSConfig))
+	*out = *(*TCPTransport)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -814,10 +772,7 @@ func Convert_apiserver_TCPTransport_To_v1alpha1_TCPTransport(in *apiserver.TCPTr
 }
 
 func autoConvert_v1alpha1_TLSConfig_To_apiserver_TLSConfig(in *TLSConfig, out *apiserver.TLSConfig, s conversion.Scope) error {
-	out.CABundle = in.CABundle
-	out.ClientKey = in.ClientKey
-	out.ClientCert = in.ClientCert
-	out.TLSServerName = in.TLSServerName
+	*out = *(*apiserver.TLSConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -827,10 +782,7 @@ func Convert_v1alpha1_TLSConfig_To_apiserver_TLSConfig(in *TLSConfig, out *apise
 }
 
 func autoConvert_apiserver_TLSConfig_To_v1alpha1_TLSConfig(in *apiserver.TLSConfig, out *TLSConfig, s conversion.Scope) error {
-	out.CABundle = in.CABundle
-	out.ClientKey = in.ClientKey
-	out.ClientCert = in.ClientCert
-	out.TLSServerName = in.TLSServerName
+	*out = *(*TLSConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -860,8 +812,7 @@ func Convert_apiserver_TracingConfiguration_To_v1alpha1_TracingConfiguration(in 
 }
 
 func autoConvert_v1alpha1_Transport_To_apiserver_Transport(in *Transport, out *apiserver.Transport, s conversion.Scope) error {
-	out.TCP = (*apiserver.TCPTransport)(unsafe.Pointer(in.TCP))
-	out.UDS = (*apiserver.UDSTransport)(unsafe.Pointer(in.UDS))
+	*out = *(*apiserver.Transport)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -871,8 +822,7 @@ func Convert_v1alpha1_Transport_To_apiserver_Transport(in *Transport, out *apise
 }
 
 func autoConvert_apiserver_Transport_To_v1alpha1_Transport(in *apiserver.Transport, out *Transport, s conversion.Scope) error {
-	out.TCP = (*TCPTransport)(unsafe.Pointer(in.TCP))
-	out.UDS = (*UDSTransport)(unsafe.Pointer(in.UDS))
+	*out = *(*Transport)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -882,7 +832,7 @@ func Convert_apiserver_Transport_To_v1alpha1_Transport(in *apiserver.Transport, 
 }
 
 func autoConvert_v1alpha1_UDSTransport_To_apiserver_UDSTransport(in *UDSTransport, out *apiserver.UDSTransport, s conversion.Scope) error {
-	out.UDSName = in.UDSName
+	*out = *(*apiserver.UDSTransport)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -892,7 +842,7 @@ func Convert_v1alpha1_UDSTransport_To_apiserver_UDSTransport(in *UDSTransport, o
 }
 
 func autoConvert_apiserver_UDSTransport_To_v1alpha1_UDSTransport(in *apiserver.UDSTransport, out *UDSTransport, s conversion.Scope) error {
-	out.UDSName = in.UDSName
+	*out = *(*UDSTransport)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -902,8 +852,7 @@ func Convert_apiserver_UDSTransport_To_v1alpha1_UDSTransport(in *apiserver.UDSTr
 }
 
 func autoConvert_v1alpha1_UserValidationRule_To_apiserver_UserValidationRule(in *UserValidationRule, out *apiserver.UserValidationRule, s conversion.Scope) error {
-	out.Expression = in.Expression
-	out.Message = in.Message
+	*out = *(*apiserver.UserValidationRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -913,8 +862,7 @@ func Convert_v1alpha1_UserValidationRule_To_apiserver_UserValidationRule(in *Use
 }
 
 func autoConvert_apiserver_UserValidationRule_To_v1alpha1_UserValidationRule(in *apiserver.UserValidationRule, out *UserValidationRule, s conversion.Scope) error {
-	out.Expression = in.Expression
-	out.Message = in.Message
+	*out = *(*UserValidationRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -974,8 +922,7 @@ func Convert_apiserver_WebhookConfiguration_To_v1alpha1_WebhookConfiguration(in 
 }
 
 func autoConvert_v1alpha1_WebhookConnectionInfo_To_apiserver_WebhookConnectionInfo(in *WebhookConnectionInfo, out *apiserver.WebhookConnectionInfo, s conversion.Scope) error {
-	out.Type = in.Type
-	out.KubeConfigFile = (*string)(unsafe.Pointer(in.KubeConfigFile))
+	*out = *(*apiserver.WebhookConnectionInfo)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -985,8 +932,7 @@ func Convert_v1alpha1_WebhookConnectionInfo_To_apiserver_WebhookConnectionInfo(i
 }
 
 func autoConvert_apiserver_WebhookConnectionInfo_To_v1alpha1_WebhookConnectionInfo(in *apiserver.WebhookConnectionInfo, out *WebhookConnectionInfo, s conversion.Scope) error {
-	out.Type = in.Type
-	out.KubeConfigFile = (*string)(unsafe.Pointer(in.KubeConfigFile))
+	*out = *(*WebhookConnectionInfo)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -996,7 +942,7 @@ func Convert_apiserver_WebhookConnectionInfo_To_v1alpha1_WebhookConnectionInfo(i
 }
 
 func autoConvert_v1alpha1_WebhookMatchCondition_To_apiserver_WebhookMatchCondition(in *WebhookMatchCondition, out *apiserver.WebhookMatchCondition, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*apiserver.WebhookMatchCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1006,7 +952,7 @@ func Convert_v1alpha1_WebhookMatchCondition_To_apiserver_WebhookMatchCondition(i
 }
 
 func autoConvert_apiserver_WebhookMatchCondition_To_v1alpha1_WebhookMatchCondition(in *apiserver.WebhookMatchCondition, out *WebhookMatchCondition, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*WebhookMatchCondition)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/zz_generated.conversion.go
@@ -281,7 +281,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1beta1_AnonymousAuthCondition_To_apiserver_AnonymousAuthCondition(in *AnonymousAuthCondition, out *apiserver.AnonymousAuthCondition, s conversion.Scope) error {
-	out.Path = in.Path
+	*out = *(*apiserver.AnonymousAuthCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -291,7 +291,7 @@ func Convert_v1beta1_AnonymousAuthCondition_To_apiserver_AnonymousAuthCondition(
 }
 
 func autoConvert_apiserver_AnonymousAuthCondition_To_v1beta1_AnonymousAuthCondition(in *apiserver.AnonymousAuthCondition, out *AnonymousAuthCondition, s conversion.Scope) error {
-	out.Path = in.Path
+	*out = *(*AnonymousAuthCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -301,8 +301,7 @@ func Convert_apiserver_AnonymousAuthCondition_To_v1beta1_AnonymousAuthCondition(
 }
 
 func autoConvert_v1beta1_AnonymousAuthConfig_To_apiserver_AnonymousAuthConfig(in *AnonymousAuthConfig, out *apiserver.AnonymousAuthConfig, s conversion.Scope) error {
-	out.Enabled = in.Enabled
-	out.Conditions = *(*[]apiserver.AnonymousAuthCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*apiserver.AnonymousAuthConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -312,8 +311,7 @@ func Convert_v1beta1_AnonymousAuthConfig_To_apiserver_AnonymousAuthConfig(in *An
 }
 
 func autoConvert_apiserver_AnonymousAuthConfig_To_v1beta1_AnonymousAuthConfig(in *apiserver.AnonymousAuthConfig, out *AnonymousAuthConfig, s conversion.Scope) error {
-	out.Enabled = in.Enabled
-	out.Conditions = *(*[]AnonymousAuthCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*AnonymousAuthConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -445,16 +443,7 @@ func Convert_apiserver_AuthorizerConfiguration_To_v1beta1_AuthorizerConfiguratio
 }
 
 func autoConvert_v1beta1_ClaimMappings_To_apiserver_ClaimMappings(in *ClaimMappings, out *apiserver.ClaimMappings, s conversion.Scope) error {
-	if err := Convert_v1beta1_PrefixedClaimOrExpression_To_apiserver_PrefixedClaimOrExpression(&in.Username, &out.Username, s); err != nil {
-		return err
-	}
-	if err := Convert_v1beta1_PrefixedClaimOrExpression_To_apiserver_PrefixedClaimOrExpression(&in.Groups, &out.Groups, s); err != nil {
-		return err
-	}
-	if err := Convert_v1beta1_ClaimOrExpression_To_apiserver_ClaimOrExpression(&in.UID, &out.UID, s); err != nil {
-		return err
-	}
-	out.Extra = *(*[]apiserver.ExtraMapping)(unsafe.Pointer(&in.Extra))
+	*out = *(*apiserver.ClaimMappings)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -464,16 +453,7 @@ func Convert_v1beta1_ClaimMappings_To_apiserver_ClaimMappings(in *ClaimMappings,
 }
 
 func autoConvert_apiserver_ClaimMappings_To_v1beta1_ClaimMappings(in *apiserver.ClaimMappings, out *ClaimMappings, s conversion.Scope) error {
-	if err := Convert_apiserver_PrefixedClaimOrExpression_To_v1beta1_PrefixedClaimOrExpression(&in.Username, &out.Username, s); err != nil {
-		return err
-	}
-	if err := Convert_apiserver_PrefixedClaimOrExpression_To_v1beta1_PrefixedClaimOrExpression(&in.Groups, &out.Groups, s); err != nil {
-		return err
-	}
-	if err := Convert_apiserver_ClaimOrExpression_To_v1beta1_ClaimOrExpression(&in.UID, &out.UID, s); err != nil {
-		return err
-	}
-	out.Extra = *(*[]ExtraMapping)(unsafe.Pointer(&in.Extra))
+	*out = *(*ClaimMappings)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -483,8 +463,7 @@ func Convert_apiserver_ClaimMappings_To_v1beta1_ClaimMappings(in *apiserver.Clai
 }
 
 func autoConvert_v1beta1_ClaimOrExpression_To_apiserver_ClaimOrExpression(in *ClaimOrExpression, out *apiserver.ClaimOrExpression, s conversion.Scope) error {
-	out.Claim = in.Claim
-	out.Expression = in.Expression
+	*out = *(*apiserver.ClaimOrExpression)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -494,8 +473,7 @@ func Convert_v1beta1_ClaimOrExpression_To_apiserver_ClaimOrExpression(in *ClaimO
 }
 
 func autoConvert_apiserver_ClaimOrExpression_To_v1beta1_ClaimOrExpression(in *apiserver.ClaimOrExpression, out *ClaimOrExpression, s conversion.Scope) error {
-	out.Claim = in.Claim
-	out.Expression = in.Expression
+	*out = *(*ClaimOrExpression)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -505,10 +483,7 @@ func Convert_apiserver_ClaimOrExpression_To_v1beta1_ClaimOrExpression(in *apiser
 }
 
 func autoConvert_v1beta1_ClaimValidationRule_To_apiserver_ClaimValidationRule(in *ClaimValidationRule, out *apiserver.ClaimValidationRule, s conversion.Scope) error {
-	out.Claim = in.Claim
-	out.RequiredValue = in.RequiredValue
-	out.Expression = in.Expression
-	out.Message = in.Message
+	*out = *(*apiserver.ClaimValidationRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -518,10 +493,7 @@ func Convert_v1beta1_ClaimValidationRule_To_apiserver_ClaimValidationRule(in *Cl
 }
 
 func autoConvert_apiserver_ClaimValidationRule_To_v1beta1_ClaimValidationRule(in *apiserver.ClaimValidationRule, out *ClaimValidationRule, s conversion.Scope) error {
-	out.Claim = in.Claim
-	out.RequiredValue = in.RequiredValue
-	out.Expression = in.Expression
-	out.Message = in.Message
+	*out = *(*ClaimValidationRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -531,8 +503,7 @@ func Convert_apiserver_ClaimValidationRule_To_v1beta1_ClaimValidationRule(in *ap
 }
 
 func autoConvert_v1beta1_Connection_To_apiserver_Connection(in *Connection, out *apiserver.Connection, s conversion.Scope) error {
-	out.ProxyProtocol = apiserver.ProtocolType(in.ProxyProtocol)
-	out.Transport = (*apiserver.Transport)(unsafe.Pointer(in.Transport))
+	*out = *(*apiserver.Connection)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -542,8 +513,7 @@ func Convert_v1beta1_Connection_To_apiserver_Connection(in *Connection, out *api
 }
 
 func autoConvert_apiserver_Connection_To_v1beta1_Connection(in *apiserver.Connection, out *Connection, s conversion.Scope) error {
-	out.ProxyProtocol = ProtocolType(in.ProxyProtocol)
-	out.Transport = (*Transport)(unsafe.Pointer(in.Transport))
+	*out = *(*Connection)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -614,8 +584,7 @@ func Convert_apiserver_EgressSelectorConfiguration_To_v1beta1_EgressSelectorConf
 }
 
 func autoConvert_v1beta1_ExtraMapping_To_apiserver_ExtraMapping(in *ExtraMapping, out *apiserver.ExtraMapping, s conversion.Scope) error {
-	out.Key = in.Key
-	out.ValueExpression = in.ValueExpression
+	*out = *(*apiserver.ExtraMapping)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -625,8 +594,7 @@ func Convert_v1beta1_ExtraMapping_To_apiserver_ExtraMapping(in *ExtraMapping, ou
 }
 
 func autoConvert_apiserver_ExtraMapping_To_v1beta1_ExtraMapping(in *apiserver.ExtraMapping, out *ExtraMapping, s conversion.Scope) error {
-	out.Key = in.Key
-	out.ValueExpression = in.ValueExpression
+	*out = *(*ExtraMapping)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -704,9 +672,7 @@ func Convert_apiserver_JWTAuthenticator_To_v1beta1_JWTAuthenticator(in *apiserve
 }
 
 func autoConvert_v1beta1_PrefixedClaimOrExpression_To_apiserver_PrefixedClaimOrExpression(in *PrefixedClaimOrExpression, out *apiserver.PrefixedClaimOrExpression, s conversion.Scope) error {
-	out.Claim = in.Claim
-	out.Prefix = (*string)(unsafe.Pointer(in.Prefix))
-	out.Expression = in.Expression
+	*out = *(*apiserver.PrefixedClaimOrExpression)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -716,9 +682,7 @@ func Convert_v1beta1_PrefixedClaimOrExpression_To_apiserver_PrefixedClaimOrExpre
 }
 
 func autoConvert_apiserver_PrefixedClaimOrExpression_To_v1beta1_PrefixedClaimOrExpression(in *apiserver.PrefixedClaimOrExpression, out *PrefixedClaimOrExpression, s conversion.Scope) error {
-	out.Claim = in.Claim
-	out.Prefix = (*string)(unsafe.Pointer(in.Prefix))
-	out.Expression = in.Expression
+	*out = *(*PrefixedClaimOrExpression)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -728,8 +692,7 @@ func Convert_apiserver_PrefixedClaimOrExpression_To_v1beta1_PrefixedClaimOrExpre
 }
 
 func autoConvert_v1beta1_TCPTransport_To_apiserver_TCPTransport(in *TCPTransport, out *apiserver.TCPTransport, s conversion.Scope) error {
-	out.URL = in.URL
-	out.TLSConfig = (*apiserver.TLSConfig)(unsafe.Pointer(in.TLSConfig))
+	*out = *(*apiserver.TCPTransport)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -739,8 +702,7 @@ func Convert_v1beta1_TCPTransport_To_apiserver_TCPTransport(in *TCPTransport, ou
 }
 
 func autoConvert_apiserver_TCPTransport_To_v1beta1_TCPTransport(in *apiserver.TCPTransport, out *TCPTransport, s conversion.Scope) error {
-	out.URL = in.URL
-	out.TLSConfig = (*TLSConfig)(unsafe.Pointer(in.TLSConfig))
+	*out = *(*TCPTransport)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -750,10 +712,7 @@ func Convert_apiserver_TCPTransport_To_v1beta1_TCPTransport(in *apiserver.TCPTra
 }
 
 func autoConvert_v1beta1_TLSConfig_To_apiserver_TLSConfig(in *TLSConfig, out *apiserver.TLSConfig, s conversion.Scope) error {
-	out.CABundle = in.CABundle
-	out.ClientKey = in.ClientKey
-	out.ClientCert = in.ClientCert
-	out.TLSServerName = in.TLSServerName
+	*out = *(*apiserver.TLSConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -763,10 +722,7 @@ func Convert_v1beta1_TLSConfig_To_apiserver_TLSConfig(in *TLSConfig, out *apiser
 }
 
 func autoConvert_apiserver_TLSConfig_To_v1beta1_TLSConfig(in *apiserver.TLSConfig, out *TLSConfig, s conversion.Scope) error {
-	out.CABundle = in.CABundle
-	out.ClientKey = in.ClientKey
-	out.ClientCert = in.ClientCert
-	out.TLSServerName = in.TLSServerName
+	*out = *(*TLSConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -796,8 +752,7 @@ func Convert_apiserver_TracingConfiguration_To_v1beta1_TracingConfiguration(in *
 }
 
 func autoConvert_v1beta1_Transport_To_apiserver_Transport(in *Transport, out *apiserver.Transport, s conversion.Scope) error {
-	out.TCP = (*apiserver.TCPTransport)(unsafe.Pointer(in.TCP))
-	out.UDS = (*apiserver.UDSTransport)(unsafe.Pointer(in.UDS))
+	*out = *(*apiserver.Transport)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -807,8 +762,7 @@ func Convert_v1beta1_Transport_To_apiserver_Transport(in *Transport, out *apiser
 }
 
 func autoConvert_apiserver_Transport_To_v1beta1_Transport(in *apiserver.Transport, out *Transport, s conversion.Scope) error {
-	out.TCP = (*TCPTransport)(unsafe.Pointer(in.TCP))
-	out.UDS = (*UDSTransport)(unsafe.Pointer(in.UDS))
+	*out = *(*Transport)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -818,7 +772,7 @@ func Convert_apiserver_Transport_To_v1beta1_Transport(in *apiserver.Transport, o
 }
 
 func autoConvert_v1beta1_UDSTransport_To_apiserver_UDSTransport(in *UDSTransport, out *apiserver.UDSTransport, s conversion.Scope) error {
-	out.UDSName = in.UDSName
+	*out = *(*apiserver.UDSTransport)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -828,7 +782,7 @@ func Convert_v1beta1_UDSTransport_To_apiserver_UDSTransport(in *UDSTransport, ou
 }
 
 func autoConvert_apiserver_UDSTransport_To_v1beta1_UDSTransport(in *apiserver.UDSTransport, out *UDSTransport, s conversion.Scope) error {
-	out.UDSName = in.UDSName
+	*out = *(*UDSTransport)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -838,8 +792,7 @@ func Convert_apiserver_UDSTransport_To_v1beta1_UDSTransport(in *apiserver.UDSTra
 }
 
 func autoConvert_v1beta1_UserValidationRule_To_apiserver_UserValidationRule(in *UserValidationRule, out *apiserver.UserValidationRule, s conversion.Scope) error {
-	out.Expression = in.Expression
-	out.Message = in.Message
+	*out = *(*apiserver.UserValidationRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -849,8 +802,7 @@ func Convert_v1beta1_UserValidationRule_To_apiserver_UserValidationRule(in *User
 }
 
 func autoConvert_apiserver_UserValidationRule_To_v1beta1_UserValidationRule(in *apiserver.UserValidationRule, out *UserValidationRule, s conversion.Scope) error {
-	out.Expression = in.Expression
-	out.Message = in.Message
+	*out = *(*UserValidationRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -910,8 +862,7 @@ func Convert_apiserver_WebhookConfiguration_To_v1beta1_WebhookConfiguration(in *
 }
 
 func autoConvert_v1beta1_WebhookConnectionInfo_To_apiserver_WebhookConnectionInfo(in *WebhookConnectionInfo, out *apiserver.WebhookConnectionInfo, s conversion.Scope) error {
-	out.Type = in.Type
-	out.KubeConfigFile = (*string)(unsafe.Pointer(in.KubeConfigFile))
+	*out = *(*apiserver.WebhookConnectionInfo)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -921,8 +872,7 @@ func Convert_v1beta1_WebhookConnectionInfo_To_apiserver_WebhookConnectionInfo(in
 }
 
 func autoConvert_apiserver_WebhookConnectionInfo_To_v1beta1_WebhookConnectionInfo(in *apiserver.WebhookConnectionInfo, out *WebhookConnectionInfo, s conversion.Scope) error {
-	out.Type = in.Type
-	out.KubeConfigFile = (*string)(unsafe.Pointer(in.KubeConfigFile))
+	*out = *(*WebhookConnectionInfo)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -932,7 +882,7 @@ func Convert_apiserver_WebhookConnectionInfo_To_v1beta1_WebhookConnectionInfo(in
 }
 
 func autoConvert_v1beta1_WebhookMatchCondition_To_apiserver_WebhookMatchCondition(in *WebhookMatchCondition, out *apiserver.WebhookMatchCondition, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*apiserver.WebhookMatchCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -942,7 +892,7 @@ func Convert_v1beta1_WebhookMatchCondition_To_apiserver_WebhookMatchCondition(in
 }
 
 func autoConvert_apiserver_WebhookMatchCondition_To_v1beta1_WebhookMatchCondition(in *apiserver.WebhookMatchCondition, out *WebhookMatchCondition, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*WebhookMatchCondition)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1/zz_generated.conversion.go
@@ -123,7 +123,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1_AuthenticationMetadata_To_audit_AuthenticationMetadata(in *AuthenticationMetadata, out *audit.AuthenticationMetadata, s conversion.Scope) error {
-	out.ImpersonationConstraint = in.ImpersonationConstraint
+	*out = *(*audit.AuthenticationMetadata)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -133,7 +133,7 @@ func Convert_v1_AuthenticationMetadata_To_audit_AuthenticationMetadata(in *Authe
 }
 
 func autoConvert_audit_AuthenticationMetadata_To_v1_AuthenticationMetadata(in *audit.AuthenticationMetadata, out *AuthenticationMetadata, s conversion.Scope) error {
-	out.ImpersonationConstraint = in.ImpersonationConstraint
+	*out = *(*AuthenticationMetadata)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -217,9 +217,7 @@ func Convert_audit_EventList_To_v1_EventList(in *audit.EventList, out *EventList
 }
 
 func autoConvert_v1_GroupResources_To_audit_GroupResources(in *GroupResources, out *audit.GroupResources, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
-	out.ResourceNames = *(*[]string)(unsafe.Pointer(&in.ResourceNames))
+	*out = *(*audit.GroupResources)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -229,9 +227,7 @@ func Convert_v1_GroupResources_To_audit_GroupResources(in *GroupResources, out *
 }
 
 func autoConvert_audit_GroupResources_To_v1_GroupResources(in *audit.GroupResources, out *GroupResources, s conversion.Scope) error {
-	out.Group = in.Group
-	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
-	out.ResourceNames = *(*[]string)(unsafe.Pointer(&in.ResourceNames))
+	*out = *(*GroupResources)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -241,14 +237,7 @@ func Convert_audit_GroupResources_To_v1_GroupResources(in *audit.GroupResources,
 }
 
 func autoConvert_v1_ObjectReference_To_audit_ObjectReference(in *ObjectReference, out *audit.ObjectReference, s conversion.Scope) error {
-	out.Resource = in.Resource
-	out.Namespace = in.Namespace
-	out.Name = in.Name
-	out.UID = types.UID(in.UID)
-	out.APIGroup = in.APIGroup
-	out.APIVersion = in.APIVersion
-	out.ResourceVersion = in.ResourceVersion
-	out.Subresource = in.Subresource
+	*out = *(*audit.ObjectReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -258,14 +247,7 @@ func Convert_v1_ObjectReference_To_audit_ObjectReference(in *ObjectReference, ou
 }
 
 func autoConvert_audit_ObjectReference_To_v1_ObjectReference(in *audit.ObjectReference, out *ObjectReference, s conversion.Scope) error {
-	out.Resource = in.Resource
-	out.Namespace = in.Namespace
-	out.Name = in.Name
-	out.UID = types.UID(in.UID)
-	out.APIGroup = in.APIGroup
-	out.APIVersion = in.APIVersion
-	out.ResourceVersion = in.ResourceVersion
-	out.Subresource = in.Subresource
+	*out = *(*ObjectReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -323,15 +305,7 @@ func Convert_audit_PolicyList_To_v1_PolicyList(in *audit.PolicyList, out *Policy
 }
 
 func autoConvert_v1_PolicyRule_To_audit_PolicyRule(in *PolicyRule, out *audit.PolicyRule, s conversion.Scope) error {
-	out.Level = audit.Level(in.Level)
-	out.Users = *(*[]string)(unsafe.Pointer(&in.Users))
-	out.UserGroups = *(*[]string)(unsafe.Pointer(&in.UserGroups))
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.Resources = *(*[]audit.GroupResources)(unsafe.Pointer(&in.Resources))
-	out.Namespaces = *(*[]string)(unsafe.Pointer(&in.Namespaces))
-	out.NonResourceURLs = *(*[]string)(unsafe.Pointer(&in.NonResourceURLs))
-	out.OmitStages = *(*[]audit.Stage)(unsafe.Pointer(&in.OmitStages))
-	out.OmitManagedFields = (*bool)(unsafe.Pointer(in.OmitManagedFields))
+	*out = *(*audit.PolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -341,15 +315,7 @@ func Convert_v1_PolicyRule_To_audit_PolicyRule(in *PolicyRule, out *audit.Policy
 }
 
 func autoConvert_audit_PolicyRule_To_v1_PolicyRule(in *audit.PolicyRule, out *PolicyRule, s conversion.Scope) error {
-	out.Level = Level(in.Level)
-	out.Users = *(*[]string)(unsafe.Pointer(&in.Users))
-	out.UserGroups = *(*[]string)(unsafe.Pointer(&in.UserGroups))
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	out.Resources = *(*[]GroupResources)(unsafe.Pointer(&in.Resources))
-	out.Namespaces = *(*[]string)(unsafe.Pointer(&in.Namespaces))
-	out.NonResourceURLs = *(*[]string)(unsafe.Pointer(&in.NonResourceURLs))
-	out.OmitStages = *(*[]Stage)(unsafe.Pointer(&in.OmitStages))
-	out.OmitManagedFields = (*bool)(unsafe.Pointer(in.OmitManagedFields))
+	*out = *(*PolicyRule)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/example/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/example/v1/zz_generated.conversion.go
@@ -24,7 +24,6 @@ package v1
 import (
 	unsafe "unsafe"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	example "k8s.io/apiserver/pkg/apis/example"
@@ -123,12 +122,7 @@ func Convert_example_Pod_To_v1_Pod(in *example.Pod, out *Pod, s conversion.Scope
 }
 
 func autoConvert_v1_PodCondition_To_example_PodCondition(in *PodCondition, out *example.PodCondition, s conversion.Scope) error {
-	out.Type = example.PodConditionType(in.Type)
-	out.Status = example.ConditionStatus(in.Status)
-	out.LastProbeTime = in.LastProbeTime
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*example.PodCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -138,12 +132,7 @@ func Convert_v1_PodCondition_To_example_PodCondition(in *PodCondition, out *exam
 }
 
 func autoConvert_example_PodCondition_To_v1_PodCondition(in *example.PodCondition, out *PodCondition, s conversion.Scope) error {
-	out.Type = PodConditionType(in.Type)
-	out.Status = ConditionStatus(in.Status)
-	out.LastProbeTime = in.LastProbeTime
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*PodCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -235,13 +224,7 @@ func Convert_example_PodSpec_To_v1_PodSpec(in *example.PodSpec, out *PodSpec, s 
 }
 
 func autoConvert_v1_PodStatus_To_example_PodStatus(in *PodStatus, out *example.PodStatus, s conversion.Scope) error {
-	out.Phase = example.PodPhase(in.Phase)
-	out.Conditions = *(*[]example.PodCondition)(unsafe.Pointer(&in.Conditions))
-	out.Message = in.Message
-	out.Reason = in.Reason
-	out.HostIP = in.HostIP
-	out.PodIP = in.PodIP
-	out.StartTime = (*metav1.Time)(unsafe.Pointer(in.StartTime))
+	*out = *(*example.PodStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -251,13 +234,7 @@ func Convert_v1_PodStatus_To_example_PodStatus(in *PodStatus, out *example.PodSt
 }
 
 func autoConvert_example_PodStatus_To_v1_PodStatus(in *example.PodStatus, out *PodStatus, s conversion.Scope) error {
-	out.Phase = PodPhase(in.Phase)
-	out.Conditions = *(*[]PodCondition)(unsafe.Pointer(&in.Conditions))
-	out.Message = in.Message
-	out.Reason = in.Reason
-	out.HostIP = in.HostIP
-	out.PodIP = in.PodIP
-	out.StartTime = (*metav1.Time)(unsafe.Pointer(in.StartTime))
+	*out = *(*PodStatus)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/example2/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/example2/v1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1
 
 import (
+	unsafe "unsafe"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -115,7 +117,7 @@ func autoConvert_example_ReplicaSetSpec_To_v1_ReplicaSetSpec(in *example.Replica
 }
 
 func autoConvert_v1_ReplicaSetStatus_To_example_ReplicaSetStatus(in *ReplicaSetStatus, out *example.ReplicaSetStatus, s conversion.Scope) error {
-	out.Replicas = in.Replicas
+	*out = *(*example.ReplicaSetStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -125,7 +127,7 @@ func Convert_v1_ReplicaSetStatus_To_example_ReplicaSetStatus(in *ReplicaSetStatu
 }
 
 func autoConvert_example_ReplicaSetStatus_To_v1_ReplicaSetStatus(in *example.ReplicaSetStatus, out *ReplicaSetStatus, s conversion.Scope) error {
-	out.Replicas = in.Replicas
+	*out = *(*ReplicaSetStatus)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1/zz_generated.conversion.go
@@ -24,7 +24,6 @@ package v1
 import (
 	unsafe "unsafe"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	clientauthentication "k8s.io/client-go/pkg/apis/clientauthentication"
@@ -181,10 +180,7 @@ func Convert_clientauthentication_ExecCredentialSpec_To_v1_ExecCredentialSpec(in
 }
 
 func autoConvert_v1_ExecCredentialStatus_To_clientauthentication_ExecCredentialStatus(in *ExecCredentialStatus, out *clientauthentication.ExecCredentialStatus, s conversion.Scope) error {
-	out.ExpirationTimestamp = (*metav1.Time)(unsafe.Pointer(in.ExpirationTimestamp))
-	out.Token = in.Token
-	out.ClientCertificateData = in.ClientCertificateData
-	out.ClientKeyData = in.ClientKeyData
+	*out = *(*clientauthentication.ExecCredentialStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -194,10 +190,7 @@ func Convert_v1_ExecCredentialStatus_To_clientauthentication_ExecCredentialStatu
 }
 
 func autoConvert_clientauthentication_ExecCredentialStatus_To_v1_ExecCredentialStatus(in *clientauthentication.ExecCredentialStatus, out *ExecCredentialStatus, s conversion.Scope) error {
-	out.ExpirationTimestamp = (*metav1.Time)(unsafe.Pointer(in.ExpirationTimestamp))
-	out.Token = in.Token
-	out.ClientCertificateData = in.ClientCertificateData
-	out.ClientKeyData = in.ClientKeyData
+	*out = *(*ExecCredentialStatus)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1beta1/zz_generated.conversion.go
@@ -24,7 +24,6 @@ package v1beta1
 import (
 	unsafe "unsafe"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	clientauthentication "k8s.io/client-go/pkg/apis/clientauthentication"
@@ -181,10 +180,7 @@ func Convert_clientauthentication_ExecCredentialSpec_To_v1beta1_ExecCredentialSp
 }
 
 func autoConvert_v1beta1_ExecCredentialStatus_To_clientauthentication_ExecCredentialStatus(in *ExecCredentialStatus, out *clientauthentication.ExecCredentialStatus, s conversion.Scope) error {
-	out.ExpirationTimestamp = (*v1.Time)(unsafe.Pointer(in.ExpirationTimestamp))
-	out.Token = in.Token
-	out.ClientCertificateData = in.ClientCertificateData
-	out.ClientKeyData = in.ClientKeyData
+	*out = *(*clientauthentication.ExecCredentialStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -194,10 +190,7 @@ func Convert_v1beta1_ExecCredentialStatus_To_clientauthentication_ExecCredential
 }
 
 func autoConvert_clientauthentication_ExecCredentialStatus_To_v1beta1_ExecCredentialStatus(in *clientauthentication.ExecCredentialStatus, out *ExecCredentialStatus, s conversion.Scope) error {
-	out.ExpirationTimestamp = (*v1.Time)(unsafe.Pointer(in.ExpirationTimestamp))
-	out.Token = in.Token
-	out.ClientCertificateData = in.ClientCertificateData
-	out.ClientKeyData = in.ClientKeyData
+	*out = *(*ExecCredentialStatus)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/client-go/scale/scheme/appsv1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/scale/scheme/appsv1beta1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package appsv1beta1
 
 import (
+	unsafe "unsafe"
+
 	v1beta1 "k8s.io/api/apps/v1beta1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -101,7 +103,7 @@ func Convert_scheme_Scale_To_v1beta1_Scale(in *scheme.Scale, out *v1beta1.Scale,
 }
 
 func autoConvert_v1beta1_ScaleSpec_To_scheme_ScaleSpec(in *v1beta1.ScaleSpec, out *scheme.ScaleSpec, s conversion.Scope) error {
-	out.Replicas = in.Replicas
+	*out = *(*scheme.ScaleSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -111,7 +113,7 @@ func Convert_v1beta1_ScaleSpec_To_scheme_ScaleSpec(in *v1beta1.ScaleSpec, out *s
 }
 
 func autoConvert_scheme_ScaleSpec_To_v1beta1_ScaleSpec(in *scheme.ScaleSpec, out *v1beta1.ScaleSpec, s conversion.Scope) error {
-	out.Replicas = in.Replicas
+	*out = *(*v1beta1.ScaleSpec)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/client-go/scale/scheme/appsv1beta2/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/scale/scheme/appsv1beta2/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package appsv1beta2
 
 import (
+	unsafe "unsafe"
+
 	v1beta2 "k8s.io/api/apps/v1beta2"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -101,7 +103,7 @@ func Convert_scheme_Scale_To_v1beta2_Scale(in *scheme.Scale, out *v1beta2.Scale,
 }
 
 func autoConvert_v1beta2_ScaleSpec_To_scheme_ScaleSpec(in *v1beta2.ScaleSpec, out *scheme.ScaleSpec, s conversion.Scope) error {
-	out.Replicas = in.Replicas
+	*out = *(*scheme.ScaleSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -111,7 +113,7 @@ func Convert_v1beta2_ScaleSpec_To_scheme_ScaleSpec(in *v1beta2.ScaleSpec, out *s
 }
 
 func autoConvert_scheme_ScaleSpec_To_v1beta2_ScaleSpec(in *scheme.ScaleSpec, out *v1beta2.ScaleSpec, s conversion.Scope) error {
-	out.Replicas = in.Replicas
+	*out = *(*v1beta2.ScaleSpec)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/client-go/scale/scheme/autoscalingv1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/scale/scheme/autoscalingv1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package autoscalingv1
 
 import (
+	unsafe "unsafe"
+
 	v1 "k8s.io/api/autoscaling/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -101,7 +103,7 @@ func Convert_scheme_Scale_To_v1_Scale(in *scheme.Scale, out *v1.Scale, s convers
 }
 
 func autoConvert_v1_ScaleSpec_To_scheme_ScaleSpec(in *v1.ScaleSpec, out *scheme.ScaleSpec, s conversion.Scope) error {
-	out.Replicas = in.Replicas
+	*out = *(*scheme.ScaleSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -111,7 +113,7 @@ func Convert_v1_ScaleSpec_To_scheme_ScaleSpec(in *v1.ScaleSpec, out *scheme.Scal
 }
 
 func autoConvert_scheme_ScaleSpec_To_v1_ScaleSpec(in *scheme.ScaleSpec, out *v1.ScaleSpec, s conversion.Scope) error {
-	out.Replicas = in.Replicas
+	*out = *(*v1.ScaleSpec)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/client-go/scale/scheme/extensionsv1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/scale/scheme/extensionsv1beta1/zz_generated.conversion.go
@@ -22,6 +22,8 @@ limitations under the License.
 package extensionsv1beta1
 
 import (
+	unsafe "unsafe"
+
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -101,7 +103,7 @@ func Convert_scheme_Scale_To_v1beta1_Scale(in *scheme.Scale, out *v1beta1.Scale,
 }
 
 func autoConvert_v1beta1_ScaleSpec_To_scheme_ScaleSpec(in *v1beta1.ScaleSpec, out *scheme.ScaleSpec, s conversion.Scope) error {
-	out.Replicas = in.Replicas
+	*out = *(*scheme.ScaleSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -111,7 +113,7 @@ func Convert_v1beta1_ScaleSpec_To_scheme_ScaleSpec(in *v1beta1.ScaleSpec, out *s
 }
 
 func autoConvert_scheme_ScaleSpec_To_v1beta1_ScaleSpec(in *scheme.ScaleSpec, out *v1beta1.ScaleSpec, s conversion.Scope) error {
-	out.Replicas = in.Replicas
+	*out = *(*v1beta1.ScaleSpec)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/zz_generated.conversion.go
@@ -229,8 +229,7 @@ func Convert_api_AuthInfo_To_v1_AuthInfo(in *api.AuthInfo, out *AuthInfo, s conv
 }
 
 func autoConvert_v1_AuthProviderConfig_To_api_AuthProviderConfig(in *AuthProviderConfig, out *api.AuthProviderConfig, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Config = *(*map[string]string)(unsafe.Pointer(&in.Config))
+	*out = *(*api.AuthProviderConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -240,8 +239,7 @@ func Convert_v1_AuthProviderConfig_To_api_AuthProviderConfig(in *AuthProviderCon
 }
 
 func autoConvert_api_AuthProviderConfig_To_v1_AuthProviderConfig(in *api.AuthProviderConfig, out *AuthProviderConfig, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Config = *(*map[string]string)(unsafe.Pointer(&in.Config))
+	*out = *(*AuthProviderConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -411,8 +409,7 @@ func Convert_api_ExecConfig_To_v1_ExecConfig(in *api.ExecConfig, out *ExecConfig
 }
 
 func autoConvert_v1_ExecEnvVar_To_api_ExecEnvVar(in *ExecEnvVar, out *api.ExecEnvVar, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Value = in.Value
+	*out = *(*api.ExecEnvVar)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -422,8 +419,7 @@ func Convert_v1_ExecEnvVar_To_api_ExecEnvVar(in *ExecEnvVar, out *api.ExecEnvVar
 }
 
 func autoConvert_api_ExecEnvVar_To_v1_ExecEnvVar(in *api.ExecEnvVar, out *ExecEnvVar, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Value = in.Value
+	*out = *(*ExecEnvVar)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/cloud-provider/config/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/cloud-provider/config/v1alpha1/zz_generated.conversion.go
@@ -191,7 +191,7 @@ func autoConvert_config_KubeCloudSharedConfiguration_To_v1alpha1_KubeCloudShared
 }
 
 func autoConvert_v1alpha1_WebhookConfiguration_To_config_WebhookConfiguration(in *WebhookConfiguration, out *config.WebhookConfiguration, s conversion.Scope) error {
-	out.Webhooks = *(*[]string)(unsafe.Pointer(&in.Webhooks))
+	*out = *(*config.WebhookConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -201,7 +201,7 @@ func Convert_v1alpha1_WebhookConfiguration_To_config_WebhookConfiguration(in *We
 }
 
 func autoConvert_config_WebhookConfiguration_To_v1alpha1_WebhookConfiguration(in *config.WebhookConfiguration, out *WebhookConfiguration, s conversion.Scope) error {
-	out.Webhooks = *(*[]string)(unsafe.Pointer(&in.Webhooks))
+	*out = *(*WebhookConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/conversion-gen/generators/conversion.go
+++ b/staging/src/k8s.io/code-generator/cmd/conversion-gen/generators/conversion.go
@@ -938,6 +938,16 @@ func (g *genConversion) doSlice(inType, outType *types.Type, sw *generator.Snipp
 }
 
 func (g *genConversion) doStruct(inType, outType *types.Type, sw *generator.SnippetWriter) {
+	ok, err := g.canUseMemoryCopyConversion(inType, outType)
+	if err != nil {
+		klog.Errorf("Type %v: error checking for direct-copy conversion: %v", inType, err)
+	}
+	if ok {
+		args := argsFromType(inType, outType).
+			With("Pointer", types.Ref("unsafe", "Pointer"))
+		sw.Do("*out = *(*$.outType|raw$)($.Pointer|raw$(in))\n", args)
+		return
+	}
 	for _, inMember := range inType.Members {
 		tagvals, err := extractTag(inMember.CommentLines)
 		if err != nil {
@@ -1112,6 +1122,44 @@ func (g *genConversion) doStruct(inType, outType *types.Type, sw *generator.Snip
 			}
 		}
 	}
+}
+
+// canUseMemoryCopyConversion reports whether two struct types can be converted
+// with a single unsafe memory copy rather than field-by-field conversion. This
+// returns true only for structs that are both memory-identical and do not have any
+// manual conversions (except copy-only conversions, which are allowed).
+func (g *genConversion) canUseMemoryCopyConversion(inType, outType *types.Type) (bool, error) {
+	if !g.useUnsafe.Equal(inType, outType) {
+		return false, nil
+	}
+	for _, inMember := range inType.Members {
+		tagvals, err := extractTag(inMember.CommentLines)
+		if err != nil {
+			return false, err
+		}
+		if len(tagvals) > 0 && tagvals[0] == "false" {
+			return false, nil // opted out of conversion-gen
+		}
+		outMember, found := findMember(outType, inMember.Name)
+		if !found {
+			return false, nil
+		}
+
+		if namer.IsPrivateGoName(inMember.Name) && g.outputPackage != inType.Name.Package {
+			return false, nil
+		}
+		if namer.IsPrivateGoName(outMember.Name) && g.outputPackage != outType.Name.Package {
+			return false, nil
+		}
+		// Bail out if there is a manual conversion other than 'copy-only'.
+		if function, ok := g.preexists(inMember.Type, outMember.Type); ok {
+			copyOnly, err := isCopyOnly(function.CommentLines)
+			if err != nil || !copyOnly {
+				return false, err
+			}
+		}
+	}
+	return true, nil
 }
 
 func (g *genConversion) isFastConversion(inType, outType *types.Type) bool {

--- a/staging/src/k8s.io/code-generator/cmd/conversion-gen/generators/conversion_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/conversion-gen/generators/conversion_test.go
@@ -1,0 +1,234 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generators
+
+import (
+	"testing"
+
+	"k8s.io/gengo/v2/types"
+)
+
+func builtin(name string) *types.Type {
+	return &types.Type{Name: types.Name{Name: name}, Kind: types.Builtin}
+}
+
+func structOf(pkg, name string, members ...types.Member) *types.Type {
+	return &types.Type{
+		Name:    types.Name{Package: pkg, Name: name},
+		Kind:    types.Struct,
+		Members: members,
+	}
+}
+
+func field(name string, t *types.Type, comments ...string) types.Member {
+	return types.Member{Name: name, Type: t, CommentLines: comments}
+}
+
+func conversionFn(comments ...string) *types.Type {
+	return &types.Type{Name: types.Name{Name: "ConversionFunc"}, CommentLines: comments}
+}
+
+func TestCanUseMemoryCopyConversion(t *testing.T) {
+	str := builtin("string")
+	i := builtin("int")
+	meta := structOf("meta", "TypeMeta", field("Kind", str))
+	metaExt := structOf("ext", "TypeMeta", field("Kind", str))
+	metaInt := structOf("int", "TypeMeta", field("Kind", str))
+	metaAlias := &types.Type{Name: types.Name{Package: "ext", Name: "MetaAlias"}, Kind: types.Alias, Underlying: metaExt}
+
+	level2Ext := structOf("ext", "Level2", field("Value", str))
+	level2Int := structOf("int", "Level2", field("Value", str))
+	level1Ext := structOf("ext", "Level1", field("Level2", level2Ext))
+	level1Int := structOf("int", "Level1", field("Level2", level2Int))
+	aSpecExt := structOf("ext", "ASpec", field("Level1", level1Ext))
+	aSpecInt := structOf("int", "ASpec", field("Level1", level1Int))
+	aExt := structOf("ext", "A", field("Spec", aSpecExt))
+	aInt := structOf("int", "A", field("Spec", aSpecInt))
+
+	tests := []struct {
+		name              string
+		outputPackage     string
+		manualConversions conversionFuncMap
+		in                *types.Type
+		out               *types.Type
+		want              bool
+		wantErr           string
+	}{
+		{
+			name: "identical",
+			in:   structOf("ext", "T", field("Name", str), field("Age", i)),
+			out:  structOf("int", "T", field("Name", str), field("Age", i)),
+			want: true,
+		},
+		{
+			name: "not identical",
+			in:   structOf("ext", "T", field("Name", str)),
+			out:  structOf("int", "T", field("Identifier", str)),
+			want: false,
+		},
+		{
+			name: "empty struct",
+			in:   structOf("ext", "T"),
+			out:  structOf("int", "T"),
+			want: true,
+		},
+		{
+			name: "member opted out of conversion generation",
+			in:   structOf("ext", "T", field("Name", str, "+k8s:conversion-gen=false")),
+			out:  structOf("int", "T", field("Name", str)),
+			want: false,
+		},
+		{
+			name: "member missing in peer",
+			in:   structOf("ext", "T", field("Name", str), field("Extra", i)),
+			out:  structOf("int", "T", field("Name", str)),
+			want: false,
+		},
+		{
+			name:          "unexported member, output package internal",
+			outputPackage: "int",
+			in:            structOf("ext", "T", field("secret", str)),
+			out:           structOf("int", "T", field("secret", str)),
+			want:          false,
+		},
+		{
+			name:          "unexported member, output package is external",
+			outputPackage: "ext",
+			in:            structOf("ext", "T", field("secret", str)),
+			out:           structOf("int", "T", field("secret", str)),
+			want:          false,
+		},
+		{
+			name:          "unexported member, but conversion happens inside package",
+			outputPackage: "p",
+			in:            structOf("p", "T", field("secret", str)),
+			out:           structOf("p", "T", field("secret", str)),
+			want:          true,
+		},
+		{
+			name:              "member has a dropping manual conversion",
+			manualConversions: conversionFuncMap{{meta, meta}: conversionFn("+k8s:conversion-fn=drop")},
+			in:                structOf("ext", "T", field("Meta", meta)),
+			out:               structOf("int", "T", field("Meta", meta)),
+			want:              false,
+		},
+		{
+			name:              "member has a manual conversion",
+			manualConversions: conversionFuncMap{{meta, meta}: conversionFn()},
+			in:                structOf("ext", "T", field("Meta", meta)),
+			out:               structOf("int", "T", field("Meta", meta)),
+			want:              false,
+		},
+		{
+			name:              "member has a copy-only manual conversion",
+			manualConversions: conversionFuncMap{{meta, meta}: conversionFn("+k8s:conversion-fn=copy-only")},
+			in:                structOf("ext", "T", field("Meta", meta)),
+			out:               structOf("int", "T", field("Meta", meta)),
+			want:              true,
+		},
+		{
+			name:              "identical types: drop is honored",
+			manualConversions: conversionFuncMap{{metaExt, metaInt}: conversionFn("+k8s:conversion-fn=drop")},
+			in:                structOf("ext", "T", field("Meta", metaExt)),
+			out:               structOf("int", "T", field("Meta", metaInt)),
+			want:              false,
+		},
+		{
+			name:              "identical types: copy-only",
+			manualConversions: conversionFuncMap{{metaExt, metaInt}: conversionFn("+k8s:conversion-fn=copy-only")},
+			in:                structOf("ext", "T", field("Meta", metaExt)),
+			out:               structOf("int", "T", field("Meta", metaInt)),
+			want:              true,
+		},
+		{
+			name:              "conversion on alias, not underlying type",
+			manualConversions: conversionFuncMap{{metaAlias, metaAlias}: conversionFn("+k8s:conversion-fn=drop")},
+			in:                structOf("ext", "T", field("Meta", metaAlias)),
+			out:               structOf("int", "T", field("Meta", metaAlias)),
+			want:              false,
+		},
+		{
+			name:    "tag parse error",
+			in:      structOf("ext", "T", field("Name", str, "+k8s:conversion-gen(a, b)=false")),
+			out:     structOf("int", "T", field("Name", str)),
+			wantErr: "multiple arguments must use 'name: value' syntax",
+		},
+		{
+			name: "equalMemoryTypes compare: identical",
+			in:   structOf("ext", "T", field("Name", str)),
+			out:  structOf("int", "T", field("Name", str)),
+			want: true,
+		},
+		{
+			name: "equalMemoryTypes compare: not identical",
+			in:   structOf("ext", "T", field("Name", str)),
+			out:  structOf("int", "T", field("Name", i)),
+			want: false,
+		},
+		{
+			name: "two members: not identical",
+			in:   structOf("ext", "T", field("OK", str), field("Bad", i, "+k8s:conversion-gen=false")),
+			out:  structOf("int", "T", field("OK", str), field("Bad", i)),
+			want: false,
+		},
+		{
+			name: "conversion-gen=true does not opt out",
+			in:   structOf("ext", "T", field("Name", str, "+k8s:conversion-gen=true")),
+			out:  structOf("int", "T", field("Name", str)),
+			want: true,
+		},
+		{
+			name:              "nested manual conversion blocks memory copy at every ancestor",
+			manualConversions: conversionFuncMap{{level2Ext, level2Int}: conversionFn()},
+			in:                aExt,
+			out:               aInt,
+			want:              false,
+		},
+		{
+			name:              "nested copy-only conversion does not block memory copy",
+			manualConversions: conversionFuncMap{{level2Ext, level2Int}: conversionFn("+k8s:conversion-fn=copy-only")},
+			in:                aExt,
+			out:               aInt,
+			want:              true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			useUnsafe := equalMemoryTypes{}
+			for pair, fn := range tt.manualConversions {
+				copyOnly, _ := isCopyOnly(fn.CommentLines)
+				if copyOnly {
+					continue
+				}
+				useUnsafe.Skip(pair.inType, pair.outType)
+			}
+			g := &genConversion{
+				outputPackage:     tt.outputPackage,
+				manualConversions: tt.manualConversions,
+				useUnsafe:         useUnsafe,
+			}
+			gotOK, err := g.canUseMemoryCopyConversion(tt.in, tt.out)
+			if err != nil && err.Error() != tt.wantErr {
+				t.Fatalf("canUseMemoryCopyConversion() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if gotOK != tt.want {
+				t.Errorf("canUseMemoryCopyConversion() = %v, want %v", gotOK, tt.want)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/code-generator/examples/apiserver/apis/core/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/apis/core/v1/zz_generated.conversion.go
@@ -118,7 +118,7 @@ func Convert_core_TestTypeList_To_v1_TestTypeList(in *core.TestTypeList, out *Te
 }
 
 func autoConvert_v1_TestTypeStatus_To_core_TestTypeStatus(in *TestTypeStatus, out *core.TestTypeStatus, s conversion.Scope) error {
-	out.Blah = in.Blah
+	*out = *(*core.TestTypeStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -128,7 +128,7 @@ func Convert_v1_TestTypeStatus_To_core_TestTypeStatus(in *TestTypeStatus, out *c
 }
 
 func autoConvert_core_TestTypeStatus_To_v1_TestTypeStatus(in *core.TestTypeStatus, out *TestTypeStatus, s conversion.Scope) error {
-	out.Blah = in.Blah
+	*out = *(*TestTypeStatus)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/apis/example/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/apis/example/v1/zz_generated.conversion.go
@@ -425,10 +425,7 @@ func Convert_example_MemoryDifferent_To_v1_MemoryDifferent(in *example.MemoryDif
 }
 
 func autoConvert_v1_MemoryIdentical_To_example_MemoryIdentical(in *MemoryIdentical, out *example.MemoryIdentical, s conversion.Scope) error {
-	out.Items = (*example.MemoryIdentical)(unsafe.Pointer(in.Items))
-	out.Properties = *(*map[string]example.MemoryIdentical)(unsafe.Pointer(&in.Properties))
-	out.AllOf = *(*[]example.MemoryIdentical)(unsafe.Pointer(&in.AllOf))
-	out.Bool = in.Bool
+	*out = *(*example.MemoryIdentical)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -438,10 +435,7 @@ func Convert_v1_MemoryIdentical_To_example_MemoryIdentical(in *MemoryIdentical, 
 }
 
 func autoConvert_example_MemoryIdentical_To_v1_MemoryIdentical(in *example.MemoryIdentical, out *MemoryIdentical, s conversion.Scope) error {
-	out.Items = (*MemoryIdentical)(unsafe.Pointer(in.Items))
-	out.Properties = *(*map[string]MemoryIdentical)(unsafe.Pointer(&in.Properties))
-	out.AllOf = *(*[]MemoryIdentical)(unsafe.Pointer(&in.AllOf))
-	out.Bool = in.Bool
+	*out = *(*MemoryIdentical)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -499,7 +493,7 @@ func Convert_example_TestTypeList_To_v1_TestTypeList(in *example.TestTypeList, o
 }
 
 func autoConvert_v1_TestTypeStatus_To_example_TestTypeStatus(in *TestTypeStatus, out *example.TestTypeStatus, s conversion.Scope) error {
-	out.Blah = in.Blah
+	*out = *(*example.TestTypeStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -509,7 +503,7 @@ func Convert_v1_TestTypeStatus_To_example_TestTypeStatus(in *TestTypeStatus, out
 }
 
 func autoConvert_example_TestTypeStatus_To_v1_TestTypeStatus(in *example.TestTypeStatus, out *TestTypeStatus, s conversion.Scope) error {
-	out.Blah = in.Blah
+	*out = *(*TestTypeStatus)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/apis/example2/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/apis/example2/v1/zz_generated.conversion.go
@@ -118,7 +118,7 @@ func Convert_example2_TestTypeList_To_v1_TestTypeList(in *example2.TestTypeList,
 }
 
 func autoConvert_v1_TestTypeStatus_To_example2_TestTypeStatus(in *TestTypeStatus, out *example2.TestTypeStatus, s conversion.Scope) error {
-	out.Blah = in.Blah
+	*out = *(*example2.TestTypeStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -128,7 +128,7 @@ func Convert_v1_TestTypeStatus_To_example2_TestTypeStatus(in *TestTypeStatus, ou
 }
 
 func autoConvert_example2_TestTypeStatus_To_v1_TestTypeStatus(in *example2.TestTypeStatus, out *TestTypeStatus, s conversion.Scope) error {
-	out.Blah = in.Blah
+	*out = *(*TestTypeStatus)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/apis/example3.io/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/apis/example3.io/v1/zz_generated.conversion.go
@@ -118,7 +118,7 @@ func Convert_example3io_TestTypeList_To_v1_TestTypeList(in *example3io.TestTypeL
 }
 
 func autoConvert_v1_TestTypeStatus_To_example3io_TestTypeStatus(in *TestTypeStatus, out *example3io.TestTypeStatus, s conversion.Scope) error {
-	out.Blah = in.Blah
+	*out = *(*example3io.TestTypeStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -128,7 +128,7 @@ func Convert_v1_TestTypeStatus_To_example3io_TestTypeStatus(in *TestTypeStatus, 
 }
 
 func autoConvert_example3io_TestTypeStatus_To_v1_TestTypeStatus(in *example3io.TestTypeStatus, out *TestTypeStatus, s conversion.Scope) error {
-	out.Blah = in.Blah
+	*out = *(*TestTypeStatus)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/controller-manager/config/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/controller-manager/config/v1alpha1/zz_generated.conversion.go
@@ -71,8 +71,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_ControllerLeaderConfiguration_To_config_ControllerLeaderConfiguration(in *ControllerLeaderConfiguration, out *config.ControllerLeaderConfiguration, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Component = in.Component
+	*out = *(*config.ControllerLeaderConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -82,8 +81,7 @@ func Convert_v1alpha1_ControllerLeaderConfiguration_To_config_ControllerLeaderCo
 }
 
 func autoConvert_config_ControllerLeaderConfiguration_To_v1alpha1_ControllerLeaderConfiguration(in *config.ControllerLeaderConfiguration, out *ControllerLeaderConfiguration, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Component = in.Component
+	*out = *(*ControllerLeaderConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/controller-manager/config/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/controller-manager/config/v1beta1/zz_generated.conversion.go
@@ -60,8 +60,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1beta1_ControllerLeaderConfiguration_To_config_ControllerLeaderConfiguration(in *ControllerLeaderConfiguration, out *config.ControllerLeaderConfiguration, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Component = in.Component
+	*out = *(*config.ControllerLeaderConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -71,8 +70,7 @@ func Convert_v1beta1_ControllerLeaderConfiguration_To_config_ControllerLeaderCon
 }
 
 func autoConvert_config_ControllerLeaderConfiguration_To_v1beta1_ControllerLeaderConfiguration(in *config.ControllerLeaderConfiguration, out *ControllerLeaderConfiguration, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Component = in.Component
+	*out = *(*ControllerLeaderConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/dynamic-resource-allocation/api/metadata/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/api/metadata/v1alpha1/zz_generated.conversion.go
@@ -24,7 +24,6 @@ package v1alpha1
 import (
 	unsafe "unsafe"
 
-	v1 "k8s.io/api/resource/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	metadata "k8s.io/dynamic-resource-allocation/api/metadata"
@@ -71,11 +70,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_Device_To_metadata_Device(in *Device, out *metadata.Device, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.Pool = in.Pool
-	out.Name = in.Name
-	out.Attributes = *(*map[v1.QualifiedName]v1.DeviceAttribute)(unsafe.Pointer(&in.Attributes))
-	out.NetworkData = (*v1.NetworkDeviceData)(unsafe.Pointer(in.NetworkData))
+	*out = *(*metadata.Device)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -85,11 +80,7 @@ func Convert_v1alpha1_Device_To_metadata_Device(in *Device, out *metadata.Device
 }
 
 func autoConvert_metadata_Device_To_v1alpha1_Device(in *metadata.Device, out *Device, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.Pool = in.Pool
-	out.Name = in.Name
-	out.Attributes = *(*map[v1.QualifiedName]v1.DeviceAttribute)(unsafe.Pointer(&in.Attributes))
-	out.NetworkData = (*v1.NetworkDeviceData)(unsafe.Pointer(in.NetworkData))
+	*out = *(*Device)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -123,8 +114,7 @@ func Convert_metadata_DeviceMetadata_To_v1alpha1_DeviceMetadata(in *metadata.Dev
 }
 
 func autoConvert_v1alpha1_DeviceMetadataRequest_To_metadata_DeviceMetadataRequest(in *DeviceMetadataRequest, out *metadata.DeviceMetadataRequest, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Devices = *(*[]metadata.Device)(unsafe.Pointer(&in.Devices))
+	*out = *(*metadata.DeviceMetadataRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -134,8 +124,7 @@ func Convert_v1alpha1_DeviceMetadataRequest_To_metadata_DeviceMetadataRequest(in
 }
 
 func autoConvert_metadata_DeviceMetadataRequest_To_v1alpha1_DeviceMetadataRequest(in *metadata.DeviceMetadataRequest, out *DeviceMetadataRequest, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Devices = *(*[]Device)(unsafe.Pointer(&in.Devices))
+	*out = *(*DeviceMetadataRequest)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/dynamic-resource-allocation/api/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/api/v1beta1/zz_generated.conversion.go
@@ -27,11 +27,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/resource/v1"
 	resourcev1beta1 "k8s.io/api/resource/v1beta1"
-	resource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	types "k8s.io/apimachinery/pkg/types"
 )
 
 func init() {
@@ -475,13 +473,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1_AllocatedDeviceStatus_To_v1beta1_AllocatedDeviceStatus(in *v1.AllocatedDeviceStatus, out *resourcev1beta1.AllocatedDeviceStatus, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.Pool = in.Pool
-	out.Device = in.Device
-	out.ShareID = (*string)(unsafe.Pointer(in.ShareID))
-	out.Conditions = *(*[]metav1.Condition)(unsafe.Pointer(&in.Conditions))
-	out.Data = (*runtime.RawExtension)(unsafe.Pointer(in.Data))
-	out.NetworkData = (*resourcev1beta1.NetworkDeviceData)(unsafe.Pointer(in.NetworkData))
+	*out = *(*resourcev1beta1.AllocatedDeviceStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -491,13 +483,7 @@ func Convert_v1_AllocatedDeviceStatus_To_v1beta1_AllocatedDeviceStatus(in *v1.Al
 }
 
 func autoConvert_v1beta1_AllocatedDeviceStatus_To_v1_AllocatedDeviceStatus(in *resourcev1beta1.AllocatedDeviceStatus, out *v1.AllocatedDeviceStatus, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.Pool = in.Pool
-	out.Device = in.Device
-	out.ShareID = (*string)(unsafe.Pointer(in.ShareID))
-	out.Conditions = *(*[]metav1.Condition)(unsafe.Pointer(&in.Conditions))
-	out.Data = (*runtime.RawExtension)(unsafe.Pointer(in.Data))
-	out.NetworkData = (*v1.NetworkDeviceData)(unsafe.Pointer(in.NetworkData))
+	*out = *(*v1.AllocatedDeviceStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -507,11 +493,7 @@ func Convert_v1beta1_AllocatedDeviceStatus_To_v1_AllocatedDeviceStatus(in *resou
 }
 
 func autoConvert_v1_AllocationResult_To_v1beta1_AllocationResult(in *v1.AllocationResult, out *resourcev1beta1.AllocationResult, s conversion.Scope) error {
-	if err := Convert_v1_DeviceAllocationResult_To_v1beta1_DeviceAllocationResult(&in.Devices, &out.Devices, s); err != nil {
-		return err
-	}
-	out.NodeSelector = (*corev1.NodeSelector)(unsafe.Pointer(in.NodeSelector))
-	out.AllocationTimestamp = (*metav1.Time)(unsafe.Pointer(in.AllocationTimestamp))
+	*out = *(*resourcev1beta1.AllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -521,11 +503,7 @@ func Convert_v1_AllocationResult_To_v1beta1_AllocationResult(in *v1.AllocationRe
 }
 
 func autoConvert_v1beta1_AllocationResult_To_v1_AllocationResult(in *resourcev1beta1.AllocationResult, out *v1.AllocationResult, s conversion.Scope) error {
-	if err := Convert_v1beta1_DeviceAllocationResult_To_v1_DeviceAllocationResult(&in.Devices, &out.Devices, s); err != nil {
-		return err
-	}
-	out.NodeSelector = (*corev1.NodeSelector)(unsafe.Pointer(in.NodeSelector))
-	out.AllocationTimestamp = (*metav1.Time)(unsafe.Pointer(in.AllocationTimestamp))
+	*out = *(*v1.AllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -535,7 +513,7 @@ func Convert_v1beta1_AllocationResult_To_v1_AllocationResult(in *resourcev1beta1
 }
 
 func autoConvert_v1_CELDeviceSelector_To_v1beta1_CELDeviceSelector(in *v1.CELDeviceSelector, out *resourcev1beta1.CELDeviceSelector, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*resourcev1beta1.CELDeviceSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -545,7 +523,7 @@ func Convert_v1_CELDeviceSelector_To_v1beta1_CELDeviceSelector(in *v1.CELDeviceS
 }
 
 func autoConvert_v1beta1_CELDeviceSelector_To_v1_CELDeviceSelector(in *resourcev1beta1.CELDeviceSelector, out *v1.CELDeviceSelector, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*v1.CELDeviceSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -555,9 +533,7 @@ func Convert_v1beta1_CELDeviceSelector_To_v1_CELDeviceSelector(in *resourcev1bet
 }
 
 func autoConvert_v1_CapacityRequestPolicy_To_v1beta1_CapacityRequestPolicy(in *v1.CapacityRequestPolicy, out *resourcev1beta1.CapacityRequestPolicy, s conversion.Scope) error {
-	out.Default = (*resource.Quantity)(unsafe.Pointer(in.Default))
-	out.ValidValues = *(*[]resource.Quantity)(unsafe.Pointer(&in.ValidValues))
-	out.ValidRange = (*resourcev1beta1.CapacityRequestPolicyRange)(unsafe.Pointer(in.ValidRange))
+	*out = *(*resourcev1beta1.CapacityRequestPolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -567,9 +543,7 @@ func Convert_v1_CapacityRequestPolicy_To_v1beta1_CapacityRequestPolicy(in *v1.Ca
 }
 
 func autoConvert_v1beta1_CapacityRequestPolicy_To_v1_CapacityRequestPolicy(in *resourcev1beta1.CapacityRequestPolicy, out *v1.CapacityRequestPolicy, s conversion.Scope) error {
-	out.Default = (*resource.Quantity)(unsafe.Pointer(in.Default))
-	out.ValidValues = *(*[]resource.Quantity)(unsafe.Pointer(&in.ValidValues))
-	out.ValidRange = (*v1.CapacityRequestPolicyRange)(unsafe.Pointer(in.ValidRange))
+	*out = *(*v1.CapacityRequestPolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -579,9 +553,7 @@ func Convert_v1beta1_CapacityRequestPolicy_To_v1_CapacityRequestPolicy(in *resou
 }
 
 func autoConvert_v1_CapacityRequestPolicyRange_To_v1beta1_CapacityRequestPolicyRange(in *v1.CapacityRequestPolicyRange, out *resourcev1beta1.CapacityRequestPolicyRange, s conversion.Scope) error {
-	out.Min = (*resource.Quantity)(unsafe.Pointer(in.Min))
-	out.Max = (*resource.Quantity)(unsafe.Pointer(in.Max))
-	out.Step = (*resource.Quantity)(unsafe.Pointer(in.Step))
+	*out = *(*resourcev1beta1.CapacityRequestPolicyRange)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -591,9 +563,7 @@ func Convert_v1_CapacityRequestPolicyRange_To_v1beta1_CapacityRequestPolicyRange
 }
 
 func autoConvert_v1beta1_CapacityRequestPolicyRange_To_v1_CapacityRequestPolicyRange(in *resourcev1beta1.CapacityRequestPolicyRange, out *v1.CapacityRequestPolicyRange, s conversion.Scope) error {
-	out.Min = (*resource.Quantity)(unsafe.Pointer(in.Min))
-	out.Max = (*resource.Quantity)(unsafe.Pointer(in.Max))
-	out.Step = (*resource.Quantity)(unsafe.Pointer(in.Step))
+	*out = *(*v1.CapacityRequestPolicyRange)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -603,7 +573,7 @@ func Convert_v1beta1_CapacityRequestPolicyRange_To_v1_CapacityRequestPolicyRange
 }
 
 func autoConvert_v1_CapacityRequirements_To_v1beta1_CapacityRequirements(in *v1.CapacityRequirements, out *resourcev1beta1.CapacityRequirements, s conversion.Scope) error {
-	out.Requests = *(*map[resourcev1beta1.QualifiedName]resource.Quantity)(unsafe.Pointer(&in.Requests))
+	*out = *(*resourcev1beta1.CapacityRequirements)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -613,7 +583,7 @@ func Convert_v1_CapacityRequirements_To_v1beta1_CapacityRequirements(in *v1.Capa
 }
 
 func autoConvert_v1beta1_CapacityRequirements_To_v1_CapacityRequirements(in *resourcev1beta1.CapacityRequirements, out *v1.CapacityRequirements, s conversion.Scope) error {
-	out.Requests = *(*map[v1.QualifiedName]resource.Quantity)(unsafe.Pointer(&in.Requests))
+	*out = *(*v1.CapacityRequirements)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -623,7 +593,7 @@ func Convert_v1beta1_CapacityRequirements_To_v1_CapacityRequirements(in *resourc
 }
 
 func autoConvert_v1_Counter_To_v1beta1_Counter(in *v1.Counter, out *resourcev1beta1.Counter, s conversion.Scope) error {
-	out.Value = in.Value
+	*out = *(*resourcev1beta1.Counter)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -633,7 +603,7 @@ func Convert_v1_Counter_To_v1beta1_Counter(in *v1.Counter, out *resourcev1beta1.
 }
 
 func autoConvert_v1beta1_Counter_To_v1_Counter(in *resourcev1beta1.Counter, out *v1.Counter, s conversion.Scope) error {
-	out.Value = in.Value
+	*out = *(*v1.Counter)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -643,8 +613,7 @@ func Convert_v1beta1_Counter_To_v1_Counter(in *resourcev1beta1.Counter, out *v1.
 }
 
 func autoConvert_v1_CounterSet_To_v1beta1_CounterSet(in *v1.CounterSet, out *resourcev1beta1.CounterSet, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Counters = *(*map[string]resourcev1beta1.Counter)(unsafe.Pointer(&in.Counters))
+	*out = *(*resourcev1beta1.CounterSet)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -654,8 +623,7 @@ func Convert_v1_CounterSet_To_v1beta1_CounterSet(in *v1.CounterSet, out *resourc
 }
 
 func autoConvert_v1beta1_CounterSet_To_v1_CounterSet(in *resourcev1beta1.CounterSet, out *v1.CounterSet, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Counters = *(*map[string]v1.Counter)(unsafe.Pointer(&in.Counters))
+	*out = *(*v1.CounterSet)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -688,11 +656,7 @@ func autoConvert_v1beta1_Device_To_v1_Device(in *resourcev1beta1.Device, out *v1
 }
 
 func autoConvert_v1_DeviceAllocationConfiguration_To_v1beta1_DeviceAllocationConfiguration(in *v1.DeviceAllocationConfiguration, out *resourcev1beta1.DeviceAllocationConfiguration, s conversion.Scope) error {
-	out.Source = resourcev1beta1.AllocationConfigSource(in.Source)
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	if err := Convert_v1_DeviceConfiguration_To_v1beta1_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*resourcev1beta1.DeviceAllocationConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -702,11 +666,7 @@ func Convert_v1_DeviceAllocationConfiguration_To_v1beta1_DeviceAllocationConfigu
 }
 
 func autoConvert_v1beta1_DeviceAllocationConfiguration_To_v1_DeviceAllocationConfiguration(in *resourcev1beta1.DeviceAllocationConfiguration, out *v1.DeviceAllocationConfiguration, s conversion.Scope) error {
-	out.Source = v1.AllocationConfigSource(in.Source)
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	if err := Convert_v1beta1_DeviceConfiguration_To_v1_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*v1.DeviceAllocationConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -716,8 +676,7 @@ func Convert_v1beta1_DeviceAllocationConfiguration_To_v1_DeviceAllocationConfigu
 }
 
 func autoConvert_v1_DeviceAllocationResult_To_v1beta1_DeviceAllocationResult(in *v1.DeviceAllocationResult, out *resourcev1beta1.DeviceAllocationResult, s conversion.Scope) error {
-	out.Results = *(*[]resourcev1beta1.DeviceRequestAllocationResult)(unsafe.Pointer(&in.Results))
-	out.Config = *(*[]resourcev1beta1.DeviceAllocationConfiguration)(unsafe.Pointer(&in.Config))
+	*out = *(*resourcev1beta1.DeviceAllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -727,8 +686,7 @@ func Convert_v1_DeviceAllocationResult_To_v1beta1_DeviceAllocationResult(in *v1.
 }
 
 func autoConvert_v1beta1_DeviceAllocationResult_To_v1_DeviceAllocationResult(in *resourcev1beta1.DeviceAllocationResult, out *v1.DeviceAllocationResult, s conversion.Scope) error {
-	out.Results = *(*[]v1.DeviceRequestAllocationResult)(unsafe.Pointer(&in.Results))
-	out.Config = *(*[]v1.DeviceAllocationConfiguration)(unsafe.Pointer(&in.Config))
+	*out = *(*v1.DeviceAllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -738,14 +696,7 @@ func Convert_v1beta1_DeviceAllocationResult_To_v1_DeviceAllocationResult(in *res
 }
 
 func autoConvert_v1_DeviceAttribute_To_v1beta1_DeviceAttribute(in *v1.DeviceAttribute, out *resourcev1beta1.DeviceAttribute, s conversion.Scope) error {
-	out.IntValue = (*int64)(unsafe.Pointer(in.IntValue))
-	out.BoolValue = (*bool)(unsafe.Pointer(in.BoolValue))
-	out.StringValue = (*string)(unsafe.Pointer(in.StringValue))
-	out.VersionValue = (*string)(unsafe.Pointer(in.VersionValue))
-	out.IntValues = *(*[]int64)(unsafe.Pointer(&in.IntValues))
-	out.BoolValues = *(*[]bool)(unsafe.Pointer(&in.BoolValues))
-	out.StringValues = *(*[]string)(unsafe.Pointer(&in.StringValues))
-	out.VersionValues = *(*[]string)(unsafe.Pointer(&in.VersionValues))
+	*out = *(*resourcev1beta1.DeviceAttribute)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -755,14 +706,7 @@ func Convert_v1_DeviceAttribute_To_v1beta1_DeviceAttribute(in *v1.DeviceAttribut
 }
 
 func autoConvert_v1beta1_DeviceAttribute_To_v1_DeviceAttribute(in *resourcev1beta1.DeviceAttribute, out *v1.DeviceAttribute, s conversion.Scope) error {
-	out.IntValue = (*int64)(unsafe.Pointer(in.IntValue))
-	out.BoolValue = (*bool)(unsafe.Pointer(in.BoolValue))
-	out.StringValue = (*string)(unsafe.Pointer(in.StringValue))
-	out.VersionValue = (*string)(unsafe.Pointer(in.VersionValue))
-	out.IntValues = *(*[]int64)(unsafe.Pointer(&in.IntValues))
-	out.BoolValues = *(*[]bool)(unsafe.Pointer(&in.BoolValues))
-	out.StringValues = *(*[]string)(unsafe.Pointer(&in.StringValues))
-	out.VersionValues = *(*[]string)(unsafe.Pointer(&in.VersionValues))
+	*out = *(*v1.DeviceAttribute)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -772,8 +716,7 @@ func Convert_v1beta1_DeviceAttribute_To_v1_DeviceAttribute(in *resourcev1beta1.D
 }
 
 func autoConvert_v1_DeviceCapacity_To_v1beta1_DeviceCapacity(in *v1.DeviceCapacity, out *resourcev1beta1.DeviceCapacity, s conversion.Scope) error {
-	out.Value = in.Value
-	out.RequestPolicy = (*resourcev1beta1.CapacityRequestPolicy)(unsafe.Pointer(in.RequestPolicy))
+	*out = *(*resourcev1beta1.DeviceCapacity)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -783,8 +726,7 @@ func Convert_v1_DeviceCapacity_To_v1beta1_DeviceCapacity(in *v1.DeviceCapacity, 
 }
 
 func autoConvert_v1beta1_DeviceCapacity_To_v1_DeviceCapacity(in *resourcev1beta1.DeviceCapacity, out *v1.DeviceCapacity, s conversion.Scope) error {
-	out.Value = in.Value
-	out.RequestPolicy = (*v1.CapacityRequestPolicy)(unsafe.Pointer(in.RequestPolicy))
+	*out = *(*v1.DeviceCapacity)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -838,10 +780,7 @@ func Convert_v1beta1_DeviceClaim_To_v1_DeviceClaim(in *resourcev1beta1.DeviceCla
 }
 
 func autoConvert_v1_DeviceClaimConfiguration_To_v1beta1_DeviceClaimConfiguration(in *v1.DeviceClaimConfiguration, out *resourcev1beta1.DeviceClaimConfiguration, s conversion.Scope) error {
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	if err := Convert_v1_DeviceConfiguration_To_v1beta1_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*resourcev1beta1.DeviceClaimConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -851,10 +790,7 @@ func Convert_v1_DeviceClaimConfiguration_To_v1beta1_DeviceClaimConfiguration(in 
 }
 
 func autoConvert_v1beta1_DeviceClaimConfiguration_To_v1_DeviceClaimConfiguration(in *resourcev1beta1.DeviceClaimConfiguration, out *v1.DeviceClaimConfiguration, s conversion.Scope) error {
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	if err := Convert_v1beta1_DeviceConfiguration_To_v1_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*v1.DeviceClaimConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -890,9 +826,7 @@ func Convert_v1beta1_DeviceClass_To_v1_DeviceClass(in *resourcev1beta1.DeviceCla
 }
 
 func autoConvert_v1_DeviceClassConfiguration_To_v1beta1_DeviceClassConfiguration(in *v1.DeviceClassConfiguration, out *resourcev1beta1.DeviceClassConfiguration, s conversion.Scope) error {
-	if err := Convert_v1_DeviceConfiguration_To_v1beta1_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*resourcev1beta1.DeviceClassConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -902,9 +836,7 @@ func Convert_v1_DeviceClassConfiguration_To_v1beta1_DeviceClassConfiguration(in 
 }
 
 func autoConvert_v1beta1_DeviceClassConfiguration_To_v1_DeviceClassConfiguration(in *resourcev1beta1.DeviceClassConfiguration, out *v1.DeviceClassConfiguration, s conversion.Scope) error {
-	if err := Convert_v1beta1_DeviceConfiguration_To_v1_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*v1.DeviceClassConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -936,9 +868,7 @@ func Convert_v1beta1_DeviceClassList_To_v1_DeviceClassList(in *resourcev1beta1.D
 }
 
 func autoConvert_v1_DeviceClassSpec_To_v1beta1_DeviceClassSpec(in *v1.DeviceClassSpec, out *resourcev1beta1.DeviceClassSpec, s conversion.Scope) error {
-	out.Selectors = *(*[]resourcev1beta1.DeviceSelector)(unsafe.Pointer(&in.Selectors))
-	out.Config = *(*[]resourcev1beta1.DeviceClassConfiguration)(unsafe.Pointer(&in.Config))
-	out.ExtendedResourceName = (*string)(unsafe.Pointer(in.ExtendedResourceName))
+	*out = *(*resourcev1beta1.DeviceClassSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -948,9 +878,7 @@ func Convert_v1_DeviceClassSpec_To_v1beta1_DeviceClassSpec(in *v1.DeviceClassSpe
 }
 
 func autoConvert_v1beta1_DeviceClassSpec_To_v1_DeviceClassSpec(in *resourcev1beta1.DeviceClassSpec, out *v1.DeviceClassSpec, s conversion.Scope) error {
-	out.Selectors = *(*[]v1.DeviceSelector)(unsafe.Pointer(&in.Selectors))
-	out.Config = *(*[]v1.DeviceClassConfiguration)(unsafe.Pointer(&in.Config))
-	out.ExtendedResourceName = (*string)(unsafe.Pointer(in.ExtendedResourceName))
+	*out = *(*v1.DeviceClassSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -960,7 +888,7 @@ func Convert_v1beta1_DeviceClassSpec_To_v1_DeviceClassSpec(in *resourcev1beta1.D
 }
 
 func autoConvert_v1_DeviceConfiguration_To_v1beta1_DeviceConfiguration(in *v1.DeviceConfiguration, out *resourcev1beta1.DeviceConfiguration, s conversion.Scope) error {
-	out.Opaque = (*resourcev1beta1.OpaqueDeviceConfiguration)(unsafe.Pointer(in.Opaque))
+	*out = *(*resourcev1beta1.DeviceConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -970,7 +898,7 @@ func Convert_v1_DeviceConfiguration_To_v1beta1_DeviceConfiguration(in *v1.Device
 }
 
 func autoConvert_v1beta1_DeviceConfiguration_To_v1_DeviceConfiguration(in *resourcev1beta1.DeviceConfiguration, out *v1.DeviceConfiguration, s conversion.Scope) error {
-	out.Opaque = (*v1.OpaqueDeviceConfiguration)(unsafe.Pointer(in.Opaque))
+	*out = *(*v1.DeviceConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -980,9 +908,7 @@ func Convert_v1beta1_DeviceConfiguration_To_v1_DeviceConfiguration(in *resourcev
 }
 
 func autoConvert_v1_DeviceConstraint_To_v1beta1_DeviceConstraint(in *v1.DeviceConstraint, out *resourcev1beta1.DeviceConstraint, s conversion.Scope) error {
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	out.MatchAttribute = (*resourcev1beta1.FullyQualifiedName)(unsafe.Pointer(in.MatchAttribute))
-	out.DistinctAttribute = (*resourcev1beta1.FullyQualifiedName)(unsafe.Pointer(in.DistinctAttribute))
+	*out = *(*resourcev1beta1.DeviceConstraint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -992,9 +918,7 @@ func Convert_v1_DeviceConstraint_To_v1beta1_DeviceConstraint(in *v1.DeviceConstr
 }
 
 func autoConvert_v1beta1_DeviceConstraint_To_v1_DeviceConstraint(in *resourcev1beta1.DeviceConstraint, out *v1.DeviceConstraint, s conversion.Scope) error {
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	out.MatchAttribute = (*v1.FullyQualifiedName)(unsafe.Pointer(in.MatchAttribute))
-	out.DistinctAttribute = (*v1.FullyQualifiedName)(unsafe.Pointer(in.DistinctAttribute))
+	*out = *(*v1.DeviceConstraint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1004,8 +928,7 @@ func Convert_v1beta1_DeviceConstraint_To_v1_DeviceConstraint(in *resourcev1beta1
 }
 
 func autoConvert_v1_DeviceCounterConsumption_To_v1beta1_DeviceCounterConsumption(in *v1.DeviceCounterConsumption, out *resourcev1beta1.DeviceCounterConsumption, s conversion.Scope) error {
-	out.CounterSet = in.CounterSet
-	out.Counters = *(*map[string]resourcev1beta1.Counter)(unsafe.Pointer(&in.Counters))
+	*out = *(*resourcev1beta1.DeviceCounterConsumption)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1015,8 +938,7 @@ func Convert_v1_DeviceCounterConsumption_To_v1beta1_DeviceCounterConsumption(in 
 }
 
 func autoConvert_v1beta1_DeviceCounterConsumption_To_v1_DeviceCounterConsumption(in *resourcev1beta1.DeviceCounterConsumption, out *v1.DeviceCounterConsumption, s conversion.Scope) error {
-	out.CounterSet = in.CounterSet
-	out.Counters = *(*map[string]v1.Counter)(unsafe.Pointer(&in.Counters))
+	*out = *(*v1.DeviceCounterConsumption)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1046,16 +968,7 @@ func autoConvert_v1beta1_DeviceRequest_To_v1_DeviceRequest(in *resourcev1beta1.D
 }
 
 func autoConvert_v1_DeviceRequestAllocationResult_To_v1beta1_DeviceRequestAllocationResult(in *v1.DeviceRequestAllocationResult, out *resourcev1beta1.DeviceRequestAllocationResult, s conversion.Scope) error {
-	out.Request = in.Request
-	out.Driver = in.Driver
-	out.Pool = in.Pool
-	out.Device = in.Device
-	out.AdminAccess = (*bool)(unsafe.Pointer(in.AdminAccess))
-	out.Tolerations = *(*[]resourcev1beta1.DeviceToleration)(unsafe.Pointer(&in.Tolerations))
-	out.BindingConditions = *(*[]string)(unsafe.Pointer(&in.BindingConditions))
-	out.BindingFailureConditions = *(*[]string)(unsafe.Pointer(&in.BindingFailureConditions))
-	out.ShareID = (*types.UID)(unsafe.Pointer(in.ShareID))
-	out.ConsumedCapacity = *(*map[resourcev1beta1.QualifiedName]resource.Quantity)(unsafe.Pointer(&in.ConsumedCapacity))
+	*out = *(*resourcev1beta1.DeviceRequestAllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1065,16 +978,7 @@ func Convert_v1_DeviceRequestAllocationResult_To_v1beta1_DeviceRequestAllocation
 }
 
 func autoConvert_v1beta1_DeviceRequestAllocationResult_To_v1_DeviceRequestAllocationResult(in *resourcev1beta1.DeviceRequestAllocationResult, out *v1.DeviceRequestAllocationResult, s conversion.Scope) error {
-	out.Request = in.Request
-	out.Driver = in.Driver
-	out.Pool = in.Pool
-	out.Device = in.Device
-	out.AdminAccess = (*bool)(unsafe.Pointer(in.AdminAccess))
-	out.Tolerations = *(*[]v1.DeviceToleration)(unsafe.Pointer(&in.Tolerations))
-	out.BindingConditions = *(*[]string)(unsafe.Pointer(&in.BindingConditions))
-	out.BindingFailureConditions = *(*[]string)(unsafe.Pointer(&in.BindingFailureConditions))
-	out.ShareID = (*types.UID)(unsafe.Pointer(in.ShareID))
-	out.ConsumedCapacity = *(*map[v1.QualifiedName]resource.Quantity)(unsafe.Pointer(&in.ConsumedCapacity))
+	*out = *(*v1.DeviceRequestAllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1084,7 +988,7 @@ func Convert_v1beta1_DeviceRequestAllocationResult_To_v1_DeviceRequestAllocation
 }
 
 func autoConvert_v1_DeviceSelector_To_v1beta1_DeviceSelector(in *v1.DeviceSelector, out *resourcev1beta1.DeviceSelector, s conversion.Scope) error {
-	out.CEL = (*resourcev1beta1.CELDeviceSelector)(unsafe.Pointer(in.CEL))
+	*out = *(*resourcev1beta1.DeviceSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1094,7 +998,7 @@ func Convert_v1_DeviceSelector_To_v1beta1_DeviceSelector(in *v1.DeviceSelector, 
 }
 
 func autoConvert_v1beta1_DeviceSelector_To_v1_DeviceSelector(in *resourcev1beta1.DeviceSelector, out *v1.DeviceSelector, s conversion.Scope) error {
-	out.CEL = (*v1.CELDeviceSelector)(unsafe.Pointer(in.CEL))
+	*out = *(*v1.DeviceSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1104,13 +1008,7 @@ func Convert_v1beta1_DeviceSelector_To_v1_DeviceSelector(in *resourcev1beta1.Dev
 }
 
 func autoConvert_v1_DeviceSubRequest_To_v1beta1_DeviceSubRequest(in *v1.DeviceSubRequest, out *resourcev1beta1.DeviceSubRequest, s conversion.Scope) error {
-	out.Name = in.Name
-	out.DeviceClassName = in.DeviceClassName
-	out.Selectors = *(*[]resourcev1beta1.DeviceSelector)(unsafe.Pointer(&in.Selectors))
-	out.AllocationMode = resourcev1beta1.DeviceAllocationMode(in.AllocationMode)
-	out.Count = in.Count
-	out.Tolerations = *(*[]resourcev1beta1.DeviceToleration)(unsafe.Pointer(&in.Tolerations))
-	out.Capacity = (*resourcev1beta1.CapacityRequirements)(unsafe.Pointer(in.Capacity))
+	*out = *(*resourcev1beta1.DeviceSubRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1120,13 +1018,7 @@ func Convert_v1_DeviceSubRequest_To_v1beta1_DeviceSubRequest(in *v1.DeviceSubReq
 }
 
 func autoConvert_v1beta1_DeviceSubRequest_To_v1_DeviceSubRequest(in *resourcev1beta1.DeviceSubRequest, out *v1.DeviceSubRequest, s conversion.Scope) error {
-	out.Name = in.Name
-	out.DeviceClassName = in.DeviceClassName
-	out.Selectors = *(*[]v1.DeviceSelector)(unsafe.Pointer(&in.Selectors))
-	out.AllocationMode = v1.DeviceAllocationMode(in.AllocationMode)
-	out.Count = in.Count
-	out.Tolerations = *(*[]v1.DeviceToleration)(unsafe.Pointer(&in.Tolerations))
-	out.Capacity = (*v1.CapacityRequirements)(unsafe.Pointer(in.Capacity))
+	*out = *(*v1.DeviceSubRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1136,10 +1028,7 @@ func Convert_v1beta1_DeviceSubRequest_To_v1_DeviceSubRequest(in *resourcev1beta1
 }
 
 func autoConvert_v1_DeviceTaint_To_v1beta1_DeviceTaint(in *v1.DeviceTaint, out *resourcev1beta1.DeviceTaint, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Value = in.Value
-	out.Effect = resourcev1beta1.DeviceTaintEffect(in.Effect)
-	out.TimeAdded = (*metav1.Time)(unsafe.Pointer(in.TimeAdded))
+	*out = *(*resourcev1beta1.DeviceTaint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1149,10 +1038,7 @@ func Convert_v1_DeviceTaint_To_v1beta1_DeviceTaint(in *v1.DeviceTaint, out *reso
 }
 
 func autoConvert_v1beta1_DeviceTaint_To_v1_DeviceTaint(in *resourcev1beta1.DeviceTaint, out *v1.DeviceTaint, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Value = in.Value
-	out.Effect = v1.DeviceTaintEffect(in.Effect)
-	out.TimeAdded = (*metav1.Time)(unsafe.Pointer(in.TimeAdded))
+	*out = *(*v1.DeviceTaint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1162,11 +1048,7 @@ func Convert_v1beta1_DeviceTaint_To_v1_DeviceTaint(in *resourcev1beta1.DeviceTai
 }
 
 func autoConvert_v1_DeviceToleration_To_v1beta1_DeviceToleration(in *v1.DeviceToleration, out *resourcev1beta1.DeviceToleration, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Operator = resourcev1beta1.DeviceTolerationOperator(in.Operator)
-	out.Value = in.Value
-	out.Effect = resourcev1beta1.DeviceTaintEffect(in.Effect)
-	out.TolerationSeconds = (*int64)(unsafe.Pointer(in.TolerationSeconds))
+	*out = *(*resourcev1beta1.DeviceToleration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1176,11 +1058,7 @@ func Convert_v1_DeviceToleration_To_v1beta1_DeviceToleration(in *v1.DeviceTolera
 }
 
 func autoConvert_v1beta1_DeviceToleration_To_v1_DeviceToleration(in *resourcev1beta1.DeviceToleration, out *v1.DeviceToleration, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Operator = v1.DeviceTolerationOperator(in.Operator)
-	out.Value = in.Value
-	out.Effect = v1.DeviceTaintEffect(in.Effect)
-	out.TolerationSeconds = (*int64)(unsafe.Pointer(in.TolerationSeconds))
+	*out = *(*v1.DeviceToleration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1190,9 +1068,7 @@ func Convert_v1beta1_DeviceToleration_To_v1_DeviceToleration(in *resourcev1beta1
 }
 
 func autoConvert_v1_NetworkDeviceData_To_v1beta1_NetworkDeviceData(in *v1.NetworkDeviceData, out *resourcev1beta1.NetworkDeviceData, s conversion.Scope) error {
-	out.InterfaceName = in.InterfaceName
-	out.IPs = *(*[]string)(unsafe.Pointer(&in.IPs))
-	out.HardwareAddress = in.HardwareAddress
+	*out = *(*resourcev1beta1.NetworkDeviceData)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1202,9 +1078,7 @@ func Convert_v1_NetworkDeviceData_To_v1beta1_NetworkDeviceData(in *v1.NetworkDev
 }
 
 func autoConvert_v1beta1_NetworkDeviceData_To_v1_NetworkDeviceData(in *resourcev1beta1.NetworkDeviceData, out *v1.NetworkDeviceData, s conversion.Scope) error {
-	out.InterfaceName = in.InterfaceName
-	out.IPs = *(*[]string)(unsafe.Pointer(&in.IPs))
-	out.HardwareAddress = in.HardwareAddress
+	*out = *(*v1.NetworkDeviceData)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1214,8 +1088,7 @@ func Convert_v1beta1_NetworkDeviceData_To_v1_NetworkDeviceData(in *resourcev1bet
 }
 
 func autoConvert_v1_NodeAllocatableResourceMapping_To_v1beta1_NodeAllocatableResourceMapping(in *v1.NodeAllocatableResourceMapping, out *resourcev1beta1.NodeAllocatableResourceMapping, s conversion.Scope) error {
-	out.CapacityKey = (*resourcev1beta1.QualifiedName)(unsafe.Pointer(in.CapacityKey))
-	out.AllocationMultiplier = (*resource.Quantity)(unsafe.Pointer(in.AllocationMultiplier))
+	*out = *(*resourcev1beta1.NodeAllocatableResourceMapping)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1225,8 +1098,7 @@ func Convert_v1_NodeAllocatableResourceMapping_To_v1beta1_NodeAllocatableResourc
 }
 
 func autoConvert_v1beta1_NodeAllocatableResourceMapping_To_v1_NodeAllocatableResourceMapping(in *resourcev1beta1.NodeAllocatableResourceMapping, out *v1.NodeAllocatableResourceMapping, s conversion.Scope) error {
-	out.CapacityKey = (*v1.QualifiedName)(unsafe.Pointer(in.CapacityKey))
-	out.AllocationMultiplier = (*resource.Quantity)(unsafe.Pointer(in.AllocationMultiplier))
+	*out = *(*v1.NodeAllocatableResourceMapping)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1236,8 +1108,7 @@ func Convert_v1beta1_NodeAllocatableResourceMapping_To_v1_NodeAllocatableResourc
 }
 
 func autoConvert_v1_OpaqueDeviceConfiguration_To_v1beta1_OpaqueDeviceConfiguration(in *v1.OpaqueDeviceConfiguration, out *resourcev1beta1.OpaqueDeviceConfiguration, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.Parameters = in.Parameters
+	*out = *(*resourcev1beta1.OpaqueDeviceConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1247,8 +1118,7 @@ func Convert_v1_OpaqueDeviceConfiguration_To_v1beta1_OpaqueDeviceConfiguration(i
 }
 
 func autoConvert_v1beta1_OpaqueDeviceConfiguration_To_v1_OpaqueDeviceConfiguration(in *resourcev1beta1.OpaqueDeviceConfiguration, out *v1.OpaqueDeviceConfiguration, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.Parameters = in.Parameters
+	*out = *(*v1.OpaqueDeviceConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1290,10 +1160,7 @@ func Convert_v1beta1_ResourceClaim_To_v1_ResourceClaim(in *resourcev1beta1.Resou
 }
 
 func autoConvert_v1_ResourceClaimConsumerReference_To_v1beta1_ResourceClaimConsumerReference(in *v1.ResourceClaimConsumerReference, out *resourcev1beta1.ResourceClaimConsumerReference, s conversion.Scope) error {
-	out.APIGroup = in.APIGroup
-	out.Resource = in.Resource
-	out.Name = in.Name
-	out.UID = types.UID(in.UID)
+	*out = *(*resourcev1beta1.ResourceClaimConsumerReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1303,10 +1170,7 @@ func Convert_v1_ResourceClaimConsumerReference_To_v1beta1_ResourceClaimConsumerR
 }
 
 func autoConvert_v1beta1_ResourceClaimConsumerReference_To_v1_ResourceClaimConsumerReference(in *resourcev1beta1.ResourceClaimConsumerReference, out *v1.ResourceClaimConsumerReference, s conversion.Scope) error {
-	out.APIGroup = in.APIGroup
-	out.Resource = in.Resource
-	out.Name = in.Name
-	out.UID = types.UID(in.UID)
+	*out = *(*v1.ResourceClaimConsumerReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1382,9 +1246,7 @@ func Convert_v1beta1_ResourceClaimSpec_To_v1_ResourceClaimSpec(in *resourcev1bet
 }
 
 func autoConvert_v1_ResourceClaimStatus_To_v1beta1_ResourceClaimStatus(in *v1.ResourceClaimStatus, out *resourcev1beta1.ResourceClaimStatus, s conversion.Scope) error {
-	out.Allocation = (*resourcev1beta1.AllocationResult)(unsafe.Pointer(in.Allocation))
-	out.ReservedFor = *(*[]resourcev1beta1.ResourceClaimConsumerReference)(unsafe.Pointer(&in.ReservedFor))
-	out.Devices = *(*[]resourcev1beta1.AllocatedDeviceStatus)(unsafe.Pointer(&in.Devices))
+	*out = *(*resourcev1beta1.ResourceClaimStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1394,9 +1256,7 @@ func Convert_v1_ResourceClaimStatus_To_v1beta1_ResourceClaimStatus(in *v1.Resour
 }
 
 func autoConvert_v1beta1_ResourceClaimStatus_To_v1_ResourceClaimStatus(in *resourcev1beta1.ResourceClaimStatus, out *v1.ResourceClaimStatus, s conversion.Scope) error {
-	out.Allocation = (*v1.AllocationResult)(unsafe.Pointer(in.Allocation))
-	out.ReservedFor = *(*[]v1.ResourceClaimConsumerReference)(unsafe.Pointer(&in.ReservedFor))
-	out.Devices = *(*[]v1.AllocatedDeviceStatus)(unsafe.Pointer(&in.Devices))
+	*out = *(*v1.ResourceClaimStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1500,9 +1360,7 @@ func Convert_v1beta1_ResourceClaimTemplateSpec_To_v1_ResourceClaimTemplateSpec(i
 }
 
 func autoConvert_v1_ResourcePool_To_v1beta1_ResourcePool(in *v1.ResourcePool, out *resourcev1beta1.ResourcePool, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Generation = in.Generation
-	out.ResourceSliceCount = in.ResourceSliceCount
+	*out = *(*resourcev1beta1.ResourcePool)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1512,9 +1370,7 @@ func Convert_v1_ResourcePool_To_v1beta1_ResourcePool(in *v1.ResourcePool, out *r
 }
 
 func autoConvert_v1beta1_ResourcePool_To_v1_ResourcePool(in *resourcev1beta1.ResourcePool, out *v1.ResourcePool, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Generation = in.Generation
-	out.ResourceSliceCount = in.ResourceSliceCount
+	*out = *(*v1.ResourcePool)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/dynamic-resource-allocation/api/v1beta2/zz_generated.conversion.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/api/v1beta2/zz_generated.conversion.go
@@ -24,14 +24,10 @@ package v1beta2
 import (
 	unsafe "unsafe"
 
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/resource/v1"
 	resourcev1beta2 "k8s.io/api/resource/v1beta2"
-	resource "k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	types "k8s.io/apimachinery/pkg/types"
 )
 
 func init() {
@@ -485,13 +481,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1_AllocatedDeviceStatus_To_v1beta2_AllocatedDeviceStatus(in *v1.AllocatedDeviceStatus, out *resourcev1beta2.AllocatedDeviceStatus, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.Pool = in.Pool
-	out.Device = in.Device
-	out.ShareID = (*string)(unsafe.Pointer(in.ShareID))
-	out.Conditions = *(*[]metav1.Condition)(unsafe.Pointer(&in.Conditions))
-	out.Data = (*runtime.RawExtension)(unsafe.Pointer(in.Data))
-	out.NetworkData = (*resourcev1beta2.NetworkDeviceData)(unsafe.Pointer(in.NetworkData))
+	*out = *(*resourcev1beta2.AllocatedDeviceStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -501,13 +491,7 @@ func Convert_v1_AllocatedDeviceStatus_To_v1beta2_AllocatedDeviceStatus(in *v1.Al
 }
 
 func autoConvert_v1beta2_AllocatedDeviceStatus_To_v1_AllocatedDeviceStatus(in *resourcev1beta2.AllocatedDeviceStatus, out *v1.AllocatedDeviceStatus, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.Pool = in.Pool
-	out.Device = in.Device
-	out.ShareID = (*string)(unsafe.Pointer(in.ShareID))
-	out.Conditions = *(*[]metav1.Condition)(unsafe.Pointer(&in.Conditions))
-	out.Data = (*runtime.RawExtension)(unsafe.Pointer(in.Data))
-	out.NetworkData = (*v1.NetworkDeviceData)(unsafe.Pointer(in.NetworkData))
+	*out = *(*v1.AllocatedDeviceStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -517,11 +501,7 @@ func Convert_v1beta2_AllocatedDeviceStatus_To_v1_AllocatedDeviceStatus(in *resou
 }
 
 func autoConvert_v1_AllocationResult_To_v1beta2_AllocationResult(in *v1.AllocationResult, out *resourcev1beta2.AllocationResult, s conversion.Scope) error {
-	if err := Convert_v1_DeviceAllocationResult_To_v1beta2_DeviceAllocationResult(&in.Devices, &out.Devices, s); err != nil {
-		return err
-	}
-	out.NodeSelector = (*corev1.NodeSelector)(unsafe.Pointer(in.NodeSelector))
-	out.AllocationTimestamp = (*metav1.Time)(unsafe.Pointer(in.AllocationTimestamp))
+	*out = *(*resourcev1beta2.AllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -531,11 +511,7 @@ func Convert_v1_AllocationResult_To_v1beta2_AllocationResult(in *v1.AllocationRe
 }
 
 func autoConvert_v1beta2_AllocationResult_To_v1_AllocationResult(in *resourcev1beta2.AllocationResult, out *v1.AllocationResult, s conversion.Scope) error {
-	if err := Convert_v1beta2_DeviceAllocationResult_To_v1_DeviceAllocationResult(&in.Devices, &out.Devices, s); err != nil {
-		return err
-	}
-	out.NodeSelector = (*corev1.NodeSelector)(unsafe.Pointer(in.NodeSelector))
-	out.AllocationTimestamp = (*metav1.Time)(unsafe.Pointer(in.AllocationTimestamp))
+	*out = *(*v1.AllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -545,7 +521,7 @@ func Convert_v1beta2_AllocationResult_To_v1_AllocationResult(in *resourcev1beta2
 }
 
 func autoConvert_v1_CELDeviceSelector_To_v1beta2_CELDeviceSelector(in *v1.CELDeviceSelector, out *resourcev1beta2.CELDeviceSelector, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*resourcev1beta2.CELDeviceSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -555,7 +531,7 @@ func Convert_v1_CELDeviceSelector_To_v1beta2_CELDeviceSelector(in *v1.CELDeviceS
 }
 
 func autoConvert_v1beta2_CELDeviceSelector_To_v1_CELDeviceSelector(in *resourcev1beta2.CELDeviceSelector, out *v1.CELDeviceSelector, s conversion.Scope) error {
-	out.Expression = in.Expression
+	*out = *(*v1.CELDeviceSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -565,9 +541,7 @@ func Convert_v1beta2_CELDeviceSelector_To_v1_CELDeviceSelector(in *resourcev1bet
 }
 
 func autoConvert_v1_CapacityRequestPolicy_To_v1beta2_CapacityRequestPolicy(in *v1.CapacityRequestPolicy, out *resourcev1beta2.CapacityRequestPolicy, s conversion.Scope) error {
-	out.Default = (*resource.Quantity)(unsafe.Pointer(in.Default))
-	out.ValidValues = *(*[]resource.Quantity)(unsafe.Pointer(&in.ValidValues))
-	out.ValidRange = (*resourcev1beta2.CapacityRequestPolicyRange)(unsafe.Pointer(in.ValidRange))
+	*out = *(*resourcev1beta2.CapacityRequestPolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -577,9 +551,7 @@ func Convert_v1_CapacityRequestPolicy_To_v1beta2_CapacityRequestPolicy(in *v1.Ca
 }
 
 func autoConvert_v1beta2_CapacityRequestPolicy_To_v1_CapacityRequestPolicy(in *resourcev1beta2.CapacityRequestPolicy, out *v1.CapacityRequestPolicy, s conversion.Scope) error {
-	out.Default = (*resource.Quantity)(unsafe.Pointer(in.Default))
-	out.ValidValues = *(*[]resource.Quantity)(unsafe.Pointer(&in.ValidValues))
-	out.ValidRange = (*v1.CapacityRequestPolicyRange)(unsafe.Pointer(in.ValidRange))
+	*out = *(*v1.CapacityRequestPolicy)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -589,9 +561,7 @@ func Convert_v1beta2_CapacityRequestPolicy_To_v1_CapacityRequestPolicy(in *resou
 }
 
 func autoConvert_v1_CapacityRequestPolicyRange_To_v1beta2_CapacityRequestPolicyRange(in *v1.CapacityRequestPolicyRange, out *resourcev1beta2.CapacityRequestPolicyRange, s conversion.Scope) error {
-	out.Min = (*resource.Quantity)(unsafe.Pointer(in.Min))
-	out.Max = (*resource.Quantity)(unsafe.Pointer(in.Max))
-	out.Step = (*resource.Quantity)(unsafe.Pointer(in.Step))
+	*out = *(*resourcev1beta2.CapacityRequestPolicyRange)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -601,9 +571,7 @@ func Convert_v1_CapacityRequestPolicyRange_To_v1beta2_CapacityRequestPolicyRange
 }
 
 func autoConvert_v1beta2_CapacityRequestPolicyRange_To_v1_CapacityRequestPolicyRange(in *resourcev1beta2.CapacityRequestPolicyRange, out *v1.CapacityRequestPolicyRange, s conversion.Scope) error {
-	out.Min = (*resource.Quantity)(unsafe.Pointer(in.Min))
-	out.Max = (*resource.Quantity)(unsafe.Pointer(in.Max))
-	out.Step = (*resource.Quantity)(unsafe.Pointer(in.Step))
+	*out = *(*v1.CapacityRequestPolicyRange)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -613,7 +581,7 @@ func Convert_v1beta2_CapacityRequestPolicyRange_To_v1_CapacityRequestPolicyRange
 }
 
 func autoConvert_v1_CapacityRequirements_To_v1beta2_CapacityRequirements(in *v1.CapacityRequirements, out *resourcev1beta2.CapacityRequirements, s conversion.Scope) error {
-	out.Requests = *(*map[resourcev1beta2.QualifiedName]resource.Quantity)(unsafe.Pointer(&in.Requests))
+	*out = *(*resourcev1beta2.CapacityRequirements)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -623,7 +591,7 @@ func Convert_v1_CapacityRequirements_To_v1beta2_CapacityRequirements(in *v1.Capa
 }
 
 func autoConvert_v1beta2_CapacityRequirements_To_v1_CapacityRequirements(in *resourcev1beta2.CapacityRequirements, out *v1.CapacityRequirements, s conversion.Scope) error {
-	out.Requests = *(*map[v1.QualifiedName]resource.Quantity)(unsafe.Pointer(&in.Requests))
+	*out = *(*v1.CapacityRequirements)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -633,7 +601,7 @@ func Convert_v1beta2_CapacityRequirements_To_v1_CapacityRequirements(in *resourc
 }
 
 func autoConvert_v1_Counter_To_v1beta2_Counter(in *v1.Counter, out *resourcev1beta2.Counter, s conversion.Scope) error {
-	out.Value = in.Value
+	*out = *(*resourcev1beta2.Counter)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -643,7 +611,7 @@ func Convert_v1_Counter_To_v1beta2_Counter(in *v1.Counter, out *resourcev1beta2.
 }
 
 func autoConvert_v1beta2_Counter_To_v1_Counter(in *resourcev1beta2.Counter, out *v1.Counter, s conversion.Scope) error {
-	out.Value = in.Value
+	*out = *(*v1.Counter)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -653,8 +621,7 @@ func Convert_v1beta2_Counter_To_v1_Counter(in *resourcev1beta2.Counter, out *v1.
 }
 
 func autoConvert_v1_CounterSet_To_v1beta2_CounterSet(in *v1.CounterSet, out *resourcev1beta2.CounterSet, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Counters = *(*map[string]resourcev1beta2.Counter)(unsafe.Pointer(&in.Counters))
+	*out = *(*resourcev1beta2.CounterSet)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -664,8 +631,7 @@ func Convert_v1_CounterSet_To_v1beta2_CounterSet(in *v1.CounterSet, out *resourc
 }
 
 func autoConvert_v1beta2_CounterSet_To_v1_CounterSet(in *resourcev1beta2.CounterSet, out *v1.CounterSet, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Counters = *(*map[string]v1.Counter)(unsafe.Pointer(&in.Counters))
+	*out = *(*v1.CounterSet)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -675,19 +641,7 @@ func Convert_v1beta2_CounterSet_To_v1_CounterSet(in *resourcev1beta2.CounterSet,
 }
 
 func autoConvert_v1_Device_To_v1beta2_Device(in *v1.Device, out *resourcev1beta2.Device, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Attributes = *(*map[resourcev1beta2.QualifiedName]resourcev1beta2.DeviceAttribute)(unsafe.Pointer(&in.Attributes))
-	out.Capacity = *(*map[resourcev1beta2.QualifiedName]resourcev1beta2.DeviceCapacity)(unsafe.Pointer(&in.Capacity))
-	out.ConsumesCounters = *(*[]resourcev1beta2.DeviceCounterConsumption)(unsafe.Pointer(&in.ConsumesCounters))
-	out.NodeName = (*string)(unsafe.Pointer(in.NodeName))
-	out.NodeSelector = (*corev1.NodeSelector)(unsafe.Pointer(in.NodeSelector))
-	out.AllNodes = (*bool)(unsafe.Pointer(in.AllNodes))
-	out.Taints = *(*[]resourcev1beta2.DeviceTaint)(unsafe.Pointer(&in.Taints))
-	out.BindsToNode = (*bool)(unsafe.Pointer(in.BindsToNode))
-	out.BindingConditions = *(*[]string)(unsafe.Pointer(&in.BindingConditions))
-	out.BindingFailureConditions = *(*[]string)(unsafe.Pointer(&in.BindingFailureConditions))
-	out.AllowMultipleAllocations = (*bool)(unsafe.Pointer(in.AllowMultipleAllocations))
-	out.NodeAllocatableResourceMappings = *(*map[corev1.ResourceName]resourcev1beta2.NodeAllocatableResourceMapping)(unsafe.Pointer(&in.NodeAllocatableResourceMappings))
+	*out = *(*resourcev1beta2.Device)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -697,19 +651,7 @@ func Convert_v1_Device_To_v1beta2_Device(in *v1.Device, out *resourcev1beta2.Dev
 }
 
 func autoConvert_v1beta2_Device_To_v1_Device(in *resourcev1beta2.Device, out *v1.Device, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Attributes = *(*map[v1.QualifiedName]v1.DeviceAttribute)(unsafe.Pointer(&in.Attributes))
-	out.Capacity = *(*map[v1.QualifiedName]v1.DeviceCapacity)(unsafe.Pointer(&in.Capacity))
-	out.ConsumesCounters = *(*[]v1.DeviceCounterConsumption)(unsafe.Pointer(&in.ConsumesCounters))
-	out.NodeName = (*string)(unsafe.Pointer(in.NodeName))
-	out.NodeSelector = (*corev1.NodeSelector)(unsafe.Pointer(in.NodeSelector))
-	out.AllNodes = (*bool)(unsafe.Pointer(in.AllNodes))
-	out.Taints = *(*[]v1.DeviceTaint)(unsafe.Pointer(&in.Taints))
-	out.BindsToNode = (*bool)(unsafe.Pointer(in.BindsToNode))
-	out.BindingConditions = *(*[]string)(unsafe.Pointer(&in.BindingConditions))
-	out.BindingFailureConditions = *(*[]string)(unsafe.Pointer(&in.BindingFailureConditions))
-	out.AllowMultipleAllocations = (*bool)(unsafe.Pointer(in.AllowMultipleAllocations))
-	out.NodeAllocatableResourceMappings = *(*map[corev1.ResourceName]v1.NodeAllocatableResourceMapping)(unsafe.Pointer(&in.NodeAllocatableResourceMappings))
+	*out = *(*v1.Device)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -719,11 +661,7 @@ func Convert_v1beta2_Device_To_v1_Device(in *resourcev1beta2.Device, out *v1.Dev
 }
 
 func autoConvert_v1_DeviceAllocationConfiguration_To_v1beta2_DeviceAllocationConfiguration(in *v1.DeviceAllocationConfiguration, out *resourcev1beta2.DeviceAllocationConfiguration, s conversion.Scope) error {
-	out.Source = resourcev1beta2.AllocationConfigSource(in.Source)
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	if err := Convert_v1_DeviceConfiguration_To_v1beta2_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*resourcev1beta2.DeviceAllocationConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -733,11 +671,7 @@ func Convert_v1_DeviceAllocationConfiguration_To_v1beta2_DeviceAllocationConfigu
 }
 
 func autoConvert_v1beta2_DeviceAllocationConfiguration_To_v1_DeviceAllocationConfiguration(in *resourcev1beta2.DeviceAllocationConfiguration, out *v1.DeviceAllocationConfiguration, s conversion.Scope) error {
-	out.Source = v1.AllocationConfigSource(in.Source)
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	if err := Convert_v1beta2_DeviceConfiguration_To_v1_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*v1.DeviceAllocationConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -747,8 +681,7 @@ func Convert_v1beta2_DeviceAllocationConfiguration_To_v1_DeviceAllocationConfigu
 }
 
 func autoConvert_v1_DeviceAllocationResult_To_v1beta2_DeviceAllocationResult(in *v1.DeviceAllocationResult, out *resourcev1beta2.DeviceAllocationResult, s conversion.Scope) error {
-	out.Results = *(*[]resourcev1beta2.DeviceRequestAllocationResult)(unsafe.Pointer(&in.Results))
-	out.Config = *(*[]resourcev1beta2.DeviceAllocationConfiguration)(unsafe.Pointer(&in.Config))
+	*out = *(*resourcev1beta2.DeviceAllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -758,8 +691,7 @@ func Convert_v1_DeviceAllocationResult_To_v1beta2_DeviceAllocationResult(in *v1.
 }
 
 func autoConvert_v1beta2_DeviceAllocationResult_To_v1_DeviceAllocationResult(in *resourcev1beta2.DeviceAllocationResult, out *v1.DeviceAllocationResult, s conversion.Scope) error {
-	out.Results = *(*[]v1.DeviceRequestAllocationResult)(unsafe.Pointer(&in.Results))
-	out.Config = *(*[]v1.DeviceAllocationConfiguration)(unsafe.Pointer(&in.Config))
+	*out = *(*v1.DeviceAllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -769,14 +701,7 @@ func Convert_v1beta2_DeviceAllocationResult_To_v1_DeviceAllocationResult(in *res
 }
 
 func autoConvert_v1_DeviceAttribute_To_v1beta2_DeviceAttribute(in *v1.DeviceAttribute, out *resourcev1beta2.DeviceAttribute, s conversion.Scope) error {
-	out.IntValue = (*int64)(unsafe.Pointer(in.IntValue))
-	out.BoolValue = (*bool)(unsafe.Pointer(in.BoolValue))
-	out.StringValue = (*string)(unsafe.Pointer(in.StringValue))
-	out.VersionValue = (*string)(unsafe.Pointer(in.VersionValue))
-	out.IntValues = *(*[]int64)(unsafe.Pointer(&in.IntValues))
-	out.BoolValues = *(*[]bool)(unsafe.Pointer(&in.BoolValues))
-	out.StringValues = *(*[]string)(unsafe.Pointer(&in.StringValues))
-	out.VersionValues = *(*[]string)(unsafe.Pointer(&in.VersionValues))
+	*out = *(*resourcev1beta2.DeviceAttribute)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -786,14 +711,7 @@ func Convert_v1_DeviceAttribute_To_v1beta2_DeviceAttribute(in *v1.DeviceAttribut
 }
 
 func autoConvert_v1beta2_DeviceAttribute_To_v1_DeviceAttribute(in *resourcev1beta2.DeviceAttribute, out *v1.DeviceAttribute, s conversion.Scope) error {
-	out.IntValue = (*int64)(unsafe.Pointer(in.IntValue))
-	out.BoolValue = (*bool)(unsafe.Pointer(in.BoolValue))
-	out.StringValue = (*string)(unsafe.Pointer(in.StringValue))
-	out.VersionValue = (*string)(unsafe.Pointer(in.VersionValue))
-	out.IntValues = *(*[]int64)(unsafe.Pointer(&in.IntValues))
-	out.BoolValues = *(*[]bool)(unsafe.Pointer(&in.BoolValues))
-	out.StringValues = *(*[]string)(unsafe.Pointer(&in.StringValues))
-	out.VersionValues = *(*[]string)(unsafe.Pointer(&in.VersionValues))
+	*out = *(*v1.DeviceAttribute)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -803,8 +721,7 @@ func Convert_v1beta2_DeviceAttribute_To_v1_DeviceAttribute(in *resourcev1beta2.D
 }
 
 func autoConvert_v1_DeviceCapacity_To_v1beta2_DeviceCapacity(in *v1.DeviceCapacity, out *resourcev1beta2.DeviceCapacity, s conversion.Scope) error {
-	out.Value = in.Value
-	out.RequestPolicy = (*resourcev1beta2.CapacityRequestPolicy)(unsafe.Pointer(in.RequestPolicy))
+	*out = *(*resourcev1beta2.DeviceCapacity)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -814,8 +731,7 @@ func Convert_v1_DeviceCapacity_To_v1beta2_DeviceCapacity(in *v1.DeviceCapacity, 
 }
 
 func autoConvert_v1beta2_DeviceCapacity_To_v1_DeviceCapacity(in *resourcev1beta2.DeviceCapacity, out *v1.DeviceCapacity, s conversion.Scope) error {
-	out.Value = in.Value
-	out.RequestPolicy = (*v1.CapacityRequestPolicy)(unsafe.Pointer(in.RequestPolicy))
+	*out = *(*v1.DeviceCapacity)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -825,9 +741,7 @@ func Convert_v1beta2_DeviceCapacity_To_v1_DeviceCapacity(in *resourcev1beta2.Dev
 }
 
 func autoConvert_v1_DeviceClaim_To_v1beta2_DeviceClaim(in *v1.DeviceClaim, out *resourcev1beta2.DeviceClaim, s conversion.Scope) error {
-	out.Requests = *(*[]resourcev1beta2.DeviceRequest)(unsafe.Pointer(&in.Requests))
-	out.Constraints = *(*[]resourcev1beta2.DeviceConstraint)(unsafe.Pointer(&in.Constraints))
-	out.Config = *(*[]resourcev1beta2.DeviceClaimConfiguration)(unsafe.Pointer(&in.Config))
+	*out = *(*resourcev1beta2.DeviceClaim)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -837,9 +751,7 @@ func Convert_v1_DeviceClaim_To_v1beta2_DeviceClaim(in *v1.DeviceClaim, out *reso
 }
 
 func autoConvert_v1beta2_DeviceClaim_To_v1_DeviceClaim(in *resourcev1beta2.DeviceClaim, out *v1.DeviceClaim, s conversion.Scope) error {
-	out.Requests = *(*[]v1.DeviceRequest)(unsafe.Pointer(&in.Requests))
-	out.Constraints = *(*[]v1.DeviceConstraint)(unsafe.Pointer(&in.Constraints))
-	out.Config = *(*[]v1.DeviceClaimConfiguration)(unsafe.Pointer(&in.Config))
+	*out = *(*v1.DeviceClaim)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -849,10 +761,7 @@ func Convert_v1beta2_DeviceClaim_To_v1_DeviceClaim(in *resourcev1beta2.DeviceCla
 }
 
 func autoConvert_v1_DeviceClaimConfiguration_To_v1beta2_DeviceClaimConfiguration(in *v1.DeviceClaimConfiguration, out *resourcev1beta2.DeviceClaimConfiguration, s conversion.Scope) error {
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	if err := Convert_v1_DeviceConfiguration_To_v1beta2_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*resourcev1beta2.DeviceClaimConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -862,10 +771,7 @@ func Convert_v1_DeviceClaimConfiguration_To_v1beta2_DeviceClaimConfiguration(in 
 }
 
 func autoConvert_v1beta2_DeviceClaimConfiguration_To_v1_DeviceClaimConfiguration(in *resourcev1beta2.DeviceClaimConfiguration, out *v1.DeviceClaimConfiguration, s conversion.Scope) error {
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	if err := Convert_v1beta2_DeviceConfiguration_To_v1_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*v1.DeviceClaimConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -901,9 +807,7 @@ func Convert_v1beta2_DeviceClass_To_v1_DeviceClass(in *resourcev1beta2.DeviceCla
 }
 
 func autoConvert_v1_DeviceClassConfiguration_To_v1beta2_DeviceClassConfiguration(in *v1.DeviceClassConfiguration, out *resourcev1beta2.DeviceClassConfiguration, s conversion.Scope) error {
-	if err := Convert_v1_DeviceConfiguration_To_v1beta2_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*resourcev1beta2.DeviceClassConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -913,9 +817,7 @@ func Convert_v1_DeviceClassConfiguration_To_v1beta2_DeviceClassConfiguration(in 
 }
 
 func autoConvert_v1beta2_DeviceClassConfiguration_To_v1_DeviceClassConfiguration(in *resourcev1beta2.DeviceClassConfiguration, out *v1.DeviceClassConfiguration, s conversion.Scope) error {
-	if err := Convert_v1beta2_DeviceConfiguration_To_v1_DeviceConfiguration(&in.DeviceConfiguration, &out.DeviceConfiguration, s); err != nil {
-		return err
-	}
+	*out = *(*v1.DeviceClassConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -947,9 +849,7 @@ func Convert_v1beta2_DeviceClassList_To_v1_DeviceClassList(in *resourcev1beta2.D
 }
 
 func autoConvert_v1_DeviceClassSpec_To_v1beta2_DeviceClassSpec(in *v1.DeviceClassSpec, out *resourcev1beta2.DeviceClassSpec, s conversion.Scope) error {
-	out.Selectors = *(*[]resourcev1beta2.DeviceSelector)(unsafe.Pointer(&in.Selectors))
-	out.Config = *(*[]resourcev1beta2.DeviceClassConfiguration)(unsafe.Pointer(&in.Config))
-	out.ExtendedResourceName = (*string)(unsafe.Pointer(in.ExtendedResourceName))
+	*out = *(*resourcev1beta2.DeviceClassSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -959,9 +859,7 @@ func Convert_v1_DeviceClassSpec_To_v1beta2_DeviceClassSpec(in *v1.DeviceClassSpe
 }
 
 func autoConvert_v1beta2_DeviceClassSpec_To_v1_DeviceClassSpec(in *resourcev1beta2.DeviceClassSpec, out *v1.DeviceClassSpec, s conversion.Scope) error {
-	out.Selectors = *(*[]v1.DeviceSelector)(unsafe.Pointer(&in.Selectors))
-	out.Config = *(*[]v1.DeviceClassConfiguration)(unsafe.Pointer(&in.Config))
-	out.ExtendedResourceName = (*string)(unsafe.Pointer(in.ExtendedResourceName))
+	*out = *(*v1.DeviceClassSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -971,7 +869,7 @@ func Convert_v1beta2_DeviceClassSpec_To_v1_DeviceClassSpec(in *resourcev1beta2.D
 }
 
 func autoConvert_v1_DeviceConfiguration_To_v1beta2_DeviceConfiguration(in *v1.DeviceConfiguration, out *resourcev1beta2.DeviceConfiguration, s conversion.Scope) error {
-	out.Opaque = (*resourcev1beta2.OpaqueDeviceConfiguration)(unsafe.Pointer(in.Opaque))
+	*out = *(*resourcev1beta2.DeviceConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -981,7 +879,7 @@ func Convert_v1_DeviceConfiguration_To_v1beta2_DeviceConfiguration(in *v1.Device
 }
 
 func autoConvert_v1beta2_DeviceConfiguration_To_v1_DeviceConfiguration(in *resourcev1beta2.DeviceConfiguration, out *v1.DeviceConfiguration, s conversion.Scope) error {
-	out.Opaque = (*v1.OpaqueDeviceConfiguration)(unsafe.Pointer(in.Opaque))
+	*out = *(*v1.DeviceConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -991,9 +889,7 @@ func Convert_v1beta2_DeviceConfiguration_To_v1_DeviceConfiguration(in *resourcev
 }
 
 func autoConvert_v1_DeviceConstraint_To_v1beta2_DeviceConstraint(in *v1.DeviceConstraint, out *resourcev1beta2.DeviceConstraint, s conversion.Scope) error {
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	out.MatchAttribute = (*resourcev1beta2.FullyQualifiedName)(unsafe.Pointer(in.MatchAttribute))
-	out.DistinctAttribute = (*resourcev1beta2.FullyQualifiedName)(unsafe.Pointer(in.DistinctAttribute))
+	*out = *(*resourcev1beta2.DeviceConstraint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1003,9 +899,7 @@ func Convert_v1_DeviceConstraint_To_v1beta2_DeviceConstraint(in *v1.DeviceConstr
 }
 
 func autoConvert_v1beta2_DeviceConstraint_To_v1_DeviceConstraint(in *resourcev1beta2.DeviceConstraint, out *v1.DeviceConstraint, s conversion.Scope) error {
-	out.Requests = *(*[]string)(unsafe.Pointer(&in.Requests))
-	out.MatchAttribute = (*v1.FullyQualifiedName)(unsafe.Pointer(in.MatchAttribute))
-	out.DistinctAttribute = (*v1.FullyQualifiedName)(unsafe.Pointer(in.DistinctAttribute))
+	*out = *(*v1.DeviceConstraint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1015,8 +909,7 @@ func Convert_v1beta2_DeviceConstraint_To_v1_DeviceConstraint(in *resourcev1beta2
 }
 
 func autoConvert_v1_DeviceCounterConsumption_To_v1beta2_DeviceCounterConsumption(in *v1.DeviceCounterConsumption, out *resourcev1beta2.DeviceCounterConsumption, s conversion.Scope) error {
-	out.CounterSet = in.CounterSet
-	out.Counters = *(*map[string]resourcev1beta2.Counter)(unsafe.Pointer(&in.Counters))
+	*out = *(*resourcev1beta2.DeviceCounterConsumption)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1026,8 +919,7 @@ func Convert_v1_DeviceCounterConsumption_To_v1beta2_DeviceCounterConsumption(in 
 }
 
 func autoConvert_v1beta2_DeviceCounterConsumption_To_v1_DeviceCounterConsumption(in *resourcev1beta2.DeviceCounterConsumption, out *v1.DeviceCounterConsumption, s conversion.Scope) error {
-	out.CounterSet = in.CounterSet
-	out.Counters = *(*map[string]v1.Counter)(unsafe.Pointer(&in.Counters))
+	*out = *(*v1.DeviceCounterConsumption)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1037,9 +929,7 @@ func Convert_v1beta2_DeviceCounterConsumption_To_v1_DeviceCounterConsumption(in 
 }
 
 func autoConvert_v1_DeviceRequest_To_v1beta2_DeviceRequest(in *v1.DeviceRequest, out *resourcev1beta2.DeviceRequest, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Exactly = (*resourcev1beta2.ExactDeviceRequest)(unsafe.Pointer(in.Exactly))
-	out.FirstAvailable = *(*[]resourcev1beta2.DeviceSubRequest)(unsafe.Pointer(&in.FirstAvailable))
+	*out = *(*resourcev1beta2.DeviceRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1049,9 +939,7 @@ func Convert_v1_DeviceRequest_To_v1beta2_DeviceRequest(in *v1.DeviceRequest, out
 }
 
 func autoConvert_v1beta2_DeviceRequest_To_v1_DeviceRequest(in *resourcev1beta2.DeviceRequest, out *v1.DeviceRequest, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Exactly = (*v1.ExactDeviceRequest)(unsafe.Pointer(in.Exactly))
-	out.FirstAvailable = *(*[]v1.DeviceSubRequest)(unsafe.Pointer(&in.FirstAvailable))
+	*out = *(*v1.DeviceRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1061,16 +949,7 @@ func Convert_v1beta2_DeviceRequest_To_v1_DeviceRequest(in *resourcev1beta2.Devic
 }
 
 func autoConvert_v1_DeviceRequestAllocationResult_To_v1beta2_DeviceRequestAllocationResult(in *v1.DeviceRequestAllocationResult, out *resourcev1beta2.DeviceRequestAllocationResult, s conversion.Scope) error {
-	out.Request = in.Request
-	out.Driver = in.Driver
-	out.Pool = in.Pool
-	out.Device = in.Device
-	out.AdminAccess = (*bool)(unsafe.Pointer(in.AdminAccess))
-	out.Tolerations = *(*[]resourcev1beta2.DeviceToleration)(unsafe.Pointer(&in.Tolerations))
-	out.BindingConditions = *(*[]string)(unsafe.Pointer(&in.BindingConditions))
-	out.BindingFailureConditions = *(*[]string)(unsafe.Pointer(&in.BindingFailureConditions))
-	out.ShareID = (*types.UID)(unsafe.Pointer(in.ShareID))
-	out.ConsumedCapacity = *(*map[resourcev1beta2.QualifiedName]resource.Quantity)(unsafe.Pointer(&in.ConsumedCapacity))
+	*out = *(*resourcev1beta2.DeviceRequestAllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1080,16 +959,7 @@ func Convert_v1_DeviceRequestAllocationResult_To_v1beta2_DeviceRequestAllocation
 }
 
 func autoConvert_v1beta2_DeviceRequestAllocationResult_To_v1_DeviceRequestAllocationResult(in *resourcev1beta2.DeviceRequestAllocationResult, out *v1.DeviceRequestAllocationResult, s conversion.Scope) error {
-	out.Request = in.Request
-	out.Driver = in.Driver
-	out.Pool = in.Pool
-	out.Device = in.Device
-	out.AdminAccess = (*bool)(unsafe.Pointer(in.AdminAccess))
-	out.Tolerations = *(*[]v1.DeviceToleration)(unsafe.Pointer(&in.Tolerations))
-	out.BindingConditions = *(*[]string)(unsafe.Pointer(&in.BindingConditions))
-	out.BindingFailureConditions = *(*[]string)(unsafe.Pointer(&in.BindingFailureConditions))
-	out.ShareID = (*types.UID)(unsafe.Pointer(in.ShareID))
-	out.ConsumedCapacity = *(*map[v1.QualifiedName]resource.Quantity)(unsafe.Pointer(&in.ConsumedCapacity))
+	*out = *(*v1.DeviceRequestAllocationResult)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1099,7 +969,7 @@ func Convert_v1beta2_DeviceRequestAllocationResult_To_v1_DeviceRequestAllocation
 }
 
 func autoConvert_v1_DeviceSelector_To_v1beta2_DeviceSelector(in *v1.DeviceSelector, out *resourcev1beta2.DeviceSelector, s conversion.Scope) error {
-	out.CEL = (*resourcev1beta2.CELDeviceSelector)(unsafe.Pointer(in.CEL))
+	*out = *(*resourcev1beta2.DeviceSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1109,7 +979,7 @@ func Convert_v1_DeviceSelector_To_v1beta2_DeviceSelector(in *v1.DeviceSelector, 
 }
 
 func autoConvert_v1beta2_DeviceSelector_To_v1_DeviceSelector(in *resourcev1beta2.DeviceSelector, out *v1.DeviceSelector, s conversion.Scope) error {
-	out.CEL = (*v1.CELDeviceSelector)(unsafe.Pointer(in.CEL))
+	*out = *(*v1.DeviceSelector)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1119,13 +989,7 @@ func Convert_v1beta2_DeviceSelector_To_v1_DeviceSelector(in *resourcev1beta2.Dev
 }
 
 func autoConvert_v1_DeviceSubRequest_To_v1beta2_DeviceSubRequest(in *v1.DeviceSubRequest, out *resourcev1beta2.DeviceSubRequest, s conversion.Scope) error {
-	out.Name = in.Name
-	out.DeviceClassName = in.DeviceClassName
-	out.Selectors = *(*[]resourcev1beta2.DeviceSelector)(unsafe.Pointer(&in.Selectors))
-	out.AllocationMode = resourcev1beta2.DeviceAllocationMode(in.AllocationMode)
-	out.Count = in.Count
-	out.Tolerations = *(*[]resourcev1beta2.DeviceToleration)(unsafe.Pointer(&in.Tolerations))
-	out.Capacity = (*resourcev1beta2.CapacityRequirements)(unsafe.Pointer(in.Capacity))
+	*out = *(*resourcev1beta2.DeviceSubRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1135,13 +999,7 @@ func Convert_v1_DeviceSubRequest_To_v1beta2_DeviceSubRequest(in *v1.DeviceSubReq
 }
 
 func autoConvert_v1beta2_DeviceSubRequest_To_v1_DeviceSubRequest(in *resourcev1beta2.DeviceSubRequest, out *v1.DeviceSubRequest, s conversion.Scope) error {
-	out.Name = in.Name
-	out.DeviceClassName = in.DeviceClassName
-	out.Selectors = *(*[]v1.DeviceSelector)(unsafe.Pointer(&in.Selectors))
-	out.AllocationMode = v1.DeviceAllocationMode(in.AllocationMode)
-	out.Count = in.Count
-	out.Tolerations = *(*[]v1.DeviceToleration)(unsafe.Pointer(&in.Tolerations))
-	out.Capacity = (*v1.CapacityRequirements)(unsafe.Pointer(in.Capacity))
+	*out = *(*v1.DeviceSubRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1151,10 +1009,7 @@ func Convert_v1beta2_DeviceSubRequest_To_v1_DeviceSubRequest(in *resourcev1beta2
 }
 
 func autoConvert_v1_DeviceTaint_To_v1beta2_DeviceTaint(in *v1.DeviceTaint, out *resourcev1beta2.DeviceTaint, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Value = in.Value
-	out.Effect = resourcev1beta2.DeviceTaintEffect(in.Effect)
-	out.TimeAdded = (*metav1.Time)(unsafe.Pointer(in.TimeAdded))
+	*out = *(*resourcev1beta2.DeviceTaint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1164,10 +1019,7 @@ func Convert_v1_DeviceTaint_To_v1beta2_DeviceTaint(in *v1.DeviceTaint, out *reso
 }
 
 func autoConvert_v1beta2_DeviceTaint_To_v1_DeviceTaint(in *resourcev1beta2.DeviceTaint, out *v1.DeviceTaint, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Value = in.Value
-	out.Effect = v1.DeviceTaintEffect(in.Effect)
-	out.TimeAdded = (*metav1.Time)(unsafe.Pointer(in.TimeAdded))
+	*out = *(*v1.DeviceTaint)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1177,11 +1029,7 @@ func Convert_v1beta2_DeviceTaint_To_v1_DeviceTaint(in *resourcev1beta2.DeviceTai
 }
 
 func autoConvert_v1_DeviceToleration_To_v1beta2_DeviceToleration(in *v1.DeviceToleration, out *resourcev1beta2.DeviceToleration, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Operator = resourcev1beta2.DeviceTolerationOperator(in.Operator)
-	out.Value = in.Value
-	out.Effect = resourcev1beta2.DeviceTaintEffect(in.Effect)
-	out.TolerationSeconds = (*int64)(unsafe.Pointer(in.TolerationSeconds))
+	*out = *(*resourcev1beta2.DeviceToleration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1191,11 +1039,7 @@ func Convert_v1_DeviceToleration_To_v1beta2_DeviceToleration(in *v1.DeviceTolera
 }
 
 func autoConvert_v1beta2_DeviceToleration_To_v1_DeviceToleration(in *resourcev1beta2.DeviceToleration, out *v1.DeviceToleration, s conversion.Scope) error {
-	out.Key = in.Key
-	out.Operator = v1.DeviceTolerationOperator(in.Operator)
-	out.Value = in.Value
-	out.Effect = v1.DeviceTaintEffect(in.Effect)
-	out.TolerationSeconds = (*int64)(unsafe.Pointer(in.TolerationSeconds))
+	*out = *(*v1.DeviceToleration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1205,13 +1049,7 @@ func Convert_v1beta2_DeviceToleration_To_v1_DeviceToleration(in *resourcev1beta2
 }
 
 func autoConvert_v1_ExactDeviceRequest_To_v1beta2_ExactDeviceRequest(in *v1.ExactDeviceRequest, out *resourcev1beta2.ExactDeviceRequest, s conversion.Scope) error {
-	out.DeviceClassName = in.DeviceClassName
-	out.Selectors = *(*[]resourcev1beta2.DeviceSelector)(unsafe.Pointer(&in.Selectors))
-	out.AllocationMode = resourcev1beta2.DeviceAllocationMode(in.AllocationMode)
-	out.Count = in.Count
-	out.AdminAccess = (*bool)(unsafe.Pointer(in.AdminAccess))
-	out.Tolerations = *(*[]resourcev1beta2.DeviceToleration)(unsafe.Pointer(&in.Tolerations))
-	out.Capacity = (*resourcev1beta2.CapacityRequirements)(unsafe.Pointer(in.Capacity))
+	*out = *(*resourcev1beta2.ExactDeviceRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1221,13 +1059,7 @@ func Convert_v1_ExactDeviceRequest_To_v1beta2_ExactDeviceRequest(in *v1.ExactDev
 }
 
 func autoConvert_v1beta2_ExactDeviceRequest_To_v1_ExactDeviceRequest(in *resourcev1beta2.ExactDeviceRequest, out *v1.ExactDeviceRequest, s conversion.Scope) error {
-	out.DeviceClassName = in.DeviceClassName
-	out.Selectors = *(*[]v1.DeviceSelector)(unsafe.Pointer(&in.Selectors))
-	out.AllocationMode = v1.DeviceAllocationMode(in.AllocationMode)
-	out.Count = in.Count
-	out.AdminAccess = (*bool)(unsafe.Pointer(in.AdminAccess))
-	out.Tolerations = *(*[]v1.DeviceToleration)(unsafe.Pointer(&in.Tolerations))
-	out.Capacity = (*v1.CapacityRequirements)(unsafe.Pointer(in.Capacity))
+	*out = *(*v1.ExactDeviceRequest)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1237,9 +1069,7 @@ func Convert_v1beta2_ExactDeviceRequest_To_v1_ExactDeviceRequest(in *resourcev1b
 }
 
 func autoConvert_v1_NetworkDeviceData_To_v1beta2_NetworkDeviceData(in *v1.NetworkDeviceData, out *resourcev1beta2.NetworkDeviceData, s conversion.Scope) error {
-	out.InterfaceName = in.InterfaceName
-	out.IPs = *(*[]string)(unsafe.Pointer(&in.IPs))
-	out.HardwareAddress = in.HardwareAddress
+	*out = *(*resourcev1beta2.NetworkDeviceData)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1249,9 +1079,7 @@ func Convert_v1_NetworkDeviceData_To_v1beta2_NetworkDeviceData(in *v1.NetworkDev
 }
 
 func autoConvert_v1beta2_NetworkDeviceData_To_v1_NetworkDeviceData(in *resourcev1beta2.NetworkDeviceData, out *v1.NetworkDeviceData, s conversion.Scope) error {
-	out.InterfaceName = in.InterfaceName
-	out.IPs = *(*[]string)(unsafe.Pointer(&in.IPs))
-	out.HardwareAddress = in.HardwareAddress
+	*out = *(*v1.NetworkDeviceData)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1261,8 +1089,7 @@ func Convert_v1beta2_NetworkDeviceData_To_v1_NetworkDeviceData(in *resourcev1bet
 }
 
 func autoConvert_v1_NodeAllocatableResourceMapping_To_v1beta2_NodeAllocatableResourceMapping(in *v1.NodeAllocatableResourceMapping, out *resourcev1beta2.NodeAllocatableResourceMapping, s conversion.Scope) error {
-	out.CapacityKey = (*resourcev1beta2.QualifiedName)(unsafe.Pointer(in.CapacityKey))
-	out.AllocationMultiplier = (*resource.Quantity)(unsafe.Pointer(in.AllocationMultiplier))
+	*out = *(*resourcev1beta2.NodeAllocatableResourceMapping)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1272,8 +1099,7 @@ func Convert_v1_NodeAllocatableResourceMapping_To_v1beta2_NodeAllocatableResourc
 }
 
 func autoConvert_v1beta2_NodeAllocatableResourceMapping_To_v1_NodeAllocatableResourceMapping(in *resourcev1beta2.NodeAllocatableResourceMapping, out *v1.NodeAllocatableResourceMapping, s conversion.Scope) error {
-	out.CapacityKey = (*v1.QualifiedName)(unsafe.Pointer(in.CapacityKey))
-	out.AllocationMultiplier = (*resource.Quantity)(unsafe.Pointer(in.AllocationMultiplier))
+	*out = *(*v1.NodeAllocatableResourceMapping)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1283,8 +1109,7 @@ func Convert_v1beta2_NodeAllocatableResourceMapping_To_v1_NodeAllocatableResourc
 }
 
 func autoConvert_v1_OpaqueDeviceConfiguration_To_v1beta2_OpaqueDeviceConfiguration(in *v1.OpaqueDeviceConfiguration, out *resourcev1beta2.OpaqueDeviceConfiguration, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.Parameters = in.Parameters
+	*out = *(*resourcev1beta2.OpaqueDeviceConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1294,8 +1119,7 @@ func Convert_v1_OpaqueDeviceConfiguration_To_v1beta2_OpaqueDeviceConfiguration(i
 }
 
 func autoConvert_v1beta2_OpaqueDeviceConfiguration_To_v1_OpaqueDeviceConfiguration(in *resourcev1beta2.OpaqueDeviceConfiguration, out *v1.OpaqueDeviceConfiguration, s conversion.Scope) error {
-	out.Driver = in.Driver
-	out.Parameters = in.Parameters
+	*out = *(*v1.OpaqueDeviceConfiguration)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1337,10 +1161,7 @@ func Convert_v1beta2_ResourceClaim_To_v1_ResourceClaim(in *resourcev1beta2.Resou
 }
 
 func autoConvert_v1_ResourceClaimConsumerReference_To_v1beta2_ResourceClaimConsumerReference(in *v1.ResourceClaimConsumerReference, out *resourcev1beta2.ResourceClaimConsumerReference, s conversion.Scope) error {
-	out.APIGroup = in.APIGroup
-	out.Resource = in.Resource
-	out.Name = in.Name
-	out.UID = types.UID(in.UID)
+	*out = *(*resourcev1beta2.ResourceClaimConsumerReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1350,10 +1171,7 @@ func Convert_v1_ResourceClaimConsumerReference_To_v1beta2_ResourceClaimConsumerR
 }
 
 func autoConvert_v1beta2_ResourceClaimConsumerReference_To_v1_ResourceClaimConsumerReference(in *resourcev1beta2.ResourceClaimConsumerReference, out *v1.ResourceClaimConsumerReference, s conversion.Scope) error {
-	out.APIGroup = in.APIGroup
-	out.Resource = in.Resource
-	out.Name = in.Name
-	out.UID = types.UID(in.UID)
+	*out = *(*v1.ResourceClaimConsumerReference)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1385,9 +1203,7 @@ func Convert_v1beta2_ResourceClaimList_To_v1_ResourceClaimList(in *resourcev1bet
 }
 
 func autoConvert_v1_ResourceClaimSpec_To_v1beta2_ResourceClaimSpec(in *v1.ResourceClaimSpec, out *resourcev1beta2.ResourceClaimSpec, s conversion.Scope) error {
-	if err := Convert_v1_DeviceClaim_To_v1beta2_DeviceClaim(&in.Devices, &out.Devices, s); err != nil {
-		return err
-	}
+	*out = *(*resourcev1beta2.ResourceClaimSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1397,9 +1213,7 @@ func Convert_v1_ResourceClaimSpec_To_v1beta2_ResourceClaimSpec(in *v1.ResourceCl
 }
 
 func autoConvert_v1beta2_ResourceClaimSpec_To_v1_ResourceClaimSpec(in *resourcev1beta2.ResourceClaimSpec, out *v1.ResourceClaimSpec, s conversion.Scope) error {
-	if err := Convert_v1beta2_DeviceClaim_To_v1_DeviceClaim(&in.Devices, &out.Devices, s); err != nil {
-		return err
-	}
+	*out = *(*v1.ResourceClaimSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1409,9 +1223,7 @@ func Convert_v1beta2_ResourceClaimSpec_To_v1_ResourceClaimSpec(in *resourcev1bet
 }
 
 func autoConvert_v1_ResourceClaimStatus_To_v1beta2_ResourceClaimStatus(in *v1.ResourceClaimStatus, out *resourcev1beta2.ResourceClaimStatus, s conversion.Scope) error {
-	out.Allocation = (*resourcev1beta2.AllocationResult)(unsafe.Pointer(in.Allocation))
-	out.ReservedFor = *(*[]resourcev1beta2.ResourceClaimConsumerReference)(unsafe.Pointer(&in.ReservedFor))
-	out.Devices = *(*[]resourcev1beta2.AllocatedDeviceStatus)(unsafe.Pointer(&in.Devices))
+	*out = *(*resourcev1beta2.ResourceClaimStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1421,9 +1233,7 @@ func Convert_v1_ResourceClaimStatus_To_v1beta2_ResourceClaimStatus(in *v1.Resour
 }
 
 func autoConvert_v1beta2_ResourceClaimStatus_To_v1_ResourceClaimStatus(in *resourcev1beta2.ResourceClaimStatus, out *v1.ResourceClaimStatus, s conversion.Scope) error {
-	out.Allocation = (*v1.AllocationResult)(unsafe.Pointer(in.Allocation))
-	out.ReservedFor = *(*[]v1.ResourceClaimConsumerReference)(unsafe.Pointer(&in.ReservedFor))
-	out.Devices = *(*[]v1.AllocatedDeviceStatus)(unsafe.Pointer(&in.Devices))
+	*out = *(*v1.ResourceClaimStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1481,10 +1291,7 @@ func Convert_v1beta2_ResourceClaimTemplateList_To_v1_ResourceClaimTemplateList(i
 }
 
 func autoConvert_v1_ResourceClaimTemplateSpec_To_v1beta2_ResourceClaimTemplateSpec(in *v1.ResourceClaimTemplateSpec, out *resourcev1beta2.ResourceClaimTemplateSpec, s conversion.Scope) error {
-	out.ObjectMeta = in.ObjectMeta
-	if err := Convert_v1_ResourceClaimSpec_To_v1beta2_ResourceClaimSpec(&in.Spec, &out.Spec, s); err != nil {
-		return err
-	}
+	*out = *(*resourcev1beta2.ResourceClaimTemplateSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1494,10 +1301,7 @@ func Convert_v1_ResourceClaimTemplateSpec_To_v1beta2_ResourceClaimTemplateSpec(i
 }
 
 func autoConvert_v1beta2_ResourceClaimTemplateSpec_To_v1_ResourceClaimTemplateSpec(in *resourcev1beta2.ResourceClaimTemplateSpec, out *v1.ResourceClaimTemplateSpec, s conversion.Scope) error {
-	out.ObjectMeta = in.ObjectMeta
-	if err := Convert_v1beta2_ResourceClaimSpec_To_v1_ResourceClaimSpec(&in.Spec, &out.Spec, s); err != nil {
-		return err
-	}
+	*out = *(*v1.ResourceClaimTemplateSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1507,9 +1311,7 @@ func Convert_v1beta2_ResourceClaimTemplateSpec_To_v1_ResourceClaimTemplateSpec(i
 }
 
 func autoConvert_v1_ResourcePool_To_v1beta2_ResourcePool(in *v1.ResourcePool, out *resourcev1beta2.ResourcePool, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Generation = in.Generation
-	out.ResourceSliceCount = in.ResourceSliceCount
+	*out = *(*resourcev1beta2.ResourcePool)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1519,9 +1321,7 @@ func Convert_v1_ResourcePool_To_v1beta2_ResourcePool(in *v1.ResourcePool, out *r
 }
 
 func autoConvert_v1beta2_ResourcePool_To_v1_ResourcePool(in *resourcev1beta2.ResourcePool, out *v1.ResourcePool, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Generation = in.Generation
-	out.ResourceSliceCount = in.ResourceSliceCount
+	*out = *(*v1.ResourcePool)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1579,16 +1379,7 @@ func Convert_v1beta2_ResourceSliceList_To_v1_ResourceSliceList(in *resourcev1bet
 }
 
 func autoConvert_v1_ResourceSliceSpec_To_v1beta2_ResourceSliceSpec(in *v1.ResourceSliceSpec, out *resourcev1beta2.ResourceSliceSpec, s conversion.Scope) error {
-	out.Driver = in.Driver
-	if err := Convert_v1_ResourcePool_To_v1beta2_ResourcePool(&in.Pool, &out.Pool, s); err != nil {
-		return err
-	}
-	out.NodeName = (*string)(unsafe.Pointer(in.NodeName))
-	out.NodeSelector = (*corev1.NodeSelector)(unsafe.Pointer(in.NodeSelector))
-	out.AllNodes = (*bool)(unsafe.Pointer(in.AllNodes))
-	out.Devices = *(*[]resourcev1beta2.Device)(unsafe.Pointer(&in.Devices))
-	out.PerDeviceNodeSelection = (*bool)(unsafe.Pointer(in.PerDeviceNodeSelection))
-	out.SharedCounters = *(*[]resourcev1beta2.CounterSet)(unsafe.Pointer(&in.SharedCounters))
+	*out = *(*resourcev1beta2.ResourceSliceSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -1598,16 +1389,7 @@ func Convert_v1_ResourceSliceSpec_To_v1beta2_ResourceSliceSpec(in *v1.ResourceSl
 }
 
 func autoConvert_v1beta2_ResourceSliceSpec_To_v1_ResourceSliceSpec(in *resourcev1beta2.ResourceSliceSpec, out *v1.ResourceSliceSpec, s conversion.Scope) error {
-	out.Driver = in.Driver
-	if err := Convert_v1beta2_ResourcePool_To_v1_ResourcePool(&in.Pool, &out.Pool, s); err != nil {
-		return err
-	}
-	out.NodeName = (*string)(unsafe.Pointer(in.NodeName))
-	out.NodeSelector = (*corev1.NodeSelector)(unsafe.Pointer(in.NodeSelector))
-	out.AllNodes = (*bool)(unsafe.Pointer(in.AllNodes))
-	out.Devices = *(*[]v1.Device)(unsafe.Pointer(&in.Devices))
-	out.PerDeviceNodeSelection = (*bool)(unsafe.Pointer(in.PerDeviceNodeSelection))
-	out.SharedCounters = *(*[]v1.CounterSet)(unsafe.Pointer(&in.SharedCounters))
+	*out = *(*v1.ResourceSliceSpec)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/zz_generated.conversion.go
@@ -133,11 +133,7 @@ func Convert_apiregistration_APIService_To_v1_APIService(in *apiregistration.API
 }
 
 func autoConvert_v1_APIServiceCondition_To_apiregistration_APIServiceCondition(in *APIServiceCondition, out *apiregistration.APIServiceCondition, s conversion.Scope) error {
-	out.Type = apiregistration.APIServiceConditionType(in.Type)
-	out.Status = apiregistration.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*apiregistration.APIServiceCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -147,11 +143,7 @@ func Convert_v1_APIServiceCondition_To_apiregistration_APIServiceCondition(in *A
 }
 
 func autoConvert_apiregistration_APIServiceCondition_To_v1_APIServiceCondition(in *apiregistration.APIServiceCondition, out *APIServiceCondition, s conversion.Scope) error {
-	out.Type = APIServiceConditionType(in.Type)
-	out.Status = ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*APIServiceCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -251,7 +243,7 @@ func Convert_apiregistration_APIServiceSpec_To_v1_APIServiceSpec(in *apiregistra
 }
 
 func autoConvert_v1_APIServiceStatus_To_apiregistration_APIServiceStatus(in *APIServiceStatus, out *apiregistration.APIServiceStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]apiregistration.APIServiceCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*apiregistration.APIServiceStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -261,7 +253,7 @@ func Convert_v1_APIServiceStatus_To_apiregistration_APIServiceStatus(in *APIServ
 }
 
 func autoConvert_apiregistration_APIServiceStatus_To_v1_APIServiceStatus(in *apiregistration.APIServiceStatus, out *APIServiceStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]APIServiceCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*APIServiceStatus)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/zz_generated.conversion.go
@@ -133,11 +133,7 @@ func Convert_apiregistration_APIService_To_v1beta1_APIService(in *apiregistratio
 }
 
 func autoConvert_v1beta1_APIServiceCondition_To_apiregistration_APIServiceCondition(in *APIServiceCondition, out *apiregistration.APIServiceCondition, s conversion.Scope) error {
-	out.Type = apiregistration.APIServiceConditionType(in.Type)
-	out.Status = apiregistration.ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*apiregistration.APIServiceCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -147,11 +143,7 @@ func Convert_v1beta1_APIServiceCondition_To_apiregistration_APIServiceCondition(
 }
 
 func autoConvert_apiregistration_APIServiceCondition_To_v1beta1_APIServiceCondition(in *apiregistration.APIServiceCondition, out *APIServiceCondition, s conversion.Scope) error {
-	out.Type = APIServiceConditionType(in.Type)
-	out.Status = ConditionStatus(in.Status)
-	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
-	out.Message = in.Message
+	*out = *(*APIServiceCondition)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -251,7 +243,7 @@ func Convert_apiregistration_APIServiceSpec_To_v1beta1_APIServiceSpec(in *apireg
 }
 
 func autoConvert_v1beta1_APIServiceStatus_To_apiregistration_APIServiceStatus(in *APIServiceStatus, out *apiregistration.APIServiceStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]apiregistration.APIServiceCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*apiregistration.APIServiceStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -261,7 +253,7 @@ func Convert_v1beta1_APIServiceStatus_To_apiregistration_APIServiceStatus(in *AP
 }
 
 func autoConvert_apiregistration_APIServiceStatus_To_v1beta1_APIServiceStatus(in *apiregistration.APIServiceStatus, out *APIServiceStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]APIServiceCondition)(unsafe.Pointer(&in.Conditions))
+	*out = *(*APIServiceStatus)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/config/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/kubectl/pkg/config/v1alpha1/zz_generated.conversion.go
@@ -80,11 +80,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_AliasOverride_To_config_AliasOverride(in *AliasOverride, out *config.AliasOverride, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Command = in.Command
-	out.PrependArgs = *(*[]string)(unsafe.Pointer(&in.PrependArgs))
-	out.AppendArgs = *(*[]string)(unsafe.Pointer(&in.AppendArgs))
-	out.Options = *(*[]config.CommandOptionDefault)(unsafe.Pointer(&in.Options))
+	*out = *(*config.AliasOverride)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -94,11 +90,7 @@ func Convert_v1alpha1_AliasOverride_To_config_AliasOverride(in *AliasOverride, o
 }
 
 func autoConvert_config_AliasOverride_To_v1alpha1_AliasOverride(in *config.AliasOverride, out *AliasOverride, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Command = in.Command
-	out.PrependArgs = *(*[]string)(unsafe.Pointer(&in.PrependArgs))
-	out.AppendArgs = *(*[]string)(unsafe.Pointer(&in.AppendArgs))
-	out.Options = *(*[]CommandOptionDefault)(unsafe.Pointer(&in.Options))
+	*out = *(*AliasOverride)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -108,8 +100,7 @@ func Convert_config_AliasOverride_To_v1alpha1_AliasOverride(in *config.AliasOver
 }
 
 func autoConvert_v1alpha1_CommandDefaults_To_config_CommandDefaults(in *CommandDefaults, out *config.CommandDefaults, s conversion.Scope) error {
-	out.Command = in.Command
-	out.Options = *(*[]config.CommandOptionDefault)(unsafe.Pointer(&in.Options))
+	*out = *(*config.CommandDefaults)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -119,8 +110,7 @@ func Convert_v1alpha1_CommandDefaults_To_config_CommandDefaults(in *CommandDefau
 }
 
 func autoConvert_config_CommandDefaults_To_v1alpha1_CommandDefaults(in *config.CommandDefaults, out *CommandDefaults, s conversion.Scope) error {
-	out.Command = in.Command
-	out.Options = *(*[]CommandOptionDefault)(unsafe.Pointer(&in.Options))
+	*out = *(*CommandDefaults)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -130,8 +120,7 @@ func Convert_config_CommandDefaults_To_v1alpha1_CommandDefaults(in *config.Comma
 }
 
 func autoConvert_v1alpha1_CommandOptionDefault_To_config_CommandOptionDefault(in *CommandOptionDefault, out *config.CommandOptionDefault, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Default = in.Default
+	*out = *(*config.CommandOptionDefault)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -141,8 +130,7 @@ func Convert_v1alpha1_CommandOptionDefault_To_config_CommandOptionDefault(in *Co
 }
 
 func autoConvert_config_CommandOptionDefault_To_v1alpha1_CommandOptionDefault(in *config.CommandOptionDefault, out *CommandOptionDefault, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Default = in.Default
+	*out = *(*CommandOptionDefault)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/config/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/kubectl/pkg/config/v1beta1/zz_generated.conversion.go
@@ -90,11 +90,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1beta1_AliasOverride_To_config_AliasOverride(in *AliasOverride, out *config.AliasOverride, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Command = in.Command
-	out.PrependArgs = *(*[]string)(unsafe.Pointer(&in.PrependArgs))
-	out.AppendArgs = *(*[]string)(unsafe.Pointer(&in.AppendArgs))
-	out.Options = *(*[]config.CommandOptionDefault)(unsafe.Pointer(&in.Options))
+	*out = *(*config.AliasOverride)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -104,11 +100,7 @@ func Convert_v1beta1_AliasOverride_To_config_AliasOverride(in *AliasOverride, ou
 }
 
 func autoConvert_config_AliasOverride_To_v1beta1_AliasOverride(in *config.AliasOverride, out *AliasOverride, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Command = in.Command
-	out.PrependArgs = *(*[]string)(unsafe.Pointer(&in.PrependArgs))
-	out.AppendArgs = *(*[]string)(unsafe.Pointer(&in.AppendArgs))
-	out.Options = *(*[]CommandOptionDefault)(unsafe.Pointer(&in.Options))
+	*out = *(*AliasOverride)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -129,8 +121,7 @@ func autoConvert_config_AllowlistEntry_To_v1beta1_AllowlistEntry(in *config.Allo
 }
 
 func autoConvert_v1beta1_CommandDefaults_To_config_CommandDefaults(in *CommandDefaults, out *config.CommandDefaults, s conversion.Scope) error {
-	out.Command = in.Command
-	out.Options = *(*[]config.CommandOptionDefault)(unsafe.Pointer(&in.Options))
+	*out = *(*config.CommandDefaults)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -140,8 +131,7 @@ func Convert_v1beta1_CommandDefaults_To_config_CommandDefaults(in *CommandDefaul
 }
 
 func autoConvert_config_CommandDefaults_To_v1beta1_CommandDefaults(in *config.CommandDefaults, out *CommandDefaults, s conversion.Scope) error {
-	out.Command = in.Command
-	out.Options = *(*[]CommandOptionDefault)(unsafe.Pointer(&in.Options))
+	*out = *(*CommandDefaults)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -151,8 +141,7 @@ func Convert_config_CommandDefaults_To_v1beta1_CommandDefaults(in *config.Comman
 }
 
 func autoConvert_v1beta1_CommandOptionDefault_To_config_CommandOptionDefault(in *CommandOptionDefault, out *config.CommandOptionDefault, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Default = in.Default
+	*out = *(*config.CommandOptionDefault)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -162,8 +151,7 @@ func Convert_v1beta1_CommandOptionDefault_To_config_CommandOptionDefault(in *Com
 }
 
 func autoConvert_config_CommandOptionDefault_To_v1beta1_CommandOptionDefault(in *config.CommandOptionDefault, out *CommandOptionDefault, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Default = in.Default
+	*out = *(*CommandOptionDefault)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/kubelet/pkg/apis/credentialprovider/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/kubelet/pkg/apis/credentialprovider/v1/zz_generated.conversion.go
@@ -71,8 +71,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1_AuthConfig_To_credentialprovider_AuthConfig(in *AuthConfig, out *credentialprovider.AuthConfig, s conversion.Scope) error {
-	out.Username = in.Username
-	out.Password = in.Password
+	*out = *(*credentialprovider.AuthConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -82,8 +81,7 @@ func Convert_v1_AuthConfig_To_credentialprovider_AuthConfig(in *AuthConfig, out 
 }
 
 func autoConvert_credentialprovider_AuthConfig_To_v1_AuthConfig(in *credentialprovider.AuthConfig, out *AuthConfig, s conversion.Scope) error {
-	out.Username = in.Username
-	out.Password = in.Password
+	*out = *(*AuthConfig)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/kubelet/pkg/apis/credentialprovider/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/kubelet/pkg/apis/credentialprovider/v1alpha1/zz_generated.conversion.go
@@ -71,8 +71,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_AuthConfig_To_credentialprovider_AuthConfig(in *AuthConfig, out *credentialprovider.AuthConfig, s conversion.Scope) error {
-	out.Username = in.Username
-	out.Password = in.Password
+	*out = *(*credentialprovider.AuthConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -82,8 +81,7 @@ func Convert_v1alpha1_AuthConfig_To_credentialprovider_AuthConfig(in *AuthConfig
 }
 
 func autoConvert_credentialprovider_AuthConfig_To_v1alpha1_AuthConfig(in *credentialprovider.AuthConfig, out *AuthConfig, s conversion.Scope) error {
-	out.Username = in.Username
-	out.Password = in.Password
+	*out = *(*AuthConfig)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/kubelet/pkg/apis/credentialprovider/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/kubelet/pkg/apis/credentialprovider/v1beta1/zz_generated.conversion.go
@@ -71,8 +71,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1beta1_AuthConfig_To_credentialprovider_AuthConfig(in *AuthConfig, out *credentialprovider.AuthConfig, s conversion.Scope) error {
-	out.Username = in.Username
-	out.Password = in.Password
+	*out = *(*credentialprovider.AuthConfig)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -82,8 +81,7 @@ func Convert_v1beta1_AuthConfig_To_credentialprovider_AuthConfig(in *AuthConfig,
 }
 
 func autoConvert_credentialprovider_AuthConfig_To_v1beta1_AuthConfig(in *credentialprovider.AuthConfig, out *AuthConfig, s conversion.Scope) error {
-	out.Username = in.Username
-	out.Password = in.Password
+	*out = *(*AuthConfig)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/kubelet/pkg/apis/dra/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/kubelet/pkg/apis/dra/v1beta1/zz_generated.conversion.go
@@ -409,6 +409,7 @@ func autoConvert_v1_NodeUnprepareResourcesResponse_To_v1beta1_NodeUnprepareResou
 }
 
 func autoConvert_v1beta1_UnimplementedDRAPluginServer_To_v1_UnimplementedDRAPluginServer(in *UnimplementedDRAPluginServer, out *v1.UnimplementedDRAPluginServer, s conversion.Scope) error {
+	*out = *(*v1.UnimplementedDRAPluginServer)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -418,6 +419,7 @@ func Convert_v1beta1_UnimplementedDRAPluginServer_To_v1_UnimplementedDRAPluginSe
 }
 
 func autoConvert_v1_UnimplementedDRAPluginServer_To_v1beta1_UnimplementedDRAPluginServer(in *v1.UnimplementedDRAPluginServer, out *UnimplementedDRAPluginServer, s conversion.Scope) error {
+	*out = *(*UnimplementedDRAPluginServer)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta2/zz_generated.conversion.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta2/zz_generated.conversion.go
@@ -24,7 +24,6 @@ package v1beta2
 import (
 	unsafe "unsafe"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	custommetrics "k8s.io/metrics/pkg/apis/custom_metrics"
@@ -81,8 +80,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1beta2_MetricIdentifier_To_custom_metrics_MetricIdentifier(in *MetricIdentifier, out *custommetrics.MetricIdentifier, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
+	*out = *(*custommetrics.MetricIdentifier)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -92,8 +90,7 @@ func Convert_v1beta2_MetricIdentifier_To_custom_metrics_MetricIdentifier(in *Met
 }
 
 func autoConvert_custom_metrics_MetricIdentifier_To_v1beta2_MetricIdentifier(in *custommetrics.MetricIdentifier, out *MetricIdentifier, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
+	*out = *(*MetricIdentifier)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/v1alpha1/zz_generated.conversion.go
@@ -91,8 +91,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_ContainerMetrics_To_metrics_ContainerMetrics(in *ContainerMetrics, out *metrics.ContainerMetrics, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Usage = *(*v1.ResourceList)(unsafe.Pointer(&in.Usage))
+	*out = *(*metrics.ContainerMetrics)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -102,8 +101,7 @@ func Convert_v1alpha1_ContainerMetrics_To_metrics_ContainerMetrics(in *Container
 }
 
 func autoConvert_metrics_ContainerMetrics_To_v1alpha1_ContainerMetrics(in *metrics.ContainerMetrics, out *ContainerMetrics, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Usage = *(*v1.ResourceList)(unsafe.Pointer(&in.Usage))
+	*out = *(*ContainerMetrics)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/v1beta1/zz_generated.conversion.go
@@ -91,8 +91,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1beta1_ContainerMetrics_To_metrics_ContainerMetrics(in *ContainerMetrics, out *metrics.ContainerMetrics, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Usage = *(*v1.ResourceList)(unsafe.Pointer(&in.Usage))
+	*out = *(*metrics.ContainerMetrics)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -102,8 +101,7 @@ func Convert_v1beta1_ContainerMetrics_To_metrics_ContainerMetrics(in *ContainerM
 }
 
 func autoConvert_metrics_ContainerMetrics_To_v1beta1_ContainerMetrics(in *metrics.ContainerMetrics, out *ContainerMetrics, s conversion.Scope) error {
-	out.Name = in.Name
-	out.Usage = *(*v1.ResourceList)(unsafe.Pointer(&in.Usage))
+	*out = *(*ContainerMetrics)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/pod-security-admission/admission/api/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/pod-security-admission/admission/api/v1/zz_generated.conversion.go
@@ -100,12 +100,7 @@ func Convert_api_PodSecurityConfiguration_To_v1_PodSecurityConfiguration(in *api
 }
 
 func autoConvert_v1_PodSecurityDefaults_To_api_PodSecurityDefaults(in *PodSecurityDefaults, out *api.PodSecurityDefaults, s conversion.Scope) error {
-	out.Enforce = in.Enforce
-	out.EnforceVersion = in.EnforceVersion
-	out.Audit = in.Audit
-	out.AuditVersion = in.AuditVersion
-	out.Warn = in.Warn
-	out.WarnVersion = in.WarnVersion
+	*out = *(*api.PodSecurityDefaults)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -115,12 +110,7 @@ func Convert_v1_PodSecurityDefaults_To_api_PodSecurityDefaults(in *PodSecurityDe
 }
 
 func autoConvert_api_PodSecurityDefaults_To_v1_PodSecurityDefaults(in *api.PodSecurityDefaults, out *PodSecurityDefaults, s conversion.Scope) error {
-	out.Enforce = in.Enforce
-	out.EnforceVersion = in.EnforceVersion
-	out.Audit = in.Audit
-	out.AuditVersion = in.AuditVersion
-	out.Warn = in.Warn
-	out.WarnVersion = in.WarnVersion
+	*out = *(*PodSecurityDefaults)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -130,9 +120,7 @@ func Convert_api_PodSecurityDefaults_To_v1_PodSecurityDefaults(in *api.PodSecuri
 }
 
 func autoConvert_v1_PodSecurityExemptions_To_api_PodSecurityExemptions(in *PodSecurityExemptions, out *api.PodSecurityExemptions, s conversion.Scope) error {
-	out.Usernames = *(*[]string)(unsafe.Pointer(&in.Usernames))
-	out.Namespaces = *(*[]string)(unsafe.Pointer(&in.Namespaces))
-	out.RuntimeClasses = *(*[]string)(unsafe.Pointer(&in.RuntimeClasses))
+	*out = *(*api.PodSecurityExemptions)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -142,9 +130,7 @@ func Convert_v1_PodSecurityExemptions_To_api_PodSecurityExemptions(in *PodSecuri
 }
 
 func autoConvert_api_PodSecurityExemptions_To_v1_PodSecurityExemptions(in *api.PodSecurityExemptions, out *PodSecurityExemptions, s conversion.Scope) error {
-	out.Usernames = *(*[]string)(unsafe.Pointer(&in.Usernames))
-	out.Namespaces = *(*[]string)(unsafe.Pointer(&in.Namespaces))
-	out.RuntimeClasses = *(*[]string)(unsafe.Pointer(&in.RuntimeClasses))
+	*out = *(*PodSecurityExemptions)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/pod-security-admission/admission/api/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/pod-security-admission/admission/api/v1alpha1/zz_generated.conversion.go
@@ -100,12 +100,7 @@ func Convert_api_PodSecurityConfiguration_To_v1alpha1_PodSecurityConfiguration(i
 }
 
 func autoConvert_v1alpha1_PodSecurityDefaults_To_api_PodSecurityDefaults(in *PodSecurityDefaults, out *api.PodSecurityDefaults, s conversion.Scope) error {
-	out.Enforce = in.Enforce
-	out.EnforceVersion = in.EnforceVersion
-	out.Audit = in.Audit
-	out.AuditVersion = in.AuditVersion
-	out.Warn = in.Warn
-	out.WarnVersion = in.WarnVersion
+	*out = *(*api.PodSecurityDefaults)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -115,12 +110,7 @@ func Convert_v1alpha1_PodSecurityDefaults_To_api_PodSecurityDefaults(in *PodSecu
 }
 
 func autoConvert_api_PodSecurityDefaults_To_v1alpha1_PodSecurityDefaults(in *api.PodSecurityDefaults, out *PodSecurityDefaults, s conversion.Scope) error {
-	out.Enforce = in.Enforce
-	out.EnforceVersion = in.EnforceVersion
-	out.Audit = in.Audit
-	out.AuditVersion = in.AuditVersion
-	out.Warn = in.Warn
-	out.WarnVersion = in.WarnVersion
+	*out = *(*PodSecurityDefaults)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -130,9 +120,7 @@ func Convert_api_PodSecurityDefaults_To_v1alpha1_PodSecurityDefaults(in *api.Pod
 }
 
 func autoConvert_v1alpha1_PodSecurityExemptions_To_api_PodSecurityExemptions(in *PodSecurityExemptions, out *api.PodSecurityExemptions, s conversion.Scope) error {
-	out.Usernames = *(*[]string)(unsafe.Pointer(&in.Usernames))
-	out.Namespaces = *(*[]string)(unsafe.Pointer(&in.Namespaces))
-	out.RuntimeClasses = *(*[]string)(unsafe.Pointer(&in.RuntimeClasses))
+	*out = *(*api.PodSecurityExemptions)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -142,9 +130,7 @@ func Convert_v1alpha1_PodSecurityExemptions_To_api_PodSecurityExemptions(in *Pod
 }
 
 func autoConvert_api_PodSecurityExemptions_To_v1alpha1_PodSecurityExemptions(in *api.PodSecurityExemptions, out *PodSecurityExemptions, s conversion.Scope) error {
-	out.Usernames = *(*[]string)(unsafe.Pointer(&in.Usernames))
-	out.Namespaces = *(*[]string)(unsafe.Pointer(&in.Namespaces))
-	out.RuntimeClasses = *(*[]string)(unsafe.Pointer(&in.RuntimeClasses))
+	*out = *(*PodSecurityExemptions)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/pod-security-admission/admission/api/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/pod-security-admission/admission/api/v1beta1/zz_generated.conversion.go
@@ -100,12 +100,7 @@ func Convert_api_PodSecurityConfiguration_To_v1beta1_PodSecurityConfiguration(in
 }
 
 func autoConvert_v1beta1_PodSecurityDefaults_To_api_PodSecurityDefaults(in *PodSecurityDefaults, out *api.PodSecurityDefaults, s conversion.Scope) error {
-	out.Enforce = in.Enforce
-	out.EnforceVersion = in.EnforceVersion
-	out.Audit = in.Audit
-	out.AuditVersion = in.AuditVersion
-	out.Warn = in.Warn
-	out.WarnVersion = in.WarnVersion
+	*out = *(*api.PodSecurityDefaults)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -115,12 +110,7 @@ func Convert_v1beta1_PodSecurityDefaults_To_api_PodSecurityDefaults(in *PodSecur
 }
 
 func autoConvert_api_PodSecurityDefaults_To_v1beta1_PodSecurityDefaults(in *api.PodSecurityDefaults, out *PodSecurityDefaults, s conversion.Scope) error {
-	out.Enforce = in.Enforce
-	out.EnforceVersion = in.EnforceVersion
-	out.Audit = in.Audit
-	out.AuditVersion = in.AuditVersion
-	out.Warn = in.Warn
-	out.WarnVersion = in.WarnVersion
+	*out = *(*PodSecurityDefaults)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -130,9 +120,7 @@ func Convert_api_PodSecurityDefaults_To_v1beta1_PodSecurityDefaults(in *api.PodS
 }
 
 func autoConvert_v1beta1_PodSecurityExemptions_To_api_PodSecurityExemptions(in *PodSecurityExemptions, out *api.PodSecurityExemptions, s conversion.Scope) error {
-	out.Usernames = *(*[]string)(unsafe.Pointer(&in.Usernames))
-	out.Namespaces = *(*[]string)(unsafe.Pointer(&in.Namespaces))
-	out.RuntimeClasses = *(*[]string)(unsafe.Pointer(&in.RuntimeClasses))
+	*out = *(*api.PodSecurityExemptions)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -142,9 +130,7 @@ func Convert_v1beta1_PodSecurityExemptions_To_api_PodSecurityExemptions(in *PodS
 }
 
 func autoConvert_api_PodSecurityExemptions_To_v1beta1_PodSecurityExemptions(in *api.PodSecurityExemptions, out *PodSecurityExemptions, s conversion.Scope) error {
-	out.Usernames = *(*[]string)(unsafe.Pointer(&in.Usernames))
-	out.Namespaces = *(*[]string)(unsafe.Pointer(&in.Namespaces))
-	out.RuntimeClasses = *(*[]string)(unsafe.Pointer(&in.RuntimeClasses))
+	*out = *(*PodSecurityExemptions)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1/zz_generated.conversion.go
@@ -231,6 +231,7 @@ func autoConvert_wardle_FlunderSpec_To_v1alpha1_FlunderSpec(in *wardle.FlunderSp
 }
 
 func autoConvert_v1alpha1_FlunderStatus_To_wardle_FlunderStatus(in *FlunderStatus, out *wardle.FlunderStatus, s conversion.Scope) error {
+	*out = *(*wardle.FlunderStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -240,6 +241,7 @@ func Convert_v1alpha1_FlunderStatus_To_wardle_FlunderStatus(in *FlunderStatus, o
 }
 
 func autoConvert_wardle_FlunderStatus_To_v1alpha1_FlunderStatus(in *wardle.FlunderStatus, out *FlunderStatus, s conversion.Scope) error {
+	*out = *(*FlunderStatus)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1beta1/zz_generated.conversion.go
@@ -134,9 +134,7 @@ func Convert_wardle_FlunderList_To_v1beta1_FlunderList(in *wardle.FlunderList, o
 }
 
 func autoConvert_v1beta1_FlunderSpec_To_wardle_FlunderSpec(in *FlunderSpec, out *wardle.FlunderSpec, s conversion.Scope) error {
-	out.FlunderReference = in.FlunderReference
-	out.FischerReference = in.FischerReference
-	out.ReferenceType = wardle.ReferenceType(in.ReferenceType)
+	*out = *(*wardle.FlunderSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -146,9 +144,7 @@ func Convert_v1beta1_FlunderSpec_To_wardle_FlunderSpec(in *FlunderSpec, out *war
 }
 
 func autoConvert_wardle_FlunderSpec_To_v1beta1_FlunderSpec(in *wardle.FlunderSpec, out *FlunderSpec, s conversion.Scope) error {
-	out.FlunderReference = in.FlunderReference
-	out.FischerReference = in.FischerReference
-	out.ReferenceType = ReferenceType(in.ReferenceType)
+	*out = *(*FlunderSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -158,6 +154,7 @@ func Convert_wardle_FlunderSpec_To_v1beta1_FlunderSpec(in *wardle.FlunderSpec, o
 }
 
 func autoConvert_v1beta1_FlunderStatus_To_wardle_FlunderStatus(in *FlunderStatus, out *wardle.FlunderStatus, s conversion.Scope) error {
+	*out = *(*wardle.FlunderStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -167,6 +164,7 @@ func Convert_v1beta1_FlunderStatus_To_wardle_FlunderStatus(in *FlunderStatus, ou
 }
 
 func autoConvert_wardle_FlunderStatus_To_v1beta1_FlunderStatus(in *wardle.FlunderStatus, out *FlunderStatus, s conversion.Scope) error {
+	*out = *(*FlunderStatus)(unsafe.Pointer(in))
 	return nil
 }
 


### PR DESCRIPTION
Builds on https://github.com/kubernetes/kubernetes/pull/139858 (to avoid merge conflicts)

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:

Replace field-by-field copying with unsafe pointer casts for memory-identical structs.

This respects manual conversions and only optimizes for cases where Go considers structs memory-identical **and** conversion-gen has no manual conversions that would be bypassed by this optimization.

Pod spec reduces to:

```go
func autoConvert_v1_PodSpec_To_core_PodSpec(in *corev1.PodSpec, out *core.PodSpec, s conversion.Scope) error {
        *out = *(*core.PodSpec)(unsafe.Pointer(in))
        return nil
}
```

Pod status reduces to:

```go
func autoConvert_v1_PodStatus_To_core_PodStatus(in *corev1.PodStatus, out *core.PodStatus, s conversion.Scope) error {
        *out = *(*core.PodStatus)(unsafe.Pointer(in))
        return nil
}
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

