### PR TITLE
devicetainteviction: use AddEventHandlerWithOptions

### DIFF
--- a/pkg/controller/devicetainteviction/device_taint_eviction.go
+++ b/pkg/controller/devicetainteviction/device_taint_eviction.go
@@ -832,7 +832,7 @@ func (tc *Controller) Run(ctx context.Context, numWorkers int) error {
 		return err
 	}
 
-	claimHandler, err := tc.claimInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	claimHandler, err := tc.claimInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj any) {
 			claim, ok := obj.(*resourceapi.ResourceClaim)
 			if !ok {
@@ -870,7 +870,7 @@ func (tc *Controller) Run(ctx context.Context, numWorkers int) error {
 			defer tc.mutex.Unlock()
 			tc.handleClaimChange(claim, nil)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	if err != nil {
 		return fmt.Errorf("adding claim event handler:%w", err)
 	}
@@ -879,7 +879,7 @@ func (tc *Controller) Run(ctx context.Context, numWorkers int) error {
 	}()
 	tc.haveSynced = append(tc.haveSynced, claimHandler.HasSyncedChecker())
 
-	podHandler, err := tc.podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	podHandler, err := tc.podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj any) {
 			pod, ok := obj.(*v1.Pod)
 			if !ok {
@@ -917,7 +917,7 @@ func (tc *Controller) Run(ctx context.Context, numWorkers int) error {
 			defer tc.mutex.Unlock()
 			tc.handlePodChange(pod, nil)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	if err != nil {
 		return fmt.Errorf("adding pod event handler: %w", err)
 	}
@@ -927,7 +927,7 @@ func (tc *Controller) Run(ctx context.Context, numWorkers int) error {
 	tc.haveSynced = append(tc.haveSynced, podHandler.HasSyncedChecker())
 
 	if tc.ruleInformer != nil {
-		ruleHandler, err := tc.ruleInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		ruleHandler, err := tc.ruleInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj any) {
 				rule, ok := obj.(*resourcbeta.DeviceTaintRule)
 				if !ok {
@@ -965,7 +965,7 @@ func (tc *Controller) Run(ctx context.Context, numWorkers int) error {
 				defer tc.mutex.Unlock()
 				tc.handleRuleChange(rule, nil)
 			},
-		})
+		}, cache.HandlerOptions{Logger: &logger})
 		if err != nil {
 			return fmt.Errorf("adding DeviceTaintRule event handler: %w", err)
 		}
@@ -975,7 +975,7 @@ func (tc *Controller) Run(ctx context.Context, numWorkers int) error {
 		tc.haveSynced = append(tc.haveSynced, ruleHandler.HasSyncedChecker())
 	}
 
-	sliceHandler, err := tc.sliceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	sliceHandler, err := tc.sliceInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj any) {
 			slice, ok := obj.(*resourceapi.ResourceSlice)
 			if !ok {
@@ -1011,7 +1011,7 @@ func (tc *Controller) Run(ctx context.Context, numWorkers int) error {
 			defer tc.mutex.Unlock()
 			tc.handleSliceChange(slice, nil)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	if err != nil {
 		return fmt.Errorf("adding slice event handler: %w", err)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it

Migrates the four informer event handlers in the device taint eviction controller (`claim`, `pod`, `DeviceTaintRule`, `ResourceSlice`) from `AddEventHandler` to `AddEventHandlerWithOptions`, passing the controller's contextual logger via `cache.HandlerOptions`. Event-handler logging now flows through the per-controller logger rather than the global `klog.Background()`, matching the sibling `resourceclaim` controller (`pkg/controller/resourceclaim/controller.go`).

The change is non-behavioral: the returned registration handles are still retained for `HasSyncedChecker` and `RemoveEventHandler` as before.

#### Which issue(s) this PR fixes

Part of #126379

#### Special notes for your reviewer

The DRA controllers in this area already use this pattern; this brings the device taint eviction controller in line.

/sig scheduling
/cc @pohly

```release-note
NONE
```