### PR TITLE
DRA resourceslice controller: fix updation after quick delete

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
@@ -816,6 +816,7 @@ func (c *Controller) syncPool(ctx context.Context, poolName string) error {
 	}
 
 	// Update existing slices.
+	updated := false
 	for i, currentSlice := range currentSliceForDesiredSlice {
 		if !changedDesiredSlices.Has(i) && !bumpedGeneration {
 			continue
@@ -839,6 +840,7 @@ func (c *Controller) syncPool(ctx context.Context, poolName string) error {
 		}
 		logger.V(5).Info("Updated existing resource slice", "slice", klog.KObj(slice))
 		atomic.AddInt64(&c.numUpdates, 1)
+		updated = true
 		c.sliceStored(ctx, "update ResourceSlice", poolName, pool, i, slice, actualSlice)
 	}
 
@@ -906,9 +908,9 @@ func (c *Controller) syncPool(ctx context.Context, poolName string) error {
 	}
 
 	now := time.Now()
-	if added {
+	if added || updated {
 		c.lastAddByPool[poolName] = now
-		logger.V(5).Info("Added slices")
+		logger.V(5).Info("Added or updated slices")
 	} else if lastAdd, ok := c.lastAddByPool[poolName]; ok && start.After(lastAdd.Add(c.mutationCacheTTL)) {
 		// This sync started after the last add expired from the cache,
 		// so we are done and don't need to check again.

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller_test.go
@@ -1504,6 +1504,53 @@ func TestControllerSyncPool(t *testing.T) {
 	}
 }
 
+func TestControllerSyncPoolResyncsAfterUpdate(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+
+	const (
+		driverName = "driver"
+		poolName   = "pool"
+	)
+	mutationCacheTTL := time.Minute
+	syncDelay := 2 * mutationCacheTTL
+	generateName := encodeIndex(0, resourceSliceIndexMinLength) + "-" + driverName + "-"
+	sliceName := generateName + "0"
+
+	kubeClient := createTestClient(features{}, metav1.Time{},
+		MakeResourceSlice().Name(sliceName).GenerateName(generateName).ResourceVersion("1").
+			Driver(driverName).AllNodes(true).Devices([]resourceapi.Device{newDevice("old-device")}).
+			Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
+	)
+	var queue workqueue.Mock[string]
+	ctrl, err := newController(ctx, Options{
+		DriverName: driverName,
+		KubeClient: kubeClient,
+		Resources: &DriverResources{
+			Pools: map[string]Pool{
+				poolName: {
+					AllNodes:   true,
+					Generation: 1,
+					Slices:     []Slice{{Devices: []resourceapi.Device{newDevice("new-device")}}},
+				},
+			},
+		},
+		Queue:            &queue,
+		MutationCacheTTL: &mutationCacheTTL,
+		SyncDelay:        &syncDelay,
+	})
+	require.NoError(t, err, "create controller")
+	defer ctrl.Stop()
+
+	require.NoError(t, ctrl.syncPool(ctx, poolName), "sync pool")
+	assert.Equal(t, Stats{NumUpdates: 1}, ctrl.GetStats())
+
+	state := queue.State()
+	require.Len(t, state.Later, 1, "one delayed re-sync should be scheduled")
+	assert.Equal(t, poolName, state.Later[0].Item)
+	assert.Positive(t, state.Later[0].Duration)
+	assert.LessOrEqual(t, state.Later[0].Duration, mutationCacheTTL)
+}
+
 // TestControllerUpdateReconcilePoolWithNameValidation verifies that Update rejects
 // invalid pool sets when ReconcilePoolWithName is set
 func TestControllerUpdateReconcilePoolWithNameValidation(t *testing.T) {

--- a/test/integration/dra/core.go
+++ b/test/integration/dra/core.go
@@ -378,6 +378,7 @@ func testPublishResourceSlices(tCtx ktesting.TContext, haveLatestAPI bool, disab
 	var gotDroppedFieldError atomic.Bool
 	var gotValidationError atomic.Bool
 	var validationErrorsOkay atomic.Bool
+	var notFoundErrorsOkay atomic.Bool
 
 	setup := func(tCtx ktesting.TContext) (*resourceslice.Controller, func(tCtx ktesting.TContext) resourceslice.Stats, resourceslice.Stats) {
 		tCtx.Helper()
@@ -387,6 +388,7 @@ func testPublishResourceSlices(tCtx ktesting.TContext, haveLatestAPI bool, disab
 		gotDroppedFieldError.Store(false)
 		gotValidationError.Store(false)
 		validationErrorsOkay.Store(false)
+		notFoundErrorsOkay.Store(false)
 
 		opts := resourceslice.Options{
 			DriverName:       driverName,
@@ -396,6 +398,9 @@ func testPublishResourceSlices(tCtx ktesting.TContext, haveLatestAPI bool, disab
 			SyncDelay:        &syncDelay,
 			ErrorHandler: func(ctx context.Context, err error, msg string) {
 				klog.FromContext(ctx).Info("ErrorHandler called", "err", err, "msg", msg)
+				if notFoundErrorsOkay.Load() && apierrors.IsNotFound(err) {
+					return
+				}
 				if !validationErrorsOkay.Load() && len(disabledFeatures) == 0 {
 					assert.NoError(tCtx, err, msg)
 					return
@@ -485,7 +490,7 @@ func testPublishResourceSlices(tCtx ktesting.TContext, haveLatestAPI bool, disab
 	runSubTest(tCtx, "fix-after-update", func(tCtx ktesting.TContext) {
 		_, getStats, expectedStats := setup(tCtx)
 
-		// Stress the controller by repeatedly updatings the slices.
+		// Stress the controller by repeatedly updating the slices.
 		for range 2 {
 			slices, err := tCtx.Client().ResourceV1().ResourceSlices().List(tCtx, listDriverSlices)
 			tCtx.ExpectNoError(err, "list slices")
@@ -502,6 +507,45 @@ func testPublishResourceSlices(tCtx ktesting.TContext, haveLatestAPI bool, disab
 			}
 			expectedStats.NumUpdates += int64(len(expectedSlices))
 			tCtx.Eventually(getStats).WithTimeout(syncDelay + 5*time.Second).Should(gomega.Equal(expectedStats))
+			expectSlices(tCtx)
+		}
+	})
+
+	runSubTest(tCtx, "recreate-after-update-delete", func(tCtx ktesting.TContext) {
+		_, getStats, expectedStats := setup(tCtx)
+
+		for range 2 {
+			slices, err := tCtx.Client().ResourceV1().ResourceSlices().List(tCtx, listDriverSlices)
+			tCtx.ExpectNoError(err, "list slices")
+
+			updated := false
+			for _, slice := range slices.Items {
+				if len(slice.Spec.Devices) == 0 {
+					continue
+				}
+				if slice.Spec.Devices[0].Attributes == nil {
+					slice.Spec.Devices[0].Attributes = make(map[resourceapi.QualifiedName]resourceapi.DeviceAttribute)
+				}
+				trueValue := true
+				slice.Spec.Devices[0].Attributes["someUnwantedAttribute"] = resourceapi.DeviceAttribute{BoolValue: &trueValue}
+				_, err := tCtx.Client().ResourceV1().ResourceSlices().Update(tCtx, &slice, metav1.UpdateOptions{})
+				tCtx.ExpectNoError(err, "update slice")
+				updated = true
+				break
+			}
+			if !updated {
+				tCtx.Fatal("expected at least one ResourceSlice with devices")
+			}
+
+			expectedStats.NumUpdates++
+			tCtx.Eventually(getStats).WithTimeout(syncDelay + 5*time.Second).Should(gomega.Equal(expectedStats))
+			expectSlices(tCtx)
+
+			tCtx.Log("deleting ResourceSlices after update")
+			notFoundErrorsOkay.Store(true)
+			tCtx.ExpectNoError(tCtx.Client().ResourceV1().ResourceSlices().DeleteCollection(tCtx, metav1.DeleteOptions{}, listDriverSlices), "delete driver slices")
+			expectedStats.NumCreates += int64(len(expectedSlices))
+			tCtx.Eventually(getStats).WithTimeout(mutationCacheTTL + syncDelay + 5*time.Second).Should(gomega.Equal(expectedStats))
 			expectSlices(tCtx)
 		}
 	})


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

When upgrading a DRA driver DaemonSet, existing `ResourceSlice` objects can be updated by the ResourceSlice controller. If those updated slices are deleted quickly afterwards, the controller may not recreate them after the mutation cache TTL expires. PR https://github.com/kubernetes/kubernetes/pull/132683 fixed the same class of issue for `ResourceSlice` create requests by scheduling another sync after the mutation cache TTL. 

This PR applies the same handling to update requests.  Updates also go through the mutation cache via `sliceStored`, so after an update the controller needs another sync after the TTL to reconcile against the informer state. Without that follow-up sync, the controller can miss the deletion event and the updated `ResourceSlice` may remain missing.         

**How We Arrived at This Conclusion:** 

During a rolling upgrade of the DRA plugin DaemonSet across 6,000 nodes, approximately 20 nodes ended up with **permanently missing ResourceSlices** that were never recreated. By correlating kubelet logs and API server audit logs, we reconstructed the following event timeline:

1. T+0s (08:22:45) — The DaemonSet controller deletes the old DRA plugin pod as part of the rolling upgrade.
2. T+30s (08:23:15) — Kubelet detects the plugin as disconnected and schedules a 30-second cleanup timer to delete all ResourceSlices for this driver.
3. T+52s (08:23:37) — The replacement pod arrives and kubelet begins syncing it.
4. T+58s (08:23:43) — The new plugin process starts and registers its gRPC servers.
5. T+59s (08:23:44) —The new plugin calls **PublishResources**. The informer cache still contains the existing ResourceSlice, so the controller issues an Update rather than a Create (likely due to non-deterministic ordering of device entries in **ResourceSlice.spec.devices** causing a spurious diff). This writes the result into the MutationCache (TTL = 1 min, expiry ~08:24:45).
6. T+60s (08:23:45.372) — The cleanup timer fires.
7. T+60s (08:23:45.410) — The cleanup worker ResourceSlice for this driver/node from the API server.
8. T+60s (08:23:45.497) — kubelet registers the new plugin and calls CancelWork() — but the cleanup already executed, so cancellation has no effect.
9. ~T+90s (08:24:15, inferred) — The delete watch event triggers a sync after syncDelay=30s. The controller checks whether the slice needs recreation, but the **MutationCache still holds the stale entry** (expiry 08:24:45). It concludes the slice exists and takes no action.
10. T+120s (08:24:45) — The MutationCache entry expires. No further event triggers reconciliation. The ResourceSlice is permanently missing, causing pods that require this driver's resources to become unschedulable on the affected node.
                  

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
NONE


#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE

