### PR TITLE
fix: overestimation of the pod's resource footprint for multi-container pods undergoing a resize

### DIFF
--- a/pkg/kubelet/cm/helpers_linux.go
+++ b/pkg/kubelet/cm/helpers_linux.go
@@ -31,6 +31,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	resourcehelper "k8s.io/component-helpers/resource"
 	"k8s.io/klog/v2"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
@@ -139,15 +140,16 @@ func ResourceConfigForPod(allocatedPod *v1.Pod, enforceCPULimits bool, cpuPeriod
 	limits := resourcehelper.PodLimits(allocatedPod, resourcehelper.PodResourcesOptions{
 		// SkipPodLevelResources is set to false when PodLevelResources feature is enabled.
 		SkipPodLevelResources: !podLevelResourcesEnabled,
-		ContainerFn: func(res v1.ResourceList, containerType resourcehelper.ContainerType) {
-			if res.Cpu().IsZero() {
-				cpuLimitsDeclared = false
-			}
-			if res.Memory().IsZero() {
-				memoryLimitsDeclared = false
-			}
-		},
 	})
+
+	for c := range podutil.ContainerIter(&allocatedPod.Spec, podutil.InitContainers|podutil.Containers) {
+		if c.Resources.Limits.Cpu().IsZero() {
+			cpuLimitsDeclared = false
+		}
+		if c.Resources.Limits.Memory().IsZero() {
+			memoryLimitsDeclared = false
+		}
+	}
 
 	if podLevelResourcesEnabled && resourcehelper.IsPodLevelResourcesSet(allocatedPod) {
 		if !allocatedPod.Spec.Resources.Limits.Cpu().IsZero() {

--- a/staging/src/k8s.io/component-helpers/resource/helpers.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers.go
@@ -49,8 +49,6 @@ type PodResourcesOptions struct {
 	InPlacePodLevelResourcesVerticalScalingEnabled bool
 	// ExcludeOverhead controls if pod overhead is excluded from the calculation.
 	ExcludeOverhead bool
-	// ContainerFn is called with the effective resources required for each container within the pod.
-	ContainerFn func(res v1.ResourceList, containerType ContainerType)
 	// NonMissingContainerRequests if provided will replace any missing container level requests for the specified resources
 	// with the given values.  If the requests for those resources are explicitly set, even if zero, they will not be modified.
 	NonMissingContainerRequests v1.ResourceList
@@ -155,27 +153,12 @@ func PodRequests(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 	}
 
 	if !opts.SkipPodLevelResources && IsPodLevelRequestsSet(pod) {
-
-		var effectiveReqs v1.ResourceList
-		if opts.InPlacePodLevelResourcesVerticalScalingEnabled && opts.UseStatusResources {
-			if pod.Status.Resources != nil {
-				effectiveReqs = determineEffectiveRequests(pod, &ResourceState{
-					Spec:      pod.Spec.Resources.Requests,
-					Actuated:  pod.Status.Resources.Requests,
-					Allocated: pod.Status.AllocatedResources,
-				})
-			}
+		effectiveReqs := pod.Spec.Resources.Requests
+		if opts.InPlacePodLevelResourcesVerticalScalingEnabled && opts.UseStatusResources && pod.Status.Resources != nil {
+			effectiveReqs = effectivePodLevelResources(pod, pod.Spec.Resources.Requests, pod.Status.Resources.Requests, pod.Status.AllocatedResources)
 		}
 
-		for resourceName, quantity := range pod.Spec.Resources.Requests {
-			if IsSupportedPodLevelResource(resourceName) {
-				reqs[resourceName] = quantity
-				if effectiveReqs != nil {
-					reqs[resourceName] = effectiveReqs[resourceName]
-				}
-
-			}
-		}
+		applyPodLevelResources(reqs, effectiveReqs)
 	}
 
 	// Add overhead for running a pod to the sum of requests if requested:
@@ -186,50 +169,86 @@ func PodRequests(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 	return reqs
 }
 
-// AggregateContainerRequests computes the total resource requests of all the containers
-// in a pod. This computation folows the formula defined in the KEP for sidecar
-// containers. See https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/753-sidecar-containers#resources-calculation-for-scheduling-and-pod-admission
-// for more details.
-func AggregateContainerRequests(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
-	// attempt to reuse the maps if passed, or allocate otherwise
-	reqs := reuseOrClearResourceList(opts.Reuse)
-	var containerStatuses map[string]*v1.ContainerStatus
+func applyPodLevelResources(result, effectiveResources v1.ResourceList) {
+	for resourceName, quantity := range effectiveResources {
+		if IsSupportedPodLevelResource(resourceName) {
+			result[resourceName] = quantity
+		}
+	}
+}
+
+func effectivePodLevelResources(pod *v1.Pod, spec v1.ResourceList, statuses ...v1.ResourceList) v1.ResourceList {
+	if IsPodResizeInfeasible(pod) {
+		spec = nil
+	}
+	return max(spec, statuses...)
+}
+
+func containerSpecRequests(container *v1.Container, _ *v1.ContainerStatus, _ bool) v1.ResourceList {
+	return container.Resources.Requests
+}
+
+func containerAllocatedRequests(container *v1.Container, containerStatus *v1.ContainerStatus, isResizeInfeasible bool) v1.ResourceList {
+	if containerStatus != nil && containerStatus.AllocatedResources != nil {
+		return containerStatus.AllocatedResources
+	}
+	if isResizeInfeasible {
+		return nil
+	}
+	return container.Resources.Requests
+}
+
+func containerActuatedRequests(container *v1.Container, containerStatus *v1.ContainerStatus, isResizeInfeasible bool) v1.ResourceList {
+	if containerStatus != nil && containerStatus.Resources != nil && containerStatus.Resources.Requests != nil {
+		return containerStatus.Resources.Requests
+	}
+	if containerStatus != nil && containerStatus.AllocatedResources != nil {
+		return containerStatus.AllocatedResources
+	}
+	if isResizeInfeasible {
+		return nil
+	}
+	return container.Resources.Requests
+}
+
+func findContainerStatus(pod *v1.Pod, name string) *v1.ContainerStatus {
+	for i := range pod.Status.ContainerStatuses {
+		if pod.Status.ContainerStatuses[i].Name == name {
+			return &pod.Status.ContainerStatuses[i]
+		}
+	}
+	for i := range pod.Status.InitContainerStatuses {
+		if pod.Status.InitContainerStatuses[i].Name == name {
+			return &pod.Status.InitContainerStatuses[i]
+		}
+	}
+	return nil
+}
+
+func isRestartableInitContainer(container *v1.Container) bool {
+	return container.RestartPolicy != nil && *container.RestartPolicy == v1.ContainerRestartPolicyAlways
+}
+
+func aggregateContainerResourcesByFn(pod *v1.Pod, opts PodResourcesOptions, getResourceList func(container *v1.Container, containerStatus *v1.ContainerStatus, isResizeInfeasible bool) v1.ResourceList) v1.ResourceList {
+	var isResizeInfeasible bool
 	if opts.UseStatusResources {
-		containerStatuses = make(map[string]*v1.ContainerStatus, len(pod.Status.ContainerStatuses)+len(pod.Status.InitContainerStatuses))
-		for i := range pod.Status.ContainerStatuses {
-			containerStatuses[pod.Status.ContainerStatuses[i].Name] = &pod.Status.ContainerStatuses[i]
-		}
-		for i := range pod.Status.InitContainerStatuses {
-			containerStatuses[pod.Status.InitContainerStatuses[i].Name] = &pod.Status.InitContainerStatuses[i]
-		}
+		isResizeInfeasible = IsPodResizeInfeasible(pod)
 	}
-
+	result := v1.ResourceList{}
 	for _, container := range pod.Spec.Containers {
-		containerReqs := container.Resources.Requests
+		var cs *v1.ContainerStatus
 		if opts.UseStatusResources {
-			cs, found := containerStatuses[container.Name]
-			if found && cs.Resources != nil {
-				containerReqs = determineEffectiveRequests(pod, &ResourceState{
-					Spec:      container.Resources.Requests,
-					Actuated:  cs.Resources.Requests,
-					Allocated: cs.AllocatedResources,
-				})
-			}
+			cs = findContainerStatus(pod, container.Name)
 		}
-
+		containerResources := getResourceList(&container, cs, isResizeInfeasible)
 		if len(opts.NonMissingContainerRequests) > 0 {
-			containerReqs = applyNonMissing(containerReqs, opts.NonMissingContainerRequests)
+			containerResources = applyNonMissing(containerResources, opts.NonMissingContainerRequests)
 		}
-
-		if opts.ContainerFn != nil {
-			opts.ContainerFn(containerReqs, Containers)
-		}
-
-		addResourceList(reqs, containerReqs)
+		addResourceList(result, containerResources)
 	}
 
-	restartableInitContainerReqs := v1.ResourceList{}
-	initContainerReqs := v1.ResourceList{}
+	restartableInitContainerResources := v1.ResourceList{}
+	initContainerResources := v1.ResourceList{}
 	// init containers define the minimum of any resource
 	//
 	// Let's say `InitContainerUse(i)` is the resource requirements when the i-th
@@ -238,45 +257,66 @@ func AggregateContainerRequests(pod *v1.Pod, opts PodResourcesOptions) v1.Resour
 	//
 	// See https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/753-sidecar-containers#exposing-pod-resource-requirements for the detail.
 	for _, container := range pod.Spec.InitContainers {
-		containerReqs := container.Resources.Requests
+		var cs *v1.ContainerStatus
 		if opts.UseStatusResources {
-			if container.RestartPolicy != nil && *container.RestartPolicy == v1.ContainerRestartPolicyAlways {
-				cs, found := containerStatuses[container.Name]
-				if found && cs.Resources != nil {
-					containerReqs = determineEffectiveRequests(pod, &ResourceState{
-						Spec:      container.Resources.Requests,
-						Actuated:  cs.Resources.Requests,
-						Allocated: cs.AllocatedResources,
-					})
-				}
-			}
+			cs = findContainerStatus(pod, container.Name)
 		}
-
+		containerResources := getResourceList(&container, cs, isResizeInfeasible)
 		if len(opts.NonMissingContainerRequests) > 0 {
-			containerReqs = applyNonMissing(containerReqs, opts.NonMissingContainerRequests)
+			containerResources = applyNonMissing(containerResources, opts.NonMissingContainerRequests)
 		}
-
-		if container.RestartPolicy != nil && *container.RestartPolicy == v1.ContainerRestartPolicyAlways {
+		// Is the init container marked as a restartable init container?
+		if isRestartableInitContainer(&container) {
 			// and add them to the resulting cumulative container requests
-			addResourceList(reqs, containerReqs)
+			addResourceList(result, containerResources)
 
 			// track our cumulative restartable init container resources
-			addResourceList(restartableInitContainerReqs, containerReqs)
-			containerReqs = restartableInitContainerReqs
+			addResourceList(restartableInitContainerResources, containerResources)
+			containerResources = restartableInitContainerResources
 		} else {
-			tmp := v1.ResourceList{}
-			addResourceList(tmp, containerReqs)
-			addResourceList(tmp, restartableInitContainerReqs)
-			containerReqs = tmp
+			combinedResources := v1.ResourceList{}
+			addResourceList(combinedResources, containerResources)
+			addResourceList(combinedResources, restartableInitContainerResources)
+			containerResources = combinedResources
 		}
-
-		if opts.ContainerFn != nil {
-			opts.ContainerFn(containerReqs, InitContainers)
-		}
-		maxResourceList(initContainerReqs, containerReqs)
+		maxResourceList(initContainerResources, containerResources)
 	}
+	maxResourceList(result, initContainerResources)
+	return result
+}
 
-	maxResourceList(reqs, initContainerReqs)
+// AggregateContainerRequests computes the total resource requests of all the containers
+// in a pod. This computation folows the formula defined in the KEP for sidecar
+// containers. See https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/753-sidecar-containers#resources-calculation-for-scheduling-and-pod-admission
+// for more details.
+func AggregateContainerRequests(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
+	// attempt to reuse the maps if passed, or allocate otherwise
+	reqs := reuseOrClearResourceList(opts.Reuse)
+	if !opts.UseStatusResources {
+		addResourceList(reqs, aggregateContainerResourcesByFn(pod, opts, containerSpecRequests))
+	} else {
+		isResizeInfeasible := IsPodResizeInfeasible(pod)
+		var specReqs, allocatedReqs, actuatedReqs v1.ResourceList
+		// When pod-level status maps are populated, they already contain the aggregate values across all containers.
+		// When unpopulated (e.g., at creation time or when feature gates are disabled), we fall back to container status aggregation.
+		// Once InPlacePodLevelResourcesVerticalScaling and InPlacePodVerticalScaling are GA and feature gates are removed,
+		// container-level fallback becomes redundant because max(spec, actuated, allocated) naturally evaluates to spec at creation time.
+		if opts.InPlacePodLevelResourcesVerticalScalingEnabled && pod.Status.AllocatedResources != nil && pod.Status.Resources != nil && pod.Status.Resources.Requests != nil {
+			specReqs = aggregateContainerResourcesByFn(pod, opts, containerSpecRequests)
+			allocatedReqs = pod.Status.AllocatedResources
+			actuatedReqs = pod.Status.Resources.Requests
+		} else {
+			specReqs = aggregateContainerResourcesByFn(pod, opts, containerSpecRequests)
+			allocatedReqs = aggregateContainerResourcesByFn(pod, opts, containerAllocatedRequests)
+			actuatedReqs = aggregateContainerResourcesByFn(pod, opts, containerActuatedRequests)
+		}
+
+		if isResizeInfeasible {
+			addResourceList(reqs, max(actuatedReqs, allocatedReqs))
+		} else {
+			addResourceList(reqs, max(specReqs, actuatedReqs, allocatedReqs))
+		}
+	}
 
 	// Add resources from node allocatable ResourceClaims
 	if opts.UseDRANodeAllocatableResourceClaimStatus && len(pod.Status.NodeAllocatableResourceClaimStatuses) > 0 {
@@ -288,26 +328,6 @@ func AggregateContainerRequests(pod *v1.Pod, opts PodResourcesOptions) v1.Resour
 	}
 
 	return reqs
-}
-
-type ResourceState struct {
-	Spec      v1.ResourceList
-	Actuated  v1.ResourceList
-	Allocated v1.ResourceList
-}
-
-func determineEffectiveRequests(pod *v1.Pod, rs *ResourceState) v1.ResourceList {
-	if IsPodResizeInfeasible(pod) {
-		return max(rs.Actuated, rs.Allocated)
-	}
-	return max(rs.Spec, rs.Actuated, rs.Allocated)
-}
-
-func determineEffectiveLimits(pod *v1.Pod, rs *ResourceState) v1.ResourceList {
-	if IsPodResizeInfeasible(pod) {
-		return rs.Actuated.DeepCopy()
-	}
-	return max(rs.Spec, rs.Actuated)
 }
 
 // IsPodResizeInfeasible returns true if the pod condition PodResizePending is set to infeasible.
@@ -347,6 +367,20 @@ func applyNonMissing(reqs v1.ResourceList, nonMissing v1.ResourceList) v1.Resour
 	return cp
 }
 
+func containerSpecLimits(c *v1.Container, _ *v1.ContainerStatus, _ bool) v1.ResourceList {
+	return c.Resources.Limits
+}
+
+func containerActuatedLimits(c *v1.Container, cs *v1.ContainerStatus, isResizeInfeasible bool) v1.ResourceList {
+	if cs != nil && cs.Resources != nil && cs.Resources.Limits != nil {
+		return cs.Resources.Limits
+	}
+	if isResizeInfeasible {
+		return nil
+	}
+	return c.Resources.Limits
+}
+
 // PodLimits computes the pod limits per the PodResourcesOptions supplied. If PodResourcesOptions is nil, then
 // the limits are returned including pod overhead for any non-zero limits. The computation is part of the API and must be reviewed
 // as an API change.
@@ -354,24 +388,11 @@ func PodLimits(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 	// attempt to reuse the maps if passed, or allocate otherwise
 	limits := AggregateContainerLimits(pod, opts)
 	if !opts.SkipPodLevelResources && IsPodLevelResourcesSet(pod) {
-
-		var effectiveLims v1.ResourceList
-		if opts.InPlacePodLevelResourcesVerticalScalingEnabled && opts.UseStatusResources {
-			if pod.Status.Resources != nil {
-				effectiveLims = determineEffectiveLimits(pod, &ResourceState{
-					Spec:     pod.Spec.Resources.Limits,
-					Actuated: pod.Status.Resources.Limits,
-				})
-			}
+		effectiveLims := pod.Spec.Resources.Limits
+		if opts.InPlacePodLevelResourcesVerticalScalingEnabled && opts.UseStatusResources && pod.Status.Resources != nil {
+			effectiveLims = effectivePodLevelResources(pod, pod.Spec.Resources.Limits, pod.Status.Resources.Limits)
 		}
-		for resourceName, quantity := range pod.Spec.Resources.Limits {
-			if IsSupportedPodLevelResource(resourceName) {
-				limits[resourceName] = quantity
-				if effectiveLims != nil {
-					limits[resourceName] = effectiveLims[resourceName]
-				}
-			}
-		}
+		applyPodLevelResources(limits, effectiveLims)
 	}
 
 	// Add overhead to non-zero limits if requested:
@@ -392,81 +413,32 @@ func PodLimits(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 // containers. See https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/753-sidecar-containers#resources-calculation-for-scheduling-and-pod-admission
 // for more details.
 func AggregateContainerLimits(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
+	opts.NonMissingContainerRequests = nil
 	// attempt to reuse the maps if passed, or allocate otherwise
 	limits := reuseOrClearResourceList(opts.Reuse)
-	var containerStatuses map[string]*v1.ContainerStatus
-	if opts.UseStatusResources {
-		containerStatuses = make(map[string]*v1.ContainerStatus, len(pod.Status.ContainerStatuses)+len(pod.Status.InitContainerStatuses))
-		for i := range pod.Status.ContainerStatuses {
-			containerStatuses[pod.Status.ContainerStatuses[i].Name] = &pod.Status.ContainerStatuses[i]
-		}
-		for i := range pod.Status.InitContainerStatuses {
-			containerStatuses[pod.Status.InitContainerStatuses[i].Name] = &pod.Status.InitContainerStatuses[i]
-		}
-	}
-
-	for _, container := range pod.Spec.Containers {
-		containerLimits := container.Resources.Limits
-		if opts.UseStatusResources {
-			cs, found := containerStatuses[container.Name]
-			if found && cs.Resources != nil {
-				containerLimits = determineEffectiveLimits(pod, &ResourceState{
-					Spec:     containerLimits,
-					Actuated: cs.Resources.Limits,
-				})
-			}
-		}
-
-		if opts.ContainerFn != nil {
-			opts.ContainerFn(containerLimits, Containers)
-		}
-		addResourceList(limits, containerLimits)
-	}
-
-	restartableInitContainerLimits := v1.ResourceList{}
-	initContainerLimits := v1.ResourceList{}
-	// init containers define the minimum of any resource
-	//
-	// Let's say `InitContainerUse(i)` is the resource requirements when the i-th
-	// init container is initializing, then
-	// `InitContainerUse(i) = sum(Resources of restartable init containers with index < i) + Resources of i-th init container`.
-	//
-	// See https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/753-sidecar-containers#exposing-pod-resource-requirements for the detail.
-	for _, container := range pod.Spec.InitContainers {
-		containerLimits := container.Resources.Limits
-		if opts.UseStatusResources {
-			if container.RestartPolicy != nil && *container.RestartPolicy == v1.ContainerRestartPolicyAlways {
-				cs, found := containerStatuses[container.Name]
-				if found && cs.Resources != nil {
-					containerLimits = determineEffectiveLimits(pod, &ResourceState{
-						Spec:     containerLimits,
-						Actuated: cs.Resources.Limits,
-					})
-				}
-			}
-		}
-
-		// Is the init container marked as a restartable init container?
-		if container.RestartPolicy != nil && *container.RestartPolicy == v1.ContainerRestartPolicyAlways {
-			addResourceList(limits, containerLimits)
-
-			// track our cumulative restartable init container resources
-			addResourceList(restartableInitContainerLimits, containerLimits)
-			containerLimits = restartableInitContainerLimits
+	if !opts.UseStatusResources {
+		addResourceList(limits, aggregateContainerResourcesByFn(pod, opts, containerSpecLimits))
+	} else {
+		isResizeInfeasible := IsPodResizeInfeasible(pod)
+		var specLimits, actuatedLimits v1.ResourceList
+		// When pod-level status maps are populated, they already contain the aggregate values across all containers.
+		// When unpopulated (e.g., at creation time or when feature gates are disabled), we fall back to container status aggregation.
+		// Once InPlacePodLevelResourcesVerticalScaling and InPlacePodVerticalScaling are GA and feature gates are removed,
+		// container-level fallback becomes redundant because max(spec, actuated) naturally evaluates to spec at creation time.
+		if opts.InPlacePodLevelResourcesVerticalScalingEnabled && pod.Status.Resources != nil && pod.Status.Resources.Limits != nil {
+			specLimits = aggregateContainerResourcesByFn(pod, opts, containerSpecLimits)
+			actuatedLimits = pod.Status.Resources.Limits
 		} else {
-			tmp := v1.ResourceList{}
-			addResourceList(tmp, containerLimits)
-			addResourceList(tmp, restartableInitContainerLimits)
-			containerLimits = tmp
+			specLimits = aggregateContainerResourcesByFn(pod, opts, containerSpecLimits)
+			actuatedLimits = aggregateContainerResourcesByFn(pod, opts, containerActuatedLimits)
 		}
 
-		if opts.ContainerFn != nil {
-			opts.ContainerFn(containerLimits, InitContainers)
+		if isResizeInfeasible {
+			addResourceList(limits, actuatedLimits)
+		} else {
+			addResourceList(limits, max(specLimits, actuatedLimits))
 		}
-		maxResourceList(initContainerLimits, containerLimits)
 	}
-
-	maxResourceList(limits, initContainerLimits)
 	return limits
 }
 

--- a/staging/src/k8s.io/component-helpers/resource/helpers_test.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers_test.go
@@ -868,6 +868,45 @@ func TestPodResourceRequests(t *testing.T) {
 				},
 			},
 		},
+		{
+			description: "aggregate request resolves max of sums instead of sum of maxes",
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("3"),
+			},
+			options: PodResourcesOptions{UseStatusResources: true},
+			containers: []v1.Container{
+				{
+					Name: "c1",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU: resource.MustParse("1"),
+						},
+					},
+				},
+				{
+					Name: "c2",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU: resource.MustParse("2"),
+						},
+					},
+				},
+			},
+			containerStatus: []v1.ContainerStatus{
+				{
+					Name: "c1",
+					AllocatedResources: v1.ResourceList{
+						v1.ResourceCPU: resource.MustParse("2"),
+					},
+				},
+				{
+					Name: "c2",
+					AllocatedResources: v1.ResourceList{
+						v1.ResourceCPU: resource.MustParse("1"),
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
@@ -1467,6 +1506,41 @@ func TestPodResourceLimits(t *testing.T) {
 						Limits: v1.ResourceList{
 							v1.ResourceMemory: resource.MustParse("2Gi"),
 						},
+					},
+				},
+			},
+		},
+		{
+			description: "aggregate limit resolves max of sums instead of sum of maxes",
+			expectedLimits: v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("3"),
+			},
+			options: PodResourcesOptions{UseStatusResources: true},
+			containers: []v1.Container{
+				{
+					Name: "c1",
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
+					},
+				},
+				{
+					Name: "c2",
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
+					},
+				},
+			},
+			containerStatuses: []v1.ContainerStatus{
+				{
+					Name: "c1",
+					Resources: &v1.ResourceRequirements{
+						Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
+					},
+				},
+				{
+					Name: "c2",
+					Resources: &v1.ResourceRequirements{
+						Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
 					},
 				},
 			},
@@ -2417,6 +2491,8 @@ func TestAggregateContainerRequestsAndLimits(t *testing.T) {
 		containerStatuses     []v1.ContainerStatus
 		initContainers        []v1.Container
 		initContainerStatuses []v1.ContainerStatus
+		podAllocatedResources v1.ResourceList
+		podResources          *v1.ResourceRequirements
 		name                  string
 		expectedRequests      v1.ResourceList
 		expectedLimits        v1.ResourceList
@@ -2632,13 +2708,184 @@ func TestAggregateContainerRequestsAndLimits(t *testing.T) {
 			},
 			expectedLimits: v1.ResourceList{},
 		},
+		{
+			name:    "aggregate container request resolves max of sums instead of sum of maxes",
+			options: PodResourcesOptions{UseStatusResources: true},
+			containers: []v1.Container{
+				{
+					Name: "c1",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
+					},
+				},
+				{
+					Name: "c2",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
+					},
+				},
+			},
+			containerStatuses: []v1.ContainerStatus{
+				{
+					Name:               "c1",
+					AllocatedResources: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
+				},
+				{
+					Name:               "c2",
+					AllocatedResources: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
+				},
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("3"),
+			},
+			expectedLimits: v1.ResourceList{},
+		},
+		{
+			name:    "aggregate container limit resolves max of sums instead of sum of maxes",
+			options: PodResourcesOptions{UseStatusResources: true},
+			containers: []v1.Container{
+				{
+					Name: "c1",
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
+					},
+				},
+				{
+					Name: "c2",
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
+					},
+				},
+			},
+			containerStatuses: []v1.ContainerStatus{
+				{
+					Name: "c1",
+					Resources: &v1.ResourceRequirements{
+						Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
+					},
+				},
+				{
+					Name: "c2",
+					Resources: &v1.ResourceRequirements{
+						Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
+					},
+				},
+			},
+			expectedRequests: v1.ResourceList{},
+			expectedLimits: v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("3"),
+			},
+		},
+		{
+			name: "aggregate container request/limit resolves directly from pod status when PLR vertical scaling enabled",
+			options: PodResourcesOptions{
+				UseStatusResources: true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			containers: []v1.Container{
+				{
+					Name: "c1",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
+						Limits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
+					},
+				},
+			},
+			podAllocatedResources: v1.ResourceList{v1.ResourceCPU: resource.MustParse("4")},
+			podResources: &v1.ResourceRequirements{
+				Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("3")},
+				Limits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("5")},
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("4"),
+			},
+			expectedLimits: v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("5"),
+			},
+		},
+		{
+			name: "falls back to container status aggregation when PLR vertical scaling enabled but podAllocatedResources is nil",
+			options: PodResourcesOptions{
+				UseStatusResources: true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			containers: []v1.Container{
+				{
+					Name: "c1",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
+						Limits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
+					},
+				},
+			},
+			containerStatuses: []v1.ContainerStatus{
+				{
+					Name:               "c1",
+					AllocatedResources: v1.ResourceList{v1.ResourceCPU: resource.MustParse("6")},
+					Resources: &v1.ResourceRequirements{
+						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("5")},
+						Limits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("7")},
+					},
+				},
+			},
+			podAllocatedResources: nil,
+			podResources: &v1.ResourceRequirements{
+				Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("3")},
+				Limits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("7")},
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("6"),
+			},
+			expectedLimits: v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("7"),
+			},
+		},
+		{
+			name: "falls back to container status aggregation when PLR vertical scaling enabled but podResources is nil",
+			options: PodResourcesOptions{
+				UseStatusResources: true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			containers: []v1.Container{
+				{
+					Name: "c1",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
+						Limits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
+					},
+				},
+			},
+			containerStatuses: []v1.ContainerStatus{
+				{
+					Name:               "c1",
+					AllocatedResources: v1.ResourceList{v1.ResourceCPU: resource.MustParse("6")},
+					Resources: &v1.ResourceRequirements{
+						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("5")},
+						Limits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("8")},
+					},
+				},
+			},
+			podAllocatedResources: v1.ResourceList{v1.ResourceCPU: resource.MustParse("6")},
+			podResources:          nil,
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("6"),
+			},
+			expectedLimits: v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("8"),
+			},
+		},
 	}
 
 	for idx, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			testPod := &v1.Pod{
-				Spec:   v1.PodSpec{Containers: tc.containers, InitContainers: tc.initContainers},
-				Status: v1.PodStatus{ContainerStatuses: tc.containerStatuses, InitContainerStatuses: tc.initContainerStatuses},
+				Spec: v1.PodSpec{Containers: tc.containers, InitContainers: tc.initContainers},
+				Status: v1.PodStatus{
+					ContainerStatuses:     tc.containerStatuses,
+					InitContainerStatuses: tc.initContainerStatuses,
+					AllocatedResources:    tc.podAllocatedResources,
+					Resources:             tc.podResources,
+				},
 			}
 			resRequests := AggregateContainerRequests(testPod, tc.options)
 			resLimits := AggregateContainerLimits(testPod, tc.options)
@@ -2713,5 +2960,217 @@ func getPod(cname string, resources podResources) *v1.Pod {
 			},
 			Overhead: overhead,
 		},
+	}
+}
+
+func TestPodRequestsAndLimitsVerticalScalingWrappers(t *testing.T) {
+	cases := []struct {
+		name             string
+		pod              *v1.Pod
+		opts             PodResourcesOptions
+		expectedRequests v1.ResourceList
+		expectedLimits   v1.ResourceList
+	}{
+		{
+			name: "pod level requests/limits with PLR vertical scaling enabled and status populated",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
+						Limits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("4")},
+					},
+					Containers: []v1.Container{
+						{
+							Name: "c1",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
+								Limits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
+							},
+						},
+					},
+				},
+				Status: v1.PodStatus{
+					AllocatedResources: v1.ResourceList{v1.ResourceCPU: resource.MustParse("3")},
+					Resources: &v1.ResourceRequirements{
+						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("3.5")},
+						Limits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("5")},
+					},
+				},
+			},
+			opts: PodResourcesOptions{
+				UseStatusResources: true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			expectedRequests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("3.5")},
+			expectedLimits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("5")},
+		},
+		{
+			name: "pod level requests/limits with PLR vertical scaling enabled and infeasible resize",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("10")},
+						Limits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("20")},
+					},
+					Containers: []v1.Container{
+						{
+							Name: "c1",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
+								Limits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
+							},
+						},
+					},
+				},
+				Status: v1.PodStatus{
+					Conditions: []v1.PodCondition{
+						{
+							Type:   v1.PodResizePending,
+							Status: v1.ConditionTrue,
+							Reason: v1.PodReasonInfeasible,
+						},
+					},
+					AllocatedResources: v1.ResourceList{v1.ResourceCPU: resource.MustParse("3")},
+					Resources: &v1.ResourceRequirements{
+						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("4")},
+						Limits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("8")},
+					},
+				},
+			},
+			opts: PodResourcesOptions{
+				UseStatusResources: true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			expectedRequests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("4")},
+			expectedLimits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("8")},
+		},
+		{
+			name: "container limits aggregation with infeasible resize",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "c1",
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("10")},
+							},
+						},
+					},
+				},
+				Status: v1.PodStatus{
+					Conditions: []v1.PodCondition{
+						{
+							Type:   v1.PodResizePending,
+							Status: v1.ConditionTrue,
+							Reason: v1.PodReasonInfeasible,
+						},
+					},
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name: "c1",
+							Resources: &v1.ResourceRequirements{
+								Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("6")},
+							},
+						},
+					},
+				},
+			},
+			opts: PodResourcesOptions{
+				UseStatusResources: true,
+			},
+			expectedRequests: v1.ResourceList{},
+			expectedLimits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("6")},
+		},
+		{
+			name: "non missing container requests applied to init container",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					InitContainers: []v1.Container{
+						{
+							Name: "i1",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
+							},
+						},
+					},
+				},
+			},
+			opts: PodResourcesOptions{
+				NonMissingContainerRequests: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1"),
+				v1.ResourceMemory: resource.MustParse("100Mi"),
+			},
+			expectedLimits: v1.ResourceList{},
+		},
+		{
+			name: "non missing container requests applied to regular container",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "c1",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
+							},
+						},
+					},
+				},
+			},
+			opts: PodResourcesOptions{
+				NonMissingContainerRequests: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1"),
+				v1.ResourceMemory: resource.MustParse("100Mi"),
+			},
+			expectedLimits: v1.ResourceList{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotReqs := PodRequests(tc.pod, tc.opts)
+			if !equality.Semantic.DeepEqual(gotReqs, tc.expectedRequests) {
+				t.Errorf("PodRequests() mismatch (-want +got):\n%s", diff.Diff(tc.expectedRequests, gotReqs))
+			}
+			gotLimits := PodLimits(tc.pod, tc.opts)
+			if !equality.Semantic.DeepEqual(gotLimits, tc.expectedLimits) {
+				t.Errorf("PodLimits() mismatch (-want +got):\n%s", diff.Diff(tc.expectedLimits, gotLimits))
+			}
+		})
+	}
+}
+
+func TestResizeConditionsAndSupportedResources(t *testing.T) {
+	pod := &v1.Pod{
+		Status: v1.PodStatus{
+			Conditions: []v1.PodCondition{
+				{
+					Type:   v1.PodResizePending,
+					Status: v1.ConditionTrue,
+					Reason: v1.PodReasonDeferred,
+				},
+			},
+		},
+	}
+	if !IsPodResizeDeferred(pod) {
+		t.Errorf("expected IsPodResizeDeferred to be true")
+	}
+	if IsPodResizeInfeasible(pod) {
+		t.Errorf("expected IsPodResizeInfeasible to be false")
+	}
+	pod.Status.Conditions[0].Reason = "Other"
+	if IsPodResizeDeferred(pod) {
+		t.Errorf("expected IsPodResizeDeferred to be false")
+	}
+
+	if !SupportedPodLevelResources().Has(v1.ResourceCPU) {
+		t.Errorf("expected SupportedPodLevelResources to contain CPU")
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

To calculate the resource footprint of a multi-container pod, individually aggregate desired, allocated, and actuated resources independently across the containers before taking the max - i.e. take the max of sums rather than the sum of maxes. This is correct because a resize is allocated / actuated **atomically**. See https://github.com/kubernetes/kubernetes/issues/140046 for more details.

Also adds some additional test coverage to helpers_test.go (bringing it to 93% code coverage for the package).

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/140046

#### Does this PR introduce a user-facing change?

```release-note
Fix the overestimation of the pod's resource footprint for multi-container pods undergoing a resize.
```

Assisted by Antigravity
