### PR TITLE
DRA resourceslice controller: fix update after quick delete

### DIFF
--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -701,6 +701,15 @@ func (ec *Controller) enqueueResourceClaim(logger klog.Logger, oldObj, newObj in
 	if claim == nil {
 		claim = oldClaim
 	}
+
+	// Inform the mutation cache before triggering sync operations (via enqueue
+	// below) so that syncs observe a current view of the claim.
+	if deleted {
+		ec.claimCache.OnDelete(claim)
+	} else {
+		ec.claimCache.OnAddOrUpdate(claim)
+	}
+
 	if !deleted {
 		// When starting up, we have to check all claims to find those with
 		// stale pods in ReservedFor. During an update, a pod might get added

--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -869,6 +869,76 @@ func TestSyncHandler(t *testing.T) {
 	}
 }
 
+// TestControllerCreateDeleteRecreate verifies that a ResourceClaim which is
+// deleted immediately after being created by the controller gets recreated on
+// the next sync. Without the OnDelete call in enqueueResourceClaim the
+// MutationCache keeps the stale "just-created" entry for up to its TTL
+// (one hour), causing findPodResourceClaim to return it and skipping the
+// recreate for that entire duration.
+func TestControllerCreateDeleteRecreate(t *testing.T) {
+	ktesting.Init(t).SyncTest("", testControllerCreateDeleteRecreate)
+}
+func testControllerCreateDeleteRecreate(tCtx ktesting.TContext) {
+	setupMetrics()
+
+	fakeKubeClient := createTestClient(testPodWithResource, template)
+	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
+	podInformer := informerFactory.Core().V1().Pods()
+	podGroupInformer := informerFactory.Scheduling().V1alpha3().PodGroups()
+	claimInformer := informerFactory.Resource().V1().ResourceClaims()
+	templateInformer := informerFactory.Resource().V1().ResourceClaimTemplates()
+
+	ec, err := NewController(tCtx.Logger(), Features{}, fakeKubeClient, podInformer, podGroupInformer, claimInformer, templateInformer)
+	tCtx.ExpectNoError(err, "creating controller")
+	tCtx.Cleanup(ec.queue.ShutDown)
+
+	informerFactory.Start(tCtx.Done())
+	tCtx.Cleanup(func() {
+		tCtx.Cancel("stopping informers")
+		informerFactory.Shutdown()
+	})
+
+	// Let informer goroutines process the initial list so the cache is warm.
+	tCtx.Wait()
+
+	// First sync: finds no existing claim, creates one, stores it in the
+	// mutation cache via claimCache.Mutation.
+	tCtx.ExpectNoError(ec.syncHandler(tCtx, podKey(testPodWithResource)))
+
+	claims, err := fakeKubeClient.ResourceV1().ResourceClaims(testNamespace).List(tCtx, metav1.ListOptions{})
+	tCtx.ExpectNoError(err)
+	if len(claims.Items) != 1 {
+		tCtx.Fatalf("expected 1 claim after first sync, got %d", len(claims.Items))
+	}
+	createdClaimName := claims.Items[0].Name
+
+	// Simulate an unexpected deletion (e.g. the claim was removed by an
+	// admin or a race between controller and GC).
+	tCtx.ExpectNoError(fakeKubeClient.ResourceV1().ResourceClaims(testNamespace).Delete(tCtx, createdClaimName, metav1.DeleteOptions{}))
+
+	// Wait for the informer goroutines to process the watch event and call
+	// enqueueResourceClaim with deleted=true. That call must invoke
+	// claimCache.OnDelete to clear the stale mutation — the code path under test.
+	tCtx.Wait()
+
+	// The mutation cache must be clear now.
+	mutClaims, err := ec.claimCache.ByIndex(claimPodOwnerIndex, string(testPodWithResource.UID))
+	tCtx.ExpectNoError(err)
+	if len(mutClaims) != 0 {
+		tCtx.Fatalf("expected empty mutation cache after delete, got %d entries", len(mutClaims))
+	}
+
+	// Second sync: must create a new claim because the mutation cache no
+	// longer holds the stale entry for the deleted claim.
+	tCtx.ExpectNoError(ec.syncHandler(tCtx, podKey(testPodWithResource)))
+
+	claims, err = fakeKubeClient.ResourceV1().ResourceClaims(testNamespace).List(tCtx, metav1.ListOptions{})
+	tCtx.ExpectNoError(err)
+	if len(claims.Items) != 1 {
+		tCtx.Fatalf("expected 1 claim after second sync (recreate), got %d", len(claims.Items))
+	}
+}
+
 func TestResourceClaimTemplateEventHandler(t *testing.T) {
 	tCtx := ktesting.Init(t)
 

--- a/staging/src/k8s.io/client-go/CHANGELOG.md
+++ b/staging/src/k8s.io/client-go/CHANGELOG.md
@@ -4,6 +4,23 @@ Go API changes are typically not included in the Kubernetes release notes, so
 noteworthy Go API changes *may* be documented here. This is currently not
 *required*, so consult the git history to see all changes.
 
+### mutation cache: support informer events
+
+Calling OnAddOrUpdate and OnDelete from event handlers is optional. Calling
+them has the advantage that the mutation cache is updated sooner. It also fixes
+incorrectly reporting a locally updated item when a) using "include adds" and
+b) the updated item got deleted in the apiserver and informer cache.
+
+Although formally a Go API break because the MutationCache interface gets
+extended, in practice that interface is expected to have only the single
+implementation in client-go itself, so no-one should be affected by this.
+
+```
+- ./tools/cache.MutationCache.OnAddOrUpdate: added
+- ./tools/cache.MutationCache.OnDelete: added
+- ./tools/cache.MutationCache.internal: added unexported method
+```
+
 ### restmapper + discovery: add context-aware APIs
 
 See [PR #129109](https://github.com/kubernetes/kubernetes/pull/129109).

--- a/staging/src/k8s.io/client-go/tools/cache/mutation_cache.go
+++ b/staging/src/k8s.io/client-go/tools/cache/mutation_cache.go
@@ -25,7 +25,10 @@ import (
 	"k8s.io/klog/v2"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	utilcache "k8s.io/apimachinery/pkg/util/cache"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -35,11 +38,14 @@ import (
 // that can be used to provide a more current view of a requested object.  It requires interpreting
 // resourceVersions for comparisons.
 // Implementations must be thread-safe.
-// TODO find a way to layer this into an informer/lister
+// OnAddOrupdate and OnDelete should be called from informer event handlers to increase
+// the accuracy of the cache.
 type MutationCache interface {
 	GetByKey(key string) (interface{}, bool, error)
 	ByIndex(indexName, indexKey string) ([]interface{}, error)
 	Mutation(interface{})
+	OnAddOrUpdate(obj runtime.Object)
+	OnDelete(obj runtime.Object)
 }
 
 // ResourceVersionComparator is able to compare object versions.
@@ -60,6 +66,21 @@ type ResourceVersionComparator interface {
 // If includeAdds is true, objects in the mutation cache will be returned even if they don't exist
 // in the underlying store. This is only safe if your use of the cache can handle mutation entries
 // remaining in the cache for up to ttl when mutations and deletes occur very closely in time.
+//
+// Note that this also applies to objects updated by the caller, not just
+// objects added by it.  That's because the MutationCache may hold an updated
+// object at a time when the underlying store already removed it because it was
+// deleted in the apiserver after the update. To address this, the caller
+// can call OnAddOrUpdate and OnDelete from informer event handlers.
+//
+// This informs the MutationCache about all changes observed by the store
+// and enables it to remove a locally added or updated object immediately once
+// it appears in the store, which prevents the "stale updated object" problem.
+//
+// This does not solve the "stale added object" problem reliably because
+// the informer might never see the added object when the add is followed
+// quickly by a delete. The caller has to handle stale added objects by
+// checking whether they still exist once the TTL is over.
 func NewIntegerResourceVersionMutationCache(logger klog.Logger, backingCache Store, indexer Indexer, ttl time.Duration, includeAdds bool) MutationCache {
 	return &mutationCache{
 		backingCache:  backingCache,
@@ -108,11 +129,24 @@ func (c *mutationCache) GetByKey(key string) (interface{}, bool, error) {
 		if !exists {
 			return nil, false, nil
 		}
+		// Don't return the tombstone.
+		if _, ok := obj.(*tombstone); ok {
+			return nil, false, nil
+		}
 	}
 	objRuntime, ok := obj.(runtime.Object)
 	if !ok {
 		return obj, true, nil
 	}
+	// If the object is from the store,
+	// then this will remove the obsolete tombstone.
+	//
+	// The newer object can never be the tombstone
+	// because a) we don't get here if only the tombstone
+	// exists (early return above) and b) the store's
+	// object must be more recent than the tombstone
+	// (the tombstone was created by an earlier store
+	// deletion).
 	return c.newerObject(key, objRuntime), true, nil
 }
 
@@ -155,6 +189,9 @@ func (c *mutationCache) ByIndex(name string, indexKey string) ([]interface{}, er
 				continue
 			}
 			if keySet.Has(key.(string)) {
+				continue
+			}
+			if _, ok := updated.(*tombstone); ok {
 				continue
 			}
 			elements, err := fn(updated)
@@ -213,13 +250,110 @@ func (c *mutationCache) Mutation(obj interface{}) {
 	if objRuntime, ok := obj.(runtime.Object); ok {
 		if mutatedObj, exists := c.mutationCache.Get(key); exists {
 			if mutatedObjRuntime, ok := mutatedObj.(runtime.Object); ok {
-				if c.comparator.CompareResourceVersion(objRuntime, mutatedObjRuntime) < 0 {
+				cmp := c.comparator.CompareResourceVersion(objRuntime, mutatedObjRuntime)
+				if cmp < 0 {
 					return
+				}
+				if t, ok := mutatedObj.(*tombstone); ok {
+					if cmp == 0 {
+						// Exactly this object instance is known to be deleted.
+						// Don't store it, keep the tombstone.
+						return
+					}
+					objMeta, err := meta.Accessor(obj)
+					if err == nil && t.GetUID() == objMeta.GetUID() {
+						// Some other revision of this object instance
+						// is known to be deleted. Also don't store it.
+						return
+					}
 				}
 			}
 		}
 	}
 	c.mutationCache.Add(key, obj, c.ttl)
+}
+
+// OnAddOrUpdate can be called to informer the cache about an object added to
+// the store or updated in in. If the object is as recent as the cached object
+// or newer, the cached object gets removed because it is no longer
+// needed. This keeps the cache smaller.
+func (c *mutationCache) OnAddOrUpdate(obj runtime.Object) {
+	key, err := DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		// this is a "nice to have", so failures shouldn't do anything weird
+		utilruntime.HandleErrorWithLogger(c.logger, err, "DeletionHandlingMetaNamespaceKeyFunc")
+		return
+	}
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if mutatedObj, exists := c.mutationCache.Get(key); exists {
+		if mutatedObj, ok := mutatedObj.(runtime.Object); ok {
+			// No need to compare the UID here: resource versions can be compared
+			// between different instances. If it's newer or equal, then the mutation
+			// cache is out-dated.
+			if c.comparator.CompareResourceVersion(obj, mutatedObj) >= 0 {
+				c.mutationCache.Remove(key)
+			}
+		}
+	}
+}
+
+// OnDelete can be called to informer the cache about an object deleted in the store.
+// If there is a cached object with the same UID or an older RV, it gets removed.
+func (c *mutationCache) OnDelete(obj runtime.Object) {
+	objMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return
+	}
+
+	key, err := DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		// this is a "nice to have", so failures shouldn't do anything weird
+		utilruntime.HandleErrorWithLogger(c.logger, err, "DeletionHandlingMetaNamespaceKeyFunc")
+		return
+	}
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if mutatedObj, exists := c.mutationCache.Get(key); exists {
+		if mutatedObj, ok := mutatedObj.(runtime.Object); ok {
+			mutatedObjMeta, err := meta.Accessor(mutatedObj)
+			if err != nil {
+				return
+			}
+			// If the deleted object is known to be more recent than the
+			// mutated one, then the mutated one must have been removed
+			// because resource versions are incremented by type, not by
+			// object instance.
+			//
+			// If the UID matches, then we can also be sure that it got
+			// removed.
+			//
+			// If neither of this is true, then the caller has added
+			// a mutated object that may or may not still exist. They
+			// have to check after the TTL.
+			if c.comparator.CompareResourceVersion(obj, mutatedObj) >= 0 ||
+				mutatedObjMeta.GetUID() == objMeta.GetUID() {
+				c.mutationCache.Remove(key)
+			} else {
+				return
+			}
+		}
+	}
+
+	// Store a tombstone object in the mutation cache.
+	// A future Mutation call is outdated if it has a RV
+	// which is lower or equal or has the same UID.
+	t := &tombstone{
+		namespace: objMeta.GetNamespace(),
+		name:      objMeta.GetName(),
+		uid:       objMeta.GetUID(),
+		rv:        objMeta.GetResourceVersion(),
+	}
+	c.mutationCache.Add(key, t, c.ttl)
 }
 
 // etcdObjectVersioner implements versioning and extracting etcd node information
@@ -261,4 +395,58 @@ func (a etcdObjectVersioner) CompareResourceVersion(lhs, rhs runtime.Object) int
 	}
 
 	return 1
+}
+
+// tombstone is a replacement for a deleted object. It has the same key as it
+// and the ResourceVersion at which the deletion was detected.
+//
+// It implements GetName, GetNamespace, GetResourceVersion and GetUID and thus
+// the code above can compare it against other, normal objects. The difference
+// is that it never gets returned by ByIndex or GetByKey.
+type tombstone struct {
+	namespace, name, rv string
+	uid                 types.UID
+}
+
+var _ metav1.Object = &tombstone{}
+var _ runtime.Object = &tombstone{}
+
+func (t *tombstone) DeepCopyObject() runtime.Object {
+	clone := *t
+	return &clone
+}
+
+func (t *tombstone) GetObjectKind() schema.ObjectKind { panic("not implemented") }
+
+func (t *tombstone) GetNamespace() string                          { return t.namespace }
+func (t *tombstone) SetNamespace(namespace string)                 { panic("not implemented") }
+func (t *tombstone) GetName() string                               { return t.name }
+func (t *tombstone) SetName(name string)                           { panic("not implemented") }
+func (t *tombstone) GetGenerateName() string                       { panic("not implemented") }
+func (t *tombstone) SetGenerateName(name string)                   { panic("not implemented") }
+func (t *tombstone) GetUID() types.UID                             { return t.uid }
+func (t *tombstone) SetUID(uid types.UID)                          { panic("not implemented") }
+func (t *tombstone) GetResourceVersion() string                    { return t.rv }
+func (t *tombstone) SetResourceVersion(version string)             { panic("not implemented") }
+func (t *tombstone) GetGeneration() int64                          { panic("not implemented") }
+func (t *tombstone) SetGeneration(generation int64)                { panic("not implemented") }
+func (t *tombstone) GetSelfLink() string                           { panic("not implemented") }
+func (t *tombstone) SetSelfLink(selfLink string)                   { panic("not implemented") }
+func (t *tombstone) GetCreationTimestamp() metav1.Time             { panic("not implemented") }
+func (t *tombstone) SetCreationTimestamp(timestamp metav1.Time)    { panic("not implemented") }
+func (t *tombstone) GetDeletionTimestamp() *metav1.Time            { panic("not implemented") }
+func (t *tombstone) SetDeletionTimestamp(timestamp *metav1.Time)   { panic("not implemented") }
+func (t *tombstone) GetDeletionGracePeriodSeconds() *int64         { panic("not implemented") }
+func (t *tombstone) SetDeletionGracePeriodSeconds(*int64)          { panic("not implemented") }
+func (t *tombstone) GetLabels() map[string]string                  { panic("not implemented") }
+func (t *tombstone) SetLabels(labels map[string]string)            { panic("not implemented") }
+func (t *tombstone) GetAnnotations() map[string]string             { panic("not implemented") }
+func (t *tombstone) SetAnnotations(annotations map[string]string)  { panic("not implemented") }
+func (t *tombstone) GetFinalizers() []string                       { panic("not implemented") }
+func (t *tombstone) SetFinalizers(finalizers []string)             { panic("not implemented") }
+func (t *tombstone) GetOwnerReferences() []metav1.OwnerReference   { panic("not implemented") }
+func (t *tombstone) SetOwnerReferences([]metav1.OwnerReference)    { panic("not implemented") }
+func (t *tombstone) GetManagedFields() []metav1.ManagedFieldsEntry { panic("not implemented") }
+func (t *tombstone) SetManagedFields(managedFields []metav1.ManagedFieldsEntry) {
+	panic("not implemented")
 }

--- a/staging/src/k8s.io/client-go/tools/cache/mutation_cache.go
+++ b/staging/src/k8s.io/client-go/tools/cache/mutation_cache.go
@@ -46,6 +46,11 @@ type MutationCache interface {
 	Mutation(interface{})
 	OnAddOrUpdate(obj runtime.Object)
 	OnDelete(obj runtime.Object)
+
+	// This interface is not meant to be implemented elsewhere.
+	// Marking it as internal enables future changes without
+	// triggering apidiff.
+	internal()
 }
 
 // ResourceVersionComparator is able to compare object versions.
@@ -355,6 +360,8 @@ func (c *mutationCache) OnDelete(obj runtime.Object) {
 	}
 	c.mutationCache.Add(key, t, c.ttl)
 }
+
+func (c *mutationCache) internal() {}
 
 // etcdObjectVersioner implements versioning and extracting etcd node information
 // for objects that have an embedded ObjectMeta or ListMeta field.

--- a/staging/src/k8s.io/client-go/tools/cache/mutation_cache_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/mutation_cache_test.go
@@ -1,0 +1,247 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+)
+
+func makeMutationTestPod(name string, uid types.UID, rv string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			UID:             uid,
+			ResourceVersion: rv,
+		},
+	}
+}
+
+func TestMutationCacheOnAddOrUpdate(t *testing.T) {
+	tests := map[string]struct {
+		mutationRV  string
+		storeUID    types.UID // UID passed to OnAddOrUpdate
+		storeRV     string    // RV passed to OnAddOrUpdate
+		wantCleared bool
+	}{
+		"equal-rv-clears": {
+			mutationRV:  "2",
+			storeUID:    "uid-1",
+			storeRV:     "2",
+			wantCleared: true,
+		},
+		"newer-store-clears": {
+			mutationRV:  "2",
+			storeUID:    "uid-1",
+			storeRV:     "3",
+			wantCleared: true,
+		},
+		"older-store-keeps": {
+			mutationRV:  "2",
+			storeUID:    "uid-1",
+			storeRV:     "1",
+			wantCleared: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			store := NewStore(MetaNamespaceKeyFunc)
+			indexer := NewIndexer(MetaNamespaceKeyFunc, Indexers{})
+			mc := NewIntegerResourceVersionMutationCache(klog.Background(), store, indexer, time.Minute, false)
+
+			mutated := makeMutationTestPod("pod", "uid-1", tc.mutationRV)
+			mc.Mutation(mutated)
+
+			mc.OnAddOrUpdate(makeMutationTestPod("pod", tc.storeUID, tc.storeRV))
+
+			// Add the pod to the backing store at RV "1" (always older than the
+			// mutation's RV "2"), so we can tell whether GetByKey returns the
+			// mutation or the backing copy.
+			require.NoError(t, store.Add(makeMutationTestPod("pod", "uid-1", "1")))
+
+			got, exists, err := mc.GetByKey("pod")
+			require.NoError(t, err)
+			require.True(t, exists)
+
+			gotRV := got.(*v1.Pod).ResourceVersion
+			if tc.wantCleared {
+				assert.Equal(t, "1", gotRV, "backing store version expected after mutation cleared")
+			} else {
+				assert.Equal(t, tc.mutationRV, gotRV, "mutation version expected")
+			}
+		})
+	}
+}
+
+// TestMutationCacheOnDelete checks the behavior of OnDelete
+// when invoked after Mutation.
+func TestMutationCacheOnDelete(t *testing.T) {
+	tests := map[string]struct {
+		deleteUID  types.UID
+		deleteRV   string
+		wantExists bool
+	}{
+		"old-rv-same-UID": {
+			deleteUID:  "uid-1",
+			deleteRV:   "1", // Could be from a stale object in DeletedFinalStateUnknown.
+			wantExists: false,
+		},
+		"new-rv-different-UID": {
+			deleteUID:  "uid-2",
+			deleteRV:   "3",
+			wantExists: false,
+		},
+		"old-rv-different-uid": {
+			deleteUID:  "uid-other",
+			deleteRV:   "1",
+			wantExists: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			store := NewStore(MetaNamespaceKeyFunc)
+			indexer := NewIndexer(MetaNamespaceKeyFunc, Indexers{})
+			mc := NewIntegerResourceVersionMutationCache(klog.Background(), store, indexer, time.Minute, true)
+
+			// Backing store has the pod at RV "2".
+			require.NoError(t, store.Add(makeMutationTestPod("pod", "uid-1", "2")))
+
+			// Mutation brings it to RV "3".
+			mc.Mutation(makeMutationTestPod("pod", "uid-1", "3"))
+			deletedPod := makeMutationTestPod("pod", tc.deleteUID, tc.deleteRV)
+			require.NoError(t, store.Delete(deletedPod))
+			mc.OnDelete(deletedPod)
+
+			_, exists, err := mc.GetByKey("pod")
+			require.NoError(t, err)
+			require.Equal(t, tc.wantExists, exists)
+		})
+	}
+}
+
+// TestMutationCacheUpdateConcurrentDelete checks the behavior when
+// Mutation is called after some informer events.
+func TestMutationCacheUpdateConcurrentDelete(t *testing.T) {
+	store := NewStore(MetaNamespaceKeyFunc)
+	indexer := NewIndexer(MetaNamespaceKeyFunc, Indexers{})
+	mc := NewIntegerResourceVersionMutationCache(klog.Background(), store, indexer, time.Hour, true)
+
+	// Backing store has the pod at RV "1".
+	require.NoError(t, store.Add(makeMutationTestPod("pod", "uid-1", "1")))
+
+	// Client starts an update leading to RV "2", which immediately gets
+	// deleted by some other client. That deletion is received before the
+	// client finishes its update.
+	updatedPod := makeMutationTestPod("pod", "uid-1", "2")
+	require.NoError(t, store.Update(updatedPod))
+	require.NoError(t, store.Delete(updatedPod))
+
+	// Informer events get delivered with a delay.
+	mc.OnAddOrUpdate(updatedPod)
+	mc.OnDelete(updatedPod)
+
+	// This Mutation call is stale, which gets detected because
+	// the mutation cache contains a tombstone object.
+	mc.Mutation(updatedPod)
+
+	_, exists, err := mc.GetByKey("pod")
+	require.NoError(t, err)
+	require.False(t, exists)
+	require.Equal(t, []any{"pod"}, mc.(*mutationCache).mutationCache.Keys())
+}
+
+// TestMutationCacheUpdateConcurrentRecreate checks the behavior when
+// Mutation is called after some informer events.
+func TestMutationCacheUpdateConcurrentRecreate(t *testing.T) {
+	store := NewStore(MetaNamespaceKeyFunc)
+	indexer := NewIndexer(MetaNamespaceKeyFunc, Indexers{})
+	mc := NewIntegerResourceVersionMutationCache(klog.Background(), store, indexer, time.Hour, true)
+
+	// Backing store has the pod at RV "1".
+	require.NoError(t, store.Add(makeMutationTestPod("pod", "uid-1", "1")))
+
+	// Client starts an update leading to RV "2", which immediately gets
+	// replaced by some other pod using the same name. Those changes are
+	// received before the client finishes its update.
+	updatedPod := makeMutationTestPod("pod", "uid-1", "2")
+	require.NoError(t, store.Update(updatedPod))
+	require.NoError(t, store.Delete(updatedPod))
+	replacementPod := makeMutationTestPod("pod", "uid-2", "3")
+	require.NoError(t, store.Add(replacementPod))
+
+	// Informer events get delivered with a delay.
+	mc.OnAddOrUpdate(updatedPod)
+	mc.OnDelete(updatedPod)
+	mc.OnAddOrUpdate(replacementPod)
+
+	// This Mutation call is stale, which gets detected because there is a more
+	// recent object in the store.
+	mc.Mutation(updatedPod)
+
+	got, exists, err := mc.GetByKey("pod")
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.Equal(t, replacementPod, got)
+	require.Empty(t, mc.(*mutationCache).mutationCache.Keys())
+}
+
+// TestMutationCacheOnDeleteClearsStaleMutation exercises the core bug that motivated
+// the OnDelete method: a mutation stored after an update must not survive once the
+// informer reports the object deleted.
+//
+// The scenario:
+//  1. The object is added by the caller (includeAdds=true) so mutation cache
+//     returns it even when the backing store is empty.
+//  2. The object is deleted on the server; the backing store is now empty.
+//  3. Without OnDelete the mutation would linger in the cache and ByIndex
+//     would still return it, preventing the caller from recreating it.
+func TestMutationCacheOnDeleteClearsStaleMutation(t *testing.T) {
+	store := NewStore(MetaNamespaceKeyFunc)
+	byNameIndex := "by-name"
+	indexer := NewIndexer(MetaNamespaceKeyFunc, Indexers{
+		byNameIndex: func(obj interface{}) ([]string, error) {
+			return []string{obj.(*v1.Pod).Name}, nil
+		},
+	})
+	mc := NewIntegerResourceVersionMutationCache(klog.Background(), store, indexer, time.Minute, true /* includeAdds */)
+
+	// Simulate an update: mutation cache holds the pod at RV "2" while the
+	// backing store is still empty (informer hasn't caught up yet).
+	mc.Mutation(makeMutationTestPod("pod", "uid-1", "2"))
+
+	items, err := mc.ByIndex(byNameIndex, "pod")
+	require.NoError(t, err)
+	assert.Len(t, items, 1, "mutation should be visible via ByIndex when backing store is empty")
+
+	// Informer reports the delete: OnDelete must clear the stale mutation so
+	// that the next ByIndex call returns nothing and lets the caller recreate
+	// the object.
+	mc.OnDelete(makeMutationTestPod("pod", "uid-1", "1"))
+
+	items, err = mc.ByIndex(byNameIndex, "pod")
+	require.NoError(t, err)
+	assert.Empty(t, items, "OnDelete must clear the mutation; ByIndex must return nothing")
+}

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
@@ -575,6 +575,7 @@ func (c *Controller) initInformer(ctx context.Context) error {
 				return
 			}
 			logger.V(5).Info("ResourceSlice add", "slice", klog.KObj(slice))
+			c.sliceStore.OnAddOrUpdate(slice)
 			c.queue.AddAfter(slice.Spec.Pool.Name, c.syncDelay)
 			logger.V(5).Info("Scheduled sync", "poolName", slice.Spec.Pool.Name, "at", time.Now().Add(c.syncDelay))
 		},
@@ -592,6 +593,7 @@ func (c *Controller) initInformer(ctx context.Context) error {
 			} else {
 				logger.V(5).Info("ResourceSlice update", "slice", klog.KObj(newSlice))
 			}
+			c.sliceStore.OnAddOrUpdate(newSlice)
 			c.queue.AddAfter(oldSlice.Spec.Pool.Name, c.syncDelay)
 			logger.V(5).Info("Scheduled sync", "pool", oldSlice.Spec.Pool.Name, "at", time.Now().Add(c.syncDelay))
 			if oldSlice.Spec.Pool.Name != newSlice.Spec.Pool.Name {
@@ -608,6 +610,7 @@ func (c *Controller) initInformer(ctx context.Context) error {
 				return
 			}
 			logger.V(5).Info("ResourceSlice delete", "slice", klog.KObj(slice))
+			c.sliceStore.OnDelete(slice)
 			c.queue.AddAfter(slice.Spec.Pool.Name, c.syncDelay)
 			logger.V(5).Info("Scheduled sync", "poolName", slice.Spec.Pool.Name, "at", time.Now().Add(c.syncDelay))
 		},

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller_test.go
@@ -1504,6 +1504,74 @@ func TestControllerSyncPool(t *testing.T) {
 	}
 }
 
+// TestControllerUpdateDeleteRecreate reproduces the bug where a ResourceSlice
+// that was updated by the controller (leaving a mutation in the MutationCache)
+// and then deleted on the apiserver was not being recreated.
+//
+// The root cause was that the MutationCache kept the stale updated object, so
+// the controller believed the slice still existed and skipped the create.
+// The fix calls OnDelete in the informer's delete event handler, which clears
+// the mutation before the work queue item is processed.
+func TestControllerUpdateDeleteRecreate(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+
+	const (
+		driverName = "driver"
+		poolName   = "pool"
+	)
+	generateName := encodeIndex(0, resourceSliceIndexMinLength) + "-" + driverName + "-"
+	sliceName := generateName + "0"
+
+	initialSlice := MakeResourceSlice().
+		Name(sliceName).
+		UID("original-uid").
+		GenerateName(generateName).
+		ResourceVersion("1").
+		Driver(driverName).
+		AllNodes(true).
+		Devices([]resourceapi.Device{newDevice("old-device")}).
+		Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).
+		Obj()
+
+	kubeClient := createTestClient(features{}, metav1.Time{}, initialSlice)
+	syncDelay := time.Duration(0)
+
+	ctrl, err := StartController(ctx, Options{
+		DriverName: driverName,
+		KubeClient: kubeClient,
+		Resources: &DriverResources{
+			Pools: map[string]Pool{
+				poolName: {
+					AllNodes:   true,
+					Generation: 1,
+					Slices:     []Slice{{Devices: []resourceapi.Device{newDevice("new-device")}}},
+				},
+			},
+		},
+		SyncDelay: &syncDelay,
+	})
+	require.NoError(t, err)
+	defer ctrl.Stop()
+
+	// Wait for the controller to update the initial slice to reflect the
+	// desired "new-device" state.
+	require.Eventually(t, func() bool {
+		return ctrl.GetStats().NumUpdates >= 1
+	}, 5*time.Second, 10*time.Millisecond, "controller should update the initial slice")
+
+	// Simulate what happens when the DRA driver restarts and kubelet deletes
+	// the slice before the driver can reclaim it.  The informer's delete
+	// handler calls OnDelete, which clears the stale mutation from the cache
+	// before the work-queue item is processed.  Without that call the
+	// MutationCache would serve the stale updated copy and syncPool would
+	// skip the necessary create.
+	require.NoError(t, kubeClient.ResourceV1().ResourceSlices().Delete(ctx, sliceName, metav1.DeleteOptions{}))
+
+	require.Eventually(t, func() bool {
+		return ctrl.GetStats().NumCreates >= 1
+	}, 5*time.Second, 10*time.Millisecond, "controller should recreate the deleted slice")
+}
+
 // TestControllerUpdateReconcilePoolWithNameValidation verifies that Update rejects
 // invalid pool sets when ReconcilePoolWithName is set
 func TestControllerUpdateReconcilePoolWithNameValidation(t *testing.T) {

--- a/test/integration/dra/core.go
+++ b/test/integration/dra/core.go
@@ -293,64 +293,67 @@ func testPublishResourceSlices(tCtx ktesting.TContext, haveLatestAPI bool, disab
 		}
 		disabledFeaturesBySlice[i] = disabledFeaturesForSlice
 	}
-	var expectedSlices []any
-	for _, spec := range expectedSliceSpecs {
-		// The matcher is precise and matches all fields, except for those few which are known to
-		// be not exactly as sent by the client. New fields have to be added when extending the API.
-		expectedSlices = append(expectedSlices, gomega.HaveField("Spec", gstruct.MatchAllFields(gstruct.Fields{
-			"Driver": gomega.Equal(driverName),
-			"Pool": gstruct.MatchAllFields(gstruct.Fields{
-				"Name":               gomega.Equal(poolName),
-				"Generation":         gomega.BeNumerically(">=", int64(1)),
-				"ResourceSliceCount": gomega.Equal(int64(len(expectedResources.Pools[poolName].Slices))),
-			}),
-			"NodeName":     matchPointer(spec.NodeName),
-			"NodeSelector": matchPointer(spec.NodeSelector),
-			"AllNodes":     gstruct.PointTo(gomega.BeTrue()),
-			"Devices": gomega.HaveExactElements(func() []any {
-				var expected []any
-				for _, device := range spec.Devices {
-					expected = append(expected, gstruct.MatchAllFields(gstruct.Fields{
-						"Name":                     gomega.Equal(device.Name),
-						"AllowMultipleAllocations": gomega.Equal(device.AllowMultipleAllocations),
-						"Attributes":               gomega.Equal(device.Attributes),
-						"Capacity":                 gomega.Equal(device.Capacity),
-						"ConsumesCounters":         gomega.Equal(device.ConsumesCounters),
-						"NodeName":                 matchPointer(device.NodeName),
-						"NodeSelector":             matchPointer(device.NodeSelector),
-						"AllNodes":                 matchPointer(device.AllNodes),
-						"Taints": gomega.HaveExactElements(func() []any {
-							var expected []any
-							for _, taint := range device.Taints {
-								if taint.TimeAdded != nil {
-									// Can do exact match.
-									expected = append(expected, gomega.Equal(taint))
-								} else {
-									// Ignore TimeAdded value.
-									expected = append(expected, gstruct.MatchAllFields(gstruct.Fields{
-										"Key":       gomega.Equal(taint.Key),
-										"Value":     gomega.Equal(taint.Value),
-										"Effect":    gomega.Equal(taint.Effect),
-										"TimeAdded": gomega.Not(gomega.BeNil()),
-									}))
+	expectedSlices := func(expectedSliceSpecs []resourceapi.ResourceSliceSpec) []any {
+		var expectedSlices []any
+		for _, spec := range expectedSliceSpecs {
+			// The matcher is precise and matches all fields, except for those few which are known to
+			// be not exactly as sent by the client. New fields have to be added when extending the API.
+			expectedSlices = append(expectedSlices, gomega.HaveField("Spec", gstruct.MatchAllFields(gstruct.Fields{
+				"Driver": gomega.Equal(driverName),
+				"Pool": gstruct.MatchAllFields(gstruct.Fields{
+					"Name":               gomega.Equal(poolName),
+					"Generation":         gomega.BeNumerically(">=", int64(1)),
+					"ResourceSliceCount": gomega.Equal(int64(len(expectedSliceSpecs))),
+				}),
+				"NodeName":     matchPointer(spec.NodeName),
+				"NodeSelector": matchPointer(spec.NodeSelector),
+				"AllNodes":     gstruct.PointTo(gomega.BeTrue()), //nolint:forbidigo // Here BeTrue is okay.
+				"Devices": gomega.HaveExactElements(func() []any {
+					var expected []any
+					for _, device := range spec.Devices {
+						expected = append(expected, gstruct.MatchAllFields(gstruct.Fields{
+							"Name":                     gomega.Equal(device.Name),
+							"AllowMultipleAllocations": gomega.Equal(device.AllowMultipleAllocations),
+							"Attributes":               gomega.Equal(device.Attributes),
+							"Capacity":                 gomega.Equal(device.Capacity),
+							"ConsumesCounters":         gomega.Equal(device.ConsumesCounters),
+							"NodeName":                 matchPointer(device.NodeName),
+							"NodeSelector":             matchPointer(device.NodeSelector),
+							"AllNodes":                 matchPointer(device.AllNodes),
+							"Taints": gomega.HaveExactElements(func() []any {
+								var expected []any
+								for _, taint := range device.Taints {
+									if taint.TimeAdded != nil {
+										// Can do exact match.
+										expected = append(expected, gomega.Equal(taint))
+									} else {
+										// Ignore TimeAdded value.
+										expected = append(expected, gstruct.MatchAllFields(gstruct.Fields{
+											"Key":       gomega.Equal(taint.Key),
+											"Value":     gomega.Equal(taint.Value),
+											"Effect":    gomega.Equal(taint.Effect),
+											"TimeAdded": gomega.Not(gomega.BeNil()),
+										}))
+									}
 								}
-							}
-							return expected
-						}()...),
-						"BindingConditions":               gomega.Equal(device.BindingConditions),
-						"BindingFailureConditions":        gomega.Equal(device.BindingFailureConditions),
-						"BindsToNode":                     gomega.Equal(device.BindsToNode),
-						"NodeAllocatableResourceMappings": gomega.Equal(device.NodeAllocatableResourceMappings),
-					}))
-				}
-				return expected
-			}()...),
-			"PerDeviceNodeSelection": matchPointer(spec.PerDeviceNodeSelection),
-			"SharedCounters":         gomega.Equal(spec.SharedCounters),
-		})))
+								return expected
+							}()...),
+							"BindingConditions":               gomega.Equal(device.BindingConditions),
+							"BindingFailureConditions":        gomega.Equal(device.BindingFailureConditions),
+							"BindsToNode":                     gomega.Equal(device.BindsToNode),
+							"NodeAllocatableResourceMappings": gomega.Equal(device.NodeAllocatableResourceMappings),
+						}))
+					}
+					return expected
+				}()...),
+				"PerDeviceNodeSelection": matchPointer(spec.PerDeviceNodeSelection),
+				"SharedCounters":         gomega.Equal(spec.SharedCounters),
+			})))
+		}
+		return expectedSlices
 	}
 
-	expectSlices := func(tCtx ktesting.TContext) {
+	expectSlices := func(tCtx ktesting.TContext, expectedSliceSpecs []resourceapi.ResourceSliceSpec) {
 		tCtx.Helper()
 
 		if !haveLatestAPI {
@@ -358,7 +361,7 @@ func testPublishResourceSlices(tCtx ktesting.TContext, haveLatestAPI bool, disab
 		}
 		slices, err := tCtx.Client().ResourceV1().ResourceSlices().List(tCtx, listDriverSlices)
 		tCtx.ExpectNoError(err, "list slices")
-		gomega.NewGomegaWithT(tCtx).Expect(slices.Items).Should(gomega.ConsistOf(expectedSlices...))
+		gomega.NewGomegaWithT(tCtx).Expect(slices.Items).Should(gomega.ConsistOf(expectedSlices(expectedSliceSpecs)...))
 	}
 
 	deleteSlices := func(tCtx ktesting.TContext) {
@@ -379,7 +382,7 @@ func testPublishResourceSlices(tCtx ktesting.TContext, haveLatestAPI bool, disab
 	var gotValidationError atomic.Bool
 	var validationErrorsOkay atomic.Bool
 
-	setup := func(tCtx ktesting.TContext) (*resourceslice.Controller, func(tCtx ktesting.TContext) resourceslice.Stats, resourceslice.Stats) {
+	setup := func(tCtx ktesting.TContext, resources *resourceslice.DriverResources) (*resourceslice.Controller, func(tCtx ktesting.TContext) resourceslice.Stats, resourceslice.Stats) {
 		tCtx.Helper()
 
 		tCtx.CleanupCtx(deleteSlices)
@@ -424,22 +427,26 @@ func testPublishResourceSlices(tCtx ktesting.TContext, haveLatestAPI bool, disab
 		tCtx.ExpectNoError(err, "start controller")
 		tCtx.Cleanup(controller.Stop)
 
+		numSlices := 0
+		for _, pool := range resources.Pools {
+			numSlices += len(pool.Slices)
+		}
 		expectedStats := resourceslice.Stats{
-			NumCreates: int64(len(expectedSlices)),
+			NumCreates: int64(numSlices),
 		}
 		getStats := func(tCtx ktesting.TContext) resourceslice.Stats {
 			return controller.GetStats()
 		}
-		tCtx.Eventually(getStats).WithTimeout(syncDelay + 5*time.Second).Should(gomega.Equal(expectedStats))
-		expectSlices(tCtx)
-
 		return controller, getStats, expectedStats
 	}
 
 	// Each sub-test starts with no slices and must clean up after itself.
 
 	runSubTest(tCtx, "create", func(tCtx ktesting.TContext) {
-		controller, getStats, expectedStats := setup(tCtx)
+		controller, getStats, expectedStats := setup(tCtx, resources)
+		tCtx.Eventually(getStats).WithTimeout(syncDelay + 5*time.Second).Should(gomega.Equal(expectedStats))
+		expectSlices(tCtx, expectedSliceSpecs)
+		tCtx.Consistently(getStats).WithTimeout(quiesencePeriod).Should(gomega.Equal(expectedStats))
 
 		// No further changes necessary.
 		tCtx.Consistently(getStats).WithTimeout(quiesencePeriod).Should(gomega.Equal(expectedStats))
@@ -467,7 +474,9 @@ func testPublishResourceSlices(tCtx ktesting.TContext, haveLatestAPI bool, disab
 	}
 
 	runSubTest(tCtx, "recreate-after-delete", func(tCtx ktesting.TContext) {
-		_, getStats, expectedStats := setup(tCtx)
+		_, getStats, expectedStats := setup(tCtx, resources)
+		tCtx.Eventually(getStats).WithTimeout(syncDelay + 5*time.Second).Should(gomega.Equal(expectedStats))
+		expectSlices(tCtx, expectedSliceSpecs)
 		tCtx.Consistently(getStats).WithTimeout(quiesencePeriod).Should(gomega.Equal(expectedStats))
 
 		// Stress the controller by repeatedly deleting the slices.
@@ -476,16 +485,19 @@ func testPublishResourceSlices(tCtx ktesting.TContext, haveLatestAPI bool, disab
 		for range 2 {
 			tCtx.Log("deleting ResourceSlices")
 			tCtx.ExpectNoError(tCtx.Client().ResourceV1().ResourceSlices().DeleteCollection(tCtx, metav1.DeleteOptions{}, listDriverSlices), "delete driver slices")
-			expectedStats.NumCreates += int64(len(expectedSlices))
+			expectedStats.NumCreates += int64(len(expectedSliceSpecs))
 			tCtx.Eventually(getStats).WithTimeout(syncDelay + 5*time.Second).Should(gomega.Equal(expectedStats))
-			expectSlices(tCtx)
+			expectSlices(tCtx, expectedSliceSpecs)
 		}
 	})
 
 	runSubTest(tCtx, "fix-after-update", func(tCtx ktesting.TContext) {
-		_, getStats, expectedStats := setup(tCtx)
+		_, getStats, expectedStats := setup(tCtx, resources)
+		tCtx.Eventually(getStats).WithTimeout(syncDelay + 5*time.Second).Should(gomega.Equal(expectedStats))
+		expectSlices(tCtx, expectedSliceSpecs)
+		tCtx.Consistently(getStats).WithTimeout(quiesencePeriod).Should(gomega.Equal(expectedStats))
 
-		// Stress the controller by repeatedly updatings the slices.
+		// Stress the controller by repeatedly updating the slices.
 		for range 2 {
 			slices, err := tCtx.Client().ResourceV1().ResourceSlices().List(tCtx, listDriverSlices)
 			tCtx.ExpectNoError(err, "list slices")
@@ -500,10 +512,63 @@ func testPublishResourceSlices(tCtx ktesting.TContext, haveLatestAPI bool, disab
 				_, err := tCtx.Client().ResourceV1().ResourceSlices().Update(tCtx, &slice, metav1.UpdateOptions{})
 				tCtx.ExpectNoError(err, "update slice")
 			}
-			expectedStats.NumUpdates += int64(len(expectedSlices))
+			expectedStats.NumUpdates += int64(len(expectedSliceSpecs))
 			tCtx.Eventually(getStats).WithTimeout(syncDelay + 5*time.Second).Should(gomega.Equal(expectedStats))
-			expectSlices(tCtx)
+			expectSlices(tCtx, expectedSliceSpecs)
 		}
+	})
+
+	runSubTest(tCtx, "recreate-after-update-delete", func(tCtx ktesting.TContext) {
+		// Simplify the test data: just one slice with a basic device.
+		resources := resources.DeepCopy()
+		pool := resources.Pools[poolName]
+		pool.Slices = pool.Slices[:1]
+		resources.Pools[poolName] = pool
+		expectedSliceSpecs := expectedSliceSpecs[:1]
+
+		// Create an incomplete ResourceSlice that the controller needs to update once it starts.
+		// This attribute is obsolete and needs to be removed.
+		device := expectedSliceSpecs[0].Devices[0].DeepCopy()
+		device.Attributes = map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+			"foo": {
+				StringValue: new("bar"),
+			},
+		}
+		slice := &resourceapi.ResourceSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "00000-" + namespace + "-slice",
+			},
+			Spec: resourceapi.ResourceSliceSpec{
+				Driver: driverName,
+				Pool: resourceapi.ResourcePool{
+					Name:               poolName,
+					Generation:         1,
+					ResourceSliceCount: 1,
+				},
+				AllNodes: new(true),
+				Devices:  []resourceapi.Device{*device},
+			},
+		}
+		slice, err := tCtx.Client().ResourceV1().ResourceSlices().Create(tCtx, slice, metav1.CreateOptions{})
+		tCtx.ExpectNoError(err, "create slice")
+		_, getStats, expectedStats := setup(tCtx, resources)
+		expectedStats.NumCreates = 0
+		expectedStats.NumUpdates = 1
+		tCtx.Eventually(getStats).WithTimeout(syncDelay + 5*time.Second).Should(gomega.Equal(expectedStats))
+		expectSlices(tCtx, expectedSliceSpecs)
+		tCtx.Consistently(getStats).WithTimeout(quiesencePeriod).Should(gomega.Equal(expectedStats))
+
+		// Verify that the existing slice got updated, then delete it.
+		slice, err = tCtx.Client().ResourceV1().ResourceSlices().Get(tCtx, slice.Name, metav1.GetOptions{})
+		tCtx.ExpectNoError(err, "get slice")
+		tCtx.Log("Deleting slice...")
+		err = tCtx.Client().ResourceV1().ResourceSlices().Delete(tCtx, slice.Name, metav1.DeleteOptions{})
+		tCtx.ExpectNoError(err, "delete slice")
+
+		// The controller must react to the deletion and recreate it.
+		expectedStats.NumCreates = 1
+		tCtx.Eventually(getStats).WithTimeout(syncDelay + 5*time.Second).Should(gomega.Equal(expectedStats))
+		expectSlices(tCtx, expectedSliceSpecs)
 	})
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When updating a ResourceSlice, a more recent copy than in the underlying store gets cached by the MutationCache. Then when that ResourceSlice gets deleted on the apiserver and then the store, the MutationCache kept the stale copy and returned it when the controller synced again, causing the controller to erroneously not recreate the deleted ResourceSlice.

Depending on timing, this could have happened while updating the DRA driver:
- Driver restarts, updating the existing ResourceSlices.
- kubelet deletes the slices before realizing that the driver is running again.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The fix is to address a long-standing TODO in the MutationCache: it needs to react to changes in the store. This allows it to drop cached objects sooner and let's it remove cached objects that are known to be deleted. Users of a MutationCache must inform the cache in their own informer event handlers *before* triggering sync operations.

This is a different approach than the one taken in https://github.com/kubernetes/kubernetes/pull/140011 where the staleness was detected via a timed resync. Such a timed resync is still needed after adding a ResourceSlice.

/assign @Lily922

This includes your integration test. The test also passed for me with current master, but that might have been just luck. We need a test which triggers the bug more reliably and of course also unit tests.

/cc @michaelasp 

This needs changes in client-go tooling.

#### Does this PR introduce a user-facing change?
```release-note
DRA drivers might not have re-created ResourcSlices that were deleted by someone else, depending on timing (driver updates, then someone else shortly afterwards deletes them).
```
