### PR TITLE
Cache and snapshot PodGroup API objects in kube-scheduler

### DIFF
--- a/pkg/scheduler/backend/cache/cache.go
+++ b/pkg/scheduler/backend/cache/cache.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -291,8 +292,10 @@ func (cache *cacheImpl) UpdateSnapshot(logger klog.Logger, nodeSnapshot *Snapsho
 		return errors.New(errMsg)
 	}
 
-	// Take a snapshot of pod group states for this scheduling cycle.
-	cache.updatePodGroupStateSnapshot(nodeSnapshot)
+	if cache.genericWorkloadEnabled {
+		// Take a snapshot of pod group states for this scheduling cycle.
+		cache.updatePodGroupStateSnapshot(nodeSnapshot)
+	}
 
 	return nil
 }
@@ -945,6 +948,35 @@ func (cache *cacheImpl) Get(namespace string, podGroupName string) (fwk.PodGroup
 	return podGroupState, nil
 }
 
+// PodGroups returns the PodGroupLister for this cache.
+func (cache *cacheImpl) PodGroups() fwk.PodGroupLister {
+	return &podGroupListerImpl{cache: cache}
+}
+
+type podGroupListerImpl struct {
+	cache *cacheImpl
+}
+
+// Get returns the cached pod group object.
+func (l *podGroupListerImpl) Get(namespace, name string) (*schedulingv1alpha3.PodGroup, error) {
+	if !l.cache.genericWorkloadEnabled {
+		return nil, fmt.Errorf("generic workload feature gate is disabled")
+	}
+	l.cache.mu.RLock()
+	defer l.cache.mu.RUnlock()
+
+	key := newPodGroupKey(namespace, name)
+	pgs, exists := l.cache.podGroupStates[key]
+	if !exists {
+		return nil, fmt.Errorf("pod group state not found for pod group %s", key)
+	}
+	pg := pgs.PodGroup()
+	if pg == nil {
+		return nil, fmt.Errorf("pod group object not found for pod group %s", key)
+	}
+	return pg, nil
+}
+
 // BindPod handles the pod binding by adding a bind API call to the dispatcher.
 // This method should be used only if the SchedulerAsyncAPICalls feature gate is enabled.
 func (cache *cacheImpl) BindPod(binding *v1.Binding) (<-chan error, error) {
@@ -984,4 +1016,58 @@ func (cache *cacheImpl) applyPVCRefCountDelta(snapshot *Snapshot) error {
 	}
 	cache.pvcRefCountsDelta = map[string]int{}
 	return nil
+}
+
+// AddPodGroup adds a pod group object to the cache.
+func (cache *cacheImpl) AddPodGroup(podGroup *schedulingv1alpha3.PodGroup) {
+	if !cache.genericWorkloadEnabled {
+		return
+	}
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	key := newPodGroupKey(podGroup.Namespace, podGroup.Name)
+	pgs, exists := cache.podGroupStates[key]
+	if !exists {
+		pgs = newPodGroupState()
+		cache.podGroupStates[key] = pgs
+	}
+	pgs.setPodGroup(podGroup)
+}
+
+// UpdatePodGroup updates a pod group object in the cache.
+func (cache *cacheImpl) UpdatePodGroup(logger klog.Logger, oldPodGroup, newPodGroup *schedulingv1alpha3.PodGroup) {
+	if !cache.genericWorkloadEnabled {
+		return
+	}
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	key := newPodGroupKey(newPodGroup.Namespace, newPodGroup.Name)
+	pgs, exists := cache.podGroupStates[key]
+	if !exists {
+		// This should not happen: the pod group state should have been already created by a prior pod group add action.
+		utilruntime.HandleErrorWithLogger(logger, nil, "Pod group state not found for update, this indicates a missed add event", "podGroup", klog.KObj(newPodGroup))
+		return
+	}
+	pgs.setPodGroup(newPodGroup)
+}
+
+// RemovePodGroup removes a pod group object from the cache.
+func (cache *cacheImpl) RemovePodGroup(podGroup *schedulingv1alpha3.PodGroup) {
+	if !cache.genericWorkloadEnabled {
+		return
+	}
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	key := newPodGroupKey(podGroup.Namespace, podGroup.Name)
+	pgs, exists := cache.podGroupStates[key]
+	if !exists {
+		return
+	}
+	pgs.removePodGroup()
+	if pgs.empty() {
+		delete(cache.podGroupStates, key)
+	}
 }

--- a/pkg/scheduler/backend/cache/cache_test.go
+++ b/pkg/scheduler/backend/cache/cache_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	v1 "k8s.io/api/core/v1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -693,9 +694,11 @@ func Test_AddPodGroupMember(t *testing.T) {
 	podWithNoPodGroup := st.MakePod().Namespace("namespace").Name("non-workload-pod").Obj()
 	unscheduledPodGroupMember := st.MakePod().Namespace("namespace").Name("unscheduled-pod").PodGroupName("pg").Obj()
 	assignedPodGroupMember := st.MakePod().Namespace("namespace").Name("assigned-pod").Node("node1").PodGroupName("pg").Obj()
+	podGroup := st.MakePodGroup().Namespace("namespace").Name("pg").Obj()
 
 	tests := []struct {
 		name                    string
+		initPodGroup            *schedulingv1alpha3.PodGroup
 		pod                     *v1.Pod
 		genericWorkloadEnabled  bool
 		expectInUnscheduledPods bool
@@ -723,11 +726,22 @@ func Test_AddPodGroupMember(t *testing.T) {
 			genericWorkloadEnabled: true,
 			expectInAssignedPods:   true,
 		},
+		{
+			name:                   "add assigned pod group member when state already exists (from PodGroup object)",
+			initPodGroup:           podGroup,
+			pod:                    assignedPodGroupMember,
+			genericWorkloadEnabled: true,
+			expectInAssignedPods:   true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cache := newCache(context.Background(), time.Second, nil, tt.genericWorkloadEnabled)
+			if tt.initPodGroup != nil {
+				cache.AddPodGroup(tt.initPodGroup)
+			}
+
 			cache.AddPodGroupMember(tt.pod)
 
 			if !tt.genericWorkloadEnabled || tt.pod.Spec.SchedulingGroup == nil {
@@ -862,10 +876,12 @@ func Test_RemovePodGroupMember(t *testing.T) {
 		PodGroupName(podGroupName).Obj()
 	pod2 := st.MakePod().Namespace("namespace").Name("assigned-pod").UID("pod2").Node("node").
 		PodGroupName(podGroupName).Obj()
+	podGroup := st.MakePodGroup().Namespace("namespace").Name(podGroupName).Obj()
 
 	tests := []struct {
 		name                     string
 		initPods                 []*v1.Pod
+		initPodGroup             *schedulingv1alpha3.PodGroup
 		podToDelete              *v1.Pod
 		expectPodGroupStateCount int
 		genericWorkloadEnabled   bool
@@ -882,6 +898,14 @@ func Test_RemovePodGroupMember(t *testing.T) {
 			initPods:                 []*v1.Pod{pod1},
 			podToDelete:              pod1,
 			expectPodGroupStateCount: 0,
+			genericWorkloadEnabled:   true,
+		},
+		{
+			name:                     "remove a last pod from a group when PodGroup object still exists shouldn't remove the state",
+			initPods:                 []*v1.Pod{pod1},
+			initPodGroup:             podGroup,
+			podToDelete:              pod1,
+			expectPodGroupStateCount: 1,
 			genericWorkloadEnabled:   true,
 		},
 		{
@@ -902,6 +926,10 @@ func Test_RemovePodGroupMember(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cache := newCache(context.Background(), time.Second, nil, tt.genericWorkloadEnabled)
+
+			if tt.initPodGroup != nil {
+				cache.AddPodGroup(tt.initPodGroup)
+			}
 
 			for _, pod := range tt.initPods {
 				cache.AddPodGroupMember(pod)
@@ -925,6 +953,182 @@ func Test_RemovePodGroupMember(t *testing.T) {
 
 			if podGroupState.AllPods().Has(tt.podToDelete.UID) {
 				t.Errorf("Expected pod %s to be deleted from pod group but it still exists", tt.podToDelete.UID)
+			}
+		})
+	}
+}
+
+func Test_AddPodGroup(t *testing.T) {
+	podGroup := st.MakePodGroup().Namespace("ns").Name("pg").Obj()
+	pod := st.MakePod().Namespace("ns").Name("pod1").PodGroupName("pg").Obj()
+
+	tests := []struct {
+		name                   string
+		initPod                *v1.Pod
+		podGroup               *schedulingv1alpha3.PodGroup
+		genericWorkloadEnabled bool
+		expectPodGroup         *schedulingv1alpha3.PodGroup
+	}{
+		{
+			name:                   "add pod group with GenericWorkload disabled should be no-op",
+			podGroup:               podGroup,
+			genericWorkloadEnabled: false,
+			expectPodGroup:         nil,
+		},
+		{
+			name:                   "add pod group",
+			podGroup:               podGroup,
+			genericWorkloadEnabled: true,
+			expectPodGroup:         podGroup,
+		},
+		{
+			name:                   "add pod group when state already exists (from pod group members)",
+			initPod:                pod,
+			podGroup:               podGroup,
+			genericWorkloadEnabled: true,
+			expectPodGroup:         podGroup,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			cache := newCache(ctx, time.Second, nil, tt.genericWorkloadEnabled)
+			if tt.initPod != nil {
+				cache.AddPodGroupMember(tt.initPod)
+			}
+			cache.AddPodGroup(tt.podGroup)
+
+			gotPodGroup, err := cache.PodGroups().Get(tt.podGroup.Namespace, tt.podGroup.Name)
+			if tt.expectPodGroup != nil {
+				if err != nil {
+					t.Fatalf("Expected pod group to exist, but got error: %v", err)
+				}
+				if diff := cmp.Diff(tt.expectPodGroup, gotPodGroup); diff != "" {
+					t.Errorf("Unexpected pod group (-want, +got):\n%s", diff)
+				}
+			} else if err == nil {
+				t.Error("Expected error getting pod group, but got none")
+			}
+		})
+	}
+}
+
+func Test_UpdatePodGroup(t *testing.T) {
+	oldPodGroup := st.MakePodGroup().Namespace("ns").Name("pg").MinCount(1).Obj()
+	newPodGroup := st.MakePodGroup().Namespace("ns").Name("pg").MinCount(2).Obj()
+
+	tests := []struct {
+		name                   string
+		initPodGroup           *schedulingv1alpha3.PodGroup
+		oldPodGroup            *schedulingv1alpha3.PodGroup
+		newPodGroup            *schedulingv1alpha3.PodGroup
+		genericWorkloadEnabled bool
+		expectPodGroup         *schedulingv1alpha3.PodGroup
+	}{
+		{
+			name:                   "update pod group with GenericWorkload disabled should be no-op",
+			oldPodGroup:            oldPodGroup,
+			newPodGroup:            newPodGroup,
+			genericWorkloadEnabled: false,
+			expectPodGroup:         nil,
+		},
+		{
+			name:                   "update pod group with GenericWorkload enabled",
+			oldPodGroup:            oldPodGroup,
+			newPodGroup:            newPodGroup,
+			genericWorkloadEnabled: true,
+			expectPodGroup:         newPodGroup,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			cache := newCache(ctx, time.Second, nil, tt.genericWorkloadEnabled)
+			cache.AddPodGroup(tt.oldPodGroup)
+
+			cache.UpdatePodGroup(logger, tt.oldPodGroup, tt.newPodGroup)
+
+			gotPodGroup, err := cache.PodGroups().Get(tt.newPodGroup.Namespace, tt.newPodGroup.Name)
+			if tt.expectPodGroup != nil {
+				if err != nil {
+					t.Fatalf("Expected pod group to exist, but got error: %v", err)
+				}
+				if diff := cmp.Diff(tt.expectPodGroup, gotPodGroup); diff != "" {
+					t.Errorf("Unexpected pod group (-want, +got):\n%s", diff)
+				}
+			} else if err == nil {
+				t.Error("Expected error getting pod group, but got none")
+			}
+		})
+	}
+}
+
+func Test_RemovePodGroup(t *testing.T) {
+	podGroup := st.MakePodGroup().Namespace("ns").Name("pg").Obj()
+	pod := st.MakePod().Namespace("ns").Name("pod1").PodGroupName("pg").Obj()
+
+	tests := []struct {
+		name                   string
+		initPod                *v1.Pod
+		podGroup               *schedulingv1alpha3.PodGroup
+		genericWorkloadEnabled bool
+		expectPodGroupExists   bool
+		expectStateExists      bool
+		expectPodsCount        int
+	}{
+		{
+			name:                   "remove pod group with GenericWorkload disabled should be no-op",
+			podGroup:               podGroup,
+			genericWorkloadEnabled: false,
+		},
+		{
+			name:                   "remove pod group with GenericWorkload enabled",
+			podGroup:               podGroup,
+			genericWorkloadEnabled: true,
+			expectStateExists:      false,
+		},
+		{
+			name:                   "remove pod group when it still has pod members",
+			initPod:                pod,
+			podGroup:               podGroup,
+			genericWorkloadEnabled: true,
+			expectStateExists:      true,
+			expectPodsCount:        1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			cache := newCache(ctx, time.Second, nil, tt.genericWorkloadEnabled)
+			if tt.initPod != nil {
+				cache.AddPodGroupMember(tt.initPod)
+			}
+			cache.AddPodGroup(tt.podGroup)
+
+			cache.RemovePodGroup(tt.podGroup)
+
+			_, err := cache.PodGroups().Get(tt.podGroup.Namespace, tt.podGroup.Name)
+			if err == nil {
+				t.Error("Expected error getting pod group, but got none")
+			}
+
+			key := newPodGroupKey(tt.podGroup.Namespace, tt.podGroup.Name)
+			pgs, exists := cache.podGroupStates[key]
+			if tt.expectStateExists {
+				if !exists {
+					t.Fatalf("Expected pod group state to exist")
+				}
+				if pgs.PodGroup() != nil {
+					t.Error("Expected pod group object inside state to be nil, but it was not")
+				}
+				if len(pgs.allPods) != tt.expectPodsCount {
+					t.Errorf("Expected %d pods in state, got %d", tt.expectPodsCount, len(pgs.allPods))
+				}
+			} else if exists {
+				t.Error("Expected pod group state to be deleted, but it still exists")
 			}
 		})
 	}

--- a/pkg/scheduler/backend/cache/interface.go
+++ b/pkg/scheduler/backend/cache/interface.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	v1 "k8s.io/api/core/v1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
@@ -119,6 +120,9 @@ type Cache interface {
 	// PodGroupStates returns a PodGroupStateLister.
 	PodGroupStates() fwk.PodGroupStateLister
 
+	// PodGroups returns a PodGroupLister used to access the cached PodGroup objects.
+	PodGroups() fwk.PodGroupLister
+
 	// AddPodGroupMember adds not assigned and not assumed pod to its pod group state.
 	AddPodGroupMember(pod *v1.Pod)
 
@@ -127,6 +131,15 @@ type Cache interface {
 
 	// RemovePodGroupMember removes a pod from its pod group state.
 	RemovePodGroupMember(pod *v1.Pod)
+
+	// AddPodGroup adds a pod group object to the cache.
+	AddPodGroup(podGroup *schedulingv1alpha3.PodGroup)
+
+	// UpdatePodGroup updates a pod group object in the cache.
+	UpdatePodGroup(logger klog.Logger, oldPodGroup, newPodGroup *schedulingv1alpha3.PodGroup)
+
+	// RemovePodGroup removes a pod group object from the cache.
+	RemovePodGroup(podGroup *schedulingv1alpha3.PodGroup)
 }
 
 // Dump is a dump of the cache state.

--- a/pkg/scheduler/backend/cache/podgroupstate.go
+++ b/pkg/scheduler/backend/cache/podgroupstate.go
@@ -22,6 +22,7 @@ import (
 	"sync/atomic"
 
 	v1 "k8s.io/api/core/v1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
@@ -63,6 +64,10 @@ func newPodGroupKey(namespace string, name string) podGroupKey {
 }
 
 // podGroupStateData holds data and functionality shared between podGroupState and podGroupStateSnapshot.
+// Note that the podGroup field is populated from the observed PodGroup API object,
+// while other fields are populated from observed Pod objects. This means podGroupStateData
+// can exist without a corresponding PodGroup API object as long as at least one
+// Pod references it.
 type podGroupStateData struct {
 	// generation gets bumped whenever the data is changed.
 	// It's used to detect changes and avoid unnecessary cloning when taking a snapshot.
@@ -77,6 +82,8 @@ type podGroupStateData struct {
 	assumedPods map[types.UID]*v1.Pod
 	// assignedPods tracks all pods belonging to the group that are assigned (bound).
 	assignedPods sets.Set[types.UID]
+	// podGroup is the cached API object of the PodGroup.
+	podGroup *schedulingv1alpha3.PodGroup
 }
 
 func newPodGroupStateData() podGroupStateData {
@@ -183,7 +190,7 @@ func (d *podGroupStateData) scheduledPods() []*v1.Pod {
 
 // empty returns true when the pod group state contains no pods.
 func (d *podGroupStateData) empty() bool {
-	return len(d.allPods) == 0
+	return len(d.allPods) == 0 && d.podGroup == nil
 }
 
 // allPodsCount returns the number of all pods known to the scheduler for this group.
@@ -196,15 +203,32 @@ func (d *podGroupStateData) scheduledPodsCount() int {
 	return len(d.assumedPods) + len(d.assignedPods)
 }
 
-// deepCopy returns a deep copy of the pod group state data.
-func (d *podGroupStateData) deepCopy() podGroupStateData {
+// clone returns a clone of the pod group state data.
+// It does not deep copy the inner Pod and PodGroup objects
+// as they should not be mutated by the scheduler.
+// Cache's and snapshot's objects are read-only from the outside,
+// unless mutated explicitly by the methods.
+func (d *podGroupStateData) clone() podGroupStateData {
 	return podGroupStateData{
 		generation:      d.generation,
 		allPods:         maps.Clone(d.allPods),
 		unscheduledPods: d.unscheduledPods.Clone(),
 		assumedPods:     maps.Clone(d.assumedPods),
 		assignedPods:    d.assignedPods.Clone(),
+		podGroup:        d.podGroup,
 	}
+}
+
+// setPodGroup sets the PodGroup object.
+func (d *podGroupStateData) setPodGroup(podGroup *schedulingv1alpha3.PodGroup) {
+	d.generation = nextPodGroupGeneration()
+	d.podGroup = podGroup
+}
+
+// removePodGroup removes the PodGroup object.
+func (d *podGroupStateData) removePodGroup() {
+	d.generation = nextPodGroupGeneration()
+	d.podGroup = nil
 }
 
 // unscheduledPodsMap returns all unscheduled pods for this pod group.
@@ -230,10 +254,10 @@ func newPodGroupState() *podGroupState {
 // snapshot returns a deep copy of the live pod group state as an immutable snapshot.
 // It must be called under the cache lock.
 func (pgs *podGroupState) snapshot() *podGroupStateSnapshot {
-	return &podGroupStateSnapshot{podGroupStateData: pgs.podGroupStateData.deepCopy()}
+	return &podGroupStateSnapshot{podGroupStateData: pgs.podGroupStateData.clone()}
 }
 
-// empty returns true when the group contains no pods.
+// empty returns true when the group contains no pods and the cached PodGroup object is nil.
 // It must be called under the cache lock.
 func (pgs *podGroupState) empty() bool {
 	pgs.lock.RLock()
@@ -287,6 +311,24 @@ func (pgs *podGroupState) forgetPod(podUID types.UID) {
 	defer pgs.lock.Unlock()
 
 	pgs.podGroupStateData.forgetPod(podUID)
+}
+
+// setPodGroup sets the PodGroup object.
+// It must be called under the cache lock.
+func (pgs *podGroupState) setPodGroup(podGroup *schedulingv1alpha3.PodGroup) {
+	pgs.lock.Lock()
+	defer pgs.lock.Unlock()
+
+	pgs.podGroupStateData.setPodGroup(podGroup)
+}
+
+// removePodGroup removes the PodGroup object.
+// It must be called under the cache lock.
+func (pgs *podGroupState) removePodGroup() {
+	pgs.lock.Lock()
+	defer pgs.lock.Unlock()
+
+	pgs.podGroupStateData.removePodGroup()
 }
 
 // AllPods returns the UIDs of all pods known to the scheduler for this group.
@@ -346,6 +388,14 @@ func (pgs *podGroupState) ScheduledPodsCount() int {
 	defer pgs.lock.RUnlock()
 
 	return pgs.podGroupStateData.scheduledPodsCount()
+}
+
+// PodGroup returns the PodGroup API object.
+func (pgs *podGroupState) PodGroup() *schedulingv1alpha3.PodGroup {
+	pgs.lock.RLock()
+	defer pgs.lock.RUnlock()
+
+	return pgs.podGroupStateData.podGroup
 }
 
 // podGroupStateSnapshot is an immutable, point-in-time copy of a podGroupState.

--- a/pkg/scheduler/backend/cache/snapshot.go
+++ b/pkg/scheduler/backend/cache/snapshot.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -87,6 +88,7 @@ func NewEmptySnapshot() *Snapshot {
 }
 
 // NewSnapshot initializes a Snapshot struct and returns it.
+// It should be used only in the tests.
 func NewSnapshot(pods []*v1.Pod, nodes []*v1.Node) *Snapshot {
 	nodeInfoMap := createNodeInfoMap(pods, nodes)
 	nodeInfoList := make([]fwk.NodeInfo, 0, len(nodeInfoMap))
@@ -112,6 +114,22 @@ func NewSnapshot(pods []*v1.Pod, nodes []*v1.Node) *Snapshot {
 		s.podGroupStates = createPodGroupStates(pods)
 	}
 
+	return s
+}
+
+// NewTestSnapshotWithPodGroups initializes a Snapshot struct with pod groups and returns it.
+// It should be used only in the tests.
+func NewTestSnapshotWithPodGroups(pods []*v1.Pod, nodes []*v1.Node, podGroups []*schedulingv1alpha3.PodGroup) *Snapshot {
+	s := NewSnapshot(pods, nodes)
+	for _, podGroup := range podGroups {
+		key := newPodGroupKey(podGroup.Namespace, podGroup.Name)
+		pgs, ok := s.podGroupStates[key]
+		if !ok {
+			pgs = &podGroupStateSnapshot{podGroupStateData: newPodGroupStateData()}
+			s.podGroupStates[key] = pgs
+		}
+		pgs.podGroup = podGroup
+	}
 	return s
 }
 
@@ -268,6 +286,31 @@ func (s *Snapshot) StorageInfos() fwk.StorageInfoLister {
 // PodGroupStates returns a PodGroupStateLister.
 func (s *Snapshot) PodGroupStates() fwk.PodGroupStateLister {
 	return &podGroupStateSnapshotLister{podGroupStates: s.podGroupStates}
+}
+
+// PodGroups returns a PodGroupLister.
+func (s *Snapshot) PodGroups() fwk.PodGroupLister {
+	return &podGroupSnapshotListerImpl{snapshot: s}
+}
+
+type podGroupSnapshotListerImpl struct {
+	snapshot *Snapshot
+}
+
+func (l *podGroupSnapshotListerImpl) Get(namespace, name string) (*schedulingv1alpha3.PodGroup, error) {
+	if !l.snapshot.genericWorkloadEnabled {
+		return nil, fmt.Errorf("generic workload feature gate is disabled")
+	}
+	key := newPodGroupKey(namespace, name)
+	pgs, exists := l.snapshot.podGroupStates[key]
+	if !exists {
+		return nil, fmt.Errorf("pod group state not found for pod group %s", key)
+	}
+	pg := pgs.podGroup
+	if pg == nil {
+		return nil, fmt.Errorf("pod group object not found for pod group %s", key)
+	}
+	return pg, nil
 }
 
 var _ fwk.PodGroupStateLister = &podGroupStateSnapshotLister{}

--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -435,6 +436,71 @@ func responsibleForPod(pod *v1.Pod, profiles profile.Map) bool {
 	return profiles.HandlesSchedulerName(pod.Spec.SchedulerName)
 }
 
+func (sched *Scheduler) addPodGroup(obj any) {
+	evt := fwk.ClusterEvent{Resource: fwk.PodGroup, ActionType: fwk.Add}
+	defer metrics.EventHandlingLatency.ObserveSince(time.Now(), evt.Label())()
+	logger := sched.logger
+	pg, ok := obj.(*schedulingv1alpha3.PodGroup)
+	if !ok {
+		utilruntime.HandleErrorWithLogger(logger, nil, "Cannot convert to *v1alpha3.PodGroup", "obj", obj)
+		return
+	}
+
+	logger.V(3).Info("Add event for pod group", "podGroup", klog.KObj(pg))
+	sched.Cache.AddPodGroup(pg)
+	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, nil, pg, nil)
+}
+
+func (sched *Scheduler) updatePodGroup(oldObj, newObj any) {
+	evt := fwk.ClusterEvent{Resource: fwk.PodGroup, ActionType: fwk.Update}
+	defer metrics.EventHandlingLatency.ObserveSince(time.Now(), evt.Label())()
+	logger := sched.logger
+	oldPG, ok := oldObj.(*schedulingv1alpha3.PodGroup)
+	if !ok {
+		utilruntime.HandleErrorWithLogger(logger, nil, "Cannot convert oldObj to *v1alpha3.PodGroup", "oldObj", oldObj)
+		return
+	}
+	newPG, ok := newObj.(*schedulingv1alpha3.PodGroup)
+	if !ok {
+		utilruntime.HandleErrorWithLogger(logger, nil, "Cannot convert newObj to *v1alpha3.PodGroup", "newObj", newObj)
+		return
+	}
+
+	if oldPG.ResourceVersion == newPG.ResourceVersion {
+		return
+	}
+
+	logger.V(4).Info("Update event for pod group", "podGroup", klog.KObj(newPG))
+	sched.Cache.UpdatePodGroup(logger, oldPG, newPG)
+	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, oldPG, newPG, nil)
+}
+
+func (sched *Scheduler) deletePodGroup(obj any) {
+	evt := fwk.ClusterEvent{Resource: fwk.PodGroup, ActionType: fwk.Delete}
+	defer metrics.EventHandlingLatency.ObserveSince(time.Now(), evt.Label())()
+
+	logger := sched.logger
+	var pg *schedulingv1alpha3.PodGroup
+	switch t := obj.(type) {
+	case *schedulingv1alpha3.PodGroup:
+		pg = t
+	case cache.DeletedFinalStateUnknown:
+		var ok bool
+		pg, ok = t.Obj.(*schedulingv1alpha3.PodGroup)
+		if !ok {
+			utilruntime.HandleErrorWithLogger(logger, nil, "Cannot convert to *v1alpha3.PodGroup", "obj", t.Obj)
+			return
+		}
+	default:
+		utilruntime.HandleErrorWithLogger(logger, nil, "Cannot convert to *v1alpha3.PodGroup", "obj", t)
+		return
+	}
+
+	logger.V(3).Info("Delete event for pod group", "podGroup", klog.KObj(pg))
+	sched.Cache.RemovePodGroup(pg)
+	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, pg, nil, nil)
+}
+
 const (
 	// syncedPollPeriod controls how often you look at the status of your sync funcs
 	syncedPollPeriod = 100 * time.Millisecond
@@ -491,6 +557,17 @@ func addAllEventHandlers(
 		return err
 	}
 	handlers = append(handlers, handlerRegistration)
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.GenericWorkload) {
+		if handlerRegistration, err = informerFactory.Scheduling().V1alpha3().PodGroups().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc:    sched.addPodGroup,
+			UpdateFunc: sched.updatePodGroup,
+			DeleteFunc: sched.deletePodGroup,
+		}); err != nil {
+			return err
+		}
+		handlers = append(handlers, handlerRegistration)
+	}
 
 	buildEvtResHandler := func(at fwk.ActionType, resource fwk.EventResource) cache.ResourceEventHandlerFuncs {
 		funcs := cache.ResourceEventHandlerFuncs{}
@@ -629,14 +706,7 @@ func addAllEventHandlers(
 			}
 			handlers = append(handlers, handlerRegistration)
 		case fwk.PodGroup:
-			if utilfeature.DefaultFeatureGate.Enabled(features.GenericWorkload) {
-				if handlerRegistration, err = informerFactory.Scheduling().V1alpha3().PodGroups().Informer().AddEventHandler(
-					buildEvtResHandler(at, fwk.PodGroup),
-				); err != nil {
-					return err
-				}
-				handlers = append(handlers, handlerRegistration)
-			}
+			// Do nothing. Registered explicitly.
 		default:
 			// Tests may not instantiate dynInformerFactory.
 			if dynInformerFactory == nil {

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -1334,3 +1334,140 @@ func TestDeletePod(t *testing.T) {
 		})
 	}
 }
+
+func TestAddPodGroup(t *testing.T) {
+	podGroup := st.MakePodGroup().Namespace("ns1").Name("pg1").Obj()
+
+	tests := []struct {
+		name     string
+		podGroup *schedulingapi.PodGroup
+	}{
+		{
+			name:     "add valid pod group",
+			podGroup: podGroup,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			sched := &Scheduler{
+				Cache:           internalcache.New(ctx, nil, true),
+				SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
+				logger:          logger,
+			}
+
+			sched.addPodGroup(tt.podGroup)
+
+			gotPodGroup, err := sched.Cache.PodGroups().Get(podGroup.Namespace, podGroup.Name)
+			if err != nil {
+				t.Errorf("Expected pod group to be in cache, got error: %v", err)
+			}
+			if diff := cmp.Diff(podGroup, gotPodGroup); diff != "" {
+				t.Errorf("Unexpected pod group in cache (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestUpdatePodGroup(t *testing.T) {
+	oldPodGroup := st.MakePodGroup().Namespace("ns1").Name("pg1").MinCount(1).Obj()
+	oldPodGroup.ResourceVersion = "1"
+	newPodGroup := st.MakePodGroup().Namespace("ns1").Name("pg1").MinCount(2).Obj()
+	newPodGroup.ResourceVersion = "2"
+
+	tests := []struct {
+		name           string
+		oldPodGroup    *schedulingapi.PodGroup
+		newPodGroup    *schedulingapi.PodGroup
+		expectPodGroup *schedulingapi.PodGroup
+	}{
+		{
+			name:           "update valid pod group",
+			oldPodGroup:    oldPodGroup,
+			newPodGroup:    newPodGroup,
+			expectPodGroup: newPodGroup,
+		},
+		{
+			name:           "update pod group with same resource version should be no-op",
+			oldPodGroup:    oldPodGroup,
+			newPodGroup:    oldPodGroup,
+			expectPodGroup: oldPodGroup,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			sched := &Scheduler{
+				Cache:           internalcache.New(ctx, nil, true),
+				SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
+				logger:          logger,
+			}
+
+			sched.Cache.AddPodGroup(tt.oldPodGroup)
+
+			sched.updatePodGroup(tt.oldPodGroup, tt.newPodGroup)
+
+			gotPodGroup, err := sched.Cache.PodGroups().Get(tt.expectPodGroup.Namespace, tt.expectPodGroup.Name)
+			if err != nil {
+				t.Errorf("Expected pod group to be in cache, got error: %v", err)
+			}
+			if diff := cmp.Diff(tt.expectPodGroup, gotPodGroup); diff != "" {
+				t.Errorf("Unexpected pod group in cache (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDeletePodGroup(t *testing.T) {
+	podGroup := st.MakePodGroup().Namespace("ns1").Name("pg1").Obj()
+
+	tests := []struct {
+		name             string
+		initPodGroup     *schedulingapi.PodGroup
+		podGroupToDelete any
+	}{
+		{
+			name:             "delete pod group",
+			initPodGroup:     podGroup,
+			podGroupToDelete: podGroup,
+		},
+		{
+			name:             "delete DeletedFinalStateUnknown tombstone with pod group",
+			initPodGroup:     podGroup,
+			podGroupToDelete: cache.DeletedFinalStateUnknown{Obj: podGroup},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			sched := &Scheduler{
+				Cache:           internalcache.New(ctx, nil, true),
+				SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
+				logger:          logger,
+			}
+
+			if tt.initPodGroup != nil {
+				sched.Cache.AddPodGroup(tt.initPodGroup)
+			}
+
+			sched.deletePodGroup(tt.podGroupToDelete)
+
+			_, err := sched.Cache.PodGroups().Get(tt.initPodGroup.Namespace, tt.initPodGroup.Name)
+			if err == nil {
+				t.Errorf("Expected pod group to be deleted from cache, but it still exists")
+			}
+		})
+	}
+}

--- a/pkg/scheduler/framework/autoscaler_contract/lister_contract_test.go
+++ b/pkg/scheduler/framework/autoscaler_contract/lister_contract_test.go
@@ -23,6 +23,7 @@ package contract
 import (
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
+	schedulingapi "k8s.io/api/scheduling/v1alpha3"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/dynamic-resource-allocation/structured/schedulerapi"
@@ -34,6 +35,7 @@ var _ fwk.StorageInfoLister = &storageInfoListerContract{}
 var _ fwk.SharedLister = &shareListerContract{}
 var _ fwk.ResourceSliceLister = &resourceSliceListerContract{}
 var _ fwk.PodGroupStateLister = &podGroupStateListerContract{}
+var _ fwk.PodGroupLister = &podGroupListerContract{}
 var _ fwk.PodGroupState = &podGroupStateContract{}
 var _ fwk.DeviceClassLister = &deviceClassListerContract{}
 var _ fwk.ResourceClaimTracker = &resourceClaimTrackerContract{}
@@ -76,6 +78,16 @@ func (c *shareListerContract) StorageInfos() fwk.StorageInfoLister {
 
 func (c *shareListerContract) PodGroupStates() fwk.PodGroupStateLister {
 	return nil
+}
+
+func (c *shareListerContract) PodGroups() fwk.PodGroupLister {
+	return nil
+}
+
+type podGroupListerContract struct{}
+
+func (c *podGroupListerContract) Get(_ string, _ string) (*schedulingapi.PodGroup, error) {
+	return nil, nil
 }
 
 type podGroupStateListerContract struct{}
@@ -182,10 +194,6 @@ func (s *sharedDRAManagerContract) DeviceClasses() fwk.DeviceClassLister {
 }
 
 func (s *sharedDRAManagerContract) DeviceClassResolver() fwk.DeviceClassResolver {
-	return nil
-}
-
-func (s *sharedDRAManagerContract) PodGroups() fwk.PodGroupLister {
 	return nil
 }
 

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -28,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/listers/scheduling/v1alpha3"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/klog/v2"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
@@ -71,7 +70,7 @@ type DefaultPreemption struct {
 
 	Executor          *preemption.Executor
 	Evaluator         *preemption.Evaluator
-	pgLister          v1alpha3.PodGroupLister
+	pgLister          fwk.PodGroupLister
 	podGroupEvaluator *preemption.PodGroupEvaluator
 
 	// IsEligiblePod returns whether a victim pod is allowed to be preempted by a preemptor pod.
@@ -114,7 +113,7 @@ func New(_ context.Context, dpArgs runtime.Object, fh fwk.Handle, fts feature.Fe
 	pl.Evaluator = preemption.NewEvaluator(Name, fh, &pl, pl.Executor)
 
 	if pl.fts.EnableGenericWorkload {
-		pl.pgLister = fh.SharedInformerFactory().Scheduling().V1alpha3().PodGroups().Lister()
+		pl.pgLister = fh.PodGroupManager().PodGroups()
 		pl.podGroupEvaluator = preemption.NewPodGroupEvaluator(fh, pl.Executor, pl.fts.EnablePodGroupPreemptionPolicy)
 	}
 
@@ -155,7 +154,7 @@ func (pl *DefaultPreemption) PreEnqueue(ctx context.Context, p *v1.Pod) *fwk.Sta
 		return nil
 	}
 	if p.Spec.SchedulingGroup != nil && pl.fts.EnableGenericWorkload {
-		pg, err := pl.pgLister.PodGroups(p.Namespace).Get(*p.Spec.SchedulingGroup.PodGroupName)
+		pg, err := pl.pgLister.Get(p.Namespace, *p.Spec.SchedulingGroup.PodGroupName)
 		// If the pg is not found do not block the pod. It's not a default preemption responsibility
 		// to block pods from pod group without pg from entering the queue.
 		if err != nil {

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -519,6 +519,11 @@ func TestPostFilter(t *testing.T) {
 					defer apiDispatcher.Close()
 				}
 
+				cache := internalcache.New(ctx, apiDispatcher, tt.features.EnableGenericWorkload)
+				for _, podGroup := range tt.podGroups {
+					cache.AddPodGroup(podGroup)
+				}
+
 				f, err := tf.NewFramework(ctx, registeredPlugins, "",
 					frameworkruntime.WithClientSet(cs),
 					frameworkruntime.WithAPIDispatcher(apiDispatcher),
@@ -526,16 +531,16 @@ func TestPostFilter(t *testing.T) {
 					frameworkruntime.WithInformerFactory(informerFactory),
 					frameworkruntime.WithPodNominator(internalqueue.NewSchedulingQueue(nil, informerFactory)),
 					frameworkruntime.WithExtenders(extenders),
-					frameworkruntime.WithSnapshotSharedLister(internalcache.NewSnapshot(tt.pods, tt.nodes)),
+					frameworkruntime.WithSnapshotSharedLister(internalcache.NewTestSnapshotWithPodGroups(tt.pods, tt.nodes, tt.podGroups)),
 					frameworkruntime.WithLogger(logger),
 					frameworkruntime.WithWaitingPods(frameworkruntime.NewWaitingPodsMap()),
 					frameworkruntime.WithPodsInPreBind(frameworkruntime.NewPodsInPreBindMap()),
+					frameworkruntime.WithPodGroupManager(cache),
 				)
 				if err != nil {
 					t.Fatal(err)
 				}
 				if asyncAPICallsEnabled {
-					cache := internalcache.New(ctx, apiDispatcher, false)
 					f.SetAPICacher(apicache.New(nil, cache))
 				}
 
@@ -2556,15 +2561,21 @@ func TestPreEnqueue(t *testing.T) {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 
+			cache := internalcache.New(ctx, nil, tt.features.EnableGenericWorkload)
+			for _, podGroup := range tt.pgs {
+				cache.AddPodGroup(podGroup)
+			}
+
 			f, err := tf.NewFramework(ctx, registeredPlugins, "",
 				frameworkruntime.WithClientSet(cs),
 				frameworkruntime.WithEventRecorder(&events.FakeRecorder{}),
 				frameworkruntime.WithInformerFactory(informerFactory),
 				frameworkruntime.WithPodNominator(internalqueue.NewSchedulingQueue(nil, informerFactory)),
-				frameworkruntime.WithSnapshotSharedLister(internalcache.NewSnapshot(pods, []*v1.Node{st.MakeNode().Name("node1").Capacity(onePodRes).Obj()})),
+				frameworkruntime.WithSnapshotSharedLister(internalcache.NewTestSnapshotWithPodGroups(pods, []*v1.Node{st.MakeNode().Name("node1").Capacity(onePodRes).Obj()}, tt.pgs)),
 				frameworkruntime.WithLogger(logger),
 				frameworkruntime.WithWaitingPods(frameworkruntime.NewWaitingPodsMap()),
 				frameworkruntime.WithPodsInPreBind(frameworkruntime.NewPodsInPreBindMap()),
+				frameworkruntime.WithPodGroupManager(cache),
 			)
 			if err != nil {
 				t.Fatal(err)
@@ -2650,11 +2661,17 @@ func TestDefaultPreemption_PodGroupPostFilter_ErrorWrapping(t *testing.T) {
 		tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
 		tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
 	}
+
+	preemptorPG := st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj()
+	cache := internalcache.New(ctx, nil, true)
+	cache.AddPodGroup(preemptorPG)
+
 	f, err := tf.NewFramework(ctx, registeredPlugins, "",
 		frameworkruntime.WithClientSet(client),
-		frameworkruntime.WithSnapshotSharedLister(internalcache.NewSnapshot(testPods, nodes)),
+		frameworkruntime.WithSnapshotSharedLister(internalcache.NewTestSnapshotWithPodGroups(testPods, nodes, []*v1alpha3.PodGroup{preemptorPG})),
 		frameworkruntime.WithInformerFactory(informerFactory),
 		frameworkruntime.WithLogger(logger),
+		frameworkruntime.WithPodGroupManager(cache),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -2668,7 +2685,6 @@ func TestDefaultPreemption_PodGroupPostFilter_ErrorWrapping(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	preemptorPG := st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj()
 	preemptorPods := []*v1.Pod{st.MakePod().Name("p").UID("p").Priority(highPriority).Obj()}
 	mockSchedulingFunc := func(ctx context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
 		return nil, fwk.NewStatus(fwk.Unschedulable)

--- a/pkg/scheduler/framework/plugins/dynamicresources/dra_manager.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dra_manager.go
@@ -27,15 +27,12 @@ import (
 	"github.com/go-logr/logr"
 
 	resourceapi "k8s.io/api/resource/v1"
-	schedulingapi "k8s.io/api/scheduling/v1alpha3"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	resourcelisters "k8s.io/client-go/listers/resource/v1"
-	schedulinglisters "k8s.io/client-go/listers/scheduling/v1alpha3"
 	"k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache"
 	resourceslicetracker "k8s.io/dynamic-resource-allocation/resourceslice/tracker"
 	"k8s.io/dynamic-resource-allocation/structured"
@@ -55,7 +52,6 @@ type DefaultDRAManager struct {
 	resourceClaimTracker  *claimTracker
 	resourceSliceLister   *resourceSliceLister
 	deviceClassLister     *deviceClassLister
-	podGroupLister        *podGroupLister
 	extendedResourceCache *extendedresourcecache.ExtendedResourceCache
 }
 
@@ -76,12 +72,6 @@ func NewDRAManager(ctx context.Context, claimsCache *assumecache.AssumeCache, re
 		manager.extendedResourceCache = extendedresourcecache.NewExtendedResourceCache(logger)
 	}
 
-	pgLister := &podGroupLister{}
-	if utilfeature.DefaultFeatureGate.Enabled(features.DRAWorkloadResourceClaims) {
-		pgLister.podGroupLister = informerFactory.Scheduling().V1alpha3().PodGroups().Lister()
-	}
-	manager.podGroupLister = pgLister
-
 	// Reacting to events is more efficient than iterating over the list
 	// repeatedly in PreFilter.
 	manager.resourceClaimTracker.cache.AddEventHandler(manager.resourceClaimTracker.allocatedDevices.handlers())
@@ -99,10 +89,6 @@ func (s *DefaultDRAManager) ResourceSlices() fwk.ResourceSliceLister {
 
 func (s *DefaultDRAManager) DeviceClasses() fwk.DeviceClassLister {
 	return s.deviceClassLister
-}
-
-func (s *DefaultDRAManager) PodGroups() fwk.PodGroupLister {
-	return s.podGroupLister
 }
 
 // DeviceClassResolver will always return a valid interface implementation. It
@@ -137,21 +123,6 @@ func (l *deviceClassLister) Get(className string) (*resourceapi.DeviceClass, err
 
 func (l *deviceClassLister) List() ([]*resourceapi.DeviceClass, error) {
 	return l.classLister.List(labels.Everything())
-}
-
-var _ fwk.PodGroupLister = &podGroupLister{}
-
-type podGroupLister struct {
-	podGroupLister schedulinglisters.PodGroupLister
-}
-
-// Get implements [fwk.PodGroupLister]. When the inner podGroupLister is nil,
-// Get always returns a new BadRequest error.
-func (l *podGroupLister) Get(namespace, podGroupName string) (*schedulingapi.PodGroup, error) {
-	if l.podGroupLister == nil {
-		return nil, apierrors.NewBadRequest("listing podgroups is disabled")
-	}
-	return l.podGroupLister.PodGroups(namespace).Get(podGroupName)
 }
 
 var _ fwk.ResourceClaimTracker = &claimTracker{}

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -389,7 +389,7 @@ func (pl *DynamicResources) podResourceClaimBindings(pod *v1.Pod) ([]resourceapi
 	}
 
 	bindings := make([]resourceapi.ResourceClaimConsumerReference, 0, len(pod.Spec.ResourceClaims))
-	podGroup, err := pl.getPodGroup(pod)
+	podGroup, err := pl.getPodGroupSnapshot(pod)
 	if err != nil {
 		return nil, err
 	}
@@ -1013,7 +1013,7 @@ func (pl *DynamicResources) unreservePodGroupClaims(ctx context.Context, pod *v1
 	if podGroupState.ScheduledPodsCount() > 0 {
 		return nil
 	}
-	podGroup, err := pl.getPodGroup(pod)
+	podGroup, err := pl.getPodGroupSnapshot(pod)
 	if err != nil {
 		return statusError(logger, err)
 	}
@@ -1736,12 +1736,12 @@ func (pl *DynamicResources) isPodReadyForBinding(state *stateData) (bool, error)
 	return true, nil
 }
 
-func (pl *DynamicResources) getPodGroup(pod *v1.Pod) (*schedulingapi.PodGroup, error) {
+func (pl *DynamicResources) getPodGroupSnapshot(pod *v1.Pod) (*schedulingapi.PodGroup, error) {
 	if !pl.fts.EnableDRAWorkloadResourceClaims ||
 		pod.Spec.SchedulingGroup == nil || pod.Spec.SchedulingGroup.PodGroupName == nil {
 		return nil, nil
 	}
-	return pl.draManager.PodGroups().Get(pod.Namespace, *pod.Spec.SchedulingGroup.PodGroupName)
+	return pl.fh.SnapshotSharedLister().PodGroups().Get(pod.Namespace, *pod.Spec.SchedulingGroup.PodGroupName)
 }
 
 // hasBindingConditions checks whether any of the claims in the state

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -4029,6 +4029,10 @@ func setup(tCtx ktesting.TContext, args *config.DynamicResourcesArgs, nodes []*v
 			tc.podGroupManager.AddPodGroupMember(pod)
 		}
 	}
+	for _, podGroup := range podGroups {
+		tc.podGroupManager.AddPodGroup(podGroup)
+	}
+	snapshot := internalcache.NewTestSnapshotWithPodGroups(nil, nil, podGroups)
 
 	opts := []runtime.Option{
 		runtime.WithClientSet(tc.client),
@@ -4036,6 +4040,7 @@ func setup(tCtx ktesting.TContext, args *config.DynamicResourcesArgs, nodes []*v
 		runtime.WithEventRecorder(&events.FakeRecorder{}),
 		runtime.WithSharedDRAManager(tc.draManager),
 		runtime.WithPodGroupManager(tc.podGroupManager),
+		runtime.WithSnapshotSharedLister(snapshot),
 	}
 	fh, err := runtime.NewFramework(tCtx, nil, nil, opts...)
 	tCtx.ExpectNoError(err, "create scheduler framework")

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
@@ -23,9 +23,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	schedulingapi "k8s.io/api/scheduling/v1alpha3"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	schedulinglisters "k8s.io/client-go/listers/scheduling/v1alpha3"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -47,7 +45,6 @@ const (
 // belonging to a PodGroup with a Gang scheduling policy.
 type GangScheduling struct {
 	handle          fwk.Handle
-	podGroupLister  schedulinglisters.PodGroupLister
 	podGroupManager fwk.PodGroupManager
 	snapshotLister  fwk.SharedLister
 }
@@ -61,7 +58,6 @@ var _ framework.PlacementFeasiblePlugin = &GangScheduling{}
 func New(_ context.Context, _ runtime.Object, fh fwk.Handle, fts feature.Features) (fwk.Plugin, error) {
 	return &GangScheduling{
 		handle:          fh,
-		podGroupLister:  fh.SharedInformerFactory().Scheduling().V1alpha3().PodGroups().Lister(),
 		podGroupManager: fh.PodGroupManager(),
 		snapshotLister:  fh.SnapshotSharedLister(),
 	}, nil
@@ -165,14 +161,10 @@ func (pl *GangScheduling) PreEnqueue(ctx context.Context, pod *v1.Pod) *fwk.Stat
 	namespace := pod.Namespace
 	schedulingGroup := pod.Spec.SchedulingGroup
 
-	podGroup, err := pl.podGroupLister.PodGroups(namespace).Get(*schedulingGroup.PodGroupName)
+	podGroup, err := pl.podGroupManager.PodGroups().Get(namespace, *schedulingGroup.PodGroupName)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			// The pod is unschedulable until its PodGroup object is created.
-			return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, fmt.Sprintf("waiting for pods's pod group %q to appear in scheduling queue", *schedulingGroup.PodGroupName))
-		}
-		klog.FromContext(ctx).Error(err, "Failed to get pod group", "pod", klog.KObj(pod), "schedulingGroup", schedulingGroup)
-		return fwk.AsStatus(fmt.Errorf("failed to get pod group %s/%s", namespace, *schedulingGroup.PodGroupName))
+		// The pod is unschedulable until its PodGroup object is created.
+		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, fmt.Sprintf("waiting for pods's pod group %q to appear in scheduling queue", *schedulingGroup.PodGroupName))
 	}
 
 	policy := podGroup.Spec.SchedulingPolicy
@@ -205,11 +197,11 @@ func (pl *GangScheduling) Permit(ctx context.Context, state fwk.CycleState, pod 
 	namespace := pod.Namespace
 	schedulingGroup := pod.Spec.SchedulingGroup
 
-	podGroup, err := pl.podGroupLister.PodGroups(namespace).Get(*schedulingGroup.PodGroupName)
+	podGroup, err := pl.snapshotLister.PodGroups().Get(namespace, *schedulingGroup.PodGroupName)
 	if err != nil {
 		// It's likely that the pod group was removed or another error happened.
 		// Returning error to retry the Pod when the pod group is added again.
-		return fwk.AsStatus(fmt.Errorf("failed to get podGroup %s/%s: %w", namespace, *schedulingGroup.PodGroupName, err)), 0
+		return fwk.AsStatus(fmt.Errorf("failed to get podGroup %s/%s from snapshot: %w", namespace, *schedulingGroup.PodGroupName, err)), 0
 	}
 
 	policy := podGroup.Spec.SchedulingPolicy

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -385,11 +385,12 @@ func TestGangSchedulingFlow(t *testing.T) {
 			}
 
 			// Populate informers and manager state for the test case.
-			for _, wl := range tt.initialPodGroups {
-				err := podGroupInformer.Informer().GetStore().Add(wl)
+			for _, pg := range tt.initialPodGroups {
+				err := podGroupInformer.Informer().GetStore().Add(pg)
 				if err != nil {
-					t.Fatalf("Failed to add podGroup %s to store: %v", wl.Name, err)
+					t.Fatalf("Failed to add podGroup %s to store: %v", pg.Name, err)
 				}
+				cache.AddPodGroup(pg)
 			}
 
 			for _, p := range tt.initialPods {
@@ -410,6 +411,10 @@ func TestGangSchedulingFlow(t *testing.T) {
 			if !gotPreEnqueueStatus.IsSuccess() {
 				// Pod is rejected.
 				return
+			}
+
+			if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
+				t.Fatalf("Failed to update snapshot: %v", err)
 			}
 
 			// Simulate that other pods have already hit Permit and are now waiting.
@@ -454,6 +459,9 @@ func TestGangSchedulingFlow(t *testing.T) {
 				// Assume pod in the cache, as in a pod-by-pod scheduling cycle, where Permit reads from cache.
 				if err := cache.AssumePod(logger, pod); err != nil {
 					t.Fatalf("Failed to assume pod %q in cache: %v", pod.Name, err)
+				}
+				if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
+					t.Fatalf("Failed to update snapshot: %v", err)
 				}
 			}
 

--- a/pkg/scheduler/framework/preemption/podgrouppreemption.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption.go
@@ -27,7 +27,6 @@ import (
 	schedulingapi "k8s.io/api/scheduling/v1alpha3"
 	"k8s.io/apimachinery/pkg/util/sets"
 	policylisters "k8s.io/client-go/listers/policy/v1"
-	schedulinglisters "k8s.io/client-go/listers/scheduling/v1alpha3"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
@@ -43,7 +42,7 @@ import (
 type PodGroupEvaluator struct {
 	Handle                         fwk.Handle
 	pdbLister                      policylisters.PodDisruptionBudgetLister
-	podGroupLister                 schedulinglisters.PodGroupLister
+	podGroupSnapshot               fwk.PodGroupLister
 	enablePodGroupPreemptionPolicy bool
 
 	Executor *Executor
@@ -53,7 +52,7 @@ func NewPodGroupEvaluator(fh fwk.Handle, executor *Executor, enablePodGroupPreem
 	return &PodGroupEvaluator{
 		Handle:                         fh,
 		pdbLister:                      fh.SharedInformerFactory().Policy().V1().PodDisruptionBudgets().Lister(),
-		podGroupLister:                 fh.SharedInformerFactory().Scheduling().V1alpha3().PodGroups().Lister(),
+		podGroupSnapshot:               fh.SnapshotSharedLister().PodGroups(),
 		enablePodGroupPreemptionPolicy: enablePodGroupPreemptionPolicy,
 		Executor:                       executor,
 	}
@@ -77,7 +76,7 @@ func (ev *PodGroupEvaluator) Preempt(ctx context.Context, pg *schedulingapi.PodG
 	if err != nil {
 		return nil, fwk.AsStatus(fmt.Errorf("failed to list node infos: %w", err))
 	}
-	domain := newDomainForWorkloadPreemption(allNodes, ev.podGroupLister, "cluster-domain")
+	domain := newDomainForWorkloadPreemption(allNodes, ev.podGroupSnapshot, "cluster-domain")
 	preemptor := newPodGroupPreemptor(pg, pods, ev.enablePodGroupPreemptionPolicy)
 	pdbs, err := getPodDisruptionBudgets(ev.pdbLister)
 	if err != nil {
@@ -308,7 +307,7 @@ func (ev *PodGroupEvaluator) preemptorEligibleToPreemptOthers(_ context.Context,
 // a pod group, it returns the priority of the pod group.
 // Otherwise, it returns the pod's own priority.
 func (ev *PodGroupEvaluator) getPodPriority(p *v1.Pod) int32 {
-	if pg := getPodGroup(p, ev.podGroupLister); pg != nil {
+	if pg := getPodGroup(p, ev.podGroupSnapshot); pg != nil {
 		return util.PodGroupPriority(pg)
 	}
 	return corev1helpers.PodPriority(p)

--- a/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
@@ -28,7 +28,6 @@ import (
 	schedulingapi "k8s.io/api/scheduling/v1alpha3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	schedulinglisters "k8s.io/client-go/listers/scheduling/v1alpha3"
 	"k8s.io/klog/v2/ktesting"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -37,21 +36,10 @@ import (
 )
 
 type mockPodGroupLister struct {
-	schedulinglisters.PodGroupLister
 	podGroups map[string]*schedulingapi.PodGroup
 }
 
-func (m *mockPodGroupLister) PodGroups(namespace string) schedulinglisters.PodGroupNamespaceLister {
-	return &mockPodGroupNamespaceLister{podGroups: m.podGroups, namespace: namespace}
-}
-
-type mockPodGroupNamespaceLister struct {
-	schedulinglisters.PodGroupNamespaceLister
-	podGroups map[string]*schedulingapi.PodGroup
-	namespace string
-}
-
-func (m *mockPodGroupNamespaceLister) Get(name string) (*schedulingapi.PodGroup, error) {
+func (m *mockPodGroupLister) Get(namespace, name string) (*schedulingapi.PodGroup, error) {
 	if pg, ok := m.podGroups[name]; ok {
 		return pg, nil
 	}
@@ -1280,7 +1268,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 			}
 
 			pl := &PodGroupEvaluator{
-				podGroupLister: pgLister,
+				podGroupSnapshot: pgLister,
 			}
 
 			res, gotStatus := pl.selectVictimsOnDomain(ctx, tt.preemptor, domain, tt.pdbs, mockSchedulingFunc)

--- a/pkg/scheduler/framework/preemption/types.go
+++ b/pkg/scheduler/framework/preemption/types.go
@@ -25,7 +25,6 @@ import (
 	schedulingapi "k8s.io/api/scheduling/v1alpha3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	schedulinglisters "k8s.io/client-go/listers/scheduling/v1alpha3"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
 	fwk "k8s.io/kube-scheduler/framework"
@@ -95,12 +94,12 @@ type domain struct {
 }
 
 // getPodGroup checks if a pod specifies a scheduling group and returns the corresponding PodGroup object if found.
-func getPodGroup(p *v1.Pod, pgLister schedulinglisters.PodGroupLister) *schedulingapi.PodGroup {
+func getPodGroup(p *v1.Pod, podGroupSnapshot fwk.PodGroupLister) *schedulingapi.PodGroup {
 	if p.Spec.SchedulingGroup == nil {
 		return nil
 	}
 	pgName := p.Spec.SchedulingGroup.PodGroupName
-	pg, err := pgLister.PodGroups(p.Namespace).Get(*pgName)
+	pg, err := podGroupSnapshot.Get(p.Namespace, *pgName)
 	if err != nil {
 		return nil
 	}
@@ -119,14 +118,11 @@ func isDisruptionModeAll(pg *schedulingapi.PodGroup) bool {
 // together into a single victim. Otherwise, they are treated as individual victims.
 // In both cases, the priority of the victim is determined by the PodGroup priority
 // if the pod belongs to a PodGroup.
-func newDomainForWorkloadPreemption(nodes []fwk.NodeInfo, pgLister schedulinglisters.PodGroupLister, name string) *domain {
+func newDomainForWorkloadPreemption(nodes []fwk.NodeInfo, podGroupSnapshot fwk.PodGroupLister, name string) *domain {
 	victimMap := map[types.UID]*victim{}
 	for _, node := range nodes {
 		for _, p := range node.GetPods() {
-			// TODO: Calling the lister here is not ideal given we do this
-			// for every pod in the cluster. Instead, we should be getting
-			// this information from the snapshot.
-			pg := getPodGroup(p.GetPod(), pgLister)
+			pg := getPodGroup(p.GetPod(), podGroupSnapshot)
 			if pg == nil {
 				victimMap[p.GetPod().UID] = newVictim([]fwk.PodInfo{p}, corev1helpers.PodPriority(p.GetPod()), []fwk.NodeInfo{node})
 				continue

--- a/pkg/scheduler/framework/runtime/batch_test.go
+++ b/pkg/scheduler/framework/runtime/batch_test.go
@@ -86,6 +86,10 @@ func (s sharedLister) PodGroupStates() fwk.PodGroupStateLister {
 	return nil
 }
 
+func (s sharedLister) PodGroups() fwk.PodGroupLister {
+	return nil
+}
+
 var batchRegistry = func() Registry {
 	r := make(Registry)
 	err := r.Register("batchTest", newBatchTestPlugin)

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -48,8 +48,17 @@ func (sched *Scheduler) scheduleOnePodGroup(ctx context.Context, podGroupInfo *f
 	// https://github.com/kubernetes/kubernetes/issues/111672
 	logger = klog.LoggerWithValues(logger, "podGroup", klog.KObj(podGroupInfo))
 	ctx = klog.NewContext(ctx, logger)
+	start := time.Now()
 
-	podGroup, err := sched.podGroupLister.PodGroups(podGroupInfo.Namespace).Get(podGroupInfo.Name)
+	if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
+		logger.Error(err, "Error updating snapshot", "podGroup", klog.KObj(podGroupInfo))
+		sched.handlePodGroupFailureBeforeScheduling(ctx, podGroupInfo, err)
+		return
+	}
+
+	// PodGroupInfo popped from the queue can have older PodGroup object.
+	// Override it here with the snapshotted version to ensure consistency throughout the cycle.
+	podGroup, err := sched.nodeInfoSnapshot.PodGroups().Get(podGroupInfo.Namespace, podGroupInfo.Name)
 	if err != nil {
 		// It can happen that the pod group was popped from the scheduling queue before it observed the PodGroup deletion.
 		// PodGroup should come back to the scheduling queue.
@@ -74,7 +83,7 @@ func (sched *Scheduler) scheduleOnePodGroup(ctx context.Context, podGroupInfo *f
 
 	logger.V(3).Info("Attempting to schedule pod group", "podGroup", klog.KObj(podGroupInfo))
 
-	sched.podGroupCycle(ctx, schedFwk, framework.NewCycleState(), podGroupInfo)
+	sched.podGroupCycle(ctx, schedFwk, framework.NewCycleState(), podGroupInfo, start)
 }
 
 // handlePodGroupFailureBeforeScheduling handles the failure of a pod group that occurred before scheduling.
@@ -200,23 +209,9 @@ func initPodSchedulingContext(ctx context.Context, pod *v1.Pod, placementCycleSt
 	}
 }
 
-// podGroupCycle runs a pod group scheduling cycle for the given pod group in a single cluster snapshot.
-func (sched *Scheduler) podGroupCycle(ctx context.Context, schedFwk framework.Framework, podGroupCycleState *framework.CycleState, podGroupInfo *framework.QueuedPodGroupInfo) {
-	// Synchronously attempt to find a fit for the pod group.
-	start := time.Now()
-
-	logger := klog.FromContext(ctx)
-	if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
-		logger.Error(err, "Error updating snapshot", "podGroup", klog.KObj(podGroupInfo))
-		result := podGroupAlgorithmResult{
-			status: fwk.AsStatus(err),
-		}
-		// Ensure podResults has an entry for each pod in the pod group with Error status.
-		result = completePodGroupAlgorithmResult(ctx, podGroupInfo, podGroupCycleState, runAllPostFilters, result)
-		sched.submitPodGroupAlgorithmResult(ctx, schedFwk, podGroupCycleState, podGroupInfo, result, start)
-		return
-	}
-
+// podGroupCycle runs a pod group scheduling cycle for the given pod group.
+// Cluster state should be snapshotted before calling this method.
+func (sched *Scheduler) podGroupCycle(ctx context.Context, schedFwk framework.Framework, podGroupCycleState *framework.CycleState, podGroupInfo *framework.QueuedPodGroupInfo, start time.Time) {
 	result := sched.podGroupSchedulingAlgorithm(ctx, schedFwk, podGroupCycleState, podGroupInfo, runAllPostFilters)
 
 	// Ensure podResults has an entry for each pod in the pod group with a status.

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -431,7 +431,6 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 
 	client := clientsetfake.NewClientset(testPodGroup)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
-	podGroupLister := informerFactory.Scheduling().V1alpha3().PodGroups().Lister()
 	informerFactory.Start(ctx.Done())
 	informerFactory.WaitForCacheSync(ctx.Done())
 
@@ -441,7 +440,6 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 		SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
 		Cache:           cache,
 		client:          client,
-		podGroupLister:  podGroupLister,
 		FailureHandler: func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *fwk.NominatingInfo, start time.Time) {
 			failureHandlerCalled = true
 			if updateSnapshotErr.Error() != status.AsError().Error() {
@@ -450,7 +448,7 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 		},
 	}
 
-	sched.podGroupCycle(ctx, schedFwk, framework.NewCycleState(), podGroupInfo)
+	sched.scheduleOnePodGroup(ctx, podGroupInfo)
 
 	if !failureHandlerCalled {
 		t.Errorf("Expected FailureHandler to be called after UpdateSnapshot failed")
@@ -506,7 +504,6 @@ func TestPodGroupCycle_FillsPodResultsOnFewerResults(t *testing.T) {
 
 	client := clientsetfake.NewSimpleClientset(testPodGroup, testNode)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
-	podGroupLister := informerFactory.Scheduling().V1alpha3().PodGroups().Lister()
 
 	informerFactory.Start(ctx.Done())
 	informerFactory.WaitForCacheSync(ctx.Done())
@@ -536,7 +533,6 @@ func TestPodGroupCycle_FillsPodResultsOnFewerResults(t *testing.T) {
 		SchedulingQueue:  internalqueue.NewTestQueue(ctx, nil),
 		Cache:            cache,
 		client:           client,
-		podGroupLister:   podGroupLister,
 		nodeInfoSnapshot: internalcache.NewEmptySnapshot(),
 		FailureHandler: func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *fwk.NominatingInfo, start time.Time) {
 			lock.Lock()
@@ -556,7 +552,7 @@ func TestPodGroupCycle_FillsPodResultsOnFewerResults(t *testing.T) {
 	}
 
 	// Run the scheduling cycle and check that all pods are handled.
-	sched.podGroupCycle(ctx, schedFwk, framework.NewCycleState(), podGroupInfo)
+	sched.podGroupCycle(ctx, schedFwk, framework.NewCycleState(), podGroupInfo, time.Now())
 
 	lock.Lock()
 	defer lock.Unlock()
@@ -685,7 +681,6 @@ func TestPodGroupCycle_PodGroupPostFilter(t *testing.T) {
 
 			client := clientsetfake.NewSimpleClientset(testPodGroup, testNode)
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
-			podGroupLister := informerFactory.Scheduling().V1alpha3().PodGroups().Lister()
 
 			informerFactory.Start(ctx.Done())
 			informerFactory.WaitForCacheSync(ctx.Done())
@@ -712,7 +707,6 @@ func TestPodGroupCycle_PodGroupPostFilter(t *testing.T) {
 				SchedulingQueue:        internalqueue.NewTestQueue(ctx, nil),
 				Cache:                  cache,
 				client:                 client,
-				podGroupLister:         podGroupLister,
 				nodeInfoSnapshot:       internalcache.NewEmptySnapshot(),
 				genericWorkloadEnabled: tt.genericWorkloadEnabled,
 				FailureHandler: func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *fwk.NominatingInfo, start time.Time) {
@@ -720,7 +714,7 @@ func TestPodGroupCycle_PodGroupPostFilter(t *testing.T) {
 			}
 
 			sched.SchedulePod = sched.schedulePod
-			sched.podGroupCycle(ctx, schedFwk, framework.NewCycleState(), podGroupInfo)
+			sched.podGroupCycle(ctx, schedFwk, framework.NewCycleState(), podGroupInfo, time.Now())
 
 			if fakePlugin.podGroupPostFilterCalled != tt.expectedPodGroupPostFilterCalled {
 				t.Errorf("Expected workload aware preemption (PodGroupPostFilter) to be %v, but got %v", tt.expectedPodGroupPostFilterCalled, fakePlugin.podGroupPostFilterCalled)
@@ -1681,13 +1675,11 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			cache.AddNode(klog.FromContext(ctx), testNode)
 
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
-			podGroupLister := informerFactory.Scheduling().V1alpha3().PodGroups().Lister()
 			informerFactory.Start(ctx.Done())
 			informerFactory.WaitForCacheSync(ctx.Done())
 
 			sched := &Scheduler{
 				client:          client,
-				podGroupLister:  podGroupLister,
 				Cache:           cache,
 				Profiles:        profile.Map{"test-scheduler": schedFwk},
 				SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
@@ -2071,10 +2063,9 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 			}
 			client := clientsetfake.NewClientset(objects...)
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
-			podGroupLister := informerFactory.Scheduling().V1alpha3().PodGroups().Lister()
 			informerFactory.Start(ctx.Done())
 			informerFactory.WaitForCacheSync(ctx.Done())
-			sched := &Scheduler{client: client, podGroupLister: podGroupLister}
+			sched := &Scheduler{client: client}
 
 			var existingLTT metav1.Time
 			if existing := apimeta.FindStatusCondition(tt.existingPodGroup.Status.Conditions, schedulingapi.PodGroupInitiallyScheduled); existing != nil {
@@ -2950,8 +2941,6 @@ func TestRunWorkloadAwarePreemption(t *testing.T) {
 				t.Fatalf("Failed to create framework: %v", err)
 			}
 
-			podGroupLister := informerFactory.Scheduling().V1alpha3().PodGroups().Lister()
-
 			if tt.pluginsRegistered {
 				informerFactory.Start(ctx.Done())
 				informerFactory.WaitForCacheSync(ctx.Done())
@@ -2961,7 +2950,6 @@ func TestRunWorkloadAwarePreemption(t *testing.T) {
 			sched := &Scheduler{
 				Cache:            cache,
 				nodeInfoSnapshot: internalcache.NewEmptySnapshot(), // Need empty snapshot to avoid nil pointer issues
-				podGroupLister:   podGroupLister,
 			}
 
 			// Just inject logger explicitly in context to avoid panic
@@ -3044,8 +3032,6 @@ func TestPodGroupCycle_NominatedNodes(t *testing.T) {
 
 	client := clientsetfake.NewSimpleClientset(testPodGroup)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
-	podGroupLister := informerFactory.Scheduling().V1alpha3().PodGroups().Lister()
-
 	informerFactory.Start(ctx.Done())
 	informerFactory.WaitForCacheSync(ctx.Done())
 
@@ -3063,7 +3049,6 @@ func TestPodGroupCycle_NominatedNodes(t *testing.T) {
 		Profiles:         profile.Map{"test-scheduler": schedFwk},
 		Cache:            cache,
 		nodeInfoSnapshot: internalcache.NewEmptySnapshot(),
-		podGroupLister:   podGroupLister,
 		client:           client,
 		SchedulingQueue:  internalqueue.NewTestQueue(ctx, nil),
 	}
@@ -3092,7 +3077,7 @@ func TestPodGroupCycle_NominatedNodes(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 	ctx = klog.NewContext(ctx, logger)
 
-	sched.podGroupCycle(ctx, schedFwk, framework.NewCycleState(), podGroupInfo)
+	sched.podGroupCycle(ctx, schedFwk, framework.NewCycleState(), podGroupInfo, time.Now())
 
 	if len(capturedFailureHandler) == 0 {
 		t.Fatalf("expected FailureHandler to be called")
@@ -3146,7 +3131,6 @@ func TestScheduleOnePodGroup_PodGroupNotFound(t *testing.T) {
 
 	client := clientsetfake.NewSimpleClientset(p1, p2)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
-	podGroupLister := informerFactory.Scheduling().V1alpha3().PodGroups().Lister()
 
 	schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
 		frameworkruntime.WithInformerFactory(informerFactory),
@@ -3164,8 +3148,8 @@ func TestScheduleOnePodGroup_PodGroupNotFound(t *testing.T) {
 
 	sched := &Scheduler{
 		Profiles:               profile.Map{"test-scheduler": schedFwk},
-		podGroupLister:         podGroupLister,
 		SchedulingQueue:        queue,
+		nodeInfoSnapshot:       internalcache.NewEmptySnapshot(),
 		Cache:                  cache,
 		client:                 client,
 		genericWorkloadEnabled: true,

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -50,7 +50,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
-	schedulinglisters "k8s.io/client-go/listers/scheduling/v1alpha3"
 	clienttesting "k8s.io/client-go/testing"
 	clientcache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/events"
@@ -1030,8 +1029,8 @@ func TestSchedulerScheduleOne(t *testing.T) {
 		var gotBinding *v1.Binding
 		var gotNominatingInfo *fwk.NominatingInfo
 
-		var podGroupLister schedulinglisters.PodGroupLister
 		var clientObjs []runtime.Object
+		var podGroup *schedulingv1alpha3.PodGroup
 		if scheduleAsPodGroup {
 			group := &v1.PodSchedulingGroup{
 				PodGroupName: new("pg"),
@@ -1046,10 +1045,10 @@ func TestSchedulerScheduleOne(t *testing.T) {
 				item.expectPodInUnschedulable = nil
 			}
 
-			testPG := &schedulingv1alpha3.PodGroup{
+			podGroup = &schedulingv1alpha3.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: item.sendPod.Namespace},
 			}
-			clientObjs = []runtime.Object{item.sendPod, testPG}
+			clientObjs = []runtime.Object{item.sendPod, podGroup}
 		} else {
 			clientObjs = []runtime.Object{item.sendPod}
 		}
@@ -1073,8 +1072,8 @@ func TestSchedulerScheduleOne(t *testing.T) {
 		internalCache := internalcache.New(ctx, apiDispatcher, scheduleAsPodGroup)
 
 		if scheduleAsPodGroup {
-			podGroupLister = informerFactory.Scheduling().V1alpha3().PodGroups().Lister()
 			internalCache.AddPodGroupMember(item.sendPod)
+			internalCache.AddPodGroup(podGroup)
 		}
 		cache := &fakecache.Cache{
 			Cache: internalCache,
@@ -1151,9 +1150,11 @@ func TestSchedulerScheduleOne(t *testing.T) {
 			SchedulingQueue:                        queue,
 			Profiles:                               profile.Map{testSchedulerName: schedFramework},
 			APIDispatcher:                          apiDispatcher,
-			podGroupLister:                         podGroupLister,
 			nominatedNodeNameForExpectationEnabled: features.nominatedNodeNameForExpectationEnabled,
 		}
+		informerFactory.Start(ctx.Done())
+		informerFactory.WaitForCacheSync(ctx.Done())
+
 		queue.Add(ctx, item.sendPod)
 
 		sched.SchedulePod = func(ctx context.Context, fwk framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (ScheduleResult, error) {
@@ -1177,8 +1178,6 @@ func TestSchedulerScheduleOne(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		informerFactory.Start(ctx.Done())
-		informerFactory.WaitForCacheSync(ctx.Done())
 		sched.nodeInfoSnapshot = internalcache.NewEmptySnapshot()
 		sched.ScheduleOne(ctx)
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
-	schedulinglisters "k8s.io/client-go/listers/scheduling/v1alpha3"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	resourceslicetracker "k8s.io/dynamic-resource-allocation/resourceslice/tracker"
@@ -113,8 +112,6 @@ type Scheduler struct {
 	// otherwise logging functions will access a nil sink and
 	// panic.
 	logger klog.Logger
-
-	podGroupLister schedulinglisters.PodGroupLister
 
 	// registeredHandlers contains the registrations of all handlers. It's used to check if all handlers have finished syncing before the scheduling cycles start.
 	registeredHandlers []cache.ResourceEventHandlerRegistration
@@ -320,10 +317,6 @@ func New(ctx context.Context,
 
 	podLister := informerFactory.Core().V1().Pods().Lister()
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
-	var podGroupLister schedulinglisters.PodGroupLister
-	if feature.DefaultFeatureGate.Enabled(features.GenericWorkload) {
-		podGroupLister = informerFactory.Scheduling().V1alpha3().PodGroups().Lister()
-	}
 
 	snapshot := options.nodeInfoSnapshot
 	if snapshot == nil {
@@ -463,7 +456,6 @@ func New(ctx context.Context,
 		logger:                                 logger,
 		APIDispatcher:                          apiDispatcher,
 		nominatedNodeNameForExpectationEnabled: feature.DefaultFeatureGate.Enabled(features.NominatedNodeNameForExpectation),
-		podGroupLister:                         podGroupLister,
 		genericWorkloadEnabled:                 feature.DefaultFeatureGate.Enabled(features.GenericWorkload),
 	}
 	sched.NextEntity = podQueue.Pop

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1157,6 +1157,7 @@ func newFramework(ctx context.Context, r frameworkruntime.Registry, profile sche
 	return frameworkruntime.NewFramework(ctx, r, &profile,
 		frameworkruntime.WithSnapshotSharedLister(internalcache.NewSnapshot(nil, nil)),
 		frameworkruntime.WithInformerFactory(informers.NewSharedInformerFactory(fake.NewClientset(), 0)),
+		frameworkruntime.WithPodGroupManager(internalcache.New(ctx, nil, false)),
 	)
 }
 

--- a/staging/src/k8s.io/kube-scheduler/framework/listers.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/listers.go
@@ -50,6 +50,14 @@ type SharedLister interface {
 	NodeInfos() NodeInfoLister
 	StorageInfos() StorageInfoLister
 	PodGroupStates() PodGroupStateLister
+	// PodGroups provides access to cached pod group objects.
+	PodGroups() PodGroupLister
+}
+
+// PodGroupLister provides read access to cached pod group objects.
+type PodGroupLister interface {
+	// Get returns the PodGroup with the given namespace and name.
+	Get(namespace, name string) (*schedulingapi.PodGroup, error)
 }
 
 // PodGroupStateLister provides read access to pod group states.
@@ -138,12 +146,6 @@ type DeviceClassResolver interface {
 	GetDeviceClass(resourceName v1.ResourceName) *resourceapi.DeviceClass
 }
 
-// PodGroupLister can be used to obtain PodGroups.
-type PodGroupLister interface {
-	// Get returns the PodGroup with the given podGroupName.
-	Get(namespace, podGroupName string) (*schedulingapi.PodGroup, error)
-}
-
 // SharedDRAManager can be used to obtain DRA objects, and track modifications to them in-memory - mainly by the DRA plugin.
 // The plugin's default implementation obtains the objects from the API. A different implementation can be
 // plugged into the framework in order to simulate the state of DRA objects. For example, Cluster Autoscaler
@@ -153,7 +155,6 @@ type SharedDRAManager interface {
 	ResourceSlices() ResourceSliceLister
 	DeviceClasses() DeviceClassLister
 	DeviceClassResolver() DeviceClassResolver
-	PodGroups() PodGroupLister
 }
 
 // CSIManager can be used to obtain CSINode objects, and track changes to CSINode objects in-memory.
@@ -168,6 +169,8 @@ type CSIManager interface {
 type PodGroupManager interface {
 	// PodGroupStates returns the PodGroupStateLister.
 	PodGroupStates() PodGroupStateLister
+	// PodGroups returns the PodGroupLister.
+	PodGroups() PodGroupLister
 }
 
 // PodGroupState provides an interface to view the state of a single pod group.

--- a/test/integration/scheduler_perf/dra.go
+++ b/test/integration/scheduler_perf/dra.go
@@ -30,7 +30,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	resourcebeta "k8s.io/api/resource/v1beta2"
-	schedulingapi "k8s.io/api/scheduling/v1alpha3"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -315,9 +314,6 @@ func (op *allocResourceClaimsOp) run(tCtx ktesting.TContext) {
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(features.DRADeviceTaintRules) {
 		expectSyncResult.Synced[reflect.TypeFor[*resourcebeta.DeviceTaintRule]()] = true
-	}
-	if utilfeature.DefaultFeatureGate.Enabled(features.GenericWorkload) {
-		expectSyncResult.Synced[reflect.TypeFor[*schedulingapi.PodGroup]()] = true
 	}
 	if diff := cmp.Diff(expectSyncResult, syncResult,
 		cmp.Transformer("TypeOf", func(t reflect.Type) string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This PR adds caching of PodGroup objects to the scheduler, so it can have a consistent, synchronized state for an internal use. Moreover, these objects are snapshotted, so the plugins can access the snapshot to make consistent decisions.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

This PR relies on https://github.com/kubernetes/kubernetes/pull/140075 to be merged first. First commit belongs to that PR.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added PodGroup methods to PodGroupManager and SharedLister, allowing scheduler plugins to obtain a consistent PodGroup state.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
