### PR TITLE
Strip managedFields in kube-proxy informers to reduce informer cache size

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/spf13/cobra"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -582,11 +583,23 @@ func (s *ProxyServer) Run(ctx context.Context) error {
 	labelSelectorNoProxyName := labels.NewSelector().Add(*noProxyName)
 	labelSelectorNoHeadlessEndpoints := labels.NewSelector().Add(*noHeadlessEndpoints)
 
+	// kube-proxy never needs the managed fields metadata, so strip it from all
+	// cached objects to reduce memory usage.
+	trimManagedFields := func(obj interface{}) (interface{}, error) {
+		if accessor, err := meta.Accessor(obj); err == nil {
+			accessor.SetManagedFields(nil)
+		}
+		return obj, nil
+	}
+
 	// Make informer that contains no filters
-	informerFactory := informers.NewSharedInformerFactoryWithOptions(s.Client, s.Config.ConfigSyncPeriod.Duration)
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(s.Client, s.Config.ConfigSyncPeriod.Duration,
+		informers.WithTransform(trimManagedFields),
+	)
 
 	// Make informers that filter out objects that do not contain a service.kubernetes.io/headless label
 	endpointSliceInformerFactory := informers.NewSharedInformerFactoryWithOptions(s.Client, s.Config.ConfigSyncPeriod.Duration,
+		informers.WithTransform(trimManagedFields),
 		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
 			options.LabelSelector = labelSelectorNoHeadlessEndpoints.String()
 		}))
@@ -597,6 +610,7 @@ func (s *ProxyServer) Run(ctx context.Context) error {
 	// are registered yet.
 	// don't watch headless services for kube-proxy, they are proxied by DNS.
 	serviceInformerFactory := informers.NewSharedInformerFactoryWithOptions(s.Client, s.Config.ConfigSyncPeriod.Duration,
+		informers.WithTransform(trimManagedFields),
 		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
 			options.LabelSelector = labelSelectorNoProxyName.String()
 			options.FieldSelector = fields.OneTermNotEqualSelector("spec.clusterIP", v1.ClusterIPNone).String()

--- a/pkg/proxy/node.go
+++ b/pkg/proxy/node.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -76,6 +77,14 @@ func newNodeManager(ctx context.Context, client clientset.Interface, resyncInter
 ) (*NodeManager, error) {
 	// make an informer that selects for the given node
 	thisNodeInformerFactory := informers.NewSharedInformerFactoryWithOptions(client, resyncInterval,
+		informers.WithTransform(func(obj interface{}) (interface{}, error) {
+			// kube-proxy never needs the managed fields metadata, so strip it
+			// from all cached objects to reduce memory usage.
+			if accessor, err := meta.Accessor(obj); err == nil {
+				accessor.SetManagedFields(nil)
+			}
+			return obj, nil
+		}),
 		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
 			options.FieldSelector = fields.OneTermEqualSelector("metadata.name", nodeName).String()
 		}))


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Strip managedFields from objects received in informers to reduce on cache size

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Improve memory usage of kube-proxy by dropping the `.metadata.managedFields` field that kube-proxy doesn't require.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

---
/cc danwinship 

I benchmarked this before and after, using:
500 Services and 500 EndpointSlices (1k items in total)
5000 Services and 5000 EndpointSlices (10k items in total)
50000 Services and 50000 EndpointSlices (100k items in total)

I think the savings are there, but very small, and there is also a lot of other noise making the benefits hard to see on the graphs.

### 500 Services and 500 EndpointSlices (1k items in total)

#### Before RAM

<img width="1485" height="692" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/ec27fca3-87d6-43f1-a4e0-c886aece9212" />

#### After RAM

<img width="1455" height="585" alt="Pasted Graphic 6" src="https://github.com/user-attachments/assets/65a298e7-5ec3-4c20-b150-9f29ae4d0965" />

#### Before CPU

<img width="1472" height="710" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/66a79cc6-63cb-4f67-bb90-095c4b1c469f" />

#### After CPU

<img width="1455" height="585" alt="Pasted Graphic 7" src="https://github.com/user-attachments/assets/eb91c225-c14f-4e02-b27b-33536b0683bf" />

### 5000 Services and 5000 EndpointSlices (10k items in total)

#### Before RAM

<img width="1457" height="621" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/9ae34f04-1236-42fc-891d-4a22198c501e" />

#### After RAM

<img width="1489" height="577" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/d05d09ce-aa3a-4898-add7-6da44dae01e6" />

#### Before CPU

<img width="1465" height="693" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/0a8e3aed-e56b-432f-b7c9-ad7e05234989" />

#### After CPU

<img width="1479" height="582" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/5e2911a8-1fd8-4d08-abf1-84ba6f19eebd" />


### 50000 Services and 50000 EndpointSlices (100k items in total)

#### Before RAM

<img width="1479" height="634" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/b3071129-2117-4a1e-9c46-819cb69d51fb" />

#### After RAM

<img width="1910" height="573" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/942f36ac-8dcc-4882-aea5-24d15e534c70" />


#### Before CPU

<img width="1452" height="728" alt="Pasted Graphic 5" src="https://github.com/user-attachments/assets/8f849a16-70dc-44a0-a4d3-9245bcb95004" />

#### After CPU

<img width="1912" height="574" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/ebc86cce-b892-4fc9-a7fa-c1b389bdd583" />
