### PR TITLE
[WIP, not ready for review] Inject top controller name and type directly in pod's annotation

### DIFF
--- a/pkg/apis/core/annotation_key_constants.go
+++ b/pkg/apis/core/annotation_key_constants.go
@@ -135,6 +135,14 @@ const (
 	// This annotation is beta-level and is only honored when PodDeletionCost feature is enabled.
 	PodDeletionCost = "controller.kubernetes.io/pod-deletion-cost"
 
+	// TopControllerName represents the name of the top-level controller that
+	// caused a pod to be created.
+	TopControllerName = "controller.kubernetes.io/top-controller-name"
+
+	// TopControllerResourceType represents the resource type of the top-level
+	// controller that caused a pod to be created.
+	TopControllerResourceType = "controller.kubernetes.io/top-controller-resource-type"
+
 	// DeprecatedAnnotationTopologyAwareHints can be used to enable or disable
 	// Topology Aware Hints for a Service. This may be set to "Auto" or
 	// "Disabled". Any other value is treated as "Disabled". This annotation has

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -573,6 +573,9 @@ func GetPodFromTemplate(template *v1.PodTemplateSpec, parentObject runtime.Objec
 		return nil, fmt.Errorf("parentObject does not have ObjectMeta, %v", err)
 	}
 	prefix := getPodsPrefix(accessor.GetName())
+	topControllerName, topControllerResourceType := topController(accessor, controllerRef)
+	desiredAnnotations[v1.TopControllerName] = topControllerName
+	desiredAnnotations[v1.TopControllerResourceType] = topControllerResourceType
 
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -587,6 +590,16 @@ func GetPodFromTemplate(template *v1.PodTemplateSpec, parentObject runtime.Objec
 	}
 	pod.Spec = *template.Spec.DeepCopy()
 	return pod, nil
+}
+
+func topController(object metav1.Object, controllerRef *metav1.OwnerReference) (string, string) {
+	if controllerRef := metav1.GetControllerOfNoCopy(object); controllerRef != nil && controllerRef.Name != "" {
+		return controllerRef.Name, controllerRef.Kind
+	}
+	if controllerRef != nil {
+		return object.GetName(), controllerRef.Kind
+	}
+	return object.GetName(), ""
 }
 
 func (r RealPodControl) createPods(ctx context.Context, namespace string, pod *v1.Pod, object runtime.Object, controllerRef *metav1.OwnerReference) error {

--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	apps "k8s.io/api/apps/v1"
+	batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -344,7 +345,11 @@ func TestCreatePodsWithGenerateName(t *testing.T) {
 			},
 			wantPod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:       controllerSpec.Spec.Template.Labels,
+					Labels: controllerSpec.Spec.Template.Labels,
+					Annotations: map[string]string{
+						v1.TopControllerName:         controllerSpec.Name,
+						v1.TopControllerResourceType: "ReplicationController",
+					},
 					GenerateName: fmt.Sprintf("%s-", controllerSpec.Name),
 				},
 				Spec: controllerSpec.Spec.Template.Spec,
@@ -358,7 +363,11 @@ func TestCreatePodsWithGenerateName(t *testing.T) {
 			},
 			wantPod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:          controllerSpec.Spec.Template.Labels,
+					Labels: controllerSpec.Spec.Template.Labels,
+					Annotations: map[string]string{
+						v1.TopControllerName:         controllerSpec.Name,
+						v1.TopControllerResourceType: "ReplicationController",
+					},
 					GenerateName:    generateName,
 					OwnerReferences: []metav1.OwnerReference{*controllerRef},
 				},
@@ -397,6 +406,118 @@ func TestCreatePodsWithGenerateName(t *testing.T) {
 			require.NoError(t, err, "unexpected error: %v", err)
 			assert.True(t, apiequality.Semantic.DeepDerivative(test.wantPod, actualPod),
 				"Body: %s", fakeHandler.RequestBody)
+		})
+	}
+}
+
+func TestGetPodFromTemplateSetsTopControllerAnnotations(t *testing.T) {
+	deployment := &apps.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "top-deployment",
+			UID:  types.UID("deployment-uid"),
+		},
+	}
+
+	tests := []struct {
+		name                 string
+		setup                func() (runtime.Object, *metav1.OwnerReference)
+		wantName             string
+		wantResourceType     string
+		templateHasStaleData bool
+	}{
+		{
+			name: "deployment via replicaset",
+			setup: func() (runtime.Object, *metav1.OwnerReference) {
+				rs := newReplicaSet("middle-replicaset", 1, types.UID("replicaset-uid"))
+				rs.OwnerReferences = []metav1.OwnerReference{
+					*metav1.NewControllerRef(deployment, apps.SchemeGroupVersion.WithKind("Deployment")),
+				}
+				return rs, metav1.NewControllerRef(rs, apps.SchemeGroupVersion.WithKind("ReplicaSet"))
+			},
+			wantName:             deployment.Name,
+			wantResourceType:     "Deployment",
+			templateHasStaleData: true,
+		},
+		{
+			name: "daemonset",
+			setup: func() (runtime.Object, *metav1.OwnerReference) {
+				ds := &apps.DaemonSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-daemonset", UID: types.UID("daemonset-uid")},
+				}
+				return ds, metav1.NewControllerRef(ds, apps.SchemeGroupVersion.WithKind("DaemonSet"))
+			},
+			wantName:             "test-daemonset",
+			wantResourceType:     "DaemonSet",
+			templateHasStaleData: true,
+		},
+		{
+			name: "job",
+			setup: func() (runtime.Object, *metav1.OwnerReference) {
+				job := &batch.Job{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-job", UID: types.UID("job-uid")},
+				}
+				return job, metav1.NewControllerRef(job, batch.SchemeGroupVersion.WithKind("Job"))
+			},
+			wantName:             "test-job",
+			wantResourceType:     "Job",
+			templateHasStaleData: true,
+		},
+		{
+			name: "statefulset",
+			setup: func() (runtime.Object, *metav1.OwnerReference) {
+				set := &apps.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-statefulset", UID: types.UID("statefulset-uid")},
+				}
+				return set, metav1.NewControllerRef(set, apps.SchemeGroupVersion.WithKind("StatefulSet"))
+			},
+			wantName:         "test-statefulset",
+			wantResourceType: "StatefulSet",
+		},
+		{
+			name: "replicaset",
+			setup: func() (runtime.Object, *metav1.OwnerReference) {
+				rs := newReplicaSet("test-replicaset", 1, types.UID("replicaset-uid"))
+				return rs, metav1.NewControllerRef(rs, apps.SchemeGroupVersion.WithKind("ReplicaSet"))
+			},
+			wantName:         "test-replicaset",
+			wantResourceType: "ReplicaSet",
+		},
+		{
+			name: "replicationcontroller",
+			setup: func() (runtime.Object, *metav1.OwnerReference) {
+				rc := newReplicationController(1)
+				rc.Name = "test-rc"
+				return rc, metav1.NewControllerRef(rc, v1.SchemeGroupVersion.WithKind("ReplicationController"))
+			},
+			wantName:         "test-rc",
+			wantResourceType: "ReplicationController",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			template := &v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "test"},
+				},
+			}
+			if test.templateHasStaleData {
+				template.Annotations = map[string]string{
+					v1.TopControllerName:         "template-name",
+					v1.TopControllerResourceType: "template-kind",
+				}
+			}
+			parent, controllerRef := test.setup()
+
+			pod, err := GetPodFromTemplate(template, parent, controllerRef)
+			require.NoError(t, err, "unexpected error")
+
+			if got := pod.Annotations[v1.TopControllerName]; got != test.wantName {
+				t.Fatalf("expected %s annotation to be %q, got %q", v1.TopControllerName, test.wantName, got)
+			}
+			if got := pod.Annotations[v1.TopControllerResourceType]; got != test.wantResourceType {
+				t.Fatalf("expected %s annotation to be %q, got %q", v1.TopControllerResourceType, test.wantResourceType, got)
+			}
 		})
 	}
 }

--- a/staging/src/k8s.io/api/core/v1/annotation_key_constants.go
+++ b/staging/src/k8s.io/api/core/v1/annotation_key_constants.go
@@ -141,6 +141,14 @@ const (
 	// This annotation is beta-level and is only honored when PodDeletionCost feature is enabled.
 	PodDeletionCost = "controller.kubernetes.io/pod-deletion-cost"
 
+	// TopControllerName represents the name of the top-level controller that
+	// caused a pod to be created.
+	TopControllerName = "controller.kubernetes.io/top-controller-name"
+
+	// TopControllerResourceType represents the resource type of the top-level
+	// controller that caused a pod to be created.
+	TopControllerResourceType = "controller.kubernetes.io/top-controller-resource-type"
+
 	// DeprecatedAnnotationTopologyAwareHints can be used to enable or disable
 	// Topology Aware Hints for a Service. This may be set to "Auto" or
 	// "Disabled". Any other value is treated as "Disabled". This annotation has


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#140025

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


Tested after patching controller-manager:

1.

```bash
kubectl apply -f - <<'EOF'
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: pause-daemon
spec:
  selector:
    matchLabels:
      app: pause-daemon
  template:
    metadata:
      labels:
        app: pause-daemon
    spec:
      containers:
      - name: pause
        image: registry.k8s.io/pause:3.10
EOF
```



2. 
```bash
 kubectl get pods -o yaml
apiVersion: v1
items:
- apiVersion: v1
  kind: Pod
  metadata:
    annotations:
      controller.kubernetes.io/top-controller-name: pause-daemon
      controller.kubernetes.io/top-controller-resource-type: DaemonSet
```
kubectl -n top-controller-test get pods -o yaml | grep top
      controller.kubernetes.io/top-controller-name: tc-daemonset
      controller.kubernetes.io/top-controller-resource-type: DaemonSet
    namespace: top-controller-test
      controller.kubernetes.io/top-controller-name: tc-deploy
      controller.kubernetes.io/top-controller-resource-type: Deployment
    namespace: top-controller-test
      controller.kubernetes.io/top-controller-name: tc-job
      controller.kubernetes.io/top-controller-resource-type: Job
    namespace: top-controller-test
      controller.kubernetes.io/top-controller-name: tc-replicaset
      controller.kubernetes.io/top-controller-resource-type: ReplicaSet
    namespace: top-controller-test
      controller.kubernetes.io/top-controller-name: tc-statefulset
      controller.kubernetes.io/top-controller-resource-type: StatefulSet
