### PR TITLE
Add regression test for invalid DeleteOptions.dryRun type

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete_test.go
@@ -181,6 +181,11 @@ func TestDeleteResourceDeleteOptions(t *testing.T) {
 			expectCode: 200,
 		},
 		{
+			name: "dryRun invalid Go type",
+			body: `{"dryRun" : "All"}`,
+			expectCode: 400,
+		},
+		{
 			name:       "orphanDependents invalid Go type",
 			body:       `{"orphanDependents": "randomString"}`,
 			expectCode: 400,
@@ -315,6 +320,11 @@ func TestDeleteCollectionDeleteOptions(t *testing.T) {
 			name:       "valid delete options",
 			body:       "{}",
 			expectCode: 200,
+		},
+		{
+			name: "dryRun invalid Go type",
+			body: `{"dryRun" : "All"}`,
+			expectCode: 400,
 		},
 		{
 			name:       "orphanDependents invalid Go type",


### PR DESCRIPTION
## What this PR does

Adds regression tests covering the case where `DeleteOptions.dryRun` is sent with an invalid JSON type (string instead of array). The API server must return HTTP 400, not 500.

### Background

A DELETE request with `{"dryRun":"All"}` (string instead of `[]string`) caused the API server to return HTTP 500 on affected versions. The production fix (wrapping the decode error with `errors.NewBadRequest`) is already in master. This PR adds regression coverage to both the single-object and collection delete paths so the 400 behavior is locked in.

## Test cases added

- `TestDeleteResourceDeleteOptions`: `"dryRun invalid Go type"` — single DELETE
- `TestDeleteCollectionDeleteOptions`: `"dryRun invalid Go type"` — collection DELETE

Both send `{"dryRun":"All"}` and assert `expectCode: 400`.

## Reproduction (from issue)

```shell
kubectl proxy --port=8001
curl -X DELETE 'http://127.0.0.1:8001/api/v1/namespaces/default/configmaps' \
  -H 'Content-Type: application/json' \
  --data-raw '{"dryRun":"All"}'
```

On affected versions this returns HTTP 500 with:
```
json: cannot unmarshal string into Go struct field DeleteOptions.dryRun of type []string
```

## Verification

```
go test -run 'TestDeleteResourceDeleteOptions|TestDeleteCollectionDeleteOptions' ./staging/src/k8s.io/apiserver/pkg/endpoints/handlers/...
ok  k8s.io/apiserver/pkg/endpoints/handlers 0.035s
```

/kind bug
/sig api-machinery