### PR TITLE
Adding ClientNodeSelection Configuration to Second Pod In Expand Test

### DIFF
--- a/test/e2e/storage/testsuites/volume_expand.go
+++ b/test/e2e/storage/testsuites/volume_expand.go
@@ -400,14 +400,20 @@ func (v *volumeExpandTestSuite) DefineTests(driver storageframework.TestDriver, 
 			l.pod = nil
 
 			ginkgo.By("Creating a new pod with same volume on the same node")
+			// The reason we pin the pod to the same node is because we do not want the pod to move to a
+			// different node when it is deleted. Keeping the pod on the same node reproduces the scenario
+			// that the volume might already be mounted when resize is attempted.
+			// We should consider adding a unit test that exercises this better.
+			// We start from the driver's ClientNodeSelection (rather than a bare {Name: nodeName}) so that
+			// any selectors/affinity required to schedule the pod are preserved, e.g. the OS node selector
+			// on Windows. We then add affinity to keep the pod on the original node.
+			pod2NodeSelection := l.config.ClientNodeSelection
+			e2epod.SetAffinity(&pod2NodeSelection, nodeName)
 			podConfig = e2epod.Config{
-				NS:           f.Namespace.Name,
-				PVCs:         []*v1.PersistentVolumeClaim{l.resource.Pvc},
-				SeLinuxLabel: e2epod.GetLinuxLabel(),
-				// The reason we use this node selection is because we do not want pod to move to different node when pod is deleted.
-				// Keeping pod on same node reproduces the scenario that volume might already be mounted when resize is attempted.
-				// We should consider adding a unit test that exercises this better.
-				NodeSelection: e2epod.NodeSelection{Name: nodeName},
+				NS:            f.Namespace.Name,
+				PVCs:          []*v1.PersistentVolumeClaim{l.resource.Pvc},
+				SeLinuxLabel:  e2epod.GetLinuxLabel(),
+				NodeSelection: pod2NodeSelection,
 				ImageID:       e2epod.GetDefaultTestImageID(),
 			}
 			l.pod2, err = e2epod.CreateSecPodWithNodeSelection(ctx, f.ClientSet, &podConfig, f.Timeouts.PodStart)


### PR DESCRIPTION
/kind flake

#### What this PR does / why we need it:

The "should resize volume when PVC is edited and the pod is re-created on the same node after controller resize is finished" test deleted the original pod and re-created a second pod pinned to the same node using a bare NodeSelection{Name: nodeName}. This discarded the driver's ClientNodeSelection, dropping any selectors/affinity required to schedule the pod. As a result the re-created pod could be scheduled in a way that the Windows VPC CNI could not satisfy, failing with FailedCreatePodSandBox.

```
23483 dump.go:53] At 2026-06-25 19:03:32 +0000 UTC - event for pod-e74fb2b9-e917-4211-b23b-23c34e25be5d: {kubelet ip-192-168-11-56.us-west-2.compute.internal} FailedCreatePodSandBox: Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "81b7c284752e7fa52b045d4c3a6ba5abfb89317cd448bd2999f5b3335db83763": plugin type="vpc-bridge" name="vpc" failed (add): failed to parse Kubernetes args: failed to get pod IP address pod-e74fb2b9-e917-4211-b23b-23c34e25be5d: error executing k8s connector: error executing connector binary: exit status 1 with execution error: pod pod-e74fb2b9-e917-4211-b23b-23c34e25be5d does not have label vpc.amazonaws.com/PrivateIPv4Address
```

#### Which issue(s) this PR is related to:

https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/2724

#### How was this change tested?

Validated on a live EKS Windows cluster (Kubernetes 1.36.1, EBS CSI driver installed) by running the affected test before and after the change, with all other variables held constant (same cluster, same focus, same `-node-os-distro=windows`).

Test under validation:
```
External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (ntfs)(allowExpansion)] [Feature:Windows] volume-expand should resize volume when PVC is edited and the pod is re-created on the same node after controller resize is finished
```

1. Baseline (before the fix) — reproduces the failure. Running the released `e2e.test` (unpatched code) against the cluster:
```
1 Failed | 8007 Skipped
[FAIL] ... volume_expand.go:415
```
The re-created pod looped on `FailedCreatePodSandBox` with `pod ... does not have label vpc.amazonaws.com/PrivateIPv4Address`. The first pod received the `PrivateIPv4Address` (it carried `ClientNodeSelection`); the re-created pod never did, because the bare `NodeSelection{Name: nodeName}`
dropped the Windows OS node selector.

2. After the fix — passes. Built `e2e.test` and `ginkgo` from this branch and ran the same focused spec against the same cluster:
```
make WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/v2/ginkgo"

_output/bin/ginkgo \
  --focus='\[Feature:Windows\] volume-expand should resize volume when PVC is edited and the pod is re-created on the same node after controller resize is finished' \
  _output/bin/e2e.test \
  -- \
  -storage.testdriver=<repo>/tests/e2e-kubernetes/manifests.yaml \
  -kubeconfig=$KUBECONFIG \
  -node-os-distro=windows \
  -repo-root=<repo>/tests/e2e-kubernetes
```
Result:
```
Ran 1 of 8008 Specs in 129.436 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 8007 Skipped
```
The re-created pod was scheduled with the Windows node selector preserved, received its `PrivateIPv4Address`, the sandbox came up, and the filesystem resize completed.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
