### PR TITLE
KAL: Enforce declarative validation tags on APIs using SSA tags

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -247,6 +247,10 @@ linters:
       # Validation makes this require at least one of the fields within to be set.
       - text: "nonpointerstructs: field (PodGroupSpec|PodGroupTemplate).SchedulingPolicy is a non-pointer struct with no required fields."
         path: "staging/src/k8s.io/api/scheduling/v1alpha3/types.go"
+      
+      # Dependenttags - pre-existing listType/listMapKey violations to be resolved later
+      - text: "dependenttags: field .* with marker \\+(?:listType|listMapKey) is missing required marker\\(s\\): \\+k8s:(?:listType|listMapKey)"
+        path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|core|extensions|flowcontrol|imagepolicy|networking|node|rbac|resource|scheduling|storage|storagemigration)/"
 
       - linters:
         - forbidigo
@@ -415,6 +419,14 @@ linters:
                   type: "All"
                   dependsOn:
                     - "k8s:optional"
+                - identifier: "listType"
+                  type: "All"
+                  dependsOn:
+                    - "k8s:listType"
+                - identifier: "listMapKey"
+                  type: "All"
+                  dependsOn:
+                    - "k8s:listMapKey"
             # jsonTags:
             #   jsonTagRegex: "^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$" # The default regex is appropriate for our use case.
             # nomaps:

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -262,6 +262,10 @@ linters:
       # Validation makes this require at least one of the fields within to be set.
       - text: "nonpointerstructs: field (PodGroupSpec|PodGroupTemplate).SchedulingPolicy is a non-pointer struct with no required fields."
         path: "staging/src/k8s.io/api/scheduling/v1alpha3/types.go"
+      
+      # Dependenttags - pre-existing listType/listMapKey violations to be resolved later
+      - text: "dependenttags: field .* with marker \\+(?:listType|listMapKey) is missing required marker\\(s\\): \\+k8s:(?:listType|listMapKey)"
+        path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|core|extensions|flowcontrol|imagepolicy|networking|node|rbac|resource|scheduling|storage|storagemigration)/"
 
       - linters:
         - forbidigo
@@ -428,6 +432,14 @@ linters:
                   type: "All"
                   dependsOn:
                     - "k8s:optional"
+                - identifier: "listType"
+                  type: "All"
+                  dependsOn:
+                    - "k8s:listType"
+                - identifier: "listMapKey"
+                  type: "All"
+                  dependsOn:
+                    - "k8s:listMapKey"
             # jsonTags:
             #   jsonTagRegex: "^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$" # The default regex is appropriate for our use case.
             # nomaps:

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -123,3 +123,7 @@
 # Validation makes this require at least one of the fields within to be set.
 - text: "nonpointerstructs: field (PodGroupSpec|PodGroupTemplate).SchedulingPolicy is a non-pointer struct with no required fields."
   path: "staging/src/k8s.io/api/scheduling/v1alpha3/types.go"
+
+# Dependenttags - pre-existing listType/listMapKey violations to be resolved later
+- text: "dependenttags: field .* with marker \\+(?:listType|listMapKey) is missing required marker\\(s\\): \\+k8s:(?:listType|listMapKey)"
+  path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|core|extensions|flowcontrol|imagepolicy|networking|node|rbac|resource|scheduling|storage|storagemigration)/"

--- a/hack/kube-api-linter/kube-api-linter.yaml
+++ b/hack/kube-api-linter/kube-api-linter.yaml
@@ -47,6 +47,14 @@ lintersConfig:
         type: "All"
         dependsOn:
           - "k8s:optional"
+      - identifier: "listType"
+        type: "All"
+        dependsOn:
+          - "k8s:listType"
+      - identifier: "listMapKey"
+        type: "All"
+        dependsOn:
+          - "k8s:listMapKey"
   # jsonTags:
   #   jsonTagRegex: "^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$" # The default regex is appropriate for our use case.
   # nomaps:


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds `dependenttags`  marker checks to the Kube API linter configuration to enforce that any fields that use server-side-apply list markers (`+listType and +listMapKey`) also specify their corresponding Declarative validation markers (`+k8s:listType and +k8s:listMapKey`). 

Currently, API authors and reviewers might add SSA tags such as (`listType=map`) and mistakenly assume they are fully declaring the validations, without realising they also need to specify the corresponding DV tags (`+k8s:listType`). This rule prevents authors from running into this edge case.  


#### Which issue(s) this PR is related to:
Fixes #139309

#### Special notes for your reviewer:



```release-note
None
```