### PR TITLE
Promote KYAML printer to stable

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/json_yaml_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/json_yaml_flags.go
@@ -17,7 +17,6 @@ limitations under the License.
 package genericclioptions
 
 import (
-	"os"
 	"slices"
 	"strings"
 
@@ -31,12 +30,7 @@ func (f *JSONYamlPrintFlags) AllowedFormats() []string {
 	if f == nil {
 		return []string{}
 	}
-	formats := []string{"json", "yaml"}
-	// We can't use the cmdutil pkg directly because of import cycle.
-	if strings.ToLower(os.Getenv("KUBECTL_KYAML")) != "false" {
-		formats = append(formats, "kyaml")
-	}
-	return formats
+	return []string{"json", "yaml", "kyaml"}
 }
 
 // JSONYamlPrintFlags provides default flags necessary for json/yaml printing.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -444,12 +444,6 @@ const (
 	// Transition to WebSockets.
 	RemoteCommandWebsockets FeatureGate = "KUBECTL_REMOTE_COMMAND_WEBSOCKETS"
 	PortForwardWebsockets   FeatureGate = "KUBECTL_PORT_FORWARD_WEBSOCKETS"
-
-	// owner: @thockin
-	// kep: https://kep.k8s.io/5296
-	//
-	// Support KYAML output.
-	KYAMLOutput FeatureGate = "KUBECTL_KYAML"
 )
 
 // IsEnabled returns true iff environment variable is set to true.


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/sig cli

#### What this PR does / why we need it:
This promotes `KUBECTL_KYAML` feature to stable. 

#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/issues/5295

#### Special notes for your reviewer:
/assign @ardaguclu @rxinui 

#### Does this PR introduce a user-facing change?
```release-note
Support for `kubectl get -o kyaml` is promoted to stable.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/5295
```
