### PR TITLE
rbac: enable commentstart kube-api-linter rule

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -14897,7 +14897,7 @@
       "description": "AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole",
       "properties": {
         "clusterRoleSelectors": {
-          "description": "ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added",
+          "description": "clusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added",
           "items": {
             "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
           },
@@ -14912,7 +14912,7 @@
       "properties": {
         "aggregationRule": {
           "$ref": "#/definitions/io.k8s.api.rbac.v1.AggregationRule",
-          "description": "AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller."
+          "description": "aggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller."
         },
         "apiVersion": {
           "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -14924,10 +14924,10 @@
         },
         "metadata": {
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
-          "description": "Standard object's metadata."
+          "description": "metadata is the standard object's metadata."
         },
         "rules": {
-          "description": "Rules holds all the PolicyRules for this ClusterRole",
+          "description": "rules holds all the PolicyRules for this ClusterRole",
           "items": {
             "$ref": "#/definitions/io.k8s.api.rbac.v1.PolicyRule"
           },
@@ -14957,14 +14957,14 @@
         },
         "metadata": {
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
-          "description": "Standard object's metadata."
+          "description": "metadata is the standard object's metadata."
         },
         "roleRef": {
           "$ref": "#/definitions/io.k8s.api.rbac.v1.RoleRef",
-          "description": "RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable."
+          "description": "roleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable."
         },
         "subjects": {
-          "description": "Subjects holds references to the objects the role applies to.",
+          "description": "subjects holds references to the objects the role applies to.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.rbac.v1.Subject"
           },
@@ -15058,7 +15058,7 @@
       "description": "PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.",
       "properties": {
         "apiGroups": {
-          "description": "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed. \"\" represents the core API group and \"*\" represents all API groups.",
+          "description": "apiGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed. \"\" represents the core API group and \"*\" represents all API groups.",
           "items": {
             "type": "string"
           },
@@ -15066,7 +15066,7 @@
           "x-kubernetes-list-type": "atomic"
         },
         "nonResourceURLs": {
-          "description": "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
+          "description": "nonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
           "items": {
             "type": "string"
           },
@@ -15074,7 +15074,7 @@
           "x-kubernetes-list-type": "atomic"
         },
         "resourceNames": {
-          "description": "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
+          "description": "resourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
           "items": {
             "type": "string"
           },
@@ -15082,7 +15082,7 @@
           "x-kubernetes-list-type": "atomic"
         },
         "resources": {
-          "description": "Resources is a list of resources this rule applies to. '*' represents all resources.",
+          "description": "resources is a list of resources this rule applies to. '*' represents all resources.",
           "items": {
             "type": "string"
           },
@@ -15090,7 +15090,7 @@
           "x-kubernetes-list-type": "atomic"
         },
         "verbs": {
-          "description": "Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.",
+          "description": "verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.",
           "items": {
             "type": "string"
           },
@@ -15116,10 +15116,10 @@
         },
         "metadata": {
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
-          "description": "Standard object's metadata."
+          "description": "metadata is the standard object's metadata."
         },
         "rules": {
-          "description": "Rules holds all the PolicyRules for this Role",
+          "description": "rules holds all the PolicyRules for this Role",
           "items": {
             "$ref": "#/definitions/io.k8s.api.rbac.v1.PolicyRule"
           },
@@ -15149,14 +15149,14 @@
         },
         "metadata": {
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
-          "description": "Standard object's metadata."
+          "description": "metadata is the standard object's metadata."
         },
         "roleRef": {
           "$ref": "#/definitions/io.k8s.api.rbac.v1.RoleRef",
-          "description": "RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable."
+          "description": "roleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable."
         },
         "subjects": {
-          "description": "Subjects holds references to the objects the role applies to.",
+          "description": "subjects holds references to the objects the role applies to.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.rbac.v1.Subject"
           },
@@ -15250,15 +15250,15 @@
       "description": "RoleRef contains information that points to the role being used",
       "properties": {
         "apiGroup": {
-          "description": "APIGroup is the group for the resource being referenced",
+          "description": "apiGroup is the group for the resource being referenced",
           "type": "string"
         },
         "kind": {
-          "description": "Kind is the type of resource being referenced",
+          "description": "kind is the type of resource being referenced",
           "type": "string"
         },
         "name": {
-          "description": "Name is the name of resource being referenced",
+          "description": "name is the name of resource being referenced",
           "type": "string"
         }
       },
@@ -15273,19 +15273,19 @@
       "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.",
       "properties": {
         "apiGroup": {
-          "description": "APIGroup holds the API group of the referenced subject. Defaults to \"\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+          "description": "apiGroup holds the API group of the referenced subject. Defaults to \"\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
           "type": "string"
         },
         "kind": {
-          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+          "description": "kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
           "type": "string"
         },
         "name": {
-          "description": "Name of the object being referenced.",
+          "description": "name of the object being referenced.",
           "type": "string"
         },
         "namespace": {
-          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
+          "description": "namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
           "type": "string"
         }
       },

--- a/api/openapi-spec/v3/apis__rbac.authorization.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__rbac.authorization.k8s.io__v1_openapi.json
@@ -5,7 +5,7 @@
         "description": "AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole",
         "properties": {
           "clusterRoleSelectors": {
-            "description": "ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added",
+            "description": "clusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added",
             "items": {
               "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
             },
@@ -24,7 +24,7 @@
                 "$ref": "#/components/schemas/io.k8s.api.rbac.v1.AggregationRule"
               }
             ],
-            "description": "AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller."
+            "description": "aggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller."
           },
           "apiVersion": {
             "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -41,10 +41,10 @@
               }
             ],
             "default": {},
-            "description": "Standard object's metadata."
+            "description": "metadata is the standard object's metadata."
           },
           "rules": {
-            "description": "Rules holds all the PolicyRules for this ClusterRole",
+            "description": "rules holds all the PolicyRules for this ClusterRole",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.rbac.v1.PolicyRule"
             },
@@ -79,7 +79,7 @@
               }
             ],
             "default": {},
-            "description": "Standard object's metadata."
+            "description": "metadata is the standard object's metadata."
           },
           "roleRef": {
             "allOf": [
@@ -88,10 +88,10 @@
               }
             ],
             "default": {},
-            "description": "RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable."
+            "description": "roleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable."
           },
           "subjects": {
-            "description": "Subjects holds references to the objects the role applies to.",
+            "description": "subjects holds references to the objects the role applies to.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.rbac.v1.Subject"
             },
@@ -195,7 +195,7 @@
         "description": "PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.",
         "properties": {
           "apiGroups": {
-            "description": "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed. \"\" represents the core API group and \"*\" represents all API groups.",
+            "description": "apiGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed. \"\" represents the core API group and \"*\" represents all API groups.",
             "items": {
               "type": "string"
             },
@@ -203,7 +203,7 @@
             "x-kubernetes-list-type": "atomic"
           },
           "nonResourceURLs": {
-            "description": "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
+            "description": "nonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
             "items": {
               "type": "string"
             },
@@ -211,7 +211,7 @@
             "x-kubernetes-list-type": "atomic"
           },
           "resourceNames": {
-            "description": "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
+            "description": "resourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
             "items": {
               "type": "string"
             },
@@ -219,7 +219,7 @@
             "x-kubernetes-list-type": "atomic"
           },
           "resources": {
-            "description": "Resources is a list of resources this rule applies to. '*' represents all resources.",
+            "description": "resources is a list of resources this rule applies to. '*' represents all resources.",
             "items": {
               "type": "string"
             },
@@ -227,7 +227,7 @@
             "x-kubernetes-list-type": "atomic"
           },
           "verbs": {
-            "description": "Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.",
+            "description": "verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.",
             "items": {
               "type": "string"
             },
@@ -258,10 +258,10 @@
               }
             ],
             "default": {},
-            "description": "Standard object's metadata."
+            "description": "metadata is the standard object's metadata."
           },
           "rules": {
-            "description": "Rules holds all the PolicyRules for this Role",
+            "description": "rules holds all the PolicyRules for this Role",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.rbac.v1.PolicyRule"
             },
@@ -296,7 +296,7 @@
               }
             ],
             "default": {},
-            "description": "Standard object's metadata."
+            "description": "metadata is the standard object's metadata."
           },
           "roleRef": {
             "allOf": [
@@ -305,10 +305,10 @@
               }
             ],
             "default": {},
-            "description": "RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable."
+            "description": "roleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable."
           },
           "subjects": {
-            "description": "Subjects holds references to the objects the role applies to.",
+            "description": "subjects holds references to the objects the role applies to.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.rbac.v1.Subject"
             },
@@ -413,17 +413,17 @@
         "properties": {
           "apiGroup": {
             "default": "",
-            "description": "APIGroup is the group for the resource being referenced",
+            "description": "apiGroup is the group for the resource being referenced",
             "type": "string"
           },
           "kind": {
             "default": "",
-            "description": "Kind is the type of resource being referenced",
+            "description": "kind is the type of resource being referenced",
             "type": "string"
           },
           "name": {
             "default": "",
-            "description": "Name is the name of resource being referenced",
+            "description": "name is the name of resource being referenced",
             "type": "string"
           }
         },
@@ -438,21 +438,21 @@
         "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.",
         "properties": {
           "apiGroup": {
-            "description": "APIGroup holds the API group of the referenced subject. Defaults to \"\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+            "description": "apiGroup holds the API group of the referenced subject. Defaults to \"\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
             "type": "string"
           },
           "kind": {
             "default": "",
-            "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+            "description": "kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
             "type": "string"
           },
           "name": {
             "default": "",
-            "description": "Name of the object being referenced.",
+            "description": "name of the object being referenced.",
             "type": "string"
           },
           "namespace": {
-            "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
+            "description": "namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
             "type": "string"
           }
         },

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -147,7 +147,7 @@ linters:
       # Commentstart - Ignore commentstart issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "godoc for field .* should start with '.* ...'"
-        path: "staging/src/k8s.io/api/(apps|batch|certificates|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(apps|batch|certificates|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|resource|scheduling|storage|storagemigration)"
       
       # notimestamp: Legacy 'Timestamp' fields retained for backward compatibility
       - text: 'notimestamp: naming convention "notimestamp": field TokenRequestStatus.ExpirationTimestamp: prefer use of the term ''time'' over ''timestamp'''

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -162,7 +162,7 @@ linters:
       # Commentstart - Ignore commentstart issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "godoc for field .* should start with '.* ...'"
-        path: "staging/src/k8s.io/api/(apps|batch|certificates|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(apps|batch|certificates|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|resource|scheduling|storage|storagemigration)"
       
       # notimestamp: Legacy 'Timestamp' fields retained for backward compatibility
       - text: 'notimestamp: naming convention "notimestamp": field TokenRequestStatus.ExpirationTimestamp: prefer use of the term ''time'' over ''timestamp'''

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -23,7 +23,7 @@
 # Commentstart - Ignore commentstart issues for existing API group
 # TODO: For each existing API group, we aim to remove it over time.
 - text: "godoc for field .* should start with '.* ...'"
-  path: "staging/src/k8s.io/api/(apps|batch|certificates|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+  path: "staging/src/k8s.io/api/(apps|batch|certificates|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|resource|scheduling|storage|storagemigration)"
 
 # notimestamp: Legacy 'Timestamp' fields retained for backward compatibility
 - text: 'notimestamp: naming convention "notimestamp": field TokenRequestStatus.ExpirationTimestamp: prefer use of the term ''time'' over ''timestamp'''

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -44237,7 +44237,7 @@ func schema_k8sio_api_rbac_v1_AggregationRule(ref common.ReferenceCallback) comm
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added",
+							Description: "clusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -44279,7 +44279,7 @@ func schema_k8sio_api_rbac_v1_ClusterRole(ref common.ReferenceCallback) common.O
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Standard object's metadata.",
+							Description: "metadata is the standard object's metadata.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(metav1.ObjectMeta{}.OpenAPIModelName()),
 						},
@@ -44291,7 +44291,7 @@ func schema_k8sio_api_rbac_v1_ClusterRole(ref common.ReferenceCallback) common.O
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Rules holds all the PolicyRules for this ClusterRole",
+							Description: "rules holds all the PolicyRules for this ClusterRole",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -44304,7 +44304,7 @@ func schema_k8sio_api_rbac_v1_ClusterRole(ref common.ReferenceCallback) common.O
 					},
 					"aggregationRule": {
 						SchemaProps: spec.SchemaProps{
-							Description: "AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.",
+							Description: "aggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.",
 							Ref:         ref(rbacv1.AggregationRule{}.OpenAPIModelName()),
 						},
 					},
@@ -44339,7 +44339,7 @@ func schema_k8sio_api_rbac_v1_ClusterRoleBinding(ref common.ReferenceCallback) c
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Standard object's metadata.",
+							Description: "metadata is the standard object's metadata.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(metav1.ObjectMeta{}.OpenAPIModelName()),
 						},
@@ -44351,7 +44351,7 @@ func schema_k8sio_api_rbac_v1_ClusterRoleBinding(ref common.ReferenceCallback) c
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Subjects holds references to the objects the role applies to.",
+							Description: "subjects holds references to the objects the role applies to.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -44364,7 +44364,7 @@ func schema_k8sio_api_rbac_v1_ClusterRoleBinding(ref common.ReferenceCallback) c
 					},
 					"roleRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable.",
+							Description: "roleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(rbacv1.RoleRef{}.OpenAPIModelName()),
 						},
@@ -44492,7 +44492,7 @@ func schema_k8sio_api_rbac_v1_PolicyRule(ref common.ReferenceCallback) common.Op
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.",
+							Description: "verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -44511,7 +44511,7 @@ func schema_k8sio_api_rbac_v1_PolicyRule(ref common.ReferenceCallback) common.Op
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed. \"\" represents the core API group and \"*\" represents all API groups.",
+							Description: "apiGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed. \"\" represents the core API group and \"*\" represents all API groups.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -44530,7 +44530,7 @@ func schema_k8sio_api_rbac_v1_PolicyRule(ref common.ReferenceCallback) common.Op
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Resources is a list of resources this rule applies to. '*' represents all resources.",
+							Description: "resources is a list of resources this rule applies to. '*' represents all resources.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -44549,7 +44549,7 @@ func schema_k8sio_api_rbac_v1_PolicyRule(ref common.ReferenceCallback) common.Op
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
+							Description: "resourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -44568,7 +44568,7 @@ func schema_k8sio_api_rbac_v1_PolicyRule(ref common.ReferenceCallback) common.Op
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
+							Description: "nonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -44610,7 +44610,7 @@ func schema_k8sio_api_rbac_v1_Role(ref common.ReferenceCallback) common.OpenAPID
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Standard object's metadata.",
+							Description: "metadata is the standard object's metadata.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(metav1.ObjectMeta{}.OpenAPIModelName()),
 						},
@@ -44622,7 +44622,7 @@ func schema_k8sio_api_rbac_v1_Role(ref common.ReferenceCallback) common.OpenAPID
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Rules holds all the PolicyRules for this Role",
+							Description: "rules holds all the PolicyRules for this Role",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -44664,7 +44664,7 @@ func schema_k8sio_api_rbac_v1_RoleBinding(ref common.ReferenceCallback) common.O
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Standard object's metadata.",
+							Description: "metadata is the standard object's metadata.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(metav1.ObjectMeta{}.OpenAPIModelName()),
 						},
@@ -44676,7 +44676,7 @@ func schema_k8sio_api_rbac_v1_RoleBinding(ref common.ReferenceCallback) common.O
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Subjects holds references to the objects the role applies to.",
+							Description: "subjects holds references to the objects the role applies to.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -44689,7 +44689,7 @@ func schema_k8sio_api_rbac_v1_RoleBinding(ref common.ReferenceCallback) common.O
 					},
 					"roleRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable.",
+							Description: "roleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(rbacv1.RoleRef{}.OpenAPIModelName()),
 						},
@@ -44812,7 +44812,7 @@ func schema_k8sio_api_rbac_v1_RoleRef(ref common.ReferenceCallback) common.OpenA
 				Properties: map[string]spec.Schema{
 					"apiGroup": {
 						SchemaProps: spec.SchemaProps{
-							Description: "APIGroup is the group for the resource being referenced",
+							Description: "apiGroup is the group for the resource being referenced",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -44820,7 +44820,7 @@ func schema_k8sio_api_rbac_v1_RoleRef(ref common.ReferenceCallback) common.OpenA
 					},
 					"kind": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Kind is the type of resource being referenced",
+							Description: "kind is the type of resource being referenced",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -44828,7 +44828,7 @@ func schema_k8sio_api_rbac_v1_RoleRef(ref common.ReferenceCallback) common.OpenA
 					},
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name is the name of resource being referenced",
+							Description: "name is the name of resource being referenced",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -44855,7 +44855,7 @@ func schema_k8sio_api_rbac_v1_Subject(ref common.ReferenceCallback) common.OpenA
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+							Description: "kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -44863,14 +44863,14 @@ func schema_k8sio_api_rbac_v1_Subject(ref common.ReferenceCallback) common.OpenA
 					},
 					"apiGroup": {
 						SchemaProps: spec.SchemaProps{
-							Description: "APIGroup holds the API group of the referenced subject. Defaults to \"\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+							Description: "apiGroup holds the API group of the referenced subject. Defaults to \"\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name of the object being referenced.",
+							Description: "name of the object being referenced.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -44878,7 +44878,7 @@ func schema_k8sio_api_rbac_v1_Subject(ref common.ReferenceCallback) common.OpenA
 					},
 					"namespace": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
+							Description: "namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -44909,7 +44909,7 @@ func schema_k8sio_api_rbac_v1alpha1_AggregationRule(ref common.ReferenceCallback
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added",
+							Description: "clusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -44951,7 +44951,7 @@ func schema_k8sio_api_rbac_v1alpha1_ClusterRole(ref common.ReferenceCallback) co
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Standard object's metadata.",
+							Description: "metadata is the standard object's metadata.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(metav1.ObjectMeta{}.OpenAPIModelName()),
 						},
@@ -44963,7 +44963,7 @@ func schema_k8sio_api_rbac_v1alpha1_ClusterRole(ref common.ReferenceCallback) co
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Rules holds all the PolicyRules for this ClusterRole",
+							Description: "rules holds all the PolicyRules for this ClusterRole",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -44976,7 +44976,7 @@ func schema_k8sio_api_rbac_v1alpha1_ClusterRole(ref common.ReferenceCallback) co
 					},
 					"aggregationRule": {
 						SchemaProps: spec.SchemaProps{
-							Description: "AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.",
+							Description: "aggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.",
 							Ref:         ref(rbacv1alpha1.AggregationRule{}.OpenAPIModelName()),
 						},
 					},
@@ -45011,7 +45011,7 @@ func schema_k8sio_api_rbac_v1alpha1_ClusterRoleBinding(ref common.ReferenceCallb
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Standard object's metadata.",
+							Description: "metadata is the standard object's metadata.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(metav1.ObjectMeta{}.OpenAPIModelName()),
 						},
@@ -45023,7 +45023,7 @@ func schema_k8sio_api_rbac_v1alpha1_ClusterRoleBinding(ref common.ReferenceCallb
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Subjects holds references to the objects the role applies to.",
+							Description: "subjects holds references to the objects the role applies to.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -45036,7 +45036,7 @@ func schema_k8sio_api_rbac_v1alpha1_ClusterRoleBinding(ref common.ReferenceCallb
 					},
 					"roleRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.",
+							Description: "roleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(rbacv1alpha1.RoleRef{}.OpenAPIModelName()),
 						},
@@ -45164,7 +45164,7 @@ func schema_k8sio_api_rbac_v1alpha1_PolicyRule(ref common.ReferenceCallback) com
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.",
+							Description: "verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -45183,7 +45183,7 @@ func schema_k8sio_api_rbac_v1alpha1_PolicyRule(ref common.ReferenceCallback) com
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed. \"\" represents the core API group and \"*\" represents all API groups.",
+							Description: "apiGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed. \"\" represents the core API group and \"*\" represents all API groups.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -45202,7 +45202,7 @@ func schema_k8sio_api_rbac_v1alpha1_PolicyRule(ref common.ReferenceCallback) com
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Resources is a list of resources this rule applies to. '*' represents all resources.",
+							Description: "resources is a list of resources this rule applies to. '*' represents all resources.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -45221,7 +45221,7 @@ func schema_k8sio_api_rbac_v1alpha1_PolicyRule(ref common.ReferenceCallback) com
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
+							Description: "resourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -45240,7 +45240,7 @@ func schema_k8sio_api_rbac_v1alpha1_PolicyRule(ref common.ReferenceCallback) com
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
+							Description: "nonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -45282,7 +45282,7 @@ func schema_k8sio_api_rbac_v1alpha1_Role(ref common.ReferenceCallback) common.Op
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Standard object's metadata.",
+							Description: "metadata is the standard object's metadata.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(metav1.ObjectMeta{}.OpenAPIModelName()),
 						},
@@ -45294,7 +45294,7 @@ func schema_k8sio_api_rbac_v1alpha1_Role(ref common.ReferenceCallback) common.Op
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Rules holds all the PolicyRules for this Role",
+							Description: "rules holds all the PolicyRules for this Role",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -45336,7 +45336,7 @@ func schema_k8sio_api_rbac_v1alpha1_RoleBinding(ref common.ReferenceCallback) co
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Standard object's metadata.",
+							Description: "metadata is the standard object's metadata.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(metav1.ObjectMeta{}.OpenAPIModelName()),
 						},
@@ -45348,7 +45348,7 @@ func schema_k8sio_api_rbac_v1alpha1_RoleBinding(ref common.ReferenceCallback) co
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Subjects holds references to the objects the role applies to.",
+							Description: "subjects holds references to the objects the role applies to.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -45361,7 +45361,7 @@ func schema_k8sio_api_rbac_v1alpha1_RoleBinding(ref common.ReferenceCallback) co
 					},
 					"roleRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.",
+							Description: "roleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(rbacv1alpha1.RoleRef{}.OpenAPIModelName()),
 						},
@@ -45484,7 +45484,7 @@ func schema_k8sio_api_rbac_v1alpha1_RoleRef(ref common.ReferenceCallback) common
 				Properties: map[string]spec.Schema{
 					"apiGroup": {
 						SchemaProps: spec.SchemaProps{
-							Description: "APIGroup is the group for the resource being referenced",
+							Description: "apiGroup is the group for the resource being referenced",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -45492,7 +45492,7 @@ func schema_k8sio_api_rbac_v1alpha1_RoleRef(ref common.ReferenceCallback) common
 					},
 					"kind": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Kind is the type of resource being referenced",
+							Description: "kind is the type of resource being referenced",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -45500,7 +45500,7 @@ func schema_k8sio_api_rbac_v1alpha1_RoleRef(ref common.ReferenceCallback) common
 					},
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name is the name of resource being referenced",
+							Description: "name is the name of resource being referenced",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -45522,7 +45522,7 @@ func schema_k8sio_api_rbac_v1alpha1_Subject(ref common.ReferenceCallback) common
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+							Description: "kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -45530,14 +45530,14 @@ func schema_k8sio_api_rbac_v1alpha1_Subject(ref common.ReferenceCallback) common
 					},
 					"apiVersion": {
 						SchemaProps: spec.SchemaProps{
-							Description: "APIVersion holds the API group and version of the referenced subject. Defaults to \"v1\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io/v1alpha1\" for User and Group subjects.",
+							Description: "apiVersion holds the API group and version of the referenced subject. Defaults to \"v1\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io/v1alpha1\" for User and Group subjects.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name of the object being referenced.",
+							Description: "name of the object being referenced.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -45545,7 +45545,7 @@ func schema_k8sio_api_rbac_v1alpha1_Subject(ref common.ReferenceCallback) common
 					},
 					"namespace": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
+							Description: "namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -45571,7 +45571,7 @@ func schema_k8sio_api_rbac_v1beta1_AggregationRule(ref common.ReferenceCallback)
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added",
+							Description: "clusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -45613,7 +45613,7 @@ func schema_k8sio_api_rbac_v1beta1_ClusterRole(ref common.ReferenceCallback) com
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Standard object's metadata.",
+							Description: "metadata is the standard object's metadata.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(metav1.ObjectMeta{}.OpenAPIModelName()),
 						},
@@ -45625,7 +45625,7 @@ func schema_k8sio_api_rbac_v1beta1_ClusterRole(ref common.ReferenceCallback) com
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Rules holds all the PolicyRules for this ClusterRole",
+							Description: "rules holds all the PolicyRules for this ClusterRole",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -45638,7 +45638,7 @@ func schema_k8sio_api_rbac_v1beta1_ClusterRole(ref common.ReferenceCallback) com
 					},
 					"aggregationRule": {
 						SchemaProps: spec.SchemaProps{
-							Description: "AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.",
+							Description: "aggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.",
 							Ref:         ref(rbacv1beta1.AggregationRule{}.OpenAPIModelName()),
 						},
 					},
@@ -45673,7 +45673,7 @@ func schema_k8sio_api_rbac_v1beta1_ClusterRoleBinding(ref common.ReferenceCallba
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Standard object's metadata.",
+							Description: "metadata is the standard object's metadata.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(metav1.ObjectMeta{}.OpenAPIModelName()),
 						},
@@ -45685,7 +45685,7 @@ func schema_k8sio_api_rbac_v1beta1_ClusterRoleBinding(ref common.ReferenceCallba
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Subjects holds references to the objects the role applies to.",
+							Description: "subjects holds references to the objects the role applies to.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -45698,7 +45698,7 @@ func schema_k8sio_api_rbac_v1beta1_ClusterRoleBinding(ref common.ReferenceCallba
 					},
 					"roleRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.",
+							Description: "roleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(rbacv1beta1.RoleRef{}.OpenAPIModelName()),
 						},
@@ -45826,7 +45826,7 @@ func schema_k8sio_api_rbac_v1beta1_PolicyRule(ref common.ReferenceCallback) comm
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.",
+							Description: "verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -45845,7 +45845,7 @@ func schema_k8sio_api_rbac_v1beta1_PolicyRule(ref common.ReferenceCallback) comm
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed. \"\" represents the core API group and \"*\" represents all API groups.",
+							Description: "apiGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed. \"\" represents the core API group and \"*\" represents all API groups.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -45864,7 +45864,7 @@ func schema_k8sio_api_rbac_v1beta1_PolicyRule(ref common.ReferenceCallback) comm
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Resources is a list of resources this rule applies to.  '*' represents all resources in the specified apiGroups. '*/foo' represents the subresource 'foo' for all resources in the specified apiGroups.",
+							Description: "resources is a list of resources this rule applies to.  '*' represents all resources in the specified apiGroups. '*/foo' represents the subresource 'foo' for all resources in the specified apiGroups.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -45883,7 +45883,7 @@ func schema_k8sio_api_rbac_v1beta1_PolicyRule(ref common.ReferenceCallback) comm
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
+							Description: "resourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -45902,7 +45902,7 @@ func schema_k8sio_api_rbac_v1beta1_PolicyRule(ref common.ReferenceCallback) comm
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
+							Description: "nonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -45944,7 +45944,7 @@ func schema_k8sio_api_rbac_v1beta1_Role(ref common.ReferenceCallback) common.Ope
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Standard object's metadata.",
+							Description: "metadata is the standard object's metadata.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(metav1.ObjectMeta{}.OpenAPIModelName()),
 						},
@@ -45956,7 +45956,7 @@ func schema_k8sio_api_rbac_v1beta1_Role(ref common.ReferenceCallback) common.Ope
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Rules holds all the PolicyRules for this Role",
+							Description: "rules holds all the PolicyRules for this Role",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -45998,7 +45998,7 @@ func schema_k8sio_api_rbac_v1beta1_RoleBinding(ref common.ReferenceCallback) com
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Standard object's metadata.",
+							Description: "metadata is the standard object's metadata.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(metav1.ObjectMeta{}.OpenAPIModelName()),
 						},
@@ -46010,7 +46010,7 @@ func schema_k8sio_api_rbac_v1beta1_RoleBinding(ref common.ReferenceCallback) com
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Subjects holds references to the objects the role applies to.",
+							Description: "subjects holds references to the objects the role applies to.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -46023,7 +46023,7 @@ func schema_k8sio_api_rbac_v1beta1_RoleBinding(ref common.ReferenceCallback) com
 					},
 					"roleRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.",
+							Description: "roleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(rbacv1beta1.RoleRef{}.OpenAPIModelName()),
 						},
@@ -46146,7 +46146,7 @@ func schema_k8sio_api_rbac_v1beta1_RoleRef(ref common.ReferenceCallback) common.
 				Properties: map[string]spec.Schema{
 					"apiGroup": {
 						SchemaProps: spec.SchemaProps{
-							Description: "APIGroup is the group for the resource being referenced",
+							Description: "apiGroup is the group for the resource being referenced",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -46154,7 +46154,7 @@ func schema_k8sio_api_rbac_v1beta1_RoleRef(ref common.ReferenceCallback) common.
 					},
 					"kind": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Kind is the type of resource being referenced",
+							Description: "kind is the type of resource being referenced",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -46162,7 +46162,7 @@ func schema_k8sio_api_rbac_v1beta1_RoleRef(ref common.ReferenceCallback) common.
 					},
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name is the name of resource being referenced",
+							Description: "name is the name of resource being referenced",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -46184,7 +46184,7 @@ func schema_k8sio_api_rbac_v1beta1_Subject(ref common.ReferenceCallback) common.
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+							Description: "kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -46192,14 +46192,14 @@ func schema_k8sio_api_rbac_v1beta1_Subject(ref common.ReferenceCallback) common.
 					},
 					"apiGroup": {
 						SchemaProps: spec.SchemaProps{
-							Description: "APIGroup holds the API group of the referenced subject. Defaults to \"\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+							Description: "apiGroup holds the API group of the referenced subject. Defaults to \"\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name of the object being referenced.",
+							Description: "name of the object being referenced.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -46207,7 +46207,7 @@ func schema_k8sio_api_rbac_v1beta1_Subject(ref common.ReferenceCallback) common.
 					},
 					"namespace": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
+							Description: "namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/staging/src/k8s.io/api/rbac/v1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1/generated.proto
@@ -30,7 +30,7 @@ option go_package = "k8s.io/api/rbac/v1";
 
 // AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole
 message AggregationRule {
-  // ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules.
+  // clusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules.
   // If any of the selectors match, then the ClusterRole's permissions will be added
   // +optional
   // +listType=atomic
@@ -39,17 +39,17 @@ message AggregationRule {
 
 // ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
 message ClusterRole {
-  // Standard object's metadata.
+  // metadata is the standard object's metadata.
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // Rules holds all the PolicyRules for this ClusterRole
+  // rules holds all the PolicyRules for this ClusterRole
   // +optional
   // +listType=atomic
   // +k8s:beta(since: "1.37")=+k8s:optional
   repeated PolicyRule rules = 2;
 
-  // AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
+  // aggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
   // If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be
   // stomped by the controller.
   // +optional
@@ -59,17 +59,17 @@ message ClusterRole {
 // ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace,
 // and adds who information via Subject.
 message ClusterRoleBinding {
-  // Standard object's metadata.
+  // metadata is the standard object's metadata.
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // Subjects holds references to the objects the role applies to.
+  // subjects holds references to the objects the role applies to.
   // +optional
   // +listType=atomic
   // +k8s:beta(since: "1.37")=+k8s:optional
   repeated Subject subjects = 2;
 
-  // RoleRef can only reference a ClusterRole in the global namespace.
+  // roleRef can only reference a ClusterRole in the global namespace.
   // If the RoleRef cannot be resolved, the Authorizer must return an error.
   // This field is immutable.
   // +required
@@ -99,29 +99,29 @@ message ClusterRoleList {
 // PolicyRule holds information that describes a policy rule, but does not contain information
 // about who the rule applies to or which namespace the rule applies to.
 message PolicyRule {
-  // Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
+  // verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
   // +listType=atomic
   // +required
   // +k8s:beta(since: "1.37")=+k8s:required
   repeated string verbs = 1;
 
-  // APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
+  // apiGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
   // the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
   // +optional
   // +listType=atomic
   repeated string apiGroups = 2;
 
-  // Resources is a list of resources this rule applies to. '*' represents all resources.
+  // resources is a list of resources this rule applies to. '*' represents all resources.
   // +optional
   // +listType=atomic
   repeated string resources = 3;
 
-  // ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+  // resourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
   // +optional
   // +listType=atomic
   repeated string resourceNames = 4;
 
-  // NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
+  // nonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
   // Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
   // Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
   // +optional
@@ -131,11 +131,11 @@ message PolicyRule {
 
 // Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.
 message Role {
-  // Standard object's metadata.
+  // metadata is the standard object's metadata.
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // Rules holds all the PolicyRules for this Role
+  // rules holds all the PolicyRules for this Role
   // +optional
   // +listType=atomic
   // +k8s:beta(since: "1.37")=+k8s:optional
@@ -146,17 +146,17 @@ message Role {
 // It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given
 // namespace only have effect in that namespace.
 message RoleBinding {
-  // Standard object's metadata.
+  // metadata is the standard object's metadata.
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // Subjects holds references to the objects the role applies to.
+  // subjects holds references to the objects the role applies to.
   // +optional
   // +listType=atomic
   // +k8s:beta(since: "1.37")=+k8s:optional
   repeated Subject subjects = 2;
 
-  // RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
+  // roleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
   // If the RoleRef cannot be resolved, the Authorizer must return an error.
   // This field is immutable.
   // +required
@@ -187,15 +187,15 @@ message RoleList {
 // RoleRef contains information that points to the role being used
 // +structType=atomic
 message RoleRef {
-  // APIGroup is the group for the resource being referenced
+  // apiGroup is the group for the resource being referenced
   // +optional
   optional string apiGroup = 1;
 
-  // Kind is the type of resource being referenced
+  // kind is the type of resource being referenced
   // +required
   optional string kind = 2;
 
-  // Name is the name of resource being referenced
+  // name is the name of resource being referenced
   // +required
   // +k8s:beta(since: "1.37")=+k8s:required
   optional string name = 3;
@@ -205,23 +205,23 @@ message RoleRef {
 // or a value for non-objects such as user and group names.
 // +structType=atomic
 message Subject {
-  // Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+  // kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
   // If the Authorizer does not recognized the kind value, the Authorizer should report an error.
   // +required
   optional string kind = 1;
 
-  // APIGroup holds the API group of the referenced subject.
+  // apiGroup holds the API group of the referenced subject.
   // Defaults to "" for ServiceAccount subjects.
   // Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
   // +optional
   optional string apiGroup = 2;
 
-  // Name of the object being referenced.
+  // name of the object being referenced.
   // +required
   // +k8s:beta(since: "1.37")=+k8s:required
   optional string name = 3;
 
-  // Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+  // namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
   // the Authorizer should report an error.
   // +optional
   optional string namespace = 4;

--- a/staging/src/k8s.io/api/rbac/v1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1/types.go
@@ -47,27 +47,27 @@ const (
 // PolicyRule holds information that describes a policy rule, but does not contain information
 // about who the rule applies to or which namespace the rule applies to.
 type PolicyRule struct {
-	// Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
+	// verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 	// +listType=atomic
 	// +required
 	// +k8s:beta(since: "1.37")=+k8s:required
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 
-	// APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
+	// apiGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
 	// the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
 	// +optional
 	// +listType=atomic
 	APIGroups []string `json:"apiGroups,omitempty" protobuf:"bytes,2,rep,name=apiGroups"`
-	// Resources is a list of resources this rule applies to. '*' represents all resources.
+	// resources is a list of resources this rule applies to. '*' represents all resources.
 	// +optional
 	// +listType=atomic
 	Resources []string `json:"resources,omitempty" protobuf:"bytes,3,rep,name=resources"`
-	// ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+	// resourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
 	// +optional
 	// +listType=atomic
 	ResourceNames []string `json:"resourceNames,omitempty" protobuf:"bytes,4,rep,name=resourceNames"`
 
-	// NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
+	// nonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
 	// Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
 	// Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
 	// +optional
@@ -79,20 +79,20 @@ type PolicyRule struct {
 // or a value for non-objects such as user and group names.
 // +structType=atomic
 type Subject struct {
-	// Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+	// kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
 	// If the Authorizer does not recognized the kind value, the Authorizer should report an error.
 	// +required
 	Kind string `json:"kind" protobuf:"bytes,1,opt,name=kind"`
-	// APIGroup holds the API group of the referenced subject.
+	// apiGroup holds the API group of the referenced subject.
 	// Defaults to "" for ServiceAccount subjects.
 	// Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
 	// +optional
 	APIGroup string `json:"apiGroup,omitempty" protobuf:"bytes,2,opt,name=apiGroup"`
-	// Name of the object being referenced.
+	// name of the object being referenced.
 	// +required
 	// +k8s:beta(since: "1.37")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,3,opt,name=name"`
-	// Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+	// namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
 	// the Authorizer should report an error.
 	// +optional
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,4,opt,name=namespace"`
@@ -101,13 +101,13 @@ type Subject struct {
 // RoleRef contains information that points to the role being used
 // +structType=atomic
 type RoleRef struct {
-	// APIGroup is the group for the resource being referenced
+	// apiGroup is the group for the resource being referenced
 	// +optional
 	APIGroup string `json:"apiGroup" protobuf:"bytes,1,opt,name=apiGroup"`
-	// Kind is the type of resource being referenced
+	// kind is the type of resource being referenced
 	// +required
 	Kind string `json:"kind" protobuf:"bytes,2,opt,name=kind"`
-	// Name is the name of resource being referenced
+	// name is the name of resource being referenced
 	// +required
 	// +k8s:beta(since: "1.37")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,3,opt,name=name"`
@@ -120,11 +120,11 @@ type RoleRef struct {
 // Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.
 type Role struct {
 	metav1.TypeMeta `json:""`
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Rules holds all the PolicyRules for this Role
+	// rules holds all the PolicyRules for this Role
 	// +optional
 	// +listType=atomic
 	// +k8s:beta(since: "1.37")=+k8s:optional
@@ -140,17 +140,17 @@ type Role struct {
 // namespace only have effect in that namespace.
 type RoleBinding struct {
 	metav1.TypeMeta `json:""`
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Subjects holds references to the objects the role applies to.
+	// subjects holds references to the objects the role applies to.
 	// +optional
 	// +listType=atomic
 	// +k8s:beta(since: "1.37")=+k8s:optional
 	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
-	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
+	// roleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
 	// If the RoleRef cannot be resolved, the Authorizer must return an error.
 	// This field is immutable.
 	// +required
@@ -194,17 +194,17 @@ type RoleList struct {
 // ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
 type ClusterRole struct {
 	metav1.TypeMeta `json:""`
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Rules holds all the PolicyRules for this ClusterRole
+	// rules holds all the PolicyRules for this ClusterRole
 	// +optional
 	// +listType=atomic
 	// +k8s:beta(since: "1.37")=+k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 
-	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
+	// aggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
 	// If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be
 	// stomped by the controller.
 	// +optional
@@ -213,7 +213,7 @@ type ClusterRole struct {
 
 // AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole
 type AggregationRule struct {
-	// ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules.
+	// clusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules.
 	// If any of the selectors match, then the ClusterRole's permissions will be added
 	// +optional
 	// +listType=atomic
@@ -229,17 +229,17 @@ type AggregationRule struct {
 // and adds who information via Subject.
 type ClusterRoleBinding struct {
 	metav1.TypeMeta `json:""`
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Subjects holds references to the objects the role applies to.
+	// subjects holds references to the objects the role applies to.
 	// +optional
 	// +listType=atomic
 	// +k8s:beta(since: "1.37")=+k8s:optional
 	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
-	// RoleRef can only reference a ClusterRole in the global namespace.
+	// roleRef can only reference a ClusterRole in the global namespace.
 	// If the RoleRef cannot be resolved, the Authorizer must return an error.
 	// This field is immutable.
 	// +required

--- a/staging/src/k8s.io/api/rbac/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/rbac/v1/types_swagger_doc_generated.go
@@ -29,7 +29,7 @@ package v1
 // AUTO-GENERATED FUNCTIONS START HERE. DO NOT EDIT.
 var map_AggregationRule = map[string]string{
 	"":                     "AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole",
-	"clusterRoleSelectors": "ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added",
+	"clusterRoleSelectors": "clusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added",
 }
 
 func (AggregationRule) SwaggerDoc() map[string]string {
@@ -38,9 +38,9 @@ func (AggregationRule) SwaggerDoc() map[string]string {
 
 var map_ClusterRole = map[string]string{
 	"":                "ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.",
-	"metadata":        "Standard object's metadata.",
-	"rules":           "Rules holds all the PolicyRules for this ClusterRole",
-	"aggregationRule": "AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.",
+	"metadata":        "metadata is the standard object's metadata.",
+	"rules":           "rules holds all the PolicyRules for this ClusterRole",
+	"aggregationRule": "aggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.",
 }
 
 func (ClusterRole) SwaggerDoc() map[string]string {
@@ -49,9 +49,9 @@ func (ClusterRole) SwaggerDoc() map[string]string {
 
 var map_ClusterRoleBinding = map[string]string{
 	"":         "ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.",
-	"metadata": "Standard object's metadata.",
-	"subjects": "Subjects holds references to the objects the role applies to.",
-	"roleRef":  "RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable.",
+	"metadata": "metadata is the standard object's metadata.",
+	"subjects": "subjects holds references to the objects the role applies to.",
+	"roleRef":  "roleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable.",
 }
 
 func (ClusterRoleBinding) SwaggerDoc() map[string]string {
@@ -80,11 +80,11 @@ func (ClusterRoleList) SwaggerDoc() map[string]string {
 
 var map_PolicyRule = map[string]string{
 	"":                "PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.",
-	"verbs":           "Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.",
-	"apiGroups":       "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed. \"\" represents the core API group and \"*\" represents all API groups.",
-	"resources":       "Resources is a list of resources this rule applies to. '*' represents all resources.",
-	"resourceNames":   "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
-	"nonResourceURLs": "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
+	"verbs":           "verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.",
+	"apiGroups":       "apiGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed. \"\" represents the core API group and \"*\" represents all API groups.",
+	"resources":       "resources is a list of resources this rule applies to. '*' represents all resources.",
+	"resourceNames":   "resourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
+	"nonResourceURLs": "nonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
 }
 
 func (PolicyRule) SwaggerDoc() map[string]string {
@@ -93,8 +93,8 @@ func (PolicyRule) SwaggerDoc() map[string]string {
 
 var map_Role = map[string]string{
 	"":         "Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.",
-	"metadata": "Standard object's metadata.",
-	"rules":    "Rules holds all the PolicyRules for this Role",
+	"metadata": "metadata is the standard object's metadata.",
+	"rules":    "rules holds all the PolicyRules for this Role",
 }
 
 func (Role) SwaggerDoc() map[string]string {
@@ -103,9 +103,9 @@ func (Role) SwaggerDoc() map[string]string {
 
 var map_RoleBinding = map[string]string{
 	"":         "RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.",
-	"metadata": "Standard object's metadata.",
-	"subjects": "Subjects holds references to the objects the role applies to.",
-	"roleRef":  "RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable.",
+	"metadata": "metadata is the standard object's metadata.",
+	"subjects": "subjects holds references to the objects the role applies to.",
+	"roleRef":  "roleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable.",
 }
 
 func (RoleBinding) SwaggerDoc() map[string]string {
@@ -134,9 +134,9 @@ func (RoleList) SwaggerDoc() map[string]string {
 
 var map_RoleRef = map[string]string{
 	"":         "RoleRef contains information that points to the role being used",
-	"apiGroup": "APIGroup is the group for the resource being referenced",
-	"kind":     "Kind is the type of resource being referenced",
-	"name":     "Name is the name of resource being referenced",
+	"apiGroup": "apiGroup is the group for the resource being referenced",
+	"kind":     "kind is the type of resource being referenced",
+	"name":     "name is the name of resource being referenced",
 }
 
 func (RoleRef) SwaggerDoc() map[string]string {
@@ -145,10 +145,10 @@ func (RoleRef) SwaggerDoc() map[string]string {
 
 var map_Subject = map[string]string{
 	"":          "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.",
-	"kind":      "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-	"apiGroup":  "APIGroup holds the API group of the referenced subject. Defaults to \"\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-	"name":      "Name of the object being referenced.",
-	"namespace": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
+	"kind":      "kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+	"apiGroup":  "apiGroup holds the API group of the referenced subject. Defaults to \"\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+	"name":      "name of the object being referenced.",
+	"namespace": "namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
 }
 
 func (Subject) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/rbac/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/generated.proto
@@ -30,7 +30,7 @@ option go_package = "k8s.io/api/rbac/v1alpha1";
 
 // AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole
 message AggregationRule {
-  // ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules.
+  // clusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules.
   // If any of the selectors match, then the ClusterRole's permissions will be added
   // +optional
   // +listType=atomic
@@ -40,17 +40,17 @@ message AggregationRule {
 // ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
 // Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.22.
 message ClusterRole {
-  // Standard object's metadata.
+  // metadata is the standard object's metadata.
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // Rules holds all the PolicyRules for this ClusterRole
+  // rules holds all the PolicyRules for this ClusterRole
   // +optional
   // +listType=atomic
   // +k8s:beta(since: "1.37")=+k8s:optional
   repeated PolicyRule rules = 2;
 
-  // AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
+  // aggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
   // If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be
   // stomped by the controller.
   // +optional
@@ -61,17 +61,17 @@ message ClusterRole {
 // and adds who information via Subject.
 // Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.22.
 message ClusterRoleBinding {
-  // Standard object's metadata.
+  // metadata is the standard object's metadata.
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // Subjects holds references to the objects the role applies to.
+  // subjects holds references to the objects the role applies to.
   // +optional
   // +listType=atomic
   // +k8s:beta(since: "1.37")=+k8s:optional
   repeated Subject subjects = 2;
 
-  // RoleRef can only reference a ClusterRole in the global namespace.
+  // roleRef can only reference a ClusterRole in the global namespace.
   // If the RoleRef cannot be resolved, the Authorizer must return an error.
   // +required
   optional RoleRef roleRef = 3;
@@ -102,29 +102,29 @@ message ClusterRoleList {
 // PolicyRule holds information that describes a policy rule, but does not contain information
 // about who the rule applies to or which namespace the rule applies to.
 message PolicyRule {
-  // Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
+  // verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
   // +listType=atomic
   // +required
   // +k8s:beta(since: "1.37")=+k8s:required
   repeated string verbs = 1;
 
-  // APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
+  // apiGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
   // the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
   // +optional
   // +listType=atomic
   repeated string apiGroups = 3;
 
-  // Resources is a list of resources this rule applies to. '*' represents all resources.
+  // resources is a list of resources this rule applies to. '*' represents all resources.
   // +optional
   // +listType=atomic
   repeated string resources = 4;
 
-  // ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+  // resourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
   // +optional
   // +listType=atomic
   repeated string resourceNames = 5;
 
-  // NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
+  // nonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
   // Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
   // Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
   // +optional
@@ -135,11 +135,11 @@ message PolicyRule {
 // Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.
 // Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.22.
 message Role {
-  // Standard object's metadata.
+  // metadata is the standard object's metadata.
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // Rules holds all the PolicyRules for this Role
+  // rules holds all the PolicyRules for this Role
   // +optional
   // +listType=atomic
   // +k8s:beta(since: "1.37")=+k8s:optional
@@ -151,17 +151,17 @@ message Role {
 // namespace only have effect in that namespace.
 // Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.22.
 message RoleBinding {
-  // Standard object's metadata.
+  // metadata is the standard object's metadata.
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // Subjects holds references to the objects the role applies to.
+  // subjects holds references to the objects the role applies to.
   // +optional
   // +listType=atomic
   // +k8s:beta(since: "1.37")=+k8s:optional
   repeated Subject subjects = 2;
 
-  // RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
+  // roleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
   // If the RoleRef cannot be resolved, the Authorizer must return an error.
   // +required
   // +k8s:alpha(since:"1.37")=+k8s:immutable
@@ -192,15 +192,15 @@ message RoleList {
 
 // RoleRef contains information that points to the role being used
 message RoleRef {
-  // APIGroup is the group for the resource being referenced
+  // apiGroup is the group for the resource being referenced
   // +optional
   optional string apiGroup = 1;
 
-  // Kind is the type of resource being referenced
+  // kind is the type of resource being referenced
   // +required
   optional string kind = 2;
 
-  // Name is the name of resource being referenced
+  // name is the name of resource being referenced
   // +required
   // +k8s:beta(since: "1.37")=+k8s:required
   optional string name = 3;
@@ -209,24 +209,24 @@ message RoleRef {
 // Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
 // or a value for non-objects such as user and group names.
 message Subject {
-  // Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+  // kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
   // If the Authorizer does not recognized the kind value, the Authorizer should report an error.
   // +required
   optional string kind = 1;
 
-  // APIVersion holds the API group and version of the referenced subject.
+  // apiVersion holds the API group and version of the referenced subject.
   // Defaults to "v1" for ServiceAccount subjects.
   // Defaults to "rbac.authorization.k8s.io/v1alpha1" for User and Group subjects.
   // +k8s:conversion-gen=false
   // +optional
   optional string apiVersion = 2;
 
-  // Name of the object being referenced.
+  // name of the object being referenced.
   // +required
   // +k8s:beta(since: "1.37")=+k8s:required
   optional string name = 3;
 
-  // Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+  // namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
   // the Authorizer should report an error.
   // +optional
   optional string namespace = 4;

--- a/staging/src/k8s.io/api/rbac/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/types.go
@@ -47,27 +47,27 @@ const (
 // PolicyRule holds information that describes a policy rule, but does not contain information
 // about who the rule applies to or which namespace the rule applies to.
 type PolicyRule struct {
-	// Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
+	// verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 	// +listType=atomic
 	// +required
 	// +k8s:beta(since: "1.37")=+k8s:required
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 
-	// APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
+	// apiGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
 	// the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
 	// +optional
 	// +listType=atomic
 	APIGroups []string `json:"apiGroups,omitempty" protobuf:"bytes,3,rep,name=apiGroups"`
-	// Resources is a list of resources this rule applies to. '*' represents all resources.
+	// resources is a list of resources this rule applies to. '*' represents all resources.
 	// +optional
 	// +listType=atomic
 	Resources []string `json:"resources,omitempty" protobuf:"bytes,4,rep,name=resources"`
-	// ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+	// resourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
 	// +optional
 	// +listType=atomic
 	ResourceNames []string `json:"resourceNames,omitempty" protobuf:"bytes,5,rep,name=resourceNames"`
 
-	// NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
+	// nonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
 	// Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
 	// Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
 	// +optional
@@ -78,21 +78,21 @@ type PolicyRule struct {
 // Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
 // or a value for non-objects such as user and group names.
 type Subject struct {
-	// Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+	// kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
 	// If the Authorizer does not recognized the kind value, the Authorizer should report an error.
 	// +required
 	Kind string `json:"kind" protobuf:"bytes,1,opt,name=kind"`
-	// APIVersion holds the API group and version of the referenced subject.
+	// apiVersion holds the API group and version of the referenced subject.
 	// Defaults to "v1" for ServiceAccount subjects.
 	// Defaults to "rbac.authorization.k8s.io/v1alpha1" for User and Group subjects.
 	// +k8s:conversion-gen=false
 	// +optional
 	APIVersion string `json:"apiVersion,omitempty" protobuf:"bytes,2,opt,name=apiVersion"`
-	// Name of the object being referenced.
+	// name of the object being referenced.
 	// +required
 	// +k8s:beta(since: "1.37")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,3,opt,name=name"`
-	// Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+	// namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
 	// the Authorizer should report an error.
 	// +optional
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,4,opt,name=namespace"`
@@ -100,13 +100,13 @@ type Subject struct {
 
 // RoleRef contains information that points to the role being used
 type RoleRef struct {
-	// APIGroup is the group for the resource being referenced
+	// apiGroup is the group for the resource being referenced
 	// +optional
 	APIGroup string `json:"apiGroup" protobuf:"bytes,1,opt,name=apiGroup"`
-	// Kind is the type of resource being referenced
+	// kind is the type of resource being referenced
 	// +required
 	Kind string `json:"kind" protobuf:"bytes,2,opt,name=kind"`
-	// Name is the name of resource being referenced
+	// name is the name of resource being referenced
 	// +required
 	// +k8s:beta(since: "1.37")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,3,opt,name=name"`
@@ -119,11 +119,11 @@ type RoleRef struct {
 // Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.22.
 type Role struct {
 	metav1.TypeMeta `json:""`
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Rules holds all the PolicyRules for this Role
+	// rules holds all the PolicyRules for this Role
 	// +optional
 	// +listType=atomic
 	// +k8s:beta(since: "1.37")=+k8s:optional
@@ -139,17 +139,17 @@ type Role struct {
 // Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.22.
 type RoleBinding struct {
 	metav1.TypeMeta `json:""`
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Subjects holds references to the objects the role applies to.
+	// subjects holds references to the objects the role applies to.
 	// +optional
 	// +listType=atomic
 	// +k8s:beta(since: "1.37")=+k8s:optional
 	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
-	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
+	// roleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
 	// If the RoleRef cannot be resolved, the Authorizer must return an error.
 	// +required
 	// +k8s:alpha(since:"1.37")=+k8s:immutable
@@ -192,17 +192,17 @@ type RoleList struct {
 // Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.22.
 type ClusterRole struct {
 	metav1.TypeMeta `json:""`
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Rules holds all the PolicyRules for this ClusterRole
+	// rules holds all the PolicyRules for this ClusterRole
 	// +optional
 	// +listType=atomic
 	// +k8s:beta(since: "1.37")=+k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 
-	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
+	// aggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
 	// If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be
 	// stomped by the controller.
 	// +optional
@@ -211,7 +211,7 @@ type ClusterRole struct {
 
 // AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole
 type AggregationRule struct {
-	// ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules.
+	// clusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules.
 	// If any of the selectors match, then the ClusterRole's permissions will be added
 	// +optional
 	// +listType=atomic
@@ -227,17 +227,17 @@ type AggregationRule struct {
 // Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.22.
 type ClusterRoleBinding struct {
 	metav1.TypeMeta `json:""`
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Subjects holds references to the objects the role applies to.
+	// subjects holds references to the objects the role applies to.
 	// +optional
 	// +listType=atomic
 	// +k8s:beta(since: "1.37")=+k8s:optional
 	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
-	// RoleRef can only reference a ClusterRole in the global namespace.
+	// roleRef can only reference a ClusterRole in the global namespace.
 	// If the RoleRef cannot be resolved, the Authorizer must return an error.
 	// +required
 	RoleRef RoleRef `json:"roleRef" protobuf:"bytes,3,opt,name=roleRef"`

--- a/staging/src/k8s.io/api/rbac/v1alpha1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/types_swagger_doc_generated.go
@@ -29,7 +29,7 @@ package v1alpha1
 // AUTO-GENERATED FUNCTIONS START HERE. DO NOT EDIT.
 var map_AggregationRule = map[string]string{
 	"":                     "AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole",
-	"clusterRoleSelectors": "ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added",
+	"clusterRoleSelectors": "clusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added",
 }
 
 func (AggregationRule) SwaggerDoc() map[string]string {
@@ -38,9 +38,9 @@ func (AggregationRule) SwaggerDoc() map[string]string {
 
 var map_ClusterRole = map[string]string{
 	"":                "ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.22.",
-	"metadata":        "Standard object's metadata.",
-	"rules":           "Rules holds all the PolicyRules for this ClusterRole",
-	"aggregationRule": "AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.",
+	"metadata":        "metadata is the standard object's metadata.",
+	"rules":           "rules holds all the PolicyRules for this ClusterRole",
+	"aggregationRule": "aggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.",
 }
 
 func (ClusterRole) SwaggerDoc() map[string]string {
@@ -49,9 +49,9 @@ func (ClusterRole) SwaggerDoc() map[string]string {
 
 var map_ClusterRoleBinding = map[string]string{
 	"":         "ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.22.",
-	"metadata": "Standard object's metadata.",
-	"subjects": "Subjects holds references to the objects the role applies to.",
-	"roleRef":  "RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.",
+	"metadata": "metadata is the standard object's metadata.",
+	"subjects": "subjects holds references to the objects the role applies to.",
+	"roleRef":  "roleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.",
 }
 
 func (ClusterRoleBinding) SwaggerDoc() map[string]string {
@@ -80,11 +80,11 @@ func (ClusterRoleList) SwaggerDoc() map[string]string {
 
 var map_PolicyRule = map[string]string{
 	"":                "PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.",
-	"verbs":           "Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.",
-	"apiGroups":       "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed. \"\" represents the core API group and \"*\" represents all API groups.",
-	"resources":       "Resources is a list of resources this rule applies to. '*' represents all resources.",
-	"resourceNames":   "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
-	"nonResourceURLs": "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
+	"verbs":           "verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.",
+	"apiGroups":       "apiGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed. \"\" represents the core API group and \"*\" represents all API groups.",
+	"resources":       "resources is a list of resources this rule applies to. '*' represents all resources.",
+	"resourceNames":   "resourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
+	"nonResourceURLs": "nonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
 }
 
 func (PolicyRule) SwaggerDoc() map[string]string {
@@ -93,8 +93,8 @@ func (PolicyRule) SwaggerDoc() map[string]string {
 
 var map_Role = map[string]string{
 	"":         "Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.22.",
-	"metadata": "Standard object's metadata.",
-	"rules":    "Rules holds all the PolicyRules for this Role",
+	"metadata": "metadata is the standard object's metadata.",
+	"rules":    "rules holds all the PolicyRules for this Role",
 }
 
 func (Role) SwaggerDoc() map[string]string {
@@ -103,9 +103,9 @@ func (Role) SwaggerDoc() map[string]string {
 
 var map_RoleBinding = map[string]string{
 	"":         "RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.22.",
-	"metadata": "Standard object's metadata.",
-	"subjects": "Subjects holds references to the objects the role applies to.",
-	"roleRef":  "RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.",
+	"metadata": "metadata is the standard object's metadata.",
+	"subjects": "subjects holds references to the objects the role applies to.",
+	"roleRef":  "roleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.",
 }
 
 func (RoleBinding) SwaggerDoc() map[string]string {
@@ -134,9 +134,9 @@ func (RoleList) SwaggerDoc() map[string]string {
 
 var map_RoleRef = map[string]string{
 	"":         "RoleRef contains information that points to the role being used",
-	"apiGroup": "APIGroup is the group for the resource being referenced",
-	"kind":     "Kind is the type of resource being referenced",
-	"name":     "Name is the name of resource being referenced",
+	"apiGroup": "apiGroup is the group for the resource being referenced",
+	"kind":     "kind is the type of resource being referenced",
+	"name":     "name is the name of resource being referenced",
 }
 
 func (RoleRef) SwaggerDoc() map[string]string {
@@ -145,10 +145,10 @@ func (RoleRef) SwaggerDoc() map[string]string {
 
 var map_Subject = map[string]string{
 	"":           "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.",
-	"kind":       "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-	"apiVersion": "APIVersion holds the API group and version of the referenced subject. Defaults to \"v1\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io/v1alpha1\" for User and Group subjects.",
-	"name":       "Name of the object being referenced.",
-	"namespace":  "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
+	"kind":       "kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+	"apiVersion": "apiVersion holds the API group and version of the referenced subject. Defaults to \"v1\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io/v1alpha1\" for User and Group subjects.",
+	"name":       "name of the object being referenced.",
+	"namespace":  "namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
 }
 
 func (Subject) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/rbac/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1beta1/generated.proto
@@ -30,7 +30,7 @@ option go_package = "k8s.io/api/rbac/v1beta1";
 
 // AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole
 message AggregationRule {
-  // ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules.
+  // clusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules.
   // If any of the selectors match, then the ClusterRole's permissions will be added
   // +optional
   // +listType=atomic
@@ -40,17 +40,17 @@ message AggregationRule {
 // ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
 // Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.22.
 message ClusterRole {
-  // Standard object's metadata.
+  // metadata is the standard object's metadata.
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // Rules holds all the PolicyRules for this ClusterRole
+  // rules holds all the PolicyRules for this ClusterRole
   // +optional
   // +listType=atomic
   // +k8s:beta(since: "1.37")=+k8s:optional
   repeated PolicyRule rules = 2;
 
-  // AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
+  // aggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
   // If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be
   // stomped by the controller.
   // +optional
@@ -61,17 +61,17 @@ message ClusterRole {
 // and adds who information via Subject.
 // Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.22.
 message ClusterRoleBinding {
-  // Standard object's metadata.
+  // metadata is the standard object's metadata.
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // Subjects holds references to the objects the role applies to.
+  // subjects holds references to the objects the role applies to.
   // +optional
   // +listType=atomic
   // +k8s:beta(since: "1.37")=+k8s:optional
   repeated Subject subjects = 2;
 
-  // RoleRef can only reference a ClusterRole in the global namespace.
+  // roleRef can only reference a ClusterRole in the global namespace.
   // If the RoleRef cannot be resolved, the Authorizer must return an error.
   // +required
   optional RoleRef roleRef = 3;
@@ -102,30 +102,30 @@ message ClusterRoleList {
 // PolicyRule holds information that describes a policy rule, but does not contain information
 // about who the rule applies to or which namespace the rule applies to.
 message PolicyRule {
-  // Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
+  // verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
   // +listType=atomic
   // +required
   // +k8s:beta(since: "1.37")=+k8s:required
   repeated string verbs = 1;
 
-  // APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
+  // apiGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
   // the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
   // +optional
   // +listType=atomic
   repeated string apiGroups = 2;
 
-  // Resources is a list of resources this rule applies to.  '*' represents all resources in the specified apiGroups.
+  // resources is a list of resources this rule applies to.  '*' represents all resources in the specified apiGroups.
   // '*/foo' represents the subresource 'foo' for all resources in the specified apiGroups.
   // +optional
   // +listType=atomic
   repeated string resources = 3;
 
-  // ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+  // resourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
   // +optional
   // +listType=atomic
   repeated string resourceNames = 4;
 
-  // NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
+  // nonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
   // Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
   // Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
   // +optional
@@ -136,11 +136,11 @@ message PolicyRule {
 // Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.
 // Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.22.
 message Role {
-  // Standard object's metadata.
+  // metadata is the standard object's metadata.
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // Rules holds all the PolicyRules for this Role
+  // rules holds all the PolicyRules for this Role
   // +optional
   // +listType=atomic
   // +k8s:beta(since: "1.37")=+k8s:optional
@@ -152,17 +152,17 @@ message Role {
 // namespace only have effect in that namespace.
 // Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.22.
 message RoleBinding {
-  // Standard object's metadata.
+  // metadata is the standard object's metadata.
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // Subjects holds references to the objects the role applies to.
+  // subjects holds references to the objects the role applies to.
   // +optional
   // +listType=atomic
   // +k8s:beta(since: "1.37")=+k8s:optional
   repeated Subject subjects = 2;
 
-  // RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
+  // roleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
   // If the RoleRef cannot be resolved, the Authorizer must return an error.
   // +required
   // +k8s:alpha(since:"1.37")=+k8s:immutable
@@ -193,15 +193,15 @@ message RoleList {
 
 // RoleRef contains information that points to the role being used
 message RoleRef {
-  // APIGroup is the group for the resource being referenced
+  // apiGroup is the group for the resource being referenced
   // +optional
   optional string apiGroup = 1;
 
-  // Kind is the type of resource being referenced
+  // kind is the type of resource being referenced
   // +required
   optional string kind = 2;
 
-  // Name is the name of resource being referenced
+  // name is the name of resource being referenced
   // +required
   // +k8s:beta(since: "1.37")=+k8s:required
   optional string name = 3;
@@ -210,23 +210,23 @@ message RoleRef {
 // Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
 // or a value for non-objects such as user and group names.
 message Subject {
-  // Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+  // kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
   // If the Authorizer does not recognized the kind value, the Authorizer should report an error.
   // +required
   optional string kind = 1;
 
-  // APIGroup holds the API group of the referenced subject.
+  // apiGroup holds the API group of the referenced subject.
   // Defaults to "" for ServiceAccount subjects.
   // Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
   // +optional
   optional string apiGroup = 2;
 
-  // Name of the object being referenced.
+  // name of the object being referenced.
   // +required
   // +k8s:beta(since: "1.37")=+k8s:required
   optional string name = 3;
 
-  // Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+  // namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
   // the Authorizer should report an error.
   // +optional
   optional string namespace = 4;

--- a/staging/src/k8s.io/api/rbac/v1beta1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1beta1/types.go
@@ -47,28 +47,28 @@ const (
 // PolicyRule holds information that describes a policy rule, but does not contain information
 // about who the rule applies to or which namespace the rule applies to.
 type PolicyRule struct {
-	// Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
+	// verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 	// +listType=atomic
 	// +required
 	// +k8s:beta(since: "1.37")=+k8s:required
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 
-	// APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
+	// apiGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
 	// the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
 	// +optional
 	// +listType=atomic
 	APIGroups []string `json:"apiGroups,omitempty" protobuf:"bytes,2,rep,name=apiGroups"`
-	// Resources is a list of resources this rule applies to.  '*' represents all resources in the specified apiGroups.
+	// resources is a list of resources this rule applies to.  '*' represents all resources in the specified apiGroups.
 	// '*/foo' represents the subresource 'foo' for all resources in the specified apiGroups.
 	// +optional
 	// +listType=atomic
 	Resources []string `json:"resources,omitempty" protobuf:"bytes,3,rep,name=resources"`
-	// ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+	// resourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
 	// +optional
 	// +listType=atomic
 	ResourceNames []string `json:"resourceNames,omitempty" protobuf:"bytes,4,rep,name=resourceNames"`
 
-	// NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
+	// nonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
 	// Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
 	// Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
 	// +optional
@@ -79,20 +79,20 @@ type PolicyRule struct {
 // Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
 // or a value for non-objects such as user and group names.
 type Subject struct {
-	// Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+	// kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
 	// If the Authorizer does not recognized the kind value, the Authorizer should report an error.
 	// +required
 	Kind string `json:"kind" protobuf:"bytes,1,opt,name=kind"`
-	// APIGroup holds the API group of the referenced subject.
+	// apiGroup holds the API group of the referenced subject.
 	// Defaults to "" for ServiceAccount subjects.
 	// Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
 	// +optional
 	APIGroup string `json:"apiGroup,omitempty" protobuf:"bytes,2,opt,name=apiGroup"`
-	// Name of the object being referenced.
+	// name of the object being referenced.
 	// +required
 	// +k8s:beta(since: "1.37")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,3,opt,name=name"`
-	// Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+	// namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
 	// the Authorizer should report an error.
 	// +optional
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,4,opt,name=namespace"`
@@ -100,13 +100,13 @@ type Subject struct {
 
 // RoleRef contains information that points to the role being used
 type RoleRef struct {
-	// APIGroup is the group for the resource being referenced
+	// apiGroup is the group for the resource being referenced
 	// +optional
 	APIGroup string `json:"apiGroup" protobuf:"bytes,1,opt,name=apiGroup"`
-	// Kind is the type of resource being referenced
+	// kind is the type of resource being referenced
 	// +required
 	Kind string `json:"kind" protobuf:"bytes,2,opt,name=kind"`
-	// Name is the name of resource being referenced
+	// name is the name of resource being referenced
 	// +required
 	// +k8s:beta(since: "1.37")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,3,opt,name=name"`
@@ -123,11 +123,11 @@ type RoleRef struct {
 // Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.22.
 type Role struct {
 	metav1.TypeMeta `json:""`
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Rules holds all the PolicyRules for this Role
+	// rules holds all the PolicyRules for this Role
 	// +optional
 	// +listType=atomic
 	// +k8s:beta(since: "1.37")=+k8s:optional
@@ -147,17 +147,17 @@ type Role struct {
 // Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.22.
 type RoleBinding struct {
 	metav1.TypeMeta `json:""`
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Subjects holds references to the objects the role applies to.
+	// subjects holds references to the objects the role applies to.
 	// +optional
 	// +listType=atomic
 	// +k8s:beta(since: "1.37")=+k8s:optional
 	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
-	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
+	// roleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
 	// If the RoleRef cannot be resolved, the Authorizer must return an error.
 	// +required
 	// +k8s:alpha(since:"1.37")=+k8s:immutable
@@ -212,16 +212,16 @@ type RoleList struct {
 // Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.22.
 type ClusterRole struct {
 	metav1.TypeMeta `json:""`
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Rules holds all the PolicyRules for this ClusterRole
+	// rules holds all the PolicyRules for this ClusterRole
 	// +optional
 	// +listType=atomic
 	// +k8s:beta(since: "1.37")=+k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
-	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
+	// aggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
 	// If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be
 	// stomped by the controller.
 	// +optional
@@ -230,7 +230,7 @@ type ClusterRole struct {
 
 // AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole
 type AggregationRule struct {
-	// ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules.
+	// clusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules.
 	// If any of the selectors match, then the ClusterRole's permissions will be added
 	// +optional
 	// +listType=atomic
@@ -250,17 +250,17 @@ type AggregationRule struct {
 // Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.22.
 type ClusterRoleBinding struct {
 	metav1.TypeMeta `json:""`
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Subjects holds references to the objects the role applies to.
+	// subjects holds references to the objects the role applies to.
 	// +optional
 	// +listType=atomic
 	// +k8s:beta(since: "1.37")=+k8s:optional
 	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
-	// RoleRef can only reference a ClusterRole in the global namespace.
+	// roleRef can only reference a ClusterRole in the global namespace.
 	// If the RoleRef cannot be resolved, the Authorizer must return an error.
 	// +required
 	RoleRef RoleRef `json:"roleRef" protobuf:"bytes,3,opt,name=roleRef"`

--- a/staging/src/k8s.io/api/rbac/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/rbac/v1beta1/types_swagger_doc_generated.go
@@ -29,7 +29,7 @@ package v1beta1
 // AUTO-GENERATED FUNCTIONS START HERE. DO NOT EDIT.
 var map_AggregationRule = map[string]string{
 	"":                     "AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole",
-	"clusterRoleSelectors": "ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added",
+	"clusterRoleSelectors": "clusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added",
 }
 
 func (AggregationRule) SwaggerDoc() map[string]string {
@@ -38,9 +38,9 @@ func (AggregationRule) SwaggerDoc() map[string]string {
 
 var map_ClusterRole = map[string]string{
 	"":                "ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.22.",
-	"metadata":        "Standard object's metadata.",
-	"rules":           "Rules holds all the PolicyRules for this ClusterRole",
-	"aggregationRule": "AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.",
+	"metadata":        "metadata is the standard object's metadata.",
+	"rules":           "rules holds all the PolicyRules for this ClusterRole",
+	"aggregationRule": "aggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.",
 }
 
 func (ClusterRole) SwaggerDoc() map[string]string {
@@ -49,9 +49,9 @@ func (ClusterRole) SwaggerDoc() map[string]string {
 
 var map_ClusterRoleBinding = map[string]string{
 	"":         "ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.22.",
-	"metadata": "Standard object's metadata.",
-	"subjects": "Subjects holds references to the objects the role applies to.",
-	"roleRef":  "RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.",
+	"metadata": "metadata is the standard object's metadata.",
+	"subjects": "subjects holds references to the objects the role applies to.",
+	"roleRef":  "roleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.",
 }
 
 func (ClusterRoleBinding) SwaggerDoc() map[string]string {
@@ -80,11 +80,11 @@ func (ClusterRoleList) SwaggerDoc() map[string]string {
 
 var map_PolicyRule = map[string]string{
 	"":                "PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.",
-	"verbs":           "Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.",
-	"apiGroups":       "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed. \"\" represents the core API group and \"*\" represents all API groups.",
-	"resources":       "Resources is a list of resources this rule applies to.  '*' represents all resources in the specified apiGroups. '*/foo' represents the subresource 'foo' for all resources in the specified apiGroups.",
-	"resourceNames":   "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
-	"nonResourceURLs": "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
+	"verbs":           "verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.",
+	"apiGroups":       "apiGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed. \"\" represents the core API group and \"*\" represents all API groups.",
+	"resources":       "resources is a list of resources this rule applies to.  '*' represents all resources in the specified apiGroups. '*/foo' represents the subresource 'foo' for all resources in the specified apiGroups.",
+	"resourceNames":   "resourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
+	"nonResourceURLs": "nonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
 }
 
 func (PolicyRule) SwaggerDoc() map[string]string {
@@ -93,8 +93,8 @@ func (PolicyRule) SwaggerDoc() map[string]string {
 
 var map_Role = map[string]string{
 	"":         "Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.22.",
-	"metadata": "Standard object's metadata.",
-	"rules":    "Rules holds all the PolicyRules for this Role",
+	"metadata": "metadata is the standard object's metadata.",
+	"rules":    "rules holds all the PolicyRules for this Role",
 }
 
 func (Role) SwaggerDoc() map[string]string {
@@ -103,9 +103,9 @@ func (Role) SwaggerDoc() map[string]string {
 
 var map_RoleBinding = map[string]string{
 	"":         "RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.22.",
-	"metadata": "Standard object's metadata.",
-	"subjects": "Subjects holds references to the objects the role applies to.",
-	"roleRef":  "RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.",
+	"metadata": "metadata is the standard object's metadata.",
+	"subjects": "subjects holds references to the objects the role applies to.",
+	"roleRef":  "roleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.",
 }
 
 func (RoleBinding) SwaggerDoc() map[string]string {
@@ -134,9 +134,9 @@ func (RoleList) SwaggerDoc() map[string]string {
 
 var map_RoleRef = map[string]string{
 	"":         "RoleRef contains information that points to the role being used",
-	"apiGroup": "APIGroup is the group for the resource being referenced",
-	"kind":     "Kind is the type of resource being referenced",
-	"name":     "Name is the name of resource being referenced",
+	"apiGroup": "apiGroup is the group for the resource being referenced",
+	"kind":     "kind is the type of resource being referenced",
+	"name":     "name is the name of resource being referenced",
 }
 
 func (RoleRef) SwaggerDoc() map[string]string {
@@ -145,10 +145,10 @@ func (RoleRef) SwaggerDoc() map[string]string {
 
 var map_Subject = map[string]string{
 	"":          "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.",
-	"kind":      "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-	"apiGroup":  "APIGroup holds the API group of the referenced subject. Defaults to \"\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-	"name":      "Name of the object being referenced.",
-	"namespace": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
+	"kind":      "kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+	"apiGroup":  "apiGroup holds the API group of the referenced subject. Defaults to \"\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+	"name":      "name of the object being referenced.",
+	"namespace": "namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
 }
 
 func (Subject) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/aggregationrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/aggregationrule.go
@@ -27,7 +27,7 @@ import (
 //
 // AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole
 type AggregationRuleApplyConfiguration struct {
-	// ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules.
+	// clusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules.
 	// If any of the selectors match, then the ClusterRole's permissions will be added
 	ClusterRoleSelectors []metav1.LabelSelectorApplyConfiguration `json:"clusterRoleSelectors,omitempty"`
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/clusterrole.go
@@ -33,11 +33,11 @@ import (
 // ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
 type ClusterRoleApplyConfiguration struct {
 	metav1.TypeMetaApplyConfiguration `json:""`
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	*metav1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	// Rules holds all the PolicyRules for this ClusterRole
+	// rules holds all the PolicyRules for this ClusterRole
 	Rules []PolicyRuleApplyConfiguration `json:"rules,omitempty"`
-	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
+	// aggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
 	// If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be
 	// stomped by the controller.
 	AggregationRule *AggregationRuleApplyConfiguration `json:"aggregationRule,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/clusterrolebinding.go
@@ -34,11 +34,11 @@ import (
 // and adds who information via Subject.
 type ClusterRoleBindingApplyConfiguration struct {
 	metav1.TypeMetaApplyConfiguration `json:""`
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	*metav1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	// Subjects holds references to the objects the role applies to.
+	// subjects holds references to the objects the role applies to.
 	Subjects []SubjectApplyConfiguration `json:"subjects,omitempty"`
-	// RoleRef can only reference a ClusterRole in the global namespace.
+	// roleRef can only reference a ClusterRole in the global namespace.
 	// If the RoleRef cannot be resolved, the Authorizer must return an error.
 	// This field is immutable.
 	RoleRef *RoleRefApplyConfiguration `json:"roleRef,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/policyrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/policyrule.go
@@ -28,16 +28,16 @@ package v1
 // PolicyRule holds information that describes a policy rule, but does not contain information
 // about who the rule applies to or which namespace the rule applies to.
 type PolicyRuleApplyConfiguration struct {
-	// Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
+	// verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 	Verbs []string `json:"verbs,omitempty"`
-	// APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
+	// apiGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
 	// the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
 	APIGroups []string `json:"apiGroups,omitempty"`
-	// Resources is a list of resources this rule applies to. '*' represents all resources.
+	// resources is a list of resources this rule applies to. '*' represents all resources.
 	Resources []string `json:"resources,omitempty"`
-	// ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+	// resourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
 	ResourceNames []string `json:"resourceNames,omitempty"`
-	// NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
+	// nonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
 	// Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
 	// Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
 	NonResourceURLs []string `json:"nonResourceURLs,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/role.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/role.go
@@ -33,9 +33,9 @@ import (
 // Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.
 type RoleApplyConfiguration struct {
 	metav1.TypeMetaApplyConfiguration `json:""`
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	*metav1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	// Rules holds all the PolicyRules for this Role
+	// rules holds all the PolicyRules for this Role
 	Rules []PolicyRuleApplyConfiguration `json:"rules,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/rolebinding.go
@@ -35,11 +35,11 @@ import (
 // namespace only have effect in that namespace.
 type RoleBindingApplyConfiguration struct {
 	metav1.TypeMetaApplyConfiguration `json:""`
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	*metav1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	// Subjects holds references to the objects the role applies to.
+	// subjects holds references to the objects the role applies to.
 	Subjects []SubjectApplyConfiguration `json:"subjects,omitempty"`
-	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
+	// roleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
 	// If the RoleRef cannot be resolved, the Authorizer must return an error.
 	// This field is immutable.
 	RoleRef *RoleRefApplyConfiguration `json:"roleRef,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/roleref.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/roleref.go
@@ -23,11 +23,11 @@ package v1
 //
 // RoleRef contains information that points to the role being used
 type RoleRefApplyConfiguration struct {
-	// APIGroup is the group for the resource being referenced
+	// apiGroup is the group for the resource being referenced
 	APIGroup *string `json:"apiGroup,omitempty"`
-	// Kind is the type of resource being referenced
+	// kind is the type of resource being referenced
 	Kind *string `json:"kind,omitempty"`
-	// Name is the name of resource being referenced
+	// name is the name of resource being referenced
 	Name *string `json:"name,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/subject.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/subject.go
@@ -24,16 +24,16 @@ package v1
 // Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
 // or a value for non-objects such as user and group names.
 type SubjectApplyConfiguration struct {
-	// Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+	// kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
 	// If the Authorizer does not recognized the kind value, the Authorizer should report an error.
 	Kind *string `json:"kind,omitempty"`
-	// APIGroup holds the API group of the referenced subject.
+	// apiGroup holds the API group of the referenced subject.
 	// Defaults to "" for ServiceAccount subjects.
 	// Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
 	APIGroup *string `json:"apiGroup,omitempty"`
-	// Name of the object being referenced.
+	// name of the object being referenced.
 	Name *string `json:"name,omitempty"`
-	// Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+	// namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
 	// the Authorizer should report an error.
 	Namespace *string `json:"namespace,omitempty"`
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/aggregationrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/aggregationrule.go
@@ -27,7 +27,7 @@ import (
 //
 // AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole
 type AggregationRuleApplyConfiguration struct {
-	// ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules.
+	// clusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules.
 	// If any of the selectors match, then the ClusterRole's permissions will be added
 	ClusterRoleSelectors []v1.LabelSelectorApplyConfiguration `json:"clusterRoleSelectors,omitempty"`
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/clusterrole.go
@@ -34,11 +34,11 @@ import (
 // Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.22.
 type ClusterRoleApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration `json:""`
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	// Rules holds all the PolicyRules for this ClusterRole
+	// rules holds all the PolicyRules for this ClusterRole
 	Rules []PolicyRuleApplyConfiguration `json:"rules,omitempty"`
-	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
+	// aggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
 	// If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be
 	// stomped by the controller.
 	AggregationRule *AggregationRuleApplyConfiguration `json:"aggregationRule,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/clusterrolebinding.go
@@ -35,11 +35,11 @@ import (
 // Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.22.
 type ClusterRoleBindingApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration `json:""`
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	// Subjects holds references to the objects the role applies to.
+	// subjects holds references to the objects the role applies to.
 	Subjects []SubjectApplyConfiguration `json:"subjects,omitempty"`
-	// RoleRef can only reference a ClusterRole in the global namespace.
+	// roleRef can only reference a ClusterRole in the global namespace.
 	// If the RoleRef cannot be resolved, the Authorizer must return an error.
 	RoleRef *RoleRefApplyConfiguration `json:"roleRef,omitempty"`
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/policyrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/policyrule.go
@@ -28,16 +28,16 @@ package v1alpha1
 // PolicyRule holds information that describes a policy rule, but does not contain information
 // about who the rule applies to or which namespace the rule applies to.
 type PolicyRuleApplyConfiguration struct {
-	// Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
+	// verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 	Verbs []string `json:"verbs,omitempty"`
-	// APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
+	// apiGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
 	// the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
 	APIGroups []string `json:"apiGroups,omitempty"`
-	// Resources is a list of resources this rule applies to. '*' represents all resources.
+	// resources is a list of resources this rule applies to. '*' represents all resources.
 	Resources []string `json:"resources,omitempty"`
-	// ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+	// resourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
 	ResourceNames []string `json:"resourceNames,omitempty"`
-	// NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
+	// nonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
 	// Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
 	// Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
 	NonResourceURLs []string `json:"nonResourceURLs,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/role.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/role.go
@@ -34,9 +34,9 @@ import (
 // Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.22.
 type RoleApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration `json:""`
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	// Rules holds all the PolicyRules for this Role
+	// rules holds all the PolicyRules for this Role
 	Rules []PolicyRuleApplyConfiguration `json:"rules,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/rolebinding.go
@@ -36,11 +36,11 @@ import (
 // Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.22.
 type RoleBindingApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration `json:""`
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	// Subjects holds references to the objects the role applies to.
+	// subjects holds references to the objects the role applies to.
 	Subjects []SubjectApplyConfiguration `json:"subjects,omitempty"`
-	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
+	// roleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
 	// If the RoleRef cannot be resolved, the Authorizer must return an error.
 	RoleRef *RoleRefApplyConfiguration `json:"roleRef,omitempty"`
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/roleref.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/roleref.go
@@ -23,11 +23,11 @@ package v1alpha1
 //
 // RoleRef contains information that points to the role being used
 type RoleRefApplyConfiguration struct {
-	// APIGroup is the group for the resource being referenced
+	// apiGroup is the group for the resource being referenced
 	APIGroup *string `json:"apiGroup,omitempty"`
-	// Kind is the type of resource being referenced
+	// kind is the type of resource being referenced
 	Kind *string `json:"kind,omitempty"`
-	// Name is the name of resource being referenced
+	// name is the name of resource being referenced
 	Name *string `json:"name,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/subject.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/subject.go
@@ -24,16 +24,16 @@ package v1alpha1
 // Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
 // or a value for non-objects such as user and group names.
 type SubjectApplyConfiguration struct {
-	// Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+	// kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
 	// If the Authorizer does not recognized the kind value, the Authorizer should report an error.
 	Kind *string `json:"kind,omitempty"`
-	// APIVersion holds the API group and version of the referenced subject.
+	// apiVersion holds the API group and version of the referenced subject.
 	// Defaults to "v1" for ServiceAccount subjects.
 	// Defaults to "rbac.authorization.k8s.io/v1alpha1" for User and Group subjects.
 	APIVersion *string `json:"apiVersion,omitempty"`
-	// Name of the object being referenced.
+	// name of the object being referenced.
 	Name *string `json:"name,omitempty"`
-	// Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+	// namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
 	// the Authorizer should report an error.
 	Namespace *string `json:"namespace,omitempty"`
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/aggregationrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/aggregationrule.go
@@ -27,7 +27,7 @@ import (
 //
 // AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole
 type AggregationRuleApplyConfiguration struct {
-	// ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules.
+	// clusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules.
 	// If any of the selectors match, then the ClusterRole's permissions will be added
 	ClusterRoleSelectors []v1.LabelSelectorApplyConfiguration `json:"clusterRoleSelectors,omitempty"`
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/clusterrole.go
@@ -34,11 +34,11 @@ import (
 // Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.22.
 type ClusterRoleApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration `json:""`
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	// Rules holds all the PolicyRules for this ClusterRole
+	// rules holds all the PolicyRules for this ClusterRole
 	Rules []PolicyRuleApplyConfiguration `json:"rules,omitempty"`
-	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
+	// aggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
 	// If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be
 	// stomped by the controller.
 	AggregationRule *AggregationRuleApplyConfiguration `json:"aggregationRule,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/clusterrolebinding.go
@@ -35,11 +35,11 @@ import (
 // Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.22.
 type ClusterRoleBindingApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration `json:""`
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	// Subjects holds references to the objects the role applies to.
+	// subjects holds references to the objects the role applies to.
 	Subjects []SubjectApplyConfiguration `json:"subjects,omitempty"`
-	// RoleRef can only reference a ClusterRole in the global namespace.
+	// roleRef can only reference a ClusterRole in the global namespace.
 	// If the RoleRef cannot be resolved, the Authorizer must return an error.
 	RoleRef *RoleRefApplyConfiguration `json:"roleRef,omitempty"`
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/policyrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/policyrule.go
@@ -28,17 +28,17 @@ package v1beta1
 // PolicyRule holds information that describes a policy rule, but does not contain information
 // about who the rule applies to or which namespace the rule applies to.
 type PolicyRuleApplyConfiguration struct {
-	// Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
+	// verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 	Verbs []string `json:"verbs,omitempty"`
-	// APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
+	// apiGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
 	// the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
 	APIGroups []string `json:"apiGroups,omitempty"`
-	// Resources is a list of resources this rule applies to.  '*' represents all resources in the specified apiGroups.
+	// resources is a list of resources this rule applies to.  '*' represents all resources in the specified apiGroups.
 	// '*/foo' represents the subresource 'foo' for all resources in the specified apiGroups.
 	Resources []string `json:"resources,omitempty"`
-	// ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+	// resourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
 	ResourceNames []string `json:"resourceNames,omitempty"`
-	// NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
+	// nonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
 	// Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
 	// Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
 	NonResourceURLs []string `json:"nonResourceURLs,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/role.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/role.go
@@ -34,9 +34,9 @@ import (
 // Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.22.
 type RoleApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration `json:""`
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	// Rules holds all the PolicyRules for this Role
+	// rules holds all the PolicyRules for this Role
 	Rules []PolicyRuleApplyConfiguration `json:"rules,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/rolebinding.go
@@ -36,11 +36,11 @@ import (
 // Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.22.
 type RoleBindingApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration `json:""`
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	// Subjects holds references to the objects the role applies to.
+	// subjects holds references to the objects the role applies to.
 	Subjects []SubjectApplyConfiguration `json:"subjects,omitempty"`
-	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
+	// roleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
 	// If the RoleRef cannot be resolved, the Authorizer must return an error.
 	RoleRef *RoleRefApplyConfiguration `json:"roleRef,omitempty"`
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/roleref.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/roleref.go
@@ -23,11 +23,11 @@ package v1beta1
 //
 // RoleRef contains information that points to the role being used
 type RoleRefApplyConfiguration struct {
-	// APIGroup is the group for the resource being referenced
+	// apiGroup is the group for the resource being referenced
 	APIGroup *string `json:"apiGroup,omitempty"`
-	// Kind is the type of resource being referenced
+	// kind is the type of resource being referenced
 	Kind *string `json:"kind,omitempty"`
-	// Name is the name of resource being referenced
+	// name is the name of resource being referenced
 	Name *string `json:"name,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/subject.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/subject.go
@@ -24,16 +24,16 @@ package v1beta1
 // Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
 // or a value for non-objects such as user and group names.
 type SubjectApplyConfiguration struct {
-	// Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+	// kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
 	// If the Authorizer does not recognized the kind value, the Authorizer should report an error.
 	Kind *string `json:"kind,omitempty"`
-	// APIGroup holds the API group of the referenced subject.
+	// apiGroup holds the API group of the referenced subject.
 	// Defaults to "" for ServiceAccount subjects.
 	// Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
 	APIGroup *string `json:"apiGroup,omitempty"`
-	// Name of the object being referenced.
+	// name of the object being referenced.
 	Name *string `json:"name,omitempty"`
-	// Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+	// namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
 	// the Authorizer should report an error.
 	Namespace *string `json:"namespace,omitempty"`
 }


### PR DESCRIPTION
Enables the `commentstart` kube-api-linter (KAL) rule for the `rbac` API group by removing it from the rule's exclusion list in `hack/kube-api-linter/exceptions.yaml` and updating the field godoc comments in `rbac/v1`, `rbac/v1alpha1`, and `rbac/v1beta1` to start with the serialized (JSON) field name, as the rule requires.

Part of the wider effort (#134671) to enable KAL rules on the built-in API groups one group at a time. Follows the same pattern as the previously merged group enablements.

**What:**
- Drop `rbac` from the `commentstart` exclusion regex.
- Update the godoc comments on `PolicyRule`, `Subject`, `RoleRef`, `Role`, `RoleBinding`, `ClusterRole`, `AggregationRule`, and `ClusterRoleBinding` fields across all three served versions to begin with their JSON field name (embedded `ObjectMeta` comments begin with "metadata").
- Regenerate the affected files (protobuf, swagger docs, client-go applyconfigurations, OpenAPI v2/v3, golangci config) — kept in a separate commit.

These are comment-only changes; no API types or behavior are affected.

**Verification:**
- `hack/verify-golangci-lint.sh ./staging/src/k8s.io/api/rbac/...` → 0 issues.
- `hack/verify-codegen.sh` → passes.
- `hack/verify-openapi-spec.sh` → passes.

/kind cleanup
/area code-generation
/sig auth

```release-note
NONE
```
