### PR TITLE
batch: enable optionalorrequired kube-api-linter rule

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4772,10 +4772,6 @@
           "type": "string"
         }
       },
-      "required": [
-        "type",
-        "status"
-      ],
       "type": "object"
     },
     "io.k8s.api.batch.v1.JobList": {
@@ -5018,9 +5014,6 @@
           "x-kubernetes-list-type": "atomic"
         }
       },
-      "required": [
-        "rules"
-      ],
       "type": "object"
     },
     "io.k8s.api.batch.v1.PodFailurePolicyOnExitCodesRequirement": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4732,6 +4732,9 @@
           "description": "Current status of a job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
+      "required": [
+        "spec"
+      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -4998,6 +5001,9 @@
           "description": "Specification of the desired behavior of the job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
+      "required": [
+        "spec"
+      ],
       "type": "object"
     },
     "io.k8s.api.batch.v1.PodFailurePolicy": {

--- a/api/openapi-spec/v3/apis__batch__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1_openapi.json
@@ -212,6 +212,9 @@
             "description": "Current status of a job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
           }
         },
+        "required": [
+          "spec"
+        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {
@@ -548,6 +551,9 @@
             "description": "Specification of the desired behavior of the job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
           }
         },
+        "required": [
+          "spec"
+        ],
         "type": "object"
       },
       "io.k8s.api.batch.v1.PodFailurePolicy": {

--- a/api/openapi-spec/v3/apis__batch__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1_openapi.json
@@ -262,10 +262,6 @@
             "type": "string"
           }
         },
-        "required": [
-          "type",
-          "status"
-        ],
         "type": "object"
       },
       "io.k8s.api.batch.v1.JobList": {
@@ -568,9 +564,6 @@
             "x-kubernetes-list-type": "atomic"
           }
         },
-        "required": [
-          "rules"
-        ],
         "type": "object"
       },
       "io.k8s.api.batch.v1.PodFailurePolicyOnExitCodesRequirement": {

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -231,7 +231,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|certificates|core|discovery|events|extensions|networking|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -241,7 +241,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|batch|certificates|core|extensions|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|certificates|core|extensions|networking|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -246,7 +246,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|certificates|core|discovery|events|extensions|networking|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -256,7 +256,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|batch|certificates|core|extensions|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|certificates|core|extensions|networking|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -107,7 +107,7 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
+  path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|certificates|core|discovery|events|extensions|networking|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -117,7 +117,7 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|batch|certificates|core|extensions|networking|storage)"
+  path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|certificates|core|extensions|networking|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -16671,6 +16671,7 @@ func schema_k8sio_api_batch_v1_Job(ref common.ReferenceCallback) common.OpenAPID
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -17099,6 +17100,7 @@ func schema_k8sio_api_batch_v1_JobTemplateSpec(ref common.ReferenceCallback) com
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -17546,7 +17548,7 @@ func schema_k8sio_api_batch_v1beta1_CronJobSpec(ref common.ReferenceCallback) co
 						},
 					},
 				},
-				Required: []string{"schedule", "jobTemplate"},
+				Required: []string{"schedule"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -16729,7 +16729,6 @@ func schema_k8sio_api_batch_v1_JobCondition(ref common.ReferenceCallback) common
 						},
 					},
 				},
-				Required: []string{"type", "status"},
 			},
 		},
 		Dependencies: []string{
@@ -17134,7 +17133,6 @@ func schema_k8sio_api_batch_v1_PodFailurePolicy(ref common.ReferenceCallback) co
 						},
 					},
 				},
-				Required: []string{"rules"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -17546,7 +17546,7 @@ func schema_k8sio_api_batch_v1beta1_CronJobSpec(ref common.ReferenceCallback) co
 						},
 					},
 				},
-				Required: []string{"schedule"},
+				Required: []string{"schedule", "jobTemplate"},
 			},
 		},
 		Dependencies: []string{
@@ -17621,6 +17621,7 @@ func schema_k8sio_api_batch_v1beta1_JobTemplateSpec(ref common.ReferenceCallback
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -17591,7 +17591,7 @@ func schema_k8sio_api_batch_v1beta1_CronJobSpec(ref common.ReferenceCallback) co
 						},
 					},
 				},
-				Required: []string{"schedule"},
+				Required: []string{"schedule", "jobTemplate"},
 			},
 		},
 		Dependencies: []string{
@@ -17666,6 +17666,7 @@ func schema_k8sio_api_batch_v1beta1_JobTemplateSpec(ref common.ReferenceCallback
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -16774,7 +16774,6 @@ func schema_k8sio_api_batch_v1_JobCondition(ref common.ReferenceCallback) common
 						},
 					},
 				},
-				Required: []string{"type", "status"},
 			},
 		},
 		Dependencies: []string{
@@ -17179,7 +17178,6 @@ func schema_k8sio_api_batch_v1_PodFailurePolicy(ref common.ReferenceCallback) co
 						},
 					},
 				},
-				Required: []string{"rules"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -16716,6 +16716,7 @@ func schema_k8sio_api_batch_v1_Job(ref common.ReferenceCallback) common.OpenAPID
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -17144,6 +17145,7 @@ func schema_k8sio_api_batch_v1_JobTemplateSpec(ref common.ReferenceCallback) com
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -17591,7 +17593,7 @@ func schema_k8sio_api_batch_v1beta1_CronJobSpec(ref common.ReferenceCallback) co
 						},
 					},
 				},
-				Required: []string{"schedule", "jobTemplate"},
+				Required: []string{"schedule"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/api/batch/v1/generated.proto
+++ b/staging/src/k8s.io/api/batch/v1/generated.proto
@@ -99,6 +99,7 @@ message CronJobSpec {
   optional bool suspend = 4;
 
   // Specifies the job that will be created when executing a CronJob.
+  // +required
   optional JobTemplateSpec jobTemplate = 5;
 
   // The number of successful finished jobs to retain. Value must be non-negative integer.
@@ -138,7 +139,7 @@ message Job {
 
   // Specification of the desired behavior of a job.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  // +optional
+  // +required
   optional JobSpec spec = 2;
 
   // Current status of a job.
@@ -150,9 +151,11 @@ message Job {
 // JobCondition describes current state of a job.
 message JobCondition {
   // Type of job condition, Complete or Failed.
+  // +required
   optional string type = 1;
 
   // Status of the condition, one of True, False, Unknown.
+  // +required
   optional string status = 2;
 
   // Last time the condition was checked.
@@ -336,6 +339,7 @@ message JobSpec {
   // Describes the pod that will be created when executing a job.
   // The only allowed template.spec.restartPolicy values are "Never" or "OnFailure".
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+  // +required
   optional .k8s.io.api.core.v1.PodTemplateSpec template = 6;
 
   // ttlSecondsAfterFinished limits the lifetime of a Job that has finished
@@ -545,7 +549,7 @@ message JobTemplateSpec {
 
   // Specification of the desired behavior of the job.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  // +optional
+  // +required
   optional JobSpec spec = 2;
 }
 
@@ -557,6 +561,7 @@ message PodFailurePolicy {
   // counter of pod failures is incremented and it is checked against
   // the backoffLimit. At most 20 elements are allowed.
   // +listType=atomic
+  // +required
   repeated PodFailurePolicyRule rules = 1;
 }
 
@@ -586,6 +591,7 @@ message PodFailurePolicyOnExitCodesRequirement {
   //   by the 'containerName' field) is not in the set of specified values.
   // Additional values are considered to be added in the future. Clients should
   // react to an unknown operator by assuming the requirement is not satisfied.
+  // +required
   optional string operator = 2;
 
   // Specifies the set of values. Each returned container exit code (might be
@@ -594,6 +600,7 @@ message PodFailurePolicyOnExitCodesRequirement {
   // and must not contain duplicates. Value '0' cannot be used for the In operator.
   // At least one element is required. At most 255 elements are allowed.
   // +listType=set
+  // +required
   repeated int32 values = 3;
 }
 
@@ -602,6 +609,7 @@ message PodFailurePolicyOnExitCodesRequirement {
 message PodFailurePolicyOnPodConditionsPattern {
   // Specifies the required Pod condition type. To match a pod condition
   // it is required that specified type equals the pod condition type.
+  // +required
   optional string type = 1;
 
   // Specifies the required Pod condition status. To match a pod condition
@@ -627,6 +635,7 @@ message PodFailurePolicyRule {
   //   counter towards the .backoffLimit is incremented.
   // Additional values are considered to be added in the future. Clients should
   // react to an unknown action by skipping the rule.
+  // +required
   optional string action = 1;
 
   // Represents the requirement on the container exit codes.
@@ -650,6 +659,7 @@ message SuccessPolicy {
   // Additionally, these rules are evaluated in order; Once the Job meets one of the rules,
   // other rules are ignored. At most 20 elements are allowed.
   // +listType=atomic
+  // +required
   repeated SuccessPolicyRule rules = 1;
 }
 

--- a/staging/src/k8s.io/api/batch/v1/generated.proto
+++ b/staging/src/k8s.io/api/batch/v1/generated.proto
@@ -151,11 +151,11 @@ message Job {
 // JobCondition describes current state of a job.
 message JobCondition {
   // Type of job condition, Complete or Failed.
-  // +required
+  // +optional
   optional string type = 1;
 
   // Status of the condition, one of True, False, Unknown.
-  // +required
+  // +optional
   optional string status = 2;
 
   // Last time the condition was checked.
@@ -561,7 +561,7 @@ message PodFailurePolicy {
   // counter of pod failures is incremented and it is checked against
   // the backoffLimit. At most 20 elements are allowed.
   // +listType=atomic
-  // +required
+  // +optional
   repeated PodFailurePolicyRule rules = 1;
 }
 

--- a/staging/src/k8s.io/api/batch/v1/types.go
+++ b/staging/src/k8s.io/api/batch/v1/types.go
@@ -77,7 +77,7 @@ type Job struct {
 
 	// Specification of the desired behavior of a job.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// +optional
+	// +required
 	Spec JobSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 
 	// Current status of a job.
@@ -190,6 +190,7 @@ type PodFailurePolicyOnExitCodesRequirement struct {
 	//   by the 'containerName' field) is not in the set of specified values.
 	// Additional values are considered to be added in the future. Clients should
 	// react to an unknown operator by assuming the requirement is not satisfied.
+	// +required
 	Operator PodFailurePolicyOnExitCodesOperator `json:"operator" protobuf:"bytes,2,req,name=operator"`
 
 	// Specifies the set of values. Each returned container exit code (might be
@@ -198,6 +199,7 @@ type PodFailurePolicyOnExitCodesRequirement struct {
 	// and must not contain duplicates. Value '0' cannot be used for the In operator.
 	// At least one element is required. At most 255 elements are allowed.
 	// +listType=set
+	// +required
 	Values []int32 `json:"values" protobuf:"varint,3,rep,name=values"`
 }
 
@@ -206,6 +208,7 @@ type PodFailurePolicyOnExitCodesRequirement struct {
 type PodFailurePolicyOnPodConditionsPattern struct {
 	// Specifies the required Pod condition type. To match a pod condition
 	// it is required that specified type equals the pod condition type.
+	// +required
 	Type corev1.PodConditionType `json:"type" protobuf:"bytes,1,req,name=type"`
 
 	// Specifies the required Pod condition status. To match a pod condition
@@ -231,6 +234,7 @@ type PodFailurePolicyRule struct {
 	//   counter towards the .backoffLimit is incremented.
 	// Additional values are considered to be added in the future. Clients should
 	// react to an unknown action by skipping the rule.
+	// +required
 	Action PodFailurePolicyAction `json:"action" protobuf:"bytes,1,req,name=action"`
 
 	// Represents the requirement on the container exit codes.
@@ -253,6 +257,7 @@ type PodFailurePolicy struct {
 	// counter of pod failures is incremented and it is checked against
 	// the backoffLimit. At most 20 elements are allowed.
 	// +listType=atomic
+	// +required
 	Rules []PodFailurePolicyRule `json:"rules" protobuf:"bytes,1,opt,name=rules"`
 }
 
@@ -265,6 +270,7 @@ type SuccessPolicy struct {
 	// Additionally, these rules are evaluated in order; Once the Job meets one of the rules,
 	// other rules are ignored. At most 20 elements are allowed.
 	// +listType=atomic
+	// +required
 	Rules []SuccessPolicyRule `json:"rules" protobuf:"bytes,1,opt,name=rules"`
 }
 
@@ -404,6 +410,7 @@ type JobSpec struct {
 	// Describes the pod that will be created when executing a job.
 	// The only allowed template.spec.restartPolicy values are "Never" or "OnFailure".
 	// More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+	// +required
 	Template corev1.PodTemplateSpec `json:"template" protobuf:"bytes,6,opt,name=template"`
 
 	// ttlSecondsAfterFinished limits the lifetime of a Job that has finished
@@ -714,8 +721,10 @@ const (
 // JobCondition describes current state of a job.
 type JobCondition struct {
 	// Type of job condition, Complete or Failed.
+	// +required
 	Type JobConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=JobConditionType"`
 	// Status of the condition, one of True, False, Unknown.
+	// +required
 	Status corev1.ConditionStatus `json:"status" protobuf:"bytes,2,opt,name=status,casttype=k8s.io/api/core/v1.ConditionStatus"`
 	// Last time the condition was checked.
 	// +optional
@@ -741,7 +750,7 @@ type JobTemplateSpec struct {
 
 	// Specification of the desired behavior of the job.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// +optional
+	// +required
 	Spec JobSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 
@@ -825,6 +834,7 @@ type CronJobSpec struct {
 	Suspend *bool `json:"suspend,omitempty" protobuf:"varint,4,opt,name=suspend"`
 
 	// Specifies the job that will be created when executing a CronJob.
+	// +required
 	JobTemplate JobTemplateSpec `json:"jobTemplate" protobuf:"bytes,5,opt,name=jobTemplate"`
 
 	// The number of successful finished jobs to retain. Value must be non-negative integer.

--- a/staging/src/k8s.io/api/batch/v1/types.go
+++ b/staging/src/k8s.io/api/batch/v1/types.go
@@ -257,7 +257,7 @@ type PodFailurePolicy struct {
 	// counter of pod failures is incremented and it is checked against
 	// the backoffLimit. At most 20 elements are allowed.
 	// +listType=atomic
-	// +required
+	// +optional
 	Rules []PodFailurePolicyRule `json:"rules" protobuf:"bytes,1,opt,name=rules"`
 }
 
@@ -721,10 +721,10 @@ const (
 // JobCondition describes current state of a job.
 type JobCondition struct {
 	// Type of job condition, Complete or Failed.
-	// +required
+	// +optional
 	Type JobConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=JobConditionType"`
 	// Status of the condition, one of True, False, Unknown.
-	// +required
+	// +optional
 	Status corev1.ConditionStatus `json:"status" protobuf:"bytes,2,opt,name=status,casttype=k8s.io/api/core/v1.ConditionStatus"`
 	// Last time the condition was checked.
 	// +optional

--- a/staging/src/k8s.io/api/batch/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/batch/v1beta1/generated.proto
@@ -99,6 +99,7 @@ message CronJobSpec {
   optional bool suspend = 4;
 
   // Specifies the job that will be created when executing a CronJob.
+  // +optional
   optional JobTemplateSpec jobTemplate = 5;
 
   // The number of successful finished jobs to retain.

--- a/staging/src/k8s.io/api/batch/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/batch/v1beta1/generated.proto
@@ -99,7 +99,7 @@ message CronJobSpec {
   optional bool suspend = 4;
 
   // Specifies the job that will be created when executing a CronJob.
-  // +optional
+  // +required
   optional JobTemplateSpec jobTemplate = 5;
 
   // The number of successful finished jobs to retain.
@@ -141,7 +141,7 @@ message JobTemplateSpec {
 
   // Specification of the desired behavior of the job.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  // +optional
+  // +required
   optional .k8s.io.api.batch.v1.JobSpec spec = 2;
 }
 

--- a/staging/src/k8s.io/api/batch/v1beta1/types.go
+++ b/staging/src/k8s.io/api/batch/v1beta1/types.go
@@ -122,6 +122,7 @@ type CronJobSpec struct {
 	Suspend *bool `json:"suspend,omitempty" protobuf:"varint,4,opt,name=suspend"`
 
 	// Specifies the job that will be created when executing a CronJob.
+	// +optional
 	JobTemplate JobTemplateSpec `json:"jobTemplate" protobuf:"bytes,5,opt,name=jobTemplate"`
 
 	// The number of successful finished jobs to retain.

--- a/staging/src/k8s.io/api/batch/v1beta1/types.go
+++ b/staging/src/k8s.io/api/batch/v1beta1/types.go
@@ -32,7 +32,7 @@ type JobTemplateSpec struct {
 
 	// Specification of the desired behavior of the job.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// +optional
+	// +required
 	Spec batchv1.JobSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 
@@ -122,7 +122,7 @@ type CronJobSpec struct {
 	Suspend *bool `json:"suspend,omitempty" protobuf:"varint,4,opt,name=suspend"`
 
 	// Specifies the job that will be created when executing a CronJob.
-	// +optional
+	// +required
 	JobTemplate JobTemplateSpec `json:"jobTemplate" protobuf:"bytes,5,opt,name=jobTemplate"`
 
 	// The number of successful finished jobs to retain.


### PR DESCRIPTION
Enables the `optionalorrequired` and `nonpointerstructs` kube-api-linter rules for the `batch` API group by removing it from the linter exclusion lists. Part of #134671.

This revives the work in #134718, which was auto-closed by the stale bot.

**What:**
- Tags each previously-untagged field in `batch/v1` and `batch/v1beta1` as `+optional` / `+required` to match what validation actually enforces. Fields that validation rejects when empty (`JobSpec.template`, `SuccessPolicy.rules`, `PodFailurePolicyRule.action`, `PodFailurePolicyOnExitCodesRequirement.operator`/`values`, `PodFailurePolicyOnPodConditionsPattern.type`) are marked `+required`; the rest stay `+optional`.
- `PodFailurePolicy.rules` and `JobCondition.type`/`status` are marked `+optional`: validation does not reject an empty rules list, an empty condition type, or an empty status (confirmed in review). This drops `rules` from `PodFailurePolicy` and `type`/`status` from `JobCondition` in the generated OpenAPI `required` sets — a backward-compatible relaxation that aligns the schema with enforced behavior.
- `Job.spec` and `JobTemplateSpec.spec` become `+required` per `nonpointerstructs` (non-pointer structs whose type has required fields), adding `spec` to their OpenAPI `required` set.
- `batch/v1beta1` `CronJobSpec.jobTemplate` and `JobTemplateSpec.spec` are marked `+required`, matching `batch/v1`. Both versions convert to the same internal type and `validateCronJobSpec` calls `ValidateJobTemplateSpec` unconditionally (`pkg/apis/batch/validation/validation.go:913`), so an empty `jobTemplate` is never accepted. `batch/v1beta1` is not served, so this changes no published schema.
- Regenerated protobuf, OpenAPI, and swagger specs. No validation/behavior change.

Verified with `hack/verify-golangci-lint.sh -c hack/golangci.yaml ./staging/src/k8s.io/api/batch/...` (0 issues).

```release-note
Updated the batch API group to improve OpenAPI schema correctness for fields being optional or required.
```

/sig apps
/assign @JoelSpeed


