### PR TITLE
Add jpbetz to API approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -367,11 +367,13 @@ aliases:
     - smarterclayton
     - thockin
     - liggitt
+    - jpbetz
   # subsets of api-approvers by sig area to help focus approval requests to those with domain knowledge
   sig-api-machinery-api-approvers:
     - deads2k
     - liggitt
     - smarterclayton
+    - jpbetz
   sig-apps-api-approvers:
     - deads2k
     - liggitt
@@ -437,6 +439,7 @@ aliases:
     - saad-ali
     - luxas
     - janetkuo
+    - jpbetz
     - justinsb
     - pwittrock
     - tallclair


### PR DESCRIPTION
#### What type of PR is this?

API approver nomination.

/kind cleanup

#### What this PR does / why we need it:

Nomination was [submitted to kubernetes-api-reviewers](https://groups.google.com/g/kubernetes-api-reviewers/c/sF4Msh0M_7s?e=48417069) on June 16, 2026 and so far has received supportive feedback.

This PR requests formal approval and addition to owners aliases.

```release-note
NONE
```