### PR TITLE
apiserver/admission: publish all VAP audit failures in a single annot…

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/admission_test.go
@@ -1172,11 +1172,21 @@ func TestAuditValidationAction(t *testing.T) {
 	}
 	testContext := setupFakeTest(t, compiler, matcher)
 
-	// Push some fake
-	noParamSourcePolicy := *denyPolicy
-	noParamSourcePolicy.Spec.ParamKind = nil
+	policy1 := *denyPolicy
+	policy1.Name = "denypolicy1.example.com"
+	policy1.Spec.ParamKind = nil
+	binding1 := *denyBindingWithAudit
+	binding1.Name = "denybinding1.example.com"
+	binding1.Spec.PolicyName = policy1.Name
 
-	compiler.RegisterDefinition(denyPolicy, func(ctx context.Context, matchedResource schema.GroupVersionResource, versionedAttr *admission.VersionedAttributes, versionedParams runtime.Object, namespace *v1.Namespace, runtimeCELCostBudget int64, authz authorizer.UnconditionalAuthorizer) validating.ValidateResult {
+	policy2 := *denyPolicy
+	policy2.Name = "denypolicy2.example.com"
+	policy2.Spec.ParamKind = nil
+	binding2 := *denyBindingWithAudit
+	binding2.Name = "denybinding2.example.com"
+	binding2.Spec.PolicyName = policy2.Name
+
+	compiler.RegisterDefinition(&policy1, func(ctx context.Context, matchedResource schema.GroupVersionResource, versionedAttr *admission.VersionedAttributes, versionedParams runtime.Object, namespace *v1.Namespace, runtimeCELCostBudget int64, authz authorizer.UnconditionalAuthorizer) validating.ValidateResult {
 		return validating.ValidateResult{
 			Decisions: []validating.PolicyDecision{
 				{
@@ -1186,8 +1196,18 @@ func TestAuditValidationAction(t *testing.T) {
 			},
 		}
 	})
+	compiler.RegisterDefinition(&policy2, func(ctx context.Context, matchedResource schema.GroupVersionResource, versionedAttr *admission.VersionedAttributes, versionedParams runtime.Object, namespace *v1.Namespace, runtimeCELCostBudget int64, authz authorizer.UnconditionalAuthorizer) validating.ValidateResult {
+		return validating.ValidateResult{
+			Decisions: []validating.PolicyDecision{
+				{
+					Action:  validating.ActionDeny,
+					Message: "I can't do that",
+				},
+			},
+		}
+	})
 
-	require.NoError(t, testContext.UpdateAndWait(&noParamSourcePolicy, denyBindingWithAudit))
+	require.NoError(t, testContext.UpdateAndWait(&policy1, &policy2, &binding1, &binding2))
 
 	attr := attributeRecord(nil, fakeParams, admission.Create)
 	warningRecorder := newWarningRecorder()
@@ -1207,13 +1227,22 @@ func TestAuditValidationAction(t *testing.T) {
 	var value []validating.ValidationFailureValue
 	jsonErr := utiljson.Unmarshal([]byte(valueJson), &value)
 	require.NoError(t, jsonErr)
-	expected := []validating.ValidationFailureValue{{
-		ExpressionIndex:   0,
-		Message:           "I'm sorry Dave",
-		ValidationActions: []admissionregistrationv1.ValidationAction{admissionregistrationv1.Audit},
-		Binding:           "denybinding.example.com",
-		Policy:            noParamSourcePolicy.Name,
-	}}
+	expected := []validating.ValidationFailureValue{
+		{
+			ExpressionIndex:   0,
+			Message:           "I'm sorry Dave",
+			ValidationActions: []admissionregistrationv1.ValidationAction{admissionregistrationv1.Audit},
+			Binding:           "denybinding1.example.com",
+			Policy:            policy1.Name,
+		},
+		{
+			ExpressionIndex:   0,
+			Message:           "I can't do that",
+			ValidationActions: []admissionregistrationv1.ValidationAction{admissionregistrationv1.Audit},
+			Binding:           "denybinding2.example.com",
+			Policy:            policy2.Name,
+		},
+	}
 	require.Equal(t, expected, value)
 
 	require.NoError(t, err)
@@ -1986,7 +2015,6 @@ func (r *warningRecorder) AddWarning(_, text string) {
 	r.Lock()
 	defer r.Unlock()
 	r.warnings.Insert(text)
-	return
 }
 
 func (r *warningRecorder) hasWarning(text string) bool {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/admission_test.go
@@ -1243,7 +1243,7 @@ func TestAuditValidationAction(t *testing.T) {
 			Policy:            policy2.Name,
 		},
 	}
-	require.Equal(t, expected, value)
+	require.ElementsMatch(t, expected, value)
 
 	require.NoError(t, err)
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/dispatcher.go
@@ -317,17 +317,38 @@ func (c *dispatcher) Dispatch(ctx context.Context, a admission.Attributes, o adm
 	return nil
 }
 
+// maxValidationFailures is the maximum number of validation failures to include in the audit annotation
+// to prevent audit logs resource exhaustion.
+// The expected size of 50 validation failures is ~10KB.
+const maxValidationFailures = 50
+
 func publishValidationFailureAnnotations(attributes admission.Attributes, failures []ValidationFailureValue) {
+	if len(failures) == 0 {
+		return
+	}
+	if len(failures) > maxValidationFailures {
+		klog.Warningf("Validation failures count %d for resource %s exceeds limit of %d; truncating audit annotation", len(failures), attributes.GetResource().String(), maxValidationFailures)
+		failures = failures[:maxValidationFailures]
+	}
+
 	key := "validation.policy.admission.k8s.io/validation_failure"
 	valueJSON, err := utiljson.Marshal(failures)
 	if err != nil {
-		klog.Warningf("Failed to marshal admission audit validation failures for key %s: %v", key, err)
+		klog.Warningf("Failed to marshal admission audit validation failures for key %s for ValidatingAdmissionPolicies and ValidatingAdmissionPolicyBindings %s: %v", key, formatPoliciesBindings(failures), err)
 		return
 	}
 	value := string(valueJSON)
 	if err := attributes.AddAnnotation(key, value); err != nil {
-		klog.Warningf("Failed to set admission audit annotation %s to %s: %v", key, value, err)
+		klog.Warningf("Failed to set admission audit annotation %s to %s for ValidatingAdmissionPolicies and ValidatingAdmissionPolicyBindings %s: %v", key, value, formatPoliciesBindings(failures), err)
 	}
+}
+
+func formatPoliciesBindings(failures []ValidationFailureValue) string {
+	var policiesBindings []string
+	for _, failure := range failures {
+		policiesBindings = append(policiesBindings, fmt.Sprintf("%s/%s", failure.Policy, failure.Binding))
+	}
+	return strings.Join(policiesBindings, ", ")
 }
 
 const maxAuditAnnotationValueLength = 10 * 1024

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/dispatcher.go
@@ -70,8 +70,8 @@ func (c *dispatcher) Start(ctx context.Context) error {
 
 // Dispatch implements generic.Dispatcher.
 func (c *dispatcher) Dispatch(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces, hooks []PolicyHook) error {
-
 	var deniedDecisions []policyDecisionWithMetadata
+	var validationFailures []ValidationFailureValue
 
 	addConfigError := func(err error, definition *admissionregistrationv1.ValidatingAdmissionPolicy, binding *admissionregistrationv1.ValidatingAdmissionPolicyBinding) {
 		// we always default the FailurePolicy if it is unset and validate it in API level
@@ -240,7 +240,13 @@ func (c *dispatcher) Dispatch(ctx context.Context, a admission.Attributes, o adm
 								})
 								celmetrics.Metrics.ObserveRejection(ctx, decision.Elapsed, definition.Name, binding.Name, ErrorType(&decision))
 							case admissionregistrationv1.Audit:
-								publishValidationFailureAnnotation(binding, i, decision, versionedAttr)
+								validationFailures = append(validationFailures, ValidationFailureValue{
+									ExpressionIndex:   i,
+									Message:           decision.Message,
+									ValidationActions: binding.Spec.ValidationActions,
+									Binding:           binding.Name,
+									Policy:            binding.Spec.PolicyName,
+								})
 								celmetrics.Metrics.ObserveAudit(ctx, decision.Elapsed, definition.Name, binding.Name, ErrorType(&decision))
 							case admissionregistrationv1.Warn:
 								warning.AddWarning(ctx, "", fmt.Sprintf("Validation failed for ValidatingAdmissionPolicy '%s' with binding '%s': %s", definition.Name, binding.Name, decision.Message))
@@ -285,6 +291,10 @@ func (c *dispatcher) Dispatch(ctx context.Context, a admission.Attributes, o adm
 		auditAnnotationCollector.publish(definition.Name, a)
 	}
 
+	if len(validationFailures) > 0 {
+		publishValidationFailureAnnotations(a, validationFailures)
+	}
+
 	if len(deniedDecisions) > 0 {
 		// TODO: refactor admission.NewForbidden so the name extraction is reusable but the code/reason is customizable
 		var message string
@@ -307,22 +317,16 @@ func (c *dispatcher) Dispatch(ctx context.Context, a admission.Attributes, o adm
 	return nil
 }
 
-func publishValidationFailureAnnotation(binding *admissionregistrationv1.ValidatingAdmissionPolicyBinding, expressionIndex int, decision PolicyDecision, attributes admission.Attributes) {
+func publishValidationFailureAnnotations(attributes admission.Attributes, failures []ValidationFailureValue) {
 	key := "validation.policy.admission.k8s.io/validation_failure"
-	// Marshal to a list of failures since, in the future, we may need to support multiple failures
-	valueJSON, err := utiljson.Marshal([]ValidationFailureValue{{
-		ExpressionIndex:   expressionIndex,
-		Message:           decision.Message,
-		ValidationActions: binding.Spec.ValidationActions,
-		Binding:           binding.Name,
-		Policy:            binding.Spec.PolicyName,
-	}})
+	valueJSON, err := utiljson.Marshal(failures)
 	if err != nil {
-		klog.Warningf("Failed to set admission audit annotation %s for ValidatingAdmissionPolicy %s and ValidatingAdmissionPolicyBinding %s: %v", key, binding.Spec.PolicyName, binding.Name, err)
+		klog.Warningf("Failed to marshal admission audit validation failures for key %s: %v", key, err)
+		return
 	}
 	value := string(valueJSON)
 	if err := attributes.AddAnnotation(key, value); err != nil {
-		klog.Warningf("Failed to set admission audit annotation %s to %s for ValidatingAdmissionPolicy %s and ValidatingAdmissionPolicyBinding %s: %v", key, value, binding.Spec.PolicyName, binding.Name, err)
+		klog.Warningf("Failed to set admission audit annotation %s to %s: %v", key, value, err)
 	}
 }
 


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

**Problem:**
When multiple ValidatingAdmissionPolicy bindings evaluate to an Audit action for a single request, the dispatcher published each validation failure immediately using the shared `"validation_failure"` annotation key. Because the admission `Attributes` interface rejects overwriting an annotation with a different value, every audit failure after the first failed to be recorded — so the audit annotation only ever captured the first failure and silently dropped the rest. Each rejected overwrite also logged a `klog.Warningf`, producing redundant warning noise under load.

**Fix:**
This PR buffers all validation failures during the admission dispatch evaluation loop and publishes them as a single marshaled slice exactly once at the end of the request evaluation. All audit failures are now recorded in the annotation instead of just the first, and the repeated overwrite errors (and their warning logs) are eliminated.

Additionally, this PR updates `TestAuditValidationAction` to verify multiple audit bindings and prevent regressions.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug in kube-apiserver where a request matching multiple ValidatingAdmissionPolicy bindings with audit actions only recorded the first validation failure in the audit annotation; all audit failures are now published in a single annotation.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
