### PR TITLE
cleanup: remove stale heapster references from comments

### DIFF
--- a/pkg/cluster/ports/ports.go
+++ b/pkg/cluster/ports/ports.go
@@ -31,9 +31,6 @@ const (
 	KubeletPort = 10250
 	// KubeletReadOnlyPort exposes basic read-only services from the kubelet.
 	// May be overridden by a flag at startup.
-	// This is necessary for heapster to collect monitoring stats from the kubelet
-	// until heapster can transition to using the SSL endpoint.
-	// TODO(roberthbailey): Remove this once we have a better solution for heapster.
 	KubeletReadOnlyPort = 10255
 	// KubeletHealthzPort exposes a healthz endpoint from the kubelet.
 	// May be overridden by a flag at startup.

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -1408,7 +1408,7 @@ func convertDesiredReplicasWithRules(currentReplicas, desiredReplicas, hpaMinRep
 	minimumAllowedReplicas = hpaMinReplicas
 
 	// Do not scaleup too much to prevent incorrect rapid increase of the number of master replicas caused by
-	// bogus CPU usage report from heapster/kubelet (like in issue #32304).
+	// bogus CPU usage report from kubelet (like in issue #32304).
 	scaleUpLimit := calculateScaleUpLimit(currentReplicas)
 
 	if hpaMaxReplicas > scaleUpLimit {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Removes stale references to Heapster from comments across 5 files.
Heapster was retired in 2019 (kubernetes-retired/heapster). The links
to its issue tracker are dead and the justifications referencing it
are no longer accurate:

- `pkg/cluster/ports/ports.go`: removes heapster-specific TODO and
  rationale comment for KubeletReadOnlyPort
- `pkg/controller/podautoscaler/horizontal.go`: removes heapster from
  a comment about bogus CPU usage reports (kubelet alone is the
  relevant source today)
- `pkg/kubelet/stats/cri_stats_provider.go`: removes link to retired
  heapster issue tracker (#1793)
- `pkg/kubelet/stats/cri_stats_provider_windows.go`: removes link to
  retired heapster issue tracker (#1793)
- `pkg/kubelet/winstats/perfcounter_nodestats_windows.go`: removes
  link to retired heapster issue tracker (#650)

Related to the heapster cleanup series: #87498, #85512, #90368, #139678

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
Comment-only changes across 5 files. No logic affected.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```