### PR TITLE
kubeadm: avoid contradictory kube-proxy bindAddress warnings

### DIFF
--- a/cmd/kubeadm/app/componentconfigs/kubeproxy.go
+++ b/cmd/kubeadm/app/componentconfigs/kubeproxy.go
@@ -114,13 +114,14 @@ func (kp *kubeProxyConfig) Default(cfg *kubeadmapi.ClusterConfiguration, localAP
 		kp.config.FeatureGates = map[string]bool{}
 	}
 
-	if kp.config.BindAddress == "" {
+	switch {
+	case kp.config.BindAddress == "":
 		kp.config.BindAddress = kubeProxyDefaultBindAddress(localAPIEndpoint.AdvertiseAddress)
-	} else if isWildcardBindAddress(kp.config.BindAddress) {
+	case isWildcardBindAddress(kp.config.BindAddress):
 		// 0.0.0.0 and :: are both valid explicit wildcard binds.
-	} else if netutils.ParseIPSloppy(kp.config.BindAddress) == nil {
+	case netutils.ParseIPSloppy(kp.config.BindAddress) == nil:
 		klog.Warningf("The bindAddress %q in %q is not a valid IP address", kp.config.BindAddress, kind)
-	} else {
+	default:
 		// Warn if the bindAddress is not the recommended wildcard default for its
 		// own IP family (0.0.0.0 for IPv4 or :: for IPv6).
 		warnDefaultComponentConfigValue(kind, "bindAddress",

--- a/cmd/kubeadm/app/componentconfigs/kubeproxy.go
+++ b/cmd/kubeadm/app/componentconfigs/kubeproxy.go
@@ -83,31 +83,17 @@ func (kp *kubeProxyConfig) Unmarshal(docmap kubeadmapi.DocumentMap) error {
 }
 
 func kubeProxyDefaultBindAddress(address string) string {
-	ip := netutils.ParseIPSloppy(address)
-	if ip.To4() != nil {
+	if ip := netutils.ParseIPSloppy(address); ip != nil && ip.To4() != nil {
 		return kubeadmapiv1.DefaultProxyBindAddressv4
 	}
 	return kubeadmapiv1.DefaultProxyBindAddressv6
 }
 
-// isKubeProxyDefaultBindAddress reports whether the given bindAddress is one of
-// the recommended wildcard defaults (0.0.0.0 for IPv4 or :: for IPv6).
-func isKubeProxyDefaultBindAddress(bindAddress string) bool {
+// isWildcardBindAddress reports whether the given bindAddress is one of the
+// recommended wildcard defaults (0.0.0.0 for IPv4 or :: for IPv6).
+func isWildcardBindAddress(bindAddress string) bool {
 	return bindAddress == kubeadmapiv1.DefaultProxyBindAddressv4 ||
 		bindAddress == kubeadmapiv1.DefaultProxyBindAddressv6
-}
-
-// kubeProxyBindAddressFamilyMismatch reports whether the kube-proxy bindAddress
-// uses a different IP family than the API server advertise address. It returns
-// false when either value cannot be parsed, since the family cannot be
-// determined in that case.
-func kubeProxyBindAddressFamilyMismatch(bindAddress, advertiseAddress string) bool {
-	bindIP := netutils.ParseIPSloppy(bindAddress)
-	advertiseIP := netutils.ParseIPSloppy(advertiseAddress)
-	if bindIP == nil || advertiseIP == nil {
-		return false
-	}
-	return (bindIP.To4() != nil) != (advertiseIP.To4() != nil)
 }
 
 func (kp *kubeProxyConfig) Get() interface{} {
@@ -130,20 +116,15 @@ func (kp *kubeProxyConfig) Default(cfg *kubeadmapi.ClusterConfiguration, localAP
 
 	if kp.config.BindAddress == "" {
 		kp.config.BindAddress = kubeProxyDefaultBindAddress(localAPIEndpoint.AdvertiseAddress)
+	} else if isWildcardBindAddress(kp.config.BindAddress) {
+		// 0.0.0.0 and :: are both valid explicit wildcard binds.
+	} else if netutils.ParseIPSloppy(kp.config.BindAddress) == nil {
+		klog.Warningf("The bindAddress %q in %q is not a valid IP address", kp.config.BindAddress, kind)
 	} else {
-		// Warn if the user-provided bindAddress uses a different IP family than
-		// the API server advertise address; a single-stack cluster would not be
-		// reachable on the other family.
-		if kubeProxyBindAddressFamilyMismatch(kp.config.BindAddress, localAPIEndpoint.AdvertiseAddress) {
-			klog.Warningf("The bindAddress %q in %q uses a different IP family than the API server advertise address %q",
-				kp.config.BindAddress, kind, localAPIEndpoint.AdvertiseAddress)
-		}
 		// Warn if the bindAddress is not the recommended wildcard default for its
 		// own IP family (0.0.0.0 for IPv4 or :: for IPv6).
-		if !isKubeProxyDefaultBindAddress(kp.config.BindAddress) {
-			warnDefaultComponentConfigValue(kind, "bindAddress",
-				kubeProxyDefaultBindAddress(kp.config.BindAddress), kp.config.BindAddress)
-		}
+		warnDefaultComponentConfigValue(kind, "bindAddress",
+			kubeProxyDefaultBindAddress(kp.config.BindAddress), kp.config.BindAddress)
 	}
 
 	if kp.config.ClusterCIDR == "" && cfg.Networking.PodSubnet != "" {

--- a/cmd/kubeadm/app/componentconfigs/kubeproxy.go
+++ b/cmd/kubeadm/app/componentconfigs/kubeproxy.go
@@ -82,12 +82,32 @@ func (kp *kubeProxyConfig) Unmarshal(docmap kubeadmapi.DocumentMap) error {
 	return kp.configBase.Unmarshal(docmap, &kp.config)
 }
 
-func kubeProxyDefaultBindAddress(localAdvertiseAddress string) string {
-	ip := netutils.ParseIPSloppy(localAdvertiseAddress)
+func kubeProxyDefaultBindAddress(address string) string {
+	ip := netutils.ParseIPSloppy(address)
 	if ip.To4() != nil {
 		return kubeadmapiv1.DefaultProxyBindAddressv4
 	}
 	return kubeadmapiv1.DefaultProxyBindAddressv6
+}
+
+// isKubeProxyDefaultBindAddress reports whether the given bindAddress is one of
+// the recommended wildcard defaults (0.0.0.0 for IPv4 or :: for IPv6).
+func isKubeProxyDefaultBindAddress(bindAddress string) bool {
+	return bindAddress == kubeadmapiv1.DefaultProxyBindAddressv4 ||
+		bindAddress == kubeadmapiv1.DefaultProxyBindAddressv6
+}
+
+// kubeProxyBindAddressFamilyMismatch reports whether the kube-proxy bindAddress
+// uses a different IP family than the API server advertise address. It returns
+// false when either value cannot be parsed, since the family cannot be
+// determined in that case.
+func kubeProxyBindAddressFamilyMismatch(bindAddress, advertiseAddress string) bool {
+	bindIP := netutils.ParseIPSloppy(bindAddress)
+	advertiseIP := netutils.ParseIPSloppy(advertiseAddress)
+	if bindIP == nil || advertiseIP == nil {
+		return false
+	}
+	return (bindIP.To4() != nil) != (advertiseIP.To4() != nil)
 }
 
 func (kp *kubeProxyConfig) Get() interface{} {
@@ -108,11 +128,22 @@ func (kp *kubeProxyConfig) Default(cfg *kubeadmapi.ClusterConfiguration, localAP
 		kp.config.FeatureGates = map[string]bool{}
 	}
 
-	defaultBindAddress := kubeProxyDefaultBindAddress(localAPIEndpoint.AdvertiseAddress)
 	if kp.config.BindAddress == "" {
-		kp.config.BindAddress = defaultBindAddress
-	} else if kp.config.BindAddress != defaultBindAddress {
-		warnDefaultComponentConfigValue(kind, "bindAddress", defaultBindAddress, kp.config.BindAddress)
+		kp.config.BindAddress = kubeProxyDefaultBindAddress(localAPIEndpoint.AdvertiseAddress)
+	} else {
+		// Warn if the user-provided bindAddress uses a different IP family than
+		// the API server advertise address; a single-stack cluster would not be
+		// reachable on the other family.
+		if kubeProxyBindAddressFamilyMismatch(kp.config.BindAddress, localAPIEndpoint.AdvertiseAddress) {
+			klog.Warningf("The bindAddress %q in %q uses a different IP family than the API server advertise address %q",
+				kp.config.BindAddress, kind, localAPIEndpoint.AdvertiseAddress)
+		}
+		// Warn if the bindAddress is not the recommended wildcard default for its
+		// own IP family (0.0.0.0 for IPv4 or :: for IPv6).
+		if !isKubeProxyDefaultBindAddress(kp.config.BindAddress) {
+			warnDefaultComponentConfigValue(kind, "bindAddress",
+				kubeProxyDefaultBindAddress(kp.config.BindAddress), kp.config.BindAddress)
+		}
 	}
 
 	if kp.config.ClusterCIDR == "" && cfg.Networking.PodSubnet != "" {

--- a/cmd/kubeadm/app/componentconfigs/kubeproxy_test.go
+++ b/cmd/kubeadm/app/componentconfigs/kubeproxy_test.go
@@ -124,63 +124,45 @@ func TestKubeProxyDefault(t *testing.T) {
 	}
 }
 
-func TestKubeProxyBindAddressFamilyMismatch(t *testing.T) {
+func TestKubeProxyDefaultBindAddress(t *testing.T) {
 	tests := []struct {
-		name             string
-		bindAddress      string
-		advertiseAddress string
-		expectMismatch   bool
+		name     string
+		address  string
+		expected string
 	}{
 		{
-			name:             "matching IPv4 families",
-			bindAddress:      kubeadmapiv1.DefaultProxyBindAddressv4,
-			advertiseAddress: "1.2.3.4",
-			expectMismatch:   false,
+			name:     "IPv4 address",
+			address:  "1.2.3.4",
+			expected: kubeadmapiv1.DefaultProxyBindAddressv4,
 		},
 		{
-			name:             "matching IPv6 families",
-			bindAddress:      kubeadmapiv1.DefaultProxyBindAddressv6,
-			advertiseAddress: "fd00::1",
-			expectMismatch:   false,
+			name:     "IPv6 address",
+			address:  "fd00::1",
+			expected: kubeadmapiv1.DefaultProxyBindAddressv6,
 		},
 		{
-			name:             "IPv6 bindAddress on IPv4 advertise address",
-			bindAddress:      kubeadmapiv1.DefaultProxyBindAddressv6,
-			advertiseAddress: "1.2.3.4",
-			expectMismatch:   true,
+			name:     "empty address",
+			address:  "",
+			expected: kubeadmapiv1.DefaultProxyBindAddressv6,
 		},
 		{
-			name:             "IPv4 bindAddress on IPv6 advertise address",
-			bindAddress:      kubeadmapiv1.DefaultProxyBindAddressv4,
-			advertiseAddress: "fd00::1",
-			expectMismatch:   true,
-		},
-		{
-			name:             "unparseable bindAddress is not a mismatch",
-			bindAddress:      "not-an-ip",
-			advertiseAddress: "1.2.3.4",
-			expectMismatch:   false,
-		},
-		{
-			name:             "unset advertise address is not a mismatch",
-			bindAddress:      kubeadmapiv1.DefaultProxyBindAddressv6,
-			advertiseAddress: "",
-			expectMismatch:   false,
+			name:     "unparseable address",
+			address:  "not-an-ip",
+			expected: kubeadmapiv1.DefaultProxyBindAddressv6,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := kubeProxyBindAddressFamilyMismatch(test.bindAddress, test.advertiseAddress)
-			if got != test.expectMismatch {
-				t.Fatalf("kubeProxyBindAddressFamilyMismatch(%q, %q) = %v, want %v",
-					test.bindAddress, test.advertiseAddress, got, test.expectMismatch)
+			if got := kubeProxyDefaultBindAddress(test.address); got != test.expected {
+				t.Fatalf("kubeProxyDefaultBindAddress(%q) = %q, want %q",
+					test.address, got, test.expected)
 			}
 		})
 	}
 }
 
-func TestIsKubeProxyDefaultBindAddress(t *testing.T) {
+func TestIsWildcardBindAddress(t *testing.T) {
 	tests := []struct {
 		bindAddress string
 		expect      bool
@@ -194,8 +176,8 @@ func TestIsKubeProxyDefaultBindAddress(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.bindAddress, func(t *testing.T) {
-			if got := isKubeProxyDefaultBindAddress(test.bindAddress); got != test.expect {
-				t.Fatalf("isKubeProxyDefaultBindAddress(%q) = %v, want %v",
+			if got := isWildcardBindAddress(test.bindAddress); got != test.expect {
+				t.Fatalf("isWildcardBindAddress(%q) = %v, want %v",
 					test.bindAddress, got, test.expect)
 			}
 		})

--- a/cmd/kubeadm/app/componentconfigs/kubeproxy_test.go
+++ b/cmd/kubeadm/app/componentconfigs/kubeproxy_test.go
@@ -124,6 +124,112 @@ func TestKubeProxyDefault(t *testing.T) {
 	}
 }
 
+func TestKubeProxyBindAddressFamilyMismatch(t *testing.T) {
+	tests := []struct {
+		name             string
+		bindAddress      string
+		advertiseAddress string
+		expectMismatch   bool
+	}{
+		{
+			name:             "matching IPv4 families",
+			bindAddress:      kubeadmapiv1.DefaultProxyBindAddressv4,
+			advertiseAddress: "1.2.3.4",
+			expectMismatch:   false,
+		},
+		{
+			name:             "matching IPv6 families",
+			bindAddress:      kubeadmapiv1.DefaultProxyBindAddressv6,
+			advertiseAddress: "fd00::1",
+			expectMismatch:   false,
+		},
+		{
+			name:             "IPv6 bindAddress on IPv4 advertise address",
+			bindAddress:      kubeadmapiv1.DefaultProxyBindAddressv6,
+			advertiseAddress: "1.2.3.4",
+			expectMismatch:   true,
+		},
+		{
+			name:             "IPv4 bindAddress on IPv6 advertise address",
+			bindAddress:      kubeadmapiv1.DefaultProxyBindAddressv4,
+			advertiseAddress: "fd00::1",
+			expectMismatch:   true,
+		},
+		{
+			name:             "unparseable bindAddress is not a mismatch",
+			bindAddress:      "not-an-ip",
+			advertiseAddress: "1.2.3.4",
+			expectMismatch:   false,
+		},
+		{
+			name:             "unset advertise address is not a mismatch",
+			bindAddress:      kubeadmapiv1.DefaultProxyBindAddressv6,
+			advertiseAddress: "",
+			expectMismatch:   false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := kubeProxyBindAddressFamilyMismatch(test.bindAddress, test.advertiseAddress)
+			if got != test.expectMismatch {
+				t.Fatalf("kubeProxyBindAddressFamilyMismatch(%q, %q) = %v, want %v",
+					test.bindAddress, test.advertiseAddress, got, test.expectMismatch)
+			}
+		})
+	}
+}
+
+func TestIsKubeProxyDefaultBindAddress(t *testing.T) {
+	tests := []struct {
+		bindAddress string
+		expect      bool
+	}{
+		{bindAddress: kubeadmapiv1.DefaultProxyBindAddressv4, expect: true},
+		{bindAddress: kubeadmapiv1.DefaultProxyBindAddressv6, expect: true},
+		{bindAddress: "10.0.0.5", expect: false},
+		{bindAddress: "fd00::5", expect: false},
+		{bindAddress: "not-an-ip", expect: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.bindAddress, func(t *testing.T) {
+			if got := isKubeProxyDefaultBindAddress(test.bindAddress); got != test.expect {
+				t.Fatalf("isKubeProxyDefaultBindAddress(%q) = %v, want %v",
+					test.bindAddress, got, test.expect)
+			}
+		})
+	}
+}
+
+func TestKubeProxyDefaultBindAddressPreserved(t *testing.T) {
+	clusterCfg := kubeadmapi.ClusterConfiguration{}
+	endpoint := kubeadmapi.APIEndpoint{
+		AdvertiseAddress: "1.2.3.4",
+	}
+
+	for _, bindAddress := range []string{
+		kubeadmapiv1.DefaultProxyBindAddressv4,
+		kubeadmapiv1.DefaultProxyBindAddressv6,
+		"10.0.0.5",
+	} {
+		t.Run(bindAddress, func(t *testing.T) {
+			got := &kubeProxyConfig{
+				configBase: configBase{
+					GroupVersion: kubeproxyconfig.SchemeGroupVersion,
+				},
+				config: kubeproxyconfig.KubeProxyConfiguration{
+					BindAddress: bindAddress,
+				},
+			}
+			got.Default(&clusterCfg, &endpoint, &kubeadmapi.NodeRegistrationOptions{})
+			if got.config.BindAddress != bindAddress {
+				t.Fatalf("expected bindAddress %q to be preserved, got %q", bindAddress, got.config.BindAddress)
+			}
+		})
+	}
+}
+
 // runKubeProxyFromTest holds common test case data and evaluation code for kubeProxyHandler.From* functions
 func runKubeProxyFromTest(t *testing.T, perform func(gvk schema.GroupVersionKind, yaml string) (kubeadmapi.ComponentConfig, error)) {
 	const (


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

kubeadm emits contradictory warnings for kube-proxy `bindAddress` when users explicitly set `0.0.0.0` or `::`. The recommended value alternated based on the API server advertise address family, even though both addresses are valid explicit kube-proxy bind choices.

This change suppresses the defaulting warning when either standard bind address is provided.

Fixes kubernetes/kubeadm#3319

#### Which issue(s) this PR is related to:

Fixes kubernetes/kubeadm#3319

#### Special notes for your reviewer:

Small defaulting-only change in kubeadm component config.

#### Does this PR introduce a user-facing change?

```release-note
kubeadm: improved the logic around warnings when the user sets a non-default bindAddress in KubeProxyConfiguration.
```

#### Testing:

```bash
go test ./cmd/kubeadm/app/componentconfigs/ -run 'TestKubeProxyDefault|TestKubeProxyDefaultBindAddressWarning' -count=1 -v
```