### PR TITLE
leaderelection: Wait for OnStartedLeading before releasing the lock

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -155,6 +155,10 @@ type LeaderElectionConfig struct {
 	// ensure all code guarded by this lease has successfully completed
 	// prior to cancelling the context, or you may have two processes
 	// simultaneously acting on the critical path.
+	//
+	// When enabled, Run() keeps renewing the lock until OnStartedLeading
+	// returns, and only then releases it. OnStartedLeading MUST return
+	// promptly after its context is cancelled, otherwise Run() will block.
 	ReleaseOnCancel bool
 
 	// Name is the name of the resource lock for debugging
@@ -171,7 +175,10 @@ type LeaderElectionConfig struct {
 // possible future callbacks:
 //   - OnChallenge()
 type LeaderCallbacks struct {
-	// OnStartedLeading is called when a LeaderElector client starts leading
+	// OnStartedLeading is called when a LeaderElector client starts leading.
+	// When ReleaseOnCancel is set, it must return after the provided context
+	// is cancelled, otherwise Run() will block. At the same time, it must only
+	// return when all spawned goroutines are terminated.
 	OnStartedLeading func(context.Context)
 	// OnStoppedLeading is called when a LeaderElector client stops leading.
 	// This callback is always called when the LeaderElector exits, even if it did not start leading.
@@ -217,8 +224,29 @@ func (le *LeaderElector) Run(ctx context.Context) {
 	}
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	go le.config.Callbacks.OnStartedLeading(ctx)
-	le.renew(ctx)
+
+	if !le.config.ReleaseOnCancel {
+		go le.config.Callbacks.OnStartedLeading(ctx)
+		le.renew(ctx)
+		return
+	}
+
+	// When ReleaseOnCancel is set, keep renewing the lock until
+	// OnStartedLeading returns, then release it. The caller's context
+	// cancellation signals OnStartedLeading to shut down, but renew()
+	// keeps the lock held until that shutdown is complete.
+	renewCtx, cancelRenew := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		defer cancelRenew()
+		le.config.Callbacks.OnStartedLeading(ctx)
+	})
+	le.renew(renewCtx)
+	// Signal OnStartedLeading to stop in case renew exited due to renewal
+	// failure rather than context cancellation.
+	cancel()
+	wg.Wait()
+	le.release(klog.FromContext(ctx))
 }
 
 // RunOrDie starts a client with the provided config or panics if the config
@@ -305,10 +333,6 @@ func (le *LeaderElector) renew(ctx context.Context) {
 		cancel()
 	}, le.config.RetryPeriod)
 
-	// if we hold the lease, give it up
-	if le.config.ReleaseOnCancel {
-		le.release(logger)
-	}
 }
 
 // release attempts to release the leader lease if we have acquired it.

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -70,6 +70,10 @@ import (
 
 const (
 	JitterFactor = 1.2
+
+	// onStartedLeadingBlockedWarningPeriod is the interval between warnings
+	// logged when OnStartedLeading has not returned after context cancellation.
+	onStartedLeadingBlockedWarningPeriod = 10 * time.Second
 )
 
 // NewLeaderElector creates a LeaderElector from a LeaderElectionConfig
@@ -214,7 +218,13 @@ type LeaderElector struct {
 
 // Run starts the leader election loop. Run will not return
 // before leader election loop is stopped by ctx or it has
-// stopped holding the leader lease
+// stopped holding the leader lease.
+//
+// When ReleaseOnCancel is true, Run keeps renewing the lock after ctx
+// is cancelled until OnStartedLeading returns, and only then releases
+// it. Run waits for OnStartedLeading to return, so it must exit
+// promptly once its context is cancelled or Run will block
+// indefinitely.
 func (le *LeaderElector) Run(ctx context.Context) {
 	defer runtime.HandleCrashWithContext(ctx)
 	defer le.config.Callbacks.OnStoppedLeading()
@@ -237,10 +247,45 @@ func (le *LeaderElector) Run(ctx context.Context) {
 	// keeps the lock held until that shutdown is complete.
 	renewCtx, cancelRenew := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
+	onStartedReturned := make(chan struct{})
 	wg.Go(func() {
-		defer cancelRenew()
+		defer func() {
+			cancelRenew()
+			close(onStartedReturned)
+		}()
 		le.config.Callbacks.OnStartedLeading(ctx)
 	})
+
+	// Log a warning periodically if OnStartedLeading is still running
+	// after the caller's context has been cancelled.
+	wg.Go(func() {
+		var (
+			warningTicker *time.Ticker
+			warningCh     <-chan time.Time
+			ctxDone       = ctx.Done()
+		)
+		defer func() {
+			if warningTicker != nil {
+				warningTicker.Stop()
+			}
+		}()
+		for {
+			select {
+			case <-onStartedReturned:
+				return
+			case <-ctxDone:
+				ctxDone = nil
+				warningTicker = time.NewTicker(onStartedLeadingBlockedWarningPeriod)
+				warningCh = warningTicker.C
+			case <-warningCh:
+				klog.FromContext(ctx).Info(
+					"Still waiting for OnStartedLeading callback to return before releasing the leader election lock",
+					"lock", le.config.Lock.Describe(),
+				)
+			}
+		}
+	})
+
 	le.renew(renewCtx)
 	// Signal OnStartedLeading to stop in case renew exited due to renewal
 	// failure rather than context cancellation.

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
@@ -841,8 +841,9 @@ func testReleaseOnCancellation(t *testing.T, objectType string) {
 		Callbacks: LeaderCallbacks{
 			OnNewLeader:      func(identity string) {},
 			OnStoppedLeading: func() {},
-			OnStartedLeading: func(context.Context) {
+			OnStartedLeading: func(ctx context.Context) {
 				close(onNewLeader)
+				<-ctx.Done()
 			},
 		},
 	}
@@ -1034,6 +1035,234 @@ func testReleaseOnCancellation(t *testing.T, objectType string) {
 			assertEqualEvents(t, test.expectedEvents, recorder.Events)
 		})
 	}
+}
+
+// TestReleaseOnRenewalFailure verifies that when leadership is lost because
+// every renewal update fails (as opposed to the parent context being
+// cancelled), Run() still returns promptly and the lock is released only
+// after OnStartedLeading has returned. The update reactor rejects all
+// renewal updates, which causes renew() to exceed its deadline and return.
+// Run() must then cancel the context given to OnStartedLeading, wait for it
+// to finish, and only then call release().
+func TestReleaseOnRenewalFailure(t *testing.T) {
+	objectType := "leases"
+
+	var (
+		lockObj   runtime.Object
+		lockObjMu sync.Mutex
+
+		events   []string
+		eventsMu sync.Mutex
+	)
+
+	trackEvent := func(name string) {
+		eventsMu.Lock()
+		defer eventsMu.Unlock()
+		events = append(events, name)
+	}
+
+	_, ctx := ktesting.NewTestContext(t)
+
+	recorder := record.NewFakeRecorder(100)
+	resourceLockConfig := rl.ResourceLockConfig{
+		Identity:      "baz",
+		EventRecorder: recorder,
+	}
+
+	c := &fake.Clientset{}
+	c.AddReactor("get", objectType, func(action fakeclient.Action) (bool, runtime.Object, error) {
+		lockObjMu.Lock()
+		defer lockObjMu.Unlock()
+		if lockObj != nil {
+			return true, lockObj, nil
+		}
+		act := action.(fakeclient.GetAction)
+		return true, nil, errors.NewNotFound(act.GetResource().GroupResource(), act.GetName())
+	})
+	c.AddReactor("create", objectType, func(action fakeclient.Action) (bool, runtime.Object, error) {
+		lockObjMu.Lock()
+		defer lockObjMu.Unlock()
+		lockObj = action.(fakeclient.CreateAction).GetObject()
+		return true, lockObj, nil
+	})
+	c.AddReactor("update", objectType, func(action fakeclient.Action) (bool, runtime.Object, error) {
+		lockObjMu.Lock()
+		defer lockObjMu.Unlock()
+
+		lease := action.(fakeclient.UpdateAction).GetObject().(*coordinationv1.Lease)
+
+		if lease.Spec.HolderIdentity != nil && *lease.Spec.HolderIdentity == "" {
+			trackEvent("lock released")
+			lockObj = lease
+			return true, lockObj, nil
+		}
+
+		return true, nil, fmt.Errorf("renewal failed")
+	})
+
+	lock, err := rl.New(objectType, "foo", "bar", c.CoreV1(), c.CoordinationV1(), resourceLockConfig)
+	if err != nil {
+		t.Fatal("Failed to create a resource lock: ", err)
+	}
+
+	lec := LeaderElectionConfig{
+		Lock:            lock,
+		LeaseDuration:   500 * time.Millisecond,
+		RenewDeadline:   200 * time.Millisecond,
+		RetryPeriod:     50 * time.Millisecond,
+		ReleaseOnCancel: true,
+		Callbacks: LeaderCallbacks{
+			OnStartedLeading: func(ctx context.Context) {
+				<-ctx.Done()
+				trackEvent("OnStartedLeading returned")
+			},
+			OnStoppedLeading: func() {},
+		},
+	}
+
+	elector, err := NewLeaderElector(lec)
+	if err != nil {
+		t.Fatal("Failed to create leader elector: ", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		elector.Run(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run() did not return; likely deadlock when leadership is lost via renewal failure")
+	}
+
+	eventsMu.Lock()
+	defer eventsMu.Unlock()
+	assert.Equal(t, []string{"OnStartedLeading returned", "lock released"}, events,
+		"OnStartedLeading must return before release()")
+}
+
+// TestReleaseOnCancelKeepsRenewingUntilStartedLeadingReturns verifies that
+// when the context is cancelled, the lock continues to be renewed until
+// OnStartedLeading has returned, and only then is the lock released.
+func TestReleaseOnCancelKeepsRenewingUntilStartedLeadingReturns(t *testing.T) {
+	objectType := "leases"
+
+	var (
+		lockObj   runtime.Object
+		lockObjMu sync.Mutex
+
+		events   []string
+		eventsMu sync.Mutex
+	)
+
+	trackEvent := func(name string) {
+		eventsMu.Lock()
+		defer eventsMu.Unlock()
+		events = append(events, name)
+	}
+
+	renewedAfterCancel := make(chan struct{})
+	closeRenewedAfterCancel := sync.OnceFunc(func() { close(renewedAfterCancel) })
+
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+
+	recorder := record.NewFakeRecorder(100)
+	resourceLockConfig := rl.ResourceLockConfig{
+		Identity:      "baz",
+		EventRecorder: recorder,
+	}
+
+	c := &fake.Clientset{}
+	c.AddReactor("get", objectType, func(action fakeclient.Action) (bool, runtime.Object, error) {
+		lockObjMu.Lock()
+		defer lockObjMu.Unlock()
+		if lockObj != nil {
+			return true, lockObj, nil
+		}
+		act := action.(fakeclient.GetAction)
+		return true, nil, errors.NewNotFound(act.GetResource().GroupResource(), act.GetName())
+	})
+	c.AddReactor("create", objectType, func(action fakeclient.Action) (bool, runtime.Object, error) {
+		lockObjMu.Lock()
+		defer lockObjMu.Unlock()
+		lockObj = action.(fakeclient.CreateAction).GetObject()
+		return true, lockObj, nil
+	})
+	c.AddReactor("update", objectType, func(action fakeclient.Action) (bool, runtime.Object, error) {
+		lockObjMu.Lock()
+		defer lockObjMu.Unlock()
+
+		lease := action.(fakeclient.UpdateAction).GetObject().(*coordinationv1.Lease)
+
+		if lease.Spec.HolderIdentity != nil && *lease.Spec.HolderIdentity == "" {
+			trackEvent("lock released")
+			lockObj = lease
+			return true, lockObj, nil
+		}
+
+		if ctx.Err() != nil {
+			closeRenewedAfterCancel()
+		}
+
+		lockObj = lease
+		return true, lockObj, nil
+	})
+
+	lock, err := rl.New(objectType, "foo", "bar", c.CoreV1(), c.CoordinationV1(), resourceLockConfig)
+	if err != nil {
+		t.Fatal("Failed to create a resource lock: ", err)
+	}
+
+	startedLeading := make(chan struct{})
+
+	lec := LeaderElectionConfig{
+		Lock:            lock,
+		LeaseDuration:   500 * time.Millisecond,
+		RenewDeadline:   300 * time.Millisecond,
+		RetryPeriod:     50 * time.Millisecond,
+		ReleaseOnCancel: true,
+		Callbacks: LeaderCallbacks{
+			OnStartedLeading: func(ctx context.Context) {
+				close(startedLeading)
+				<-ctx.Done()
+				// Wait for at least one renewal after cancellation before returning.
+				<-renewedAfterCancel
+				trackEvent("OnStartedLeading returned")
+			},
+			OnStoppedLeading: func() {},
+		},
+	}
+
+	elector, err := NewLeaderElector(lec)
+	if err != nil {
+		t.Fatal("Failed to create leader elector: ", err)
+	}
+
+	runReturned := make(chan struct{})
+	go func() {
+		elector.Run(ctx)
+		close(runReturned)
+	}()
+
+	await := func(ch <-chan struct{}, msg string) {
+		select {
+		case <-ch:
+		case <-time.After(5 * time.Second):
+			t.Fatal(msg)
+		}
+	}
+
+	await(startedLeading, "failed to become the leader")
+	cancel()
+	await(runReturned, "Run() did not return; likely renew() stopped after context cancellation while OnStartedLeading was still running")
+
+	eventsMu.Lock()
+	defer eventsMu.Unlock()
+	assert.Equal(t, []string{"OnStartedLeading returned", "lock released"}, events,
+		"OnStartedLeading must return before the lock is released")
 }
 
 func TestLeaderElectionConfigValidation(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When ReleaseOnCancel is true, LeaderElector.Run() waits for the OnStartedLeading callback to return before exiting. This ensures that the code guarded by the lease has finished before release() is called in renew(), preventing a window where two leaders could be active simultaneously.

Previously, OnStartedLeading was fired in a goroutine and Run() would return as soon as renew() exited, without waiting for the callback. This meant the lock could be released while the callback (e.g. running controllers) was still executing.

You can theoretically achieve the same with some context magic and synchronization in OnStartedLeading, but it's overly complicated for fixing this issue which should actually be addressed in the library.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Aligned leader election to keep renewing the lock until OnStartedLeading returns when ReleaseOnCancel is set
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A