### PR TITLE
DRA: standardize mdevUUID attribute for virtualization workloads

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/attribute.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/attribute.go
@@ -37,6 +37,12 @@ const (
 	// referring to a PCI (Peripheral Component Interconnect) device.
 	// This attribute can be used to identify PCI devices.
 	StandardDeviceAttributePCIBusID resourceapi.QualifiedName = StandardDeviceAttributePrefix + "pciBusID"
+
+	// StandardDeviceAttributeMdevUUID is a standard device attribute name
+	// which describes the UUID of the mediated device (mdev) for virtualization workloads.
+	// The value is a string value representing a 128-bit UUID (e.g., "123e4567-e89b-12d3-a456-426614174000").
+	// This attribute can be used to identify mediated devices.
+	StandardDeviceAttributeMdevUUID resourceapi.QualifiedName = StandardDeviceAttributePrefix + "mdevUUID"
 )
 
 // DeviceAttribute represents a device attribute name and its value

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/mdev.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/mdev.go
@@ -1,0 +1,59 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceattribute
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	resourceapi "k8s.io/api/resource/v1"
+)
+
+// GetMdevUUIDAttribute returns a DeviceAttribute with the mediated device (mdev) UUID
+// as a string value.
+//
+// It returns an error if the mdev UUID is empty or is not in the canonical UUID format
+// (8-4-4-4-12 hex digits), e.g., "123e4567-e89b-12d3-a456-426614174000".
+func GetMdevUUIDAttribute(mdevUUID string) (DeviceAttribute, error) {
+	if err := verifyMdevUUIDFormat(mdevUUID); err != nil {
+		return DeviceAttribute{}, err
+	}
+
+	normalizedUUID := strings.ToLower(mdevUUID)
+
+	attr := DeviceAttribute{
+		Name:  StandardDeviceAttributeMdevUUID,
+		Value: resourceapi.DeviceAttribute{StringValue: &normalizedUUID},
+	}
+
+	return attr, nil
+}
+
+// verifyMdevUUIDFormat verifies that the mdev UUID is in the canonical UUID format (8-4-4-4-12 hex digits).
+func verifyMdevUUIDFormat(mdevUUID string) error {
+	if mdevUUID == "" {
+		return fmt.Errorf("mdev UUID cannot be empty")
+	}
+
+	uuidRegexp := regexp.MustCompile(`^(?i)[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+	if !uuidRegexp.MatchString(mdevUUID) {
+		return fmt.Errorf("invalid mdev UUID format: %s", mdevUUID)
+	}
+
+	return nil
+}

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/mdev_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/mdev_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceattribute
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	resourceapi "k8s.io/api/resource/v1"
+)
+
+func TestGetMdevUUIDAttribute(t *testing.T) {
+	validUUID := "123e4567-e89b-12d3-a456-426614174000"
+	expectedAttribute := DeviceAttribute{
+		Name:  StandardDeviceAttributeMdevUUID,
+		Value: resourceapi.DeviceAttribute{StringValue: &validUUID},
+	}
+
+	tests := map[string]struct {
+		mdevUUID          string
+		expectedAttribute *DeviceAttribute
+		expectsError      bool
+		expectedErrMsg    string
+	}{
+		"valid lowercase UUID": {
+			mdevUUID:          validUUID,
+			expectedAttribute: &expectedAttribute,
+			expectsError:      false,
+		},
+		"valid uppercase UUID (normalized to lowercase)": {
+			mdevUUID:          strings.ToUpper(validUUID),
+			expectedAttribute: &expectedAttribute,
+			expectsError:      false,
+		},
+		"invalid empty mdev UUID": {
+			mdevUUID:          "",
+			expectedAttribute: nil,
+			expectsError:      true,
+			expectedErrMsg:    "mdev UUID cannot be empty",
+		},
+		"invalid mdev UUID format (no hyphens)": {
+			mdevUUID:          "123e4567e89b12d3a456426614174000",
+			expectedAttribute: nil,
+			expectsError:      true,
+			expectedErrMsg:    "invalid mdev UUID format: 123e4567e89b12d3a456426614174000",
+		},
+		"invalid mdev UUID format (incorrect character)": {
+			mdevUUID:          "123e4567-e89b-12d3-a456-42661417400g",
+			expectedAttribute: nil,
+			expectsError:      true,
+			expectedErrMsg:    "invalid mdev UUID format: 123e4567-e89b-12d3-a456-42661417400g",
+		},
+		"invalid mdev UUID format (incorrect segment lengths)": {
+			mdevUUID:          "123e4567-e89b-12d3-a4564-26614174000",
+			expectedAttribute: nil,
+			expectsError:      true,
+			expectedErrMsg:    "invalid mdev UUID format: 123e4567-e89b-12d3-a4564-26614174000",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := GetMdevUUIDAttribute(test.mdevUUID)
+			if test.expectsError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+					return
+				}
+				if !strings.Contains(err.Error(), test.expectedErrMsg) {
+					t.Errorf("Expected error message to contain %q, got %q", test.expectedErrMsg, err.Error())
+					return
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, *test.expectedAttribute) {
+				t.Errorf("Expected attribute %v, got %v", test.expectedAttribute, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

With alpha-level DRA support integrated in virtualization runtimes like KubeVIrt , there is a specific attribute `mdevUUID` used for mediated device virtualization.

Currently, there is no standard attribute defined for mediated device UUIDs, which could lead to different DRA drivers introducing vendor specific keys for this property. This PR introduces `mdevUUID` to ensure all drivers expose this uniformly.

#### Which issue(s) this PR is related to:

Fixes [#135552](https://github.com/kubernetes/kubernetes/issues/135552)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```