### PR TITLE
Return an error when AddPlugin fails instead of logging

### DIFF
--- a/pkg/kubelet/pluginmanager/operationexecutor/operation_generator.go
+++ b/pkg/kubelet/pluginmanager/operationexecutor/operation_generator.go
@@ -83,8 +83,6 @@ func (og *operationGenerator) GenerateRegisterPluginFunc(
 	actualStateOfWorldUpdater ActualStateOfWorldUpdater) func() error {
 
 	registerPluginFunc := func() error {
-		logger := klog.FromContext(ctx)
-
 		client, conn, err := dial(ctx, socketPath, dialTimeoutDuration)
 		if err != nil {
 			return fmt.Errorf("RegisterPlugin error -- dial failed at socket %s, err: %v", socketPath, err)
@@ -127,7 +125,10 @@ func (og *operationGenerator) GenerateRegisterPluginFunc(
 			Endpoint:   infoResp.Endpoint,
 		})
 		if err != nil {
-			logger.Error(err, "RegisterPlugin error -- failed to add plugin", "path", socketPath)
+			if notifyErr := og.notifyPlugin(ctx, client, false, fmt.Sprintf("RegisterPlugin error -- failed to add plugin with err: %v", err)); notifyErr != nil {
+				return fmt.Errorf("RegisterPlugin error -- failed to notify plugin consumer for socket %s, err: %v", socketPath, notifyErr)
+			}
+			return fmt.Errorf("RegisterPlugin error -- failed to add plugin with err: %v", err)
 		}
 		if err := handler.RegisterPlugin(ctx, infoResp.Name, infoResp.Endpoint, infoResp.SupportedVersions, nil); err != nil {
 			actualStateOfWorldUpdater.RemovePlugin(socketPath)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Currently the error from actualStateOfWorldUpdater.AddPlugin is only logged. It never returns an error nor notify the plugin consumer. 

#### Which issue(s) this PR is related to:
Fixes #136462
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
