### PR TITLE
test(scheduler): protect scheduler plugin test state from data races

### DIFF
--- a/test/integration/scheduler/plugins/plugins_test.go
+++ b/test/integration/scheduler/plugins/plugins_test.go
@@ -167,11 +167,25 @@ type PostFilterPlugin struct {
 }
 
 type ReservePlugin struct {
+	mutex                 sync.Mutex
 	name                  string
 	numReserveCalled      int
 	failReserve           bool
 	numUnreserveCalled    int
 	pluginInvokeEventChan chan pluginInvokeEvent
+}
+
+func (rp *ReservePlugin) deepCopy() *ReservePlugin {
+	rp.mutex.Lock()
+	defer rp.mutex.Unlock()
+
+	return &ReservePlugin{
+		name:                  rp.name,
+		numReserveCalled:      rp.numReserveCalled,
+		failReserve:           rp.failReserve,
+		numUnreserveCalled:    rp.numUnreserveCalled,
+		pluginInvokeEventChan: rp.pluginInvokeEventChan,
+	}
 }
 
 type PreScorePlugin struct {
@@ -454,8 +468,12 @@ func (rp *ReservePlugin) Name() string {
 // Reserve is a test function that increments an intenral counter and returns
 // an error or nil, depending on the value of "failReserve".
 func (rp *ReservePlugin) Reserve(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *fwk.Status {
+	rp.mutex.Lock()
 	rp.numReserveCalled++
-	if rp.failReserve {
+	failReserve := rp.failReserve
+	rp.mutex.Unlock()
+
+	if failReserve {
 		return fwk.NewStatus(fwk.Error, fmt.Sprintf("injecting failure for pod %v", pod.Name))
 	}
 	return nil
@@ -465,11 +483,16 @@ func (rp *ReservePlugin) Reserve(ctx context.Context, state fwk.CycleState, pod 
 // an event to a channel. While Unreserve implementations should normally be
 // idempotent, we relax that requirement here for testing purposes.
 func (rp *ReservePlugin) Unreserve(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) {
+	rp.mutex.Lock()
 	rp.numUnreserveCalled++
-	if rp.pluginInvokeEventChan != nil {
+	numUnreserveCalled := rp.numUnreserveCalled
+	pluginInvokeEventChan := rp.pluginInvokeEventChan
+	rp.mutex.Unlock()
+
+	if pluginInvokeEventChan != nil {
 		select {
 		case <-ctx.Done():
-		case rp.pluginInvokeEventChan <- pluginInvokeEvent{pluginName: rp.Name(), val: rp.numUnreserveCalled}:
+		case pluginInvokeEventChan <- pluginInvokeEvent{pluginName: rp.Name(), val: numUnreserveCalled}:
 		}
 	}
 }
@@ -1203,7 +1226,7 @@ func TestReservePluginReserve(t *testing.T) {
 				}
 			}
 
-			if reservePlugin.numReserveCalled == 0 {
+			if reservePlugin.deepCopy().numReserveCalled == 0 {
 				t.Errorf("Expected the reserve plugin to be called.")
 			}
 		})
@@ -1470,18 +1493,19 @@ func TestUnReserveReservePlugins(t *testing.T) {
 				}
 
 				for i, pl := range test.plugins {
+					p := pl.deepCopy()
 					if i <= test.failPluginIdx {
-						if pl.numReserveCalled != 1 {
-							t.Errorf("Reserve Plugins %s numReserveCalled = %d, want 1.", pl.name, pl.numReserveCalled)
+						if p.numReserveCalled != 1 {
+							t.Errorf("Reserve Plugins %s numReserveCalled = %d, want 1.", p.name, p.numReserveCalled)
 						}
 					} else {
-						if pl.numReserveCalled != 0 {
-							t.Errorf("Reserve Plugins %s numReserveCalled = %d, want 0.", pl.name, pl.numReserveCalled)
+						if p.numReserveCalled != 0 {
+							t.Errorf("Reserve Plugins %s numReserveCalled = %d, want 0.", p.name, p.numReserveCalled)
 						}
 					}
 
-					if pl.numUnreserveCalled != 1 {
-						t.Errorf("Reserve Plugin %s numUnreserveCalled = %d, want 1.", pl.name, pl.numUnreserveCalled)
+					if p.numUnreserveCalled != 1 {
+						t.Errorf("Reserve Plugin %s numUnreserveCalled = %d, want 1.", p.name, p.numUnreserveCalled)
 					}
 				}
 			} else {
@@ -1490,11 +1514,12 @@ func TestUnReserveReservePlugins(t *testing.T) {
 				}
 
 				for _, pl := range test.plugins {
-					if pl.numReserveCalled != 1 {
-						t.Errorf("Reserve Plugin %s numReserveCalled = %d, want 1.", pl.name, pl.numReserveCalled)
+					p := pl.deepCopy()
+					if p.numReserveCalled != 1 {
+						t.Errorf("Reserve Plugin %s numReserveCalled = %d, want 1.", p.name, p.numReserveCalled)
 					}
-					if pl.numUnreserveCalled != 0 {
-						t.Errorf("Reserve Plugin %s numUnreserveCalled = %d, want 0.", pl.name, pl.numUnreserveCalled)
+					if p.numUnreserveCalled != 0 {
+						t.Errorf("Reserve Plugin %s numUnreserveCalled = %d, want 0.", p.name, p.numUnreserveCalled)
 					}
 				}
 			}
@@ -1563,8 +1588,9 @@ func TestUnReservePermitPlugins(t *testing.T) {
 				}
 
 				// Verify the Reserve Plugins
-				if reservePlugin.numUnreserveCalled != 1 {
-					t.Errorf("Reserve Plugin %s numUnreserveCalled = %d, want 1.", reservePlugin.name, reservePlugin.numUnreserveCalled)
+				p := reservePlugin.deepCopy()
+				if p.numUnreserveCalled != 1 {
+					t.Errorf("Reserve Plugin %s numUnreserveCalled = %d, want 1.", p.name, p.numUnreserveCalled)
 				}
 			} else {
 				if err = testutils.WaitForPodToSchedule(testCtx.Ctx, testCtx.ClientSet, pod); err != nil {
@@ -1572,12 +1598,13 @@ func TestUnReservePermitPlugins(t *testing.T) {
 				}
 
 				// Verify the Reserve Plugins
-				if reservePlugin.numUnreserveCalled != 0 {
-					t.Errorf("Reserve Plugin %s numUnreserveCalled = %d, want 0.", reservePlugin.name, reservePlugin.numUnreserveCalled)
+				p := reservePlugin.deepCopy()
+				if p.numUnreserveCalled != 0 {
+					t.Errorf("Reserve Plugin %s numUnreserveCalled = %d, want 0.", p.name, p.numUnreserveCalled)
 				}
 			}
 
-			if test.plugin.numPermitCalled != 1 {
+			if test.plugin.deepCopy().numPermitCalled != 1 {
 				t.Errorf("Expected the Permit plugin to be called.")
 			}
 		})
@@ -1636,8 +1663,9 @@ func TestUnReservePreBindPlugins(t *testing.T) {
 				}
 
 				// Verify the Reserve Plugins
-				if reservePlugin.numUnreserveCalled != 1 {
-					t.Errorf("Reserve Plugin %s numUnreserveCalled = %d, want 1.", reservePlugin.name, reservePlugin.numUnreserveCalled)
+				p := reservePlugin.deepCopy()
+				if p.numUnreserveCalled != 1 {
+					t.Errorf("Reserve Plugin %s numUnreserveCalled = %d, want 1.", p.name, p.numUnreserveCalled)
 				}
 			} else {
 				if err = testutils.WaitForPodToSchedule(testCtx.Ctx, testCtx.ClientSet, pod); err != nil {
@@ -1645,8 +1673,9 @@ func TestUnReservePreBindPlugins(t *testing.T) {
 				}
 
 				// Verify the Reserve Plugins
-				if reservePlugin.numUnreserveCalled != 0 {
-					t.Errorf("Reserve Plugin %s numUnreserveCalled = %d, want 0.", reservePlugin.name, reservePlugin.numUnreserveCalled)
+				p := reservePlugin.deepCopy()
+				if p.numUnreserveCalled != 0 {
+					t.Errorf("Reserve Plugin %s numUnreserveCalled = %d, want 0.", p.name, p.numUnreserveCalled)
 				}
 			}
 
@@ -1708,8 +1737,9 @@ func TestUnReserveBindPlugins(t *testing.T) {
 				}
 
 				// Verify the Reserve Plugins
-				if reservePlugin.numUnreserveCalled != 1 {
-					t.Errorf("Reserve Plugin %s numUnreserveCalled = %d, want 1.", reservePlugin.name, reservePlugin.numUnreserveCalled)
+				p := reservePlugin.deepCopy()
+				if p.numUnreserveCalled != 1 {
+					t.Errorf("Reserve Plugin %s numUnreserveCalled = %d, want 1.", p.name, p.numUnreserveCalled)
 				}
 			} else {
 				if err = testutils.WaitForPodToSchedule(testCtx.Ctx, testCtx.ClientSet, pod); err != nil {
@@ -1717,8 +1747,9 @@ func TestUnReserveBindPlugins(t *testing.T) {
 				}
 
 				// Verify the Reserve Plugins
-				if reservePlugin.numUnreserveCalled != 0 {
-					t.Errorf("Reserve Plugin %s numUnreserveCalled = %d, want 0.", reservePlugin.name, reservePlugin.numUnreserveCalled)
+				p := reservePlugin.deepCopy()
+				if p.numUnreserveCalled != 0 {
+					t.Errorf("Reserve Plugin %s numUnreserveCalled = %d, want 0.", p.name, p.numUnreserveCalled)
 				}
 			}
 
@@ -1894,8 +1925,8 @@ func TestBindPlugin(t *testing.T) {
 				}); err != nil {
 					t.Errorf("Expected the postbind plugin to be called once, was called %d times.", postBindPlugin.numPostBindCalled)
 				}
-				if reservePlugin.numUnreserveCalled != 0 {
-					t.Errorf("Expected unreserve to not be called, was called %d times.", reservePlugin.numUnreserveCalled)
+				if p := reservePlugin.deepCopy(); p.numUnreserveCalled != 0 {
+					t.Errorf("Expected unreserve to not be called, was called %d times.", p.numUnreserveCalled)
 				}
 			} else if test.expectBindFailed {
 				// bind plugin fails to bind the pod
@@ -2142,7 +2173,7 @@ func TestMultiplePermitPlugins(t *testing.T) {
 		t.Errorf("Expected the pod to be scheduled. error: %v", err)
 	}
 
-	if perPlugin1.numPermitCalled == 0 || perPlugin2.numPermitCalled == 0 {
+	if perPlugin1.deepCopy().numPermitCalled == 0 || perPlugin2.deepCopy().numPermitCalled == 0 {
 		t.Errorf("Expected the permit plugin to be called.")
 	}
 }
@@ -2211,6 +2242,11 @@ func TestCoSchedulingWithPermitPlugin(t *testing.T) {
 		},
 	}
 
+	podPairMatches := func(waitingPod, pairedPod, podAName, podBName string) bool {
+		return (waitingPod == podAName && pairedPod == podBName) ||
+			(waitingPod == podBName && pairedPod == podAName)
+	}
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 
@@ -2249,10 +2285,10 @@ func TestCoSchedulingWithPermitPlugin(t *testing.T) {
 				if err = testutils.WaitForPodUnschedulable(testCtx.Ctx, testCtx.ClientSet, podB); err != nil {
 					t.Errorf("Didn't expect the second pod to be scheduled. error: %v", err)
 				}
-				if !((permitPlugin.waitingPod == podA.Name && permitPlugin.rejectingPod == podB.Name) ||
-					(permitPlugin.waitingPod == podB.Name && permitPlugin.rejectingPod == podA.Name)) {
+				p := permitPlugin.deepCopy()
+				if !podPairMatches(p.waitingPod, p.rejectingPod, podA.Name, podB.Name) {
 					t.Errorf("Expect one pod to wait and another pod to reject instead %s waited and %s rejected.",
-						permitPlugin.waitingPod, permitPlugin.rejectingPod)
+						p.waitingPod, p.rejectingPod)
 				}
 			} else {
 				if err = testutils.WaitForPodToSchedule(testCtx.Ctx, testCtx.ClientSet, podA); err != nil {
@@ -2261,10 +2297,10 @@ func TestCoSchedulingWithPermitPlugin(t *testing.T) {
 				if err = testutils.WaitForPodToSchedule(testCtx.Ctx, testCtx.ClientSet, podB); err != nil {
 					t.Errorf("Expected the second pod to be scheduled. error: %v", err)
 				}
-				if !((permitPlugin.waitingPod == podA.Name && permitPlugin.allowingPod == podB.Name) ||
-					(permitPlugin.waitingPod == podB.Name && permitPlugin.allowingPod == podA.Name)) {
+				p := permitPlugin.deepCopy()
+				if !podPairMatches(p.waitingPod, p.allowingPod, podA.Name, podB.Name) {
 					t.Errorf("Expect one pod to wait and another pod to allow instead %s waited and %s allowed.",
-						permitPlugin.waitingPod, permitPlugin.allowingPod)
+						p.waitingPod, p.allowingPod)
 				}
 			}
 
@@ -2624,7 +2660,7 @@ func TestPreemptWithPermitPlugin(t *testing.T) {
 					}
 				}
 
-				if permitPlugin.numPermitCalled == 0 {
+				if permitPlugin.deepCopy().numPermitCalled == 0 {
 					t.Errorf("Expected the permit plugin to be called.")
 				}
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

  This PR protects shared state in scheduler plugin integration test helpers.

  `ReservePlugin` counters are now guarded by a mutex and read through a snapshot helper. `PermitPlugin` assertions now read `waitingPod`, `rejectingPod`, `allowingPod`, and
  `numPermitCalled` through the existing locked `deepCopy()` helper.

  This avoids unsynchronized reads and writes between the test goroutine and scheduler/plugin goroutines.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

This is a test-only change. It does not change scheduler behavior.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
