### PR TITLE
storage: migrate CSIDriver volumeLifecycleModes to declarative validation

### DIFF
--- a/pkg/apis/storage/v1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1/zz_generated.validations.go
@@ -165,7 +165,80 @@ func Validate_CSIDriver(
 		errs = append(errs, fn(fldPath.Child("metadata"), &obj.ObjectMeta, oldVal, oldObj != nil)...)
 	}
 
-	// field storagev1.CSIDriver.Spec has no validation
+	{ // field storagev1.CSIDriver.Spec
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *storagev1.CSIDriverSpec,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_CSIDriverSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *storagev1.CSIDriver) *storagev1.CSIDriverSpec {
+				return &oldObj.Spec
+			})
+		errs = append(errs, fn(fldPath.Child("spec"), &obj.Spec, oldVal, oldObj != nil)...)
+	}
+
+	return errs
+}
+
+// Validate_CSIDriverSpec validates an instance of CSIDriverSpec according
+// to declarative validation rules in the API schema.
+func Validate_CSIDriverSpec(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *storagev1.CSIDriverSpec) (errs field.ErrorList) {
+
+	// field storagev1.CSIDriverSpec.AttachRequired has no validation
+	// field storagev1.CSIDriverSpec.PodInfoOnMount has no validation
+
+	{ // field storagev1.CSIDriverSpec.VolumeLifecycleModes
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj []storagev1.VolumeLifecycleMode,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *storagev1.CSIDriverSpec) []storagev1.VolumeLifecycleMode {
+				return oldObj.VolumeLifecycleModes
+			})
+		errs = append(errs, fn(fldPath.Child("volumeLifecycleModes"), obj.VolumeLifecycleModes, oldVal, oldObj != nil)...)
+	}
+
+	// field storagev1.CSIDriverSpec.StorageCapacity has no validation
+	// field storagev1.CSIDriverSpec.FSGroupPolicy has no validation
+	// field storagev1.CSIDriverSpec.TokenRequests has no validation
+	// field storagev1.CSIDriverSpec.RequiresRepublish has no validation
+	// field storagev1.CSIDriverSpec.SELinuxMount has no validation
+	// field storagev1.CSIDriverSpec.NodeAllocatableUpdatePeriodSeconds has no validation
+	// field storagev1.CSIDriverSpec.ServiceAccountTokenInSecrets has no validation
+	// field storagev1.CSIDriverSpec.PreventPodSchedulingIfMissing has no validation
 	return errs
 }
 

--- a/pkg/apis/storage/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1beta1/zz_generated.validations.go
@@ -165,7 +165,80 @@ func Validate_CSIDriver(
 		errs = append(errs, fn(fldPath.Child("metadata"), &obj.ObjectMeta, oldVal, oldObj != nil)...)
 	}
 
-	// field storagev1beta1.CSIDriver.Spec has no validation
+	{ // field storagev1beta1.CSIDriver.Spec
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *storagev1beta1.CSIDriverSpec,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_CSIDriverSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *storagev1beta1.CSIDriver) *storagev1beta1.CSIDriverSpec {
+				return &oldObj.Spec
+			})
+		errs = append(errs, fn(fldPath.Child("spec"), &obj.Spec, oldVal, oldObj != nil)...)
+	}
+
+	return errs
+}
+
+// Validate_CSIDriverSpec validates an instance of CSIDriverSpec according
+// to declarative validation rules in the API schema.
+func Validate_CSIDriverSpec(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *storagev1beta1.CSIDriverSpec) (errs field.ErrorList) {
+
+	// field storagev1beta1.CSIDriverSpec.AttachRequired has no validation
+	// field storagev1beta1.CSIDriverSpec.PodInfoOnMount has no validation
+
+	{ // field storagev1beta1.CSIDriverSpec.VolumeLifecycleModes
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj []storagev1beta1.VolumeLifecycleMode,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *storagev1beta1.CSIDriverSpec) []storagev1beta1.VolumeLifecycleMode {
+				return oldObj.VolumeLifecycleModes
+			})
+		errs = append(errs, fn(fldPath.Child("volumeLifecycleModes"), obj.VolumeLifecycleModes, oldVal, oldObj != nil)...)
+	}
+
+	// field storagev1beta1.CSIDriverSpec.StorageCapacity has no validation
+	// field storagev1beta1.CSIDriverSpec.FSGroupPolicy has no validation
+	// field storagev1beta1.CSIDriverSpec.TokenRequests has no validation
+	// field storagev1beta1.CSIDriverSpec.RequiresRepublish has no validation
+	// field storagev1beta1.CSIDriverSpec.SELinuxMount has no validation
+	// field storagev1beta1.CSIDriverSpec.NodeAllocatableUpdatePeriodSeconds has no validation
+	// field storagev1beta1.CSIDriverSpec.ServiceAccountTokenInSecrets has no validation
+	// field storagev1beta1.CSIDriverSpec.PreventPodSchedulingIfMissing has no validation
 	return errs
 }
 

--- a/pkg/apis/storage/validation/validation.go
+++ b/pkg/apis/storage/validation/validation.go
@@ -401,7 +401,7 @@ func ValidateCSIDriverUpdate(new, old *storage.CSIDriver) field.ErrorList {
 
 	// immutable fields should not be mutated.
 	allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(new.Spec.AttachRequired, old.Spec.AttachRequired, field.NewPath("spec", "attachedRequired"))...)
-	allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(new.Spec.VolumeLifecycleModes, old.Spec.VolumeLifecycleModes, field.NewPath("spec", "volumeLifecycleModes"))...)
+	allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(new.Spec.VolumeLifecycleModes, old.Spec.VolumeLifecycleModes, field.NewPath("spec", "volumeLifecycleModes")).WithOrigin("immutable").MarkCoveredByDeclarative()...)
 
 	return allErrs
 }

--- a/staging/src/k8s.io/api/storage/v1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1/generated.proto
@@ -124,6 +124,8 @@ message CSIDriverSpec {
   //
   // +optional
   // +listType=set
+  // +k8s:alpha(since: "1.37")=+k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:immutable
   repeated string volumeLifecycleModes = 3;
 
   // storageCapacity indicates that the CSI volume driver wants pod scheduling to consider the storage

--- a/staging/src/k8s.io/api/storage/v1/types.go
+++ b/staging/src/k8s.io/api/storage/v1/types.go
@@ -358,6 +358,8 @@ type CSIDriverSpec struct {
 	//
 	// +optional
 	// +listType=set
+	// +k8s:alpha(since: "1.37")=+k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:immutable
 	VolumeLifecycleModes []VolumeLifecycleMode `json:"volumeLifecycleModes,omitempty" protobuf:"bytes,3,opt,name=volumeLifecycleModes"`
 
 	// storageCapacity indicates that the CSI volume driver wants pod scheduling to consider the storage

--- a/staging/src/k8s.io/api/storage/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1beta1/generated.proto
@@ -127,6 +127,8 @@ message CSIDriverSpec {
   //
   // +optional
   // +listType=atomic
+  // +k8s:alpha(since: "1.37")=+k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:immutable
   repeated string volumeLifecycleModes = 3;
 
   // storageCapacity indicates that the CSI volume driver wants pod scheduling to consider the storage

--- a/staging/src/k8s.io/api/storage/v1beta1/types.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/types.go
@@ -372,6 +372,8 @@ type CSIDriverSpec struct {
 	//
 	// +optional
 	// +listType=atomic
+	// +k8s:alpha(since: "1.37")=+k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:immutable
 	VolumeLifecycleModes []VolumeLifecycleMode `json:"volumeLifecycleModes,omitempty" protobuf:"bytes,3,opt,name=volumeLifecycleModes"`
 
 	// storageCapacity indicates that the CSI volume driver wants pod scheduling to consider the storage

--- a/test/declarative_validation/storage/csidriver/declarative_validation_test.go
+++ b/test/declarative_validation/storage/csidriver/declarative_validation_test.go
@@ -20,7 +20,9 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	storage "k8s.io/kubernetes/pkg/apis/storage"
 	registry "k8s.io/kubernetes/pkg/registry/storage/csidriver"
 	"k8s.io/kubernetes/test/declarative_validation/meta"
@@ -67,6 +69,45 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 		Verb:              "update",
 	})
 
+	testCases := map[string]struct {
+		oldObj       storage.CSIDriver
+		updateObj    storage.CSIDriver
+		expectedErrs field.ErrorList
+	}{
+		"valid update": {
+			oldObj:    mkCSIDriver(),
+			updateObj: mkCSIDriver(),
+		},
+		"invalid update volumeLifecycleModes changed": {
+			oldObj:    mkCSIDriver(TweakVolumeLifecycleModes(storage.VolumeLifecyclePersistent)),
+			updateObj: mkCSIDriver(TweakVolumeLifecycleModes(storage.VolumeLifecycleEphemeral)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "volumeLifecycleModes"), nil, "").WithOrigin("immutable").MarkAlpha(),
+			},
+		},
+		"invalid update volumeLifecycleModes unset to set": {
+			oldObj:    mkCSIDriver(),
+			updateObj: mkCSIDriver(TweakVolumeLifecycleModes(storage.VolumeLifecyclePersistent)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "volumeLifecycleModes"), nil, "").WithOrigin("immutable").MarkAlpha(),
+			},
+		},
+		"invalid update volumeLifecycleModes set to unset": {
+			oldObj:    mkCSIDriver(TweakVolumeLifecycleModes(storage.VolumeLifecyclePersistent)),
+			updateObj: mkCSIDriver(),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "volumeLifecycleModes"), nil, "").WithOrigin("immutable").MarkAlpha(),
+			},
+		},
+	}
+	for k, tc := range testCases {
+		t.Run(k, func(t *testing.T) {
+			tc.oldObj.ResourceVersion = "1"
+			tc.updateObj.ResourceVersion = "2"
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, registry.Strategy, tc.expectedErrs)
+		})
+	}
+
 	updateObj := mkCSIDriver()
 	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
@@ -88,4 +129,10 @@ func mkCSIDriver(tweaks ...func(csi *storage.CSIDriver)) storage.CSIDriver {
 		tweak(&csi)
 	}
 	return csi
+}
+
+func TweakVolumeLifecycleModes(modes ...storage.VolumeLifecycleMode) func(csi *storage.CSIDriver) {
+	return func(csi *storage.CSIDriver) {
+		csi.Spec.VolumeLifecycleModes = modes
+	}
 }

--- a/test/declarative_validation/storage/csidriver/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storage/csidriver/zz_generated.validations.v1_test.go
@@ -37,6 +37,9 @@ func init() {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
 			},
+			"spec.volumeLifecycleModes": {
+				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
+			},
 		},
 	)
 }

--- a/test/declarative_validation/storage/csidriver/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storage/csidriver/zz_generated.validations.v1beta1_test.go
@@ -37,6 +37,9 @@ func init() {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
 			},
+			"spec.volumeLifecycleModes": {
+				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
+			},
 		},
 	)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`CSIDriver.spec.volumeLifecycleModes` is an immutable field, currently
enforced by a hand-written `ValidateImmutableField` call in
`ValidateCSIDriverUpdate`. This migrates that rule to declarative
validation as part of KEP-5073: it adds the `+k8s:immutable` marker
(alpha since 1.37) to the `storage/v1` and `storage/v1beta1` types and
marks the hand-written check as covered by declarative validation.

There is no behavior change — the generated declarative validation is
equivalent to the existing hand-written check, which the parity tests in
`test/declarative_validation/storage/csidriver` assert directly
(changed / unset→set / set→unset).

The generated code (`zz_generated.validations.go`, proto, and the
coverage test files) is produced by `hack/update-codegen.sh` and kept in
a separate commit.

#### Which issue(s) this PR fixes:

Part of #136785

#### Special notes for your reviewers:

Scoped to `volumeLifecycleModes` only. The sibling immutable field
`spec.attachRequired` is intentionally left out: its hand-written check
uses the path `spec.attachedRequired` (a typo vs. the JSON name) and it
is validated as required despite being `+optional`, so migrating it would
be a behavior change better handled in a separate PR.

/sig storage
/sig api-machinery
/cc @aaron-prindle @yongruilin

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
