### PR TITLE
Make utf8 replacement char test pass on Go 1.27

### DIFF
--- a/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api_json_126_test.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api_json_126_test.go
@@ -1,0 +1,22 @@
+//go:build !go1.27
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+// 1.26 marshals a \u-escaped replacement char
+const stdlibSerializedReplacementChar = "\\ufffd"

--- a/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api_json_127_test.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api_json_127_test.go
@@ -1,0 +1,22 @@
+//go:build go1.27
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+// 1.27 marshals the replacement char without escaping
+const stdlibSerializedReplacementChar = "\ufffd"

--- a/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api_json_test.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api_json_test.go
@@ -62,10 +62,10 @@ func TestKeyValueCompat(t *testing.T) {
 		},
 		{
 			name:                 "non-utf8 env",
-			envs:                 []*KeyValue{{Key: "key", Value: []byte{'A', 0x80, 'Z'}}}, // invalid utf8 continuation byte (0x80)
-			variantJSON:          `[{"key":"key","value":"A` + "\x80" + `Z"}]`,             // an alternate JSON input containing the invalid utf8 byte that should coerce to the same result
-			expectedJSON:         `[{"key":"key","value":"A\ufffdZ"}]`,                     // coerced to utf8 replacement character (\ufffd) on marshal
-			expectedRoundTripped: []*KeyValue{{Key: "key", Value: []byte("A\ufffdZ")}},     // round-trips to replacement character (\ufffd) on unmarshal
+			envs:                 []*KeyValue{{Key: "key", Value: []byte{'A', 0x80, 'Z'}}},              // invalid utf8 continuation byte (0x80)
+			variantJSON:          `[{"key":"key","value":"A` + "\x80" + `Z"}]`,                          // an alternate JSON input containing the invalid utf8 byte that should coerce to the same result
+			expectedJSON:         `[{"key":"key","value":"A` + stdlibSerializedReplacementChar + `Z"}]`, // coerced to utf8 replacement character (\ufffd) on marshal
+			expectedRoundTripped: []*KeyValue{{Key: "key", Value: []byte("A\ufffdZ")}},                  // round-trips to replacement character (\ufffd) on unmarshal
 		},
 	}
 


### PR DESCRIPTION
/kind cleanup
/kind failing-test
/assign @dims

follow up to https://github.com/kubernetes/kubernetes/pull/139964 to make the unit test pass with go 1.27 UTF8 replacement char encoding as well

```release-note
NONE
```