### PR TITLE
cleanup: fix double "the" and other comment typos in pkg

### DIFF
--- a/pkg/apis/batch/types.go
+++ b/pkg/apis/batch/types.go
@@ -453,7 +453,7 @@ type JobSpec struct {
 	// - Failed means to wait until a previously created Pod is fully terminated (has phase
 	//   Failed or Succeeded) before creating a replacement Pod.
 	//
-	// When using podFailurePolicy, Failed is the the only allowed value.
+	// When using podFailurePolicy, Failed is the only allowed value.
 	// TerminatingOrFailed and Failed are allowed values when podFailurePolicy is not in use.
 	// +optional
 	PodReplacementPolicy *PodReplacementPolicy

--- a/pkg/apis/certificates/types.go
+++ b/pkg/apis/certificates/types.go
@@ -377,7 +377,7 @@ type PodCertificateRequestSpec struct {
 	// Version 2.0](https://www.secg.org/sec1-v2.pdf) (as implemented by the
 	// golang library function crypto/ecdsa.SignASN1)
 	//
-	// If the key is an ED25519 key, the the signature is as described by the
+	// If the key is an ED25519 key, then the signature is as described by the
 	// [ED25519 Specification](https://ed25519.cr.yp.to/) (as implemented by the
 	// golang library crypto/ed25519.Sign).
 	//

--- a/pkg/kubelet/cm/dra/claiminfo.go
+++ b/pkg/kubelet/cm/dra/claiminfo.go
@@ -265,7 +265,7 @@ func (cache *claimInfoCache) syncToCheckpoint() error {
 	return cache.checkpointer.Store(checkpoint)
 }
 
-// claimsInUse computes the the current counter vector for DRAResourceClaimsInUse.
+// claimsInUse computes the current counter vector for DRAResourceClaimsInUse.
 // It returns a map of driver name to number of claims which have been prepared using
 // the driver. The [kubeletmetrics.DRAResourceClaimsInUseAnyDriver] key stands for
 // all prepared claims.

--- a/pkg/scheduler/backend/cache/snapshot.go
+++ b/pkg/scheduler/backend/cache/snapshot.go
@@ -36,7 +36,7 @@ type placementNodes struct {
 	// This is useful for quickly returning the entire list to the caller.
 	nodeInfoList []fwk.NodeInfo
 	// nodeInfoSet contains the set of nodes in the placement.
-	// This is useful for quickly checking if a node belongs the the placement.
+	// This is useful for quickly checking if a node belongs to the placement.
 	nodeInfoSet sets.Set[string]
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Corrects duplicate "the" and other spelling/grammatical typos in comments across several packages:
- `pkg/kubelet/cm/dra/claiminfo.go` (fixed "the the")
- `pkg/apis/batch/types.go` (fixed "the the")
- `pkg/apis/certificates/types.go` (fixed "the the" to "then the")
- `pkg/scheduler/backend/cache/snapshot.go` (fixed "belongs the the" to "belongs to the")

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
None. These are trivial comment-only cleanups.

#### Does this PR introduce a user-facing change?
```release-note
NONE
