### PR TITLE
flake(scheduler): reactivate preemptor after in-memory preemption

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -2577,12 +2577,12 @@ func TestPreEnqueue(t *testing.T) {
 
 			finishPreemption := make(chan struct{})
 
-			p.Executor.PreemptPod = func(ctx context.Context, c preemption.Candidate, preemptor preemption.ExecutorPreemptor, victim *v1.Pod, pluginName string) error {
+			p.Executor.PreemptPod = func(ctx context.Context, c preemption.Candidate, preemptor preemption.ExecutorPreemptor, victim *v1.Pod, pluginName string) (bool, error) {
 				if !tt.features.EnableAsyncPreemption {
-					return nil
+					return false, nil
 				}
 				<-finishPreemption
-				return nil
+				return false, nil
 			}
 
 			// Fill the cycle state

--- a/pkg/scheduler/framework/preemption/executor.go
+++ b/pkg/scheduler/framework/preemption/executor.go
@@ -104,7 +104,6 @@ func NewExecutor(fh fwk.Handle, fts feature.Features) *Executor {
 	e.PreemptPod = func(ctx context.Context, c Candidate, preemptor ExecutorPreemptor, victim *v1.Pod, pluginName string) (bool, error) {
 		logger := klog.FromContext(ctx)
 
-		skipAPICall := false
 		preemptedInMemory := false
 		eventMessage := fmt.Sprintf("Preempted by %s %v on node %v", preemptor.Type(), preemptor.UID(), c.Name())
 		// If the victim is a WaitingPod, try to preempt it without a delete call (victim will go back to backoff queue).
@@ -112,20 +111,18 @@ func NewExecutor(fh fwk.Handle, fts feature.Features) *Executor {
 		if waitingPod := e.fh.GetWaitingPod(victim.UID); waitingPod != nil {
 			if waitingPod.Preempt(pluginName, "preempted") {
 				logger.V(2).Info("Preemptor preempted a waiting pod", "preemptorType", preemptor.Type(), "preemptor", klog.KObj(preemptor), "waitingPod", klog.KObj(victim), "node", c.Name())
-				skipAPICall = true
 				preemptedInMemory = true
 			}
 		} else if podInPreBind := e.fh.GetPodInPreBind(victim.UID); podInPreBind != nil {
 			// If the victim is in the preBind cancel the binding process.
 			if podInPreBind.CancelPod(fmt.Sprintf("preempted by %s", pluginName)) {
 				logger.V(2).Info("Preemptor rejected a pod in preBind", "preemptorType", preemptor.Type(), "preemptor", klog.KObj(preemptor), "podInPreBind", klog.KObj(victim), "node", c.Name())
-				skipAPICall = true
 				preemptedInMemory = true
 			} else {
 				logger.V(5).Info("Failed to reject a pod in preBind, falling back to deletion via api call", "preemptor", klog.KObj(preemptor), "podInPreBind", klog.KObj(victim), "node", c.Name())
 			}
 		}
-		if !skipAPICall {
+		if !preemptedInMemory {
 			condition := &v1.PodCondition{
 				Type:               v1.DisruptionTarget,
 				ObservedGeneration: apipod.CalculatePodConditionObservedGeneration(&victim.Status, victim.Generation, v1.DisruptionTarget),

--- a/pkg/scheduler/framework/preemption/executor.go
+++ b/pkg/scheduler/framework/preemption/executor.go
@@ -85,9 +85,10 @@ type Executor struct {
 	// to prevent the pods/podgroups from entering the scheduling cycle while waiting for preemption to complete.
 	lastVictimsPendingPreemption map[types.UID]pendingVictim
 
-	// PreemptPod is a function that actually makes API calls to preempt a specific Pod.
+	// PreemptPod is a function that actually preempts a specific Pod. It returns true
+	// when the victim was preempted only in scheduler memory, without a delete call.
 	// This is exposed to be replaced during tests.
-	PreemptPod func(ctx context.Context, c Candidate, preemptor ExecutorPreemptor, victim *v1.Pod, pluginName string) error
+	PreemptPod func(ctx context.Context, c Candidate, preemptor ExecutorPreemptor, victim *v1.Pod, pluginName string) (bool, error)
 }
 
 // NewExecutor creates a new preemption executor.
@@ -100,10 +101,11 @@ func NewExecutor(fh fwk.Handle, fts feature.Features) *Executor {
 		fts:                          fts,
 	}
 
-	e.PreemptPod = func(ctx context.Context, c Candidate, preemptor ExecutorPreemptor, victim *v1.Pod, pluginName string) error {
+	e.PreemptPod = func(ctx context.Context, c Candidate, preemptor ExecutorPreemptor, victim *v1.Pod, pluginName string) (bool, error) {
 		logger := klog.FromContext(ctx)
 
 		skipAPICall := false
+		preemptedInMemory := false
 		eventMessage := fmt.Sprintf("Preempted by %s %v on node %v", preemptor.Type(), preemptor.UID(), c.Name())
 		// If the victim is a WaitingPod, try to preempt it without a delete call (victim will go back to backoff queue).
 		// Otherwise we should delete the victim.
@@ -111,12 +113,14 @@ func NewExecutor(fh fwk.Handle, fts feature.Features) *Executor {
 			if waitingPod.Preempt(pluginName, "preempted") {
 				logger.V(2).Info("Preemptor preempted a waiting pod", "preemptorType", preemptor.Type(), "preemptor", klog.KObj(preemptor), "waitingPod", klog.KObj(victim), "node", c.Name())
 				skipAPICall = true
+				preemptedInMemory = true
 			}
 		} else if podInPreBind := e.fh.GetPodInPreBind(victim.UID); podInPreBind != nil {
 			// If the victim is in the preBind cancel the binding process.
 			if podInPreBind.CancelPod(fmt.Sprintf("preempted by %s", pluginName)) {
 				logger.V(2).Info("Preemptor rejected a pod in preBind", "preemptorType", preemptor.Type(), "preemptor", klog.KObj(preemptor), "podInPreBind", klog.KObj(victim), "node", c.Name())
 				skipAPICall = true
+				preemptedInMemory = true
 			} else {
 				logger.V(5).Info("Failed to reject a pod in preBind, falling back to deletion via api call", "preemptor", klog.KObj(preemptor), "podInPreBind", klog.KObj(victim), "node", c.Name())
 			}
@@ -135,19 +139,19 @@ func NewExecutor(fh fwk.Handle, fts feature.Features) *Executor {
 				if err := util.PatchPodStatus(ctx, fh.ClientSet(), victim.Name, victim.Namespace, &victim.Status, newStatus); err != nil {
 					if !apierrors.IsNotFound(err) {
 						logger.Error(err, "Could not add DisruptionTarget condition due to preemption", "preemptor", klog.KObj(preemptor), "victim", klog.KObj(victim))
-						return err
+						return false, err
 					}
 					logger.V(2).Info("Victim Pod is already deleted", "preemptor", klog.KObj(preemptor), "victim", klog.KObj(victim), "node", c.Name())
-					return nil
+					return false, nil
 				}
 			}
 			if err := util.DeletePod(ctx, fh.ClientSet(), victim); err != nil {
 				if !apierrors.IsNotFound(err) {
 					logger.Error(err, "Tried to preempted pod", "pod", klog.KObj(victim), "preemptor", klog.KObj(preemptor))
-					return err
+					return false, err
 				}
 				logger.V(2).Info("Victim Pod is already deleted", "preemptor", klog.KObj(preemptor), "victim", klog.KObj(victim), "node", c.Name())
-				return nil
+				return false, nil
 			}
 			logger.V(2).Info("Preemptor Pod preempted victim Pod", "preemptor", klog.KObj(preemptor), "victim", klog.KObj(victim), "node", c.Name())
 		} else {
@@ -156,7 +160,7 @@ func NewExecutor(fh fwk.Handle, fts feature.Features) *Executor {
 
 		fh.EventRecorder().WithLogger(logger).Eventf(victim, preemptor.Obj(), v1.EventTypeNormal, "Preempted", "Preempting", eventMessage)
 
-		return nil
+		return preemptedInMemory, nil
 	}
 
 	return e
@@ -227,7 +231,7 @@ func (e *Executor) prepareCandidateAsync(c Candidate, preemptor ExecutorPreempto
 	preemptedLastVictimInMemory := false
 	preemptPod := func(index int) {
 		victim := victimPods[index]
-		if err := e.PreemptPod(ctx, c, preemptor, victim, pluginName); err != nil {
+		if _, err := e.PreemptPod(ctx, c, preemptor, victim, pluginName); err != nil {
 			errCh.SendWithCancel(err, cancel)
 		}
 	}
@@ -292,11 +296,11 @@ func (e *Executor) prepareCandidateAsync(c Candidate, preemptor ExecutorPreempto
 			e.lastVictimsPendingPreemption[preemptor.UID()] = pendingVictim{namespace: lastVictim.Namespace, name: lastVictim.Name}
 			e.mu.Unlock()
 
-			mayPreemptLastVictimInMemory := e.fh.GetWaitingPod(lastVictim.UID) != nil || e.fh.GetPodInPreBind(lastVictim.UID) != nil
-			if err := e.PreemptPod(ctx, c, preemptor, lastVictim, pluginName); err != nil {
+			preemptedInMemory, err := e.PreemptPod(ctx, c, preemptor, lastVictim, pluginName)
+			if err != nil {
 				utilruntime.HandleErrorWithContext(ctx, err, "Error occurred during async preemption of the last victim")
 				result = metrics.GoroutineResultError
-			} else if mayPreemptLastVictimInMemory {
+			} else if preemptedInMemory {
 				preemptedLastVictimInMemory = true
 			}
 		}
@@ -330,7 +334,7 @@ func (e *Executor) prepareCandidate(ctx context.Context, c Candidate, preemptor 
 			logger.V(2).Info("Victim Pod is already being deleted, skipping the API call for it", "preemptor", klog.KObj(preemptor), "node", c.Name(), "victim", klog.KObj(victim))
 			return
 		}
-		if err := e.PreemptPod(ctx, c, preemptor, victim, pluginName); err != nil {
+		if _, err := e.PreemptPod(ctx, c, preemptor, victim, pluginName); err != nil {
 			errCh.SendWithCancel(err, cancel)
 		}
 	}, pluginName)

--- a/pkg/scheduler/framework/preemption/executor.go
+++ b/pkg/scheduler/framework/preemption/executor.go
@@ -223,6 +223,8 @@ func (e *Executor) prepareCandidateAsync(c Candidate, preemptor ExecutorPreempto
 	metrics.PreemptionVictims.Observe(float64(len(c.Victims().Pods)))
 
 	errCh := parallelize.NewResultChannel[error]()
+	// PreEnqueue only watches the last victim for completion, so activate when that victim won't emit a deletion event.
+	preemptedLastVictimInMemory := false
 	preemptPod := func(index int) {
 		victim := victimPods[index]
 		if err := e.PreemptPod(ctx, c, preemptor, victim, pluginName); err != nil {
@@ -241,9 +243,9 @@ func (e *Executor) prepareCandidateAsync(c Candidate, preemptor ExecutorPreempto
 		defer metrics.PreemptionGoroutinesDuration.WithLabelValues(result).Observe(metrics.SinceInSeconds(startTime))
 		defer metrics.PreemptionGoroutinesExecutionTotal.WithLabelValues(result).Inc()
 		defer func() {
-			if result == metrics.GoroutineResultError {
-				// When API call isn't successful, the preemptor's Pods may get stuck in the unschedulable pod pool in the worst case.
-				// So, we should move the preemptor's Pods to the activeQ.
+			if result == metrics.GoroutineResultError || preemptedLastVictimInMemory {
+				// When API call isn't successful or no victim deletion event will be produced, the preemptor's
+				// Pods may get stuck in the unschedulable pod pool in the worst case.
 				e.fh.Activate(logger, preemptor.Pods())
 			}
 		}()
@@ -290,9 +292,12 @@ func (e *Executor) prepareCandidateAsync(c Candidate, preemptor ExecutorPreempto
 			e.lastVictimsPendingPreemption[preemptor.UID()] = pendingVictim{namespace: lastVictim.Namespace, name: lastVictim.Name}
 			e.mu.Unlock()
 
+			mayPreemptLastVictimInMemory := e.fh.GetWaitingPod(lastVictim.UID) != nil || e.fh.GetPodInPreBind(lastVictim.UID) != nil
 			if err := e.PreemptPod(ctx, c, preemptor, lastVictim, pluginName); err != nil {
 				utilruntime.HandleErrorWithContext(ctx, err, "Error occurred during async preemption of the last victim")
 				result = metrics.GoroutineResultError
+			} else if mayPreemptLastVictimInMemory {
+				preemptedLastVictimInMemory = true
 			}
 		}
 		e.mu.Lock()

--- a/pkg/scheduler/framework/preemption/executor_test.go
+++ b/pkg/scheduler/framework/preemption/executor_test.go
@@ -1420,6 +1420,136 @@ func TestPreemptPod(t *testing.T) {
 	}
 }
 
+func TestPrepareCandidateAsyncActivatesPreemptorAfterLastVictimInMemoryPreemption(t *testing.T) {
+	preemptorPod := st.MakePod().Name("p").UID("p").Priority(highPriority).Obj()
+	waitingVictim := st.MakePod().Name("waiting-v").UID("waiting-v").Priority(midPriority).Node("node1").Obj()
+	preBindVictim := st.MakePod().Name("prebind-v").UID("prebind-v").Priority(midPriority).Node("node1").Obj()
+	apiVictim := st.MakePod().Name("api-v").UID("api-v").Priority(midPriority).Node("node1").Obj()
+
+	tests := []struct {
+		name                  string
+		victimPods            []*v1.Pod
+		inMemoryVictim        *v1.Pod
+		addVictimToPrebind    bool
+		addVictimToWaiting    bool
+		wantPreemptorActivate bool
+	}{
+		{
+			name:                  "last waiting pod",
+			victimPods:            []*v1.Pod{waitingVictim},
+			inMemoryVictim:        waitingVictim,
+			addVictimToWaiting:    true,
+			wantPreemptorActivate: true,
+		},
+		{
+			name:                  "last preBind pod",
+			victimPods:            []*v1.Pod{preBindVictim},
+			inMemoryVictim:        preBindVictim,
+			addVictimToPrebind:    true,
+			wantPreemptorActivate: true,
+		},
+		{
+			name:               "non-last waiting pod",
+			victimPods:         []*v1.Pod{waitingVictim.DeepCopy(), apiVictim.DeepCopy()},
+			inMemoryVictim:     waitingVictim.DeepCopy(),
+			addVictimToWaiting: true,
+		},
+		{
+			name:               "non-last preBind pod",
+			victimPods:         []*v1.Pod{preBindVictim.DeepCopy(), apiVictim.DeepCopy()},
+			inMemoryVictim:     preBindVictim.DeepCopy(),
+			addVictimToPrebind: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics.Register()
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			mu := &sync.RWMutex{}
+			fakeActivator := &fakePodActivator{activatedPods: make(map[string]*v1.Pod), mu: mu}
+			podsInPreBind := frameworkruntime.NewPodsInPreBindMap()
+			waitingPods := frameworkruntime.NewWaitingPodsMap()
+			registeredPlugins := append([]tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New)},
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				tf.RegisterPermitPlugin(waitingPermitPluginName, newWaitingPermitPlugin),
+			)
+			objects := []runtime.Object{preemptorPod}
+			podsForSnapshot := make([]*v1.Pod, 0, len(tt.victimPods))
+			for _, pod := range tt.victimPods {
+				objects = append(objects, pod)
+				podsForSnapshot = append(podsForSnapshot, pod)
+			}
+			cs := clientsetfake.NewClientset(objects...)
+			informerFactory := informers.NewSharedInformerFactory(cs, 0)
+			eventBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: cs.EventsV1()})
+
+			fwk, err := tf.NewFramework(
+				ctx,
+				registeredPlugins, "",
+				frameworkruntime.WithClientSet(cs),
+				frameworkruntime.WithSnapshotSharedLister(internalcache.NewSnapshot(podsForSnapshot, []*v1.Node{st.MakeNode().Name("node1").Obj()})),
+				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithWaitingPods(waitingPods),
+				frameworkruntime.WithPodsInPreBind(podsInPreBind),
+				frameworkruntime.WithLogger(logger),
+				frameworkruntime.WithEventRecorder(eventBroadcaster.NewRecorder(scheme.Scheme, "test-scheduler")),
+				frameworkruntime.WithPodActivator(fakeActivator),
+				frameworkruntime.WithPodNominator(internalqueue.NewSchedulingQueue(nil, informerFactory)),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var victimCtx context.Context
+			var cancelVictim context.CancelCauseFunc
+			if tt.addVictimToPrebind {
+				victimCtx, cancelVictim = context.WithCancelCause(context.Background())
+				fwk.AddPodInPreBind(tt.inMemoryVictim.UID, cancelVictim)
+			}
+			if tt.addVictimToWaiting {
+				pluginsWaitTime, status := fwk.RunPermitPlugins(ctx, framework.NewCycleState(), tt.inMemoryVictim, "node1")
+				if !status.IsWait() {
+					t.Fatalf("Failed to add a pod to waiting list")
+				}
+				fwk.AddWaitingPod(tt.inMemoryVictim, pluginsWaitTime)
+			}
+
+			executor := NewExecutor(fwk, feature.Features{EnableAsyncPreemption: true})
+			candidate := &candidate{
+				name: "node1",
+				victims: &extenderv1.Victims{
+					Pods: tt.victimPods,
+				},
+			}
+			executor.prepareCandidateAsync(candidate, &podExecutorPreemptor{Pod: preemptorPod}, "test-plugin")
+
+			if err := wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+				executor.mu.RLock()
+				preempting := len(executor.preempting) != 0
+				executor.mu.RUnlock()
+				return !preempting, nil
+			}); err != nil {
+				t.Fatalf("Timed out waiting for async preemption to finish: %v", err)
+			}
+
+			mu.RLock()
+			defer mu.RUnlock()
+			_, activated := fakeActivator.activatedPods[preemptorPod.Name]
+			if activated != tt.wantPreemptorActivate {
+				t.Fatalf("Preemptor activation = %v, want %v; activated pods: %v", activated, tt.wantPreemptorActivate, fakeActivator.activatedPods)
+			}
+			if tt.addVictimToPrebind && victimCtx.Err() == nil {
+				t.Fatalf("Expected preBind victim context to be cancelled")
+			}
+		})
+	}
+}
+
 // waitingPermitPlugin is a PermitPlugin that always returns Wait.
 type waitingPermitPlugin struct{}
 

--- a/pkg/scheduler/framework/preemption/executor_test.go
+++ b/pkg/scheduler/framework/preemption/executor_test.go
@@ -903,7 +903,7 @@ func TestPrepareCandidateAsyncSetsPreemptingSets(t *testing.T) {
 					// preemptPodCallsCounter helps verify if the last victim pod gets preempted after other victims.
 					preemptPodCallsCounter := 0
 					preemptFunc := executor.PreemptPod
-					executor.PreemptPod = func(ctx context.Context, c Candidate, preemptor ExecutorPreemptor, victim *v1.Pod, pluginName string) error {
+					executor.PreemptPod = func(ctx context.Context, c Candidate, preemptor ExecutorPreemptor, victim *v1.Pod, pluginName string) (bool, error) {
 						// Verify contents of the sets: preempting and lastVictimsPendingPreemption before preemption of subsequent pods.
 						executor.mu.RLock()
 						preemptPodCallsCounter++
@@ -1391,9 +1391,12 @@ func TestPreemptPod(t *testing.T) {
 					preemptor = &podGroupExecutorPreemptor{pg: preemptorPodGroup, pods: preemptorPods}
 				}
 
-				err = pe.PreemptPod(ctx, &candidate{name: "fake-node"}, preemptor, victimPod, "test-plugin")
+				preemptedInMemory, err := pe.PreemptPod(ctx, &candidate{name: "fake-node"}, preemptor, victimPod, "test-plugin")
 				if err != nil {
 					t.Fatal(err)
+				}
+				if preemptedInMemory != (tt.addVictimToPrebind || tt.addVictimToWaiting) {
+					t.Errorf("PreemptPod() preemptedInMemory = %v, want %v", preemptedInMemory, tt.addVictimToPrebind || tt.addVictimToWaiting)
 				}
 				if tt.expectCancel {
 					if victimCtx.Err() == nil {
@@ -1427,12 +1430,13 @@ func TestPrepareCandidateAsyncActivatesPreemptorAfterLastVictimInMemoryPreemptio
 	apiVictim := st.MakePod().Name("api-v").UID("api-v").Priority(midPriority).Node("node1").Obj()
 
 	tests := []struct {
-		name                  string
-		victimPods            []*v1.Pod
-		inMemoryVictim        *v1.Pod
-		addVictimToPrebind    bool
-		addVictimToWaiting    bool
-		wantPreemptorActivate bool
+		name                        string
+		victimPods                  []*v1.Pod
+		inMemoryVictim              *v1.Pod
+		addVictimToPrebind          bool
+		addVictimToPrebindOnPreempt bool
+		addVictimToWaiting          bool
+		wantPreemptorActivate       bool
 	}{
 		{
 			name:                  "last waiting pod",
@@ -1447,6 +1451,13 @@ func TestPrepareCandidateAsyncActivatesPreemptorAfterLastVictimInMemoryPreemptio
 			inMemoryVictim:        preBindVictim,
 			addVictimToPrebind:    true,
 			wantPreemptorActivate: true,
+		},
+		{
+			name:                        "last pod enters preBind during preemption",
+			victimPods:                  []*v1.Pod{preBindVictim.DeepCopy()},
+			inMemoryVictim:              preBindVictim.DeepCopy(),
+			addVictimToPrebindOnPreempt: true,
+			wantPreemptorActivate:       true,
 		},
 		{
 			name:               "non-last waiting pod",
@@ -1520,6 +1531,16 @@ func TestPrepareCandidateAsyncActivatesPreemptorAfterLastVictimInMemoryPreemptio
 			}
 
 			executor := NewExecutor(fwk, feature.Features{EnableAsyncPreemption: true})
+			if tt.addVictimToPrebindOnPreempt {
+				preemptFunc := executor.PreemptPod
+				executor.PreemptPod = func(ctx context.Context, c Candidate, preemptor ExecutorPreemptor, victim *v1.Pod, pluginName string) (bool, error) {
+					if victim.UID == tt.inMemoryVictim.UID {
+						victimCtx, cancelVictim = context.WithCancelCause(context.Background())
+						fwk.AddPodInPreBind(victim.UID, cancelVictim)
+					}
+					return preemptFunc(ctx, c, preemptor, victim, pluginName)
+				}
+			}
 			candidate := &candidate{
 				name: "node1",
 				victims: &extenderv1.Victims{
@@ -1543,7 +1564,7 @@ func TestPrepareCandidateAsyncActivatesPreemptorAfterLastVictimInMemoryPreemptio
 			if activated != tt.wantPreemptorActivate {
 				t.Fatalf("Preemptor activation = %v, want %v; activated pods: %v", activated, tt.wantPreemptorActivate, fakeActivator.activatedPods)
 			}
-			if tt.addVictimToPrebind && victimCtx.Err() == nil {
+			if (tt.addVictimToPrebind || tt.addVictimToPrebindOnPreempt) && (victimCtx == nil || victimCtx.Err() == nil) {
 				t.Fatalf("Expected preBind victim context to be cancelled")
 			}
 		})

--- a/pkg/scheduler/framework/preemption/executor_test.go
+++ b/pkg/scheduler/framework/preemption/executor_test.go
@@ -1551,9 +1551,8 @@ func TestPrepareCandidateAsyncActivatesPreemptorAfterLastVictimInMemoryPreemptio
 
 			if err := wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 				executor.mu.RLock()
-				preempting := len(executor.preempting) != 0
-				executor.mu.RUnlock()
-				return !preempting, nil
+				defer executor.mu.RUnlock()
+				return len(executor.preempting) == 0, nil
 			}); err != nil {
 				t.Fatalf("Timed out waiting for async preemption to finish: %v", err)
 			}

--- a/pkg/scheduler/framework/preemption/executor_test.go
+++ b/pkg/scheduler/framework/preemption/executor_test.go
@@ -198,8 +198,12 @@ func TestIsPodRunningPreemption(t *testing.T) {
 }
 
 type fakePodActivator struct {
-	activatedPods map[string]*v1.Pod
-	mu            *sync.RWMutex
+	activatedPods            map[string]*v1.Pod
+	mu                       *sync.RWMutex
+	activatedCh              chan struct{}
+	activatedOnce            sync.Once
+	isPreempting             func() bool
+	activatedWhilePreempting bool
 }
 
 func (f *fakePodActivator) Activate(logger klog.Logger, pods map[string]*v1.Pod) {
@@ -207,6 +211,14 @@ func (f *fakePodActivator) Activate(logger klog.Logger, pods map[string]*v1.Pod)
 	defer f.mu.Unlock()
 	for name, pod := range pods {
 		f.activatedPods[name] = pod
+	}
+	if f.isPreempting != nil && f.isPreempting() {
+		f.activatedWhilePreempting = true
+	}
+	if f.activatedCh != nil {
+		f.activatedOnce.Do(func() {
+			close(f.activatedCh)
+		})
 	}
 }
 
@@ -1425,6 +1437,8 @@ func TestPreemptPod(t *testing.T) {
 
 func TestPrepareCandidateAsyncActivatesPreemptorAfterLastVictimInMemoryPreemption(t *testing.T) {
 	preemptorPod := st.MakePod().Name("p").UID("p").Priority(highPriority).Obj()
+	secondPreemptorPod := st.MakePod().Name("p2").UID("p2").Priority(highPriority).Obj()
+	preemptorPodGroup := &schedulingapi.PodGroup{ObjectMeta: metav1.ObjectMeta{Name: "pg", UID: "pg"}}
 	waitingVictim := st.MakePod().Name("waiting-v").UID("waiting-v").Priority(midPriority).Node("node1").Obj()
 	preBindVictim := st.MakePod().Name("prebind-v").UID("prebind-v").Priority(midPriority).Node("node1").Obj()
 	apiVictim := st.MakePod().Name("api-v").UID("api-v").Priority(midPriority).Node("node1").Obj()
@@ -1436,6 +1450,8 @@ func TestPrepareCandidateAsyncActivatesPreemptorAfterLastVictimInMemoryPreemptio
 		addVictimToPrebind          bool
 		addVictimToPrebindOnPreempt bool
 		addVictimToWaiting          bool
+		preemptorPodGroup           *schedulingapi.PodGroup
+		preemptorPods               []*v1.Pod
 		wantPreemptorActivate       bool
 	}{
 		{
@@ -1460,6 +1476,22 @@ func TestPrepareCandidateAsyncActivatesPreemptorAfterLastVictimInMemoryPreemptio
 			wantPreemptorActivate:       true,
 		},
 		{
+			name:                  "last waiting pod after API-deleted victim",
+			victimPods:            []*v1.Pod{apiVictim.DeepCopy(), waitingVictim.DeepCopy()},
+			inMemoryVictim:        waitingVictim.DeepCopy(),
+			addVictimToWaiting:    true,
+			wantPreemptorActivate: true,
+		},
+		{
+			name:                  "last waiting pod for pod group",
+			victimPods:            []*v1.Pod{waitingVictim.DeepCopy()},
+			inMemoryVictim:        waitingVictim.DeepCopy(),
+			addVictimToWaiting:    true,
+			preemptorPodGroup:     preemptorPodGroup,
+			preemptorPods:         []*v1.Pod{preemptorPod.DeepCopy(), secondPreemptorPod.DeepCopy()},
+			wantPreemptorActivate: true,
+		},
+		{
 			name:               "non-last waiting pod",
 			victimPods:         []*v1.Pod{waitingVictim.DeepCopy(), apiVictim.DeepCopy()},
 			inMemoryVictim:     waitingVictim.DeepCopy(),
@@ -1481,7 +1513,7 @@ func TestPrepareCandidateAsyncActivatesPreemptorAfterLastVictimInMemoryPreemptio
 			defer cancel()
 
 			mu := &sync.RWMutex{}
-			fakeActivator := &fakePodActivator{activatedPods: make(map[string]*v1.Pod), mu: mu}
+			fakeActivator := &fakePodActivator{activatedPods: make(map[string]*v1.Pod), mu: mu, activatedCh: make(chan struct{})}
 			podsInPreBind := frameworkruntime.NewPodsInPreBindMap()
 			waitingPods := frameworkruntime.NewWaitingPodsMap()
 			registeredPlugins := append([]tf.RegisterPluginFunc{
@@ -1489,7 +1521,19 @@ func TestPrepareCandidateAsyncActivatesPreemptorAfterLastVictimInMemoryPreemptio
 				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
 				tf.RegisterPermitPlugin(waitingPermitPluginName, newWaitingPermitPlugin),
 			)
-			objects := []runtime.Object{preemptorPod}
+			preemptorPods := tt.preemptorPods
+			if len(preemptorPods) == 0 {
+				preemptorPods = []*v1.Pod{preemptorPod.DeepCopy()}
+			}
+			var preemptor ExecutorPreemptor = &podExecutorPreemptor{Pod: preemptorPods[0]}
+			if tt.preemptorPodGroup != nil {
+				preemptor = &podGroupExecutorPreemptor{pg: tt.preemptorPodGroup, pods: preemptorPods}
+			}
+
+			objects := make([]runtime.Object, 0, len(preemptorPods)+len(tt.victimPods))
+			for _, pod := range preemptorPods {
+				objects = append(objects, pod)
+			}
 			podsForSnapshot := make([]*v1.Pod, 0, len(tt.victimPods))
 			for _, pod := range tt.victimPods {
 				objects = append(objects, pod)
@@ -1531,6 +1575,11 @@ func TestPrepareCandidateAsyncActivatesPreemptorAfterLastVictimInMemoryPreemptio
 			}
 
 			executor := NewExecutor(fwk, feature.Features{EnableAsyncPreemption: true})
+			fakeActivator.isPreempting = func() bool {
+				executor.mu.RLock()
+				defer executor.mu.RUnlock()
+				return executor.preempting.Has(preemptor.UID())
+			}
 			if tt.addVictimToPrebindOnPreempt {
 				preemptFunc := executor.PreemptPod
 				executor.PreemptPod = func(ctx context.Context, c Candidate, preemptor ExecutorPreemptor, victim *v1.Pod, pluginName string) (bool, error) {
@@ -1547,21 +1596,41 @@ func TestPrepareCandidateAsyncActivatesPreemptorAfterLastVictimInMemoryPreemptio
 					Pods: tt.victimPods,
 				},
 			}
-			executor.prepareCandidateAsync(candidate, &podExecutorPreemptor{Pod: preemptorPod}, "test-plugin")
+			executor.prepareCandidateAsync(candidate, preemptor, "test-plugin")
 
-			if err := wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
-				executor.mu.RLock()
-				defer executor.mu.RUnlock()
-				return len(executor.preempting) == 0, nil
-			}); err != nil {
-				t.Fatalf("Timed out waiting for async preemption to finish: %v", err)
+			if tt.wantPreemptorActivate {
+				select {
+				case <-fakeActivator.activatedCh:
+				case <-time.After(wait.ForeverTestTimeout):
+					t.Fatal("Timed out waiting for preemptor activation")
+				}
+			} else {
+				if err := wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+					executor.mu.RLock()
+					defer executor.mu.RUnlock()
+					return len(executor.preempting) == 0, nil
+				}); err != nil {
+					t.Fatalf("Timed out waiting for async preemption to finish: %v", err)
+				}
 			}
 
 			mu.RLock()
 			defer mu.RUnlock()
-			_, activated := fakeActivator.activatedPods[preemptorPod.Name]
-			if activated != tt.wantPreemptorActivate {
-				t.Fatalf("Preemptor activation = %v, want %v; activated pods: %v", activated, tt.wantPreemptorActivate, fakeActivator.activatedPods)
+			if fakeActivator.activatedWhilePreempting {
+				t.Fatal("Preemptor was activated before its preempting state was cleared")
+			}
+			wantActivatedPods := 0
+			if tt.wantPreemptorActivate {
+				wantActivatedPods = len(preemptor.Pods())
+			}
+			if len(fakeActivator.activatedPods) != wantActivatedPods {
+				t.Fatalf("Activated pod count = %d, want %d; activated pods: %v", len(fakeActivator.activatedPods), wantActivatedPods, fakeActivator.activatedPods)
+			}
+			for name := range preemptor.Pods() {
+				_, gotActivated := fakeActivator.activatedPods[name]
+				if gotActivated != tt.wantPreemptorActivate {
+					t.Fatalf("Preemptor pod %q activation = %v, want %v; activated pods: %v", name, gotActivated, tt.wantPreemptorActivate, fakeActivator.activatedPods)
+				}
 			}
 			if (tt.addVictimToPrebind || tt.addVictimToPrebindOnPreempt) && (victimCtx == nil || victimCtx.Err() == nil) {
 				t.Fatalf("Expected preBind victim context to be cancelled")

--- a/test/integration/scheduler/nominated_node_name/nominated_node_name_test.go
+++ b/test/integration/scheduler/nominated_node_name/nominated_node_name_test.go
@@ -492,7 +492,7 @@ func TestPreemptionAndNominatedNodeNameScenarios(t *testing.T) {
 						}
 
 						preemptPodFn := preemptionPlugin.Executor.PreemptPod
-						preemptionPlugin.Executor.PreemptPod = func(ctx context.Context, c preemption.Candidate, preemptor preemption.ExecutorPreemptor, victim *v1.Pod, pluginName string) error {
+						preemptionPlugin.Executor.PreemptPod = func(ctx context.Context, c preemption.Candidate, preemptor preemption.ExecutorPreemptor, victim *v1.Pod, pluginName string) (bool, error) {
 							// block the preemption goroutine to complete until the test case allows it to proceed.
 							lock.Lock()
 							ch, ok := preemptionDoneChannels[preemptor.GetName()]

--- a/test/integration/scheduler/preemption/preemption_test.go
+++ b/test/integration/scheduler/preemption/preemption_test.go
@@ -1311,7 +1311,7 @@ func TestAsyncPreemption(t *testing.T) {
 					}
 
 					preemptPodFn := preemptionPlugin.Executor.PreemptPod
-					preemptionPlugin.Executor.PreemptPod = func(ctx context.Context, c preemption.Candidate, preemptor preemption.ExecutorPreemptor, victim *v1.Pod, pluginName string) error {
+					preemptionPlugin.Executor.PreemptPod = func(ctx context.Context, c preemption.Candidate, preemptor preemption.ExecutorPreemptor, victim *v1.Pod, pluginName string) (bool, error) {
 						// block the preemption goroutine to complete until the test case allows it to proceed.
 						lock.Lock()
 						ch, ok := preemptionDoneChannels[preemptor.GetName()]

--- a/test/integration/scheduler/preemption/preemption_test.go
+++ b/test/integration/scheduler/preemption/preemption_test.go
@@ -1851,6 +1851,11 @@ func TestPreemptionRespectsWaitingPod(t *testing.T) {
 	case <-time.After(wait.ForeverTestTimeout):
 		t.Fatalf("Timed out waiting for victim to reach WaitOnPermit")
 	}
+	if err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+		return testCtx.Scheduler.Profiles[v1.DefaultSchedulerName].GetWaitingPod(victim.UID) != nil, nil
+	}); err != nil {
+		t.Fatalf("Timed out waiting for victim to be recorded as a waiting pod: %v", err)
+	}
 
 	smallNodeRes := map[v1.ResourceName]string{
 		v1.ResourceCPU:    "1",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
reactivate preemptor after in-memory preemption
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #139554

#### Special notes for your reviewer:
  Verified with:

  - `make test WHAT=./pkg/scheduler/framework/preemption KUBE_TEST_ARGS='-count=1'`
  - `make test-integration WHAT=./test/integration/scheduler/preemption KUBE_TEST_ARGS='-run TestPreemptionRespects -count=1'`
  - `stress -p 8 -count 400 -timeout 3m /private/tmp/preemption.test -test.run 'TestPreemptionRespects(WaitingPod|BindingPod)$' -test.count=1 -test.timeout=120s`

  Stress result: `400 runs total, 0 failures`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
