### PR TITLE
flake stabilize HPA reconciliation metric assertion

### DIFF
--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -1198,11 +1198,20 @@ func (tc *testCase) verifyRecordedMetric(ctx context.Context, t *testing.T) {
 	}
 
 	if tc.expectedReconciliationCount > 0 {
-		v, err := metricstestutil.GetCounterMetricValue(monitor.ReconciliationsTotal.WithLabelValues(actionStr, errorStr))
-		if err != nil {
-			t.Fatalf("error getting reconciliations total metric: %v", err)
+		var v float64
+		var lastErr error
+		if err := wait.PollUntilContextTimeout(ctx, 20*time.Millisecond, 100*time.Millisecond, true, func(ctx context.Context) (done bool, err error) {
+			v, lastErr = metricstestutil.GetCounterMetricValue(monitor.ReconciliationsTotal.WithLabelValues(actionStr, errorStr))
+			if lastErr != nil {
+				return false, nil
+			}
+			return int(v) >= tc.expectedReconciliationCount, nil
+		}); err != nil {
+			if lastErr != nil {
+				t.Fatalf("error getting reconciliations total metric: %v", lastErr)
+			}
+			assert.GreaterOrEqual(t, int(v), tc.expectedReconciliationCount, "reconciliation count should be at least %d", tc.expectedReconciliationCount)
 		}
-		assert.GreaterOrEqual(t, int(v), tc.expectedReconciliationCount, "reconciliation count should be at least %d", tc.expectedReconciliationCount)
 
 		for metricType, expectedAction := range tc.expectedReportedMetricComputationActionLabels {
 			expectedError := tc.expectedReportedMetricComputationErrorLabels[metricType]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

 /kind failing-test
 /kind flake

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
 This PR stabilizes `TestReconciliationsTotalCountMultipleReconciliations`.

  The test waits for HPA reconciliations through `tc.processed`, which is sent by the fake client after the HPA status update. However, `ReconciliationsTotal` is incremented later from
  the `defer` in `reconcileAutoscaler`, after the reconciliation function returns.

  That leaves a small race in the test:

  1. the third reconciliation reaches the fake status update
  2. `tc.processed` is sent
  3. the test observes enough processed events
  4. the test reads `ReconciliationsTotal`
  5. the controller has not yet run the deferred metric observation

  In that window, the test can observe `2` instead of the expected `3`, causing a flake.

  This PR fixes the test by polling `ReconciliationsTotal` until the expected reconciliation count is observed or the existing short timeout expires. This matches the existing polling
  pattern used by nearby metric assertions and does not change controller behavior.
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->


#### Special notes for your reviewer:

Observed in CI:

  https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-unit/2071161362150592512

  Failure:

  ```text
  Error: "2" is not greater than or equal to "3"
  Messages: reconciliation count should be at least 3
```
  Validation run locally:

  stress -count 500 -p 8 -timeout 180s /private/tmp/podautoscaler-hpa-race.test -test.run TestReconciliationsTotalCountMultipleReconciliations -test.count=1 -test.timeout=180s
  1m29s: 500 runs total, 0 failures

  go test -race ./pkg/controller/podautoscaler
  ok    k8s.io/kubernetes/pkg/controller/podautoscaler  25.091s

  git diff --check

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
 NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
 NONE
```
