### PR TITLE
Reimplement WAP with in place filter reprieval

### DIFF
--- a/pkg/scheduler/backend/cache/podgroupstate.go
+++ b/pkg/scheduler/backend/cache/podgroupstate.go
@@ -449,3 +449,8 @@ func (s *podGroupStateSnapshot) AllPodsCount() int {
 func (s *podGroupStateSnapshot) ScheduledPodsCount() int {
 	return s.podGroupStateData.scheduledPodsCount()
 }
+
+// Clone returns a pod group state snapshot with cloned podGroupStateData.
+func (s *podGroupStateSnapshot) Clone() *podGroupStateSnapshot {
+	return &podGroupStateSnapshot{podGroupStateData: s.podGroupStateData.clone()}
+}

--- a/pkg/scheduler/backend/cache/snapshot.go
+++ b/pkg/scheduler/backend/cache/snapshot.go
@@ -50,6 +50,7 @@ type snapshotBackupData struct {
 	havePodsWithAffinityNodeInfoList             []fwk.NodeInfo
 	havePodsWithRequiredAntiAffinityNodeInfoList []fwk.NodeInfo
 	usedPVCRefCounts                             map[string]int
+	podGroupStates                               map[podGroupKey]*podGroupStateSnapshot
 }
 
 // newSnapshotBackupData is creating a snapshotBackupData struct and it is filling it with original data from snapshot.
@@ -61,6 +62,7 @@ func newSnapshotBackupData(s *Snapshot) *snapshotBackupData {
 		havePodsWithAffinityNodeInfoList: s.havePodsWithAffinityNodeInfoList,
 		havePodsWithRequiredAntiAffinityNodeInfoList: s.havePodsWithRequiredAntiAffinityNodeInfoList,
 		usedPVCRefCounts: s.usedPVCRefCounts,
+		podGroupStates:   s.podGroupStates,
 	}
 }
 
@@ -71,6 +73,7 @@ func (b *snapshotBackupData) restore(s *Snapshot) {
 	s.havePodsWithAffinityNodeInfoList = b.havePodsWithAffinityNodeInfoList
 	s.havePodsWithRequiredAntiAffinityNodeInfoList = b.havePodsWithRequiredAntiAffinityNodeInfoList
 	s.usedPVCRefCounts = b.usedPVCRefCounts
+	s.podGroupStates = b.podGroupStates
 }
 
 // Snapshot is a snapshot of cache NodeInfo and NodeTree order. The scheduler takes a
@@ -249,6 +252,13 @@ func (s *Snapshot) StartMutations() error {
 
 	s.usedPVCRefCounts = make(map[string]int)
 	maps.Copy(s.usedPVCRefCounts, s.snapshotBackup.usedPVCRefCounts)
+
+	if s.genericWorkloadEnabled {
+		s.podGroupStates = make(map[podGroupKey]*podGroupStateSnapshot)
+		for k, v := range s.snapshotBackup.podGroupStates {
+			s.podGroupStates[k] = v.Clone()
+		}
+	}
 
 	return nil
 }
@@ -644,4 +654,111 @@ func (s *Snapshot) ListNodesInPlacement() ([]fwk.NodeInfo, error) {
 		return s.List()
 	}
 	return s.placementNodes.nodeInfoList, nil
+}
+
+// AddPod adds a pod to the snapshot.
+// AddPod should be called only if the mutation was started via StartMutations.
+// Compared to the AssumePod() function, the AddPod does not have to be reverted
+// via RemovePod(). The state will be reverted when EndMutation is called.
+// This function is not thread safe, so it should be executed when no other routines can write/read from the snapshot.
+func (s *Snapshot) AddPod(podInfo fwk.PodInfo, nodeName string) error {
+	if s.snapshotBackup == nil {
+		return fmt.Errorf("AddPod() called outside of mutation session")
+	}
+	nodeInfo, ok := s.nodeInfoMap[nodeName]
+	if !ok {
+		nodeInfo = framework.NewNodeInfo()
+		s.nodeInfoMap[nodeName] = nodeInfo
+	}
+
+	hadPodsWithAffinity := len(nodeInfo.PodsWithAffinity) > 0
+	hadPodsWithRequiredAntiAffinity := len(nodeInfo.PodsWithRequiredAntiAffinity) > 0
+
+	pod := podInfo.GetPod()
+	nodeInfo.AddPodInfo(podInfo)
+
+	// nodeInfo.AddPodInfo maintains the NodeInfo's affinity and PVC indexes;
+	// the snapshot-wide indexes must be updated to match, otherwise inter-pod
+	// (anti-)affinity and VolumeRestrictions plugins observe stale state.
+	if !hadPodsWithAffinity && len(nodeInfo.PodsWithAffinity) > 0 {
+		s.havePodsWithAffinityNodeInfoList = append(s.havePodsWithAffinityNodeInfoList, nodeInfo)
+	}
+	if !hadPodsWithRequiredAntiAffinity && len(nodeInfo.PodsWithRequiredAntiAffinity) > 0 {
+		s.havePodsWithRequiredAntiAffinityNodeInfoList = append(s.havePodsWithRequiredAntiAffinityNodeInfoList, nodeInfo)
+	}
+
+	for pvcKey := range framework.PodPVCKeys(pod) {
+		s.usedPVCRefCounts[pvcKey]++
+	}
+
+	if s.genericWorkloadEnabled && pod.Spec.SchedulingGroup != nil {
+		pgKey := newPodGroupKey(pod.Namespace, *pod.Spec.SchedulingGroup.PodGroupName)
+		if pgs, ok := s.podGroupStates[pgKey]; ok {
+			pgs.addPod(pod)
+		}
+	}
+
+	return nil
+}
+
+// RemovePod removes a pod from the snapshot.
+// RemovePod should be called only if the mutation was started via StartMutation.
+// The state will be reverted when EndMutation is called.
+// This function is not thread safe, so it should be executed when no other routines can write/read from the snapshot.
+func (s *Snapshot) RemovePod(logger klog.Logger, pod *v1.Pod, nodeName string) error {
+	if s.snapshotBackup == nil {
+		return fmt.Errorf("RemovePod() called outside of mutation session")
+	}
+	nodeInfo, ok := s.nodeInfoMap[nodeName]
+	if !ok {
+		return fmt.Errorf("node %q not found in the snapshot", nodeName)
+	}
+
+	hadPodsWithAffinity := len(nodeInfo.PodsWithAffinity) > 0
+	hadPodsWithRequiredAntiAffinity := len(nodeInfo.PodsWithRequiredAntiAffinity) > 0
+
+	if err := nodeInfo.RemovePod(logger, pod); err != nil {
+		return err
+	}
+
+	havePodsWithAffinity := len(nodeInfo.PodsWithAffinity) > 0
+	havePodsWithRequiredAntiAffinity := len(nodeInfo.PodsWithRequiredAntiAffinity) > 0
+
+	if hadPodsWithAffinity && !havePodsWithAffinity {
+		s.havePodsWithAffinityNodeInfoList = removeNodeInfoFromList(logger, s.havePodsWithAffinityNodeInfoList, nodeInfo)
+	}
+	if hadPodsWithRequiredAntiAffinity && !havePodsWithRequiredAntiAffinity {
+		s.havePodsWithRequiredAntiAffinityNodeInfoList = removeNodeInfoFromList(logger, s.havePodsWithRequiredAntiAffinityNodeInfoList, nodeInfo)
+	}
+	for pvcKey := range framework.PodPVCKeys(pod) {
+		s.usedPVCRefCounts[pvcKey]--
+		if s.usedPVCRefCounts[pvcKey] <= 0 {
+			delete(s.usedPVCRefCounts, pvcKey)
+		}
+	}
+
+	if s.genericWorkloadEnabled && pod.Spec.SchedulingGroup != nil {
+		pgKey := newPodGroupKey(pod.Namespace, *pod.Spec.SchedulingGroup.PodGroupName)
+		if pgs, ok := s.podGroupStates[pgKey]; ok {
+			pgs.deletePod(pod.UID)
+		}
+	}
+
+	if len(nodeInfo.Pods) == 0 && nodeInfo.Node() == nil {
+		delete(s.nodeInfoMap, nodeName)
+	}
+	return nil
+}
+
+// removeNodeInfoFromList quickly removes a NodeInfo from a list without respecting the order of the list.
+func removeNodeInfoFromList(logger klog.Logger, list []fwk.NodeInfo, nodeInfoToRemove fwk.NodeInfo) []fwk.NodeInfo {
+	for i, nodeInfo := range list {
+		if nodeInfo == nodeInfoToRemove {
+			list[i] = list[len(list)-1]
+			list[len(list)-1] = nil
+			return list[:len(list)-1]
+		}
+	}
+	logger.Error(nil, "NodeInfo not found in the list", "nodeInfo", nodeInfoToRemove)
+	return list
 }

--- a/pkg/scheduler/backend/cache/snapshot_test.go
+++ b/pkg/scheduler/backend/cache/snapshot_test.go
@@ -20,18 +20,23 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	v1 "k8s.io/api/core/v1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
 	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 )
@@ -1113,7 +1118,7 @@ func TestSnapshot_Mutations(t *testing.T) {
 			s := NewSnapshot(tt.initialPods, tt.initialNodes)
 
 			// Store original state for deep verification
-			origNodeInfoMap, origNodeInfoList, origAffinityList, origAntiAffinityList, origUsedPVCRefCounts := simplifySnapshot(s)
+			origNodeInfoMap, origNodeInfoList, origAffinityList, origAntiAffinityList, origUsedPVCRefCounts, origPGStates := simplifySnapshot(s)
 
 			err := s.StartMutations()
 			if err != nil {
@@ -1126,34 +1131,38 @@ func TestSnapshot_Mutations(t *testing.T) {
 			}
 
 			// Get state after for verification
-			postRestoreNodeInfoMap, postRestoreNodeInfoList, postRestoreAffinityList, postRestoreAntiAffinityList, postRestoreUsedPVCRefCounts := simplifySnapshot(s)
+			postRestoreNodeInfoMap, postRestoreNodeInfoList, postRestoreAffinityList, postRestoreAntiAffinityList, postRestoreUsedPVCRefCounts, postRestorePGStates := simplifySnapshot(s)
 
-			if cmp.Diff(origNodeInfoMap, postRestoreNodeInfoMap) != "" {
-				t.Errorf("nodeInfoMap mismatch: want %v, got %v", origNodeInfoMap, postRestoreNodeInfoMap)
+			if diff := cmp.Diff(origNodeInfoMap, postRestoreNodeInfoMap); diff != "" {
+				t.Errorf("nodeInfoMap mismatch (-want +got):\n%s", diff)
 			}
-			if cmp.Diff(origNodeInfoList, postRestoreNodeInfoList) != "" {
-				t.Errorf("nodeInfoList mismatch: want %v, got %v", origNodeInfoList, postRestoreNodeInfoList)
+			if diff := cmp.Diff(origNodeInfoList, postRestoreNodeInfoList); diff != "" {
+				t.Errorf("nodeInfoList mismatch (-want +got):\n%s", diff)
 			}
-			if cmp.Diff(origAffinityList, postRestoreAffinityList) != "" {
-				t.Errorf("havePodsWithAffinityNodeInfoList mismatch: want %v, got %v", origAffinityList, postRestoreAffinityList)
+			if diff := cmp.Diff(origAffinityList, postRestoreAffinityList); diff != "" {
+				t.Errorf("havePodsWithAffinityNodeInfoList mismatch (-want +got):\n%s", diff)
 			}
-			if cmp.Diff(origAntiAffinityList, postRestoreAntiAffinityList) != "" {
-				t.Errorf("havePodsWithRequiredAntiAffinityNodeInfoList mismatch: want %v, got %v", origAntiAffinityList, postRestoreAntiAffinityList)
+			if diff := cmp.Diff(origAntiAffinityList, postRestoreAntiAffinityList); diff != "" {
+				t.Errorf("havePodsWithRequiredAntiAffinityNodeInfoList mismatch (-want +got):\n%s", diff)
 			}
-			if cmp.Diff(origUsedPVCRefCounts, postRestoreUsedPVCRefCounts) != "" {
-				t.Errorf("usedPVCRefCounts mismatch: want %v, got %v", origUsedPVCRefCounts, postRestoreUsedPVCRefCounts)
+			if diff := cmp.Diff(origUsedPVCRefCounts, postRestoreUsedPVCRefCounts); diff != "" {
+				t.Errorf("usedPVCRefCounts mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(origPGStates, postRestorePGStates); diff != "" {
+				t.Errorf("podGroupStates mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
 // simplifySnapshot for comparison in unit tests
-func simplifySnapshot(s *Snapshot) (map[string][]string, []string, []string, []string, map[string]int) {
+func simplifySnapshot(s *Snapshot) (map[string][]string, []string, []string, []string, map[string]int, map[string][]string) {
 	nodeInfoMap := make(map[string][]string)
 	var nodeInfoList []string
 	var affinityList []string
 	var antiAffinityList []string
 	usedPVCRefCounts := make(map[string]int)
+	pgStates := make(map[string][]string)
 	for _, nodeInfo := range s.nodeInfoMap {
 		for _, p := range nodeInfo.GetPods() {
 			nodeInfoMap[nodeInfo.Node().Name] = append(nodeInfoMap[nodeInfo.Node().Name], p.GetPod().Name)
@@ -1169,7 +1178,19 @@ func simplifySnapshot(s *Snapshot) (map[string][]string, []string, []string, []s
 		antiAffinityList = append(antiAffinityList, nodeInfo.Node().Name)
 	}
 	maps.Copy(usedPVCRefCounts, s.usedPVCRefCounts)
-	return nodeInfoMap, nodeInfoList, affinityList, antiAffinityList, usedPVCRefCounts
+
+	if s.genericWorkloadEnabled {
+		for key, pgs := range s.podGroupStates {
+			var podNames []string
+			for _, p := range pgs.ScheduledPods() {
+				podNames = append(podNames, p.Name)
+			}
+			sort.Strings(podNames)
+			pgStates[key.String()] = podNames
+		}
+	}
+
+	return nodeInfoMap, nodeInfoList, affinityList, antiAffinityList, usedPVCRefCounts, pgStates
 }
 
 func TestSnapshot_MultipleMutations(t *testing.T) {
@@ -1311,6 +1332,376 @@ func TestSnapshot_CreateUsedPVCRefCounts(t *testing.T) {
 			actual := createUsedPVCRefCounts(tt.nodeInfoMap)
 			if diff := cmp.Diff(actual, tt.expectedPVCRefCount); diff != "" {
 				t.Errorf("Unexpected pvcRefCount (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSnapshot_AddRemovePodWithoutMutations(t *testing.T) {
+	node := st.MakeNode().Name("node-1").Obj()
+	pod := st.MakePod().Name("p1").Node("node-1").Obj()
+	podInfo, _ := framework.NewPodInfo(pod)
+
+	tests := []struct {
+		name        string
+		podToAdd    *framework.PodInfo
+		podToRemove *v1.Pod
+	}{
+		{
+			name:     "AddPod without mutation session should fail",
+			podToAdd: podInfo,
+		},
+		{
+			name:        "RemovePod without mutation session should fail",
+			podToRemove: pod,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
+			s := NewSnapshot([]*v1.Pod{pod}, []*v1.Node{node})
+			var err error
+			if tt.podToAdd != nil {
+				err = s.AddPod(tt.podToAdd, tt.podToAdd.Pod.Spec.NodeName)
+			}
+			if tt.podToRemove != nil {
+				err = s.RemovePod(logger, tt.podToRemove, tt.podToRemove.Spec.NodeName)
+			}
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestSnapshot_AddRemovePod(t *testing.T) {
+	podWithAffinity := st.MakePod().Name("p-aff").Namespace("ns").UID("p-aff").PodAffinity("key", &metav1.LabelSelector{MatchLabels: map[string]string{"key": "value"}}, st.PodAffinityWithRequiredReq).Node("node-1").Obj()
+	podWithAntiAffinity := st.MakePod().Name("p-anti").Namespace("ns").UID("p-anti").PodAntiAffinity("key", &metav1.LabelSelector{MatchLabels: map[string]string{"key": "value"}}, st.PodAntiAffinityWithRequiredReq).Node("node-1").Obj()
+	podWithPVC := st.MakePod().Name("p-pvc").Namespace("ns").UID("p-pvc").PVC("pvc-1").Node("node-1").Obj()
+
+	type operation struct {
+		opType    string // "add" or "remove"
+		pod       *v1.Pod
+		nodeName  string // optional, defaults to pod.Spec.NodeName if empty
+		expectErr bool
+	}
+
+	tests := []struct {
+		name                  string
+		initialPods           []*v1.Pod
+		initialNodes          []*v1.Node
+		initialPodGroups      []*schedulingv1alpha3.PodGroup
+		operations            []operation
+		expectedAffinityNodes int
+		expectedAntiAffNodes  int
+		expectedPVCCount      map[string]int
+		expectedPodsOnNode    map[string][]string
+		expectedMissingNodes  []string
+		expectedPodGroups     map[string][]string
+	}{
+		{
+			name:                  "AddPod with affinity",
+			initialNodes:          []*v1.Node{st.MakeNode().Name("node-1").Obj()},
+			operations:            []operation{{opType: "add", pod: podWithAffinity}},
+			expectedAffinityNodes: 1,
+			expectedPodsOnNode:    map[string][]string{"node-1": {"p-aff"}},
+		},
+		{
+			name:                  "AddPod with anti-affinity",
+			initialNodes:          []*v1.Node{st.MakeNode().Name("node-1").Obj()},
+			operations:            []operation{{opType: "add", pod: podWithAntiAffinity}},
+			expectedAffinityNodes: 1,
+			expectedAntiAffNodes:  1,
+			expectedPodsOnNode:    map[string][]string{"node-1": {"p-anti"}},
+		},
+		{
+			name:               "AddPod with PVC updates usedPVCRefCounts",
+			initialNodes:       []*v1.Node{st.MakeNode().Name("node-1").Obj()},
+			operations:         []operation{{opType: "add", pod: podWithPVC}},
+			expectedPVCCount:   map[string]int{"ns/pvc-1": 1},
+			expectedPodsOnNode: map[string][]string{"node-1": {"p-pvc"}},
+		},
+		{
+			name:                  "RemovePod removes node from affinity list",
+			initialNodes:          []*v1.Node{st.MakeNode().Name("node-1").Obj()},
+			initialPods:           []*v1.Pod{podWithAffinity},
+			operations:            []operation{{opType: "remove", pod: podWithAffinity}},
+			expectedAffinityNodes: 0,
+			expectedPodsOnNode:    map[string][]string{"node-1": {}},
+		},
+		{
+			name:                  "RemovePod removes node from anti-affinity list",
+			initialNodes:          []*v1.Node{st.MakeNode().Name("node-1").Obj()},
+			initialPods:           []*v1.Pod{podWithAntiAffinity},
+			operations:            []operation{{opType: "remove", pod: podWithAntiAffinity}},
+			expectedAffinityNodes: 0,
+			expectedAntiAffNodes:  0,
+			expectedPodsOnNode:    map[string][]string{"node-1": {}},
+		},
+		{
+			name:               "RemovePod with PVC updates usedPVCRefCounts",
+			initialNodes:       []*v1.Node{st.MakeNode().Name("node-1").Obj()},
+			initialPods:        []*v1.Pod{podWithPVC},
+			operations:         []operation{{opType: "remove", pod: podWithPVC}},
+			expectedPVCCount:   map[string]int{},
+			expectedPodsOnNode: map[string][]string{"node-1": {}},
+		},
+		{
+			name: "Multiple nodes and pods",
+			initialNodes: []*v1.Node{
+				st.MakeNode().Name("node-1").Obj(),
+				st.MakeNode().Name("node-2").Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("p1").UID("p1").Node("node-1").Obj(),
+			},
+			operations: []operation{
+				{opType: "add", pod: st.MakePod().Name("p2").UID("p2").Node("node-2").Obj()},
+				{opType: "add", pod: podWithAffinity},
+				{opType: "remove", pod: st.MakePod().Name("p1").UID("p1").Node("node-1").Obj()},
+			},
+			expectedAffinityNodes: 1,
+			expectedPodsOnNode: map[string][]string{
+				"node-1": {"p-aff"},
+				"node-2": {"p2"},
+			},
+		},
+		{
+			name:         "AddPod, RemovePod, AddPod sequence",
+			initialNodes: []*v1.Node{st.MakeNode().Name("node-1").Obj()},
+			operations: []operation{
+				{opType: "add", pod: podWithAffinity},
+				{opType: "remove", pod: podWithAffinity},
+				{opType: "add", pod: podWithAffinity},
+			},
+			expectedAffinityNodes: 1,
+			expectedPodsOnNode:    map[string][]string{"node-1": {"p-aff"}},
+		},
+		{
+			name:         "Remove non-existent pod",
+			initialNodes: []*v1.Node{st.MakeNode().Name("node-1").Obj()},
+			initialPods:  []*v1.Pod{},
+			operations: []operation{
+				{opType: "remove", pod: podWithAffinity, expectErr: true},
+			},
+			expectedAffinityNodes: 0,
+			expectedPodsOnNode:    map[string][]string{"node-1": {}},
+		},
+		{
+			name:         "Remove pod from non-existent node",
+			initialNodes: []*v1.Node{st.MakeNode().Name("node-1").Obj()},
+			initialPods:  []*v1.Pod{},
+			operations: []operation{
+				{opType: "remove", pod: podWithAffinity, nodeName: "non-existent-node", expectErr: true},
+			},
+			expectedAffinityNodes: 0,
+			expectedPodsOnNode:    map[string][]string{"node-1": {}},
+		},
+		{
+			name:         "Node lifecycle: temp node created and deleted",
+			initialNodes: []*v1.Node{st.MakeNode().Name("real-node").Obj()},
+			initialPods:  []*v1.Pod{},
+			operations: []operation{
+				{opType: "add", pod: st.MakePod().Name("p-real").UID("uid-real").Node("real-node").Obj()},
+				{opType: "add", pod: st.MakePod().Name("p-temp").UID("uid-temp").Node("temp-node").Obj()},
+				{opType: "remove", pod: st.MakePod().Name("p-real").UID("uid-real").Node("real-node").Obj()},
+				{opType: "remove", pod: st.MakePod().Name("p-temp").UID("uid-temp").Node("temp-node").Obj()},
+			},
+			expectedPodsOnNode: map[string][]string{
+				"real-node": {},
+			},
+			expectedMissingNodes: []string{"temp-node"},
+		},
+		{
+			name:         "Partial removal of affinity pods",
+			initialNodes: []*v1.Node{st.MakeNode().Name("node-1").Obj()},
+			initialPods:  []*v1.Pod{},
+			operations: []operation{
+				{opType: "add", pod: st.MakePod().Name("p-aff-1").UID("uid-1").PodAffinity("key", &metav1.LabelSelector{MatchLabels: map[string]string{"key": "value"}}, st.PodAffinityWithRequiredReq).Node("node-1").Obj()},
+				{opType: "add", pod: st.MakePod().Name("p-aff-2").UID("uid-2").PodAffinity("key", &metav1.LabelSelector{MatchLabels: map[string]string{"key": "value"}}, st.PodAffinityWithRequiredReq).Node("node-1").Obj()},
+				{opType: "remove", pod: st.MakePod().Name("p-aff-1").UID("uid-1").PodAffinity("key", &metav1.LabelSelector{MatchLabels: map[string]string{"key": "value"}}, st.PodAffinityWithRequiredReq).Node("node-1").Obj()},
+			},
+			expectedAffinityNodes: 1,
+			expectedPodsOnNode:    map[string][]string{"node-1": {"p-aff-2"}},
+		},
+		{
+			name:         "Shared PVC reference counting",
+			initialNodes: []*v1.Node{st.MakeNode().Name("node-1").Obj(), st.MakeNode().Name("node-2").Obj()},
+			initialPods:  []*v1.Pod{},
+			operations: []operation{
+				{opType: "add", pod: st.MakePod().Name("p-pvc-1").UID("uid-1").Namespace("ns").PVC("shared-pvc").Node("node-1").Obj()},
+				{opType: "add", pod: st.MakePod().Name("p-pvc-2").UID("uid-2").Namespace("ns").PVC("shared-pvc").Node("node-2").Obj()},
+				{opType: "remove", pod: st.MakePod().Name("p-pvc-1").UID("uid-1").Namespace("ns").PVC("shared-pvc").Node("node-1").Obj()},
+			},
+			expectedPVCCount: map[string]int{"ns/shared-pvc": 1},
+		},
+		{
+			name: "Affinity list middle removal",
+			initialNodes: []*v1.Node{
+				st.MakeNode().Name("node-1").Obj(),
+				st.MakeNode().Name("node-2").Obj(),
+				st.MakeNode().Name("node-3").Obj(),
+			},
+			initialPods: []*v1.Pod{},
+			operations: []operation{
+				{opType: "add", pod: st.MakePod().Name("p-aff-1").UID("uid-1").PodAffinity("k", &metav1.LabelSelector{}, st.PodAffinityWithRequiredReq).Node("node-1").Obj()},
+				{opType: "add", pod: st.MakePod().Name("p-aff-2").UID("uid-2").PodAffinity("k", &metav1.LabelSelector{}, st.PodAffinityWithRequiredReq).Node("node-2").Obj()},
+				{opType: "add", pod: st.MakePod().Name("p-aff-3").UID("uid-3").PodAffinity("k", &metav1.LabelSelector{}, st.PodAffinityWithRequiredReq).Node("node-3").Obj()},
+				{opType: "remove", pod: st.MakePod().Name("p-aff-2").UID("uid-2").PodAffinity("k", &metav1.LabelSelector{}, st.PodAffinityWithRequiredReq).Node("node-2").Obj()},
+			},
+			expectedAffinityNodes: 2,
+			expectedPodsOnNode: map[string][]string{
+				"node-1": {"p-aff-1"},
+				"node-3": {"p-aff-3"},
+			},
+		},
+		{
+			name:             "PodGroup state updates",
+			initialNodes:     []*v1.Node{st.MakeNode().Name("node-1").Obj(), st.MakeNode().Name("node-2").Obj()},
+			initialPods:      []*v1.Pod{},
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{st.MakePodGroup().Name("pg1").Namespace("ns").Obj()},
+			operations: []operation{
+				{opType: "add", pod: st.MakePod().Name("p1").UID("uid-1").Namespace("ns").PodGroupName("pg1").Node("node-1").Obj()},
+				{opType: "add", pod: st.MakePod().Name("p2").UID("uid-2").Namespace("ns").PodGroupName("pg1").Node("node-2").Obj()},
+				{opType: "remove", pod: st.MakePod().Name("p1").UID("uid-1").Namespace("ns").PodGroupName("pg1").Node("node-1").Obj()},
+			},
+			expectedPodsOnNode: map[string][]string{
+				"node-2": {"p2"},
+			},
+			expectedPodGroups: map[string][]string{
+				"ns/pg1": {"p2"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
+			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+				features.GenericWorkload: true,
+			})
+			s := NewTestSnapshotWithPodGroups(tt.initialPods, tt.initialNodes, tt.initialPodGroups)
+
+			// Store original state for deep verification
+			origNodeInfoMap, origNodeInfoList, origAffinityList, origAntiAffinityList, origUsedPVCRefCounts, origPGStates := simplifySnapshot(s)
+
+			err := s.StartMutations()
+			if err != nil {
+				t.Fatalf("failed to start mutation: %v", err)
+			}
+
+			for _, op := range tt.operations {
+				nodeName := op.nodeName
+				if nodeName == "" {
+					nodeName = op.pod.Spec.NodeName
+				}
+				switch op.opType {
+				case "add":
+					podInfo, _ := framework.NewPodInfo(op.pod)
+					err := s.AddPod(podInfo, nodeName)
+					if op.expectErr {
+						if err == nil {
+							t.Fatalf("expected error adding pod, got nil")
+						}
+					} else if err != nil {
+						t.Fatalf("unexpected error adding pod: %v", err)
+					}
+				case "remove":
+					err := s.RemovePod(logger, op.pod, nodeName)
+					if op.expectErr {
+						if err == nil {
+							t.Fatalf("expected error removing pod, got nil")
+						}
+					} else if err != nil {
+						t.Fatalf("unexpected error removing pod: %v", err)
+					}
+				default:
+					t.Fatalf("unknown operation type %q", op.opType)
+				}
+			}
+
+			if tt.expectedMissingNodes != nil {
+				for _, nodeName := range tt.expectedMissingNodes {
+					_, err := s.Get(nodeName)
+					if err == nil {
+						t.Errorf("expected node %s to be missing, but it exists", nodeName)
+					}
+				}
+			}
+
+			// Verify state during mutation
+			affNodes, _ := s.HavePodsWithAffinityList()
+			if len(affNodes) != tt.expectedAffinityNodes {
+				t.Errorf("expected %d nodes with affinity, got %d", tt.expectedAffinityNodes, len(affNodes))
+			}
+
+			antiAffNodes, _ := s.HavePodsWithRequiredAntiAffinityList()
+			if len(antiAffNodes) != tt.expectedAntiAffNodes {
+				t.Errorf("expected %d nodes with anti-affinity, got %d", tt.expectedAntiAffNodes, len(antiAffNodes))
+			}
+
+			if tt.expectedPVCCount != nil {
+				if diff := cmp.Diff(tt.expectedPVCCount, s.usedPVCRefCounts); diff != "" {
+					t.Errorf("usedPVCRefCounts mismatch (-want +got):\n%s", diff)
+				}
+			}
+
+			if tt.expectedPodGroups != nil {
+				_, _, _, _, _, gotPGStates := simplifySnapshot(s)
+				if diff := cmp.Diff(tt.expectedPodGroups, gotPGStates); diff != "" {
+					t.Errorf("podGroupStates mismatch (-want +got):\n%s", diff)
+				}
+			}
+
+			// Verify visibility in Get()
+			if tt.expectedPodsOnNode != nil {
+				for nodeName, expectedPods := range tt.expectedPodsOnNode {
+					nodeInfo, err := s.Get(nodeName)
+					if err != nil {
+						t.Fatalf("unexpected error getting node %s: %v", nodeName, err)
+					}
+					podsOnNode := make([]string, 0, len(nodeInfo.GetPods()))
+					for _, p := range nodeInfo.GetPods() {
+						podsOnNode = append(podsOnNode, p.GetPod().Name)
+					}
+					if len(podsOnNode) == 0 {
+						podsOnNode = []string{}
+					}
+					if len(expectedPods) == 0 {
+						expectedPods = []string{}
+					}
+					if diff := cmp.Diff(expectedPods, podsOnNode); diff != "" {
+						t.Errorf("unexpected pods on node %s: (-want +got):\n%s", nodeName, diff)
+					}
+				}
+			}
+
+			err = s.EndMutations()
+			if err != nil {
+				t.Fatalf("failed to end mutation: %v", err)
+			}
+
+			// Verify state is reverted
+			postRestoreNodeInfoMap, postRestoreNodeInfoList, postRestoreAffinityList, postRestoreAntiAffinityList, postRestoreUsedPVCRefCounts, postRestorePGStates := simplifySnapshot(s)
+
+			if diff := cmp.Diff(origNodeInfoMap, postRestoreNodeInfoMap); diff != "" {
+				t.Errorf("nodeInfoMap mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(origNodeInfoList, postRestoreNodeInfoList); diff != "" {
+				t.Errorf("nodeInfoList mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(origAffinityList, postRestoreAffinityList); diff != "" {
+				t.Errorf("havePodsWithAffinityNodeInfoList mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(origAntiAffinityList, postRestoreAntiAffinityList); diff != "" {
+				t.Errorf("havePodsWithRequiredAntiAffinityNodeInfoList mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(origUsedPVCRefCounts, postRestoreUsedPVCRefCounts); diff != "" {
+				t.Errorf("usedPVCRefCounts mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(origPGStates, postRestorePGStates); diff != "" {
+				t.Errorf("podGroupStates mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -248,16 +248,6 @@ type Framework interface {
 	// RunPostBindPlugins runs the set of configured PostBind plugins.
 	RunPostBindPlugins(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string)
 
-	// RunReservePluginsReserve runs the Reserve method of the set of
-	// configured Reserve plugins. If any of these calls returns an error, it
-	// does not continue running the remaining ones and returns the error. In
-	// such case, pod will not be scheduled.
-	RunReservePluginsReserve(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *fwk.Status
-
-	// RunReservePluginsUnreserve runs the Unreserve method of the set of
-	// configured Reserve plugins.
-	RunReservePluginsUnreserve(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string)
-
 	// RunPermitPlugins runs the set of configured Permit plugins. If any of these
 	// plugins returns a status other than "Success" or "Wait", it does not continue
 	// running the remaining plugins and returns an error. Otherwise, if any of the

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -2437,8 +2437,9 @@ type fakePodActivator struct {
 func (f *fakePodActivator) Activate(logger klog.Logger, pods map[string]*v1.Pod) {}
 
 type mockProposedAssignment struct {
-	nodeName string
-	pod      *v1.Pod
+	nodeName   string
+	podInfo    fwk.PodInfo
+	cycleState fwk.CycleState
 }
 
 func (pa *mockProposedAssignment) GetNodeName() string {
@@ -2446,7 +2447,15 @@ func (pa *mockProposedAssignment) GetNodeName() string {
 }
 
 func (pa *mockProposedAssignment) GetPod() *v1.Pod {
-	return pa.pod
+	return pa.podInfo.GetPod()
+}
+
+func (pa *mockProposedAssignment) GetPodInfo() fwk.PodInfo {
+	return pa.podInfo
+}
+
+func (pa *mockProposedAssignment) GetCycleState() fwk.CycleState {
+	return pa.cycleState
 }
 
 func TestPreEnqueue(t *testing.T) {
@@ -2637,15 +2646,19 @@ func TestPreEnqueue(t *testing.T) {
 				var pgSchedulingFunc fwk.PodGroupSchedulingFunc = func(_ context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
 					nodeInfo, _ := f.SnapshotSharedLister().NodeInfos().Get("node1")
 					if len(nodeInfo.GetPods()) == 0 {
+						triggerPodInfo, _ := framework.NewPodInfo(tt.podToTriggerPreemption)
+						checkPodInfo, _ := framework.NewPodInfo(tt.podToCheck)
 						return &fwk.PodGroupAssignments{
 							ProposedAssignments: []fwk.ProposedAssignment{
 								&mockProposedAssignment{
-									nodeName: "node1",
-									pod:      tt.podToTriggerPreemption,
+									podInfo:    triggerPodInfo,
+									nodeName:   "node1",
+									cycleState: framework.NewCycleState(),
 								},
 								&mockProposedAssignment{
-									nodeName: "node1",
-									pod:      tt.podToCheck,
+									podInfo:    checkPodInfo,
+									nodeName:   "node1",
+									cycleState: framework.NewCycleState(),
 								},
 							},
 						}, fwk.NewStatus(fwk.Success)
@@ -2865,7 +2878,7 @@ func TestDefaultPreemption_PodGroupPostFilter_InvalidSnapshot(t *testing.T) {
 
 			preemptorPods := []*v1.Pod{st.MakePod().Name("p").UID("p").Priority(highPriority).Obj()}
 			mockSchedulingFunc := func(ctx context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
-				return nil, nil
+				return nil, fwk.NewStatus(fwk.Unschedulable)
 			}
 
 			pgInfo := &framework.PodGroupInfo{
@@ -2890,6 +2903,14 @@ type mockMutableSnapshotLister struct {
 	fwk.MutableSnapshotSharedLister
 	startMutationError error
 	endMutationError   error
+}
+
+func (m *mockMutableSnapshotLister) AddPod(podInfo fwk.PodInfo, nodeName string) error {
+	return nil
+}
+
+func (m *mockMutableSnapshotLister) RemovePod(logger klog.Logger, pod *v1.Pod, nodeName string) error {
+	return nil
 }
 
 func (m *mockMutableSnapshotLister) StartMutations() error {

--- a/pkg/scheduler/framework/plugins/noderesources/fit_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit_test.go
@@ -2333,16 +2333,24 @@ func testFitSignPod(tCtx ktesting.TContext) {
 }
 
 type podAssignment struct {
-	pod      *v1.Pod
+	podInfo  *framework.PodInfo
 	nodeName string
 }
 
 func (pa *podAssignment) GetPod() *v1.Pod {
-	return pa.pod
+	return pa.podInfo.GetPod()
 }
 
 func (pa *podAssignment) GetNodeName() string {
 	return pa.nodeName
+}
+
+func (pa *podAssignment) GetCycleState() fwk.CycleState {
+	return nil
+}
+
+func (pa *podAssignment) GetPodInfo() fwk.PodInfo {
+	return pa.podInfo
 }
 
 func TestScorePlacement_Resources(t *testing.T) {
@@ -2567,8 +2575,9 @@ func TestScorePlacement_Resources(t *testing.T) {
 			proposedAssignments := make([]fwk.ProposedAssignment, 0, len(tc.podGroupPods))
 			for _, pod := range tc.podGroupPods {
 				if nodeName, ok := tc.podGroupAssignments[pod.UID]; ok {
+					podInfo, _ := framework.NewPodInfo(pod)
 					proposedAssignments = append(proposedAssignments, &podAssignment{
-						pod:      pod,
+						podInfo:  podInfo,
 						nodeName: nodeName,
 					})
 				}

--- a/pkg/scheduler/framework/plugins/podgrouppodscount/podgroup_pods_count_test.go
+++ b/pkg/scheduler/framework/plugins/podgrouppodscount/podgroup_pods_count_test.go
@@ -43,7 +43,7 @@ func init() {
 
 type mockProposedAssignment struct {
 	nodeName string
-	pod      *v1.Pod
+	podInfo  *framework.PodInfo
 }
 
 var _ fwk.ProposedAssignment = &mockProposedAssignment{}
@@ -53,7 +53,15 @@ func (pa *mockProposedAssignment) GetNodeName() string {
 }
 
 func (pa *mockProposedAssignment) GetPod() *v1.Pod {
-	return pa.pod
+	return pa.podInfo.GetPod()
+}
+
+func (pa *mockProposedAssignment) GetPodInfo() fwk.PodInfo {
+	return pa.podInfo
+}
+
+func (pa *mockProposedAssignment) GetCycleState() fwk.CycleState {
+	return nil
 }
 
 func TestScorePlacement(t *testing.T) {
@@ -67,14 +75,16 @@ func TestScorePlacement(t *testing.T) {
 		return createPod(podName, podGroupName, "")
 	}
 
+	podInfo1, _ := framework.NewPodInfo(createPodWithoutNode("proposed-pod-1", podGroupName))
+	podInfo2, _ := framework.NewPodInfo(createPodWithoutNode("proposed-pod-2", podGroupName))
 	proposedAssignments := []fwk.ProposedAssignment{
 		&mockProposedAssignment{
 			nodeName: "node1",
-			pod:      createPodWithoutNode("proposed-pod-1", podGroupName),
+			podInfo:  podInfo1,
 		},
 		&mockProposedAssignment{
 			nodeName: "node2",
-			pod:      createPodWithoutNode("proposed-pod-2", podGroupName),
+			podInfo:  podInfo2,
 		},
 	}
 

--- a/pkg/scheduler/framework/preemption/podgrouppreemption.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption.go
@@ -18,6 +18,7 @@ package preemption
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -66,8 +67,11 @@ func NewPodGroupEvaluator(fh fwk.Handle, executor *Executor, enablePodGroupPreem
 // The preemption logic modifies the NodeInfo provided by a Handle
 // podGroupSchedulingFunc is a function that will be run to check feasibility of a pod group
 // scheduling after modifying the node state.
+// It is called only once, after all victims are removed from NodeInfos.
+// Then the logic tries to reprieve as many victims as possible with preemptor
+// pods assumed in their place.
 // The caller is expected to backup the NodeInfo before calling this function
-// And rollback the state to the backup after function is finished.
+// and rollback the state to the backup after function is finished.
 func (ev *PodGroupEvaluator) Preempt(ctx context.Context, pg *schedulingapi.PodGroup, pods []*v1.Pod, podGroupSchedulingFunc fwk.PodGroupSchedulingFunc) (*fwk.PodGroupPostFilterResult, *fwk.Status) {
 	// In case of workload-aware preemption, the domain is whole cluster.
 	// We do not make a snapshot of node info. Those nodes will be shared
@@ -112,30 +116,64 @@ func (ev *PodGroupEvaluator) selectVictimsOnDomain(
 		nameToNode[nodeInfo.Node().Name] = nodeInfo
 	}
 
+	mutableLister := ev.Handle.MutableSnapshotSharedLister()
+
 	// Ensure the preemptor is eligible to preempt other pods.
 	if ok, msg := ev.preemptorEligibleToPreemptOthers(ctx, preemptor, nameToNode); !ok {
 		logger.V(5).Info("Preemptor is not eligible for preemption", "preemptor", klog.KObj(preemptor.podGroup), "reason", msg)
 		return nil, fwk.NewStatus(fwk.Unschedulable, msg)
 	}
 
-	// Compared to the default preemption algorithm do not run the runPreFilterExtensionRemovePod
-	// or runPreFilterExtensionAddPod as pod group scheduling does prefilter anyway.
+	// removePods removes all victims from the snapshot.
+	// This is called before the podGroupSchedulingFunc so it does not have
+	// to update any cycle states as podGroupSchedulingFunc creates empty CycleStates
+	// and fills them by running PreFilter plugins for preemptor pods.
 	removePods := func(v *victim) error {
 		for _, pi := range v.Pods() {
-			nodeInfo := nameToNode[pi.GetPod().Spec.NodeName]
-			if err := nodeInfo.RemovePod(logger, pi.GetPod()); err != nil {
+			if err := mutableLister.RemovePod(logger, pi.GetPod(), pi.GetPod().Spec.NodeName); err != nil {
 				return err
 			}
 		}
-
 		return nil
 	}
-	addPods := func(v *victim) error {
+
+	// addVictimPodsWithPreFilter simulates adding back victim's pods to the snapshot
+	// and calls PreFilterExtensionAddPod() for all preemptor pods's proposed valid assignments.
+	// The node passed to the RunPreFilterExtensionAddPod will have the victim pod
+	// added.
+	addVictimPodsWithPreFilter := func(v *victim, preemptorAssignments []fwk.ProposedAssignment) error {
 		for _, pi := range v.Pods() {
 			nodeInfo := nameToNode[pi.GetPod().Spec.NodeName]
-			nodeInfo.AddPodInfo(pi)
+			if err := mutableLister.AddPod(pi, pi.GetPod().Spec.NodeName); err != nil {
+				return err
+			}
+			for _, assignment := range preemptorAssignments {
+				status := ev.Handle.RunPreFilterExtensionAddPod(ctx, assignment.GetCycleState(), assignment.GetPod(), pi, nodeInfo)
+				if !status.IsSuccess() {
+					return status.AsError()
+				}
+			}
 		}
+		return nil
+	}
 
+	// removeVictimPodsWithPreFilter removes all victims from the snapshot
+	// and calls PreFilterExtensionRemovePod(victim) for all preemptor pods.
+	// The node passed to the RunPreFilterExtensionRemovePod will have the victim pod
+	// removed.
+	removeVictimPodsWithPreFilter := func(v *victim, preemptorAssignments []fwk.ProposedAssignment) error {
+		for _, pi := range v.Pods() {
+			nodeInfo := nameToNode[pi.GetPod().Spec.NodeName]
+			if err := mutableLister.RemovePod(logger, pi.GetPod(), pi.GetPod().Spec.NodeName); err != nil {
+				return err
+			}
+			for _, assignment := range preemptorAssignments {
+				status := ev.Handle.RunPreFilterExtensionRemovePod(ctx, assignment.GetCycleState(), assignment.GetPod(), pi, nodeInfo)
+				if !status.IsSuccess() {
+					return status.AsError()
+				}
+			}
+		}
 		return nil
 	}
 
@@ -173,7 +211,6 @@ func (ev *PodGroupEvaluator) selectVictimsOnDomain(
 	if !status.IsSuccess() {
 		return nil, status
 	}
-	maxScheduledCount := len(podGroupAssignments.ProposedAssignments)
 
 	sort.Slice(potentialVictims, func(i, j int) bool {
 		return moreImportantVictim(potentialVictims[i], potentialVictims[j])
@@ -182,40 +219,66 @@ func (ev *PodGroupEvaluator) selectVictimsOnDomain(
 	violatingVictims, nonViolatingVictims := filterVictimsWithPDBViolation(potentialVictims, pdbs)
 	numViolatingVictim := 0
 
-	reprieveVictim := func(v *victim) (bool, *fwk.PodGroupAssignments, error) {
-		if err := addPods(v); err != nil {
-			return false, nil, err
+	validAssignment := make([]fwk.ProposedAssignment, 0, len(podGroupAssignments.ProposedAssignments))
+
+	// Prepare podInfos for each of the assigned preemptor pods
+	for _, assignment := range podGroupAssignments.ProposedAssignments {
+		if assignment.GetNodeName() != "" {
+			validAssignment = append(validAssignment, assignment)
 		}
+	}
 
-		assignments, status := podGroupSchedulingFunc(ctx)
-		fits := status.IsSuccess()
-		scheduledCount := 0
-		if assignments != nil {
-			scheduledCount = len(assignments.ProposedAssignments)
+	// reprieveVictim tries to reprieve a victim as a single unit.
+	// It adds all victim's pods back to snapshot and to CycleStates of preemptor pods
+	// It then goes through preemptor's proposed assignments and runs FilterPlugins for a given preemptor
+	// pod on proposed node.
+	// If all FilterPlugins succeed, it returns true.
+	// Preemptor pods are evaluated in the same order as in the scheduling cycle.
+	// This logic uses the CycleState returned for each of the preemptor pods from the
+	// scheduling algorithm called on a cluster without victims.
+	// This means that the CycleState for the Nth preemptor pod was created with:
+	// - all previous preemptor pods assumed and reserved
+	// - no knowledge of upcoming preemptor pods
+	reprieveVictim := func(v *victim, preemptorAssignments []fwk.ProposedAssignment) (fits bool, err error) {
+		if err = addVictimPodsWithPreFilter(v, preemptorAssignments); err != nil {
+			return false, err
 		}
-
-		// For a PodGroup using default scheduling algorithm it's possible to schedule more pods after reprieving.
-		// More in: https://github.com/kubernetes/kubernetes/pull/138757#discussion_r3199360621
-		maxScheduledCount = max(maxScheduledCount, scheduledCount)
-
-		// Do not reprieve the victim if it reduces the number of scheduled Pods for a PodGroup.
-		if scheduledCount < maxScheduledCount {
-			fits = false
-		}
-
-		if !fits {
-			if err := removePods(v); err != nil {
-				return false, nil, err
+		cleanupFns := []func() error{}
+		defer func() {
+			for i := len(cleanupFns) - 1; i >= 0; i-- {
+				if cleanupErr := cleanupFns[i](); cleanupErr != nil {
+					err = errors.Join(err, cleanupErr)
+				}
 			}
-			var names []string
-			for _, p := range v.Pods() {
-				names = append(names, p.GetPod().Name)
+		}()
+		fits = true
+		for _, assignment := range preemptorAssignments {
+			nodeInfo := nameToNode[assignment.GetNodeName()]
+			s := ev.Handle.RunFilterPluginsWithNominatedPods(ctx, assignment.GetCycleState(), assignment.GetPod(), nodeInfo)
+			if !s.IsSuccess() {
+				if err = removeVictimPodsWithPreFilter(v, preemptorAssignments); err != nil {
+					return false, err
+				}
+				if l := logger.V(6); l.Enabled() {
+					l.Info("Pods are potential preemption victims on domain", "pods", toPodNames(v.Pods()), "domain", domain.GetName())
+				}
+				return false, nil
 			}
-			pods := strings.Join(names, ",")
-			logger.V(6).Info("Pods are potential preemption victims on domain", "pods", pods, "domain", domain.GetName())
+			// Simulate assuming a preemptor pod and reserving stateful plugins resources.
+			// We do not need to add the preemptor pod to the cycle state of upcoming preemptor pods.
+			// This is because the cycle state was created with them already assumed.
+			if err = mutableLister.AddPod(assignment.GetPodInfo(), assignment.GetNodeName()); err != nil {
+				return false, err
+			}
+			ev.Handle.RunReservePluginsReserve(ctx, assignment.GetCycleState(), assignment.GetPod(), nodeInfo.Node().GetName())
+			cleanupFns = append(cleanupFns, func() error {
+				if ev.Handle.RunReservePluginsUnreserve(ctx, assignment.GetCycleState(), assignment.GetPod(), nodeInfo.Node().GetName()); err != nil {
+					return err
+				}
+				return mutableLister.RemovePod(logger, assignment.GetPod(), assignment.GetNodeName())
+			})
 		}
-
-		return fits, assignments, nil
+		return fits, nil
 	}
 
 	// Try to reprieve as many pods as possible. We first try to reprieve the PDB
@@ -223,22 +286,18 @@ func (ev *PodGroupEvaluator) selectVictimsOnDomain(
 	// from the highest importance victims.
 	var victimsToPreempt []*victim
 	for _, v := range violatingVictims {
-		if fits, assignments, err := reprieveVictim(v); err != nil {
+		if fits, err := reprieveVictim(v, validAssignment); err != nil {
 			return nil, fwk.AsStatus(err)
-		} else if fits {
-			podGroupAssignments = assignments
-		} else {
+		} else if !fits {
 			victimsToPreempt = append(victimsToPreempt, v)
 			numViolatingVictim++
 		}
 	}
 
 	for _, v := range nonViolatingVictims {
-		if fits, assignments, err := reprieveVictim(v); err != nil {
+		if fits, err := reprieveVictim(v, validAssignment); err != nil {
 			return nil, fwk.AsStatus(err)
-		} else if fits {
-			podGroupAssignments = assignments
-		} else {
+		} else if !fits {
 			victimsToPreempt = append(victimsToPreempt, v)
 		}
 	}
@@ -257,18 +316,24 @@ func (ev *PodGroupEvaluator) selectVictimsOnDomain(
 		Pods: podsToPreempt,
 	}
 	n := make(map[types.NamespacedName]*fwk.NominatingInfo)
-	for _, p := range podGroupAssignments.ProposedAssignments {
-		if p.GetNodeName() != "" {
-			pod := p.GetPod()
-			podKey := types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
-			n[podKey] = &fwk.NominatingInfo{
-				NominatingMode:    fwk.ModeOverride,
-				NominatedNodeName: p.GetNodeName(),
-			}
+	for _, p := range validAssignment {
+		pod := p.GetPod()
+		podKey := types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
+		n[podKey] = &fwk.NominatingInfo{
+			NominatingMode:    fwk.ModeOverride,
+			NominatedNodeName: p.GetNodeName(),
 		}
 	}
 
 	return &selectVictimsResult{nominatedNodeNames: n, victims: v}, nil
+}
+
+func toPodNames(pods []fwk.PodInfo) string {
+	names := make([]string, len(pods))
+	for i, p := range pods {
+		names[i] = p.GetPod().Namespace + "/" + p.GetPod().Name
+	}
+	return strings.Join(names, ",")
 }
 
 // isPreemptionAllowed returns whether the victim residing on nodeInfo can be preempted by the preemptor

--- a/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
@@ -19,6 +19,7 @@ package preemption
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -27,14 +28,71 @@ import (
 	policy "k8s.io/api/policy/v1"
 	schedulingapi "k8s.io/api/scheduling/v1alpha3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/informers"
+	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/klog/v2/ktesting"
 	fwk "k8s.io/kube-scheduler/framework"
+	internalcache "k8s.io/kubernetes/pkg/scheduler/backend/cache"
+	internalqueue "k8s.io/kubernetes/pkg/scheduler/backend/queue"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework/parallelize"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/queuesort"
+	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
+	tf "k8s.io/kubernetes/pkg/scheduler/testing/framework"
 	"k8s.io/kubernetes/pkg/scheduler/util"
 )
+
+type mockFilterPlugin struct {
+	nodeCapacities []nodeCapacity
+}
+
+func getCapacity(pod *v1.Pod) int {
+	if v, ok := pod.Labels["size"]; ok {
+		if i, err := strconv.Atoi(v); err == nil {
+			return i
+		}
+	}
+	return 1
+}
+
+// Filter check whether the pod fits into the node based on the capacity
+// Node capacity is taken from hard coded capacities in plugin
+// Pod size is taken from pod label "size". If the label is not present the
+// size defaults to 1.
+func (m *mockFilterPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
+	newPodCapacity := getCapacity(pod)
+	nodeCapacity := 0
+	for _, n := range m.nodeCapacities {
+		if n.nodeName == nodeInfo.Node().Name {
+			nodeCapacity = n.capacity
+			break
+		}
+	}
+	currentNodeSize := 0
+	for _, p := range nodeInfo.GetPods() {
+		currentNodeSize += getCapacity(p.GetPod())
+	}
+	if currentNodeSize+newPodCapacity > nodeCapacity {
+		return fwk.NewStatus(fwk.Unschedulable, "not enough capacity")
+	}
+	return fwk.NewStatus(fwk.Success)
+}
+
+func (m *mockFilterPlugin) Name() string {
+	return "mockFilterPlugin"
+}
+
+type nodeCapacity struct {
+	nodeName string
+	capacity int
+}
+
+var _ fwk.FilterPlugin = &mockFilterPlugin{}
 
 type mockPodGroupLister struct {
 	podGroups map[string]*schedulingapi.PodGroup
@@ -61,98 +119,106 @@ func makePodGroupPreemptorWithPreemptionPolicy(pg *schedulingapi.PodGroup, pods 
 }
 
 func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
-	// blockingRule mocks complex scheduling constraints for tests.
-	// It states: "Node 'nodeName' can host 'capacity' preempting pods,
-	// but ONLY IF the pods in 'blockingVictims' are removed first."
-	type blockingRule struct {
-		nodeName        string
-		capacity        int              // Available slots for preemptor once victims are removed.
-		blockingVictims sets.Set[string] // Pods on the node preventing capacity usage.
-	}
-
 	tests := []struct {
-		name                     string
-		nodeNames                []string
-		initPods                 []*v1.Pod
-		initPodGroups            []*schedulingapi.PodGroup
-		preemptor                *podGroupPreemptor
-		pdbs                     []*policy.PodDisruptionBudget
-		blockingRules            []blockingRule
-		customMockSchedulingFunc func(ctx context.Context, domainNodes []fwk.NodeInfo) (*fwk.PodGroupAssignments, *fwk.Status)
-		expectedPods             []string
-		expectedStatus           *fwk.Status
+		name            string
+		nodes           []*v1.Node
+		initPods        []*v1.Pod
+		initPodGroups   []*schedulingapi.PodGroup
+		preemptor       *podGroupPreemptor
+		pdbs            []*policy.PodDisruptionBudget
+		nodeCapacities  []nodeCapacity
+		expectedVictims []string
+		expectedStatus  *fwk.Status
 	}{
 		{
-			name:      "Mix of no-group and single-pod-groups",
-			nodeNames: []string{"node1", "node2", "node3"},
+			name: "Priority: mix of no groups and pod groups",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+			},
 			initPods: []*v1.Pod{
-				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
+				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Labels(map[string]string{"size": "1"}).Obj(),
+				st.MakePod().Name("p2").UID("v2").Node("node1").Priority(lowPriority).Labels(map[string]string{"size": "1"}).PodGroupName("pg1").Obj(),
+			},
+			initPodGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeSingle().Priority(lowPriority).Obj(),
+			},
+			preemptor: makePodGroupPreemptor(
+				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
+				[]*v1.Pod{st.MakePod().Name("p").UID("p").Priority(highPriority).Labels(map[string]string{"size": "1"}).Obj()},
+			),
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 2,
+				},
+			},
+			expectedVictims: []string{"p1"}, // p1 is less important than p2 because it's not part of a pod group
+			expectedStatus:  fwk.NewStatus(fwk.Success),
+		},
+		{
+			name: "Priority: StartTime of pods from same group with disruption mode single ",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+			},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).PodGroupName("pg1").StartTime(metav1.Unix(1, 0)).Obj(),
+				st.MakePod().Name("p2").UID("v2").Node("node1").Priority(lowPriority).PodGroupName("pg1").StartTime(metav1.Unix(0, 0)).Obj(),
+			},
+			initPodGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeSingle().Priority(lowPriority).Obj(),
+			},
+			preemptor: makePodGroupPreemptor(
+				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
+				[]*v1.Pod{st.MakePod().Name("p").UID("p").Priority(highPriority).Obj()},
+			),
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 2,
+				},
+			},
+			expectedVictims: []string{"p1"}, // p1 is less important than p2 because of later StartTime
+			expectedStatus:  fwk.NewStatus(fwk.Success),
+		},
+		{
+			name: "Pod group with disruption mode group not reprieved",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+			},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).PodGroupName("pg1").Obj(),
 				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).PodGroupName("pg1").Obj(),
-				st.MakePod().Name("p3").UID("v3").Node("node3").Priority(lowPriority).PodGroupName("pg2").Obj(),
 			},
 			initPodGroups: []*schedulingapi.PodGroup{
-				st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeSingle().Priority(lowPriority).Obj(),
-				st.MakePodGroup().Name("pg2").UID("pg2").DisruptionModeSingle().Priority(lowPriority).Obj(),
+				st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeAll().Priority(lowPriority).Obj(),
 			},
 			preemptor: makePodGroupPreemptor(
 				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
 				[]*v1.Pod{st.MakePod().Name("p").UID("p").Priority(highPriority).Obj()},
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
-				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("p2")},
-				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("p3")},
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 1,
+				},
+				{
+					nodeName: "node2",
+					capacity: 1,
+				},
 			},
-			expectedPods:   []string{"p1"}, // p1 is less important than p2 because it's not part of a pod group
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{"p1", "p2"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 		{
-			name:      "Priority: Shared group vs no group",
-			nodeNames: []string{"node1", "node2", "node3"},
-			initPods: []*v1.Pod{
-				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).PodGroupName("pg1").StartTime(metav1.Unix(1, 0)).Obj(),
-				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).PodGroupName("pg1").StartTime(metav1.Unix(0, 0)).Obj(),
-				st.MakePod().Name("p3").UID("v3").Node("node3").Priority(midPriority).Obj(),
+			name: "Complex Mixed: Shared, different, and no groups",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+				st.MakeNode().Name("node3").Obj(),
+				st.MakeNode().Name("node4").Obj(),
+				st.MakeNode().Name("node5").Obj(),
 			},
-			initPodGroups: []*schedulingapi.PodGroup{
-				st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeSingle().Priority(lowPriority).Obj(),
-			},
-			preemptor: makePodGroupPreemptor(
-				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
-				[]*v1.Pod{st.MakePod().Name("p").UID("p").Priority(highPriority).Obj()},
-			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
-				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("p2")},
-				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("p3")},
-			},
-			expectedPods:   []string{"p1"}, // p1 is less important than p2 because of later StartTime
-			expectedStatus: fwk.NewStatus(fwk.Success),
-		},
-		{
-			name:      "Shared Group: Preempt separately",
-			nodeNames: []string{"node1", "node2"},
-			initPods: []*v1.Pod{
-				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).PodGroupName("pg1").StartTime(metav1.Unix(1, 0)).Obj(),
-				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).PodGroupName("pg1").StartTime(metav1.Unix(0, 0)).Obj(),
-			},
-			initPodGroups: []*schedulingapi.PodGroup{
-				st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeSingle().Priority(lowPriority).Obj(),
-			},
-			preemptor: makePodGroupPreemptor(
-				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
-				[]*v1.Pod{st.MakePod().Name("p").UID("p").Priority(highPriority).Obj()},
-			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
-				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("p2")},
-			},
-			expectedPods:   []string{"p1"}, // p1 is less important than p2
-			expectedStatus: fwk.NewStatus(fwk.Success),
-		},
-		{
-			name:      "Complex Mixed: Shared, different, and no groups",
-			nodeNames: []string{"node1", "node2", "node3", "node4", "node5"},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).PodGroupName("pg1").StartTime(metav1.Unix(2, 0)).Obj(),
 				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).PodGroupName("pg1").StartTime(metav1.Unix(1, 0)).Obj(),
@@ -173,22 +239,39 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 					st.MakePod().Name("p-3").UID("p-3").Priority(highPriority).Obj(),
 				},
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
-				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("p2")},
-				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("p3")},
-				{nodeName: "node4", capacity: 1, blockingVictims: sets.New("p4")},
-				{nodeName: "node5", capacity: 1, blockingVictims: sets.New("p5")},
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 2,
+				},
+				{
+					nodeName: "node2",
+					capacity: 1,
+				},
+				{
+					nodeName: "node3",
+					capacity: 2,
+				},
+				{
+					nodeName: "node4",
+					capacity: 2,
+				},
+				{
+					nodeName: "node5",
+					capacity: 2,
+				},
 			},
-			expectedPods:   []string{"p1", "p2", "p3"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{"p2"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 		{
-			name:      "PDB: Mixed groups",
-			nodeNames: []string{"node1", "node2"},
+			name: "PDB: Mixed groups",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("victim-pdb").UID("v1").Node("node1").Label("app", "foo").Priority(lowPriority).PodGroupName("pg1").Obj(),
-				st.MakePod().Name("victim-no-pdb").UID("v2").Node("node2").Priority(lowPriority).PodGroupName("pg1").Obj(),
+				st.MakePod().Name("victim-no-pdb").UID("v2").Node("node1").Priority(lowPriority).PodGroupName("pg1").Obj(),
 			},
 			pdbs: []*policy.PodDisruptionBudget{
 				{
@@ -200,16 +283,22 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
 				[]*v1.Pod{st.MakePod().Name("p").UID("p").Priority(highPriority).Obj()},
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("victim-pdb")},
-				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("victim-no-pdb")},
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 2,
+				},
 			},
-			expectedPods:   []string{"victim-no-pdb"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{"victim-no-pdb"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 		{
-			name:      "PodGroup preemptor with PreemptLowerPriority preemption policy performs preemption",
-			nodeNames: []string{"node1", "node2", "node3"},
+			name: "PodGroup preemptor with PreemptLowerPriority preemption policy performs preemption",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+				st.MakeNode().Name("node3").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
 				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).PodGroupName("pg1").Obj(),
@@ -220,17 +309,21 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				[]*v1.Pod{st.MakePod().Name("p-1").UID("p-1").Priority(highPriority).Obj()},
 				schedulingapi.PreemptLowerPriority,
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
-				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("p2")},
-				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("p3")},
+			nodeCapacities: []nodeCapacity{
+				{nodeName: "node1", capacity: 1},
+				{nodeName: "node2", capacity: 1},
+				{nodeName: "node3", capacity: 1},
 			},
-			expectedPods:   []string{"p1"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{"p1"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 		{
-			name:      "PodGroup preemptor with PreemptLowerPriority preemption policy performs preemption, ignoring member pod preemption policy",
-			nodeNames: []string{"node1", "node2", "node3"},
+			name: "PodGroup preemptor with PreemptLowerPriority preemption policy performs preemption, ignoring member pod preemption policy",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+				st.MakeNode().Name("node3").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
 				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).PodGroupName("pg1").Obj(),
@@ -243,17 +336,21 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				},
 				schedulingapi.PreemptLowerPriority,
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
-				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("p2")},
-				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("p3")},
+			nodeCapacities: []nodeCapacity{
+				{nodeName: "node1", capacity: 1},
+				{nodeName: "node2", capacity: 1},
+				{nodeName: "node3", capacity: 1},
 			},
-			expectedPods:   []string{"p1"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{"p1"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 		{
-			name:      "PodGroup preemptor with PreemptNever policy does not perform preemption",
-			nodeNames: []string{"node1", "node2", "node3"},
+			name: "PodGroup preemptor with PreemptNever policy does not perform preemption",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+				st.MakeNode().Name("node3").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
 				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).PodGroupName("pg1").Obj(),
@@ -267,17 +364,28 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				},
 				schedulingapi.PreemptNever,
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
-				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("p2")},
-				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("p3")},
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 100,
+				},
+				{
+					nodeName: "node2",
+					capacity: 100,
+				},
+				{
+					nodeName: "node3",
+					capacity: 100,
+				},
 			},
-			expectedPods:   []string{},
-			expectedStatus: fwk.NewStatus(fwk.Unschedulable, "not eligible due to preemptionPolicy=Never."),
+			expectedVictims: []string{},
+			expectedStatus:  fwk.NewStatus(fwk.Unschedulable),
 		},
 		{
-			name:      "Preemptor group is not eligible if any member has nominated node with terminating pods",
-			nodeNames: []string{"node1"},
+			name: "Preemptor group is not eligible if any member has nominated node with terminating pods",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("victim").UID("v1").Node("node1").Priority(lowPriority).Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByScheduler).Terminating().Obj(),
 			},
@@ -288,13 +396,21 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 					st.MakePod().Name("p2").UID("p2").Priority(highPriority).NominatedNodeName("node1").Obj(),
 				},
 			),
-			blockingRules:  []blockingRule{},
-			expectedPods:   []string{},
-			expectedStatus: fwk.NewStatus(fwk.Unschedulable, "not eligible due to a terminating pod on the nominated node."),
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 100,
+				},
+			},
+			expectedVictims: []string{}, // no victims when preemptor is not eligible for preemption
+			expectedStatus:  fwk.NewStatus(fwk.Unschedulable, "not eligible due to a terminating pod on the nominated node."),
 		},
 		{
-			name:      "Preemptor group is eligible if terminating pods are on non-nominated nodes",
-			nodeNames: []string{"node1", "node2"},
+			name: "Preemptor group is eligible if terminating pods are on non-nominated nodes",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("victim").UID("v1").Node("node2").Priority(lowPriority).Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByScheduler).Terminating().Obj(),
 				st.MakePod().Name("other-victim").UID("v2").Node("node1").Priority(lowPriority).Obj(),
@@ -307,15 +423,24 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 					st.MakePod().Name("p2").UID("p2").Priority(highPriority).NominatedNodeName("node1").Obj(),
 				},
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", blockingVictims: sets.New("other-victim"), capacity: 1},
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 1,
+				},
+				{
+					nodeName: "node2",
+					capacity: 1,
+				},
 			},
-			expectedPods:   []string{"other-victim"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{"other-victim", "victim"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 		{
-			name:      "Preemptor group is not eligible if nominated node has terminating pod belonging to a pod group of lower priority",
-			nodeNames: []string{"node1"},
+			name: "Preemptor group is not eligible if nominated node has terminating pod belonging to a pod group of lower priority",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("victim").UID("v1").Node("node1").Priority(highPriority).PodGroupName("victim-pg").Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByScheduler).Terminating().Obj(),
 			},
@@ -329,13 +454,21 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 					st.MakePod().Name("p2").UID("p2").Priority(highPriority).NominatedNodeName("node1").Obj(),
 				},
 			),
-			blockingRules:  []blockingRule{},
-			expectedPods:   []string{},
-			expectedStatus: fwk.NewStatus(fwk.Unschedulable, "not eligible due to a terminating pod on the nominated node."),
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 100,
+				},
+			},
+			expectedVictims: []string{},
+			expectedStatus:  fwk.NewStatus(fwk.Unschedulable, "not eligible due to a terminating pod on the nominated node."),
 		},
 		{
-			name:      "Preemptor group is eligible if nominated node has terminating pod belonging to a pod group of higher priority",
-			nodeNames: []string{"node1"},
+			name: "Preemptor group is eligible if nominated node has terminating pod belonging to a pod group of higher priority",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("victim").UID("v1").Node("node1").Priority(lowPriority).PodGroupName("victim-pg").Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByScheduler).Terminating().Obj(),
 				st.MakePod().Name("other-victim").UID("v2").Node("node1").Priority(lowPriority).Obj(),
@@ -350,15 +483,24 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 					st.MakePod().Name("p2").UID("p2").Priority(midPriority).NominatedNodeName("node1").Obj(),
 				},
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", blockingVictims: sets.New("other-victim"), capacity: 1},
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 2,
+				},
+				{
+					nodeName: "node2",
+					capacity: 1,
+				},
 			},
-			expectedPods:   []string{"other-victim"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{"other-victim"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 		{
-			name:      "Preemptor group is not eligible if nominated node has terminating pod belonging to a pod group of lower priority with DisruptionModePod",
-			nodeNames: []string{"node1"},
+			name: "Preemptor group is not eligible if nominated node has terminating pod belonging to a pod group of lower priority with DisruptionModePod",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("victim").UID("v1").Node("node1").Priority(highPriority).PodGroupName("victim-pg").Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByScheduler).Terminating().Obj(),
 			},
@@ -372,13 +514,21 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 					st.MakePod().Name("p2").UID("p2").Priority(highPriority).NominatedNodeName("node1").Obj(),
 				},
 			),
-			blockingRules:  []blockingRule{},
-			expectedPods:   []string{},
-			expectedStatus: fwk.NewStatus(fwk.Unschedulable, "not eligible due to a terminating pod on the nominated node."),
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 100,
+				},
+			},
+			expectedVictims: []string{},
+			expectedStatus:  fwk.NewStatus(fwk.Unschedulable, "not eligible due to a terminating pod on the nominated node."),
 		},
 		{
-			name:      "Preemptor group is eligible if nominated node has terminating pod belonging to a pod group of higher priority with nil DisruptionMode",
-			nodeNames: []string{"node1"},
+			name: "Preemptor group is eligible if nominated node has terminating pod belonging to a pod group of higher priority with nil DisruptionMode",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("victim").UID("v1").Node("node1").Priority(lowPriority).PodGroupName("victim-pg").Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByScheduler).Terminating().Obj(),
 				st.MakePod().Name("other-victim").UID("v2").Node("node1").Priority(lowPriority).Obj(),
@@ -393,15 +543,24 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 					st.MakePod().Name("p2").UID("p2").Priority(midPriority).NominatedNodeName("node1").Obj(),
 				},
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", blockingVictims: sets.New("other-victim"), capacity: 1},
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 2,
+				},
+				{
+					nodeName: "node2",
+					capacity: 1,
+				},
 			},
-			expectedPods:   []string{"other-victim"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{"other-victim"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 		{
-			name:      "Preempt single lower priority pod",
-			nodeNames: []string{"node1"},
+			name: "Preempt single lower priority pod",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
 			},
@@ -409,15 +568,20 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
 				[]*v1.Pod{st.MakePod().Name("p").UID("p").Priority(highPriority).Obj()},
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", blockingVictims: sets.New("p1"), capacity: 1},
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 1,
+				},
 			},
-			expectedPods:   []string{"p1"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{"p1"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 		{
-			name:      "Priority: Prefer lower priority victim",
-			nodeNames: []string{"node1"},
+			name: "Priority: Prefer lower priority victim",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
 				st.MakePod().Name("p2").UID("v2").Node("node1").Priority(midPriority).Obj(),
@@ -427,17 +591,20 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
 				[]*v1.Pod{st.MakePod().Name("p").UID("p").Priority(highPriority).Obj()},
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", blockingVictims: sets.New("p1"), capacity: 1},
-				{nodeName: "node1", blockingVictims: sets.New("p2"), capacity: 1},
-				{nodeName: "node1", blockingVictims: sets.New("p3"), capacity: 1},
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 2,
+				},
 			},
-			expectedPods:   []string{"p1"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{"p1", "p2"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 		{
-			name:      "Efficiency: Preempt minimum number of victims",
-			nodeNames: []string{"node1"},
+			name: "Efficiency: Preempt minimum number of victims",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
 				st.MakePod().Name("p2").UID("v2").Node("node1").Priority(lowPriority).Obj(),
@@ -448,16 +615,20 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
 				[]*v1.Pod{st.MakePod().Name("p").UID("p").Priority(highPriority).Obj()},
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", blockingVictims: sets.New("p1", "p2"), capacity: 1},
-				{nodeName: "node1", blockingVictims: sets.New("p1"), capacity: 1},
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 3,
+				},
 			},
-			expectedPods:   []string{"p1"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{"p3", "p4"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 		{
-			name:      "PDB: Prefer non-violating victim",
-			nodeNames: []string{"node1"},
+			name: "PDB: Prefer non-violating victim",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("victim-pdb").UID("v1").Node("node1").Label("app", "foo").Priority(lowPriority).Obj(),
 				st.MakePod().Name("victim-no-pdb").UID("v2").Node("node1").Priority(lowPriority).Obj(),
@@ -472,16 +643,44 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
 				[]*v1.Pod{st.MakePod().Name("p").UID("p").Priority(highPriority).Obj()},
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", blockingVictims: sets.New("victim-pdb"), capacity: 1},
-				{nodeName: "node1", blockingVictims: sets.New("victim-no-pdb"), capacity: 1},
+			nodeCapacities: []nodeCapacity{
+				{nodeName: "node1", capacity: 2},
 			},
-			expectedPods:   []string{"victim-no-pdb"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{"victim-no-pdb"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 		{
-			name:      "PodGroup preemptor with PreemptLowerPriority preemption policy performs preemption with PodGroup victims",
-			nodeNames: []string{"node1", "node2", "node3"},
+			name: "PDB: Prefer removing non-violating victim over lower priority violating victim",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+			},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("victim-pdb").UID("v1").Node("node1").Label("app", "foo").Priority(lowPriority).Obj(),
+				st.MakePod().Name("victim-no-pdb").UID("v2").Node("node1").Priority(midPriority).Obj(),
+			},
+			pdbs: []*policy.PodDisruptionBudget{
+				{
+					Spec:   policy.PodDisruptionBudgetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}}},
+					Status: policy.PodDisruptionBudgetStatus{DisruptionsAllowed: 0},
+				},
+			},
+			preemptor: makePodGroupPreemptor(
+				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
+				[]*v1.Pod{st.MakePod().Name("p").UID("p").Priority(highPriority).Obj()},
+			),
+			nodeCapacities: []nodeCapacity{
+				{nodeName: "node1", capacity: 2},
+			},
+			expectedVictims: []string{"victim-no-pdb"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
+		},
+		{
+			name: "PodGroup preemptor with PreemptLowerPriority preemption policy performs preemption with PodGroup victims",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+				st.MakeNode().Name("node3").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
 				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).PodGroupName("pg1").Obj(),
@@ -491,6 +690,11 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeSingle().Priority(lowPriority).Obj(),
 				st.MakePodGroup().Name("pg2").UID("pg2").DisruptionModeSingle().Priority(lowPriority).Obj(),
 			},
+			nodeCapacities: []nodeCapacity{
+				{nodeName: "node1", capacity: 1},
+				{nodeName: "node2", capacity: 1},
+				{nodeName: "node3", capacity: 1},
+			},
 			preemptor: makePodGroupPreemptorWithPreemptionPolicy(
 				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
 				[]*v1.Pod{
@@ -498,17 +702,16 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				},
 				schedulingapi.PreemptLowerPriority,
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
-				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("p2")},
-				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("p3")},
-			},
-			expectedPods:   []string{"p1"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{"p1"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 		{
-			name:      "PodGroup preemptor with PreemptLowerPriority preemption policy performs preemption with PodGroup victims, ignoring member pod preemption policy",
-			nodeNames: []string{"node1", "node2", "node3"},
+			name: "PodGroup preemptor with PreemptLowerPriority preemption policy performs preemption with PodGroup victims, ignoring member pod preemption policy",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+				st.MakeNode().Name("node3").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
 				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).PodGroupName("pg1").Obj(),
@@ -525,17 +728,21 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				},
 				schedulingapi.PreemptLowerPriority,
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
-				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("p2")},
-				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("p3")},
+			nodeCapacities: []nodeCapacity{
+				{nodeName: "node1", capacity: 1},
+				{nodeName: "node2", capacity: 1},
+				{nodeName: "node3", capacity: 1},
 			},
-			expectedPods:   []string{"p1"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{"p1"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 		{
-			name:      "PodGroup preemptor with PreemptNever preemption policy does not perform preemption with PodGroup victims",
-			nodeNames: []string{"node1", "node2", "node3"},
+			name: "PodGroup preemptor with PreemptNever preemption policy does not perform preemption with PodGroup victims",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+				st.MakeNode().Name("node3").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
 				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).PodGroupName("pg1").Obj(),
@@ -553,17 +760,19 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				},
 				schedulingapi.PreemptNever,
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
-				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("p2")},
-				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("p3")},
+			nodeCapacities: []nodeCapacity{
+				{nodeName: "node1", capacity: 1},
+				{nodeName: "node2", capacity: 1},
+				{nodeName: "node3", capacity: 1},
 			},
-			expectedPods:   []string{},
-			expectedStatus: fwk.NewStatus(fwk.Unschedulable, "not eligible due to preemptionPolicy=Never."),
+			expectedVictims: []string{},
+			expectedStatus:  fwk.NewStatus(fwk.Unschedulable, "not eligible due to preemptionPolicy=Never."),
 		},
 		{
-			name:      "PDB: Prefer lower priority pod for preemption, when preemption without pdb violation is not possible",
-			nodeNames: []string{"node1"},
+			name: "PDB: Prefer lower priority pod for preemption, when preemption without pdb violation is not possible",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("p1").UID("v1").Node("node1").Label("app", "foo").Priority(lowPriority).Obj(),
 				st.MakePod().Name("p2").UID("v2").Node("node1").Label("app", "foo").Priority(midPriority).Obj(),
@@ -578,16 +787,21 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
 				[]*v1.Pod{st.MakePod().Name("p").UID("p").Priority(highPriority).Obj()},
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", blockingVictims: sets.New("p1"), capacity: 1},
-				{nodeName: "node1", blockingVictims: sets.New("p2"), capacity: 1},
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 2,
+				},
 			},
-			expectedPods:   []string{"p1"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{"p1"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 		{
-			name:      "PodGroup: Preempt group as a whole",
-			nodeNames: []string{"node1", "node2"},
+			name: "PodGroup: Preempt group as a whole",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).PodGroupName("pg1").Obj(),
 				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).PodGroupName("pg1").Obj(),
@@ -599,15 +813,25 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
 				[]*v1.Pod{st.MakePod().Name("p").UID("p").Priority(highPriority).Obj()},
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
+			// preemptor will be assigned to p1.
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 1,
+				},
+				{
+					nodeName: "node1",
+					capacity: 2,
+				},
 			},
-			expectedPods:   []string{"p1", "p2"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{"p1", "p2"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 		{
-			name:      "PodGroup: Prefer single pod over podGroup for preemption candidate",
-			nodeNames: []string{"node1"},
+			name: "PodGroup: Prefer single pod over podGroup for preemption candidate",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("p1").UID("p1").Node("node1").Priority(lowPriority).Obj(),
 				st.MakePod().Name("g1-1").UID("g1").Node("node1").PodGroupName("pg1").Priority(lowPriority).Obj(),
@@ -620,16 +844,21 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
 				[]*v1.Pod{st.MakePod().Name("p").UID("p").Priority(highPriority).Obj()},
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", blockingVictims: sets.New("g1-1", "g1-2"), capacity: 1},
-				{nodeName: "node1", blockingVictims: sets.New("p1"), capacity: 1},
+			// node 1 can fit preemptor + pg1 or preemptor + p1
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 3,
+				},
 			},
-			expectedPods:   []string{"p1"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{"p1"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 		{
-			name:      "PodGroup: Preempt group as a whole on single node",
-			nodeNames: []string{"node1"},
+			name: "PodGroup: Preempt group as a whole on single node",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("g1-1").UID("g1").Node("node1").PodGroupName("pg1").Priority(lowPriority).Obj(),
 				st.MakePod().Name("g1-2").UID("g2").Node("node1").PodGroupName("pg1").Priority(lowPriority).Obj(),
@@ -642,15 +871,21 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
 				[]*v1.Pod{st.MakePod().Name("p").UID("p").Priority(highPriority).Obj()},
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("g1-1")}, // Only g1-1 is blocking
+			// node 1 can fit preemptor + pg1 or preemptor + p1
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 3,
+				},
 			},
-			expectedPods:   []string{"g1-1", "g1-2"}, // Both must be preempted
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{"g1-1", "g1-2"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 		{
-			name:      "PDB: Unit violation if any member violates",
-			nodeNames: []string{"node1"},
+			name: "PDB: Unit violation if any member violates",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("g1-1").UID("g1").Node("node1").Label("app", "foo").PodGroupName("pg1").Priority(lowPriority).Obj(),
 				st.MakePod().Name("g1-2").UID("g2").Node("node1").PodGroupName("pg1").Priority(lowPriority).Obj(),
@@ -669,38 +904,21 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
 				[]*v1.Pod{st.MakePod().Name("p").UID("p").Priority(highPriority).Obj()},
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("g1-1")}, // Only g1-1 is blocking
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},   // p1 is also blocking
+			// node 1 can fit preemptor + pg1 or preemptor + p1
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 3,
+				},
 			},
-			expectedPods:   []string{"p1"}, // p1 is preferred because pg1 unit-violates PDB (via g1-1)
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{"p1"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 		{
-			name:      "PodGroup: Prefer preempting single pod over group of same priority",
-			nodeNames: []string{"node1"},
-			initPods: []*v1.Pod{
-				st.MakePod().Name("p1").UID("p1").Node("node1").Priority(lowPriority).Obj(),
-				st.MakePod().Name("g1-1").UID("g1").Node("node1").PodGroupName("pg1").Priority(lowPriority).Obj(),
-				st.MakePod().Name("g1-2").UID("g2").Node("node1").PodGroupName("pg1").Priority(lowPriority).Obj(),
+			name: "Failure: Cannot preempt the victim with higher priority",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
 			},
-			initPodGroups: []*schedulingapi.PodGroup{
-				st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeAll().Priority(lowPriority).Obj(),
-			},
-			preemptor: makePodGroupPreemptor(
-				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
-				[]*v1.Pod{st.MakePod().Name("p").UID("p").Priority(highPriority).Obj()},
-			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("g1-1", "g1-2")},
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
-			},
-			expectedPods:   []string{"p1"}, // p1 is preempted because the PodGroup is "more important" at the same priority level
-			expectedStatus: fwk.NewStatus(fwk.Success),
-		},
-		{
-			name:      "Failure: Cannot preempt the victim with higher priority",
-			nodeNames: []string{"node1"},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(highPriority).Obj(),
 			},
@@ -708,27 +926,63 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePodGroup().Name("preemptor-pg").Priority(midPriority).Obj(),
 				[]*v1.Pod{st.MakePod().Name("p").UID("p").Priority(midPriority).Obj()},
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", blockingVictims: sets.New("p1")},
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 100,
+				},
 			},
-			expectedPods:   []string{},
-			expectedStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable),
+			expectedVictims: []string{},
+			expectedStatus:  fwk.NewStatus(fwk.UnschedulableAndUnresolvable),
 		},
 		{
-			name:      "Failure: Cannot preempt if node is empty",
-			nodeNames: []string{"node1"},
-			initPods:  []*v1.Pod{},
+			name: "Failure: Cannot preempt the victim with equal priority",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+			},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(midPriority).Obj(),
+			},
 			preemptor: makePodGroupPreemptor(
 				st.MakePodGroup().Name("preemptor-pg").Priority(midPriority).Obj(),
 				[]*v1.Pod{st.MakePod().Name("p").UID("p").Priority(midPriority).Obj()},
 			),
-			blockingRules:  []blockingRule{},
-			expectedPods:   []string{},
-			expectedStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable),
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 100,
+				},
+			},
+			expectedVictims: []string{},
+			expectedStatus:  fwk.NewStatus(fwk.UnschedulableAndUnresolvable),
 		},
 		{
-			name:      "Priority divergence: candidate victim PodGroup has lower priority than the Pods from that group",
-			nodeNames: []string{"node1", "node2"},
+			name: "Failure: Cannot preempt if node is empty",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+			},
+			initPods: []*v1.Pod{},
+			preemptor: makePodGroupPreemptor(
+				st.MakePodGroup().Name("preemptor-pg").Priority(midPriority).Obj(),
+				[]*v1.Pod{st.MakePod().Name("p").UID("p").Priority(midPriority).Obj()},
+			),
+			// This test paths that aborts the preemption if there are no victims.
+			// even if there is enough space on nodes
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 100,
+				},
+			},
+			expectedVictims: []string{},
+			expectedStatus:  fwk.NewStatus(fwk.UnschedulableAndUnresolvable),
+		},
+		{
+			name: "Priority divergence: candidate victim PodGroup has lower priority than the Pods from that group",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(highPriority).PodGroupName("pg1").Obj(),
 				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(highPriority).PodGroupName("pg1").Obj(),
@@ -740,15 +994,25 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
 				[]*v1.Pod{st.MakePod().Name("p").UID("p").Priority(highPriority).Obj()},
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 1,
+				},
+				{
+					nodeName: "node2",
+					capacity: 1,
+				},
 			},
-			expectedPods:   []string{"p1", "p2"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{"p1", "p2"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 		{
-			name:      "Priority divergence: candidate victim PodGroup has higher priority than the Pods from that group",
-			nodeNames: []string{"node1", "node2"},
+			name: "Priority divergence: candidate victim PodGroup has higher priority than the Pods from that group",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).PodGroupName("pg1").Obj(),
 				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).PodGroupName("pg1").Obj(),
@@ -760,113 +1024,27 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePodGroup().Name("preemptor-pg").Priority(midPriority).Obj(),
 				[]*v1.Pod{st.MakePod().Name("p").UID("p").Priority(midPriority).Obj()},
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
-			},
-			expectedPods:   []string{},
-			expectedStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable),
-		},
-		{
-			name:      "Priority divergence: preemptor PodGroup has higher priority than the Pod from preemptor PodGroup",
-			nodeNames: []string{"node1", "node2"},
-			initPods: []*v1.Pod{
-				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(midPriority).PodGroupName("pg1").Obj(),
-				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(midPriority).PodGroupName("pg1").Obj(),
-			},
-			initPodGroups: []*schedulingapi.PodGroup{
-				st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeAll().Priority(midPriority).Obj(),
-			},
-			preemptor: makePodGroupPreemptor(
-				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
-				[]*v1.Pod{st.MakePod().Name("p").UID("p").Priority(lowPriority).Obj()},
-			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
-			},
-			expectedPods:   []string{"p1", "p2"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
-		},
-		{
-			name:      "Priority divergence: preemptor PodGroup has lower priority than the Pod from preemptor PodGroup",
-			nodeNames: []string{"node1", "node2"},
-			initPods: []*v1.Pod{
-				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(midPriority).PodGroupName("pg1").Obj(),
-				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(midPriority).PodGroupName("pg1").Obj(),
-			},
-			initPodGroups: []*schedulingapi.PodGroup{
-				st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeAll().Priority(midPriority).Obj(),
-			},
-			preemptor: makePodGroupPreemptor(
-				st.MakePodGroup().Name("preemptor-pg").Priority(lowPriority).Obj(),
-				[]*v1.Pod{st.MakePod().Name("p").UID("p").Priority(highPriority).Obj()},
-			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
-			},
-			expectedPods:   []string{},
-			expectedStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable),
-		},
-		{
-			name:      "Gang scheduling: do not reprieve if it reduces scheduled pods below max possible",
-			nodeNames: []string{"node1", "node2", "node3"},
-			initPods: []*v1.Pod{
-				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
-				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(midPriority).Obj(),
-				st.MakePod().Name("p3").UID("v3").Node("node3").Priority(midPriority).Obj(),
-			},
-			initPodGroups: []*schedulingapi.PodGroup{},
-			preemptor: makePodGroupPreemptor(
-				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).MinCount(2).Obj(),
-				[]*v1.Pod{
-					st.MakePod().Name("p-a").UID("p-a").Priority(highPriority).Obj(),
-					st.MakePod().Name("p-b").UID("p-b").Priority(highPriority).Obj(),
-					st.MakePod().Name("p-c").UID("p-c").Priority(highPriority).Obj(),
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 1,
 				},
-			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
-				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("p2")},
-				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("p3")},
-			},
-			// maxScheduledCount will be 3 (all 3 preemptor pods can be scheduled if p1, p2, p3 are preempted).
-			// If any of p1, p2, p3 are reprieved, scheduledCount drops to 2.
-			// Even though 2 >= MinCount(2), we shouldn't reprieve because it reduces scheduledCount < maxScheduledCount(3).
-			// So, all 3 should be preempted.
-			expectedPods:   []string{"p1", "p2", "p3"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
-		},
-		{
-			name:      "Gang scheduling: reprieve if it does not reduce scheduled pods below max possible",
-			nodeNames: []string{"node1", "node2", "node3", "node4"},
-			initPods: []*v1.Pod{
-				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
-				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).Obj(),
-				st.MakePod().Name("p3").UID("v3").Node("node3").Priority(lowPriority).Obj(),
-				st.MakePod().Name("p4").UID("v4").Node("node4").Priority(midPriority).Obj(),
-			},
-			initPodGroups: []*schedulingapi.PodGroup{},
-			preemptor: makePodGroupPreemptor(
-				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).MinCount(2).Obj(),
-				[]*v1.Pod{
-					st.MakePod().Name("p-a").UID("p-a").Priority(highPriority).Obj(),
-					st.MakePod().Name("p-b").UID("p-b").Priority(highPriority).Obj(),
-					st.MakePod().Name("p-c").UID("p-c").Priority(highPriority).Obj(),
+				{
+					nodeName: "node2",
+					capacity: 1,
 				},
-			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
-				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("p2")},
-				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("p3")},
-				{nodeName: "node4", capacity: 1, blockingVictims: sets.New("p4")},
 			},
-			// Preemptor has 3 pods and minCount of 2, so maxScheduledCount will be 3.
-			// Pod p4 with highest priority of all victims could be reprieved and we will still be able to schedule all of pods.
-			expectedPods:   []string{"p1", "p2", "p3"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{},
+			expectedStatus:  fwk.NewStatus(fwk.UnschedulableAndUnresolvable),
 		},
 		{
-			name:      "Gang scheduling: schedule as many pods as possible without preempting higher priority pods, but still more than minCount",
-			nodeNames: []string{"node1", "node2", "node3", "node4"},
+			name: "Gang scheduling: schedule as many pods as possible without preempting higher priority pods, but still more than minCount",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+				st.MakeNode().Name("node3").Obj(),
+				st.MakeNode().Name("node4").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
 				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).Obj(),
@@ -882,19 +1060,35 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 					st.MakePod().Name("p-c").UID("p-c").Priority(highPriority).Obj(),
 				},
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
-				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("p2")},
-				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("p3")},
-				{nodeName: "node4", capacity: 1, blockingVictims: sets.New("p4")},
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 1,
+				},
+				{
+					nodeName: "node2",
+					capacity: 1,
+				},
+				{
+					nodeName: "node3",
+					capacity: 1,
+				},
+				{
+					nodeName: "node4",
+					capacity: 1,
+				},
 			},
 			// Preemptor has 3 pods and minCount of 1, but maxScheduledCount will be 2, because there are higher priority pods p3, p4.
-			expectedPods:   []string{"p1", "p2"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{"p1", "p2"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 		{
-			name:      "Gang scheduling: do not reprieve victim pod group of lower priority",
-			nodeNames: []string{"node1", "node2", "node3"},
+			name: "Gang scheduling: do not reprieve victim pod group of lower priority",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+				st.MakeNode().Name("node3").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("v1").UID("v1").Node("node1").Namespace(v1.NamespaceDefault).PodGroupName("victim-pg").Priority(midPriority).Obj(),
 				st.MakePod().Name("v2").UID("v2").Node("node2").Namespace(v1.NamespaceDefault).PodGroupName("victim-pg").Priority(midPriority).Obj(),
@@ -911,17 +1105,31 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 					st.MakePod().Name("p-c").UID("p-c").Priority(highPriority).Obj(),
 				},
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("v1")},
-				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("v2")},
-				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("v3")},
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 1,
+				},
+				{
+					nodeName: "node2",
+					capacity: 1,
+				},
+				{
+					nodeName: "node3",
+					capacity: 1,
+				},
 			},
-			expectedPods:   []string{"v1", "v2", "v3"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{"v1", "v2", "v3"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 		{
-			name:      "Gang scheduling: preempt a pod group victim but do not schedule full pod group",
-			nodeNames: []string{"node1", "node2", "node3", "node4"},
+			name: "Gang scheduling: preempt a pod group victim but do not schedule full pod group",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+				st.MakeNode().Name("node3").Obj(),
+				st.MakeNode().Name("node4").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("v1").UID("v1").Node("node1").Namespace(v1.NamespaceDefault).PodGroupName("victim-pg").Priority(midPriority).Obj(),
 				st.MakePod().Name("v2").UID("v2").Node("node2").Namespace(v1.NamespaceDefault).PodGroupName("victim-pg").Priority(midPriority).Obj(),
@@ -940,70 +1148,35 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 					st.MakePod().Name("p-c").UID("p-c").Priority(highPriority).Obj(),
 				},
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("v1")},
-				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("v2")},
-				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("v3")},
-				{nodeName: "node4", capacity: 1, blockingVictims: sets.New("v4")},
-			},
-			expectedPods:   []string{"v1", "v2"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
-		},
-		{
-			name:      "Basic scheduling: do not reprieve if it reduces scheduled pods below max possible",
-			nodeNames: []string{"node1", "node2", "node3"},
-			initPods: []*v1.Pod{
-				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
-				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(midPriority).Obj(),
-				st.MakePod().Name("p3").UID("v3").Node("node3").Priority(midPriority).Obj(),
-			},
-			initPodGroups: []*schedulingapi.PodGroup{},
-			preemptor: makePodGroupPreemptor(
-				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).BasicPolicy().Obj(),
-				[]*v1.Pod{
-					st.MakePod().Name("p-a").UID("p-a").Priority(highPriority).Obj(),
-					st.MakePod().Name("p-b").UID("p-b").Priority(highPriority).Obj(),
-					st.MakePod().Name("p-c").UID("p-c").Priority(highPriority).Obj(),
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 1,
 				},
-			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
-				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("p2")},
-				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("p3")},
-			},
-			expectedPods:   []string{"p1", "p2", "p3"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
-		},
-		{
-			name:      "Basic scheduling: reprieve if it does not reduce scheduled pods below max possible",
-			nodeNames: []string{"node1", "node2", "node3", "node4"},
-			initPods: []*v1.Pod{
-				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
-				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).Obj(),
-				st.MakePod().Name("p3").UID("v3").Node("node3").Priority(lowPriority).Obj(),
-				st.MakePod().Name("p4").UID("v4").Node("node4").Priority(midPriority).Obj(),
-			},
-			initPodGroups: []*schedulingapi.PodGroup{},
-			preemptor: makePodGroupPreemptor(
-				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).BasicPolicy().Obj(),
-				[]*v1.Pod{
-					st.MakePod().Name("p-a").UID("p-a").Priority(highPriority).Obj(),
-					st.MakePod().Name("p-b").UID("p-b").Priority(highPriority).Obj(),
-					st.MakePod().Name("p-c").UID("p-c").Priority(highPriority).Obj(),
+				{
+					nodeName: "node2",
+					capacity: 1,
 				},
-			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
-				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("p2")},
-				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("p3")},
-				{nodeName: "node4", capacity: 1, blockingVictims: sets.New("p4")},
+				{
+					nodeName: "node3",
+					capacity: 1,
+				},
+				{
+					nodeName: "node4",
+					capacity: 1,
+				},
 			},
-			expectedPods:   []string{"p1", "p2", "p3"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{"v1", "v2"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 		{
-			name:      "Basic scheduling: schedule as many pods as possible without preempting higher priority pods",
-			nodeNames: []string{"node1", "node2", "node3", "node4"},
+			name: "Basic scheduling: schedule as many pods as possible without preempting higher priority pods",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+				st.MakeNode().Name("node3").Obj(),
+				st.MakeNode().Name("node4").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
 				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).Obj(),
@@ -1019,110 +1192,34 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 					st.MakePod().Name("p-c").UID("p-c").Priority(highPriority).Obj(),
 				},
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
-				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("p2")},
-				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("p3")},
-				{nodeName: "node4", capacity: 1, blockingVictims: sets.New("p4")},
-			},
-			expectedPods:   []string{"p1", "p2"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
-		},
-		{
-			name:      "Reprieval allows more pods to schedule than initial maxScheduledCount due to greedy placement",
-			nodeNames: []string{"nodeA", "nodeB"},
-			initPods: []*v1.Pod{
-				st.MakePod().Name("v1").UID("v1").Node("nodeA").Priority(midPriority).Obj(),
-				st.MakePod().Name("v2").UID("v2").Node("nodeB").Priority(lowPriority).Obj(),
-			},
-			initPodGroups: []*schedulingapi.PodGroup{},
-			preemptor: makePodGroupPreemptor(
-				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).BasicPolicy().Obj(),
-				[]*v1.Pod{
-					st.MakePod().Name("p1").UID("p1").Priority(highPriority).Obj(),
-					st.MakePod().Name("p2").UID("p2").Priority(highPriority).Obj(),
-					st.MakePod().Name("p3").UID("p3").Priority(highPriority).Obj(),
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 1,
 				},
-			),
-			customMockSchedulingFunc: func(ctx context.Context, domainNodes []fwk.NodeInfo) (*fwk.PodGroupAssignments, *fwk.Status) {
-				v1Present, v2Present := false, false
-				for _, n := range domainNodes {
-					for _, pod := range n.GetPods() {
-						if pod.GetPod().Name == "v1" {
-							v1Present = true
-						} else if pod.GetPod().Name == "v2" {
-							v2Present = true
-						}
-					}
-				}
-
-				scheduledCount := 2
-				if v1Present && !v2Present {
-					scheduledCount = 3 // v1 reprieved: this increases scheduledCount!
-				}
-
-				proposedAssignments := make([]fwk.ProposedAssignment, scheduledCount)
-				for i := range scheduledCount {
-					pod := st.MakePod().Name(fmt.Sprintf("p%d", i+1)).UID(fmt.Sprintf("p%d", i+1)).Obj()
-					proposedAssignments[i] = &testProposedAssignment{pod: pod, nodeName: "node1"}
-				}
-				return &fwk.PodGroupAssignments{
-					ProposedAssignments: proposedAssignments,
-				}, fwk.NewStatus(fwk.Success)
-			},
-			expectedPods:   []string{"v2"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
-		},
-		{
-			name:      "Reprieval allows more pods to schedule than initial maxScheduledCount due to greedy placement (gang > minCount)",
-			nodeNames: []string{"nodeA", "nodeB"},
-			initPods: []*v1.Pod{
-				st.MakePod().Name("v1").UID("v1").Node("nodeA").Priority(midPriority).Obj(),
-				st.MakePod().Name("v2").UID("v2").Node("nodeB").Priority(lowPriority).Obj(),
-			},
-			initPodGroups: []*schedulingapi.PodGroup{},
-			preemptor: makePodGroupPreemptor(
-				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).MinCount(3).Obj(),
-				[]*v1.Pod{
-					st.MakePod().Name("p1").UID("p1").Priority(highPriority).Obj(),
-					st.MakePod().Name("p2").UID("p2").Priority(highPriority).Obj(),
-					st.MakePod().Name("p3").UID("p3").Priority(highPriority).Obj(),
-					st.MakePod().Name("p4").UID("p4").Priority(highPriority).Obj(),
+				{
+					nodeName: "node2",
+					capacity: 1,
 				},
-			),
-			customMockSchedulingFunc: func(ctx context.Context, domainNodes []fwk.NodeInfo) (*fwk.PodGroupAssignments, *fwk.Status) {
-				v1Present, v2Present := false, false
-				for _, n := range domainNodes {
-					for _, pod := range n.GetPods() {
-						if pod.GetPod().Name == "v1" {
-							v1Present = true
-						} else if pod.GetPod().Name == "v2" {
-							v2Present = true
-						}
-					}
-				}
-
-				scheduledCount := 3
-				if v1Present && !v2Present {
-					scheduledCount = 4 // v1 reprieved: this increases scheduledCount!
-				}
-
-				proposedAssignments := make([]fwk.ProposedAssignment, scheduledCount)
-				for i := range scheduledCount {
-					pod := st.MakePod().Name(fmt.Sprintf("p%d", i+1)).UID(fmt.Sprintf("p%d", i+1)).Obj()
-					proposedAssignments[i] = &testProposedAssignment{pod: pod, nodeName: "node1"}
-				}
-
-				return &fwk.PodGroupAssignments{
-					ProposedAssignments: proposedAssignments,
-				}, fwk.NewStatus(fwk.Success)
+				{
+					nodeName: "node3",
+					capacity: 1,
+				},
+				{
+					nodeName: "node4",
+					capacity: 1,
+				},
 			},
-			expectedPods:   []string{"v2"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{"p1", "p2"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 		{
-			name:      "Basic scheduling: do not reprieve victim pod group of lower priority",
-			nodeNames: []string{"node1", "node2", "node3"},
+			name: "Basic scheduling: do not reprieve victim pod group of lower priority",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+				st.MakeNode().Name("node3").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("v1").UID("v1").Node("node1").Namespace(v1.NamespaceDefault).PodGroupName("victim-pg").Priority(midPriority).Obj(),
 				st.MakePod().Name("v2").UID("v2").Node("node2").Namespace(v1.NamespaceDefault).PodGroupName("victim-pg").Priority(midPriority).Obj(),
@@ -1139,17 +1236,31 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 					st.MakePod().Name("p-c").UID("p-c").Priority(highPriority).Obj(),
 				},
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("v1")},
-				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("v2")},
-				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("v3")},
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 1,
+				},
+				{
+					nodeName: "node2",
+					capacity: 1,
+				},
+				{
+					nodeName: "node3",
+					capacity: 1,
+				},
 			},
-			expectedPods:   []string{"v1", "v2", "v3"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{"v1", "v2", "v3"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 		{
-			name:      "Basic scheduling: preempt a pod group victim but do not schedule full pod group",
-			nodeNames: []string{"node1", "node2", "node3", "node4"},
+			name: "Basic scheduling: preempt a pod group victim but do not schedule full pod group",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+				st.MakeNode().Name("node3").Obj(),
+				st.MakeNode().Name("node4").Obj(),
+			},
 			initPods: []*v1.Pod{
 				st.MakePod().Name("v1").UID("v1").Node("node1").Namespace(v1.NamespaceDefault).PodGroupName("victim-pg").Priority(midPriority).Obj(),
 				st.MakePod().Name("v2").UID("v2").Node("node2").Namespace(v1.NamespaceDefault).PodGroupName("victim-pg").Priority(midPriority).Obj(),
@@ -1168,39 +1279,125 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 					st.MakePod().Name("p-c").UID("p-c").Priority(highPriority).Obj(),
 				},
 			),
-			blockingRules: []blockingRule{
-				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("v1")},
-				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("v2")},
-				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("v3")},
-				{nodeName: "node4", capacity: 1, blockingVictims: sets.New("v4")},
+			nodeCapacities: []nodeCapacity{
+				{
+					nodeName: "node1",
+					capacity: 1,
+				},
+				{
+					nodeName: "node2",
+					capacity: 1,
+				},
+				{
+					nodeName: "node3",
+					capacity: 1,
+				},
+				{
+					nodeName: "node4",
+					capacity: 1,
+				},
 			},
-			expectedPods:   []string{"v1", "v2"},
-			expectedStatus: fwk.NewStatus(fwk.Success),
+			expectedVictims: []string{"v1", "v2"},
+			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
-			nodes := make([]*v1.Node, len(tt.nodeNames))
-			for i, nodeName := range tt.nodeNames {
-				nodes[i] = st.MakeNode().Name(nodeName).Obj()
+			logger, ctx := ktesting.NewTestContext(t)
+
+			mockFilterFactory := func(ctx context.Context, _ runtime.Object, fh fwk.Handle) (fwk.Plugin, error) {
+				return &mockFilterPlugin{
+					nodeCapacities: tt.nodeCapacities,
+				}, nil
 			}
 
-			// Build nodes with pods
-			nodeInfos := make(map[string]fwk.NodeInfo)
-			for _, node := range nodes {
-				nodeInfos[node.Name] = framework.NewNodeInfo()
-				nodeInfos[node.Name].SetNode(node)
+			registeredPlugins := append([]tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterPluginAsExtensions("mockFilterPlugin", mockFilterFactory, "Filter")},
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+			)
+			var objs []runtime.Object
+			for _, p := range append(tt.initPods, tt.preemptor.pods...) {
+				objs = append(objs, p)
 			}
-			for _, p := range tt.initPods {
-				podInfo, _ := framework.NewPodInfo(p)
-				nodeInfos[p.Spec.NodeName].AddPodInfo(podInfo)
+			for _, n := range tt.nodes {
+				objs = append(objs, n)
+			}
+			informerFactory := informers.NewSharedInformerFactory(clientsetfake.NewClientset(objs...), 0)
+			parallelism := parallelize.DefaultParallelism
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			snapshot := internalcache.NewSnapshot(tt.initPods, tt.nodes)
+			f, err := tf.NewFramework(
+				ctx,
+				registeredPlugins, "",
+				frameworkruntime.WithPodNominator(internalqueue.NewSchedulingQueue(nil, informerFactory)),
+				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithParallelism(parallelism),
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithMutableSnapshotLister(snapshot),
+				frameworkruntime.WithLogger(logger),
+			)
+			if err != nil {
+				t.Fatal(err)
 			}
 
-			var domainNodes []fwk.NodeInfo
-			for _, name := range tt.nodeNames {
-				domainNodes = append(domainNodes, nodeInfos[name])
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
+
+			// mockSchedulingFunc is used to simulate the scheduling of the preemptor pod group.
+			// For each of the Pod it goes through each node and if there is enough capacity it assigns the pod to the node.
+			// After assigning a pod, the next pod starts from the next node (round-robin).
+			// If the number of assigned pods is less than the minCount, it returns Unschedulable
+			// Node capacities are taken from the nodeCapacities slice.
+			// Pod sizes are taken from the "size" label on a pod, defaulting to 1 if the label is not set.
+			var mockSchedulingFunc fwk.PodGroupSchedulingFunc = func(ctx context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
+				minCount := 1
+				if tt.preemptor.podGroup != nil {
+					if tt.preemptor.podGroup.Spec.SchedulingPolicy.Gang != nil {
+						minCount = int(tt.preemptor.podGroup.Spec.SchedulingPolicy.Gang.MinCount)
+					}
+				}
+
+				nodeMap := make(map[string]fwk.NodeInfo)
+				assignedSizes := make(map[string]int)
+				currentNodes, _ := f.SnapshotSharedLister().NodeInfos().List()
+				for _, n := range currentNodes {
+					nodeMap[n.Node().Name] = n
+					nodeSize := 0
+					for _, existingPod := range n.GetPods() {
+						nodeSize += getCapacity(existingPod.GetPod())
+					}
+					assignedSizes[n.Node().Name] = nodeSize
+				}
+				assignments := make([]fwk.ProposedAssignment, 0)
+
+				nodeIdx := 0
+				numNodes := len(tt.nodes)
+				for _, p := range tt.preemptor.Members() {
+					pSize := getCapacity(p)
+					for step := range numNodes {
+						i := (nodeIdx + step) % numNodes
+						n := tt.nodes[i]
+						nodeCapacity := tt.nodeCapacities[i].capacity
+						nodeSize := assignedSizes[n.GetName()]
+						if nodeSize+pSize <= nodeCapacity {
+							assignments = append(assignments, &mockProposedAssignment{
+								pod:        p,
+								nodeName:   n.GetName(),
+								cycleState: framework.NewCycleState(),
+							})
+							assignedSizes[n.GetName()] += pSize
+							nodeIdx = (i + 1) % numNodes
+							break
+						}
+					}
+				}
+				if len(assignments) >= minCount {
+					return &fwk.PodGroupAssignments{ProposedAssignments: assignments}, fwk.NewStatus(fwk.Success)
+				}
+				return nil, fwk.NewStatus(fwk.Unschedulable)
 			}
 
 			podGroups := make(map[string]*schedulingapi.PodGroup)
@@ -1208,73 +1405,22 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				podGroups[pg.Name] = pg
 			}
 			pgLister := &mockPodGroupLister{podGroups: podGroups}
-			domain := newDomainForWorkloadPreemption(domainNodes, pgLister, "test-domain")
-
-			// Create a mock podGroupSchedulingFunc.
-			// This simulates whether the preempting PodGroup can schedule given the current
-			// hypothetical state of the cluster (where some candidate victims might be removed).
-			var mockSchedulingFunc fwk.PodGroupSchedulingFunc = func(ctx context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
-				if tt.customMockSchedulingFunc != nil {
-					return tt.customMockSchedulingFunc(ctx, domainNodes)
-				}
-				neededSlots := len(tt.preemptor.Members())
-				if tt.preemptor.podGroup != nil {
-					if tt.preemptor.podGroup.Spec.SchedulingPolicy.Gang != nil {
-						neededSlots = int(tt.preemptor.podGroup.Spec.SchedulingPolicy.Gang.MinCount)
-					} else {
-						// For non-gang pod groups (e.g., BasicPolicy), scheduling even 1 pod is considered a success
-						// since there's no all-or-nothing constraint.
-						neededSlots = 1
-					}
-				}
-
-				availableSlots := 0
-				nodeMap := make(map[string]fwk.NodeInfo)
-				for _, n := range domainNodes {
-					nodeMap[n.Node().Name] = n
-				}
-
-				for _, rule := range tt.blockingRules {
-					node, exists := nodeMap[rule.nodeName]
-					if !exists {
-						continue
-					}
-
-					isBlocked := false
-					for _, pod := range node.GetPods() {
-						// If any of the blocking victims are still on the simulated node, it provides 0 capacity.
-						if rule.blockingVictims.Has(pod.GetPod().Name) {
-							isBlocked = true
-							break
-						}
-					}
-
-					// If all blocking victims are removed, the node provides its capacity.
-					if !isBlocked {
-						availableSlots += rule.capacity
-					}
-				}
-
-				if availableSlots >= neededSlots {
-					assignmentsCount := min(availableSlots, len(tt.preemptor.Members()))
-					proposedAssignments := make([]fwk.ProposedAssignment, assignmentsCount)
-					for i := range assignmentsCount {
-						proposedAssignments[i] = &testProposedAssignment{pod: tt.preemptor.Members()[i], nodeName: "node1"}
-					}
-					return &fwk.PodGroupAssignments{
-						ProposedAssignments: proposedAssignments,
-					}, fwk.NewStatus(fwk.Success)
-				}
-				return nil, fwk.NewStatus(fwk.Unschedulable)
-			}
-
 			pl := &PodGroupEvaluator{
+				Handle:           f,
 				podGroupSnapshot: pgLister,
 			}
 
+			if err := pl.Handle.MutableSnapshotSharedLister().StartMutations(); err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			domainNodes, _ := snapshot.NodeInfos().List()
+			domain := newDomainForWorkloadPreemption(domainNodes, pgLister, "test-domain")
 			res, gotStatus := pl.selectVictimsOnDomain(ctx, tt.preemptor, domain, tt.pdbs, mockSchedulingFunc)
 			if !gotStatus.IsSuccess() {
 				t.Logf("SelectVictimsOnDomain failed: %v", gotStatus.Message())
+			}
+			if err := pl.Handle.MutableSnapshotSharedLister().EndMutations(); err != nil {
+				t.Errorf("Unexpected error: %v", err)
 			}
 
 			wantCode := tt.expectedStatus.Code()
@@ -1293,7 +1439,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 			for _, p := range res.victims.Pods {
 				gotNames.Insert(p.Name)
 			}
-			wantNames := sets.New(tt.expectedPods...)
+			wantNames := sets.New(tt.expectedVictims...)
 			if diff := cmp.Diff(wantNames, gotNames); diff != "" {
 				t.Errorf("Victims mismatch (-want +got):\n%s", diff)
 			}
@@ -1438,21 +1584,8 @@ func TestMoreImportantVictim(t *testing.T) {
 	}
 }
 
-type testProposedAssignment struct {
-	pod      *v1.Pod
-	nodeName string
-}
-
-func (a *testProposedAssignment) GetPod() *v1.Pod {
-	return a.pod
-}
-
-func (a *testProposedAssignment) GetNodeName() string {
-	return a.nodeName
-}
-
 func TestPodGroupEvaluator_SelectVictimsOnDomain_NominatedNodes(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	logger, ctx := ktesting.NewTestContext(t)
 
 	p1 := st.MakePod().Name("p1").UID("p1").Obj()
 	p2 := st.MakePod().Name("p2").UID("p2").Obj()
@@ -1462,31 +1595,64 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain_NominatedNodes(t *testing.T) {
 		[]*v1.Pod{p1, p2},
 	)
 
+	node1 := st.MakeNode().Name("node1").Obj()
 	domainNodes := []fwk.NodeInfo{
 		framework.NewNodeInfo(),
 	}
-	domainNodes[0].SetNode(st.MakeNode().Name("node1").Obj())
+	domainNodes[0].SetNode(node1)
 
 	// Add a low priority pod as a potential victim to satisfy the check
 	p3 := st.MakePod().Name("p3").UID("p3").Node("node1").Priority(lowPriority).Obj()
 	podInfo, _ := framework.NewPodInfo(p3)
 	domainNodes[0].AddPodInfo(podInfo)
+	objs := []runtime.Object{p1, p2, p3, node1}
+	informerFactory := informers.NewSharedInformerFactory(clientsetfake.NewClientset(objs...), 0)
+	registeredPlugins := []tf.RegisterPluginFunc{
+		tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+		tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+	}
+	snapshot := internalcache.NewSnapshot([]*v1.Pod{p3}, []*v1.Node{node1})
+	f, err := tf.NewFramework(
+		ctx,
+		registeredPlugins, "",
+		frameworkruntime.WithPodNominator(internalqueue.NewSchedulingQueue(nil, informerFactory)),
+		frameworkruntime.WithInformerFactory(informerFactory),
+		frameworkruntime.WithSnapshotSharedLister(snapshot),
+		frameworkruntime.WithMutableSnapshotLister(snapshot),
+		frameworkruntime.WithLogger(logger),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	informerFactory.Start(ctx.Done())
+	informerFactory.WaitForCacheSync(ctx.Done())
 
 	pgLister := &mockPodGroupLister{podGroups: make(map[string]*schedulingapi.PodGroup)}
 	domain := newDomainForWorkloadPreemption(domainNodes, pgLister, "test-domain")
 
 	mockSchedulingFunc := func(ctx context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
+		cs1 := framework.NewCycleState()
+		cs2 := framework.NewCycleState()
+		f.RunPreFilterPlugins(ctx, cs1, p1)
+		f.RunPreFilterPlugins(ctx, cs2, p2)
 		return &fwk.PodGroupAssignments{
 			ProposedAssignments: []fwk.ProposedAssignment{
-				&testProposedAssignment{pod: p1, nodeName: "node1"},
-				&testProposedAssignment{pod: p2, nodeName: ""}, // No node assigned
+				&mockProposedAssignment{pod: p1, nodeName: "node1", cycleState: cs1},
+				&mockProposedAssignment{pod: p2, nodeName: "", cycleState: cs2},
 			},
 		}, fwk.NewStatus(fwk.Success)
 	}
 
-	pl := &PodGroupEvaluator{}
+	pl := &PodGroupEvaluator{Handle: f}
 
+	if err := pl.Handle.MutableSnapshotSharedLister().StartMutations(); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
 	result, gotStatus := pl.selectVictimsOnDomain(ctx, preemptor, domain, nil, mockSchedulingFunc)
+	if err := pl.Handle.MutableSnapshotSharedLister().EndMutations(); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
 	if !gotStatus.IsSuccess() {
 		t.Fatalf("SelectVictimsOnDomain failed: %v", gotStatus.Message())
 	}
@@ -1503,4 +1669,27 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain_NominatedNodes(t *testing.T) {
 	if info, ok := result.nominatedNodeNames[namespacedName]; !ok || info.NominatedNodeName != "node1" {
 		t.Errorf("Expected p1 to be nominated for node1, got %v", info)
 	}
+}
+
+type mockProposedAssignment struct {
+	nodeName   string
+	pod        *v1.Pod
+	cycleState fwk.CycleState
+}
+
+func (pa *mockProposedAssignment) GetNodeName() string {
+	return pa.nodeName
+}
+
+func (pa *mockProposedAssignment) GetPod() *v1.Pod {
+	return pa.pod
+}
+
+func (pa *mockProposedAssignment) GetPodInfo() fwk.PodInfo {
+	podInfo, _ := framework.NewPodInfo(pa.pod)
+	return podInfo
+}
+
+func (pa *mockProposedAssignment) GetCycleState() fwk.CycleState {
+	return pa.cycleState
 }

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -256,8 +256,8 @@ func (sched *Scheduler) podGroupCycle(ctx context.Context, schedFwk framework.Fr
 		pgPostFilterResult, status := schedFwk.RunPodGroupPostFilterPlugins(ctx, podGroupCycleState, podGroupInfo.PodGroupInfo, pgSchedulingFunc)
 		if status.IsSuccess() {
 			for i := range result.podResults {
-				pod := result.podResults[i].pod
-				namespacedName := types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
+				podInfo := result.podResults[i].podInfo
+				namespacedName := types.NamespacedName{Namespace: podInfo.Pod.Namespace, Name: podInfo.Pod.Name}
 				if nodeNameInfo, ok := pgPostFilterResult.NominatingInfos[namespacedName]; ok {
 					result.podResults[i].scheduleResult.nominatingInfo = nodeNameInfo
 					result.waitingOnPreemption = true
@@ -277,8 +277,8 @@ func (sched *Scheduler) podGroupCycle(ctx context.Context, schedFwk framework.Fr
 
 // algorithmResult stores the scheduling result and status for a scheduling attempt of a single pod.
 type algorithmResult struct {
-	// pod is the pod the result applies to.
-	pod *v1.Pod
+	// podInfo is the pod info for the pod the result applies to.
+	podInfo *framework.PodInfo
 	// scheduleResult is a scheduling algorithm result.
 	scheduleResult ScheduleResult
 	// podCtx is a specific pod scheduling context used for the scheduling algorithm.
@@ -304,11 +304,19 @@ const (
 )
 
 func (ar *algorithmResult) GetPod() *v1.Pod {
-	return ar.pod
+	return ar.podInfo.Pod
+}
+
+func (ar *algorithmResult) GetPodInfo() fwk.PodInfo {
+	return ar.podInfo
 }
 
 func (ar *algorithmResult) GetNodeName() string {
 	return ar.scheduleResult.SuggestedHost
+}
+
+func (ar *algorithmResult) GetCycleState() fwk.CycleState {
+	return ar.podCtx.state
 }
 
 // podGroupAlgorithmResult stores the scheduling pod scheduling results for a pod group
@@ -453,7 +461,7 @@ func (sched *Scheduler) podGroupPodSchedulingAlgorithm(ctx context.Context, sche
 		} else {
 			// In case of pod being just unschedulable or having an error, just return now.
 			return algorithmResult{
-				pod:                pod,
+				podInfo:            podInfo.PodInfo,
 				scheduleResult:     scheduleResult,
 				podCtx:             podCtx,
 				schedulingDuration: time.Since(start),
@@ -464,7 +472,7 @@ func (sched *Scheduler) podGroupPodSchedulingAlgorithm(ctx context.Context, sche
 	assumedPodInfo, assumeStatus := sched.assumeAndReserve(ctx, podCtx.state, schedFwk, podInfo, scheduleResult)
 	if !assumeStatus.IsSuccess() {
 		return algorithmResult{
-			pod:                pod,
+			podInfo:            podInfo.PodInfo,
 			scheduleResult:     ScheduleResult{nominatingInfo: clearNominatedNode},
 			podCtx:             podCtx,
 			schedulingDuration: time.Since(start),
@@ -480,7 +488,7 @@ func (sched *Scheduler) podGroupPodSchedulingAlgorithm(ctx context.Context, sche
 	}
 
 	return algorithmResult{
-		pod:                pod,
+		podInfo:            podInfo.PodInfo,
 		scheduleResult:     scheduleResult,
 		podCtx:             podCtx,
 		schedulingDuration: time.Since(start),
@@ -503,9 +511,9 @@ func completePodGroupAlgorithmResult(ctx context.Context, podGroupInfo *framewor
 		placementCycleState := framework.NewCycleState()
 		placementCycleState.SetPodGroupSchedulingCycle(podGroupState)
 		newResults[i] = algorithmResult{
-			pod:    pInfo.Pod,
-			podCtx: initPodSchedulingContext(ctx, pInfo.Pod, placementCycleState, postFilterMode),
-			status: podGroupResult.status.Clone(),
+			podInfo: pInfo.PodInfo,
+			podCtx:  initPodSchedulingContext(ctx, pInfo.Pod, placementCycleState, postFilterMode),
+			status:  podGroupResult.status.Clone(),
 		}
 	}
 	podGroupResult.podResults = newResults

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -2285,7 +2285,10 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 		st.MakeNode().Name("node1").Obj(),
 		st.MakeNode().Name("node2").Obj(),
 	}
-	podGroupPod := st.MakePod().Name("foo").UID("foo").PodGroupName("pg").Obj()
+	podGroupPodInfo, err := framework.NewPodInfo(st.MakePod().Name("foo").UID("foo").PodGroupName("pg").Obj())
+	if err != nil {
+		t.Fatalf("Failed to create pod info: %v", err)
+	}
 
 	tests := map[string]struct {
 		placementPlugin           fakePlacementPlugin
@@ -2306,7 +2309,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			expectedResult: podGroupAlgorithmResult{
 				podResults: []algorithmResult{
 					{
-						pod: podGroupPod,
+						podInfo: podGroupPodInfo,
 						scheduleResult: ScheduleResult{
 							SuggestedHost:  nodes[0].Name,
 							EvaluatedNodes: 1,
@@ -2331,7 +2334,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			expectedResult: podGroupAlgorithmResult{
 				podResults: []algorithmResult{
 					{
-						pod: podGroupPod,
+						podInfo: podGroupPodInfo,
 						scheduleResult: ScheduleResult{
 							SuggestedHost:  nodes[1].Name,
 							EvaluatedNodes: 1,
@@ -2368,7 +2371,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			expectedResult: podGroupAlgorithmResult{
 				podResults: []algorithmResult{
 					{
-						pod: podGroupPod,
+						podInfo: podGroupPodInfo,
 						scheduleResult: ScheduleResult{
 							EvaluatedNodes: 0,
 							FeasibleNodes:  0,
@@ -2402,7 +2405,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			expectedResult: podGroupAlgorithmResult{
 				podResults: []algorithmResult{
 					{
-						pod: podGroupPod,
+						podInfo: podGroupPodInfo,
 						scheduleResult: ScheduleResult{
 							SuggestedHost:  "node1",
 							EvaluatedNodes: 1,
@@ -2430,7 +2433,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			expectedResult: podGroupAlgorithmResult{
 				podResults: []algorithmResult{
 					{
-						pod: podGroupPod,
+						podInfo: podGroupPodInfo,
 						scheduleResult: ScheduleResult{
 							SuggestedHost:  nodes[0].Name,
 							EvaluatedNodes: 1,
@@ -2462,7 +2465,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			expectedResult: podGroupAlgorithmResult{
 				podResults: []algorithmResult{
 					{
-						pod: podGroupPod,
+						podInfo: podGroupPodInfo,
 						scheduleResult: ScheduleResult{
 							SuggestedHost:  nodes[0].Name,
 							EvaluatedNodes: 1,
@@ -2565,11 +2568,11 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			pgInfo := &framework.QueuedPodGroupInfo{
 				QueuedPodInfos: []*framework.QueuedPodInfo{
 					{
-						PodInfo: &framework.PodInfo{Pod: podGroupPod},
+						PodInfo: podGroupPodInfo,
 					},
 				},
 				PodGroupInfo: &framework.PodGroupInfo{
-					UnscheduledPods: []*v1.Pod{podGroupPod},
+					UnscheduledPods: []*v1.Pod{podGroupPodInfo.Pod},
 				},
 			}
 
@@ -2580,7 +2583,8 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 					podGroupAlgorithmResult{},
 					algorithmResult{},
 					ScheduleResult{},
-					fwk.Status{}),
+					fwk.Status{},
+					framework.PodInfo{}),
 				cmpopts.IgnoreFields(podGroupAlgorithmResult{}, "placementCycleState"),
 				cmpopts.IgnoreFields(algorithmResult{}, "podCtx", "schedulingDuration"),
 				statusCmpOpt,

--- a/staging/src/k8s.io/kube-scheduler/framework/interface.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/interface.go
@@ -984,4 +984,12 @@ type PluginsRunner interface {
 	// PreFilter plugins. It returns directly if any of the plugins return any
 	// status other than Success.
 	RunPreFilterExtensionRemovePod(ctx context.Context, state CycleState, podToSchedule *v1.Pod, podInfoToRemove PodInfo, nodeInfo NodeInfo) *Status
+	// RunReservePluginsReserve runs the Reserve method of the set of
+	// configured Reserve plugins. If any of these calls returns an error, it
+	// does not continue running the remaining ones and returns the error. In
+	// such case, pod will not be scheduled.
+	RunReservePluginsReserve(ctx context.Context, state CycleState, pod *v1.Pod, nodeName string) *Status
+	// RunReservePluginsUnreserve runs the Unreserve method of the set of
+	// configured Reserve plugins.
+	RunReservePluginsUnreserve(ctx context.Context, state CycleState, pod *v1.Pod, nodeName string)
 }

--- a/staging/src/k8s.io/kube-scheduler/framework/listers.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/listers.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/dynamic-resource-allocation/structured"
+	"k8s.io/klog/v2"
 )
 
 // NodeInfoLister interface represents anything that can list/get NodeInfo objects from node name.
@@ -72,6 +73,14 @@ type MutableSnapshotSharedLister interface {
 	StartMutations() error
 	// EndMutations ends the mutation session and restores the snapshot state to the one before StartMutations.
 	EndMutations() error
+	// AddPod adds a given pod to the snapshot.
+	// AddPod should be called only if the mutation was started via StartMutations.
+	// This function is not thread safe, so it should be executed when no other routines can write/read from the snapshot.
+	AddPod(podInfo PodInfo, nodeName string) error
+	// RemovePod removes a given pod from the snapshot.
+	// RemovePod should be called only if the mutation was started via StartMutations.
+	// The state will be reverted when EndMutations is called.
+	RemovePod(logger klog.Logger, pod *v1.Pod, nodeName string) error
 }
 
 // PodGroupStateLister provides read access to pod group states.

--- a/staging/src/k8s.io/kube-scheduler/framework/types.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/types.go
@@ -675,8 +675,13 @@ type Placement struct {
 type ProposedAssignment interface {
 	// GetPod returns the pod that has the proposed node assignment.
 	GetPod() *v1.Pod
+	// GetPodInfo returns the PodInfo for the pod that has the proposed node assignment.
+	// It should be treated as immutable, read only data.
+	GetPodInfo() PodInfo
 	// GetNodeName returns the name of the proposed node for the pod.
 	GetNodeName() string
+	// GetCycleState returns the CycleState computed for this pod during pod group scheduling cycle.
+	GetCycleState() CycleState
 }
 
 // PodGroupAssignments holds the temporary assignments of pods in a pod group to nodes for a placement.

--- a/test/integration/scheduler/preemption/podgrouppreemption_test.go
+++ b/test/integration/scheduler/preemption/podgrouppreemption_test.go
@@ -38,6 +38,7 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler"
+	config "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	configtesting "k8s.io/kubernetes/pkg/scheduler/apis/config/testing"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
@@ -49,6 +50,10 @@ import (
 
 // TestPodGroupPreemption tests preemption scenarios involving pod groups.
 func TestPodGroupPreemption(t *testing.T) {
+	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+		features.GenericWorkload:   true,
+		features.PodLevelResources: true,
+	})
 	tests := []struct {
 		name          string
 		nodes         []*v1.Node
@@ -64,6 +69,8 @@ func TestPodGroupPreemption(t *testing.T) {
 		expectedToHaveNNNInfo              []string
 		expectedPodsPreemptedByWAP         int
 		enablePodGroupPreemptionPolicy     bool
+		customPluginName                   string
+		customPluginFunc                   frameworkruntime.PluginFactory
 	}{
 		{
 			name: "Full PodGroup Preemption",
@@ -151,19 +158,20 @@ func TestPodGroupPreemption(t *testing.T) {
 				// low-1 takes half CPU on node1
 				st.MakePod().Name("low-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Node("node1").Obj(),
 				// very-low-1 takes all CPU on node2
-				st.MakePod().Name("very-low-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").ZeroTerminationGracePeriod().Priority(5).Node("node2").Obj(),
+				st.MakePod().Name("very-low-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(5).Node("node2").Obj(),
 			},
 			preemptorPods: []*v1.Pod{
 				st.MakePod().Name("high-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg1").ZeroTerminationGracePeriod().Priority(100).Obj(),
 				st.MakePod().Name("high-2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg1").ZeroTerminationGracePeriod().Priority(100).Obj(),
 				st.MakePod().Name("high-3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg1").ZeroTerminationGracePeriod().Priority(100).Obj(),
 			},
-			// high-1 will fit on node1 (it has 1 CPU free).
-			// high-2 and high-3 will fit on node2 if very-low-1 is preempted.
-			// high-2 will preempt very-low-1 and high-3 will schedule in next cycle to free space.
-			expectedScheduled:          []string{"high-1", "high-2", "high-3", "low-1"},
-			expectedPreempted:          []string{"very-low-1"},
-			expectedToHaveNNNInfo:      []string{"high-2"},
+			// with default scoring the assignments without victims will be
+			// high-1, high-3 -> node1
+			// high-2 -> node2
+			// very-low-1 can be reprieved on node2
+			expectedScheduled:          []string{"high-1", "high-2", "high-3", "very-low-1"},
+			expectedPreempted:          []string{"low-1"},
+			expectedToHaveNNNInfo:      []string{},
 			expectedPodsPreemptedByWAP: 1,
 		},
 		{
@@ -312,58 +320,6 @@ func TestPodGroupPreemption(t *testing.T) {
 			expectedPodsPreemptedByWAP: 3,
 		},
 		{
-			name: "Gang scheduling: do not reprieve if it reduces scheduled pods below max possible",
-			nodes: []*v1.Node{
-				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
-				st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
-				st.MakeNode().Name("node3").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
-			},
-			podGroups: []*schedulingapi.PodGroup{
-				st.MakePodGroup().Name("preemptor-pg").Namespace("default").Priority(100).MinCount(2).Obj(),
-			},
-			initialPods: []*v1.Pod{
-				st.MakePod().Name("p1").Node("node1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
-				st.MakePod().Name("p2").Node("node2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(50).Obj(),
-				st.MakePod().Name("p3").Node("node3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(50).Obj(),
-			},
-			preemptorPods: []*v1.Pod{
-				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
-				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
-				st.MakePod().Name("p-c").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
-			},
-			expectedScheduled:          []string{"p-a", "p-b", "p-c"},
-			expectedPreempted:          []string{"p1", "p2", "p3"},
-			expectedToHaveNNNInfo:      []string{"p-a", "p-b", "p-c"},
-			expectedPodsPreemptedByWAP: 3,
-		},
-		{
-			name: "Gang scheduling: reprieve if it does not reduce scheduled pods below max possible",
-			nodes: []*v1.Node{
-				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
-				st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
-				st.MakeNode().Name("node3").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
-				st.MakeNode().Name("node4").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
-			},
-			podGroups: []*schedulingapi.PodGroup{
-				st.MakePodGroup().Name("preemptor-pg").Namespace("default").Priority(100).MinCount(2).Obj(),
-			},
-			initialPods: []*v1.Pod{
-				st.MakePod().Name("p1").Node("node1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
-				st.MakePod().Name("p2").Node("node2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
-				st.MakePod().Name("p3").Node("node3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
-				st.MakePod().Name("p4").Node("node4").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(50).Obj(),
-			},
-			preemptorPods: []*v1.Pod{
-				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
-				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
-				st.MakePod().Name("p-c").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
-			},
-			expectedScheduled:          []string{"p-a", "p-b", "p-c", "p4"},
-			expectedPreempted:          []string{"p1", "p2", "p3"},
-			expectedToHaveNNNInfo:      []string{"p-a", "p-b", "p-c"},
-			expectedPodsPreemptedByWAP: 3,
-		},
-		{
 			name: "Gang scheduling: schedule as many pods as possible without preempting higher priority pods, but still more than minCount",
 			nodes: []*v1.Node{
 				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
@@ -401,7 +357,7 @@ func TestPodGroupPreemption(t *testing.T) {
 			},
 			podGroups: []*schedulingapi.PodGroup{
 				st.MakePodGroup().Name("victim-pg").Namespace("default").Priority(50).DisruptionModeAll().MinCount(1).Obj(),
-				st.MakePodGroup().Name("preemptor-pg").Namespace("default").Priority(100).MinCount(1).Obj(),
+				st.MakePodGroup().Name("preemptor-pg").Namespace("default").Priority(100).MinCount(3).Obj(),
 			},
 			initialPods: []*v1.Pod{
 				st.MakePod().Name("v1").Node("node1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("victim-pg").ZeroTerminationGracePeriod().Priority(50).Obj(),
@@ -552,9 +508,16 @@ func TestPodGroupPreemption(t *testing.T) {
 				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
 				st.MakePod().Name("p-c").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
 			},
-			expectedScheduled:          []string{"p-a", "p-b", "p-c"},
-			expectedPreempted:          []string{"v1", "v2", "v3"},
-			expectedToHaveNNNInfo:      []string{"p-a", "p-b", "p-c"},
+			expectedScheduled: []string{"p-a", "p-b", "p-c"},
+			expectedPreempted: []string{"v1", "v2", "v3"},
+			// There are no guarantees about NNN,
+			// depending on the number of queued pods in WAS cycle
+			// WAP can preempt different number of pods
+			// It's also possible that WAP will preempt enough pods
+			// so the further WAS cycle (after observing more pods)
+			// will no longer need to run WAP.
+			// In that case it's possible that none of the pods will have NNN set.
+			expectedToHaveNNNInfo:      []string{},
 			expectedPodsPreemptedByWAP: 3,
 		},
 		{
@@ -762,6 +725,248 @@ func TestPodGroupPreemption(t *testing.T) {
 			expectedUnschedulable:      []string{"high-1", "high-2", "high-3"},
 			expectedPodsPreemptedByWAP: 0,
 		},
+		{
+			name: "Gang scheduling: preemption with node resources",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Label("kubernetes.io/hostname", "node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "2", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node2").Label("kubernetes.io/hostname", "node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "2", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+			},
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("preemptor-pg").Namespace("default").Priority(100).MinCount(2).Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("initial-pod").Label("app", "initial").Node("node1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
+			},
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("preemptor-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
+				st.MakePod().Name("preemptor-2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
+			},
+			expectedScheduled:          []string{"preemptor-1", "preemptor-2"},
+			expectedPreempted:          []string{"initial-pod"},
+			expectedToHaveNNNInfo:      []string{"preemptor-1", "preemptor-2"},
+			expectedPodsPreemptedByWAP: 1,
+		},
+		{
+			name: "Gang scheduling: preemption with node resources, prioritizes reprieval of higher priority pods",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Label("kubernetes.io/hostname", "node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "2", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node2").Label("kubernetes.io/hostname", "node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "2", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+			},
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("preemptor-pg").Namespace("default").Priority(100).MinCount(2).Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("initial-pod-1").Label("app", "initial").Node("node1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(5).Obj(),
+				st.MakePod().Name("initial-pod-2").Label("app", "initial").Node("node1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
+			},
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("preemptor-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).
+					NodeSelector(map[string]string{"kubernetes.io/hostname": "node1"}).Obj(),
+				st.MakePod().Name("preemptor-2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).
+					NodeSelector(map[string]string{"kubernetes.io/hostname": "node2"}).Obj(),
+			},
+			expectedScheduled:          []string{"preemptor-1", "preemptor-2"},
+			expectedPreempted:          []string{"initial-pod-1"},
+			expectedToHaveNNNInfo:      []string{"preemptor-1", "preemptor-2"},
+			expectedPodsPreemptedByWAP: 1,
+		},
+		{
+			name: "Gang scheduling: preemption with pod level resources",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Label("kubernetes.io/hostname", "node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "2", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node2").Label("kubernetes.io/hostname", "node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "2", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+			},
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("preemptor-pg").Namespace("default").Priority(100).MinCount(2).Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("initial-pod").Label("app", "initial").Node("node1").PodLevelResourceRequests(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
+			},
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("preemptor-1").PodLevelResourceRequests(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).
+					PodAntiAffinityExists("app", "kubernetes.io/hostname", st.PodAntiAffinityWithRequiredReq).Obj(),
+				st.MakePod().Name("preemptor-2").PodLevelResourceRequests(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).
+					PodAntiAffinityExists("app", "kubernetes.io/hostname", st.PodAntiAffinityWithRequiredReq).Obj(),
+			},
+			expectedScheduled:          []string{"preemptor-1", "preemptor-2"},
+			expectedPreempted:          []string{"initial-pod"},
+			expectedToHaveNNNInfo:      []string{"preemptor-1", "preemptor-2"},
+			expectedPodsPreemptedByWAP: 1,
+		},
+		{
+			// Even though there is enough resources to keep initial pod when scheduling preemptor
+			// due to the pod anti affinity it cannot be reprieved.
+			name: "Gang scheduling: preemption with pod anti-affinity constraints",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Label("kubernetes.io/hostname", "node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "2", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node2").Label("kubernetes.io/hostname", "node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "2", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+			},
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("preemptor-pg").Namespace("default").Priority(100).MinCount(2).Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("initial-pod").Label("app", "initial").Node("node1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "0.25"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
+			},
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("preemptor-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1.5"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).
+					PodAntiAffinityExists("app", "kubernetes.io/hostname", st.PodAntiAffinityWithRequiredReq).Obj(),
+				st.MakePod().Name("preemptor-2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1.5"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).
+					PodAntiAffinityExists("app", "kubernetes.io/hostname", st.PodAntiAffinityWithRequiredReq).Obj(),
+			},
+			expectedScheduled:          []string{"preemptor-1", "preemptor-2"},
+			expectedPreempted:          []string{"initial-pod"},
+			expectedToHaveNNNInfo:      []string{"preemptor-1", "preemptor-2"},
+			expectedPodsPreemptedByWAP: 1,
+		},
+		{
+			// Even though there is enough resources to keep initial pod when scheduling preemptor
+			// due to the pod node port it cannot be reprieved.
+			name: "Gang scheduling: preemption with pod node port",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "2", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "2", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+			},
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("preemptor-pg").Namespace("default").Priority(100).MinCount(2).Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("initial-pod").ContainerPort([]v1.ContainerPort{{ContainerPort: 8080, HostPort: 8080}}).Node("node1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "0.25"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
+			},
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("preemptor-1").ContainerPort([]v1.ContainerPort{{ContainerPort: 8080, HostPort: 8080}}).Req(map[v1.ResourceName]string{v1.ResourceCPU: "1.5"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
+				st.MakePod().Name("preemptor-2").ContainerPort([]v1.ContainerPort{{ContainerPort: 8080, HostPort: 8080}}).Req(map[v1.ResourceName]string{v1.ResourceCPU: "1.5"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
+			},
+			expectedScheduled:          []string{"preemptor-1", "preemptor-2"},
+			expectedPreempted:          []string{"initial-pod"},
+			expectedToHaveNNNInfo:      []string{"preemptor-1", "preemptor-2"},
+			expectedPodsPreemptedByWAP: 1,
+		},
+		{
+			// Even though there is enough resources to keep initial pod when scheduling preemptor
+			// due to the pod topolgy spread it cannot be reprieved.
+			name: "Gang scheduling: preemption with pod topology spread constraints",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Label("kubernetes.io/hostname", "node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "16", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node2").Label("kubernetes.io/hostname", "node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "16", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+			},
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("preemptor-pg").Namespace("default").Priority(100).MinCount(2).Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("initial-pod").Label("app", "foo").Node("node1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
+			},
+			preemptorPods: []*v1.Pod{
+				func() *v1.Pod {
+					p := st.MakePod().Name("preemptor-1").Label("app", "foo").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).
+						NodeSelector(map[string]string{"kubernetes.io/hostname": "node1"}).Obj()
+					p.Spec.TopologySpreadConstraints = []v1.TopologySpreadConstraint{
+						{
+							MaxSkew:           2,
+							TopologyKey:       "kubernetes.io/hostname",
+							WhenUnsatisfiable: v1.DoNotSchedule,
+							LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
+							MinDomains:        new(int32(10)),
+						},
+					}
+					return p
+				}(),
+				func() *v1.Pod {
+					p := st.MakePod().Name("preemptor-2").Label("app", "foo").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).
+						NodeSelector(map[string]string{"kubernetes.io/hostname": "node1"}).Obj()
+					p.Spec.TopologySpreadConstraints = []v1.TopologySpreadConstraint{
+						{
+							MaxSkew:           2,
+							TopologyKey:       "kubernetes.io/hostname",
+							WhenUnsatisfiable: v1.DoNotSchedule,
+							LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
+							MinDomains:        new(int32(10)),
+						},
+					}
+					return p
+				}(),
+			},
+			expectedScheduled:          []string{"preemptor-1", "preemptor-2"},
+			expectedPreempted:          []string{"initial-pod"},
+			expectedToHaveNNNInfo:      []string{"preemptor-1", "preemptor-2"},
+			expectedPodsPreemptedByWAP: 1,
+		},
+		{
+			name: "Gang scheduling: preemption with pod topology spread constraints, single reprieve",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Label("kubernetes.io/hostname", "node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "16", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node2").Label("kubernetes.io/hostname", "node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "16", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+			},
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("preemptor-pg").Namespace("default").Priority(100).MinCount(2).Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("initial-pod").Label("app", "foo").Node("node1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
+				// initial-pod-2 can be reprieved even though it has lower priority, because it won't cause skew
+				st.MakePod().Name("initial-pod-2").Label("app", "foo").Node("node2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(5).Obj(),
+			},
+			preemptorPods: []*v1.Pod{
+				func() *v1.Pod {
+					p := st.MakePod().Name("preemptor-1").Label("app", "foo").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).
+						NodeSelector(map[string]string{"kubernetes.io/hostname": "node1"}).Obj()
+					p.Spec.TopologySpreadConstraints = []v1.TopologySpreadConstraint{
+						{
+							MaxSkew:           2,
+							TopologyKey:       "kubernetes.io/hostname",
+							WhenUnsatisfiable: v1.DoNotSchedule,
+							LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
+							MinDomains:        new(int32(10)),
+						},
+					}
+					return p
+				}(),
+				func() *v1.Pod {
+					p := st.MakePod().Name("preemptor-2").Label("app", "foo").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).
+						NodeSelector(map[string]string{"kubernetes.io/hostname": "node1"}).Obj()
+					p.Spec.TopologySpreadConstraints = []v1.TopologySpreadConstraint{
+						{
+							MaxSkew:           2,
+							TopologyKey:       "kubernetes.io/hostname",
+							WhenUnsatisfiable: v1.DoNotSchedule,
+							LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
+							MinDomains:        new(int32(10)),
+						},
+					}
+					return p
+				}(),
+			},
+			expectedScheduled:          []string{"preemptor-1", "preemptor-2"},
+			expectedPreempted:          []string{"initial-pod"},
+			expectedToHaveNNNInfo:      []string{"preemptor-1", "preemptor-2"},
+			expectedPodsPreemptedByWAP: 1,
+		},
+		{
+			// This scenario verifies that during reprieval we respect Reserve plugins.
+			// The number of reserved pods + pods with "resource-taken" is at max 2.
+			name: "Reserve plugins are called during preemption simulation, so second pod fails",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "3", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+			},
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("preemptor-pg").Priority(100).MinCount(2).Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("v1").Node("node1").Label("resource-taken", "true").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(15).Obj(),
+				st.MakePod().Name("v2").Node("node1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
+			},
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("p-a").Label("test-plugin", "true").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
+				st.MakePod().Name("p-b").Label("test-plugin", "true").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
+			},
+			expectedScheduled:          []string{"p-a", "p-b", "v2"},
+			expectedPreempted:          []string{"v1"},
+			expectedUnschedulable:      []string{},
+			expectedToHaveNNNInfo:      []string{},
+			expectedPodsPreemptedByWAP: 1,
+			customPluginName:           "mockReservePlugin",
+			customPluginFunc: func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+				return &mockReservePlugin{maxPods: 2}, nil
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -806,6 +1011,14 @@ func TestPodGroupPreemption(t *testing.T) {
 					},
 				}},
 			})
+
+			if tt.customPluginName != "" {
+				err := registry.Register(tt.customPluginName, tt.customPluginFunc)
+				if err != nil {
+					t.Fatalf("Error registering custom plugin: %v", err)
+				}
+				cfg.Profiles[0].Plugins.MultiPoint.Enabled = append(cfg.Profiles[0].Plugins.MultiPoint.Enabled, config.Plugin{Name: tt.customPluginName})
+			}
 
 			// Set PodMaxBackoff to 1 second to turn on backoff and allow apiCacher to get information about
 			// pod NNN. Without this we might have a race between starting binding and update of apiCacher.
@@ -879,8 +1092,9 @@ func TestPodGroupPreemption(t *testing.T) {
 
 			// 5. Wait for preemption to complete if WAP calls are expected
 			if tt.expectedPodsPreemptedByWAP > 0 {
+				wapCalls := 0
 				err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 10*time.Second, false, func(ctx context.Context) (bool, error) {
-					wapCalls := 0
+					wapCalls = 0
 					for _, podName := range tt.expectedPreempted {
 						events, err := cs.CoreV1().Events(ns).List(ctx, metav1.ListOptions{
 							FieldSelector: "involvedObject.name=" + podName,
@@ -898,7 +1112,7 @@ func TestPodGroupPreemption(t *testing.T) {
 					return wapCalls == tt.expectedPodsPreemptedByWAP, nil
 				})
 				if err != nil {
-					t.Errorf("WorkloadAwarePreemption was not called %d times within timeout", tt.expectedPodsPreemptedByWAP)
+					t.Errorf("WorkloadAwarePreemption was not called expected times within timeout: want=%d, got=%d", wapCalls, tt.expectedPodsPreemptedByWAP)
 				}
 			}
 
@@ -942,6 +1156,42 @@ func TestPodGroupPreemption(t *testing.T) {
 					t.Errorf("Pod %s was expected to have nominated node name but didn't", podName)
 				}
 			}
+
+			// 10. Dump the state of pods to ease debugging failed runs.
+			if t.Failed() {
+				t.Log("Dumping states of initial and preemptor pods:")
+				var allPods []string
+				for _, p := range tt.initialPods {
+					allPods = append(allPods, p.Name)
+				}
+				for _, p := range tt.preemptorPods {
+					allPods = append(allPods, p.Name)
+				}
+				for _, podName := range allPods {
+					pod, err := cs.CoreV1().Pods(ns).Get(testCtx.Ctx, podName, metav1.GetOptions{})
+					if err != nil {
+						if apierrors.IsNotFound(err) {
+							t.Logf("Pod %q: not present in cluster", podName)
+						} else {
+							t.Logf("Pod %q: failed to get: %v", podName, err)
+						}
+						continue
+					}
+
+					var statusStr string
+					if pod.Spec.NodeName != "" {
+						statusStr = "scheduled on node " + pod.Spec.NodeName
+					} else {
+						_, cond := podutil.GetPodCondition(&pod.Status, v1.PodScheduled)
+						if cond != nil && cond.Status == v1.ConditionFalse && cond.Reason == v1.PodReasonUnschedulable {
+							statusStr = "unschedulable"
+						} else {
+							statusStr = "pending"
+						}
+					}
+					t.Logf("Pod %q: status=%s, phase=%s", podName, statusStr, pod.Status.Phase)
+				}
+			}
 		})
 	}
 }
@@ -965,3 +1215,54 @@ func (bp *mockBindPlugin) Bind(ctx context.Context, state fwk.CycleState, p *v1.
 }
 
 var _ fwk.BindPlugin = &mockBindPlugin{}
+
+type mockReservePlugin struct {
+	lock          sync.Mutex
+	reservedCount int
+	maxPods       int
+}
+
+func (p *mockReservePlugin) Name() string {
+	return "mockReservePlugin"
+}
+
+func (p *mockReservePlugin) Reserve(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *fwk.Status {
+	if pod.Labels["test-plugin"] != "true" {
+		return nil
+	}
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.reservedCount++
+	return nil
+}
+
+func (p *mockReservePlugin) Unreserve(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) {
+	if pod.Labels["test-plugin"] != "true" {
+		return
+	}
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.reservedCount--
+}
+
+func (p *mockReservePlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
+	if pod.Labels["test-plugin"] != "true" {
+		return nil
+	}
+	takenCount := 0
+	for _, p := range nodeInfo.GetPods() {
+		if p.GetPod().Labels["resource-taken"] == "true" {
+			takenCount++
+		}
+	}
+
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	if p.reservedCount+takenCount >= p.maxPods {
+		return fwk.NewStatus(fwk.Unschedulable, "already reserved")
+	}
+	return nil
+}
+
+var _ fwk.ReservePlugin = &mockReservePlugin{}
+var _ fwk.FilterPlugin = &mockReservePlugin{}


### PR DESCRIPTION
 #### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

This PR aligns the implementation of the Workload-Aware Preemption with the description of it from the KEP: https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/5710-workload-aware-preemption/README.md

The main changes include:
- running only one scheduling algorithm after victims are removed
- reusing CycleStates from scheduling algorithm for victim reprieval
- running Filter plugins on each of the preemptors for victim reprieval

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/issues/5710

#### Special notes for your reviewer:

There is one little problem with this approach. Removing pods from NodeInfo in preemption does not change the state of `havePodsWithRequiredAntiAffinityNodeInfoList`, `havePodsWithAffinityNodeInfoList`, `usedPVCSet` in the Snapshot structure. The same issue currently exists in the pod group cycle and there is an open PR to resolve that:  https://github.com/kubernetes/kubernetes/pull/139054

However the lack of this support is not a blocker here as for all three fields in WAP we will produce false positives. For `havePodsWithRequiredAntiAffinityNodeInfoList` and `havePodsWithAffinityNodeInfoList` it means that we will potentially scan more nodes than necessary.  For usedPVCSet it means that we will not support a case where removing a pod with PVC would unblock scheduling of preemptor. This is on par with the current pod by pod preemption .

With this change the time needed to complete test scenarios from https://github.com/kubernetes/kubernetes/pull/139773 from minutes to seconds.  

#### Does this PR introduce a user-facing change?

```release-note
Workload-Aware Preemption now runs only one scheduling attempt, on a cluster with all potential victims removed. This can lead to a suboptimal preemption victims choice at the cost of significant performance improvement.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- [KEP]: https://github.com/kubernetes/enhancements/issues/5710

