### PR TITLE
storage/cacher/store/watch_cache_storage: extract LatestSnapshotLocked and rename GetLatestSnapshotLocked to GetLatestSnapshotOrBuildLocked

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/watch_cache_storage.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/watch_cache_storage.go
@@ -99,21 +99,21 @@ func (w *WatchCacheStorage) MarkConsistent(consistent bool) {
 	}
 }
 
-func (w *WatchCacheStorage) GetLatestSnapshotLocked(key, continueKey string) (Snapshot, error) {
-	if w.snapshots != nil && w.snapshottingEnabled.Load() {
-		snap, ok := w.snapshots.Latest()
-		if ok {
-			// Snapshots are added in order as we update store, so the
-			// latest snapshot match latest store state and latest revision.
-			return snap, nil
-		}
+func (w *WatchCacheStorage) LatestSnapshotLocked() (Snapshot, bool) {
+	if w.SnapshottingEnabled() {
+		return w.snapshots.Latest()
+	}
+	return nil, false
+}
+
+func (w *WatchCacheStorage) GetLatestSnapshotOrBuildLocked(key, continueKey string) (Snapshot, error) {
+	if snap, ok := w.LatestSnapshotLocked(); ok {
+		// Snapshots are added in order as we update store, so the
+		// latest snapshot match latest store state and latest revision.
+		return snap, nil
 	}
 	// TODO: Consider using Indexer Clone() after benchmarking.
-	snap, err := orderedSnapshotResponseFromIndexer(w.store, key, continueKey)
-	if err != nil {
-		return nil, err
-	}
-	return snap, nil
+	return orderedSnapshotResponseFromIndexer(w.store, key, continueKey)
 }
 
 func orderedSnapshotResponseFromIndexer(indexer Indexer, key, continueKey string) (Snapshot, error) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/watch_cache_storage_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/watch_cache_storage_test.go
@@ -69,6 +69,29 @@ func TestWatchCacheStorageMarkConsistent(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestLatestSnapshotLocked(t *testing.T) {
+	keyFunc := func(obj runtime.Object) (string, error) {
+		return obj.(*mockObject).key, nil
+	}
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ListFromCacheSnapshot, true)
+
+	indexers := &cache.Indexers{}
+	s := NewWatchCacheStorage(keyFunc, indexers)
+
+	_, ok := s.LatestSnapshotLocked()
+	assert.False(t, ok, "expected no snapshot before any writes")
+
+	elem := &Element{Key: "foo", Object: &mockObject{key: "foo", val: "100"}}
+	require.NoError(t, s.UpdateStoreLocked(watch.Added, elem, 100))
+
+	snap, ok := s.LatestSnapshotLocked()
+	require.True(t, ok, "expected snapshot after write")
+	items, err := snap.OrderedListPrefix("", "")
+	require.NoError(t, err)
+	assert.Len(t, items, 1)
+	assert.Equal(t, &mockObject{key: "foo", val: "100"}, items[0].(*Element).Object)
+}
+
 func TestWatchCacheStorageMatchExactResourceVersionFallback(t *testing.T) {
 	keyFunc := func(obj runtime.Object) (string, error) {
 		return obj.(*mockObject).key, nil

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -498,7 +498,7 @@ func (w *watchCache) waitAndGetLatestSnapshot(ctx context.Context, minResourceVe
 			return snap, w.resourceVersion, matchValue.IndexName, nil
 		}
 	}
-	snap, err = w.storage.GetLatestSnapshotLocked(key, continueKey)
+	snap, err = w.storage.GetLatestSnapshotOrBuildLocked(key, continueKey)
 	return snap, w.resourceVersion, "", err
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#139928 needs a method that returns the latest immutable snapshot without the O(N) fallback. 

Rather than adding a new method that duplicates the first half of `GetLatestSnapshotLocked`, this PR extracts that logic into `LatestSnapshotLocked()` and renames the original to `GetLatestSnapshotOrBuildLocked` to make the fallback cost explicit. 

Pure refactoring, no behavior change

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
