### PR TITLE
Return errors from ToleratesTaint for invalid numeric toleration values

### DIFF
--- a/pkg/apis/core/v1/helper/helpers.go
+++ b/pkg/apis/core/v1/helper/helpers.go
@@ -290,29 +290,34 @@ func AddOrUpdateTolerationInPodSpec(spec *v1.PodSpec, toleration *v1.Toleration)
 }
 
 // GetMatchingTolerations returns true and list of Tolerations matching all Taints if all are tolerated, or false otherwise.
-func GetMatchingTolerations(logger klog.Logger, taints []v1.Taint, tolerations []v1.Toleration) (bool, []v1.Toleration) {
+func GetMatchingTolerations(logger klog.Logger, taints []v1.Taint, tolerations []v1.Toleration) (bool, []v1.Toleration, error) {
 	if len(taints) == 0 {
-		return true, []v1.Toleration{}
+		return true, []v1.Toleration{}, nil
 	}
 	if len(tolerations) == 0 && len(taints) > 0 {
-		return false, []v1.Toleration{}
+		return false, []v1.Toleration{}, nil
 	}
 	enableComparisonOperators := utilfeature.DefaultFeatureGate.Enabled(features.TaintTolerationComparisonOperators)
 	result := []v1.Toleration{}
 	for i := range taints {
 		tolerated := false
+		var firstErr error
 		for j := range tolerations {
-			if tolerations[j].ToleratesTaint(logger, &taints[i], enableComparisonOperators) {
+			matched, err := tolerations[j].ToleratesTaint(&taints[i], enableComparisonOperators)
+			if matched {
 				result = append(result, tolerations[j])
 				tolerated = true
 				break
 			}
+			if firstErr == nil && err != nil {
+				firstErr = err
+			}
 		}
 		if !tolerated {
-			return false, []v1.Toleration{}
+			return false, []v1.Toleration{}, firstErr
 		}
 	}
-	return true, result
+	return true, result, nil
 }
 
 // ScopedResourceSelectorRequirementsAsSelector converts the ScopedResourceSelectorRequirement api type into a struct that implements

--- a/pkg/apis/core/v1/helper/helpers.go
+++ b/pkg/apis/core/v1/helper/helpers.go
@@ -18,8 +18,9 @@ package helper
 
 import (
 	"fmt"
-	"k8s.io/klog/v2"
 	"strings"
+
+	"k8s.io/klog/v2"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -301,20 +302,20 @@ func GetMatchingTolerations(logger klog.Logger, taints []v1.Taint, tolerations [
 	result := []v1.Toleration{}
 	for i := range taints {
 		tolerated := false
-		var firstErr error
+		var firstWarning error
 		for j := range tolerations {
-			matched, err := tolerations[j].ToleratesTaint(&taints[i], enableComparisonOperators)
+			matched, warning := tolerations[j].ToleratesTaint(&taints[i], enableComparisonOperators)
 			if matched {
 				result = append(result, tolerations[j])
 				tolerated = true
 				break
 			}
-			if firstErr == nil && err != nil {
-				firstErr = err
+			if firstWarning == nil && warning != nil {
+				firstWarning = warning
 			}
 		}
 		if !tolerated {
-			return false, []v1.Toleration{}, firstErr
+			return false, []v1.Toleration{}, firstWarning
 		}
 	}
 	return true, result, nil

--- a/pkg/apis/core/v1/helper/helpers_test.go
+++ b/pkg/apis/core/v1/helper/helpers_test.go
@@ -24,6 +24,10 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/klog/v2/ktesting"
+	"k8s.io/kubernetes/pkg/features"
 )
 
 func TestIsNativeResource(t *testing.T) {
@@ -671,6 +675,59 @@ func TestNodeSelectorRequirementKeyExistsInNodeSelectorTerms(t *testing.T) {
 		if test.exists != keyExists {
 			t.Errorf("test %s failed. Expected %v but got %v", test.name, test.exists, keyExists)
 		}
+	}
+}
+
+func TestGetMatchingTolerations(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	testCases := []struct {
+		description                 string
+		tolerations                 []v1.Toleration
+		taints                      []v1.Taint
+		expectTolerated             bool
+		expectError                 bool
+		enableComparisonOperatorsFG bool
+	}{
+		{
+			description: "numeric Gt operator with non-numeric taint value returns error",
+			tolerations: []v1.Toleration{
+				{
+					Key:      "node.kubernetes.io/sla",
+					Operator: "Gt",
+					Value:    "950",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+			},
+			taints: []v1.Taint{
+				{
+					Key:    "node.kubernetes.io/sla",
+					Value:  "high",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			expectTolerated:             false,
+			expectError:                 true,
+			enableComparisonOperatorsFG: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TaintTolerationComparisonOperators, tc.enableComparisonOperatorsFG)
+			tolerated, matching, err := GetMatchingTolerations(logger, tc.taints, tc.tolerations)
+			if (err != nil) != tc.expectError {
+				t.Errorf("expect error %v, got %v", tc.expectError, err)
+			}
+			if tc.expectTolerated != tolerated {
+				t.Errorf("expect tolerated %v, got %v", tc.expectTolerated, tolerated)
+			}
+			if tolerated && len(matching) == 0 {
+				t.Errorf("expected matching tolerations when tolerated is true")
+			}
+			if !tolerated && len(matching) != 0 {
+				t.Errorf("expected no matching tolerations when tolerated is false, got %+v", matching)
+			}
+		})
 	}
 }
 

--- a/pkg/apis/core/v1/helper/helpers_test.go
+++ b/pkg/apis/core/v1/helper/helpers_test.go
@@ -685,7 +685,7 @@ func TestGetMatchingTolerations(t *testing.T) {
 		tolerations                 []v1.Toleration
 		taints                      []v1.Taint
 		expectTolerated             bool
-		expectError                 bool
+		expectWarning               bool
 		enableComparisonOperatorsFG bool
 	}{
 		{
@@ -706,7 +706,7 @@ func TestGetMatchingTolerations(t *testing.T) {
 				},
 			},
 			expectTolerated:             false,
-			expectError:                 true,
+			expectWarning:               true,
 			enableComparisonOperatorsFG: true,
 		},
 	}
@@ -714,9 +714,9 @@ func TestGetMatchingTolerations(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TaintTolerationComparisonOperators, tc.enableComparisonOperatorsFG)
-			tolerated, matching, err := GetMatchingTolerations(logger, tc.taints, tc.tolerations)
-			if (err != nil) != tc.expectError {
-				t.Errorf("expect error %v, got %v", tc.expectError, err)
+			tolerated, matching, warning := GetMatchingTolerations(logger, tc.taints, tc.tolerations)
+			if (warning != nil) != tc.expectWarning {
+				t.Errorf("expect warning %v, got %v", tc.expectWarning, warning)
 			}
 			if tc.expectTolerated != tolerated {
 				t.Errorf("expect tolerated %v, got %v", tc.expectTolerated, tolerated)

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -1394,9 +1394,12 @@ func NodeShouldRunDaemonPod(logger klog.Logger, node *v1.Node, ds *apps.DaemonSe
 
 	if !fitsTaints {
 		// Scheduled daemon pods should continue running if they tolerate NoExecute taint.
-		_, hasUntoleratedTaint := v1helper.FindMatchingUntoleratedTaint(logger, taints, pod.Spec.Tolerations, func(t *v1.Taint) bool {
+		_, hasUntoleratedTaint, err := v1helper.FindMatchingUntoleratedTaint(logger, taints, pod.Spec.Tolerations, func(t *v1.Taint) bool {
 			return t.Effect == v1.TaintEffectNoExecute
 		}, utilfeature.DefaultFeatureGate.Enabled(features.TaintTolerationComparisonOperators))
+		if err != nil {
+			logger.Error(err, "Failed to match daemon pod tolerations against NoExecute taints", "node", klog.KObj(node), "daemonSet", klog.KObj(ds))
+		}
 		return false, !hasUntoleratedTaint
 	}
 
@@ -1408,9 +1411,12 @@ func predicates(logger klog.Logger, pod *v1.Pod, node *v1.Node, taints []v1.Tain
 	fitsNodeName = len(pod.Spec.NodeName) == 0 || pod.Spec.NodeName == node.Name
 	// Ignore parsing errors for backwards compatibility.
 	fitsNodeAffinity, _ = nodeaffinity.GetRequiredNodeAffinity(pod).Match(node)
-	_, hasUntoleratedTaint := v1helper.FindMatchingUntoleratedTaint(logger, taints, pod.Spec.Tolerations, func(t *v1.Taint) bool {
+	_, hasUntoleratedTaint, err := v1helper.FindMatchingUntoleratedTaint(logger, taints, pod.Spec.Tolerations, func(t *v1.Taint) bool {
 		return t.Effect == v1.TaintEffectNoExecute || t.Effect == v1.TaintEffectNoSchedule
 	}, utilfeature.DefaultFeatureGate.Enabled(features.TaintTolerationComparisonOperators))
+	if err != nil {
+		logger.Error(err, "Failed to match pod tolerations against node taints", "pod", klog.KObj(pod), "node", klog.KObj(node))
+	}
 	fitsTaints = !hasUntoleratedTaint
 	return
 }

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -1421,11 +1421,11 @@ func nodeShouldRunDaemonPod(logger klog.Logger, node *v1.Node, ds *apps.DaemonSe
 
 	if !fitsTaints {
 		// Scheduled daemon pods should continue running if they tolerate NoExecute taint.
-		_, hasUntoleratedTaint, err := v1helper.FindMatchingUntoleratedTaint(logger, taints, tolerations, func(t *v1.Taint) bool {
+		_, hasUntoleratedTaint, warning := v1helper.FindMatchingUntoleratedTaint(logger, taints, tolerations, func(t *v1.Taint) bool {
 			return t.Effect == v1.TaintEffectNoExecute
 		}, utilfeature.DefaultFeatureGate.Enabled(features.TaintTolerationComparisonOperators))
-		if err != nil {
-			logger.Error(err, "Failed to match daemon pod tolerations against NoExecute taints", "node", klog.KObj(node), "daemonSet", klog.KObj(ds))
+		if warning != nil {
+			logger.V(4).Info("Failed to match daemon pod tolerations against NoExecute taints", "node", klog.KObj(node), "daemonSet", klog.KObj(ds), "warning", warning)
 		}
 		return false, !hasUntoleratedTaint
 	}
@@ -1439,11 +1439,11 @@ func nodeShouldRunDaemonPod(logger klog.Logger, node *v1.Node, ds *apps.DaemonSe
 func predicates(logger klog.Logger, node *v1.Node, taints []v1.Taint, tolerations []v1.Toleration, requiredNodeAffinity nodeaffinity.RequiredNodeAffinity) (fitsNodeAffinity, fitsTaints bool) {
 	// Ignore parsing errors for backwards compatibility.
 	fitsNodeAffinity, _ = requiredNodeAffinity.Match(node)
-	_, hasUntoleratedTaint, err := v1helper.FindMatchingUntoleratedTaint(logger, taints, tolerations, func(t *v1.Taint) bool {
+	_, hasUntoleratedTaint, warning := v1helper.FindMatchingUntoleratedTaint(logger, taints, tolerations, func(t *v1.Taint) bool {
 		return t.Effect == v1.TaintEffectNoExecute || t.Effect == v1.TaintEffectNoSchedule
 	}, utilfeature.DefaultFeatureGate.Enabled(features.TaintTolerationComparisonOperators))
-	if err != nil {
-		logger.Error(err, "Failed to match tolerations against node taints", "node", klog.KObj(node))
+	if warning != nil {
+		logger.V(4).Info("Failed to match tolerations against node taints", "node", klog.KObj(node), "warning", warning)
 	}
 	fitsTaints = !hasUntoleratedTaint
 	return

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -1443,7 +1443,7 @@ func predicates(logger klog.Logger, node *v1.Node, taints []v1.Taint, toleration
 		return t.Effect == v1.TaintEffectNoExecute || t.Effect == v1.TaintEffectNoSchedule
 	}, utilfeature.DefaultFeatureGate.Enabled(features.TaintTolerationComparisonOperators))
 	if err != nil {
-		logger.Error(err, "Failed to match pod tolerations against node taints", "pod", klog.KObj(pod), "node", klog.KObj(node))
+		logger.Error(err, "Failed to match tolerations against node taints", "node", klog.KObj(node))
 	}
 	fitsTaints = !hasUntoleratedTaint
 	return

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -1421,9 +1421,12 @@ func nodeShouldRunDaemonPod(logger klog.Logger, node *v1.Node, ds *apps.DaemonSe
 
 	if !fitsTaints {
 		// Scheduled daemon pods should continue running if they tolerate NoExecute taint.
-		_, hasUntoleratedTaint := v1helper.FindMatchingUntoleratedTaint(logger, taints, tolerations, func(t *v1.Taint) bool {
+		_, hasUntoleratedTaint, err := v1helper.FindMatchingUntoleratedTaint(logger, taints, tolerations, func(t *v1.Taint) bool {
 			return t.Effect == v1.TaintEffectNoExecute
 		}, utilfeature.DefaultFeatureGate.Enabled(features.TaintTolerationComparisonOperators))
+		if err != nil {
+			logger.Error(err, "Failed to match daemon pod tolerations against NoExecute taints", "node", klog.KObj(node), "daemonSet", klog.KObj(ds))
+		}
 		return false, !hasUntoleratedTaint
 	}
 
@@ -1436,9 +1439,12 @@ func nodeShouldRunDaemonPod(logger klog.Logger, node *v1.Node, ds *apps.DaemonSe
 func predicates(logger klog.Logger, node *v1.Node, taints []v1.Taint, tolerations []v1.Toleration, requiredNodeAffinity nodeaffinity.RequiredNodeAffinity) (fitsNodeAffinity, fitsTaints bool) {
 	// Ignore parsing errors for backwards compatibility.
 	fitsNodeAffinity, _ = requiredNodeAffinity.Match(node)
-	_, hasUntoleratedTaint := v1helper.FindMatchingUntoleratedTaint(logger, taints, tolerations, func(t *v1.Taint) bool {
+	_, hasUntoleratedTaint, err := v1helper.FindMatchingUntoleratedTaint(logger, taints, tolerations, func(t *v1.Taint) bool {
 		return t.Effect == v1.TaintEffectNoExecute || t.Effect == v1.TaintEffectNoSchedule
 	}, utilfeature.DefaultFeatureGate.Enabled(features.TaintTolerationComparisonOperators))
+	if err != nil {
+		logger.Error(err, "Failed to match pod tolerations against node taints", "pod", klog.KObj(pod), "node", klog.KObj(node))
+	}
 	fitsTaints = !hasUntoleratedTaint
 	return
 }

--- a/pkg/controller/tainteviction/taint_eviction.go
+++ b/pkg/controller/tainteviction/taint_eviction.go
@@ -460,7 +460,10 @@ func (tc *Controller) processPodOnNode(
 	if len(taints) == 0 {
 		tc.cancelWorkWithEvent(logger, podNamespacedName)
 	}
-	allTolerated, usedTolerations := v1helper.GetMatchingTolerations(logger, taints, tolerations)
+	allTolerated, usedTolerations, err := v1helper.GetMatchingTolerations(logger, taints, tolerations)
+	if err != nil {
+		logger.Error(err, "Failed to match pod tolerations against NoExecute taints", "pod", podNamespacedName.String(), "node", klog.KRef("", nodeName))
+	}
 	if !allTolerated {
 		logger.V(2).Info("Not all taints are tolerated after update for pod on node", "pod", podNamespacedName.String(), "node", klog.KRef("", nodeName))
 		// We're canceling scheduled work (if any), as we're going to delete the Pod right away.

--- a/pkg/controller/tainteviction/taint_eviction.go
+++ b/pkg/controller/tainteviction/taint_eviction.go
@@ -460,9 +460,9 @@ func (tc *Controller) processPodOnNode(
 	if len(taints) == 0 {
 		tc.cancelWorkWithEvent(logger, podNamespacedName)
 	}
-	allTolerated, usedTolerations, err := v1helper.GetMatchingTolerations(logger, taints, tolerations)
-	if err != nil {
-		logger.Error(err, "Failed to match pod tolerations against NoExecute taints", "pod", podNamespacedName.String(), "node", klog.KRef("", nodeName))
+	allTolerated, usedTolerations, warning := v1helper.GetMatchingTolerations(logger, taints, tolerations)
+	if warning != nil {
+		logger.V(4).Info("Failed to match pod tolerations against NoExecute taints", "pod", podNamespacedName.String(), "node", klog.KRef("", nodeName), "warning", warning)
 	}
 	if !allTolerated {
 		logger.V(2).Info("Not all taints are tolerated after update for pod on node", "pod", podNamespacedName.String(), "node", klog.KRef("", nodeName))

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -168,10 +168,11 @@ func (m *managerImpl) Admit(ctx context.Context, attrs *lifecycle.PodAdmitAttrib
 
 		// When node has memory pressure, check BestEffort Pod's toleration:
 		// admit it if tolerates memory pressure taint, fail for other tolerations, e.g. DiskPressure.
-		if corev1helpers.TolerationsTolerateTaint(logger, attrs.Pod.Spec.Tolerations, &v1.Taint{
+		toleratesMemoryPressure, _ := corev1helpers.TolerationsTolerateTaint(logger, attrs.Pod.Spec.Tolerations, &v1.Taint{
 			Key:    v1.TaintNodeMemoryPressure,
 			Effect: v1.TaintEffectNoSchedule,
-		}, utilfeature.DefaultFeatureGate.Enabled(features.TaintTolerationComparisonOperators)) {
+		}, utilfeature.DefaultFeatureGate.Enabled(features.TaintTolerationComparisonOperators))
+		if toleratesMemoryPressure {
 			return lifecycle.PodAdmitResult{Admit: true}
 		}
 	}

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -168,10 +168,13 @@ func (m *managerImpl) Admit(ctx context.Context, attrs *lifecycle.PodAdmitAttrib
 
 		// When node has memory pressure, check BestEffort Pod's toleration:
 		// admit it if tolerates memory pressure taint, fail for other tolerations, e.g. DiskPressure.
-		toleratesMemoryPressure, _ := corev1helpers.TolerationsTolerateTaint(logger, attrs.Pod.Spec.Tolerations, &v1.Taint{
+		toleratesMemoryPressure, warning := corev1helpers.TolerationsTolerateTaint(logger, attrs.Pod.Spec.Tolerations, &v1.Taint{
 			Key:    v1.TaintNodeMemoryPressure,
 			Effect: v1.TaintEffectNoSchedule,
 		}, utilfeature.DefaultFeatureGate.Enabled(features.TaintTolerationComparisonOperators))
+		if warning != nil {
+			logger.V(4).Info("Failed to match tolerations against memory pressure taint", "warning", warning)
+		}
 		if toleratesMemoryPressure {
 			return lifecycle.PodAdmitResult{Admit: true}
 		}

--- a/pkg/kubelet/lifecycle/predicate.go
+++ b/pkg/kubelet/lifecycle/predicate.go
@@ -447,11 +447,13 @@ func generalFilter(logger klog.Logger, pod *v1.Pod, nodeInfo *schedulerframework
 
 	// Check taint/toleration except for static pods
 	if !types.IsStaticPod(pod) {
-		_, isUntolerated := corev1.FindMatchingUntoleratedTaint(logger, nodeInfo.Node().Spec.Taints, pod.Spec.Tolerations, func(t *v1.Taint) bool {
+		_, isUntolerated, err := corev1.FindMatchingUntoleratedTaint(logger, nodeInfo.Node().Spec.Taints, pod.Spec.Tolerations, func(t *v1.Taint) bool {
 			// Kubelet is only interested in the NoExecute taint.
 			return t.Effect == v1.TaintEffectNoExecute
 		}, utilfeature.DefaultFeatureGate.Enabled(features.TaintTolerationComparisonOperators))
-		if isUntolerated {
+		if err != nil {
+			reasons = append(reasons, &PredicateFailureError{tainttoleration.Name, err.Error()})
+		} else if isUntolerated {
 			reasons = append(reasons, &PredicateFailureError{tainttoleration.Name, tainttoleration.ErrReasonNotMatch})
 		}
 	}

--- a/pkg/kubelet/lifecycle/predicate.go
+++ b/pkg/kubelet/lifecycle/predicate.go
@@ -447,12 +447,12 @@ func generalFilter(logger klog.Logger, pod *v1.Pod, nodeInfo *schedulerframework
 
 	// Check taint/toleration except for static pods
 	if !types.IsStaticPod(pod) {
-		_, isUntolerated, err := corev1.FindMatchingUntoleratedTaint(logger, nodeInfo.Node().Spec.Taints, pod.Spec.Tolerations, func(t *v1.Taint) bool {
+		_, isUntolerated, warning := corev1.FindMatchingUntoleratedTaint(logger, nodeInfo.Node().Spec.Taints, pod.Spec.Tolerations, func(t *v1.Taint) bool {
 			// Kubelet is only interested in the NoExecute taint.
 			return t.Effect == v1.TaintEffectNoExecute
 		}, utilfeature.DefaultFeatureGate.Enabled(features.TaintTolerationComparisonOperators))
-		if err != nil {
-			reasons = append(reasons, &PredicateFailureError{tainttoleration.Name, err.Error()})
+		if warning != nil {
+			reasons = append(reasons, &PredicateFailureError{tainttoleration.Name, warning.Error()})
 		} else if isUntolerated {
 			reasons = append(reasons, &PredicateFailureError{tainttoleration.Name, tainttoleration.ErrReasonNotMatch})
 		}

--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
+++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
@@ -74,10 +74,11 @@ func (pl *NodeUnschedulable) isSchedulableAfterTargetPodTolerationChange(logger 
 	// - Taint can be added, but can't be modified nor removed.
 	// - If the Pod already has the toleration, it shouldn't have rejected by this plugin in the first place.
 	//   Meaning, here this Pod has been rejected by this plugin, and hence it shouldn't have the toleration yet.
-	if v1helper.TolerationsTolerateTaint(logger, modifiedPod.Spec.Tolerations, &v1.Taint{
+	toleratesUnschedulable, _ := v1helper.TolerationsTolerateTaint(logger, modifiedPod.Spec.Tolerations, &v1.Taint{
 		Key:    v1.TaintNodeUnschedulable,
 		Effect: v1.TaintEffectNoSchedule,
-	}, utilfeature.DefaultFeatureGate.Enabled(features.TaintTolerationComparisonOperators)) {
+	}, utilfeature.DefaultFeatureGate.Enabled(features.TaintTolerationComparisonOperators))
+	if toleratesUnschedulable {
 		// This update makes the pod tolerate the unschedulable taint.
 		logger.V(5).Info("a new toleration is added for the unschedulable Pod, and it may make it schedulable", "pod", klog.KObj(modifiedPod))
 		return fwk.Queue, nil
@@ -131,7 +132,7 @@ func (pl *NodeUnschedulable) Filter(ctx context.Context, _ fwk.CycleState, pod *
 
 	logger := klog.FromContext(ctx)
 	// If pod tolerate unschedulable taint, it's also tolerate `node.Spec.Unschedulable`.
-	podToleratesUnschedulable := v1helper.TolerationsTolerateTaint(logger, pod.Spec.Tolerations, &v1.Taint{
+	podToleratesUnschedulable, _ := v1helper.TolerationsTolerateTaint(logger, pod.Spec.Tolerations, &v1.Taint{
 		Key:    v1.TaintNodeUnschedulable,
 		Effect: v1.TaintEffectNoSchedule,
 	}, utilfeature.DefaultFeatureGate.Enabled(features.TaintTolerationComparisonOperators))

--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
+++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
@@ -77,10 +77,11 @@ func (pl *NodeUnschedulable) isSchedulableAfterTargetPodTolerationChange(logger 
 	// - Taint can be added, but can't be modified nor removed.
 	// - If the Pod already has the toleration, it shouldn't have rejected by this plugin in the first place.
 	//   Meaning, here this Pod has been rejected by this plugin, and hence it shouldn't have the toleration yet.
-	if v1helper.TolerationsTolerateTaint(logger, modifiedPod.Spec.Tolerations, &v1.Taint{
+	toleratesUnschedulable, _ := v1helper.TolerationsTolerateTaint(logger, modifiedPod.Spec.Tolerations, &v1.Taint{
 		Key:    v1.TaintNodeUnschedulable,
 		Effect: v1.TaintEffectNoSchedule,
-	}, pl.enableTaintTolerationComparisonOperators) {
+	}, pl.enableTaintTolerationComparisonOperators)
+	if toleratesUnschedulable {
 		// This update makes the pod tolerate the unschedulable taint.
 		logger.V(5).Info("a new toleration is added for the unschedulable Pod, and it may make it schedulable", "pod", klog.KObj(modifiedPod))
 		return fwk.Queue, nil
@@ -150,7 +151,7 @@ func (pl *NodeUnschedulable) Filter(ctx context.Context, _ fwk.CycleState, pod *
 
 	logger := klog.FromContext(ctx)
 	// If pod tolerate unschedulable taint, it's also tolerate `node.Spec.Unschedulable`.
-	podToleratesUnschedulable := v1helper.TolerationsTolerateTaint(logger, pod.Spec.Tolerations, &v1.Taint{
+	podToleratesUnschedulable, _ := v1helper.TolerationsTolerateTaint(logger, pod.Spec.Tolerations, &v1.Taint{
 		Key:    v1.TaintNodeUnschedulable,
 		Effect: v1.TaintEffectNoSchedule,
 	}, pl.enableTaintTolerationComparisonOperators)

--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
+++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
@@ -77,10 +77,13 @@ func (pl *NodeUnschedulable) isSchedulableAfterTargetPodTolerationChange(logger 
 	// - Taint can be added, but can't be modified nor removed.
 	// - If the Pod already has the toleration, it shouldn't have rejected by this plugin in the first place.
 	//   Meaning, here this Pod has been rejected by this plugin, and hence it shouldn't have the toleration yet.
-	toleratesUnschedulable, _ := v1helper.TolerationsTolerateTaint(logger, modifiedPod.Spec.Tolerations, &v1.Taint{
+	toleratesUnschedulable, warning := v1helper.TolerationsTolerateTaint(logger, modifiedPod.Spec.Tolerations, &v1.Taint{
 		Key:    v1.TaintNodeUnschedulable,
 		Effect: v1.TaintEffectNoSchedule,
 	}, pl.enableTaintTolerationComparisonOperators)
+	if warning != nil {
+		logger.Info("Failed to match tolerations against unschedulable taint", "warning", warning)
+	}
 	if toleratesUnschedulable {
 		// This update makes the pod tolerate the unschedulable taint.
 		logger.V(5).Info("a new toleration is added for the unschedulable Pod, and it may make it schedulable", "pod", klog.KObj(modifiedPod))
@@ -151,10 +154,13 @@ func (pl *NodeUnschedulable) Filter(ctx context.Context, _ fwk.CycleState, pod *
 
 	logger := klog.FromContext(ctx)
 	// If pod tolerate unschedulable taint, it's also tolerate `node.Spec.Unschedulable`.
-	podToleratesUnschedulable, _ := v1helper.TolerationsTolerateTaint(logger, pod.Spec.Tolerations, &v1.Taint{
+	podToleratesUnschedulable, warning := v1helper.TolerationsTolerateTaint(logger, pod.Spec.Tolerations, &v1.Taint{
 		Key:    v1.TaintNodeUnschedulable,
 		Effect: v1.TaintEffectNoSchedule,
 	}, pl.enableTaintTolerationComparisonOperators)
+	if warning != nil {
+		logger.V(4).Info("Failed to match tolerations against unschedulable taint", "warning", warning)
+	}
 	if !podToleratesUnschedulable {
 		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonUnschedulable)
 	}

--- a/pkg/scheduler/framework/plugins/podtopologyspread/common.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/common.go
@@ -49,7 +49,7 @@ func (tsc *topologySpreadConstraint) matchNodeInclusionPolicies(logger klog.Logg
 	}
 
 	if tsc.NodeTaintsPolicy == v1.NodeInclusionPolicyHonor {
-		if _, untolerated := v1helper.FindMatchingUntoleratedTaint(logger, node.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc(), enableComparisonOperators); untolerated {
+		if _, untolerated, _ := v1helper.FindMatchingUntoleratedTaint(logger, node.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc(), enableComparisonOperators); untolerated {
 			return false
 		}
 	}

--- a/pkg/scheduler/framework/plugins/podtopologyspread/common.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/common.go
@@ -49,7 +49,11 @@ func (tsc *topologySpreadConstraint) matchNodeInclusionPolicies(logger klog.Logg
 	}
 
 	if tsc.NodeTaintsPolicy == v1.NodeInclusionPolicyHonor {
-		if _, untolerated, _ := v1helper.FindMatchingUntoleratedTaint(logger, node.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc(), enableComparisonOperators); untolerated {
+		_, untolerated, warning := v1helper.FindMatchingUntoleratedTaint(logger, node.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc(), enableComparisonOperators)
+		if warning != nil {
+			logger.V(4).Info("Failed to match tolerations against node taints", "node", klog.KObj(node), "pod", klog.KObj(pod), "warning", warning)
+		}
+		if untolerated {
 			return false
 		}
 	}

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
@@ -84,10 +84,10 @@ func (pl *TaintToleration) isSchedulableAfterNodeChange(logger klog.Logger, pod 
 
 	wasUntolerated := true
 	if originalNode != nil {
-		_, wasUntolerated = v1helper.FindMatchingUntoleratedTaint(logger, originalNode.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc(), pl.enableTaintTolerationComparisonOperators)
+		_, wasUntolerated, _ = v1helper.FindMatchingUntoleratedTaint(logger, originalNode.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc(), pl.enableTaintTolerationComparisonOperators)
 	}
 
-	_, isUntolerated := v1helper.FindMatchingUntoleratedTaint(logger, modifiedNode.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc(), pl.enableTaintTolerationComparisonOperators)
+	_, isUntolerated, _ := v1helper.FindMatchingUntoleratedTaint(logger, modifiedNode.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc(), pl.enableTaintTolerationComparisonOperators)
 
 	if wasUntolerated && !isUntolerated {
 		logger.V(5).Info("node was created or updated, and this may make the Pod rejected by TaintToleration plugin in the previous scheduling cycle schedulable", "pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))
@@ -103,9 +103,12 @@ func (pl *TaintToleration) Filter(ctx context.Context, state fwk.CycleState, pod
 	logger := klog.FromContext(ctx)
 	node := nodeInfo.Node()
 
-	taint, isUntolerated := v1helper.FindMatchingUntoleratedTaint(logger, node.Spec.Taints, pod.Spec.Tolerations,
+	taint, isUntolerated, err := v1helper.FindMatchingUntoleratedTaint(logger, node.Spec.Taints, pod.Spec.Tolerations,
 		helper.DoNotScheduleTaintsFilterFunc(),
 		pl.enableTaintTolerationComparisonOperators)
+	if err != nil {
+		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable).WithError(err)
+	}
 	if !isUntolerated {
 		return nil
 	}
@@ -167,7 +170,8 @@ func (pl *TaintToleration) countIntolerableTaintsPreferNoSchedule(logger klog.Lo
 			continue
 		}
 
-		if !v1helper.TolerationsTolerateTaint(logger, tolerations, &taint, pl.enableTaintTolerationComparisonOperators) {
+		tolerated, _ := v1helper.TolerationsTolerateTaint(logger, tolerations, &taint, pl.enableTaintTolerationComparisonOperators)
+		if !tolerated {
 			intolerableTaints++
 		}
 	}

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
@@ -50,6 +50,8 @@ const (
 	preScoreStateKey = "PreScore" + Name
 	// ErrReasonNotMatch is the Filter reason status when not matching.
 	ErrReasonNotMatch = "node(s) had taints that the pod didn't tolerate"
+	// taintComparisonFailedLogMessage is logged when numeric taint/toleration comparison fails.
+	taintComparisonFailedLogMessage = "node had a taint that could not be compared with pod tolerations"
 )
 
 // Name returns name of the plugin. It is used in logs, etc.
@@ -84,10 +86,16 @@ func (pl *TaintToleration) isSchedulableAfterNodeChange(logger klog.Logger, pod 
 
 	wasUntolerated := true
 	if originalNode != nil {
-		_, wasUntolerated, _ = v1helper.FindMatchingUntoleratedTaint(logger, originalNode.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc(), pl.enableTaintTolerationComparisonOperators)
+		_, wasUntolerated, err = v1helper.FindMatchingUntoleratedTaint(logger, originalNode.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc(), pl.enableTaintTolerationComparisonOperators)
+		if err != nil {
+			logger.V(4).Info(taintComparisonFailedLogMessage, "node", klog.KObj(originalNode), "pod", klog.KObj(pod), "err", err)
+		}
 	}
 
-	_, isUntolerated, _ := v1helper.FindMatchingUntoleratedTaint(logger, modifiedNode.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc(), pl.enableTaintTolerationComparisonOperators)
+	_, isUntolerated, err := v1helper.FindMatchingUntoleratedTaint(logger, modifiedNode.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc(), pl.enableTaintTolerationComparisonOperators)
+	if err != nil {
+		logger.V(4).Info(taintComparisonFailedLogMessage, "node", klog.KObj(modifiedNode), "pod", klog.KObj(pod), "err", err)
+	}
 
 	if wasUntolerated && !isUntolerated {
 		logger.V(5).Info("node was created or updated, and this may make the Pod rejected by TaintToleration plugin in the previous scheduling cycle schedulable", "pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))
@@ -110,7 +118,7 @@ func (pl *TaintToleration) Filter(ctx context.Context, state fwk.CycleState, pod
 		return nil
 	}
 	if err != nil {
-		logger.V(4).Info("node had a taint that could not be compared with pod tolerations", "node", klog.KObj(node), "pod", klog.KObj(pod), "untoleratedTaint", taint, "err", err)
+		logger.V(4).Info(taintComparisonFailedLogMessage, "node", klog.KObj(node), "pod", klog.KObj(pod), "untoleratedTaint", taint, "err", err)
 	} else {
 		logger.V(4).Info("node had untolerated taints", "node", klog.KObj(node), "pod", klog.KObj(pod), "untoleratedTaint", taint)
 	}
@@ -163,14 +171,17 @@ func getPreScoreState(cycleState fwk.CycleState) (*preScoreState, error) {
 }
 
 // CountIntolerableTaintsPreferNoSchedule gives the count of intolerable taints of a pod with effect PreferNoSchedule
-func (pl *TaintToleration) countIntolerableTaintsPreferNoSchedule(logger klog.Logger, taints []v1.Taint, tolerations []v1.Toleration) (intolerableTaints int) {
+func (pl *TaintToleration) countIntolerableTaintsPreferNoSchedule(logger klog.Logger, node *v1.Node, pod *v1.Pod, taints []v1.Taint, tolerations []v1.Toleration) (intolerableTaints int) {
 	for _, taint := range taints {
 		// check only on taints that have effect PreferNoSchedule
 		if taint.Effect != v1.TaintEffectPreferNoSchedule {
 			continue
 		}
 
-		tolerated, _ := v1helper.TolerationsTolerateTaint(logger, tolerations, &taint, pl.enableTaintTolerationComparisonOperators)
+		tolerated, err := v1helper.TolerationsTolerateTaint(logger, tolerations, &taint, pl.enableTaintTolerationComparisonOperators)
+		if err != nil {
+			logger.V(4).Info(taintComparisonFailedLogMessage, "node", klog.KObj(node), "pod", klog.KObj(pod), "taint", taint, "err", err)
+		}
 		if !tolerated {
 			intolerableTaints++
 		}
@@ -189,7 +200,7 @@ func (pl *TaintToleration) Score(ctx context.Context, state fwk.CycleState, pod 
 		return 0, fwk.AsStatus(err)
 	}
 
-	score := int64(pl.countIntolerableTaintsPreferNoSchedule(logger, node.Spec.Taints, s.tolerationsPreferNoSchedule))
+	score := int64(pl.countIntolerableTaintsPreferNoSchedule(logger, node, pod, node.Spec.Taints, s.tolerationsPreferNoSchedule))
 	return score, nil
 }
 

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
@@ -106,14 +106,14 @@ func (pl *TaintToleration) Filter(ctx context.Context, state fwk.CycleState, pod
 	taint, isUntolerated, err := v1helper.FindMatchingUntoleratedTaint(logger, node.Spec.Taints, pod.Spec.Tolerations,
 		helper.DoNotScheduleTaintsFilterFunc(),
 		pl.enableTaintTolerationComparisonOperators)
-	if err != nil {
-		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable).WithError(err)
-	}
 	if !isUntolerated {
 		return nil
 	}
-
-	logger.V(4).Info("node had untolerated taints", "node", klog.KObj(node), "pod", klog.KObj(pod), "untoleratedTaint", taint)
+	if err != nil {
+		logger.V(4).Info("node had a taint that could not be compared with pod tolerations", "node", klog.KObj(node), "pod", klog.KObj(pod), "untoleratedTaint", taint, "err", err)
+	} else {
+		logger.V(4).Info("node had untolerated taints", "node", klog.KObj(node), "pod", klog.KObj(pod), "untoleratedTaint", taint)
+	}
 	return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "node(s) had untolerated taint(s)")
 }
 

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
@@ -125,14 +125,14 @@ func (pl *TaintToleration) Filter(ctx context.Context, state fwk.CycleState, pod
 	taint, isUntolerated, err := v1helper.FindMatchingUntoleratedTaint(logger, node.Spec.Taints, pod.Spec.Tolerations,
 		helper.DoNotScheduleTaintsFilterFunc(),
 		pl.enableTaintTolerationComparisonOperators)
-	if err != nil {
-		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable).WithError(err)
-	}
 	if !isUntolerated {
 		return nil
 	}
-
-	logger.V(4).Info("node had untolerated taints", "node", klog.KObj(node), "pod", klog.KObj(pod), "untoleratedTaint", taint)
+	if err != nil {
+		logger.V(4).Info("node had a taint that could not be compared with pod tolerations", "node", klog.KObj(node), "pod", klog.KObj(pod), "untoleratedTaint", taint, "err", err)
+	} else {
+		logger.V(4).Info("node had untolerated taints", "node", klog.KObj(node), "pod", klog.KObj(pod), "untoleratedTaint", taint)
+	}
 	return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "node(s) had untolerated taint(s)")
 }
 

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
@@ -87,10 +87,10 @@ func (pl *TaintToleration) isSchedulableAfterNodeChange(logger klog.Logger, pod 
 
 	wasUntolerated := true
 	if originalNode != nil {
-		_, wasUntolerated = v1helper.FindMatchingUntoleratedTaint(logger, originalNode.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc(), pl.enableTaintTolerationComparisonOperators)
+		_, wasUntolerated, _ = v1helper.FindMatchingUntoleratedTaint(logger, originalNode.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc(), pl.enableTaintTolerationComparisonOperators)
 	}
 
-	_, isUntolerated := v1helper.FindMatchingUntoleratedTaint(logger, modifiedNode.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc(), pl.enableTaintTolerationComparisonOperators)
+	_, isUntolerated, _ := v1helper.FindMatchingUntoleratedTaint(logger, modifiedNode.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc(), pl.enableTaintTolerationComparisonOperators)
 
 	if wasUntolerated && !isUntolerated {
 		logger.V(5).Info("node was created or updated, and this may make the Pod rejected by TaintToleration plugin in the previous scheduling cycle schedulable", "pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))
@@ -122,9 +122,12 @@ func (pl *TaintToleration) Filter(ctx context.Context, state fwk.CycleState, pod
 	logger := klog.FromContext(ctx)
 	node := nodeInfo.Node()
 
-	taint, isUntolerated := v1helper.FindMatchingUntoleratedTaint(logger, node.Spec.Taints, pod.Spec.Tolerations,
+	taint, isUntolerated, err := v1helper.FindMatchingUntoleratedTaint(logger, node.Spec.Taints, pod.Spec.Tolerations,
 		helper.DoNotScheduleTaintsFilterFunc(),
 		pl.enableTaintTolerationComparisonOperators)
+	if err != nil {
+		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable).WithError(err)
+	}
 	if !isUntolerated {
 		return nil
 	}
@@ -186,7 +189,8 @@ func (pl *TaintToleration) countIntolerableTaintsPreferNoSchedule(logger klog.Lo
 			continue
 		}
 
-		if !v1helper.TolerationsTolerateTaint(logger, tolerations, &taint, pl.enableTaintTolerationComparisonOperators) {
+		tolerated, _ := v1helper.TolerationsTolerateTaint(logger, tolerations, &taint, pl.enableTaintTolerationComparisonOperators)
+		if !tolerated {
 			intolerableTaints++
 		}
 	}

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
@@ -88,16 +88,17 @@ func (pl *TaintToleration) isSchedulableAfterNodeChange(logger klog.Logger, pod 
 	}
 
 	wasUntolerated := true
+	var warning error
 	if originalNode != nil {
-		_, wasUntolerated, err = v1helper.FindMatchingUntoleratedTaint(logger, originalNode.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc(), pl.enableTaintTolerationComparisonOperators)
-		if err != nil {
-			logger.V(4).Info(taintComparisonFailedLogMessage, "node", klog.KObj(originalNode), "pod", klog.KObj(pod), "err", err)
+		_, wasUntolerated, warning = v1helper.FindMatchingUntoleratedTaint(logger, originalNode.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc(), pl.enableTaintTolerationComparisonOperators)
+		if warning != nil {
+			logger.V(4).Info(taintComparisonFailedLogMessage, "node", klog.KObj(originalNode), "pod", klog.KObj(pod), "warning", warning)
 		}
 	}
 
-	_, isUntolerated, err := v1helper.FindMatchingUntoleratedTaint(logger, modifiedNode.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc(), pl.enableTaintTolerationComparisonOperators)
-	if err != nil {
-		logger.V(4).Info(taintComparisonFailedLogMessage, "node", klog.KObj(modifiedNode), "pod", klog.KObj(pod), "err", err)
+	_, isUntolerated, warning := v1helper.FindMatchingUntoleratedTaint(logger, modifiedNode.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc(), pl.enableTaintTolerationComparisonOperators)
+	if warning != nil {
+		logger.V(4).Info(taintComparisonFailedLogMessage, "node", klog.KObj(modifiedNode), "pod", klog.KObj(pod), "warning", warning)
 	}
 
 	if wasUntolerated && !isUntolerated {
@@ -130,14 +131,14 @@ func (pl *TaintToleration) Filter(ctx context.Context, state fwk.CycleState, pod
 	logger := klog.FromContext(ctx)
 	node := nodeInfo.Node()
 
-	taint, isUntolerated, err := v1helper.FindMatchingUntoleratedTaint(logger, node.Spec.Taints, pod.Spec.Tolerations,
+	taint, isUntolerated, warning := v1helper.FindMatchingUntoleratedTaint(logger, node.Spec.Taints, pod.Spec.Tolerations,
 		helper.DoNotScheduleTaintsFilterFunc(),
 		pl.enableTaintTolerationComparisonOperators)
 	if !isUntolerated {
 		return nil
 	}
-	if err != nil {
-		logger.V(4).Info(taintComparisonFailedLogMessage, "node", klog.KObj(node), "pod", klog.KObj(pod), "untoleratedTaint", taint, "err", err)
+	if warning != nil {
+		logger.V(4).Info(taintComparisonFailedLogMessage, "node", klog.KObj(node), "pod", klog.KObj(pod), "untoleratedTaint", taint, "warning", warning)
 	} else {
 		logger.V(4).Info("node had untolerated taints", "node", klog.KObj(node), "pod", klog.KObj(pod), "untoleratedTaint", taint)
 	}
@@ -197,9 +198,9 @@ func (pl *TaintToleration) countIntolerableTaintsPreferNoSchedule(logger klog.Lo
 			continue
 		}
 
-		tolerated, err := v1helper.TolerationsTolerateTaint(logger, tolerations, &taint, pl.enableTaintTolerationComparisonOperators)
-		if err != nil {
-			logger.V(4).Info(taintComparisonFailedLogMessage, "node", klog.KObj(node), "pod", klog.KObj(pod), "taint", taint, "err", err)
+		tolerated, warning := v1helper.TolerationsTolerateTaint(logger, tolerations, &taint, pl.enableTaintTolerationComparisonOperators)
+		if warning != nil {
+			logger.V(4).Info(taintComparisonFailedLogMessage, "node", klog.KObj(node), "pod", klog.KObj(pod), "taint", taint, "warning", warning)
 		}
 		if !tolerated {
 			intolerableTaints++

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
@@ -53,6 +53,8 @@ const (
 	preScoreStateKey = "PreScore" + Name
 	// ErrReasonNotMatch is the Filter reason status when not matching.
 	ErrReasonNotMatch = "node(s) had taints that the pod didn't tolerate"
+	// taintComparisonFailedLogMessage is logged when numeric taint/toleration comparison fails.
+	taintComparisonFailedLogMessage = "node had a taint that could not be compared with pod tolerations"
 )
 
 // Name returns name of the plugin. It is used in logs, etc.
@@ -87,10 +89,16 @@ func (pl *TaintToleration) isSchedulableAfterNodeChange(logger klog.Logger, pod 
 
 	wasUntolerated := true
 	if originalNode != nil {
-		_, wasUntolerated, _ = v1helper.FindMatchingUntoleratedTaint(logger, originalNode.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc(), pl.enableTaintTolerationComparisonOperators)
+		_, wasUntolerated, err = v1helper.FindMatchingUntoleratedTaint(logger, originalNode.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc(), pl.enableTaintTolerationComparisonOperators)
+		if err != nil {
+			logger.V(4).Info(taintComparisonFailedLogMessage, "node", klog.KObj(originalNode), "pod", klog.KObj(pod), "err", err)
+		}
 	}
 
-	_, isUntolerated, _ := v1helper.FindMatchingUntoleratedTaint(logger, modifiedNode.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc(), pl.enableTaintTolerationComparisonOperators)
+	_, isUntolerated, err := v1helper.FindMatchingUntoleratedTaint(logger, modifiedNode.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc(), pl.enableTaintTolerationComparisonOperators)
+	if err != nil {
+		logger.V(4).Info(taintComparisonFailedLogMessage, "node", klog.KObj(modifiedNode), "pod", klog.KObj(pod), "err", err)
+	}
 
 	if wasUntolerated && !isUntolerated {
 		logger.V(5).Info("node was created or updated, and this may make the Pod rejected by TaintToleration plugin in the previous scheduling cycle schedulable", "pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))
@@ -129,7 +137,7 @@ func (pl *TaintToleration) Filter(ctx context.Context, state fwk.CycleState, pod
 		return nil
 	}
 	if err != nil {
-		logger.V(4).Info("node had a taint that could not be compared with pod tolerations", "node", klog.KObj(node), "pod", klog.KObj(pod), "untoleratedTaint", taint, "err", err)
+		logger.V(4).Info(taintComparisonFailedLogMessage, "node", klog.KObj(node), "pod", klog.KObj(pod), "untoleratedTaint", taint, "err", err)
 	} else {
 		logger.V(4).Info("node had untolerated taints", "node", klog.KObj(node), "pod", klog.KObj(pod), "untoleratedTaint", taint)
 	}
@@ -182,14 +190,17 @@ func getPreScoreState(cycleState fwk.CycleState) (*preScoreState, error) {
 }
 
 // CountIntolerableTaintsPreferNoSchedule gives the count of intolerable taints of a pod with effect PreferNoSchedule
-func (pl *TaintToleration) countIntolerableTaintsPreferNoSchedule(logger klog.Logger, taints []v1.Taint, tolerations []v1.Toleration) (intolerableTaints int) {
+func (pl *TaintToleration) countIntolerableTaintsPreferNoSchedule(logger klog.Logger, node *v1.Node, pod *v1.Pod, taints []v1.Taint, tolerations []v1.Toleration) (intolerableTaints int) {
 	for _, taint := range taints {
 		// check only on taints that have effect PreferNoSchedule
 		if taint.Effect != v1.TaintEffectPreferNoSchedule {
 			continue
 		}
 
-		tolerated, _ := v1helper.TolerationsTolerateTaint(logger, tolerations, &taint, pl.enableTaintTolerationComparisonOperators)
+		tolerated, err := v1helper.TolerationsTolerateTaint(logger, tolerations, &taint, pl.enableTaintTolerationComparisonOperators)
+		if err != nil {
+			logger.V(4).Info(taintComparisonFailedLogMessage, "node", klog.KObj(node), "pod", klog.KObj(pod), "taint", taint, "err", err)
+		}
 		if !tolerated {
 			intolerableTaints++
 		}
@@ -208,7 +219,7 @@ func (pl *TaintToleration) Score(ctx context.Context, state fwk.CycleState, pod 
 		return 0, fwk.AsStatus(err)
 	}
 
-	score := int64(pl.countIntolerableTaintsPreferNoSchedule(logger, node.Spec.Taints, s.tolerationsPreferNoSchedule))
+	score := int64(pl.countIntolerableTaintsPreferNoSchedule(logger, node, pod, node.Spec.Taints, s.tolerationsPreferNoSchedule))
 	return score, nil
 }
 

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
@@ -18,6 +18,7 @@ package tainttoleration
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -282,6 +283,28 @@ func TestTaintTolerationScore(t *testing.T) {
 			},
 			enableTaintTolerationComparisonOps: true,
 		},
+		{
+			name: "Score ignores parse errors from numeric PreferNoSchedule taint value",
+			pod: podWithTolerations("pod1", []v1.Toleration{{
+				Key:      "node.kubernetes.io/sla",
+				Operator: v1.TolerationOpGt,
+				Value:    "950",
+				Effect:   v1.TaintEffectPreferNoSchedule,
+			}}),
+			nodes: []*v1.Node{
+				nodeWithTaints("nodeA", nil),
+				nodeWithTaints("nodeB", []v1.Taint{{
+					Key:    "node.kubernetes.io/sla",
+					Value:  "high",
+					Effect: v1.TaintEffectPreferNoSchedule,
+				}}),
+			},
+			expectedList: []fwk.NodeScore{
+				{Name: "nodeA", Score: fwk.MaxScore},
+				{Name: "nodeB", Score: 0},
+			},
+			enableTaintTolerationComparisonOps: true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -419,11 +442,10 @@ func TestTaintTolerationFilter(t *testing.T) {
 			enableTaintTolerationComparisonOps: true,
 		},
 		{
-			name: "Pod with Gt toleration cannot be scheduled on node with non-numeric taint value",
-			pod:  podWithTolerations("pod1", []v1.Toleration{{Key: "node.kubernetes.io/sla", Operator: "Gt", Value: "950", Effect: "NoSchedule"}}),
-			node: nodeWithTaints("nodeA", []v1.Taint{{Key: "node.kubernetes.io/sla", Value: "high", Effect: "NoSchedule"}}),
-			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable,
-				"node(s) had untolerated taint(s)"),
+			name:                               "Pod with Gt toleration cannot be scheduled on node with non-numeric taint value",
+			pod:                                podWithTolerations("pod1", []v1.Toleration{{Key: "node.kubernetes.io/sla", Operator: "Gt", Value: "950", Effect: "NoSchedule"}}),
+			node:                               nodeWithTaints("nodeA", []v1.Taint{{Key: "node.kubernetes.io/sla", Value: "high", Effect: "NoSchedule"}}),
+			wantStatus:                         fwk.NewStatus(fwk.UnschedulableAndUnresolvable).WithError(errors.New(`failed to parse taint value "high" as int64: must be a valid decimal integer in canonical form`)),
 			enableTaintTolerationComparisonOps: true,
 		},
 	}
@@ -439,8 +461,8 @@ func TestTaintTolerationFilter(t *testing.T) {
 				t.Fatalf("creating plugin: %v", err)
 			}
 			gotStatus := p.(fwk.FilterPlugin).Filter(ctx, nil, test.pod, nodeInfo)
-			if diff := cmp.Diff(test.wantStatus, gotStatus); diff != "" {
-				t.Errorf("Unexpected status (-want,+got):\n%s", diff)
+			if test.wantStatus.Code() != gotStatus.Code() || test.wantStatus.Message() != gotStatus.Message() {
+				t.Errorf("Unexpected status (-want,+got):\n%s", cmp.Diff(test.wantStatus, gotStatus))
 			}
 		})
 	}
@@ -525,8 +547,8 @@ func TestTaintTolerationFilterWithFeatureGate(t *testing.T) {
 				t.Fatalf("creating plugin: %v", err)
 			}
 			gotStatus := p.(fwk.FilterPlugin).Filter(ctx, nil, test.pod, nodeInfo)
-			if diff := cmp.Diff(test.wantStatus, gotStatus); diff != "" {
-				t.Errorf("Unexpected status (-want,+got):\n%s", diff)
+			if test.wantStatus.Code() != gotStatus.Code() || test.wantStatus.Message() != gotStatus.Message() {
+				t.Errorf("Unexpected status (-want,+got):\n%s", cmp.Diff(test.wantStatus, gotStatus))
 			}
 		})
 	}

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
@@ -18,7 +18,6 @@ package tainttoleration
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -445,7 +444,17 @@ func TestTaintTolerationFilter(t *testing.T) {
 			name:                               "Pod with Gt toleration cannot be scheduled on node with non-numeric taint value",
 			pod:                                podWithTolerations("pod1", []v1.Toleration{{Key: "node.kubernetes.io/sla", Operator: "Gt", Value: "950", Effect: "NoSchedule"}}),
 			node:                               nodeWithTaints("nodeA", []v1.Taint{{Key: "node.kubernetes.io/sla", Value: "high", Effect: "NoSchedule"}}),
-			wantStatus:                         fwk.NewStatus(fwk.UnschedulableAndUnresolvable).WithError(errors.New(`failed to parse taint value "high" as int64: must be a valid decimal integer in canonical form`)),
+			wantStatus:                         fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "node(s) had untolerated taint(s)"),
+			enableTaintTolerationComparisonOps: true,
+		},
+		{
+			name: "Parse error before clean untolerated taint still reports stable Filter reason",
+			pod:  podWithTolerations("pod1", []v1.Toleration{{Key: "node.kubernetes.io/sla", Operator: "Gt", Value: "950", Effect: "NoSchedule"}}),
+			node: nodeWithTaints("nodeA", []v1.Taint{
+				{Key: "node.kubernetes.io/sla", Value: "high", Effect: "NoSchedule"},
+				{Key: "dedicated", Value: "gpu", Effect: "NoSchedule"},
+			}),
+			wantStatus:                         fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "node(s) had untolerated taint(s)"),
 			enableTaintTolerationComparisonOps: true,
 		},
 	}

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
@@ -18,6 +18,7 @@ package tainttoleration
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -284,6 +285,28 @@ func TestTaintTolerationScore(t *testing.T) {
 			},
 			enableTaintTolerationComparisonOps: true,
 		},
+		{
+			name: "Score ignores parse errors from numeric PreferNoSchedule taint value",
+			pod: podWithTolerations("pod1", []v1.Toleration{{
+				Key:      "node.kubernetes.io/sla",
+				Operator: v1.TolerationOpGt,
+				Value:    "950",
+				Effect:   v1.TaintEffectPreferNoSchedule,
+			}}),
+			nodes: []*v1.Node{
+				nodeWithTaints("nodeA", nil),
+				nodeWithTaints("nodeB", []v1.Taint{{
+					Key:    "node.kubernetes.io/sla",
+					Value:  "high",
+					Effect: v1.TaintEffectPreferNoSchedule,
+				}}),
+			},
+			expectedList: []fwk.NodeScore{
+				{Name: "nodeA", Score: fwk.MaxScore},
+				{Name: "nodeB", Score: 0},
+			},
+			enableTaintTolerationComparisonOps: true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -421,11 +444,10 @@ func TestTaintTolerationFilter(t *testing.T) {
 			enableTaintTolerationComparisonOps: true,
 		},
 		{
-			name: "Pod with Gt toleration cannot be scheduled on node with non-numeric taint value",
-			pod:  podWithTolerations("pod1", []v1.Toleration{{Key: "node.kubernetes.io/sla", Operator: "Gt", Value: "950", Effect: "NoSchedule"}}),
-			node: nodeWithTaints("nodeA", []v1.Taint{{Key: "node.kubernetes.io/sla", Value: "high", Effect: "NoSchedule"}}),
-			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable,
-				"node(s) had untolerated taint(s)"),
+			name:                               "Pod with Gt toleration cannot be scheduled on node with non-numeric taint value",
+			pod:                                podWithTolerations("pod1", []v1.Toleration{{Key: "node.kubernetes.io/sla", Operator: "Gt", Value: "950", Effect: "NoSchedule"}}),
+			node:                               nodeWithTaints("nodeA", []v1.Taint{{Key: "node.kubernetes.io/sla", Value: "high", Effect: "NoSchedule"}}),
+			wantStatus:                         fwk.NewStatus(fwk.UnschedulableAndUnresolvable).WithError(errors.New(`failed to parse taint value "high" as int64: must be a valid decimal integer in canonical form`)),
 			enableTaintTolerationComparisonOps: true,
 		},
 	}
@@ -441,8 +463,8 @@ func TestTaintTolerationFilter(t *testing.T) {
 				t.Fatalf("creating plugin: %v", err)
 			}
 			gotStatus := p.(fwk.FilterPlugin).Filter(ctx, nil, test.pod, nodeInfo)
-			if diff := cmp.Diff(test.wantStatus, gotStatus); diff != "" {
-				t.Errorf("Unexpected status (-want,+got):\n%s", diff)
+			if test.wantStatus.Code() != gotStatus.Code() || test.wantStatus.Message() != gotStatus.Message() {
+				t.Errorf("Unexpected status (-want,+got):\n%s", cmp.Diff(test.wantStatus, gotStatus))
 			}
 		})
 	}
@@ -527,8 +549,8 @@ func TestTaintTolerationFilterWithFeatureGate(t *testing.T) {
 				t.Fatalf("creating plugin: %v", err)
 			}
 			gotStatus := p.(fwk.FilterPlugin).Filter(ctx, nil, test.pod, nodeInfo)
-			if diff := cmp.Diff(test.wantStatus, gotStatus); diff != "" {
-				t.Errorf("Unexpected status (-want,+got):\n%s", diff)
+			if test.wantStatus.Code() != gotStatus.Code() || test.wantStatus.Message() != gotStatus.Message() {
+				t.Errorf("Unexpected status (-want,+got):\n%s", cmp.Diff(test.wantStatus, gotStatus))
 			}
 		})
 	}

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
@@ -18,7 +18,6 @@ package tainttoleration
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -447,7 +446,17 @@ func TestTaintTolerationFilter(t *testing.T) {
 			name:                               "Pod with Gt toleration cannot be scheduled on node with non-numeric taint value",
 			pod:                                podWithTolerations("pod1", []v1.Toleration{{Key: "node.kubernetes.io/sla", Operator: "Gt", Value: "950", Effect: "NoSchedule"}}),
 			node:                               nodeWithTaints("nodeA", []v1.Taint{{Key: "node.kubernetes.io/sla", Value: "high", Effect: "NoSchedule"}}),
-			wantStatus:                         fwk.NewStatus(fwk.UnschedulableAndUnresolvable).WithError(errors.New(`failed to parse taint value "high" as int64: must be a valid decimal integer in canonical form`)),
+			wantStatus:                         fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "node(s) had untolerated taint(s)"),
+			enableTaintTolerationComparisonOps: true,
+		},
+		{
+			name: "Parse error before clean untolerated taint still reports stable Filter reason",
+			pod:  podWithTolerations("pod1", []v1.Toleration{{Key: "node.kubernetes.io/sla", Operator: "Gt", Value: "950", Effect: "NoSchedule"}}),
+			node: nodeWithTaints("nodeA", []v1.Taint{
+				{Key: "node.kubernetes.io/sla", Value: "high", Effect: "NoSchedule"},
+				{Key: "dedicated", Value: "gpu", Effect: "NoSchedule"},
+			}),
+			wantStatus:                         fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "node(s) had untolerated taint(s)"),
 			enableTaintTolerationComparisonOps: true,
 		},
 	}

--- a/staging/src/k8s.io/api/core/v1/toleration.go
+++ b/staging/src/k8s.io/api/core/v1/toleration.go
@@ -17,13 +17,11 @@ limitations under the License.
 package v1
 
 import (
-	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/validate/content"
-
-	"k8s.io/klog/v2"
 )
 
 // MatchToleration checks if the toleration matches tolerationToMatch. Tolerations are unique by <key,effect,operator,value>,
@@ -49,64 +47,59 @@ func (t *Toleration) MatchToleration(tolerationToMatch *Toleration) bool {
 //     between toleration.value and taint.value.
 //  5. If enableComparisonOperators is false and the toleration uses 'Lt' or 'Gt'
 //     operators, the toleration does not match (returns false).
-func (t *Toleration) ToleratesTaint(logger klog.Logger, taint *Taint, enableComparisonOperators bool) bool {
+func (t *Toleration) ToleratesTaint(taint *Taint, enableComparisonOperators bool) (bool, error) {
 	if len(t.Effect) > 0 && t.Effect != taint.Effect {
-		return false
+		return false, nil
 	}
 
 	if len(t.Key) > 0 && t.Key != taint.Key {
-		return false
+		return false, nil
 	}
 
 	// TODO: Use proper defaulting when Toleration becomes a field of PodSpec
 	switch t.Operator {
 	// empty operator means Equal
 	case "", TolerationOpEqual:
-		return t.Value == taint.Value
+		return t.Value == taint.Value, nil
 	case TolerationOpExists:
-		return true
+		return true, nil
 	case TolerationOpLt, TolerationOpGt:
 		// If comparison operators are disabled, this toleration doesn't match
 		if !enableComparisonOperators {
-			return false
+			return false, nil
 		}
-		return compareNumericValues(logger, t.Value, taint.Value, t.Operator)
+		return compareNumericValues(t.Value, taint.Value, t.Operator)
 	default:
-		return false
+		return false, nil
 	}
 }
 
 // compareNumericValues performs numeric comparison between toleration and taint values
-func compareNumericValues(logger klog.Logger, tolerationVal, taintVal string, op TolerationOperator) bool {
-
+func compareNumericValues(tolerationVal, taintVal string, op TolerationOperator) (bool, error) {
 	errorMsgs := content.IsDecimalInteger(tolerationVal)
 	if len(errorMsgs) > 0 {
-		logger.Error(errors.New(strings.Join(errorMsgs, ",")), "failed to parse toleration value as int64", "toleration", tolerationVal)
-		return false
+		return false, fmt.Errorf("failed to parse toleration value %q as int64: %s", tolerationVal, strings.Join(errorMsgs, ","))
 	}
 	tVal, err := strconv.ParseInt(tolerationVal, 10, 64)
 	if err != nil {
-		logger.Error(err, "failed to parse toleration value as int64", "toleration", tolerationVal)
-		return false
+		return false, fmt.Errorf("failed to parse toleration value %q as int64: %w", tolerationVal, err)
 	}
 
 	errorMsgs = content.IsDecimalInteger(taintVal)
 	if len(errorMsgs) > 0 {
-		logger.Error(errors.New(strings.Join(errorMsgs, ",")), "failed to parse taint value as int64", "taint", taintVal)
-		return false
+		return false, fmt.Errorf("failed to parse taint value %q as int64: %s", taintVal, strings.Join(errorMsgs, ","))
 	}
 	tntVal, err := strconv.ParseInt(taintVal, 10, 64)
 	if err != nil {
-		logger.Error(err, "failed to parse taint value as int64", "taint", taintVal)
-		return false
+		return false, fmt.Errorf("failed to parse taint value %q as int64: %w", taintVal, err)
 	}
 
 	switch op {
 	case TolerationOpLt:
-		return tntVal < tVal
+		return tntVal < tVal, nil
 	case TolerationOpGt:
-		return tntVal > tVal
+		return tntVal > tVal, nil
 	default:
-		return false
+		return false, nil
 	}
 }

--- a/staging/src/k8s.io/api/core/v1/toleration_test.go
+++ b/staging/src/k8s.io/api/core/v1/toleration_test.go
@@ -16,13 +16,9 @@ limitations under the License.
 
 package v1
 
-import (
-	"k8s.io/klog/v2/ktesting"
-	"testing"
-)
+import "testing"
 
 func TestTolerationToleratesTaint(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
 	testCases := []struct {
 		description                                string
 		toleration                                 Toleration
@@ -248,20 +244,24 @@ func TestTolerationToleratesTaint(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		if tolerated := tc.toleration.ToleratesTaint(logger, &tc.taint, tc.enableTaintTolerationComparisonOperatorsFG); tc.expectTolerated != tolerated {
+		tolerated, err := tc.toleration.ToleratesTaint(&tc.taint, tc.enableTaintTolerationComparisonOperatorsFG)
+		if (err != nil) != tc.expectError {
+			t.Errorf("[%s] expect error %v, got %v", tc.description, tc.expectError, err)
+		}
+		if tc.expectTolerated != tolerated {
 			t.Errorf("[%s] expect %v, got %v: toleration %+v, taint %s", tc.description, tc.expectTolerated, tolerated, tc.toleration, tc.taint.ToString())
 		}
 	}
 }
 
 func TestCompareNumericValues(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
 	testCases := []struct {
 		description    string
 		tolerationVal  string
 		taintVal       string
 		operator       TolerationOperator
 		expectedResult bool
+		expectError    bool
 	}{
 		// Valid Gt operator cases
 		{
@@ -365,6 +365,7 @@ func TestCompareNumericValues(t *testing.T) {
 			taintVal:       "100",
 			operator:       TolerationOpGt,
 			expectedResult: false,
+			expectError:    true,
 		},
 		{
 			description:    "Gt operator - invalid toleration value (empty string), expect false",
@@ -372,6 +373,7 @@ func TestCompareNumericValues(t *testing.T) {
 			taintVal:       "100",
 			operator:       TolerationOpGt,
 			expectedResult: false,
+			expectError:    true,
 		},
 		{
 			description:    "Gt operator - invalid toleration value (leading zero), expect false",
@@ -379,6 +381,7 @@ func TestCompareNumericValues(t *testing.T) {
 			taintVal:       "200",
 			operator:       TolerationOpGt,
 			expectedResult: false,
+			expectError:    true,
 		},
 		{
 			description:    "Gt operator - invalid toleration value (plus sign), expect false",
@@ -386,6 +389,7 @@ func TestCompareNumericValues(t *testing.T) {
 			taintVal:       "200",
 			operator:       TolerationOpGt,
 			expectedResult: false,
+			expectError:    true,
 		},
 		{
 			description:    "Gt operator - invalid toleration value (floating point), expect false",
@@ -393,6 +397,7 @@ func TestCompareNumericValues(t *testing.T) {
 			taintVal:       "200",
 			operator:       TolerationOpGt,
 			expectedResult: false,
+			expectError:    true,
 		},
 		{
 			description:    "Gt operator - invalid toleration value (just minus sign), expect false",
@@ -400,6 +405,7 @@ func TestCompareNumericValues(t *testing.T) {
 			taintVal:       "100",
 			operator:       TolerationOpGt,
 			expectedResult: false,
+			expectError:    true,
 		},
 
 		// Invalid taint values - should return false
@@ -409,6 +415,7 @@ func TestCompareNumericValues(t *testing.T) {
 			taintVal:       "xyz",
 			operator:       TolerationOpGt,
 			expectedResult: false,
+			expectError:    true,
 		},
 		{
 			description:    "Gt operator - invalid taint value (empty string), expect false",
@@ -416,6 +423,7 @@ func TestCompareNumericValues(t *testing.T) {
 			taintVal:       "",
 			operator:       TolerationOpGt,
 			expectedResult: false,
+			expectError:    true,
 		},
 		{
 			description:    "Gt operator - invalid taint value (leading zero), expect false",
@@ -423,6 +431,7 @@ func TestCompareNumericValues(t *testing.T) {
 			taintVal:       "0200",
 			operator:       TolerationOpGt,
 			expectedResult: false,
+			expectError:    true,
 		},
 		{
 			description:    "Lt operator - invalid taint value (plus sign), expect false",
@@ -430,6 +439,7 @@ func TestCompareNumericValues(t *testing.T) {
 			taintVal:       "+200",
 			operator:       TolerationOpLt,
 			expectedResult: false,
+			expectError:    true,
 		},
 		{
 			description:    "Lt operator - invalid taint value (spaces), expect false",
@@ -437,6 +447,7 @@ func TestCompareNumericValues(t *testing.T) {
 			taintVal:       " 200 ",
 			operator:       TolerationOpLt,
 			expectedResult: false,
+			expectError:    true,
 		},
 
 		// Invalid operator - should return false
@@ -490,7 +501,10 @@ func TestCompareNumericValues(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			result := compareNumericValues(logger, tc.tolerationVal, tc.taintVal, tc.operator)
+			result, err := compareNumericValues(tc.tolerationVal, tc.taintVal, tc.operator)
+			if (err != nil) != tc.expectError {
+				t.Errorf("[%s] expect error %v, got %v", tc.description, tc.expectError, err)
+			}
 			if result != tc.expectedResult {
 				t.Errorf("[%s] expected %v, got %v: tolerationVal=%q, taintVal=%q, operator=%v",
 					tc.description, tc.expectedResult, result, tc.tolerationVal, tc.taintVal, tc.operator)

--- a/staging/src/k8s.io/api/go.mod
+++ b/staging/src/k8s.io/api/go.mod
@@ -6,10 +6,7 @@ go 1.26.0
 
 godebug default=go1.26
 
-require (
-	k8s.io/apimachinery v0.0.0
-	k8s.io/klog/v2 v2.140.0
-)
+require k8s.io/apimachinery v0.0.0
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -25,6 +22,7 @@ require (
 	golang.org/x/net v0.55.1-0.20260602153038-42abb857022c // indirect
 	golang.org/x/text v0.37.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260618221249-bc653b64f974 // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect

--- a/staging/src/k8s.io/api/go.mod
+++ b/staging/src/k8s.io/api/go.mod
@@ -6,10 +6,7 @@ go 1.26.0
 
 godebug default=go1.26
 
-require (
-	k8s.io/apimachinery v0.0.0
-	k8s.io/klog/v2 v2.140.0
-)
+require k8s.io/apimachinery v0.0.0
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -25,6 +22,7 @@ require (
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260721132016-d427ff9ee9ad // indirect
 	k8s.io/utils v0.0.0-20260626114624-be93311217bd // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect

--- a/staging/src/k8s.io/component-helpers/scheduling/corev1/helpers.go
+++ b/staging/src/k8s.io/component-helpers/scheduling/corev1/helpers.go
@@ -77,20 +77,31 @@ func TolerationsTolerateTaint(logger klog.Logger, tolerations []v1.Toleration, t
 
 type taintsFilterFunc func(*v1.Taint) bool
 
-// FindMatchingUntoleratedTaint checks if the given tolerations tolerates
-// all the filtered taints, and returns the first taint without a toleration
-// Returns true if there is an untolerated taint
-// Returns false if all taints are tolerated
+// FindMatchingUntoleratedTaint checks if the given tolerations tolerate
+// all the filtered taints, and returns a taint without a matching toleration.
+// Prefer a cleanly untolerated taint over a comparison parse failure so callers
+// get a stable result regardless of taint order.
+// Returns true if there is an untolerated taint (or only comparison errors).
+// Returns false if all taints are tolerated.
 func FindMatchingUntoleratedTaint(logger klog.Logger, taints []v1.Taint, tolerations []v1.Toleration, inclusionFilter taintsFilterFunc, enableComparisonOperators bool) (v1.Taint, bool, error) {
 	filteredTaints := getFilteredTaints(taints, inclusionFilter)
+	var firstErrTaint v1.Taint
+	var firstErr error
 	for _, taint := range filteredTaints {
 		tolerated, err := TolerationsTolerateTaint(logger, tolerations, &taint, enableComparisonOperators)
 		if err != nil {
-			return taint, true, err
+			if firstErr == nil {
+				firstErr = err
+				firstErrTaint = taint
+			}
+			continue
 		}
 		if !tolerated {
 			return taint, true, nil
 		}
+	}
+	if firstErr != nil {
+		return firstErrTaint, true, firstErr
 	}
 	return v1.Taint{}, false, nil
 }

--- a/staging/src/k8s.io/component-helpers/scheduling/corev1/helpers.go
+++ b/staging/src/k8s.io/component-helpers/scheduling/corev1/helpers.go
@@ -61,13 +61,18 @@ func GetAvoidPodsFromNodeAnnotations(annotations map[string]string) (v1.AvoidPod
 }
 
 // TolerationsTolerateTaint checks if taint is tolerated by any of the tolerations.
-func TolerationsTolerateTaint(logger klog.Logger, tolerations []v1.Toleration, taint *v1.Taint, enableComparisonOperators bool) bool {
+func TolerationsTolerateTaint(logger klog.Logger, tolerations []v1.Toleration, taint *v1.Taint, enableComparisonOperators bool) (bool, error) {
+	var firstErr error
 	for i := range tolerations {
-		if tolerations[i].ToleratesTaint(logger, taint, enableComparisonOperators) {
-			return true
+		tolerated, err := tolerations[i].ToleratesTaint(taint, enableComparisonOperators)
+		if tolerated {
+			return true, nil
+		}
+		if firstErr == nil && err != nil {
+			firstErr = err
 		}
 	}
-	return false
+	return false, firstErr
 }
 
 type taintsFilterFunc func(*v1.Taint) bool
@@ -76,14 +81,18 @@ type taintsFilterFunc func(*v1.Taint) bool
 // all the filtered taints, and returns the first taint without a toleration
 // Returns true if there is an untolerated taint
 // Returns false if all taints are tolerated
-func FindMatchingUntoleratedTaint(logger klog.Logger, taints []v1.Taint, tolerations []v1.Toleration, inclusionFilter taintsFilterFunc, enableComparisonOperators bool) (v1.Taint, bool) {
+func FindMatchingUntoleratedTaint(logger klog.Logger, taints []v1.Taint, tolerations []v1.Toleration, inclusionFilter taintsFilterFunc, enableComparisonOperators bool) (v1.Taint, bool, error) {
 	filteredTaints := getFilteredTaints(taints, inclusionFilter)
 	for _, taint := range filteredTaints {
-		if !TolerationsTolerateTaint(logger, tolerations, &taint, enableComparisonOperators) {
-			return taint, true
+		tolerated, err := TolerationsTolerateTaint(logger, tolerations, &taint, enableComparisonOperators)
+		if err != nil {
+			return taint, true, err
+		}
+		if !tolerated {
+			return taint, true, nil
 		}
 	}
-	return v1.Taint{}, false
+	return v1.Taint{}, false, nil
 }
 
 // getFilteredTaints returns a list of taints satisfying the filter predicate

--- a/staging/src/k8s.io/component-helpers/scheduling/corev1/helpers.go
+++ b/staging/src/k8s.io/component-helpers/scheduling/corev1/helpers.go
@@ -62,17 +62,17 @@ func GetAvoidPodsFromNodeAnnotations(annotations map[string]string) (v1.AvoidPod
 
 // TolerationsTolerateTaint checks if taint is tolerated by any of the tolerations.
 func TolerationsTolerateTaint(logger klog.Logger, tolerations []v1.Toleration, taint *v1.Taint, enableComparisonOperators bool) (bool, error) {
-	var firstErr error
+	var firstWarning error
 	for i := range tolerations {
-		tolerated, err := tolerations[i].ToleratesTaint(taint, enableComparisonOperators)
+		tolerated, warning := tolerations[i].ToleratesTaint(taint, enableComparisonOperators)
 		if tolerated {
 			return true, nil
 		}
-		if firstErr == nil && err != nil {
-			firstErr = err
+		if firstWarning == nil && warning != nil {
+			firstWarning = warning
 		}
 	}
-	return false, firstErr
+	return false, firstWarning
 }
 
 type taintsFilterFunc func(*v1.Taint) bool
@@ -85,14 +85,14 @@ type taintsFilterFunc func(*v1.Taint) bool
 // Returns false if all taints are tolerated.
 func FindMatchingUntoleratedTaint(logger klog.Logger, taints []v1.Taint, tolerations []v1.Toleration, inclusionFilter taintsFilterFunc, enableComparisonOperators bool) (v1.Taint, bool, error) {
 	filteredTaints := getFilteredTaints(taints, inclusionFilter)
-	var firstErrTaint v1.Taint
-	var firstErr error
+	var firstWarningTaint v1.Taint
+	var firstWarning error
 	for _, taint := range filteredTaints {
-		tolerated, err := TolerationsTolerateTaint(logger, tolerations, &taint, enableComparisonOperators)
-		if err != nil {
-			if firstErr == nil {
-				firstErr = err
-				firstErrTaint = taint
+		tolerated, warning := TolerationsTolerateTaint(logger, tolerations, &taint, enableComparisonOperators)
+		if warning != nil {
+			if firstWarning == nil {
+				firstWarning = warning
+				firstWarningTaint = taint
 			}
 			continue
 		}
@@ -100,8 +100,8 @@ func FindMatchingUntoleratedTaint(logger klog.Logger, taints []v1.Taint, tolerat
 			return taint, true, nil
 		}
 	}
-	if firstErr != nil {
-		return firstErrTaint, true, firstErr
+	if firstWarning != nil {
+		return firstWarningTaint, true, firstWarning
 	}
 	return v1.Taint{}, false, nil
 }

--- a/staging/src/k8s.io/component-helpers/scheduling/corev1/helpers_test.go
+++ b/staging/src/k8s.io/component-helpers/scheduling/corev1/helpers_test.go
@@ -836,10 +836,39 @@ func TestFindMatchingUntoleratedTaint(t *testing.T) {
 			expectError:                 true,
 			enableComparisonOperatorsFG: true,
 		},
+		{
+			description: "numeric Gt parse error is ignored when a later toleration matches the taint",
+			tolerations: []v1.Toleration{
+				{
+					Key:      "node.kubernetes.io/sla",
+					Operator: "Gt",
+					Value:    "950",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "node.kubernetes.io/sla",
+					Operator: "Exists",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+			},
+			taints: []v1.Taint{
+				{
+					Key:    "node.kubernetes.io/sla",
+					Value:  "high",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			applyFilter:                 func(t *v1.Taint) bool { return true },
+			expectTolerated:             true,
+			enableComparisonOperatorsFG: true,
+		},
 	}
 
 	for _, tc := range testCases {
-		_, untolerated := FindMatchingUntoleratedTaint(logger, tc.taints, tc.tolerations, tc.applyFilter, tc.enableComparisonOperatorsFG)
+		_, untolerated, err := FindMatchingUntoleratedTaint(logger, tc.taints, tc.tolerations, tc.applyFilter, tc.enableComparisonOperatorsFG)
+		if (err != nil) != tc.expectError {
+			t.Errorf("[%s] expect error %v, got %v", tc.description, tc.expectError, err)
+		}
 		if tc.expectTolerated != !untolerated {
 			filteredTaints := []v1.Taint{}
 			for _, taint := range tc.taints {

--- a/staging/src/k8s.io/component-helpers/scheduling/corev1/helpers_test.go
+++ b/staging/src/k8s.io/component-helpers/scheduling/corev1/helpers_test.go
@@ -653,6 +653,7 @@ func TestFindMatchingUntoleratedTaint(t *testing.T) {
 		applyFilter                 taintsFilterFunc
 		expectTolerated             bool
 		expectError                 bool
+		expectUntoleratedTaint      *v1.Taint
 		enableComparisonOperatorsFG bool
 	}{
 		{
@@ -858,9 +859,14 @@ func TestFindMatchingUntoleratedTaint(t *testing.T) {
 					Effect: v1.TaintEffectNoSchedule,
 				},
 			},
-			applyFilter:                 func(t *v1.Taint) bool { return true },
-			expectTolerated:             false,
-			expectError:                 false,
+			applyFilter:     func(t *v1.Taint) bool { return true },
+			expectTolerated: false,
+			expectError:     false,
+			expectUntoleratedTaint: &v1.Taint{
+				Key:    "dedicated",
+				Value:  "gpu",
+				Effect: v1.TaintEffectNoSchedule,
+			},
 			enableComparisonOperatorsFG: true,
 		},
 		{
@@ -885,9 +891,14 @@ func TestFindMatchingUntoleratedTaint(t *testing.T) {
 					Effect: v1.TaintEffectNoSchedule,
 				},
 			},
-			applyFilter:                 func(t *v1.Taint) bool { return true },
-			expectTolerated:             false,
-			expectError:                 false,
+			applyFilter:     func(t *v1.Taint) bool { return true },
+			expectTolerated: false,
+			expectError:     false,
+			expectUntoleratedTaint: &v1.Taint{
+				Key:    "dedicated",
+				Value:  "gpu",
+				Effect: v1.TaintEffectNoSchedule,
+			},
 			enableComparisonOperatorsFG: true,
 		},
 		{
@@ -919,7 +930,7 @@ func TestFindMatchingUntoleratedTaint(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		_, untolerated, err := FindMatchingUntoleratedTaint(logger, tc.taints, tc.tolerations, tc.applyFilter, tc.enableComparisonOperatorsFG)
+		untoleratedTaint, untolerated, err := FindMatchingUntoleratedTaint(logger, tc.taints, tc.tolerations, tc.applyFilter, tc.enableComparisonOperatorsFG)
 		if (err != nil) != tc.expectError {
 			t.Errorf("[%s] expect error %v, got %v", tc.description, tc.expectError, err)
 		}
@@ -932,6 +943,9 @@ func TestFindMatchingUntoleratedTaint(t *testing.T) {
 				filteredTaints = append(filteredTaints, taint)
 			}
 			t.Errorf("[%s] expect tolerations %+v tolerate filtered taints %+v in taints %+v", tc.description, tc.tolerations, filteredTaints, tc.taints)
+		}
+		if tc.expectUntoleratedTaint != nil && !apiequality.Semantic.DeepEqual(*tc.expectUntoleratedTaint, untoleratedTaint) {
+			t.Errorf("[%s] expect untolerated taint %+v, got %+v", tc.description, *tc.expectUntoleratedTaint, untoleratedTaint)
 		}
 	}
 }

--- a/staging/src/k8s.io/component-helpers/scheduling/corev1/helpers_test.go
+++ b/staging/src/k8s.io/component-helpers/scheduling/corev1/helpers_test.go
@@ -837,6 +837,60 @@ func TestFindMatchingUntoleratedTaint(t *testing.T) {
 			enableComparisonOperatorsFG: true,
 		},
 		{
+			description: "prefer cleanly untolerated taint over earlier comparison parse error",
+			tolerations: []v1.Toleration{
+				{
+					Key:      "node.kubernetes.io/sla",
+					Operator: "Gt",
+					Value:    "950",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+			},
+			taints: []v1.Taint{
+				{
+					Key:    "node.kubernetes.io/sla",
+					Value:  "high",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    "dedicated",
+					Value:  "gpu",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			applyFilter:                 func(t *v1.Taint) bool { return true },
+			expectTolerated:             false,
+			expectError:                 false,
+			enableComparisonOperatorsFG: true,
+		},
+		{
+			description: "prefer cleanly untolerated taint even when it appears before comparison parse error",
+			tolerations: []v1.Toleration{
+				{
+					Key:      "node.kubernetes.io/sla",
+					Operator: "Gt",
+					Value:    "950",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+			},
+			taints: []v1.Taint{
+				{
+					Key:    "dedicated",
+					Value:  "gpu",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    "node.kubernetes.io/sla",
+					Value:  "high",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			applyFilter:                 func(t *v1.Taint) bool { return true },
+			expectTolerated:             false,
+			expectError:                 false,
+			enableComparisonOperatorsFG: true,
+		},
+		{
 			description: "numeric Gt parse error is ignored when a later toleration matches the taint",
 			tolerations: []v1.Toleration{
 				{

--- a/staging/src/k8s.io/component-helpers/scheduling/corev1/helpers_test.go
+++ b/staging/src/k8s.io/component-helpers/scheduling/corev1/helpers_test.go
@@ -652,7 +652,7 @@ func TestFindMatchingUntoleratedTaint(t *testing.T) {
 		taints                      []v1.Taint
 		applyFilter                 taintsFilterFunc
 		expectTolerated             bool
-		expectError                 bool
+		expectWarning               bool
 		expectUntoleratedTaint      *v1.Taint
 		enableComparisonOperatorsFG bool
 	}{
@@ -834,7 +834,7 @@ func TestFindMatchingUntoleratedTaint(t *testing.T) {
 			},
 			applyFilter:                 func(t *v1.Taint) bool { return true },
 			expectTolerated:             false,
-			expectError:                 true,
+			expectWarning:               true,
 			enableComparisonOperatorsFG: true,
 		},
 		{
@@ -861,7 +861,7 @@ func TestFindMatchingUntoleratedTaint(t *testing.T) {
 			},
 			applyFilter:     func(t *v1.Taint) bool { return true },
 			expectTolerated: false,
-			expectError:     false,
+			expectWarning:   false,
 			expectUntoleratedTaint: &v1.Taint{
 				Key:    "dedicated",
 				Value:  "gpu",
@@ -893,7 +893,7 @@ func TestFindMatchingUntoleratedTaint(t *testing.T) {
 			},
 			applyFilter:     func(t *v1.Taint) bool { return true },
 			expectTolerated: false,
-			expectError:     false,
+			expectWarning:   false,
 			expectUntoleratedTaint: &v1.Taint{
 				Key:    "dedicated",
 				Value:  "gpu",
@@ -930,9 +930,9 @@ func TestFindMatchingUntoleratedTaint(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		untoleratedTaint, untolerated, err := FindMatchingUntoleratedTaint(logger, tc.taints, tc.tolerations, tc.applyFilter, tc.enableComparisonOperatorsFG)
-		if (err != nil) != tc.expectError {
-			t.Errorf("[%s] expect error %v, got %v", tc.description, tc.expectError, err)
+		untoleratedTaint, untolerated, warning := FindMatchingUntoleratedTaint(logger, tc.taints, tc.tolerations, tc.applyFilter, tc.enableComparisonOperatorsFG)
+		if (warning != nil) != tc.expectWarning {
+			t.Errorf("[%s] expect error %v, got %v", tc.description, tc.expectWarning, warning)
 		}
 		if tc.expectTolerated != !untolerated {
 			filteredTaints := []v1.Taint{}

--- a/test/e2e/framework/node/resource.go
+++ b/test/e2e/framework/node/resource.go
@@ -406,7 +406,8 @@ func toleratesTaintsWithNoScheduleNoExecuteEffects(logger klog.Logger, taints []
 	toleratesTaint := func(taint v1.Taint) bool {
 		for _, toleration := range tolerations {
 			//	TaintTolerationComparisonOperators feature gate will be false for e2e since the feature is in Alpha.
-			if toleration.ToleratesTaint(logger, &taint, false) {
+			tolerates, _ := toleration.ToleratesTaint(&taint, false)
+			if tolerates {
 				return true
 			}
 		}

--- a/test/integration/scheduler/eventhandler/eventhandler_test.go
+++ b/test/integration/scheduler/eventhandler/eventhandler_test.go
@@ -61,7 +61,8 @@ func (pl *fooPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v1.P
 		return nil
 	}
 
-	if corev1.TolerationsTolerateTaint(logger, pod.Spec.Tolerations, &nodeInfo.Node().Spec.Taints[0], utilfeature.DefaultFeatureGate.Enabled(features.TaintTolerationComparisonOperators)) {
+	tolerates, _ := corev1.TolerationsTolerateTaint(logger, pod.Spec.Tolerations, &nodeInfo.Node().Spec.Taints[0], utilfeature.DefaultFeatureGate.Enabled(features.TaintTolerationComparisonOperators))
+	if tolerates {
 		return nil
 	}
 	return fwk.NewStatus(fwk.Unschedulable)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
Fixes #135243

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
TaintToleration Gt/Lt: invalid numeric values now fail Filter with an error (Score still ignores them).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
