### PR TITLE
Cleanup: hidden metrics for apiserver

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -1244,33 +1244,6 @@
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
-- name: request_concurrency_in_use
-  subsystem: flowcontrol
-  namespace: apiserver
-  help: Concurrency (number of seats) occupied by the currently executing (initial
-    stage for a WATCH, any stage otherwise) requests in the API Priority and Fairness
-    subsystem
-  type: Gauge
-  deprecatedVersion: 1.31.0
-  stabilityLevel: ALPHA
-  labels:
-  - flow_schema
-  - priority_level
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: request_concurrency_limit
-  subsystem: flowcontrol
-  namespace: apiserver
-  help: Nominal number of execution seats configured for each priority level
-  type: Gauge
-  deprecatedVersion: 1.30.0
-  stabilityLevel: ALPHA
-  labels:
-  - priority_level
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
 - name: request_dispatch_no_accommodation_total
   subsystem: flowcontrol
   namespace: apiserver
@@ -1779,47 +1752,6 @@
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
-- name: request_slo_duration_seconds
-  subsystem: apiserver
-  help: Response latency distribution (not counting webhook duration and priority
-    & fairness queue wait times) in seconds for each verb, group, version, resource,
-    subresource, scope and component.
-  type: Histogram
-  deprecatedVersion: 1.27.0
-  stabilityLevel: ALPHA
-  labels:
-  - component
-  - group
-  - resource
-  - scope
-  - subresource
-  - verb
-  - version
-  buckets:
-  - 0.05
-  - 0.1
-  - 0.2
-  - 0.4
-  - 0.6
-  - 0.8
-  - 1
-  - 1.25
-  - 1.5
-  - 2
-  - 3
-  - 4
-  - 5
-  - 6
-  - 8
-  - 10
-  - 15
-  - 20
-  - 30
-  - 45
-  - 60
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
 - name: request_terminations_total
   subsystem: apiserver
   help: Number of requests which apiserver terminated in self-defense.
@@ -1953,17 +1885,6 @@
   help: Total number of failed data encryption key(DEK) generation operations.
   type: Counter
   stabilityLevel: ALPHA
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: storage_db_total_size_in_bytes
-  subsystem: apiserver
-  help: Total size of the storage database file physically allocated in bytes.
-  type: Gauge
-  deprecatedVersion: 1.28.0
-  stabilityLevel: ALPHA
-  labels:
-  - endpoint
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -96,16 +96,6 @@ var (
 		},
 		[]string{"group", "resource"},
 	)
-	dbTotalSize = compbasemetrics.NewGaugeVec(
-		&compbasemetrics.GaugeOpts{
-			Subsystem:         "apiserver",
-			Name:              "storage_db_total_size_in_bytes",
-			Help:              "Total size of the storage database file physically allocated in bytes.",
-			StabilityLevel:    compbasemetrics.ALPHA,
-			DeprecatedVersion: "1.28.0",
-		},
-		[]string{"endpoint"},
-	)
 	storageSizeDescription   = compbasemetrics.NewDesc("apiserver_storage_size_bytes", "Size of the storage database file physically allocated in bytes.", []string{"storage_cluster_id"}, nil, compbasemetrics.STABLE, "")
 	storageMonitor           = &monitorCollector{monitorGetter: func() ([]Monitor, error) { return nil, nil }}
 	etcdEventsReceivedCounts = compbasemetrics.NewCounterVec(
@@ -166,7 +156,6 @@ func Register() {
 		legacyregistry.MustRegister(objectCounts)
 		legacyregistry.MustRegister(resourceSizeEstimate)
 		legacyregistry.MustRegister(newObjectCounts)
-		legacyregistry.MustRegister(dbTotalSize)
 		legacyregistry.CustomMustRegister(storageMonitor)
 		legacyregistry.MustRegister(etcdEventsReceivedCounts)
 		legacyregistry.MustRegister(etcdBookmarkCounts)
@@ -242,12 +231,6 @@ func Reset() {
 // This is a variable to facilitate testing.
 var sinceInSeconds = func(start time.Time) float64 {
 	return time.Since(start).Seconds()
-}
-
-// UpdateEtcdDbSize sets the etcd_db_total_size_in_bytes metric.
-// Deprecated: Metric etcd_db_total_size_in_bytes will be replaced with apiserver_storage_size_bytes
-func UpdateEtcdDbSize(ep string, size int64) {
-	dbTotalSize.WithLabelValues(ep).Set(float64(size))
 }
 
 // SetStorageMonitorGetter sets monitor getter to allow monitoring etcd stats.

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -41,8 +41,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 
-	"k8s.io/klog/v2"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -69,8 +67,6 @@ const (
 	// It is set to 20 seconds as times shorter than that will cause TLS connections to fail
 	// on heavily loaded arm64 CPUs (issue #64649)
 	dialTimeout = 20 * time.Second
-
-	dbMetricsMonitorJitter = 0.5
 )
 
 // TODO(negz): Stop using a package scoped logger. At the time of writing we're
@@ -90,7 +86,6 @@ func init() {
 	// metrics to our global registry here.
 	// For reference: https://github.com/kubernetes/kubernetes/pull/81387
 	legacyregistry.RawMustRegister(grpcpromClientMetrics)
-	dbMetricsMonitors = make(map[string]struct{})
 
 	l, err := logutil.CreateDefaultZapLogger(etcdClientDebugLevel())
 	if err != nil {
@@ -404,9 +399,6 @@ var (
 	// compactorsMu guards access to compactors map
 	compactorsMu sync.Mutex
 	compactors   = map[string]*runningCompactor{}
-	// dbMetricsMonitorsMu guards access to dbMetricsMonitors map
-	dbMetricsMonitorsMu sync.Mutex
-	dbMetricsMonitors   map[string]struct{}
 )
 
 // startCompactorOnce start one compactor per transport. If the interval get smaller on repeated calls, the
@@ -475,13 +467,6 @@ func newETCD3Storage(c storagebackend.ConfigForResource, newFunc, newListFunc fu
 	// decorate the KV instance so we can track etcd latency per request.
 	client.KV = etcd3.NewETCDLatencyTracker(client.KV)
 
-	stopDBSizeMonitor, err := startDBSizeMonitorPerEndpoint(client.Client, c.DBMetricPollInterval)
-	if err != nil {
-		stopCompactor()
-		_ = client.Close()
-		return nil, nil, err
-	}
-
 	transformer := c.Transformer
 	if transformer == nil {
 		transformer = identity.NewEncryptCheckTransformer()
@@ -497,7 +482,6 @@ func newETCD3Storage(c storagebackend.ConfigForResource, newFunc, newListFunc fu
 	store, err := etcd3.New(client, compactor, c.Codec, newFunc, newListFunc, c.Prefix, resourcePrefix, c.GroupResource, transformer, c.LeaseManagerConfig, decoder, versioner)
 	if err != nil {
 		stopCompactor()
-		stopDBSizeMonitor()
 		_ = client.Close()
 		return nil, nil, err
 	}
@@ -508,7 +492,6 @@ func newETCD3Storage(c storagebackend.ConfigForResource, newFunc, newListFunc fu
 		// TODO: fix duplicated storage destroy calls higher level
 		once.Do(func() {
 			stopCompactor()
-			stopDBSizeMonitor()
 			store.Close()
 			_ = client.Close()
 		})
@@ -518,38 +501,4 @@ func newETCD3Storage(c storagebackend.ConfigForResource, newFunc, newListFunc fu
 		storage = etcd3.NewStoreWithUnsafeCorruptObjectDeletion(storage, c.GroupResource)
 	}
 	return storage, destroyFunc, nil
-}
-
-// startDBSizeMonitorPerEndpoint starts a loop to monitor etcd database size and update the
-// corresponding metric etcd_db_total_size_in_bytes for each etcd server endpoint.
-// Deprecated: Will be replaced with newETCD3ProberMonitor
-func startDBSizeMonitorPerEndpoint(client *clientv3.Client, interval time.Duration) (func(), error) {
-	if interval == 0 {
-		return func() {}, nil
-	}
-	dbMetricsMonitorsMu.Lock()
-	defer dbMetricsMonitorsMu.Unlock()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	for _, ep := range client.Endpoints() {
-		if _, found := dbMetricsMonitors[ep]; found {
-			continue
-		}
-		dbMetricsMonitors[ep] = struct{}{}
-		endpoint := ep
-		klog.V(4).Infof("Start monitoring storage db size metric for endpoint %s with polling interval %v", endpoint, interval)
-		go wait.JitterUntilWithContext(ctx, func(context.Context) {
-			epStatus, err := client.Maintenance.Status(ctx, endpoint)
-			if err != nil {
-				klog.V(4).Infof("Failed to get storage db size for ep %s: %v", endpoint, err)
-				metrics.UpdateEtcdDbSize(endpoint, -1)
-			} else {
-				metrics.UpdateEtcdDbSize(endpoint, epStatus.DbSize)
-			}
-		}, interval, dbMetricsMonitorJitter, true)
-	}
-
-	return func() {
-		cancel()
-	}, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
@@ -455,18 +455,6 @@ func (uss *uniformScenarioState) finalReview() {
 			uss.t.Log("Success with" + e)
 		}
 	}
-	if uss.evalExecutingMetrics && len(uss.expectedConcurrencyInUse) > 0 {
-		e := `
-				# HELP apiserver_flowcontrol_request_concurrency_in_use [ALPHA] Concurrency (number of seats) occupied by the currently executing (initial stage for a WATCH, any stage otherwise) requests in the API Priority and Fairness subsystem
-				# TYPE apiserver_flowcontrol_request_concurrency_in_use gauge
-` + uss.expectedConcurrencyInUse
-		err := metrics.GatherAndCompare(e, "apiserver_flowcontrol_request_concurrency_in_use")
-		if err != nil {
-			uss.t.Error(err)
-		} else {
-			uss.t.Log("Success with" + e)
-		}
-	}
 	if uss.evalExecutingMetrics && len(expectedRejects) > 0 {
 		e := `
 				# HELP apiserver_flowcontrol_rejected_requests_total [BETA] Number of requests rejected by API Priority and Fairness subsystem

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/metrics.go
@@ -231,18 +231,6 @@ var (
 		},
 		[]string{priorityLevel, flowSchema},
 	)
-	apiserverRequestConcurrencyLimit = compbasemetrics.NewGaugeVec(
-		&compbasemetrics.GaugeOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "request_concurrency_limit",
-			Help:      "Nominal number of execution seats configured for each priority level",
-			// Remove this metric once all suppported releases have the equal nominal_limit_seats metric
-			DeprecatedVersion: "1.30.0",
-			StabilityLevel:    compbasemetrics.ALPHA,
-		},
-		[]string{priorityLevel},
-	)
 	apiserverCurrentExecutingRequests = compbasemetrics.NewGaugeVec(
 		&compbasemetrics.GaugeOpts{
 			Namespace:      namespace,
@@ -260,18 +248,6 @@ var (
 			Name:           "current_executing_seats",
 			Help:           "Concurrency (number of seats) occupied by the currently executing (initial stage for a WATCH, any stage otherwise) requests in the API Priority and Fairness subsystem",
 			StabilityLevel: compbasemetrics.BETA,
-		},
-		[]string{priorityLevel, flowSchema},
-	)
-	apiserverRequestConcurrencyInUse = compbasemetrics.NewGaugeVec(
-		&compbasemetrics.GaugeOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "request_concurrency_in_use",
-			Help:      "Concurrency (number of seats) occupied by the currently executing (initial stage for a WATCH, any stage otherwise) requests in the API Priority and Fairness subsystem",
-			// Remove this metric once all suppported releases have the equal current_executing_seats metric
-			DeprecatedVersion: "1.31.0",
-			StabilityLevel:    compbasemetrics.ALPHA,
 		},
 		[]string{priorityLevel, flowSchema},
 	)
@@ -467,8 +443,6 @@ var (
 		apiserverCurrentInqueueRequests,
 		apiserverCurrentInqueueSeats,
 		apiserverRequestQueueLength,
-		apiserverRequestConcurrencyLimit,
-		apiserverRequestConcurrencyInUse,
 		apiserverCurrentExecutingSeats,
 		apiserverCurrentExecutingRequests,
 		apiserverRequestWaitingSeconds,
@@ -558,7 +532,6 @@ func SetDispatchMetrics(priorityLevel string, r, s, sMin, sMax, discountedSMin, 
 // the currently executing requests of the given flowSchema and priorityLevel
 func AddSeatConcurrencyInUse(priorityLevel, flowSchema string, delta int) {
 	apiserverCurrentExecutingSeats.WithLabelValues(priorityLevel, flowSchema).Add(float64(delta))
-	apiserverRequestConcurrencyInUse.WithLabelValues(priorityLevel, flowSchema).Add(float64(delta))
 }
 
 // AddReject increments the # of rejected requests for flow control
@@ -612,7 +585,6 @@ func AddDispatchWithNoAccommodation(priorityLevel, flowSchema string) {
 }
 
 func SetPriorityLevelConfiguration(priorityLevel string, nominalCL, minCL, maxCL int) {
-	apiserverRequestConcurrencyLimit.WithLabelValues(priorityLevel).Set(float64(nominalCL))
 	apiserverNominalConcurrencyLimits.WithLabelValues(priorityLevel).Set(float64(nominalCL))
 	apiserverMinimumConcurrencyLimits.WithLabelValues(priorityLevel).Set(float64(minCL))
 	apiserverMaximumConcurrencyLimits.WithLabelValues(priorityLevel).Set(float64(maxCL))


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Cleanup deprecated metrics.
This will have no impact for end-users as these metrics are hidden once deprecated.

#### Which issue(s) this PR is related to:

Split from #136720

#### Special notes for your reviewer:

Original PR needs rebase, already asked @dgrisonnet, and he's okay with me taking over.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
