### PR TITLE
Add PodGroup object to PodGroupInfo for scheduling cycle consistency

### DIFF
--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
@@ -272,10 +272,7 @@ func getPlacementFeasibleState(placementCycleState fwk.PlacementCycleState) *pla
 // The function will only return success once the gang's MinCount is satisfied or if the pod group is not using gang scheduling policy.
 // In case there are not enough remaining pods to satisfy the gang's MinCount, it returns Unschedulable which will terminate the pod group scheduling cycle early.
 func (pl *GangScheduling) PlacementFeasible(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroupInfo fwk.PodGroupInfo) *fwk.Status {
-	pg, err := pl.podGroupLister.PodGroups(podGroupInfo.GetNamespace()).Get(podGroupInfo.GetName())
-	if err != nil {
-		return fwk.AsStatus(fmt.Errorf("failed to get podGroup %s to compute gang feasibility: %w", klog.KObj(podGroupInfo), err))
-	}
+	pg := podGroupInfo.GetPodGroup()
 
 	gangPolicy := pg.Spec.SchedulingPolicy.Gang
 	// This plugin only cares about pods with a Gang scheduling policy.

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -717,6 +717,7 @@ func TestPlacementFeasible(t *testing.T) {
 				namespace:       namespace,
 				name:            pgName,
 				unscheduledPods: tc.unscheduledPods,
+				podGroup:        pg,
 			}
 
 			cycleState := schedulerframework.NewCycleState()
@@ -740,8 +741,10 @@ type testPodGroupInfo struct {
 	namespace       string
 	name            string
 	unscheduledPods []*v1.Pod
+	podGroup        *schedulingapi.PodGroup
 }
 
-func (t *testPodGroupInfo) GetNamespace() string          { return t.namespace }
-func (t *testPodGroupInfo) GetName() string               { return t.name }
-func (t *testPodGroupInfo) GetUnscheduledPods() []*v1.Pod { return t.unscheduledPods }
+func (t *testPodGroupInfo) GetNamespace() string                 { return t.namespace }
+func (t *testPodGroupInfo) GetName() string                      { return t.name }
+func (t *testPodGroupInfo) GetUnscheduledPods() []*v1.Pod        { return t.unscheduledPods }
+func (t *testPodGroupInfo) GetPodGroup() *schedulingapi.PodGroup { return t.podGroup }

--- a/pkg/scheduler/framework/plugins/topologyaware/topology_placement.go
+++ b/pkg/scheduler/framework/plugins/topologyaware/topology_placement.go
@@ -23,7 +23,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	schedulingapi "k8s.io/api/scheduling/v1alpha3"
 	"k8s.io/apimachinery/pkg/runtime"
-	schedulinglisters "k8s.io/client-go/listers/scheduling/v1alpha3"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
@@ -37,8 +36,7 @@ const (
 
 // TopologyPlacement is a plugin that generates placements for a pod group based on its topology constraints.
 type TopologyPlacement struct {
-	handle         fwk.Handle
-	podGroupLister schedulinglisters.PodGroupLister
+	handle fwk.Handle
 }
 
 var _ fwk.PlacementGeneratePlugin = &TopologyPlacement{}
@@ -46,8 +44,7 @@ var _ fwk.PlacementGeneratePlugin = &TopologyPlacement{}
 // New initializes a new plugin and returns it.
 func New(_ context.Context, _ runtime.Object, fh fwk.Handle, fts feature.Features) (*TopologyPlacement, error) {
 	return &TopologyPlacement{
-		handle:         fh,
-		podGroupLister: fh.SharedInformerFactory().Scheduling().V1alpha3().PodGroups().Lister(),
+		handle: fh,
 	}, nil
 }
 
@@ -59,10 +56,7 @@ func (pl *TopologyPlacement) Name() string {
 // GeneratePlacements generates placements for a pod group based on the topology constraints in the pod group spec.
 // It uses the parent placement to find the nodes that are available for placement.
 func (pl *TopologyPlacement) GeneratePlacements(ctx context.Context, state fwk.PodGroupCycleState, podGroup fwk.PodGroupInfo, parentPlacement *fwk.Placement) (*fwk.GeneratePlacementsResult, *fwk.Status) {
-	podGroupResource, err := pl.podGroupLister.PodGroups(podGroup.GetNamespace()).Get(podGroup.GetName())
-	if err != nil {
-		return nil, fwk.AsStatus(err)
-	}
+	podGroupResource := podGroup.GetPodGroup()
 	topologyKey, ok := pl.getTopologyKey(podGroupResource)
 	if !ok {
 		// No topology constraints, return a single placement with no constraints.

--- a/pkg/scheduler/framework/plugins/topologyaware/topology_placement_test.go
+++ b/pkg/scheduler/framework/plugins/topologyaware/topology_placement_test.go
@@ -231,6 +231,7 @@ func TestGeneratePlacements(t *testing.T) {
 			podGroupInfo := &framework.PodGroupInfo{
 				Name:      tt.podGroup.Name,
 				Namespace: tt.podGroup.Namespace,
+				PodGroup:  tt.podGroup,
 			}
 
 			result, status := pl.GeneratePlacements(tCtx, framework.NewCycleState(), podGroupInfo, placement)

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -26,17 +26,17 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
-	"k8s.io/klog/v2"
-
-	"k8s.io/apimachinery/pkg/api/resource"
 	ndf "k8s.io/component-helpers/nodedeclaredfeatures"
 	resourcehelper "k8s.io/component-helpers/resource"
+	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
+	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/features"
 	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
@@ -963,6 +963,8 @@ type PodGroupInfo struct {
 	// PodGroupManager.PodGroupState can be used for that.
 	// The order of the pods is deterministic and based on signature, priority and timestamp.
 	UnscheduledPods []*v1.Pod
+	// PodGroup is a PodGroup API object.
+	PodGroup *schedulingv1alpha3.PodGroup
 }
 
 func (pgi *PodGroupInfo) GetName() string {
@@ -975,6 +977,10 @@ func (pgi *PodGroupInfo) GetNamespace() string {
 
 func (pgi *PodGroupInfo) GetUnscheduledPods() []*v1.Pod {
 	return pgi.UnscheduledPods
+}
+
+func (pgi *PodGroupInfo) GetPodGroup() *schedulingv1alpha3.PodGroup {
+	return pgi.PodGroup
 }
 
 // PodInfo is a wrapper to a Pod with additional pre-computed information to

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -49,24 +49,18 @@ func (sched *Scheduler) scheduleOnePodGroup(ctx context.Context, podGroupInfo *f
 	logger = klog.LoggerWithValues(logger, "podGroup", klog.KObj(podGroupInfo))
 	ctx = klog.NewContext(ctx, logger)
 
-	err := sched.validatePodGroup(podGroupInfo)
-
+	podGroup, err := sched.podGroupLister.PodGroups(podGroupInfo.Namespace).Get(podGroupInfo.Name)
 	if err != nil {
-		for _, podInfo := range podGroupInfo.QueuedPodInfos {
-			podFwk, podFwkErr := sched.frameworkForPod(podInfo.Pod)
-			if podFwkErr != nil {
-				// This shouldn't happen, because we only accept for scheduling the pods
-				// which specify a scheduler name that matches one of the profiles.
-				logger.Error(podFwkErr, "Error occurred")
-				sched.SchedulingQueue.Done(podInfo.Pod.UID)
-				return
-			}
-			sched.FailureHandler(ctx, podFwk, podInfo, fwk.AsStatus(err), clearNominatedNode, time.Now())
-		}
-		err := sched.SchedulingQueue.AddAttemptedPodGroupIfNeeded(logger, podGroupInfo, sched.SchedulingQueue.SchedulingCycle())
-		if err != nil {
-			utilruntime.HandleErrorWithContext(ctx, err, "Failed to pod group back to scheduling queue", "podGroup", klog.KObj(podGroupInfo))
-		}
+		// It can happen that the pod group was popped from the scheduling queue before it observed the PodGroup deletion.
+		// PodGroup should come back to the scheduling queue.
+		sched.handlePodGroupFailureBeforeScheduling(ctx, podGroupInfo, err)
+		return
+	}
+	podGroupInfo.PodGroup = podGroup
+
+	err = sched.validatePodGroup(podGroupInfo)
+	if err != nil {
+		sched.handlePodGroupFailureBeforeScheduling(ctx, podGroupInfo, err)
 		return
 	}
 	schedFwk := sched.frameworkForPodGroup(podGroupInfo)
@@ -83,18 +77,34 @@ func (sched *Scheduler) scheduleOnePodGroup(ctx context.Context, podGroupInfo *f
 	sched.podGroupCycle(ctx, schedFwk, framework.NewCycleState(), podGroupInfo)
 }
 
+// handlePodGroupFailureBeforeScheduling handles the failure of a pod group that occurred before scheduling.
+func (sched *Scheduler) handlePodGroupFailureBeforeScheduling(ctx context.Context, podGroupInfo *framework.QueuedPodGroupInfo, err error) {
+	logger := klog.FromContext(ctx)
+
+	for _, podInfo := range podGroupInfo.QueuedPodInfos {
+		podFwk, podFwkErr := sched.frameworkForPod(podInfo.Pod)
+		if podFwkErr != nil {
+			// This shouldn't happen, because we only accept for scheduling the pods
+			// which specify a scheduler name that matches one of the profiles.
+			logger.Error(podFwkErr, "Error occurred")
+			sched.SchedulingQueue.Done(podInfo.Pod.UID)
+			continue
+		}
+		sched.FailureHandler(ctx, podFwk, podInfo, fwk.AsStatus(err), clearNominatedNode, time.Now())
+	}
+	err = sched.SchedulingQueue.AddAttemptedPodGroupIfNeeded(logger, podGroupInfo, sched.SchedulingQueue.SchedulingCycle())
+	if err != nil {
+		utilruntime.HandleErrorWithContext(ctx, err, "Failed to add pod group back to scheduling queue", "podGroup", klog.KObj(podGroupInfo))
+	}
+}
+
 func (sched *Scheduler) validatePodGroup(podGroupInfo *framework.QueuedPodGroupInfo) error {
 	if len(podGroupInfo.QueuedPodInfos) == 0 {
 		return fmt.Errorf("pod group has no pods to schedule")
 	}
 
 	schedulerName := podGroupInfo.QueuedPodInfos[0].Pod.Spec.SchedulerName
-
-	pg, err := sched.podGroupLister.PodGroups(podGroupInfo.Namespace).Get(podGroupInfo.Name)
-	if err != nil {
-		return fmt.Errorf("pod group cannot be retrieved: %w", err)
-	}
-	podGroupPriority := util.PodGroupPriority(pg)
+	podGroupPriority := util.PodGroupPriority(podGroupInfo.PodGroup)
 
 	for _, pInfo := range podGroupInfo.QueuedPodInfos {
 		if pInfo.Pod.Spec.SchedulerName != schedulerName {
@@ -248,10 +258,7 @@ func (sched *Scheduler) runWorkloadAwarePreemption(ctx context.Context, schedFwk
 		return nil, fwk.NewStatus(fwk.Unschedulable, "default preemption plugin is not registered, workload aware preemption is disabled")
 	}
 
-	pg, err := schedFwk.SharedInformerFactory().Scheduling().V1alpha3().PodGroups().Lister().PodGroups(podGroupInfo.Namespace).Get(podGroupInfo.Name)
-	if err != nil {
-		return nil, fwk.AsStatus(fmt.Errorf("failed to get pod group object: %w", err))
-	}
+	pg := podGroupInfo.PodGroup
 	if pg.Spec.SchedulingConstraints != nil && len(pg.Spec.SchedulingConstraints.Topology) > 0 {
 		return nil, fwk.NewStatus(fwk.Unschedulable, "workload aware preemption is not supported for pod groups with scheduling constraints")
 	}
@@ -629,12 +636,7 @@ func (sched *Scheduler) updatePodGroupCondition(ctx context.Context,
 
 	// If the PodGroup was already successfully scheduled, don't regress the
 	// condition back to False on a subsequent cycle for extra pods.
-	pg, err := sched.podGroupLister.PodGroups(podGroupInfo.Namespace).Get(podGroupInfo.Name)
-	if err != nil {
-		utilruntime.HandleErrorWithLogger(logger, err, "Failed to get PodGroup for status update", "podGroup", klog.KObj(podGroupInfo))
-		return
-	}
-
+	pg := podGroupInfo.PodGroup
 	existing := apimeta.FindStatusCondition(pg.Status.Conditions, condition.Type)
 	if existing != nil && existing.Status == metav1.ConditionTrue && condition.Status != metav1.ConditionTrue {
 		return

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -18,7 +18,6 @@ package scheduler
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -277,20 +276,17 @@ func TestValidatePodGroup(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			overrides := featuregatetesting.FeatureOverrides{
+			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
 				features.GenericWorkload: true,
-			}
-			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, overrides)
-			_, ctx := ktesting.NewTestContext(t)
-			testPodGroupInfo := &framework.PodGroupInfo{Name: tt.podGroup.Name, Namespace: tt.podGroup.Namespace}
-			client := clientsetfake.NewClientset(tt.podGroup)
-			informerFactory := informers.NewSharedInformerFactory(client, 0)
-			podGroupLister := informerFactory.Scheduling().V1alpha3().PodGroups().Lister()
-			informerFactory.Start(ctx.Done())
-			informerFactory.WaitForCacheSync(ctx.Done())
-			sched := &Scheduler{Profiles: tt.profiles, podGroupLister: podGroupLister}
+			})
+			sched := &Scheduler{Profiles: tt.profiles}
+
 			podGroupInfo := &framework.QueuedPodGroupInfo{
-				PodGroupInfo: testPodGroupInfo,
+				PodGroupInfo: &framework.PodGroupInfo{
+					Name:      tt.podGroup.Name,
+					Namespace: tt.podGroup.Namespace,
+					PodGroup:  tt.podGroup,
+				},
 			}
 			for _, pod := range tt.pods {
 				podGroupInfo.UnscheduledPods = append(podGroupInfo.UnscheduledPods, pod)
@@ -394,6 +390,7 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 			Name:            "pg",
 			Namespace:       "default",
 			UnscheduledPods: []*v1.Pod{p1, p2},
+			PodGroup:        testPodGroup,
 		},
 	}
 
@@ -477,6 +474,7 @@ func TestPodGroupCycle_FillsPodResultsOnFewerResults(t *testing.T) {
 			Name:            "pg",
 			Namespace:       "default",
 			UnscheduledPods: []*v1.Pod{p1, p2, p3},
+			PodGroup:        testPodGroup,
 		},
 	}
 
@@ -636,6 +634,7 @@ func TestPodGroupCycle_PodGroupPostFilter(t *testing.T) {
 					Name:            "pg",
 					Namespace:       "default",
 					UnscheduledPods: []*v1.Pod{p1, p2},
+					PodGroup:        testPodGroup,
 				},
 			}
 
@@ -1638,6 +1637,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			if tt.existingPodGroup != nil {
 				pg = tt.existingPodGroup
 			}
+			podGroupInfo.PodGroupInfo.PodGroup = pg
 			client := clientsetfake.NewClientset(testNode, pg)
 			client.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
 				if action.GetSubresource() != "binding" {
@@ -2039,23 +2039,6 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 			expectLastTransitionTimeUnchanged: true,
 		},
 		{
-			name:         "PodGroup not found does not panic",
-			namespace:    "ns1",
-			podGroupName: "nonexistent",
-			condition: &metav1.Condition{
-				Type:    schedulingapi.PodGroupInitiallyScheduled,
-				Status:  metav1.ConditionTrue,
-				Reason:  "SomeReason",
-				Message: "test",
-			},
-			expectCondition: &metav1.Condition{
-				Type:    schedulingapi.PodGroupInitiallyScheduled,
-				Status:  metav1.ConditionTrue,
-				Reason:  "SomeReason",
-				Message: "test",
-			},
-		},
-		{
 			name: "ObservedGeneration is set from PodGroup generation",
 			existingPodGroup: &schedulingv1alpha3.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg-gen", Namespace: "ns1", Generation: 7},
@@ -2094,27 +2077,20 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 			sched := &Scheduler{client: client, podGroupLister: podGroupLister}
 
 			var existingLTT metav1.Time
-			if tt.existingPodGroup != nil {
-				if existing := apimeta.FindStatusCondition(tt.existingPodGroup.Status.Conditions, schedulingapi.PodGroupInitiallyScheduled); existing != nil {
-					existingLTT = existing.LastTransitionTime
-				}
+			if existing := apimeta.FindStatusCondition(tt.existingPodGroup.Status.Conditions, schedulingapi.PodGroupInitiallyScheduled); existing != nil {
+				existingLTT = existing.LastTransitionTime
 			}
 
 			podGroupInfo := &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
 					Namespace: tt.namespace,
 					Name:      tt.podGroupName,
+					PodGroup:  tt.existingPodGroup,
 				},
 			}
 			sched.updatePodGroupCondition(ctx, podGroupInfo, tt.condition)
 
 			updatedPodGroup, err := client.SchedulingV1alpha3().PodGroups(tt.namespace).Get(ctx, tt.podGroupName, metav1.GetOptions{})
-			if tt.existingPodGroup == nil {
-				if err == nil {
-					t.Fatalf("Expected PodGroup to not be found, but got: %v", updatedPodGroup)
-				}
-				return
-			}
 			if err != nil {
 				t.Fatalf("Failed to get PodGroup: %v", err)
 			}
@@ -2847,7 +2823,7 @@ func TestRunWorkloadAwarePreemption(t *testing.T) {
 	tests := []struct {
 		name                 string
 		podGroupInfo         *framework.QueuedPodGroupInfo
-		existingPodGroups    []*schedulingv1alpha3.PodGroup
+		existingPodGroup     *schedulingv1alpha3.PodGroup
 		pluginsRegistered    bool
 		pluginReturnStatus   *fwk.Status
 		pluginNominatedNodes map[string]*fwk.NominatingInfo
@@ -2862,17 +2838,6 @@ func TestRunWorkloadAwarePreemption(t *testing.T) {
 			expectedStatus:    fwk.NewStatus(fwk.Unschedulable, "default preemption plugin is not registered, workload aware preemption is disabled"),
 		},
 		{
-			name: "error when pod group is not found in informer",
-			podGroupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "default", Name: "missing-pg"},
-				QueuedPodInfos: []*framework.QueuedPodInfo{
-					{PodInfo: &framework.PodInfo{Pod: st.MakePod().Name("p1").Namespace("default").Obj()}},
-				},
-			},
-			pluginsRegistered: true,
-			expectedStatus:    fwk.AsStatus(fmt.Errorf("failed to get pod group object: podgroup.scheduling.k8s.io \"missing-pg\" not found")),
-		},
-		{
 			name: "error when pod group has scheduling constraints",
 			podGroupInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{Namespace: "default", Name: "pg-with-constraints"},
@@ -2880,13 +2845,11 @@ func TestRunWorkloadAwarePreemption(t *testing.T) {
 					{PodInfo: &framework.PodInfo{Pod: st.MakePod().Name("p1").Namespace("default").Obj()}},
 				},
 			},
-			existingPodGroups: []*schedulingv1alpha3.PodGroup{
-				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pg-with-constraints"},
-					Spec: schedulingv1alpha3.PodGroupSpec{
-						SchedulingConstraints: &schedulingv1alpha3.PodGroupSchedulingConstraints{
-							Topology: []schedulingv1alpha3.TopologyConstraint{{}}, // non-empty
-						},
+			existingPodGroup: &schedulingv1alpha3.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pg-with-constraints"},
+				Spec: schedulingv1alpha3.PodGroupSpec{
+					SchedulingConstraints: &schedulingv1alpha3.PodGroupSchedulingConstraints{
+						Topology: []schedulingv1alpha3.TopologyConstraint{{}}, // non-empty
 					},
 				},
 			},
@@ -2901,10 +2864,8 @@ func TestRunWorkloadAwarePreemption(t *testing.T) {
 					{PodInfo: &framework.PodInfo{Pod: st.MakePod().Name("p1").Namespace("default").Obj()}},
 				},
 			},
-			existingPodGroups: []*schedulingv1alpha3.PodGroup{
-				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pg-success"},
-				},
+			existingPodGroup: &schedulingv1alpha3.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pg-success"},
 			},
 			pluginsRegistered:  true,
 			pluginReturnStatus: fwk.NewStatus(fwk.Success),
@@ -2921,27 +2882,12 @@ func TestRunWorkloadAwarePreemption(t *testing.T) {
 					{PodInfo: &framework.PodInfo{Pod: st.MakePod().Name("p1").Namespace("default").Obj()}},
 				},
 			},
-			existingPodGroups: []*schedulingv1alpha3.PodGroup{
-				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pg-unschedulable"},
-				},
+			existingPodGroup: &schedulingv1alpha3.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pg-unschedulable"},
 			},
 			pluginsRegistered:  true,
 			pluginReturnStatus: fwk.NewStatus(fwk.Unschedulable, "not enough resources"),
 			expectedStatus:     fwk.NewStatus(fwk.Unschedulable, "not enough resources"),
-		},
-		{
-			name: "error when pod group does not exist",
-			podGroupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "default", Name: "pg-unschedulable"},
-				QueuedPodInfos: []*framework.QueuedPodInfo{
-					{PodInfo: &framework.PodInfo{Pod: st.MakePod().Name("p1").Namespace("default").Obj()}},
-				},
-			},
-			existingPodGroups:  []*schedulingv1alpha3.PodGroup{},
-			pluginsRegistered:  true,
-			pluginReturnStatus: fwk.NewStatus(fwk.Success),
-			expectedStatus:     fwk.AsStatus(fmt.Errorf("failed to get pod group object: %w", errors.New("podgroup.scheduling.k8s.io \"pg-unschedulable\" not found"))),
 		},
 	}
 
@@ -2989,8 +2935,9 @@ func TestRunWorkloadAwarePreemption(t *testing.T) {
 			}
 
 			objs := []runtime.Object{}
-			for _, pg := range tt.existingPodGroups {
-				objs = append(objs, pg)
+			if tt.existingPodGroup != nil {
+				objs = append(objs, tt.existingPodGroup)
+				tt.podGroupInfo.PodGroup = tt.existingPodGroup
 			}
 			client := clientsetfake.NewSimpleClientset(objs...)
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
@@ -3055,6 +3002,7 @@ func TestPodGroupCycle_NominatedNodes(t *testing.T) {
 			Name:            "pg",
 			Namespace:       "default",
 			UnscheduledPods: []*v1.Pod{p1, p2},
+			PodGroup:        testPodGroup,
 		},
 	}
 
@@ -3156,5 +3104,84 @@ func TestPodGroupCycle_NominatedNodes(t *testing.T) {
 
 	if capturedFailureHandler[p2.Name] != nil {
 		t.Errorf("Expected p2 to not be nominated, got %v", capturedFailureHandler[p2.Name])
+	}
+}
+
+func TestScheduleOnePodGroup_PodGroupNotFound(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
+
+	p1 := st.MakePod().Name("p1").Namespace("default").UID("p1").PodGroupName("pg").SchedulerName("test-scheduler").Obj()
+	p2 := st.MakePod().Name("p2").Namespace("default").UID("p2").PodGroupName("pg").SchedulerName("test-scheduler").Obj()
+	qInfo1 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p1}}
+	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
+
+	podGroupInfo := &framework.QueuedPodGroupInfo{
+		QueuedPodInfos: []*framework.QueuedPodInfo{qInfo1, qInfo2},
+		PodGroupInfo: &framework.PodGroupInfo{
+			Name:            "pg",
+			Namespace:       "default",
+			UnscheduledPods: []*v1.Pod{p1, p2},
+		},
+	}
+
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	registry := frameworkruntime.Registry{
+		queuesort.Name:     queuesort.New,
+		defaultbinder.Name: defaultbinder.New,
+	}
+	profileCfg := config.KubeSchedulerProfile{
+		SchedulerName: "test-scheduler",
+		Plugins: &config.Plugins{
+			QueueSort: config.PluginSet{
+				Enabled: []config.Plugin{{Name: queuesort.Name}},
+			},
+			Bind: config.PluginSet{
+				Enabled: []config.Plugin{{Name: defaultbinder.Name}},
+			},
+		},
+	}
+
+	client := clientsetfake.NewSimpleClientset(p1, p2)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	podGroupLister := informerFactory.Scheduling().V1alpha3().PodGroups().Lister()
+
+	schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
+		frameworkruntime.WithInformerFactory(informerFactory),
+		frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create new framework: %v", err)
+	}
+
+	cache := internalcache.New(ctx, nil, true)
+	queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
+
+	informerFactory.Start(ctx.Done())
+	informerFactory.WaitForCacheSync(ctx.Done())
+
+	sched := &Scheduler{
+		Profiles:               profile.Map{"test-scheduler": schedFwk},
+		podGroupLister:         podGroupLister,
+		SchedulingQueue:        queue,
+		Cache:                  cache,
+		client:                 client,
+		genericWorkloadEnabled: true,
+	}
+	sched.FailureHandler = sched.handleSchedulingFailure
+
+	sched.scheduleOnePodGroup(ctx, podGroupInfo)
+
+	// Verify that the pods are put back into the scheduling queue.
+	pendingPods, _ := queue.PendingPods()
+	gotPendingPods := sets.New[string]()
+	for _, pod := range pendingPods {
+		gotPendingPods.Insert(pod.Name)
+	}
+	expectedPods := sets.New("p1", "p2")
+	if diff := cmp.Diff(expectedPods, gotPendingPods); diff != "" {
+		t.Errorf("Unexpected pods in scheduling queue (-want,+got)\n%s", diff)
 	}
 }

--- a/staging/src/k8s.io/kube-scheduler/framework/types.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/types.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -653,6 +654,8 @@ type PodGroupInfo interface {
 	GetName() string
 	// GetNamespace returns the namespace the pod group belongs to.
 	GetNamespace() string
+	// GetPodGroup returns the PodGroup API object.
+	GetPodGroup() *schedulingv1alpha3.PodGroup
 }
 
 // Placement determines the resources to be considered when scheduling a pod group.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This PR adds PodGroup API object to PodGroupInfo, so the PodGroup state can be consistent throughout the scheduling cycle.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added the PodGroup field to the PodGroupInfo object in kube-scheduler to enable plugins to obtain a consistent state throughout the scheduling cycle.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
