### PR TITLE
CEL: move `.includes` function to standard lists library

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/environment/base.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/environment/base.go
@@ -69,7 +69,6 @@ var baseOpts = []VersionedOptions{
 
 			UnversionedLib(library.URLs),
 			UnversionedLib(library.Regex),
-			UnversionedLib(library.Lists),
 
 			// cel-go v0.17.7 change the cost of has() from 0 to 1, but also provided the CostEstimatorOptions option to preserve the old behavior, so we enabled it at the same time we bumped our cel version to v0.17.7.
 			// Since it is a regression fix, we apply it uniformly to all code use v0.17.7.
@@ -82,6 +81,13 @@ var baseOpts = []VersionedOptions{
 			// cel-go v0.17.7 change the cost of has() from 0 to 1, but also provided the CostEstimatorOptions option to preserve the old behavior, so we enabled it at the same time we bumped our cel version to v0.17.7.
 			// Since it is a regression fix, we apply it uniformly to all code use v0.17.7.
 			cel.CostTrackerOptions(interpreter.PresenceTestHasCost(false)),
+		},
+	},
+	{
+		IntroducedVersion: version.MajorMinor(1, 0),
+		RemovedVersion:    version.MajorMinor(1, 37),
+		EnvOptions: []cel.EnvOption{
+			library.Lists(library.ListsVersion(0)),
 		},
 	},
 	{
@@ -171,6 +177,12 @@ var baseOpts = []VersionedOptions{
 		IntroducedVersion: version.MajorMinor(1, 34),
 		EnvOptions: []cel.EnvOption{
 			ext.Lists(ext.ListsVersion(3)),
+		},
+	},
+	{
+		IntroducedVersion: version.MajorMinor(1, 37),
+		EnvOptions: []cel.EnvOption{
+			library.Lists(library.ListsVersion(1)),
 		},
 	},
 	StrictCostOpt,

--- a/staging/src/k8s.io/apiserver/pkg/cel/environment/environment_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/environment/environment_test.go
@@ -52,6 +52,19 @@ func TestBaseEnvironment(t *testing.T) {
 			},
 		})
 
+	// Gated functions like 'includes' become available at 1.37. When the default compatibility version rolls over to 1.37 or later, 'includes' will be valid. We dynamically select valid/invalid expressions depending on the current DefaultCompatibilityVersion to prevent test failures during Kubernetes version bump.
+	var defaultCompatibilityInvalid []string
+	var defaultCompatibilityValid []string
+	if DefaultCompatibilityVersion().AtLeast(version.MajorMinor(1, 37)) {
+		defaultCompatibilityValid = []string{
+			"[1, 2].includes(2) == true",
+		}
+	} else {
+		defaultCompatibilityInvalid = []string{
+			"[1, 2].includes(2)",
+		}
+	}
+
 	cases := []struct {
 		name                    string
 		typeVersionCombinations []envTypeAndVersion
@@ -294,6 +307,42 @@ func TestBaseEnvironment(t *testing.T) {
 						cel.Variable("gadget", cel.ObjectType("Gadget")),
 					},
 				},
+			},
+		},
+		{
+			name: "includes function version gating (default compatibility version)",
+			typeVersionCombinations: []envTypeAndVersion{
+				{version: DefaultCompatibilityVersion(), envType: NewExpressions},
+			},
+			invalidExpressions: defaultCompatibilityInvalid,
+			validExpressions:   defaultCompatibilityValid,
+		},
+		{
+			name: "includes function version gating (emulated version 1.36)",
+			typeVersionCombinations: []envTypeAndVersion{
+				{version: version.MajorMinor(1, 36), envType: NewExpressions},
+			},
+			invalidExpressions: []string{
+				"[1, 2].includes(2)",
+			},
+		},
+		{
+			name: "includes function available (emulated version 1.37)",
+			typeVersionCombinations: []envTypeAndVersion{
+				{version: version.MajorMinor(1, 37), envType: NewExpressions},
+			},
+			validExpressions: []string{
+				"[1, 2].includes(2) == true",
+			},
+		},
+		{
+			name: "includes function available (stored expressions for default/1.36)",
+			typeVersionCombinations: []envTypeAndVersion{
+				{version: DefaultCompatibilityVersion(), envType: StoredExpressions},
+				{version: version.MajorMinor(1, 36), envType: StoredExpressions},
+			},
+			validExpressions: []string{
+				"[1, 2].includes(2) == true",
 			},
 		},
 	}

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/cost.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/cost.go
@@ -101,7 +101,7 @@ func (l *CostEstimator) CallCost(function, overloadId string, args []ref.Val, re
 			cost := selectorCostEstimate(checker.SizeEstimate{Min: selectorLength, Max: selectorLength})
 			return &cost.Max
 		}
-	case "isSorted", "sum", "max", "min", "indexOf", "lastIndexOf":
+	case "isSorted", "sum", "max", "min", "indexOf", "lastIndexOf", "includes":
 		var cost uint64
 		if len(args) > 0 {
 			cost += traversalCost(args[0]) // these O(n) operations all cost roughly the cost of a single traversal
@@ -287,7 +287,7 @@ func (l *CostEstimator) EstimateCallCost(function, overloadId string, target *ch
 		if len(args) == 1 {
 			return &checker.CallEstimate{CostEstimate: selectorCostEstimate(l.sizeEstimate(args[0]))}
 		}
-	case "isSorted", "sum", "max", "min", "indexOf", "lastIndexOf":
+	case "isSorted", "sum", "max", "min", "indexOf", "lastIndexOf", "includes":
 		if target != nil {
 			// Charge 1 cost for comparing each element in the list
 			elCost := checker.CostEstimate{Min: 1, Max: 1}
@@ -300,7 +300,12 @@ func (l *CostEstimator) EstimateCallCost(function, overloadId string, target *ch
 					elCost = elCost.Add(sz.MultiplyByCostFactor(common.StringTraversalCostFactor))
 				}
 				return &checker.CallEstimate{CostEstimate: l.sizeEstimate(*target).MultiplyByCost(elCost)}
-			} else { // the target is a string, which is supported by indexOf and lastIndexOf
+			} else if function == "includes" {
+				// Since target can be a list under DynType, the worst case is a list comparison of size n,
+				// where each comparison costs 1.
+				return &checker.CallEstimate{CostEstimate: l.sizeEstimate(*target).MultiplyByCost(elCost)}
+			} else {
+				// the target is a string, which is supported by indexOf and lastIndexOf
 				return &checker.CallEstimate{CostEstimate: l.sizeEstimate(*target).MultiplyByCostFactor(common.StringTraversalCostFactor)}
 			}
 		}

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/cost_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/cost_test.go
@@ -198,6 +198,66 @@ func TestIndexOfCost(t *testing.T) {
 	}
 }
 
+func TestIncludesCost(t *testing.T) {
+	cases := []struct {
+		opts  []string
+		costs []comparableCost
+	}{
+		{
+			opts: []string{".includes(%s)"},
+			costs: []comparableCost{
+				{
+					comparableLiteral: intListLiteral, param: "3",
+					expectedEstimatedCost: checker.CostEstimate{Min: 15, Max: 15}, expectedRuntimeCost: 15,
+				},
+				{
+					comparableLiteral: uintListLiteral, param: "uint(3)",
+					expectedEstimatedCost: checker.CostEstimate{Min: 21, Max: 21}, expectedRuntimeCost: 21, // +5 for numeric casts
+				},
+				{
+					comparableLiteral: doubleListLiteral, param: "3.0",
+					expectedEstimatedCost: checker.CostEstimate{Min: 15, Max: 15}, expectedRuntimeCost: 15,
+				},
+				{
+					comparableLiteral: boolListLiteral, param: "true",
+					expectedEstimatedCost: checker.CostEstimate{Min: 15, Max: 15}, expectedRuntimeCost: 15,
+				},
+				{
+					comparableLiteral: stringListLiteral, param: "'x'",
+					expectedEstimatedCost: checker.CostEstimate{Min: 15, Max: 25}, expectedRuntimeCost: 15, // +5 for string comparisons
+				},
+				{
+					comparableLiteral: bytesListLiteral, param: "bytes('x')",
+					expectedEstimatedCost: checker.CostEstimate{Min: 26, Max: 36}, expectedRuntimeCost: 26, // +11 for casts from string to byte, +5 for byte comparisons
+				},
+				{
+					comparableLiteral: durationListLiteral, param: "duration('3s')",
+					expectedEstimatedCost: checker.CostEstimate{Min: 21, Max: 21}, expectedRuntimeCost: 21, // +6 for casts from duration to byte
+				},
+				{
+					comparableLiteral: timestampListLiteral, param: "timestamp('2011-01-03T00:00:00.000+01:00')",
+					expectedEstimatedCost: checker.CostEstimate{Min: 21, Max: 21}, expectedRuntimeCost: 21, // +6 for casts from timestamp to byte
+				},
+				{
+					comparableLiteral: stringLiteral, param: "'123'",
+					expectedEstimatedCost: checker.CostEstimate{Min: 50, Max: 50}, expectedRuntimeCost: 5,
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		for _, op := range tc.opts {
+			for _, typ := range tc.costs {
+				opWithParam := fmt.Sprintf(op, typ.param)
+				t.Run(typ.comparableLiteral+opWithParam, func(t *testing.T) {
+					e := typ.comparableLiteral + opWithParam
+					testCost(t, e, typ.expectedEstimatedCost, typ.expectedRuntimeCost)
+				})
+			}
+		}
+	}
+}
+
 func TestURLsCost(t *testing.T) {
 	cases := []struct {
 		ops                []string
@@ -1290,7 +1350,7 @@ func testCost(t *testing.T, expr string, expectEsimatedCost checker.CostEstimate
 		ext.Strings(ext.StringsVersion(2)),
 		URLs(),
 		Regex(),
-		Lists(),
+		Lists(ListsVersion(1)),
 		Authz(),
 		AuthzSelectors(),
 		Quantity(),

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/library_compatibility_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/library_compatibility_test.go
@@ -59,6 +59,8 @@ func TestLibraryCompatibility(t *testing.T) {
 		"jsonpatch.escapeKey",
 		// Kubernetes <1.33>:
 		"semver", "isSemver", "major", "minor", "patch",
+		// Kubernetes <1.37>:
+		"includes",
 		// Kubernetes <1.??>:
 	)
 

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/lists.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/lists.go
@@ -18,6 +18,7 @@ package library
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
@@ -87,13 +88,45 @@ import (
 //	['a', 'b', 'b', 'c'].lastIndexOf('b') // returns 2
 //	[1.0].indexOf(1.1) // returns -1
 //	[].indexOf('string') // returns -1
-func Lists() cel.EnvOption {
-	return cel.Lib(listsLib)
+//
+// includes
+//
+// Returns true if the target list contains the element, or if the target is equal to the element.
+//
+//	<dyn>.includes(<dyn>) <bool>
+//
+// Examples:
+//
+//	[1, 2, 3].includes(2) // returns true
+//	[1, 2, 3].includes(4) // returns false
+//	'model-a'.includes('model-a') // returns true
+//	'model-a'.includes('model-b') // returns false
+//
+// ListsOption is a functional interface for configuring the lists library.
+type ListsOption func(*lists) *lists
+
+// ListsVersion sets the version of the lists library to use.
+func ListsVersion(version uint32) ListsOption {
+	return func(lib *lists) *lists {
+		lib.version = version
+		return lib
+	}
 }
 
-var listsLib = &lists{}
+// Lists provides a CEL function library extension of list utility functions.
+func Lists(options ...ListsOption) cel.EnvOption {
+	l := &lists{}
+	for _, o := range options {
+		l = o(l)
+	}
+	return cel.Lib(l)
+}
 
-type lists struct{}
+var listsLib = &lists{version: math.MaxUint32}
+
+type lists struct {
+	version uint32
+}
 
 func (*lists) LibraryName() string {
 	return "kubernetes.lists"
@@ -103,8 +136,45 @@ func (*lists) Types() []*cel.Type {
 	return []*cel.Type{}
 }
 
-func (*lists) declarations() map[string][]cel.FunctionOpt {
-	return listsLibraryDecls
+func (l *lists) declarations() map[string][]cel.FunctionOpt {
+	decls := map[string][]cel.FunctionOpt{
+		"isSorted": templatedOverloads(comparableTypes, func(name string, paramType *cel.Type) cel.FunctionOpt {
+			return cel.MemberOverload(fmt.Sprintf("list_%s_is_sorted_bool", name),
+				[]*cel.Type{cel.ListType(paramType)}, cel.BoolType, cel.UnaryBinding(isSorted))
+		}),
+		"sum": templatedOverloads(summableTypes, func(name string, paramType *cel.Type) cel.FunctionOpt {
+			return cel.MemberOverload(fmt.Sprintf("list_%s_sum_%s", name, name),
+				[]*cel.Type{cel.ListType(paramType)}, paramType, cel.UnaryBinding(func(list ref.Val) ref.Val {
+					return sum(
+						func() ref.Val {
+							return zeroValuesOfSummableTypes[name]
+						})(list)
+				}))
+		}),
+		"max": templatedOverloads(comparableTypes, func(name string, paramType *cel.Type) cel.FunctionOpt {
+			return cel.MemberOverload(fmt.Sprintf("list_%s_max_%s", name, name),
+				[]*cel.Type{cel.ListType(paramType)}, paramType, cel.UnaryBinding(max()))
+		}),
+		"min": templatedOverloads(comparableTypes, func(name string, paramType *cel.Type) cel.FunctionOpt {
+			return cel.MemberOverload(fmt.Sprintf("list_%s_min_%s", name, name),
+				[]*cel.Type{cel.ListType(paramType)}, paramType, cel.UnaryBinding(min()))
+		}),
+		"indexOf": {
+			cel.MemberOverload("list_a_index_of_int", []*cel.Type{cel.ListType(paramA), paramA}, cel.IntType,
+				cel.BinaryBinding(indexOf)),
+		},
+		"lastIndexOf": {
+			cel.MemberOverload("list_a_last_index_of_int", []*cel.Type{cel.ListType(paramA), paramA}, cel.IntType,
+				cel.BinaryBinding(lastIndexOf)),
+		},
+	}
+	if l.version >= 1 {
+		decls["includes"] = []cel.FunctionOpt{
+			cel.MemberOverload("list_includes_dyn_dyn", []*cel.Type{cel.DynType, cel.DynType}, cel.BoolType,
+				cel.BinaryBinding(includes)),
+		}
+	}
+	return decls
 }
 
 var paramA = cel.TypeParamType("A")
@@ -141,46 +211,19 @@ var comparableTypes = []namedCELType{
 	{typeName: "bytes", celType: cel.BytesType},
 }
 
-// WARNING: All library additions or modifications must follow
-// https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/2876-crd-validation-expression-language#function-library-updates
-var listsLibraryDecls = map[string][]cel.FunctionOpt{
-	"isSorted": templatedOverloads(comparableTypes, func(name string, paramType *cel.Type) cel.FunctionOpt {
-		return cel.MemberOverload(fmt.Sprintf("list_%s_is_sorted_bool", name),
-			[]*cel.Type{cel.ListType(paramType)}, cel.BoolType, cel.UnaryBinding(isSorted))
-	}),
-	"sum": templatedOverloads(summableTypes, func(name string, paramType *cel.Type) cel.FunctionOpt {
-		return cel.MemberOverload(fmt.Sprintf("list_%s_sum_%s", name, name),
-			[]*cel.Type{cel.ListType(paramType)}, paramType, cel.UnaryBinding(func(list ref.Val) ref.Val {
-				return sum(
-					func() ref.Val {
-						return zeroValuesOfSummableTypes[name]
-					})(list)
-			}))
-	}),
-	"max": templatedOverloads(comparableTypes, func(name string, paramType *cel.Type) cel.FunctionOpt {
-		return cel.MemberOverload(fmt.Sprintf("list_%s_max_%s", name, name),
-			[]*cel.Type{cel.ListType(paramType)}, paramType, cel.UnaryBinding(max()))
-	}),
-	"min": templatedOverloads(comparableTypes, func(name string, paramType *cel.Type) cel.FunctionOpt {
-		return cel.MemberOverload(fmt.Sprintf("list_%s_min_%s", name, name),
-			[]*cel.Type{cel.ListType(paramType)}, paramType, cel.UnaryBinding(min()))
-	}),
-	"indexOf": {
-		cel.MemberOverload("list_a_index_of_int", []*cel.Type{cel.ListType(paramA), paramA}, cel.IntType,
-			cel.BinaryBinding(indexOf)),
-	},
-	"lastIndexOf": {
-		cel.MemberOverload("list_a_last_index_of_int", []*cel.Type{cel.ListType(paramA), paramA}, cel.IntType,
-			cel.BinaryBinding(lastIndexOf)),
-	},
-}
-
-func (*lists) CompileOptions() []cel.EnvOption {
+func (l *lists) CompileOptions() []cel.EnvOption {
 	options := []cel.EnvOption{}
-	for name, overloads := range listsLibraryDecls {
+	for name, overloads := range l.declarations() {
 		options = append(options, cel.Function(name, overloads...))
 	}
 	return options
+}
+
+// IncludesOption returns the EnvOption to register the includes function directly.
+func IncludesOption() cel.EnvOption {
+	return cel.Function("includes",
+		cel.MemberOverload("list_includes_dyn_dyn", []*cel.Type{cel.DynType, cel.DynType}, cel.BoolType,
+			cel.BinaryBinding(includes)))
 }
 
 func (*lists) ProgramOptions() []cel.ProgramOption {
@@ -309,6 +352,24 @@ func lastIndexOf(list ref.Val, item ref.Val) ref.Val {
 		}
 	}
 	return types.Int(-1)
+}
+
+func includes(target, arg ref.Val) ref.Val {
+	if list, ok := target.(traits.Lister); ok {
+		it := list.Iterator()
+		for it.HasNext() == types.True {
+			item := it.Next()
+			if item.Equal(arg) == types.True {
+				return types.True
+			}
+		}
+		return types.False
+	}
+
+	if target.Equal(arg) == types.True {
+		return types.True
+	}
+	return types.False
 }
 
 // templatedOverloads returns overloads for each of the provided types. The template function is called with each type

--- a/staging/src/k8s.io/dynamic-resource-allocation/cel/compile.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/cel/compile.go
@@ -521,13 +521,8 @@ func newCompiler(features Features) *compiler {
 				return features.EnableListTypeAttributes
 			},
 			EnvOptions: []cel.EnvOption{
-				cel.Function("includes",
-					cel.MemberOverload("dra_includes_dyn_dyn",
-						[]*cel.Type{cel.DynType, cel.DynType},
-						cel.BoolType,
-						cel.BinaryBinding(includesFunc),
-					),
-				),
+				// TODO(https://github.com/kubernetes/kubernetes/issues/140074): Remove in 1.38 when 1.36 support is dropped and includes is natively provided by Lists(ListsVersion(1)) starting in 1.37.
+				library.IncludesOption(),
 			},
 		},
 	}
@@ -549,38 +544,6 @@ func newCompiler(features Features) *compiler {
 		envset:        envset,
 		declaredTypes: declaredTypes,
 	}
-}
-
-// includesFunc implements the "includes" function for CEL (<target>.includes(<arg>)),
-// which checks whether the target includes the argument.
-// It supports both singular values and lists.
-//
-// WARNING: includes is not applicable to lists longer than
-// resourceapi.ResourceSliceMaxAttributeValuesPerDevice. A runtime error gets
-// returned in that case to prevent unbounded execution cost.
-// The target is expected to be a scalar or list attribute, but users can
-// technically call "includes" on any value.
-func includesFunc(target, arg ref.Val) ref.Val {
-	if list, ok := target.(traits.Lister); ok {
-		i := 0
-		it := list.Iterator()
-		for it.HasNext() == types.True {
-			if i >= resourceapi.ResourceSliceMaxAttributeValuesPerDevice {
-				return types.NewErr("'includes' function cannot be applied to lists longer than %d values", resourceapi.ResourceSliceMaxAttributeValuesPerDevice)
-			}
-			item := it.Next()
-			if item.Equal(arg) == types.True {
-				return types.True
-			}
-			i++
-		}
-		return types.False
-	}
-
-	if target.Equal(arg) == types.True {
-		return types.True
-	}
-	return types.False
 }
 
 func withMaxElements(in *apiservercel.DeclType, maxElements uint64) *apiservercel.DeclType {
@@ -635,15 +598,6 @@ func (e *draCostEstimator) EstimateSize(element checker.AstNode) *checker.SizeEs
 }
 
 func (e *draCostEstimator) EstimateCallCost(function, overloadID string, target *checker.AstNode, args []checker.AstNode) *checker.CallEstimate {
-	if function == "includes" && overloadID == "dra_includes_dyn_dyn" {
-		// "<target>.includes(<arg>)" is equivalent with "<arg> in <target>"
-		// whose complexity is linear with the size of the target.
-		if target != nil {
-			targetSizeEstimate := checker.SizeEstimate{Min: 0, Max: resourceapi.ResourceSliceMaxAttributeValuesPerDevice}
-			return &checker.CallEstimate{CostEstimate: targetSizeEstimate.MultiplyByCost(checker.CostEstimate{Min: 1, Max: 1})}
-		}
-	}
-
 	return e.base.EstimateCallCost(function, overloadID, target, args)
 }
 

--- a/staging/src/k8s.io/dynamic-resource-allocation/cel/compile.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/cel/compile.go
@@ -221,8 +221,7 @@ func (c compiler) CompileCELExpression(expression string, options Options) Compi
 }
 
 func (c *compiler) newCostEstimator(typesFromEnv typesFromEnv) checker.CostEstimator {
-	base := &library.CostEstimator{SizeEstimator: &sizeEstimator{typesFromEnv}}
-	return &draCostEstimator{base: base}
+	return &library.CostEstimator{SizeEstimator: &sizeEstimator{typesFromEnv}}
 }
 
 type typesFromEnv struct {
@@ -586,19 +585,6 @@ func (m mapper) Find(key ref.Val) (ref.Val, bool) {
 	}
 
 	return m.defaultValue, true
-}
-
-// draCostEstimator is a wrapper around the base CEL CostEstimator to provide custom cost estimates for DRA-specific functions and types.
-type draCostEstimator struct {
-	base *library.CostEstimator
-}
-
-func (e *draCostEstimator) EstimateSize(element checker.AstNode) *checker.SizeEstimate {
-	return e.base.EstimateSize(element)
-}
-
-func (e *draCostEstimator) EstimateCallCost(function, overloadID string, target *checker.AstNode, args []checker.AstNode) *checker.CallEstimate {
-	return e.base.EstimateCallCost(function, overloadID, target, args)
 }
 
 // sizeEstimator tells the cost estimator the maximum size of maps, strings, or lists accessible through the `device` variable.

--- a/staging/src/k8s.io/dynamic-resource-allocation/cel/compile_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/cel/compile_test.go
@@ -203,7 +203,7 @@ var testcases = map[string]struct {
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValues: []string{"fish", "bird"}}},
 		driver:      "dra.example.com",
 		expectMatch: true,
-		expectCost:  4 + 48, /* cost of "includes" is max list length */
+		expectCost:  4 + 64, /* cost of "includes" on dynamic type */
 	},
 	"list-of-bool": {
 		expression:  `device.attributes["dra.example.com"].names.size() == 2`,
@@ -270,7 +270,7 @@ var testcases = map[string]struct {
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"attr": {StringValue: new("fish")}},
 		driver:      "dra.example.com",
 		expectMatch: true,
-		expectCost:  4 + 48, /* cost of "includes" is max list length */
+		expectCost:  4 + 64, /* cost of "includes" on dynamic type */
 	},
 	"includes-function-on-bool-scalar-positive": {
 		features:    &Features{EnableListTypeAttributes: true},
@@ -278,7 +278,7 @@ var testcases = map[string]struct {
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {BoolValue: new(true)}},
 		driver:      "dra.example.com",
 		expectMatch: true,
-		expectCost:  4 + 48, /* cost of "includes" is max list length */
+		expectCost:  4 + 64, /* cost of "includes" on dynamic type */
 	},
 	"includes-function-on-bool-scalar-negative": {
 		features:    &Features{EnableListTypeAttributes: true},
@@ -287,7 +287,7 @@ var testcases = map[string]struct {
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {BoolValue: new(false)}},
 		driver:      "dra.example.com",
 		expectMatch: false,
-		expectCost:  4 + 48, /* cost of "includes" is max list length */
+		expectCost:  4 + 64, /* cost of "includes" on dynamic type */
 	},
 	"includes-function-on-bool-list-positive": {
 		features:    &Features{EnableListTypeAttributes: true},
@@ -295,7 +295,7 @@ var testcases = map[string]struct {
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {BoolValues: []bool{true, false}}},
 		driver:      "dra.example.com",
 		expectMatch: true,
-		expectCost:  4 + 48, /* cost of "includes" is max list length */
+		expectCost:  4 + 64, /* cost of "includes" on dynamic type */
 	},
 	"includes-function-on-bool-list-negative": {
 		features:    &Features{EnableListTypeAttributes: true},
@@ -303,7 +303,7 @@ var testcases = map[string]struct {
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {BoolValues: []bool{true, true}}},
 		driver:      "dra.example.com",
 		expectMatch: false,
-		expectCost:  4 + 48, /* cost of "includes" is max list length */
+		expectCost:  4 + 64, /* cost of "includes" on dynamic type */
 	},
 	"includes-function-on-int-scalar-positive": {
 		features:    &Features{EnableListTypeAttributes: true},
@@ -311,7 +311,7 @@ var testcases = map[string]struct {
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {IntValue: new(int64(1))}},
 		driver:      "dra.example.com",
 		expectMatch: true,
-		expectCost:  4 + 48, /* cost of "includes" is max list length */
+		expectCost:  4 + 64, /* cost of "includes" on dynamic type */
 	},
 	"includes-function-on-int-scalar-negative": {
 		features:    &Features{EnableListTypeAttributes: true},
@@ -319,7 +319,7 @@ var testcases = map[string]struct {
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {IntValue: new(int64(2))}},
 		driver:      "dra.example.com",
 		expectMatch: false,
-		expectCost:  4 + 48, /* cost of "includes" is max list length */
+		expectCost:  4 + 64, /* cost of "includes" on dynamic type */
 	},
 	"includes-function-on-int-list-positive": {
 		features:    &Features{EnableListTypeAttributes: true},
@@ -327,7 +327,7 @@ var testcases = map[string]struct {
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {IntValues: []int64{1, 2}}},
 		driver:      "dra.example.com",
 		expectMatch: true,
-		expectCost:  4 + 48, /* cost of "includes" is max list length */
+		expectCost:  4 + 64, /* cost of "includes" on dynamic type */
 	},
 	"includes-function-on-int-list-negative": {
 		features:    &Features{EnableListTypeAttributes: true},
@@ -335,7 +335,7 @@ var testcases = map[string]struct {
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {IntValues: []int64{1, 2}}},
 		driver:      "dra.example.com",
 		expectMatch: false,
-		expectCost:  4 + 48, /* cost of "includes" is max list length */
+		expectCost:  4 + 64, /* cost of "includes" on dynamic type */
 	},
 	"includes-function-on-string-scalar-positive": {
 		features:    &Features{EnableListTypeAttributes: true},
@@ -343,7 +343,7 @@ var testcases = map[string]struct {
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValue: new("fish")}},
 		driver:      "dra.example.com",
 		expectMatch: true,
-		expectCost:  4 + 48, /* cost of "includes" is max list length */
+		expectCost:  4 + 64, /* cost of "includes" on dynamic type */
 	},
 	"includes-function-on-string-scalar-negative": {
 		features:    &Features{EnableListTypeAttributes: true},
@@ -351,7 +351,7 @@ var testcases = map[string]struct {
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValue: new("fish")}},
 		driver:      "dra.example.com",
 		expectMatch: false,
-		expectCost:  4 + 48, /* cost of "includes" is max list length */
+		expectCost:  4 + 64, /* cost of "includes" on dynamic type */
 	},
 	"includes-function-on-string-list-positive": {
 		features:    &Features{EnableListTypeAttributes: true},
@@ -359,7 +359,7 @@ var testcases = map[string]struct {
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValues: []string{"fish", "bird"}}},
 		driver:      "dra.example.com",
 		expectMatch: true,
-		expectCost:  4 + 48, /* cost of "includes" is max list length */
+		expectCost:  4 + 64, /* cost of "includes" on dynamic type */
 	},
 	"includes-function-on-string-list-negative": {
 		features:    &Features{EnableListTypeAttributes: true},
@@ -367,7 +367,7 @@ var testcases = map[string]struct {
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValues: []string{"fish", "bird"}}},
 		driver:      "dra.example.com",
 		expectMatch: false,
-		expectCost:  4 + 48, /* cost of "includes" is max list length */
+		expectCost:  4 + 64, /* cost of "includes" on dynamic type */
 	},
 	"includes-function-on-semver-scalar-positive": {
 		features:    &Features{EnableListTypeAttributes: true},
@@ -375,7 +375,7 @@ var testcases = map[string]struct {
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {VersionValue: new("1.0.0")}},
 		driver:      "dra.example.com",
 		expectMatch: true,
-		expectCost:  4 + 48 /* cost of "includes" is max list length */ + 1,
+		expectCost:  4 + 64 /* cost of "includes" on dynamic type */ + 1,
 	},
 	"includes-function-on-semver-scalar-negative": {
 		features:    &Features{EnableListTypeAttributes: true},
@@ -383,7 +383,7 @@ var testcases = map[string]struct {
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {VersionValue: new("1.0.0")}},
 		driver:      "dra.example.com",
 		expectMatch: false,
-		expectCost:  4 + 48 /* cost of "includes" is max list length */ + 1,
+		expectCost:  4 + 64 /* cost of "includes" on dynamic type */ + 1,
 	},
 	"includes-function-on-semver-list-positive": {
 		features:    &Features{EnableListTypeAttributes: true},
@@ -391,7 +391,7 @@ var testcases = map[string]struct {
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {VersionValues: []string{"1.0.0", "2.0.0"}}},
 		driver:      "dra.example.com",
 		expectMatch: true,
-		expectCost:  4 + 48 /* cost of "includes" is max list length */ + 1,
+		expectCost:  4 + 64 /* cost of "includes" on dynamic type */ + 1,
 	},
 	"includes-function-on-semver-list-negative": {
 		features:    &Features{EnableListTypeAttributes: true},
@@ -399,7 +399,7 @@ var testcases = map[string]struct {
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {VersionValues: []string{"1.0.0", "2.0.0"}}},
 		driver:      "dra.example.com",
 		expectMatch: false,
-		expectCost:  4 + 48 /* cost of "includes" is max list length */ + 1,
+		expectCost:  4 + 64 /* cost of "includes" on dynamic type */ + 1,
 	},
 	"includes-function-on-very-long-list-positive": {
 		features:   &Features{EnableListTypeAttributes: true},
@@ -413,29 +413,12 @@ var testcases = map[string]struct {
 		}()}},
 		driver:      "dra.example.com",
 		expectMatch: false,
-		expectCost:  4 + 48, /* cost of "includes" is max list length */
-	},
-	"includes-function-on-very-long-list-runtime-error": {
-		features:   &Features{EnableListTypeAttributes: true},
-		expression: fmt.Sprintf(`device.attributes["dra.example.com"].name.includes("value-%d")`, resourceapi.ResourceSliceMaxAttributeValuesPerDevice+1),
-		attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValues: func() []string {
-			values := make([]string, resourceapi.ResourceSliceMaxAttributeValuesPerDevice+1)
-			for i := range values {
-				values[i] = fmt.Sprintf("value-%d", i)
-			}
-			return values
-		}()}},
-		driver:           "dra.example.com",
-		expectMatchError: fmt.Sprintf("'includes' function cannot be applied to lists longer than %d values", resourceapi.ResourceSliceMaxAttributeValuesPerDevice),
-		expectCost:       4 + 48, /* cost of "includes" is max list length */
+		expectCost:  4 + 64, /* cost of "includes" on dynamic type */
 	},
 	"in-operator-on-list": {
 		// This case is for documenting purpose to present the difference of call cost estimation
 		// between "in" operator and "includes" function.
-		// The cost estimation of "includes" is based on resourceapi.ResourceSliceMaxAttributeValuesPerDevice
-		// because it's designed for checking whether a value is included in an device attribute list.
-		// Instead, the cost estimation of "in" operator is based on maxElementsListTypeEnabled
-		// (MaxElements in AttributeType(cel.DeclType)) as this operator is CEL standard one.
+		// The cost estimation of both "in" operator and "includes" function is based on maxElementsListTypeEnabled.
 		expression:  `1 in device.attributes["dra.example.com"].names`,
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"names": {IntValues: []int64{1, 2, 3}}},
 		driver:      "dra.example.com",


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR moves `.includes` CEL member function from DRA internal package to Kubernetes standard lists library.

As suggested in https://github.com/kubernetes/kubernetes/pull/137190#discussion_r2954678534

**Key changes**
- ` lists.go`: Added `includes` overload definition, documentation and implementation.
- `cost.go` : Added cost estimation logic.

- `compile.go`: Removed inline `includes` declaration, `includesFunc` , and custom DRA cost estimation.

Versioned the lists cel library to introduce `.include()` gradually. `Lists(ListsVersion(1))` adds `.includes` function. `Lists(ListsVersion(0))` is registered for emulated versions, `Lists(ListVersion(1))` is starting in 1.37. This ensures that standard users cannot use .includes in emulated versions.

#### Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes/kubernetes/issues/137872

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```