### PR TITLE
Pod Certificates: Node-restriction support for signer names

### DIFF
--- a/plugin/pkg/admission/noderestriction/admission.go
+++ b/plugin/pkg/admission/noderestriction/admission.go
@@ -151,6 +151,11 @@ func (p *Plugin) ValidateInitialization() error {
 			return fmt.Errorf("%s requires an authorizer", PluginName)
 		}
 	}
+	if p.podCertificateRequestsEnabled {
+		if p.authz == nil {
+			return fmt.Errorf("%s requires an authorizer", PluginName)
+		}
+	}
 	if p.serviceAccountGetter == nil {
 		return fmt.Errorf("%s requires a service account getter", PluginName)
 	}
@@ -162,7 +167,7 @@ func (p *Plugin) ValidateInitialization() error {
 
 // SetUnconditionalAuthorizer sets the authorizer.
 func (p *Plugin) SetUnconditionalAuthorizer(authz authorizer.UnconditionalAuthorizer) {
-	if p.serviceAccountNodeAudienceRestriction {
+	if p.serviceAccountNodeAudienceRestriction || p.podCertificateRequestsEnabled {
 		p.authz = authz
 	}
 }
@@ -226,7 +231,7 @@ func (p *Plugin) Admit(ctx context.Context, a admission.Attributes, o admission.
 		return p.admitServiceAccount(ctx, nodeName, a)
 
 	case podCertificateRequestResource:
-		return p.admitPodCertificateRequest(nodeName, a)
+		return p.admitPodCertificateRequest(ctx, nodeName, a)
 
 	case leaseResource:
 		return p.admitLease(nodeName, a)
@@ -726,17 +731,12 @@ func (p *Plugin) validateNodeServiceAccountAudience(ctx context.Context, tr *aut
 		return nil
 	}
 
-	userInfo := a.GetUserInfo()
-	attrs := authorizer.AttributesRecord{
-		User:            userInfo, // this is the user info of the node requesting the token
-		Verb:            "request-serviceaccounts-token-audience",
-		Namespace:       a.GetNamespace(),
-		APIGroup:        "",
-		APIVersion:      "v1",
-		Resource:        requestedAudience, // this gives us the audience for which node is requesting a token for; wildcard will allow all audiences
-		Name:            a.GetName(),       // this gives us the service account name for which node is requesting a token for; if not set, default will allow all service accounts
-		ResourceRequest: true,
-	}
+	attrs := buildAuthorizerAttributes(
+		a,
+		"request-serviceaccounts-token-audience",
+		requestedAudience,
+		a.GetName(), // This API operation is on the service account, so this is the SA name.
+	)
 
 	authorized, _, err := p.authz.Authorize(ctx, attrs)
 	// an authorizer like RBAC could encounter evaluation errors and still allow the request, so authorizer decision is checked before error here.
@@ -745,10 +745,10 @@ func (p *Plugin) validateNodeServiceAccountAudience(ctx context.Context, tr *aut
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("error authorizing %s to request tokens for audience %q: %w", userInfo.GetName(), requestedAudience, err)
+		return fmt.Errorf("error authorizing %s to request tokens for audience %q: %w", a.GetUserInfo().GetName(), requestedAudience, err)
 	}
 
-	return fmt.Errorf("%s is not authorized to request tokens for audience %q", userInfo.GetName(), requestedAudience)
+	return fmt.Errorf("%s is not authorized to request tokens for audience %q", a.GetUserInfo().GetName(), requestedAudience)
 }
 
 func (p *Plugin) podReferencesAudience(ctx context.Context, pod *v1.Pod, audience string) (bool, error) {
@@ -850,7 +850,7 @@ func (p *Plugin) csiDriverHasAudience(driverName, audience string) (bool, error)
 	return false, nil
 }
 
-func (p *Plugin) admitPodCertificateRequest(nodeName string, a admission.Attributes) error {
+func (p *Plugin) admitPodCertificateRequest(ctx context.Context, nodeName string, a admission.Attributes) error {
 	if !p.podCertificateRequestsEnabled {
 		return admission.NewForbidden(a, fmt.Errorf("PodCertificateRequest feature gate is disabled"))
 	}
@@ -924,7 +924,72 @@ func (p *Plugin) admitPodCertificateRequest(nodeName string, a admission.Attribu
 		return fmt.Errorf("PodCertificateRequest for pod %q names service account UID %q, which differs from the running service account (%q)", namespace+"/"+req.Spec.PodName, req.Spec.ServiceAccountUID, sa.ObjectMeta.UID)
 	}
 
+	// Does this node have a reason to be requesting this service account /
+	// signername combo?
+	if err := p.validateNodePodCertificateSigner(ctx, pod, req, a); err != nil {
+		return admission.NewForbidden(a, err)
+	}
+
 	return nil
+}
+
+func (p *Plugin) validateNodePodCertificateSigner(ctx context.Context, pod *v1.Pod, req *certapi.PodCertificateRequest, a admission.Attributes) error {
+	// Direct reference to service account / signer combo.
+	if podHasPodCertificateVolumeForSigner(pod, req.Spec.SignerName) {
+		return nil
+	}
+
+	// Check for authorization, similar to validateNodeServiceAccountAudience.
+
+	// RBAC can't handle resources that contain slashes.  Apply the same munging
+	// that we use for encoding signerNames into ClusterTrustBundle names.
+	mungedSignerName := strings.ReplaceAll(req.Spec.SignerName, "/", ":")
+
+	attrs := buildAuthorizerAttributes(
+		a,
+		"request-serviceaccounts-podcertificate-signer",
+		mungedSignerName,
+		req.Spec.ServiceAccountName,
+	)
+
+	authorized, _, err := p.authz.Authorize(ctx, attrs)
+	// an authorizer like RBAC could encounter evaluation errors and still allow the request, so authorizer decision is checked before error here.
+	// following the same pattern as withAuthorization (ref: https://github.com/kubernetes/kubernetes/blob/2b025e645975d6d51bf38c008f972c632cf49657/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization.go#L71-L91)
+	if authorized == authorizer.DecisionAllow {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error authorizing %s to request podcertificaterequests for signer %q: %w", a.GetUserInfo().GetName(), req.Spec.SignerName, err)
+	}
+	return fmt.Errorf("pod %q does not mount a podCertificate projected volume for signer %q", a.GetNamespace()+"/"+req.Spec.PodName, req.Spec.SignerName)
+}
+
+func buildAuthorizerAttributes(a admission.Attributes, verb, resource, name string) authorizer.AttributesRecord {
+	return authorizer.AttributesRecord{
+		User:            a.GetUserInfo(),
+		Verb:            verb,
+		APIGroup:        a.GetResource().Group,
+		APIVersion:      a.GetResource().Version,
+		Resource:        resource,
+		Namespace:       a.GetNamespace(),
+		Name:            name,
+		ResourceRequest: true,
+	}
+}
+
+func podHasPodCertificateVolumeForSigner(pod *v1.Pod, signerName string) bool {
+	for i := range pod.Spec.Volumes {
+		if pod.Spec.Volumes[i].Projected == nil {
+			continue
+		}
+		for j := range pod.Spec.Volumes[i].Projected.Sources {
+			s := &pod.Spec.Volumes[i].Projected.Sources[j]
+			if s.PodCertificate != nil && s.PodCertificate.SignerName == signerName {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (p *Plugin) admitLease(nodeName string, a admission.Attributes) error {

--- a/plugin/pkg/admission/noderestriction/admission_test.go
+++ b/plugin/pkg/admission/noderestriction/admission_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -269,6 +270,12 @@ func (a *admitTestCase) run(t *testing.T) {
 		}
 		if len(a.err) > 0 && !strings.Contains(err.Error(), a.err) {
 			t.Errorf("nodePlugin.Admit() error = %v, expected %v", err, a.err)
+		}
+
+		if fakeAuthz, ok := a.authz.(*fakeAuthorizer); ok {
+			if !fakeAuthz.alreadyCalled {
+				t.Errorf("fake authorizer did not receive a call during the test case")
+			}
 		}
 	})
 }
@@ -642,7 +649,39 @@ func Test_nodePlugin_Admit(t *testing.T) {
 
 	_, v1PodRequestingPCR := makeTestPod("ns", "pcrpod", pcrNode1.ObjectMeta.Name, false)
 	v1PodRequestingPCR.Spec.ServiceAccountName = pcrSA.Name
+	v1PodRequestingPCR.Spec.Volumes = []corev1.Volume{{
+		Name: "pod-cert",
+		VolumeSource: corev1.VolumeSource{
+			Projected: &corev1.ProjectedVolumeSource{
+				Sources: []corev1.VolumeProjection{{
+					PodCertificate: &corev1.PodCertificateProjection{
+						SignerName: "example.com/foo",
+					},
+				}},
+			},
+		},
+	}}
 	checkNilError(t, pcrPodIndex.Add(v1PodRequestingPCR))
+
+	_, v1PodNoPCRVolume := makeTestPod("ns", "pcrpod-novolume", pcrNode1.ObjectMeta.Name, false)
+	v1PodNoPCRVolume.Spec.ServiceAccountName = pcrSA.Name
+	checkNilError(t, pcrPodIndex.Add(v1PodNoPCRVolume))
+
+	_, v1PodWrongSignerPCRVolume := makeTestPod("ns", "pcrpod-wrongsigner", pcrNode1.ObjectMeta.Name, false)
+	v1PodWrongSignerPCRVolume.Spec.ServiceAccountName = pcrSA.Name
+	v1PodWrongSignerPCRVolume.Spec.Volumes = []corev1.Volume{{
+		Name: "pod-cert",
+		VolumeSource: corev1.VolumeSource{
+			Projected: &corev1.ProjectedVolumeSource{
+				Sources: []corev1.VolumeProjection{{
+					PodCertificate: &corev1.PodCertificateProjection{
+						SignerName: "example.com/other",
+					},
+				}},
+			},
+		},
+	}}
+	checkNilError(t, pcrPodIndex.Add(v1PodWrongSignerPCRVolume))
 
 	tests := []admitTestCase{
 		// Mirror pods bound to us
@@ -1424,13 +1463,13 @@ func Test_nodePlugin_Admit(t *testing.T) {
 			},
 			attributes: admission.NewAttributesRecord(makeTokenRequest(coremypod.Name, coremypod.UID, []string{"foo"}), nil, tokenrequestKind, coremypod.Namespace, "mysa", svcacctResource, "token", admission.Create, &metav1.CreateOptions{}, false, mynode),
 			err:        `serviceaccounts "mysa" is forbidden: system:node:mynode is not authorized to request tokens for audience "foo"`,
-			authz: fakeAuthorizer{
+			authz: saAuthorizerBuilder{
 				t:                  t,
 				serviceAccountName: "mysa",
 				namespace:          coremypod.Namespace,
 				requestAudience:    "foo",
 				decision:           authorizer.DecisionDeny,
-			},
+			}.build(),
 		},
 		{
 			name:            "allow create of token when audience in pod --> csi --> driver --> tokenrequest with audience and ServiceAccountNodeAudienceRestriction is enabled",
@@ -1454,13 +1493,13 @@ func Test_nodePlugin_Admit(t *testing.T) {
 			},
 			attributes: admission.NewAttributesRecord(makeTokenRequest(coremypodWithCSI.Name, v1mypodWithCSI.UID, []string{"bar"}), nil, tokenrequestKind, coremypod.Namespace, "mysa", svcacctResource, "token", admission.Create, &metav1.CreateOptions{}, false, mynode),
 			err:        `system:node:mynode is not authorized to request tokens for audience "bar"`,
-			authz: fakeAuthorizer{
+			authz: saAuthorizerBuilder{
 				t:                  t,
 				serviceAccountName: "mysa",
 				namespace:          coremypod.Namespace,
 				requestAudience:    "bar",
 				decision:           authorizer.DecisionDeny,
-			},
+			}.build(),
 		},
 		{
 			name:            "forbid create of token when audience in pod --> csi --> driver --> tokenrequest with audience and ServiceAccountNodeAudienceRestriction is enabled, csidriver not found",
@@ -1473,7 +1512,6 @@ func Test_nodePlugin_Admit(t *testing.T) {
 			},
 			attributes: admission.NewAttributesRecord(makeTokenRequest(coremypodWithCSI.Name, v1mypodWithCSI.UID, []string{"foo"}), nil, tokenrequestKind, coremypod.Namespace, "mysa", svcacctResource, "token", admission.Create, &metav1.CreateOptions{}, false, mynode),
 			err:        `error validating audience "foo": csidriver.storage.k8s.io "com.example.csi.mydriver" not found`,
-			authz:      fakeAuthorizer{},
 		},
 		{
 			name:            "allow create of token when audience in pod --> pvc --> pv --> csi --> driver --> tokenrequest with audience and ServiceAccountNodeAudienceRestriction is enabled",
@@ -1501,13 +1539,13 @@ func Test_nodePlugin_Admit(t *testing.T) {
 			},
 			attributes: admission.NewAttributesRecord(makeTokenRequest(coremypodWithPVCRefCSI.Name, v1mypodWithPVCRefCSI.UID, []string{"bar"}), nil, tokenrequestKind, coremypod.Namespace, "mysa", svcacctResource, "token", admission.Create, &metav1.CreateOptions{}, false, mynode),
 			err:        `system:node:mynode is not authorized to request tokens for audience "bar"`,
-			authz: fakeAuthorizer{
+			authz: saAuthorizerBuilder{
 				t:                  t,
 				serviceAccountName: "mysa",
 				namespace:          coremypod.Namespace,
 				requestAudience:    "bar",
 				decision:           authorizer.DecisionDeny,
-			},
+			}.build(),
 		},
 		{
 			name:            "forbid create of token when audience in pod --> pvc --> pv --> csi --> driver --> tokenrequest with audience and ServiceAccountNodeAudienceRestriction is enabled, pvc not found",
@@ -1522,7 +1560,6 @@ func Test_nodePlugin_Admit(t *testing.T) {
 			},
 			attributes: admission.NewAttributesRecord(makeTokenRequest(coremypodWithPVCRefCSI.Name, v1mypodWithPVCRefCSI.UID, []string{"foo"}), nil, tokenrequestKind, coremypod.Namespace, "mysa", svcacctResource, "token", admission.Create, &metav1.CreateOptions{}, false, mynode),
 			err:        `error validating audience "foo": persistentvolumeclaim "pvclaim" not found`,
-			authz:      fakeAuthorizer{},
 		},
 		{
 			name:            "forbid create of token when audience in pod --> pvc --> pv --> csi --> driver --> tokenrequest with audience and ServiceAccountNodeAudienceRestriction is enabled, pv not found",
@@ -1537,7 +1574,6 @@ func Test_nodePlugin_Admit(t *testing.T) {
 			},
 			attributes: admission.NewAttributesRecord(makeTokenRequest(coremypodWithPVCRefCSI.Name, v1mypodWithPVCRefCSI.UID, []string{"foo"}), nil, tokenrequestKind, coremypod.Namespace, "mysa", svcacctResource, "token", admission.Create, &metav1.CreateOptions{}, false, mynode),
 			err:        `error validating audience "foo": persistentvolume "pvname" not found`,
-			authz:      fakeAuthorizer{},
 		},
 		{
 			name:            "allow create of token when audience in pod --> ephemeral --> pvc --> pv --> csi --> driver --> tokenrequest with audience and ServiceAccountNodeAudienceRestriction is enabled",
@@ -1565,13 +1601,13 @@ func Test_nodePlugin_Admit(t *testing.T) {
 			},
 			attributes: admission.NewAttributesRecord(makeTokenRequest(coremypodWithEphemeralVolume.Name, v1mypodWithEphemeralVolume.UID, []string{"bar"}), nil, tokenrequestKind, coremypod.Namespace, "mysa", svcacctResource, "token", admission.Create, &metav1.CreateOptions{}, false, mynode),
 			err:        `system:node:mynode is not authorized to request tokens for audience "bar"`,
-			authz: fakeAuthorizer{
+			authz: saAuthorizerBuilder{
 				t:                  t,
 				serviceAccountName: "mysa",
 				namespace:          coremypod.Namespace,
 				requestAudience:    "bar",
 				decision:           authorizer.DecisionDeny,
-			},
+			}.build(),
 		},
 		{
 			name:            "allow create of token when ServiceAccountNodeAudienceRestriction is disabled, pvc not found should not be checked",
@@ -1658,13 +1694,13 @@ func Test_nodePlugin_Admit(t *testing.T) {
 				featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.ServiceAccountNodeAudienceRestriction, true)
 			},
 			attributes: admission.NewAttributesRecord(makeTokenRequest(coremypod.Name, v1mypod.UID, []string{"foo"}), nil, tokenrequestKind, coremypod.Namespace, "mysa", svcacctResource, "token", admission.Create, &metav1.CreateOptions{}, false, mynode),
-			authz: fakeAuthorizer{
+			authz: saAuthorizerBuilder{
 				t:                  t,
 				serviceAccountName: "mysa",
 				namespace:          coremypod.Namespace,
 				requestAudience:    "foo",
 				decision:           authorizer.DecisionAllow,
-			},
+			}.build(),
 		},
 		{
 			name:            "forbid create of token when ServiceAccountNodeAudienceRestriction is enabled, clusterrole and clusterrolebinding for audience not configured",
@@ -1678,13 +1714,13 @@ func Test_nodePlugin_Admit(t *testing.T) {
 				featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.ServiceAccountNodeAudienceRestriction, true)
 			},
 			attributes: admission.NewAttributesRecord(makeTokenRequest(coremypod.Name, v1mypod.UID, []string{"foo"}), nil, tokenrequestKind, coremypod.Namespace, "mysa", svcacctResource, "token", admission.Create, &metav1.CreateOptions{}, false, mynode),
-			authz: fakeAuthorizer{
+			authz: saAuthorizerBuilder{
 				t:                  t,
 				serviceAccountName: "mysa",
 				namespace:          coremypod.Namespace,
 				requestAudience:    "foo",
 				decision:           authorizer.DecisionDeny,
-			},
+			}.build(),
 			err: `serviceaccounts "mysa" is forbidden: system:node:mynode is not authorized to request tokens for audience "foo"`,
 		},
 
@@ -1867,6 +1903,7 @@ func Test_nodePlugin_Admit(t *testing.T) {
 			nodesGetter:          pcrNodes,
 			attributes:           createPCRAttributes(v1PodRequestingPCR.ObjectMeta.Namespace, v1PodRequestingPCR.ObjectMeta.Name, v1PodRequestingPCR.ObjectMeta.UID, v1PodRequestingPCR.Spec.ServiceAccountName, "", pcrNode1.ObjectMeta.Name, pcrNode1.ObjectMeta.UID, pcrNode1UserInfo),
 			err:                  "PodCertificateRequest feature gate is disabled",
+			authz:                &uncallableAuthorizer{},
 		},
 		{
 			name:                 "allow node1 create PCR that references pod on node1",
@@ -1879,6 +1916,7 @@ func Test_nodePlugin_Admit(t *testing.T) {
 				t.Helper()
 				featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.PodCertificateRequest, true)
 			},
+			authz: &uncallableAuthorizer{},
 		},
 		{
 			name:                 "deny create node2 create PCR that references pod on node1",
@@ -1891,7 +1929,8 @@ func Test_nodePlugin_Admit(t *testing.T) {
 				t.Helper()
 				featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.PodCertificateRequest, true)
 			},
-			err: `PodCertificateRequest.Spec.NodeName="pcr-node-1", which is not the requesting node "pcr-node-2"`,
+			authz: &uncallableAuthorizer{},
+			err:   `PodCertificateRequest.Spec.NodeName="pcr-node-1", which is not the requesting node "pcr-node-2"`,
 		},
 		{
 			name:                 "deny node1 create PCR that references nonexistent pod",
@@ -1904,7 +1943,8 @@ func Test_nodePlugin_Admit(t *testing.T) {
 				t.Helper()
 				featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.PodCertificateRequest, true)
 			},
-			err: `pod "nonexistent-pod" not found`,
+			authz: &uncallableAuthorizer{},
+			err:   `pod "nonexistent-pod" not found`,
 		},
 		{
 			name:                 "deny node1 create PCR that references nonexistent sa",
@@ -1917,7 +1957,8 @@ func Test_nodePlugin_Admit(t *testing.T) {
 				t.Helper()
 				featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.PodCertificateRequest, true)
 			},
-			err: `PodCertificateRequest for pod "ns/pcrpod" contains serviceAccountName ("nonexistent-sa") that differs from running pod ("pcr-sa")`,
+			authz: &uncallableAuthorizer{},
+			err:   `PodCertificateRequest for pod "ns/pcrpod" contains serviceAccountName ("nonexistent-sa") that differs from running pod ("pcr-sa")`,
 		},
 		{
 			name:                 "deny node1 create PCR that references nonexistent node",
@@ -1930,7 +1971,8 @@ func Test_nodePlugin_Admit(t *testing.T) {
 				t.Helper()
 				featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.PodCertificateRequest, true)
 			},
-			err: `PodCertificateRequest.Spec.NodeName="nonexistent-node", which is not the requesting node "pcr-node-1"`,
+			authz: &uncallableAuthorizer{},
+			err:   `PodCertificateRequest.Spec.NodeName="nonexistent-node", which is not the requesting node "pcr-node-1"`,
 		},
 		{
 			name:                 "deny node1 create PCR with mismatched pod UID",
@@ -1943,7 +1985,8 @@ func Test_nodePlugin_Admit(t *testing.T) {
 				t.Helper()
 				featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.PodCertificateRequest, true)
 			},
-			err: `PodCertificateRequest for pod "ns/pcrpod" contains pod UID ("wrong-uid") which differs from running pod "pod-uid"`,
+			authz: &uncallableAuthorizer{},
+			err:   `PodCertificateRequest for pod "ns/pcrpod" contains pod UID ("wrong-uid") which differs from running pod "pod-uid"`,
 		},
 		{
 			name:                 "deny node1 create PCR with mismatched SA UID",
@@ -1965,7 +2008,8 @@ func Test_nodePlugin_Admit(t *testing.T) {
 				t.Helper()
 				featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.PodCertificateRequest, true)
 			},
-			err: `PodCertificateRequest for pod "ns/pcrpod" names service account UID "wrong-uid", which differs from the running service account ("pcr-sa-uid")`,
+			authz: &uncallableAuthorizer{},
+			err:   `PodCertificateRequest for pod "ns/pcrpod" names service account UID "wrong-uid", which differs from the running service account ("pcr-sa-uid")`,
 		},
 		{
 			name:                 "deny node1 create PCR with mismatched node UID",
@@ -1987,7 +2031,107 @@ func Test_nodePlugin_Admit(t *testing.T) {
 				t.Helper()
 				featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.PodCertificateRequest, true)
 			},
-			err: `PodCertificateRequest for pod "ns/pcrpod" names node UID "wrong-uid", inconsistent with the running node ("pcr-node-1-uid")`,
+			authz: &uncallableAuthorizer{},
+			err:   `PodCertificateRequest for pod "ns/pcrpod" names node UID "wrong-uid", inconsistent with the running node ("pcr-node-1-uid")`,
+		},
+		{
+			name:                 "deny node1 create PCR for pod without podCertificate volume",
+			podsGetter:           pcrPods,
+			serviceAccountGetter: pcrServiceAccounts,
+			nodesGetter:          pcrNodes,
+			attributes:           createPCRAttributes(v1PodNoPCRVolume.ObjectMeta.Namespace, v1PodNoPCRVolume.ObjectMeta.Name, v1PodNoPCRVolume.ObjectMeta.UID, pcrSA.ObjectMeta.Name, pcrSA.ObjectMeta.UID, pcrNode1.ObjectMeta.Name, pcrNode1.ObjectMeta.UID, pcrNode1UserInfo),
+			features:             feature.DefaultFeatureGate,
+			setupFunc: func(t *testing.T) {
+				t.Helper()
+				featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.PodCertificateRequest, true)
+			},
+			authz: &fakeAuthorizer{
+				t:          t,
+				userName:   "system:node:" + pcrNode1.ObjectMeta.Name,
+				groups:     []string{"system:nodes"},
+				verb:       "request-serviceaccounts-podcertificate-signer",
+				apiGroup:   "certificates.k8s.io",
+				apiVersion: "v1beta1",
+				resource:   "example.com:foo",
+				namespace:  v1PodNoPCRVolume.ObjectMeta.Namespace,
+				name:       pcrSA.ObjectMeta.Name,
+				decision:   authorizer.DecisionDeny,
+			},
+			err: `pod "ns/pcrpod-novolume" does not mount a podCertificate projected volume for signer "example.com/foo"`,
+		},
+		{
+			name:                 "deny node1 create PCR for pod without podCertificate volume",
+			podsGetter:           pcrPods,
+			serviceAccountGetter: pcrServiceAccounts,
+			nodesGetter:          pcrNodes,
+			attributes:           createPCRAttributes(v1PodNoPCRVolume.ObjectMeta.Namespace, v1PodNoPCRVolume.ObjectMeta.Name, v1PodNoPCRVolume.ObjectMeta.UID, pcrSA.ObjectMeta.Name, pcrSA.ObjectMeta.UID, pcrNode1.ObjectMeta.Name, pcrNode1.ObjectMeta.UID, pcrNode1UserInfo),
+			features:             feature.DefaultFeatureGate,
+			setupFunc: func(t *testing.T) {
+				t.Helper()
+				featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.PodCertificateRequest, true)
+			},
+			authz: &fakeAuthorizer{
+				t:          t,
+				userName:   "system:node:" + pcrNode1.ObjectMeta.Name,
+				groups:     []string{"system:nodes"},
+				verb:       "request-serviceaccounts-podcertificate-signer",
+				apiGroup:   "certificates.k8s.io",
+				apiVersion: "v1beta1",
+				resource:   "example.com:foo",
+				namespace:  v1PodNoPCRVolume.ObjectMeta.Namespace,
+				name:       pcrSA.ObjectMeta.Name,
+				decision:   authorizer.DecisionNoOpinion,
+			},
+			err: `pod "ns/pcrpod-novolume" does not mount a podCertificate projected volume for signer "example.com/foo"`,
+		},
+		{
+			name:                 "deny node1 create PCR for pod with podCertificate volume for wrong signer",
+			podsGetter:           pcrPods,
+			serviceAccountGetter: pcrServiceAccounts,
+			nodesGetter:          pcrNodes,
+			attributes:           createPCRAttributes(v1PodWrongSignerPCRVolume.ObjectMeta.Namespace, v1PodWrongSignerPCRVolume.ObjectMeta.Name, v1PodWrongSignerPCRVolume.ObjectMeta.UID, pcrSA.ObjectMeta.Name, pcrSA.ObjectMeta.UID, pcrNode1.ObjectMeta.Name, pcrNode1.ObjectMeta.UID, pcrNode1UserInfo),
+			features:             feature.DefaultFeatureGate,
+			setupFunc: func(t *testing.T) {
+				t.Helper()
+				featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.PodCertificateRequest, true)
+			},
+			authz: &fakeAuthorizer{
+				t:          t,
+				userName:   "system:node:" + pcrNode1.ObjectMeta.Name,
+				groups:     []string{"system:nodes"},
+				verb:       "request-serviceaccounts-podcertificate-signer",
+				apiGroup:   "certificates.k8s.io",
+				apiVersion: "v1beta1",
+				resource:   "example.com:foo",
+				namespace:  v1PodWrongSignerPCRVolume.ObjectMeta.Namespace,
+				name:       pcrSA.ObjectMeta.Name,
+				decision:   authorizer.DecisionDeny,
+			},
+			err: `pod "ns/pcrpod-wrongsigner" does not mount a podCertificate projected volume for signer "example.com/foo"`,
+		},
+		{
+			name:                 "allow node1 create PCR for pod without podCertificate volume when bypass is granted",
+			podsGetter:           pcrPods,
+			serviceAccountGetter: pcrServiceAccounts,
+			nodesGetter:          pcrNodes,
+			attributes:           createPCRAttributes(v1PodNoPCRVolume.ObjectMeta.Namespace, v1PodNoPCRVolume.ObjectMeta.Name, v1PodNoPCRVolume.ObjectMeta.UID, pcrSA.ObjectMeta.Name, pcrSA.ObjectMeta.UID, pcrNode1.ObjectMeta.Name, pcrNode1.ObjectMeta.UID, pcrNode1UserInfo),
+			features:             feature.DefaultFeatureGate,
+			setupFunc: func(t *testing.T) {
+				t.Helper()
+				featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.PodCertificateRequest, true)
+			},
+			authz: &fakeAuthorizer{
+				t:          t,
+				userName:   "system:node:" + pcrNode1.ObjectMeta.Name,
+				groups:     []string{"system:nodes"},
+				verb:       "request-serviceaccounts-podcertificate-signer",
+				apiGroup:   "certificates.k8s.io",
+				apiVersion: "v1beta1",
+				resource:   "example.com:foo",
+				namespace:  v1PodNoPCRVolume.ObjectMeta.Namespace,
+				name:       pcrSA.ObjectMeta.Name,
+				decision:   authorizer.DecisionAllow,
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -2383,8 +2527,8 @@ func createCSRAttributes(cn, signer string, validCsr bool, key any, user user.In
 }
 
 func createPCRAttributes(namespace string, podName string, podUID types.UID, serviceAccountName string, serviceAccountUID types.UID, nodeName string, nodeUID types.UID, user user.Info) admission.Attributes {
-	pcrResource := certificatesapi.Resource("podcertificaterequests").WithVersion("v1alpha1")
-	pcrKind := certificatesapi.Kind("PodCertificateRequest").WithVersion("v1alpha1")
+	pcrResource := certificatesapi.Resource("podcertificaterequests").WithVersion("v1beta1")
+	pcrKind := certificatesapi.Kind("PodCertificateRequest").WithVersion("v1beta1")
 
 	pcr := &certificatesapi.PodCertificateRequest{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2593,7 +2737,73 @@ func checkNilError(t *testing.T, err error) {
 	}
 }
 
+// An authorizer that fails the test if it is called.  Some flows through the
+// noderestriction admission plugin are expected not to make authorization
+// checks, use this implementation to enforce that.
+type uncallableAuthorizer struct {
+	t *testing.T
+}
+
+var _ authorizer.UnconditionalAuthorizer = (*uncallableAuthorizer)(nil)
+
+func (f *uncallableAuthorizer) Authorize(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+	f.t.Errorf("the admission logic called the authorizer when it was not supposed to")
+	return authorizer.DecisionNoOpinion, "", nil
+}
+
 type fakeAuthorizer struct {
+	t        *testing.T
+	userName string
+	groups   []string
+
+	verb string
+
+	apiGroup   string
+	apiVersion string
+
+	resource  string
+	namespace string
+	name      string
+
+	decision authorizer.Decision
+	err      error
+
+	alreadyCalled bool
+}
+
+var _ authorizer.UnconditionalAuthorizer = (*fakeAuthorizer)(nil)
+
+func (f *fakeAuthorizer) Authorize(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+	if f.alreadyCalled {
+		f.t.Errorf("authorizer called more than once; the admission logic should call the authorizer at most once")
+		return authorizer.DecisionNoOpinion, "", nil
+	}
+	f.alreadyCalled = true
+
+	if f.err != nil {
+		return f.decision, "forced error", f.err
+	}
+
+	expectedAttrs := authorizer.AttributesRecord{
+		User:       &user.DefaultInfo{Name: f.userName, Groups: f.groups},
+		Verb:       f.verb,
+		Namespace:  f.namespace,
+		APIGroup:   f.apiGroup,
+		APIVersion: f.apiVersion,
+		Resource:   f.resource,
+		Name:       f.name,
+
+		ResourceRequest: true,
+	}
+
+	if diff := cmp.Diff(expectedAttrs, a); diff != "" {
+		f.t.Errorf("unexpected authorizer attributes; diff (-got +want)\n%s", diff)
+	}
+
+	return f.decision, "", nil
+}
+
+type saAuthorizerBuilder struct {
 	t                  *testing.T
 	serviceAccountName string
 	namespace          string
@@ -2602,25 +2812,23 @@ type fakeAuthorizer struct {
 	err                error
 }
 
-func (f fakeAuthorizer) Authorize(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
-	if f.err != nil {
-		return f.decision, "forced error", f.err
-	}
+func (s saAuthorizerBuilder) build() *fakeAuthorizer {
+	return &fakeAuthorizer{
+		t: s.t,
 
-	expectedAttrs := authorizer.AttributesRecord{
-		User:            &user.DefaultInfo{Name: "system:node:mynode", Groups: []string{"system:nodes"}},
-		Verb:            "request-serviceaccounts-token-audience",
-		Namespace:       f.namespace,
-		APIGroup:        "",
-		APIVersion:      "v1",
-		Resource:        f.requestAudience,
-		Name:            f.serviceAccountName,
-		ResourceRequest: true,
-	}
+		userName: "system:node:mynode",
+		groups:   []string{"system:nodes"},
 
-	if !reflect.DeepEqual(a, expectedAttrs) {
-		f.t.Errorf("expected attributes: %v, got: %v", expectedAttrs, a)
-	}
+		verb: "request-serviceaccounts-token-audience",
 
-	return f.decision, "", nil
+		apiGroup:   "",
+		apiVersion: "v1",
+
+		resource:  s.requestAudience,
+		namespace: s.namespace,
+		name:      s.serviceAccountName,
+
+		decision: s.decision,
+		err:      s.err,
+	}
 }

--- a/test/integration/podcertificaterequests/podcertificate_integration_test.go
+++ b/test/integration/podcertificaterequests/podcertificate_integration_test.go
@@ -28,6 +28,7 @@ import (
 
 	certsv1beta1 "k8s.io/api/certificates/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -38,6 +39,7 @@ import (
 	"k8s.io/klog/v2/ktesting"
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/pkg/controller/certificates/cleaner"
+	"k8s.io/kubernetes/test/integration/authutil"
 	"k8s.io/kubernetes/test/integration/framework"
 	"k8s.io/kubernetes/test/utils/hermeticpodcertificatesigner"
 	"k8s.io/utils/clock"
@@ -261,6 +263,7 @@ func TestNodeRestriction(t *testing.T) {
 					Image: "notarealimage",
 				},
 			},
+			Volumes: podCertificateVolume("kubernetes.io/foo"),
 		},
 	}
 	pod, err = client.CoreV1().Pods("default").Create(ctx, pod, metav1.CreateOptions{})
@@ -464,6 +467,7 @@ func TestNodeAuthorization(t *testing.T) {
 					Image: "notarealimage",
 				},
 			},
+			Volumes: podCertificateVolume("kubernetes.io/foo"),
 		},
 	}
 	pod, err = client.CoreV1().Pods("default").Create(ctx, pod, metav1.CreateOptions{})
@@ -684,6 +688,7 @@ func TestNodeAuthorizerNamespaceNameConfusion(t *testing.T) {
 					Image: "notarealimage",
 				},
 			},
+			Volumes: podCertificateVolume("kubernetes.io/foo"),
 		},
 	}
 	podBarFoo, err = client.CoreV1().Pods("bar").Create(ctx, podBarFoo, metav1.CreateOptions{})
@@ -704,6 +709,7 @@ func TestNodeAuthorizerNamespaceNameConfusion(t *testing.T) {
 					Image: "notarealimage",
 				},
 			},
+			Volumes: podCertificateVolume("kubernetes.io/foo"),
 		},
 	}
 	podFooBar, err = client.CoreV1().Pods("foo").Create(ctx, podFooBar, metav1.CreateOptions{})
@@ -851,6 +857,149 @@ func TestNodeAuthorizerNamespaceNameConfusion(t *testing.T) {
 	})
 }
 
+func TestSignerNameAuthorization(t *testing.T) {
+	// The noderestriction admission plugin normally requires that a pod mount a
+	// podCertificate projected volume for a given signer before its node is
+	// allowed to create a PodCertificateRequest for that signer.  As an
+	// administrator override, granting the
+	// "request-serviceaccounts-podcertificate-signer" verb on the signer name
+	// for a service account also authorizes the request.  This test exercises
+	// that override path with a pod that does *not* mount a podCertificate
+	// volume.
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Run an apiserver with PodCertificateRequest features enabled.
+	s := kubeapiservertesting.StartTestServerOrDie(
+		t,
+		kubeapiservertesting.NewDefaultTestServerOptions(),
+		[]string{
+			"--authorization-mode=Node,RBAC",
+			"--enable-admission-plugins=NodeRestriction",
+			"--feature-gates=PodCertificateRequest=true",
+			fmt.Sprintf("--runtime-config=%s=true", certsv1beta1.SchemeGroupVersion),
+		},
+		framework.SharedEtcd(),
+	)
+	defer s.TearDownFn()
+
+	client := clientset.NewForConfigOrDie(s.ClientConfig)
+
+	// Make node1
+	node1 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+		},
+		Spec: corev1.NodeSpec{},
+	}
+	node1, err := client.CoreV1().Nodes().Create(ctx, node1, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Unexpected error creating node1: %v", err)
+	}
+
+	// Make a serviceaccount
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "sa1",
+		},
+	}
+	sa, err = client.CoreV1().ServiceAccounts("default").Create(ctx, sa, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Unexpected error creating sa1: %v", err)
+	}
+
+	// Make a pod that does *not* mount a podCertificate projected volume.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "pod1",
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: sa.ObjectMeta.Name,
+			NodeName:           node1.ObjectMeta.Name,
+			Containers: []corev1.Container{
+				{
+					Name:  "main",
+					Image: "notarealimage",
+				},
+			},
+		},
+	}
+	pod, err = client.CoreV1().Pods("default").Create(ctx, pod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Unexpected error creating pod1: %v", err)
+	}
+
+	// Create a clientset that impersonates node1
+	node1Client, err := nodeClient(s.ClientConfig, "node1")
+	if err != nil {
+		t.Fatalf("Error in create clientset: %v", err)
+	}
+
+	_, _, pubPKIX, proof := mustMakeEd25519KeyAndProof(t, []byte(pod.ObjectMeta.UID))
+	makePCR := func() *certsv1beta1.PodCertificateRequest {
+		return &certsv1beta1.PodCertificateRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "pcr1",
+			},
+			Spec: certsv1beta1.PodCertificateRequestSpec{
+				SignerName:                "kubernetes.io/foo",
+				PodName:                   pod.ObjectMeta.Name,
+				PodUID:                    pod.ObjectMeta.UID,
+				ServiceAccountName:        sa.ObjectMeta.Name,
+				ServiceAccountUID:         sa.ObjectMeta.UID,
+				NodeName:                  types.NodeName(node1.ObjectMeta.Name),
+				NodeUID:                   node1.ObjectMeta.UID,
+				PKIXPublicKey:             pubPKIX,
+				ProofOfPossession:         proof,
+				UnverifiedUserAnnotations: map[string]string{hermeticpodcertificatesigner.SpiffePathKey: "pod1"},
+			},
+		}
+	}
+
+	t.Run("node1 cannot create PCR before the signer is authorized", func(t *testing.T) {
+		// Informer lag inside kube-apiserver could cause us to get a
+		// non-Forbidden error from the noderestriction admission plugin.  This
+		// should be transient, so wait for some time to see if we reach our
+		// durable Forbidden condition.
+		var lastErr string
+		err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
+			_, err := node1Client.CertificatesV1beta1().PodCertificateRequests("default").Create(ctx, makePCR(), metav1.CreateOptions{})
+			if err == nil || k8serrors.IsForbidden(err) {
+				return true, err
+			}
+			if errStr := err.Error(); errStr != lastErr {
+				t.Logf("Create PodCertificateRequest default/pcr1 as node1 failed with non-Forbidden error: %v, retrying...", err)
+				lastErr = errStr
+			}
+			return false, nil
+		})
+		if err == nil {
+			t.Fatalf("PCR creation unexpectedly succeeded before the signer was authorized")
+		} else if !k8serrors.IsForbidden(err) {
+			t.Fatalf("PCR creation failed with unexpected error code (wanted Forbidden): %v", err)
+		}
+	})
+
+	// Grant node1 the ability to request the kubernetes.io/foo signer for sa1.
+	authutil.GrantUserAuthorization(t, ctx, client, "system:node:node1", rbacv1.PolicyRule{
+		APIGroups:     []string{certsv1beta1.GroupName},
+		Resources:     []string{"kubernetes.io:foo"},
+		Verbs:         []string{"request-serviceaccounts-podcertificate-signer"},
+		ResourceNames: []string{sa.ObjectMeta.Name},
+	})
+
+	t.Run("node1 can create PCR once the signer is authorized via RBAC", func(t *testing.T) {
+		_, err := node1Client.CertificatesV1beta1().PodCertificateRequests("default").Create(ctx, makePCR(), metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("PCR creation unexpectedly failed after the signer was authorized: %v", err)
+		}
+	})
+}
+
 func serviceAccountClient(cfg *restclient.Config, ns, sa string) (*clientset.Clientset, error) {
 	newCfg := restclient.CopyConfig(cfg)
 	newCfg.Impersonate.UserName = fmt.Sprintf("system:serviceaccount:%s:%s", ns, sa)
@@ -863,6 +1012,31 @@ func nodeClient(cfg *restclient.Config, node string) (*clientset.Clientset, erro
 	newCfg.Impersonate.UserName = fmt.Sprintf("system:node:%s", node)
 	newCfg.Impersonate.Groups = []string{"system:authenticated", "system:nodes"}
 	return clientset.NewForConfig(newCfg)
+}
+
+// podCertificateVolume returns a projected volume that mounts a podCertificate
+// for the given signer.  Pods that mount such a volume are allowed by the
+// noderestriction admission plugin to have a PodCertificateRequest created for
+// the matching signer.
+func podCertificateVolume(signerName string) []corev1.Volume {
+	return []corev1.Volume{
+		{
+			Name: "podcert",
+			VolumeSource: corev1.VolumeSource{
+				Projected: &corev1.ProjectedVolumeSource{
+					Sources: []corev1.VolumeProjection{
+						{
+							PodCertificate: &corev1.PodCertificateProjection{
+								SignerName:           signerName,
+								KeyType:              "ED25519",
+								CredentialBundlePath: "creds.pem",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 func mustMakeEd25519KeyAndProof(t *testing.T, toBeSigned []byte) (ed25519.PrivateKey, ed25519.PublicKey, []byte, []byte) {


### PR DESCRIPTION
Kubelet's ability to generate service account tokens is restricted by the noderestriction admission plugin, which checks to make sure that the relevant pod actually mounts a token volume with the requested audience.

This commit adds an analogous mechanism for Pod Certificates, restricting the signer names that Kubelet can request.

The feature includes a similar authorizer-based override, where granting the "request-podcertificate-signer" verb for a given signer name allows bypassing the restriction.

Prepared with Claude Code.



/kind bug
/kind api-change

```release-note
The NodeRestriction admission plugin now adds a defense-in-depth check for PodCertificateRequests.  A node may only create a PodCertificateRequest referring to a particular signer name if the pod actually mounts a podCertificate projected volume source that refers to that signer name, or if an authorization check for the user (verb=request-podcertificate-signer resource=<signerName>) succeeds.
```

