### PR TITLE
Label FeatureGate-only e2e tests with proper Feature labels

### DIFF
--- a/test/e2e/common/node/container_restart_policy.go
+++ b/test/e2e/common/node/container_restart_policy.go
@@ -34,7 +34,7 @@ import (
 	"github.com/onsi/gomega"
 )
 
-var _ = SIGDescribe("Pod Extended (container restart policy)", framework.WithFeatureGate(features.ContainerRestartRules), func() {
+var _ = SIGDescribe("Pod Extended (container restart policy)", framework.WithNodeConformance(), framework.WithFeatureGate(features.ContainerRestartRules), func() {
 	f := framework.NewDefaultFramework("pods")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 
@@ -173,7 +173,7 @@ var _ = SIGDescribe("Pod Extended (container restart policy)", framework.WithFea
 	})
 })
 
-var _ = SIGDescribe("Pod Extended (RestartAllContainers)", framework.WithFeatureGate(features.ContainerRestartRules), framework.WithFeatureGate(features.RestartAllContainersOnContainerExits), func() {
+var _ = SIGDescribe("Pod Extended (RestartAllContainers)", framework.WithNodeConformance(), framework.WithFeatureGate(features.ContainerRestartRules), framework.WithFeatureGate(features.RestartAllContainersOnContainerExits), func() {
 	f := framework.NewDefaultFramework("pods")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 

--- a/test/e2e/common/node/pod_level_resources_resize.go
+++ b/test/e2e/common/node/pod_level_resources_resize.go
@@ -436,7 +436,7 @@ func doBurstablePodLevelResizeTests(f *framework.Framework) {
 	)
 }
 
-var _ = SIGDescribe("PLR Pod InPlace Resize", framework.WithFeatureGate(features.InPlacePodLevelResourcesVerticalScaling), func() {
+var _ = SIGDescribe("PLR Pod InPlace Resize", framework.WithNodeConformance(), framework.WithFeatureGate(features.InPlacePodLevelResourcesVerticalScaling), func() {
 	f := framework.NewDefaultFramework("pod-level-resources-resize-tests")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 	ginkgo.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -879,7 +879,7 @@ var _ = SIGDescribe("Pod InPlace Resize Container", func() {
 	doPodResizeMemoryLimitDecreaseTest(f)
 })
 
-var _ = SIGDescribe("Pod InPlace Resize Init Container", framework.WithFeatureGate(features.InPlacePodVerticalScalingInitContainers), func() {
+var _ = SIGDescribe("Pod InPlace Resize Init Container", framework.WithNodeConformance(), framework.WithFeatureGate(features.InPlacePodVerticalScalingInitContainers), func() {
 	f := framework.NewDefaultFramework("pod-resize-tests")
 
 	ginkgo.BeforeEach(func(ctx context.Context) {

--- a/test/e2e_node/device_plugin_failures_pod_status_test.go
+++ b/test/e2e_node/device_plugin_failures_pod_status_test.go
@@ -39,7 +39,7 @@ import (
 	"k8s.io/kubernetes/test/e2e_node/testdeviceplugin"
 )
 
-var _ = SIGDescribe("Device Plugin Failures Pod Status", framework.WithFeatureGate(features.ResourceHealthStatus), func() {
+var _ = SIGDescribe("Device Plugin Failures Pod Status", framework.WithNodeConformance(), framework.WithFeatureGate(features.ResourceHealthStatus), func() {
 	f := framework.NewDefaultFramework("device-plugin-failures")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

The `ci-cri-containerd-node-e2e-unlabelled` job is timing out because tests that
should be categorized under `[Feature:X]` are slipping through the skip regex.

The skip regex uses `[Feature:.+]` to exclude feature tests, but
`framework.WithFeatureGate()` produces `[FeatureGate:X]` in test names — not
`[Feature:X]`. When these feature gates graduated to Beta (default=true) in 1.36,
the tests started actually executing instead of self-skipping at runtime, landing
~53 extra tests (many of them pod resize table entries) in the unlabelled job with
`--nodes=1`, causing the 300m timeout.

The established pattern is to use **both** `feature.X` (for job routing via
`[Feature:X]` text) and `WithFeatureGate(features.Y)` (for runtime semantics).
This is already done by CPUManager, MemoryManager, DRA, HugePages,
ContainerStopSignals, EnvFiles, etc. The tests fixed here were missing the
`feature.X` half.

**Changes:**
- Add `feature.InPlacePodVerticalScaling` to `pod_level_resources_resize.go` and
  `pod_resize.go` (init container SIGDescribe)
- Add `feature.ContainerRestartRules` to both SIGDescribe blocks in
  `container_restart_policy.go`
- Add `feature.DevicePlugin` to `device_plugin_failures_pod_status_test.go`

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The root cause is a mismatch between `[FeatureGate:X]` (produced by
`WithFeatureGate`) and `[Feature:X]` (what job regexes match). This is not a new
pattern — 10+ existing test suites already use both decorators together. The 4
files changed here were simply missing the `feature.X` decorator.

/sig node
/area test
/priority important-soon

https://testgrid.k8s.io/sig-node-containerd#node-e2e-unlabelled

The job keeps hitting timeouts.
#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
N/A
```