### PR TITLE
Add node resource test to e2e serial lanes

### DIFF
--- a/test/e2e_node/node_container_manager_test.go
+++ b/test/e2e_node/node_container_manager_test.go
@@ -45,37 +45,12 @@ import (
 	"github.com/onsi/gomega"
 )
 
-func setDesiredConfiguration(initialConfig *kubeletconfig.KubeletConfiguration, cgroupManager cm.CgroupManager) {
-	initialConfig.EnforceNodeAllocatable = []string{"pods", kubeReservedCgroup, systemReservedCgroup}
-	initialConfig.SystemReserved = map[string]string{
-		string(v1.ResourceCPU):    "100m",
-		string(v1.ResourceMemory): "100Mi",
-		string(pidlimit.PIDs):     "1000",
-	}
-	initialConfig.KubeReserved = map[string]string{
-		string(v1.ResourceCPU):    "100m",
-		string(v1.ResourceMemory): "100Mi",
-		string(pidlimit.PIDs):     "738",
-	}
-	initialConfig.EvictionHard = map[string]string{"memory.available": "100Mi"}
-	// Necessary for allocatable cgroup creation.
-	initialConfig.CgroupsPerQOS = true
-	initialConfig.KubeReservedCgroup = kubeReservedCgroup
-	initialConfig.SystemReservedCgroup = systemReservedCgroup
-
-	if initialConfig.CgroupDriver == "systemd" {
-		initialConfig.KubeReservedCgroup = cm.NewCgroupName(cm.RootCgroupName, kubeReservedCgroup).ToSystemd()
-		initialConfig.SystemReservedCgroup = cm.NewCgroupName(cm.RootCgroupName, systemReservedCgroup).ToSystemd()
-	}
-}
-
 var _ = SIGDescribe("Node Container Manager", framework.WithSerial(), func() {
 	f := framework.NewDefaultFramework("node-container-manager")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 	f.Describe("Validate Node Allocatable", feature.NodeAllocatable, func() {
 		ginkgo.It("sets up the node and runs the test", func(ctx context.Context) {
-			ginkgo.Skip("currently broken")
-			framework.ExpectNoError(runTest(ctx, f))
+			framework.ExpectNoError(validateNodeAllocatableEnforcement(ctx, f))
 		})
 	})
 	f.Describe("Validate CGroup management", func() {
@@ -134,6 +109,30 @@ var _ = SIGDescribe("Node Container Manager", framework.WithSerial(), func() {
 	})
 })
 
+func configureNodeAllocatableReservations(initialConfig *kubeletconfig.KubeletConfiguration) {
+	initialConfig.EnforceNodeAllocatable = []string{"pods", kubeReservedCgroup, systemReservedCgroup}
+	initialConfig.SystemReserved = map[string]string{
+		string(v1.ResourceCPU):    "100m",
+		string(v1.ResourceMemory): "100Mi",
+		string(pidlimit.PIDs):     "1000",
+	}
+	initialConfig.KubeReserved = map[string]string{
+		string(v1.ResourceCPU):    "100m",
+		string(v1.ResourceMemory): "100Mi",
+		string(pidlimit.PIDs):     "738",
+	}
+	initialConfig.EvictionHard = map[string]string{"memory.available": "100Mi"}
+	// Necessary for allocatable cgroup creation.
+	initialConfig.CgroupsPerQOS = true
+	initialConfig.KubeReservedCgroup = kubeReservedCgroup
+	initialConfig.SystemReservedCgroup = systemReservedCgroup
+
+	if initialConfig.CgroupDriver == "systemd" {
+		initialConfig.KubeReservedCgroup = cm.NewCgroupName(cm.RootCgroupName, kubeReservedCgroup).ToSystemd()
+		initialConfig.SystemReservedCgroup = cm.NewCgroupName(cm.RootCgroupName, systemReservedCgroup).ToSystemd()
+	}
+}
+
 func expectFileValToEqual(filePath string, expectedValue, delta int64) error {
 	out, err := os.ReadFile(filePath)
 	if err != nil {
@@ -181,39 +180,29 @@ const (
 	nodeAllocatableCgroup = "kubepods"
 )
 
-func createIfNotExists(cm cm.CgroupManager, cgroupConfig *cm.CgroupConfig) error {
-	if !cm.Exists(cgroupConfig.Name) {
-		if err := cm.Create(klog.Background(), cgroupConfig); err != nil {
-			return err
+var reservationCgroups = []cm.CgroupName{
+	cm.NewCgroupName(cm.RootCgroupName, kubeReservedCgroup),
+	cm.NewCgroupName(cm.RootCgroupName, systemReservedCgroup),
+}
+
+func createTemporaryCgroupsForReservation(cgroupManager cm.CgroupManager) error {
+	for _, name := range reservationCgroups {
+		if !cgroupManager.Exists(name) {
+			if err := cgroupManager.Create(klog.Background(), &cm.CgroupConfig{Name: name}); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
 }
 
-func createTemporaryCgroupsForReservation(cgroupManager cm.CgroupManager) error {
-	// Create kube reserved cgroup
-	cgroupConfig := &cm.CgroupConfig{
-		Name: cm.NewCgroupName(cm.RootCgroupName, kubeReservedCgroup),
-	}
-	if err := createIfNotExists(cgroupManager, cgroupConfig); err != nil {
-		return err
-	}
-	// Create system reserved cgroup
-	cgroupConfig.Name = cm.NewCgroupName(cm.RootCgroupName, systemReservedCgroup)
-
-	return createIfNotExists(cgroupManager, cgroupConfig)
-}
-
 func destroyTemporaryCgroupsForReservation(cgroupManager cm.CgroupManager) error {
-	// Create kube reserved cgroup
-	cgroupConfig := &cm.CgroupConfig{
-		Name: cm.NewCgroupName(cm.RootCgroupName, kubeReservedCgroup),
+	for _, name := range reservationCgroups {
+		if err := cgroupManager.Destroy(klog.Background(), &cm.CgroupConfig{Name: name}); err != nil {
+			return err
+		}
 	}
-	if err := cgroupManager.Destroy(klog.Background(), cgroupConfig); err != nil {
-		return err
-	}
-	cgroupConfig.Name = cm.NewCgroupName(cm.RootCgroupName, systemReservedCgroup)
-	return cgroupManager.Destroy(klog.Background(), cgroupConfig)
+	return nil
 }
 
 // convertSharesToWeight converts from cgroup v1 cpu.shares to cgroup v2 cpu.weight
@@ -221,37 +210,24 @@ func convertSharesToWeight(shares int64) int64 {
 	return 1 + ((shares-2)*9999)/262142
 }
 
-func runTest(ctx context.Context, f *framework.Framework) error {
+func validateNodeAllocatableEnforcement(ctx context.Context, f *framework.Framework) error {
 	var oldCfg *kubeletconfig.KubeletConfiguration
 	subsystems, err := cm.GetCgroupSubsystems()
 	if err != nil {
 		return err
 	}
-	// Get current kubelet configuration
+
 	oldCfg, err = getCurrentKubeletConfig(ctx)
 	if err != nil {
 		return err
 	}
 
-	// Create a cgroup manager object for manipulating cgroups.
 	cgroupManager := cm.NewCgroupManager(klog.Background(), subsystems, oldCfg.CgroupDriver)
 
 	ginkgo.DeferCleanup(destroyTemporaryCgroupsForReservation, cgroupManager)
 	ginkgo.DeferCleanup(func(ctx context.Context) {
 		if oldCfg != nil {
-			// Update the Kubelet configuration.
-			ginkgo.By("Stopping the kubelet")
-			restartKubelet := mustStopKubelet(ctx, f)
-
-			// wait until the kubelet health check will fail
-			gomega.Eventually(ctx, func() bool {
-				return e2enode.HealthCheck(kubeletHealthCheckURL)
-			}, time.Minute, time.Second).Should(gomega.BeFalseBecause("expected kubelet health check to be failed"))
-
-			framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(oldCfg))
-
-			ginkgo.By("Restarting the kubelet")
-			restartKubelet(ctx)
+			updateKubeletConfig(ctx, f, oldCfg, true)
 		}
 	})
 	if err := createTemporaryCgroupsForReservation(cgroupManager); err != nil {
@@ -259,8 +235,7 @@ func runTest(ctx context.Context, f *framework.Framework) error {
 	}
 
 	newCfg := oldCfg.DeepCopy()
-	// Change existing kubelet configuration
-	setDesiredConfiguration(newCfg, cgroupManager)
+	configureNodeAllocatableReservations(newCfg)
 	// Set the new kubelet configuration.
 	// Update the Kubelet configuration.
 	ginkgo.By("Stopping the kubelet")
@@ -278,16 +253,12 @@ func runTest(ctx context.Context, f *framework.Framework) error {
 		return fmt.Errorf("Expected Node Allocatable Cgroup %q not to exist", expectedNAPodCgroup)
 	}
 
+	deleteStateFile(cpuManagerStateFile)
+	deleteStateFile(memoryManagerStateFile)
 	framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(newCfg))
 
 	ginkgo.By("Starting the kubelet")
 	restartKubelet(ctx)
-
-	if err != nil {
-		return err
-	}
-	// Set new config and current config.
-	currentConfig := newCfg
 
 	if !cgroupManager.Exists(expectedNAPodCgroup) {
 		return fmt.Errorf("Expected Node Allocatable Cgroup %q to exist", expectedNAPodCgroup)
@@ -308,111 +279,72 @@ func runTest(ctx context.Context, f *framework.Framework) error {
 		if len(nodeList.Items) != 1 {
 			return fmt.Errorf("Unexpected number of node objects for node e2e. Expects only one node: %+v", nodeList)
 		}
-		cgroupName := nodeAllocatableCgroup
-		if currentConfig.CgroupDriver == "systemd" {
-			cgroupName = nodeAllocatableCgroup + ".slice"
-		}
+		cgroupName := cgroupPathForDriver(newCfg.CgroupDriver, cgroupManager, cm.NewCgroupName(cm.RootCgroupName, nodeAllocatableCgroup))
 
 		node := nodeList.Items[0]
 		capacity := node.Status.Capacity
 		allocatableCPU, allocatableMemory, allocatablePIDs := getAllocatableLimits("200m", "200Mi", "1738", capacity)
-		// Total Memory reservation is 200Mi excluding eviction thresholds.
-		// Expect CPU shares on node allocatable cgroup to equal allocatable.
 		shares := int64(cm.MilliCPUToShares(allocatableCPU.MilliValue()))
-		if IsCgroup2UnifiedMode() {
-			// convert to the cgroup v2 cpu.weight value
-			if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["cpu"], cgroupName, "cpu.weight"), convertSharesToWeight(shares), 10); err != nil {
-				return err
-			}
-		} else {
-			if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["cpu"], cgroupName, "cpu.shares"), shares, 10); err != nil {
-				return err
-			}
+		if err := expectCPUValue(subsystems, cgroupName, shares); err != nil {
+			return err
 		}
-		// Expect Memory limit on node allocatable cgroup to equal allocatable.
 		if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["memory"], cgroupName, memoryLimitFile), allocatableMemory.Value(), 0); err != nil {
 			return err
 		}
-		// Expect PID limit on node allocatable cgroup to equal allocatable.
 		if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["pids"], cgroupName, "pids.max"), allocatablePIDs.Value(), 0); err != nil {
 			return err
 		}
 
 		// Check that Allocatable reported to scheduler includes eviction thresholds.
 		schedulerAllocatable := node.Status.Allocatable
-		// Memory allocatable should take into account eviction thresholds.
-		// Process IDs are not a scheduler resource and as such cannot be tested here.
 		allocatableCPU, allocatableMemory, _ = getAllocatableLimits("200m", "300Mi", "1738", capacity)
-		// Expect allocatable to include all resources in capacity.
 		if len(schedulerAllocatable) != len(capacity) {
 			return fmt.Errorf("Expected all resources in capacity to be found in allocatable")
 		}
-		// CPU based evictions are not supported.
 		if allocatableCPU.Cmp(schedulerAllocatable[v1.ResourceCPU]) != 0 {
 			return fmt.Errorf("Unexpected cpu allocatable value exposed by the node. Expected: %v, got: %v, capacity: %v", allocatableCPU, schedulerAllocatable[v1.ResourceCPU], capacity[v1.ResourceCPU])
 		}
 		if allocatableMemory.Cmp(schedulerAllocatable[v1.ResourceMemory]) != 0 {
 			return fmt.Errorf("Unexpected memory allocatable value exposed by the node. Expected: %v, got: %v, capacity: %v", allocatableMemory, schedulerAllocatable[v1.ResourceMemory], capacity[v1.ResourceMemory])
 		}
+
 		return nil
 	}, time.Minute, 5*time.Second).Should(gomega.Succeed())
 
-	cgroupPath := ""
-	if currentConfig.CgroupDriver == "systemd" {
-		cgroupPath = cm.NewCgroupName(cm.RootCgroupName, kubeReservedCgroup).ToSystemd()
-	} else {
-		cgroupPath = cgroupManager.Name(cm.NewCgroupName(cm.RootCgroupName, kubeReservedCgroup))
-	}
-	// Expect CPU shares on kube reserved cgroup to equal it's reservation which is `100m`.
-	kubeReservedCPU := resource.MustParse(currentConfig.KubeReserved[string(v1.ResourceCPU)])
-	shares := int64(cm.MilliCPUToShares(kubeReservedCPU.MilliValue()))
-	if IsCgroup2UnifiedMode() {
-		if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["cpu"], cgroupPath, "cpu.weight"), convertSharesToWeight(shares), 10); err != nil {
+	for _, rc := range []struct {
+		cgroupName string
+		reserved   map[string]string
+	}{
+		{cgroupPathForDriver(newCfg.CgroupDriver, cgroupManager, cm.NewCgroupName(cm.RootCgroupName, kubeReservedCgroup)), newCfg.KubeReserved},
+		{cgroupPathForDriver(newCfg.CgroupDriver, cgroupManager, cm.NewCgroupName(cm.RootCgroupName, systemReservedCgroup)), newCfg.SystemReserved},
+	} {
+		reservedCPU := resource.MustParse(rc.reserved[string(v1.ResourceCPU)])
+		shares := int64(cm.MilliCPUToShares(reservedCPU.MilliValue()))
+		if err := expectCPUValue(subsystems, rc.cgroupName, shares); err != nil {
 			return err
 		}
-	} else {
-		if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["cpu"], cgroupPath, "cpu.shares"), shares, 10); err != nil {
+		reservedMemory := resource.MustParse(rc.reserved[string(v1.ResourceMemory)])
+		if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["memory"], rc.cgroupName, memoryLimitFile), reservedMemory.Value(), 0); err != nil {
 			return err
 		}
-	}
-	// Expect Memory limit kube reserved cgroup to equal configured value `100Mi`.
-	kubeReservedMemory := resource.MustParse(currentConfig.KubeReserved[string(v1.ResourceMemory)])
-	if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["memory"], cgroupPath, memoryLimitFile), kubeReservedMemory.Value(), 0); err != nil {
-		return err
-	}
-	// Expect process ID limit kube reserved cgroup to equal configured value `738`.
-	kubeReservedPIDs := resource.MustParse(currentConfig.KubeReserved[string(pidlimit.PIDs)])
-	if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["pids"], cgroupPath, "pids.max"), kubeReservedPIDs.Value(), 0); err != nil {
-		return err
-	}
-
-	if currentConfig.CgroupDriver == "systemd" {
-		cgroupPath = cm.NewCgroupName(cm.RootCgroupName, systemReservedCgroup).ToSystemd()
-	} else {
-		cgroupPath = cgroupManager.Name(cm.NewCgroupName(cm.RootCgroupName, systemReservedCgroup))
-	}
-
-	// Expect CPU shares on system reserved cgroup to equal it's reservation which is `100m`.
-	systemReservedCPU := resource.MustParse(currentConfig.SystemReserved[string(v1.ResourceCPU)])
-	shares = int64(cm.MilliCPUToShares(systemReservedCPU.MilliValue()))
-	if IsCgroup2UnifiedMode() {
-		if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["cpu"], cgroupPath, "cpu.weight"), convertSharesToWeight(shares), 10); err != nil {
+		reservedPIDs := resource.MustParse(rc.reserved[string(pidlimit.PIDs)])
+		if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["pids"], rc.cgroupName, "pids.max"), reservedPIDs.Value(), 0); err != nil {
 			return err
 		}
-	} else {
-		if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["cpu"], cgroupPath, "cpu.shares"), shares, 10); err != nil {
-			return err
-		}
-	}
-	// Expect Memory limit on node allocatable cgroup to equal allocatable.
-	systemReservedMemory := resource.MustParse(currentConfig.SystemReserved[string(v1.ResourceMemory)])
-	if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["memory"], cgroupPath, memoryLimitFile), systemReservedMemory.Value(), 0); err != nil {
-		return err
-	}
-	// Expect process ID limit system reserved cgroup to equal configured value `1000`.
-	systemReservedPIDs := resource.MustParse(currentConfig.SystemReserved[string(pidlimit.PIDs)])
-	if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["pids"], cgroupPath, "pids.max"), systemReservedPIDs.Value(), 0); err != nil {
-		return err
 	}
 	return nil
+}
+
+func cgroupPathForDriver(driver string, cgroupManager cm.CgroupManager, name cm.CgroupName) string {
+	if driver == "systemd" {
+		return name.ToSystemd()
+	}
+	return cgroupManager.Name(name)
+}
+
+func expectCPUValue(subsystems *cm.CgroupSubsystems, cgroupPath string, shares int64) error {
+	if IsCgroup2UnifiedMode() {
+		return expectFileValToEqual(filepath.Join(subsystems.MountPoints["cpu"], cgroupPath, "cpu.weight"), convertSharesToWeight(shares), 10)
+	}
+	return expectFileValToEqual(filepath.Join(subsystems.MountPoints["cpu"], cgroupPath, "cpu.shares"), shares, 10)
 }

--- a/test/e2e_node/node_container_manager_test.go
+++ b/test/e2e_node/node_container_manager_test.go
@@ -185,10 +185,10 @@ var reservationCgroups = []cm.CgroupName{
 	cm.NewCgroupName(cm.RootCgroupName, systemReservedCgroup),
 }
 
-func createTemporaryCgroupsForReservation(cgroupManager cm.CgroupManager) error {
+func createTemporaryCgroupsForReservation(logger klog.Logger, cgroupManager cm.CgroupManager) error {
 	for _, name := range reservationCgroups {
 		if !cgroupManager.Exists(name) {
-			if err := cgroupManager.Create(klog.Background(), &cm.CgroupConfig{Name: name}); err != nil {
+			if err := cgroupManager.Create(logger, &cm.CgroupConfig{Name: name}); err != nil {
 				return err
 			}
 		}
@@ -196,9 +196,9 @@ func createTemporaryCgroupsForReservation(cgroupManager cm.CgroupManager) error 
 	return nil
 }
 
-func destroyTemporaryCgroupsForReservation(cgroupManager cm.CgroupManager) error {
+func destroyTemporaryCgroupsForReservation(logger klog.Logger, cgroupManager cm.CgroupManager) error {
 	for _, name := range reservationCgroups {
-		if err := cgroupManager.Destroy(klog.Background(), &cm.CgroupConfig{Name: name}); err != nil {
+		if err := cgroupManager.Destroy(logger, &cm.CgroupConfig{Name: name}); err != nil {
 			return err
 		}
 	}
@@ -211,6 +211,7 @@ func convertSharesToWeight(shares int64) int64 {
 }
 
 func validateNodeAllocatableEnforcement(ctx context.Context, f *framework.Framework) error {
+	logger := klog.FromContext(ctx)
 	var oldCfg *kubeletconfig.KubeletConfiguration
 	subsystems, err := cm.GetCgroupSubsystems()
 	if err != nil {
@@ -222,15 +223,15 @@ func validateNodeAllocatableEnforcement(ctx context.Context, f *framework.Framew
 		return err
 	}
 
-	cgroupManager := cm.NewCgroupManager(klog.Background(), subsystems, oldCfg.CgroupDriver)
+	cgroupManager := cm.NewCgroupManager(logger, subsystems, oldCfg.CgroupDriver)
 
-	ginkgo.DeferCleanup(destroyTemporaryCgroupsForReservation, cgroupManager)
+	ginkgo.DeferCleanup(destroyTemporaryCgroupsForReservation, logger, cgroupManager)
 	ginkgo.DeferCleanup(func(ctx context.Context) {
 		if oldCfg != nil {
 			updateKubeletConfig(ctx, f, oldCfg, true)
 		}
 	})
-	if err := createTemporaryCgroupsForReservation(cgroupManager); err != nil {
+	if err := createTemporaryCgroupsForReservation(logger, cgroupManager); err != nil {
 		return err
 	}
 
@@ -244,7 +245,7 @@ func validateNodeAllocatableEnforcement(ctx context.Context, f *framework.Framew
 	expectedNAPodCgroup := cm.NewCgroupName(cm.RootCgroupName, nodeAllocatableCgroup)
 
 	// Cleanup from the previous kubelet, to verify the new one creates it correctly
-	if err := cgroupManager.Destroy(klog.Background(), &cm.CgroupConfig{
+	if err := cgroupManager.Destroy(logger, &cm.CgroupConfig{
 		Name: cm.NewCgroupName(expectedNAPodCgroup),
 	}); err != nil {
 		return err
@@ -253,6 +254,9 @@ func validateNodeAllocatableEnforcement(ctx context.Context, f *framework.Framew
 		return fmt.Errorf("Expected Node Allocatable Cgroup %q not to exist", expectedNAPodCgroup)
 	}
 
+	// Stale state files from the previous kubelet run can cause startup failures
+	// when reconfiguring resource reservations. This mirrors updateKubeletConfig
+	// behavior when deleteStateFiles is true.
 	deleteStateFile(cpuManagerStateFile)
 	deleteStateFile(memoryManagerStateFile)
 	framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(newCfg))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind failing-test

#### What this PR does / why we need it:
Re-enable https://github.com/kubernetes/kubernetes/pull/133353/changes for testing system reserved.

I have analyzed and refactored the test. Changes are:
- Added `deleteStateFile(cpuManagerStateFile)` and `deleteStateFile(memoryManagerStateFile)` as a caution to ensure that nothing leaks out
- Used common code and reduced all the duplication which was present in the test

From the following tests it can be seen that this test is stable:
https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/139975/pull-node-crio-kubelet-serial/2069681144852385792
https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/139975/pull-kubernetes-node-e2e-containerd/2069681447152652288
https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/139975/pull-kubernetes-node-kubelet-serial-containerd/2069681447253315584
https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/139975/pull-kubernetes-node-swap-ubuntu-serial/2069633295297024000

Log:
```
E2eNode Suite: [It] [sig-node] Node Container Manager Validate Node Allocatable [Feature:NodeAllocatable] sets up the node and runs the test [Serial]
```

Ref: https://github.com/kubernetes/kubernetes/pull/133353

  What changed 

  1. Removed ginkgo.Skip("currently broken") — the test runs again.
  2. Added state file cleanup, that is, deleteStateFile(cpuManagerStateFile) and deleteStateFile(memoryManagerStateFile) are called before writing the new kubelet config. This prevents stale CPU/memory manager state from leaking across test runs, which was a likely cause of the original flakiness (the reviewer @ffromani specifically noted "some test leaked and caused other tests to flake/fail down the chain").
  3. Replaced manual kubelet restart with updateKubeletConfig(): the cleanup DeferCleanup now uses the shared updateKubeletConfig(ctx, f, oldCfg, true) helper instead of hand-rolling stop/health-check-wait/write-config/restart. This is more robust and consistent with other tests.
  4. Deduplicated cgroup verification: the kube-reserved and system-reserved cgroup checks (CPU, memory, PIDs) were copy-pasted blocks differing only by cgroup name and reservation map. They're now a single loop over a []struct{cgroupName, reserved} slice.
  5. Extracted two helpers to eliminate repeated cgroup v1/v2 branching:
     - cgroupPathForDriver() — resolves cgroup path based on systemd vs cgroupfs driver
     - expectCPUValue() — checks cpu.weight (cgroup v2) or cpu.shares (cgroup v1)
  6. Renamed for clarity:
     - setDesiredConfiguration → configureNodeAllocatableReservations (more descriptive)
     - runTest → validateNodeAllocatableEnforcement (says what it validates)
     - createIfNotExists inlined into createTemporaryCgroupsForReservation (used once, loop over reservationCgroups slice)

The test has been run across multiple CI lanes (CRI-O serial, containerd, swap-ubuntu-serial) with passing results — links are in the PR description.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
