### PR TITLE
deflake subPath stale bind-mount remount e2e

### DIFF
--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -1124,7 +1124,30 @@ func testSubpathStaleBindMountRemount(ctx context.Context, f *framework.Framewor
 			`crictl stop "$cid" && echo "stopped $cid"`,
 		pod.UID, containerName,
 	)
-	stopResult, stopErr := hostExec.IssueCommandWithResult(ctx, stopCmd, podNode)
+	// crictl stop occasionally fails at the containerd gRPC client with
+	// RST_STREAM / DEADLINE_EXCEEDED. crictl stop is idempotent, so retry.
+	// If kubelet already restarted the container (RestartCount >= 1), the stop
+	// took effect even though our RPC reply was lost — treat as success and
+	// stop retrying instead of looping until timeout.
+	var stopResult string
+	stopErr := wait.PollUntilContextTimeout(ctx, 5*time.Second, 60*time.Second, true,
+		func(ctx context.Context) (bool, error) {
+			out, err := hostExec.IssueCommandWithResult(ctx, stopCmd, podNode)
+			stopResult = out
+			if err == nil {
+				return true, nil
+			}
+			if p, getErr := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{}); getErr == nil {
+				for _, cs := range p.Status.ContainerStatuses {
+					if cs.Name == containerName && cs.RestartCount >= 1 {
+						framework.Logf("crictl stop returned %v, but container already restarted (count=%d); treating as success", err, cs.RestartCount)
+						return true, nil
+					}
+				}
+			}
+			framework.Logf("crictl stop failed (will retry): %v — %s", err, out)
+			return false, nil
+		})
 	framework.ExpectNoError(stopErr, "stopping container via crictl for pod %s: %s", pod.UID, stopResult)
 	framework.Logf("crictl stop result: %s", stopResult)
 

--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -1144,6 +1144,8 @@ func testSubpathStaleBindMountRemount(ctx context.Context, f *framework.Framewor
 						return true, nil
 					}
 				}
+			} else {
+				framework.Logf("crictl stop failed (will retry): %v — failed to get pod: %v", err, getErr)
 			}
 			framework.Logf("crictl stop failed (will retry): %v — %s", err, out)
 			return false, nil

--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -1141,6 +1141,7 @@ func testSubpathStaleBindMountRemount(ctx context.Context, f *framework.Framewor
 				for _, cs := range p.Status.ContainerStatuses {
 					if cs.Name == containerName && cs.RestartCount >= 1 {
 						framework.Logf("crictl stop returned %v, but container already restarted (count=%d); treating as success", err, cs.RestartCount)
+						stopResult = "container already restarted"
 						return true, nil
 					}
 				}


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
Retries the crictl stop call in the subPath stale bind-mount remount e2e
test to handle transient containerd gRPC client failures (RST_STREAM /
DeadlineExceeded). crictl stop is idempotent; a bounded retry with a guard
that detects whether kubelet already restarted the container prevents the
test from failing on a lost RPC reply.

#### Which issue(s) this PR is related to:
Ref: #140008

#### Special notes for your reviewer:
This PR was written in part with the assistance of generative AI.

The flake rate is ~9/196,994 (0.005%) and cannot be reproduced locally.
After merge, the linked issue should remain open for one informing-cycle
window to confirm the flake count drops against the baseline.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
```