### PR TITLE
cleanup: hidden metrics for pod log

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -3404,30 +3404,6 @@
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
-- name: pods_logs_backend_tls_failure_total
-  subsystem: pod_logs
-  namespace: kube_apiserver
-  help: Total number of requests for pods/logs that failed due to kubelet server TLS
-    verification
-  type: Counter
-  deprecatedVersion: 1.27.0
-  stabilityLevel: ALPHA
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: pods_logs_insecure_backend_total
-  subsystem: pod_logs
-  namespace: kube_apiserver
-  help: 'Total number of requests for pods/logs sliced by usage type: enforce_tls,
-    skip_tls_allowed, skip_tls_denied'
-  type: Counter
-  deprecatedVersion: 1.27.0
-  stabilityLevel: ALPHA
-  labels:
-  - usage
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
 - name: active_pods
   subsystem: kubelet
   help: The number of pods the kubelet considers active and which are being considered

--- a/pkg/registry/core/pod/rest/log.go
+++ b/pkg/registry/core/pod/rest/log.go
@@ -104,14 +104,13 @@ func (r *LogREST) Get(ctx context.Context, name string, opts runtime.Object) (ru
 		return nil, err
 	}
 	return &genericrest.LocationStreamer{
-		Location:                              location,
-		Transport:                             transport,
-		ContentType:                           "text/plain",
-		Flush:                                 logOpts.Follow,
-		ResponseChecker:                       genericrest.NewGenericHttpResponseChecker(api.Resource("pods/log"), name),
-		RedirectChecker:                       genericrest.PreventRedirects,
-		TLSVerificationErrorCounter:           podLogsTLSFailure,
-		DeprecatedTLSVerificationErrorCounter: deprecatedPodLogsTLSFailure,
+		Location:                    location,
+		Transport:                   transport,
+		ContentType:                 "text/plain",
+		Flush:                       logOpts.Follow,
+		ResponseChecker:             genericrest.NewGenericHttpResponseChecker(api.Resource("pods/log"), name),
+		RedirectChecker:             genericrest.PreventRedirects,
+		TLSVerificationErrorCounter: podLogsTLSFailure,
 	}, nil
 }
 
@@ -127,8 +126,6 @@ func countSkipTLSMetric(insecureSkipTLSVerifyBackend bool) {
 		return
 	}
 	counter.Inc()
-
-	deprecatedPodLogsUsage.WithLabelValues(usageType).Inc()
 }
 
 // NewGetOptions creates a new options object

--- a/pkg/registry/core/pod/rest/metrics.go
+++ b/pkg/registry/core/pod/rest/metrics.go
@@ -44,19 +44,6 @@ var (
 		[]string{"usage"},
 	)
 
-	// deprecatedPodLogsUsage counts and categorizes how the insecure backend skip TLS option is used and allowed.
-	deprecatedPodLogsUsage = metrics.NewCounterVec(
-		&metrics.CounterOpts{
-			Namespace:         namespace,
-			Subsystem:         subsystem,
-			Name:              "pods_logs_insecure_backend_total",
-			Help:              "Total number of requests for pods/logs sliced by usage type: enforce_tls, skip_tls_allowed, skip_tls_denied",
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.27.0",
-		},
-		[]string{"usage"},
-	)
-
 	// podLogsTLSFailure counts how many attempts to get pod logs fail on tls verification
 	podLogsTLSFailure = metrics.NewCounter(
 		&metrics.CounterOpts{
@@ -67,18 +54,6 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
-
-	// deprecatedPodLogsTLSFailure counts how many attempts to get pod logs fail on tls verification
-	deprecatedPodLogsTLSFailure = metrics.NewCounter(
-		&metrics.CounterOpts{
-			Namespace:         namespace,
-			Subsystem:         subsystem,
-			Name:              "pods_logs_backend_tls_failure_total",
-			Help:              "Total number of requests for pods/logs that failed due to kubelet server TLS verification",
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.27.0",
-		},
-	)
 )
 
 var registerMetricsOnce sync.Once
@@ -87,7 +62,5 @@ func registerMetrics() {
 	registerMetricsOnce.Do(func() {
 		legacyregistry.MustRegister(podLogsUsage)
 		legacyregistry.MustRegister(podLogsTLSFailure)
-		legacyregistry.MustRegister(deprecatedPodLogsUsage)
-		legacyregistry.MustRegister(deprecatedPodLogsTLSFailure)
 	})
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/streamer.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/streamer.go
@@ -46,10 +46,6 @@ type LocationStreamer struct {
 	// TLSVerificationErrorCounter is an optional value that will Inc every time a TLS error is encountered.  This can
 	// be wired a single prometheus counter instance to get counts overall.
 	TLSVerificationErrorCounter CounterMetric
-	// DeprecatedTLSVerificationErrorCounter is a temporary field used to rename
-	// the kube_apiserver_pod_logs_pods_logs_backend_tls_failure_total metric
-	// with a one release deprecation period in 1.27.0.
-	DeprecatedTLSVerificationErrorCounter CounterMetric
 }
 
 // a LocationStreamer must implement a rest.ResourceStreamer
@@ -91,9 +87,6 @@ func (s *LocationStreamer) InputStream(ctx context.Context, apiVersion, acceptHe
 		// TODO prefer segregate TLS errors more reliably, but we do want to increment a count
 		if strings.Contains(err.Error(), "x509:") && s.TLSVerificationErrorCounter != nil {
 			s.TLSVerificationErrorCounter.Inc()
-			if s.DeprecatedTLSVerificationErrorCounter != nil {
-				s.DeprecatedTLSVerificationErrorCounter.Inc()
-			}
 		}
 		return nil, false, "", err
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Cleanup deprecated metrics.
This will have no impact for end-users as these metrics are hidden once deprecated.

#### Which issue(s) this PR is related to:

Split from #136720

#### Special notes for your reviewer:

Original PR needs rebase, already asked @dgrisonnet, and he's okay with me taking over.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
