### PR TITLE
portallocator: replace deprecated sets.String/sets.Int with generic sets.Set

### DIFF
--- a/pkg/registry/core/service/portallocator/allocator_test.go
+++ b/pkg/registry/core/service/portallocator/allocator_test.go
@@ -41,7 +41,7 @@ func TestAllocate(t *testing.T) {
 	if f := r.Used(); f != 0 {
 		t.Errorf("unexpected used %d", f)
 	}
-	found := sets.NewString()
+	found := sets.New[string]()
 	count := 0
 	for r.Free() > 0 {
 		p, err := r.AllocateNext()
@@ -174,11 +174,11 @@ func TestForEach(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testCases := []sets.Int{
-		sets.NewInt(),
-		sets.NewInt(10000),
-		sets.NewInt(10000, 10200),
-		sets.NewInt(10000, 10099, 10200),
+	testCases := []sets.Set[int]{
+		sets.New[int](),
+		sets.New[int](10000),
+		sets.New[int](10000, 10200),
+		sets.New[int](10000, 10099, 10200),
 	}
 
 	for i, tc := range testCases {
@@ -196,7 +196,7 @@ func TestForEach(t *testing.T) {
 			}
 		}
 
-		calls := sets.NewInt()
+		calls := sets.New[int]()
 		r.ForEach(func(port int) {
 			calls.Insert(port)
 		})
@@ -204,7 +204,7 @@ func TestForEach(t *testing.T) {
 			t.Errorf("[%d] expected %d calls, got %d", i, len(tc), len(calls))
 		}
 		if !calls.Equal(tc) {
-			t.Errorf("[%d] expected calls to equal testcase: %v vs %v", i, calls.List(), tc.List())
+			t.Errorf("[%d] expected calls to equal testcase: %v vs %v", i, sets.List(calls), sets.List(tc))
 		}
 	}
 }
@@ -427,7 +427,7 @@ func TestNodePortMetrics(t *testing.T) {
 	expectMetrics(t, em)
 
 	// allocate 2 ports
-	found := sets.NewInt()
+	found := sets.New[int]()
 	for i := 0; i < 2; i++ {
 		port, err := a.AllocateNext()
 		if err != nil {
@@ -520,7 +520,7 @@ func TestNodePortAllocatedMetrics(t *testing.T) {
 	expectMetrics(t, em)
 
 	// allocate 2 dynamic port
-	found := sets.NewInt()
+	found := sets.New[int]()
 	for i := 0; i < 2; i++ {
 		port, err := a.AllocateNext()
 		if err != nil {

--- a/pkg/registry/core/service/portallocator/controller/repair.go
+++ b/pkg/registry/core/service/portallocator/controller/repair.go
@@ -236,7 +236,7 @@ func (c *Repair) doRunOnce() error {
 func collectServiceNodePorts(service *corev1.Service) []int {
 	var servicePorts []int
 	// map from nodePort to set of protocols
-	seen := make(map[int]sets.String)
+	seen := make(map[int]sets.Set[string])
 	for _, port := range service.Spec.Ports {
 		nodePort := int(port.NodePort)
 		if nodePort == 0 {
@@ -245,7 +245,7 @@ func collectServiceNodePorts(service *corev1.Service) []int {
 		proto := string(port.Protocol)
 		s := seen[nodePort]
 		if s == nil { // have not seen this nodePort before
-			s = sets.NewString(proto)
+			s = sets.New[string](proto)
 			servicePorts = append(servicePorts, nodePort)
 		} else if s.Has(proto) { // same nodePort with same protocol
 			servicePorts = append(servicePorts, nodePort)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`sets.String` and `sets.Int` are deprecated in favor of the generic `sets.Set[T]` (see the `// Deprecated:` markers and package doc in `staging/src/k8s.io/apimachinery/pkg/util/sets`). This converts the remaining deprecated usages in the service port allocator to the generic API:

- `controller/repair.go`: `map[int]sets.String` → `map[int]sets.Set[string]`, `sets.NewString` → `sets.New[string]`
- `allocator_test.go`: `sets.NewString` / `sets.NewInt` / `[]sets.Int` → their generic equivalents, and `.List()` → `sets.List()`

This is behavior-preserving and the portallocator counterpart to the recently merged ipallocator conversion (#139890).

#### Which issue(s) this PR is related to:

Related to #133935

#### Special notes for your reviewer:

Mechanical change confined to a single package. Verified locally: `go test -race`, `go vet`, `gofmt`, and `hack/verify-golangci-lint.sh` all pass with no issues.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/sig network
