### PR TITLE
fix(scheduler): refresh pod status after patch conflicts

### DIFF
--- a/pkg/scheduler/framework/api_calls/pod_status_patch.go
+++ b/pkg/scheduler/framework/api_calls/pod_status_patch.go
@@ -22,9 +22,11 @@ import (
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
@@ -44,6 +46,8 @@ type PodStatusPatchCall struct {
 	podRef klog.ObjectRef
 	// podStatus contains the actual status of the pod.
 	podStatus *v1.PodStatus
+	// podResourceVersion contains the resource version of the pod used to calculate podStatus.
+	podResourceVersion string
 	// newConditions is a list of conditions to update.
 	newConditions []*v1.PodCondition
 	// nominatingInfo is a nominating info to update.
@@ -52,11 +56,12 @@ type PodStatusPatchCall struct {
 
 func NewPodStatusPatchCall(pod *v1.Pod, conditions []*v1.PodCondition, nominatingInfo *fwk.NominatingInfo) *PodStatusPatchCall {
 	return &PodStatusPatchCall{
-		podUID:         pod.UID,
-		podRef:         klog.KObj(pod),
-		podStatus:      pod.Status.DeepCopy(),
-		newConditions:  conditions,
-		nominatingInfo: nominatingInfo,
+		podUID:             pod.UID,
+		podRef:             klog.KObj(pod),
+		podStatus:          pod.Status.DeepCopy(),
+		podResourceVersion: pod.ResourceVersion,
+		newConditions:      conditions,
+		nominatingInfo:     nominatingInfo,
 	}
 }
 
@@ -95,7 +100,13 @@ func (psuc *PodStatusPatchCall) Execute(ctx context.Context, client clientset.In
 	for _, condition := range psuc.newConditions {
 		conditions = append(conditions, condition.DeepCopy())
 	}
-	podStatusCopy := psuc.podStatus.DeepCopy()
+	baseStatus := psuc.podStatus.DeepCopy()
+	baseResourceVersion := psuc.podResourceVersion
+	nominatingInfo := psuc.nominatingInfo
+	if nominatingInfo != nil {
+		nominatingInfoCopy := *nominatingInfo
+		nominatingInfo = &nominatingInfoCopy
+	}
 	psuc.lock.Unlock()
 
 	logger := klog.FromContext(ctx)
@@ -103,15 +114,31 @@ func (psuc *PodStatusPatchCall) Execute(ctx context.Context, client clientset.In
 		logger.V(3).Info("Updating pod condition", "pod", psuc.podRef, "conditionType", condition.Type, "conditionStatus", condition.Status, "conditionReason", condition.Reason)
 	}
 
-	// Sync status to have the condition and nominatingInfo applied on a podStatusCopy.
-	anySynced := syncStatus(podStatusCopy, conditions, psuc.nominatingInfo)
-	if !anySynced {
-		logger.V(5).Info("Pod status patch call does not need to be executed because it has no effect", "pod", psuc.podRef)
-		return nil
-	}
+	err := retry.OnError(retry.DefaultBackoff, apierrors.IsConflict, func() error {
+		podStatusCopy := baseStatus.DeepCopy()
+		// Sync status to have the condition and nominatingInfo applied on a podStatusCopy.
+		anySynced := syncStatus(podStatusCopy, conditions, nominatingInfo)
+		if !anySynced {
+			logger.V(5).Info("Pod status patch call does not need to be executed because it has no effect", "pod", psuc.podRef)
+			return nil
+		}
 
-	// It's safe to run PatchPodStatus even on outdated pod object.
-	err := util.PatchPodStatus(ctx, client, psuc.podRef.Name, psuc.podRef.Namespace, "", psuc.podStatus, podStatusCopy)
+		err := util.PatchPodStatus(ctx, client, psuc.podRef.Name, psuc.podRef.Namespace, baseResourceVersion, baseStatus, podStatusCopy)
+		if !apierrors.IsConflict(err) {
+			return err
+		}
+
+		pod, getErr := client.CoreV1().Pods(psuc.podRef.Namespace).Get(ctx, psuc.podRef.Name, metav1.GetOptions{})
+		if getErr != nil {
+			return getErr
+		}
+		if pod.UID != psuc.podUID {
+			return fmt.Errorf("pod %s UID changed from %q to %q", psuc.podRef, psuc.podUID, pod.UID)
+		}
+		baseStatus = pod.Status.DeepCopy()
+		baseResourceVersion = pod.ResourceVersion
+		return err
+	})
 	if err != nil {
 		logger.Error(err, "Failed to patch pod status", "pod", psuc.podRef)
 		return err
@@ -131,6 +158,7 @@ func (psuc *PodStatusPatchCall) Sync(obj metav1.Object) (metav1.Object, error) {
 		// Set podStatus only if the call execution haven't started yet,
 		// because otherwise it's irrelevant and might race.
 		psuc.podStatus = pod.Status.DeepCopy()
+		psuc.podResourceVersion = pod.ResourceVersion
 	}
 	newConditions := make([]*v1.PodCondition, 0, len(psuc.newConditions))
 	for _, condition := range psuc.newConditions {

--- a/pkg/scheduler/framework/api_calls/pod_status_patch_test.go
+++ b/pkg/scheduler/framework/api_calls/pod_status_patch_test.go
@@ -22,8 +22,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/klog/v2/ktesting"
@@ -433,6 +435,39 @@ func TestPodStatusPatchCall_Execute(t *testing.T) {
 		}
 		if patched {
 			t.Error("Expected patch API not to be called if the call is no-op")
+		}
+	})
+
+	t.Run("Refreshes pod status after conflict", func(t *testing.T) {
+		condition := &v1.PodCondition{
+			Type:    v1.PodScheduled,
+			Status:  v1.ConditionFalse,
+			Reason:  v1.PodReasonUnschedulable,
+			Message: "reject pod",
+		}
+		latestPod := pod.DeepCopy()
+		latestPod.Status.Conditions = []v1.PodCondition{*condition}
+		client := fake.NewClientset(latestPod)
+		patches := 0
+		gets := 0
+		client.PrependReactor("patch", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+			patches++
+			return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "pods"}, pod.Name, nil)
+		})
+		client.PrependReactor("get", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+			gets++
+			return true, latestPod, nil
+		})
+
+		call := NewPodStatusPatchCall(pod, []*v1.PodCondition{condition}, &fwk.NominatingInfo{NominatingMode: fwk.ModeNoop})
+		if err := call.Execute(ctx, client); err != nil {
+			t.Fatalf("Unexpected error returned by Execute(): %v", err)
+		}
+		if patches == 0 {
+			t.Error("Expected patch API to be called")
+		}
+		if gets == 0 {
+			t.Error("Expected latest pod to be fetched after conflict")
 		}
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR hardens the async scheduler Pod status patch path used when `SchedulerAsyncAPICalls` is enabled.

`PodStatusPatchCall` may execute with a stale Pod status snapshot. If the status patch is guarded by a resourceVersion and hits a conflict, retrying with the same base status/resourceVersion cannot make progress. This PR makes `PodStatusPatchCall` refresh the Pod after a conflict, verify the UID still matches, recompute the desired status patch from the latest status, and retry from that refreshed base.

This only affects the async API-cacher path:

`framework.APICacher().PatchPodStatus(...) -> PodStatusPatchCall.Execute`

It is intended as defensive handling for async Pod status patch conflicts, for example status updates to `PodScheduled` or `status.nominatedNodeName` issued through `APICacher`.

This PR is not claiming to fix #140098. After re-checking the listed integration flakes, those failures appear to come from the synchronous `handleSchedulingFailure -> updatePod -> util.PatchPodStatus` path. #140177 is the more targeted fix for that regression.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This was initially motivated by scheduler integration flakes with Pod status update conflicts, but those specific flakes do not appear to exercise the async `PodStatusPatchCall` path. I have re-scoped this PR to async API-cacher hardening only.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
