### PR TITLE
validation-gen: Stop setting locked GA DeclarativeValidation gate in DV test harness

### DIFF
--- a/pkg/api/testing/validation.go
+++ b/pkg/api/testing/validation.go
@@ -376,7 +376,6 @@ func verifyValidationEquivalence(t *testing.T, expectedErrs field.ErrorList, run
 	t.Run("with declarative validation (Beta enabled)", func(t *testing.T) {
 		validationmetrics.ResetValidationMetricsInstance()
 		featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
-			features.DeclarativeValidation:     true,
 			features.DeclarativeValidationBeta: true,
 		})
 		errs := runValidations(ctx)
@@ -395,7 +394,6 @@ func verifyValidationEquivalence(t *testing.T, expectedErrs field.ErrorList, run
 	t.Run("with declarative validation (Beta disabled)", func(t *testing.T) {
 		validationmetrics.ResetValidationMetricsInstance()
 		featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
-			features.DeclarativeValidation:     true,
 			features.DeclarativeValidationBeta: false,
 		})
 		errs := runValidations(ctx)
@@ -419,7 +417,6 @@ func verifyValidationEquivalence(t *testing.T, expectedErrs field.ErrorList, run
 		// We don't strictly need to set feature gates here as the context override should force enforcement,
 		// but setting them ensures a consistent environment.
 		featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
-			features.DeclarativeValidation:     true,
 			features.DeclarativeValidationBeta: true,
 		})
 		testCtx := rest.WithAllDeclarativeEnforcedForTest(ctx)


### PR DESCRIPTION
The gate is GA and locked to true, so explicitly setting it in the equivalence test harness only emits a 'setting GA feature gate' warning without changing behavior. Rely on its locked default instead.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
The `DeclarativeValidation` feature gate is GA and locked to `true`. The declarative validation equivalence test harness still explicitly set it via `SetFeatureGatesDuringTest`, which only emitted a `setting GA feature gate. It will be removed in a future release.` warning on every test run without changing behavior.

This removes the redundant `features.DeclarativeValidation: true` from the three subtests, relying on the gate's locked default instead. This eliminates the warning noise (e.g. when running `go test -v ./test/declarative_validation/...`) while keeping the test behavior identical — only `DeclarativeValidationBeta` (and the All-Rules-Enforced context override) is still toggled.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
