### PR TITLE
Fix flaky etcd SIGKILL e2e test by using pkill -9 -x etcd

### DIFF
--- a/test/e2e/apimachinery/etcd_failure.go
+++ b/test/e2e/apimachinery/etcd_failure.go
@@ -74,7 +74,7 @@ var _ = SIGDescribe("Etcd failure", framework.WithDisruptive(), func() {
 		etcdFailTest(
 			ctx,
 			f,
-			"pgrep etcd | grep -v etcd-manager | xargs -I {} sudo kill -9 {}",
+			"sudo pkill -9 -x etcd",
 			"echo 'do nothing. monit should restart etcd.'",
 		)
 	})


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

`pgrep etcd` also matches the short-lived `etcdctl` liveness-probe processes, so the kill command can hit one as it exits and fail with a non-zero exit, failing the test. `sudo pkill -9 -x etcd` matches only the exact `etcd` process.

Error from logs: 
```
ssh ...:22: command:   pgrep etcd | grep -v etcd-manager | xargs -I {} sudo kill -9 {}
ssh ...:22: stdout:    ""
ssh ...:22: stderr:    "kill: (107029): No such process\n"
ssh ...:22: exit code: 123
[FAILED] in [It] - etcd_failure.go:121
```

[etcdctl ref](https://github.com/kubernetes/kubernetes/blob/2544f4dda29d6606e25a2f3269e6470d870c998d/cluster/gce/manifests/etcd.manifest#L75-L90)

Seen recently on `ci-kubernetes-e2e-gce-cos-serial-master`: [2065035624120848384](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gce-cos-serial-master/2065035624120848384), [2066066175028105216](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gce-cos-serial-master/2066066175028105216), [2068630579112316928](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gce-cos-serial-master/2068630579112316928).

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```