### PR TITLE
Fix typos in comments and log messages

### DIFF
--- a/pkg/kubelet/images/pullmanager/fs_pullrecords.go
+++ b/pkg/kubelet/images/pullmanager/fs_pullrecords.go
@@ -307,7 +307,7 @@ func writeFile(dir, filename string, content []byte) error {
 	return nil
 }
 
-// processDirFiles reads files in a given directory and peforms `fileAction` action on those.
+// processDirFiles reads files in a given directory and performs `fileAction` action on those.
 func processDirFiles(dirName string, fileAction func(filePath string, fileContent []byte) error) error {
 	var walkErrors []error
 	err := filepath.WalkDir(dirName, func(path string, d fs.DirEntry, err error) error {

--- a/pkg/kubelet/logs/container_log_manager_test.go
+++ b/pkg/kubelet/logs/container_log_manager_test.go
@@ -163,7 +163,7 @@ func TestRotateLogs(t *testing.T) {
 	// Push the items into the queue for before starting the worker to avoid issue with the queue being empty.
 	require.NoError(t, c.rotateLogs(tCtx))
 
-	// Start a routine that can monitor the queue and shutdown the queue to trigger the retrun from the processQueueItems
+	// Start a routine that can monitor the queue and shutdown the queue to trigger the return from the processQueueItems
 	// Keeping the monitor duration smaller in order to keep the unwanted delay in the test to a minimal.
 	go func() {
 		pollTimeoutCtx, cancel := context.WithTimeout(tCtx, 10*time.Second)

--- a/pkg/proxy/endpoint.go
+++ b/pkg/proxy/endpoint.go
@@ -119,7 +119,7 @@ func (info *BaseEndpointInfo) IsServing() bool {
 	return info.serving
 }
 
-// IsTerminating retruns true if an endpoint is terminating. For pods,
+// IsTerminating returns true if an endpoint is terminating. For pods,
 // that is any pod with a deletion timestamp.
 func (info *BaseEndpointInfo) IsTerminating() bool {
 	return info.terminating

--- a/pkg/util/kernel/constants.go
+++ b/pkg/util/kernel/constants.go
@@ -20,7 +20,7 @@ package kernel
 // (ref: https://github.com/torvalds/linux/commit/122ff243f5f104194750ecbc76d5946dd1eec934)
 const IPLocalReservedPortsNamespacedKernelVersion = "3.16"
 
-// IPVSConnReuseModeMinSupportedKernelVersion is the minium kernel version supporting net.ipv4.vs.conn_reuse_mode.
+// IPVSConnReuseModeMinSupportedKernelVersion is the minimum kernel version supporting net.ipv4.vs.conn_reuse_mode.
 // (ref: https://github.com/torvalds/linux/commit/d752c364571743d696c2a54a449ce77550c35ac5)
 const IPVSConnReuseModeMinSupportedKernelVersion = "4.1"
 

--- a/plugin/pkg/admission/runtimeclass/admission.go
+++ b/plugin/pkg/admission/runtimeclass/admission.go
@@ -18,7 +18,7 @@ limitations under the License.
 // take RuntimeClass into account. For RuntimeClass definitions which describe an overhead associated
 // with running a pod, this admission controller will set the pod.Spec.Overhead field accordingly. This
 // field should only be set through this controller, so validation will be carried out to ensure the pod's
-// value matches what is defined in the coresponding RuntimeClass.
+// value matches what is defined in the corresponding RuntimeClass.
 package runtimeclass
 
 import (

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -985,7 +985,7 @@ func (c *Cacher) dispatchEvent(event *watchCacheEvent) {
 		// from it justifies increased memory usage, so for now we drop the cached
 		// serializations after dispatching this event.
 		//
-		// Given that CachingObject is just wrapping the object and not perfoming
+		// Given that CachingObject is just wrapping the object and not performing
 		// deep-copying (until some field is explicitly being modified), we create
 		// it unconditionally to ensure safety and reduce deep-copying.
 		//

--- a/staging/src/k8s.io/client-go/tools/remotecommand/websocket.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/websocket.go
@@ -516,7 +516,7 @@ func (h *heartbeat) start() {
 			// gorilla/websockets library docs: "The Close and WriteControl methods can
 			// be called concurrently with all other methods."
 			if err := h.conn.WriteControl(gwebsocket.PingMessage, h.message, time.Now().Add(pingReadDeadline)); err == nil {
-				h.logger.V(6).Info("Websocket Ping succeeeded")
+				h.logger.V(6).Info("Websocket Ping succeeded")
 			} else {
 				h.logger.Error(err, "Websocket Ping failed")
 				if errors.Is(err, gwebsocket.ErrCloseSent) {

--- a/test/e2e/common/node/security_context.go
+++ b/test/e2e/common/node/security_context.go
@@ -454,7 +454,7 @@ var _ = SIGDescribe("Security Context", func() {
 		/*
 			Release: v1.15
 			Testname: Security Context, runAsUser=65534
-			Description: Container is created with runAsUser option by passing uid 65534 to run as unpriviledged user. Pod MUST be in Succeeded phase.
+			Description: Container is created with runAsUser option by passing uid 65534 to run as unprivileged user. Pod MUST be in Succeeded phase.
 			[LinuxOnly]: This test is marked as LinuxOnly since Windows does not support running as UID / GID.
 		*/
 		framework.ConformanceIt("should run the container with uid 65534 [LinuxOnly]", f.WithNodeConformance(), func(ctx context.Context) {

--- a/test/e2e/framework/node/resource.go
+++ b/test/e2e/framework/node/resource.go
@@ -364,7 +364,7 @@ func GetReadyNodesIncludingTainted(ctx context.Context, c clientset.Interface) (
 }
 
 // isNodeUntainted tests whether a fake pod can be scheduled on "node", given its current taints.
-// TODO: need to discuss wether to return bool and error type
+// TODO: need to discuss whether to return bool and error type
 func isNodeUntainted(logger klog.Logger, node *v1.Node) bool {
 	return isNodeUntaintedWithNonblocking(logger, node, "")
 }
@@ -482,7 +482,7 @@ func hasNonblockingTaint(node *v1.Node, nonblockingTaints string) bool {
 //     system daemons from the node's total "CPU" ( or "Memory" ) resource, upon failure is empty.
 //   - the second return value, upon success is the available portion of a node's allocatable "CPU" capacity, calculated by subtracting "CPU"
 //     ( or "Memory" ) resource reserved for node's pods from the node's allocatable "CPU" ( or "Memory" ) resource, upon failure is empty.
-//   - the third return value, upon success is nil, upon failure is the coresponding error.
+//   - the third return value, upon success is nil, upon failure is the corresponding error.
 func GetNodeAllocatableAndAvailableQuantities(ctx context.Context, c clientset.Interface, n *v1.Node, resourceName v1.ResourceName) (resource.Quantity, resource.Quantity, error) {
 	var nodeAllocatable, podAllocated, nodeAvailable resource.Quantity
 	switch resourceName {

--- a/test/integration/scheduler/queueing/queue.go
+++ b/test/integration/scheduler/queueing/queue.go
@@ -106,12 +106,12 @@ type CoreResourceEnqueueTestCase struct {
 	// PrioritySort and DefaultPreemption are enabled by default because they are required by the framework.
 	// If empty, all plugins are enabled.
 	EnablePlugins []string
-	// EnabledRAExtendedResource indicates wether the test case should run with feature gate
+	// EnabledRAExtendedResource indicates whether the test case should run with feature gate
 	// DRAExtendedResource enabled or not.
 	EnableDRAExtendedResource bool
 	// EnableNodeDeclaredFeatures indicates if the test case runs with the NodeDeclaredFeatures feature gate enabled.
 	EnableNodeDeclaredFeatures bool
-	// EnableGenericWorkload indicates wether the test case should run with feature gate
+	// EnableGenericWorkload indicates whether the test case should run with feature gate
 	// GenericWorkload enabled or not.
 	EnableGenericWorkload bool
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Fix typos in comments and log messages across multiple packages:
- "wether" → "whether"
- "coresponding" → "corresponding"
- "retruns" → "returns"
- "peforms" → "performs"
- "retrun" → "return"
- "minium" → "minimum"
- "succeeeded" → "succeeded"
- "perfoming" → "performing"
- "unpriviledged" → "unprivileged"

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

All changes are in comments or log strings only — no functional changes.

#### Does this PR introduce a user-facing change?

```release-note
NONE

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
