### PR TITLE
apimachinery: pluralize vowel-y kinds with s

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
@@ -141,10 +141,22 @@ func UnsafeGuessKindToResource(kind schema.GroupVersionKind) ( /*plural*/ schema
 	case "s":
 		return kind.GroupVersion().WithResource(singularName + "es"), singular
 	case "y":
+		if len(singularName) > 1 && isVowel(singularName[len(singularName)-2]) {
+			return kind.GroupVersion().WithResource(singularName + "s"), singular
+		}
 		return kind.GroupVersion().WithResource(strings.TrimSuffix(singularName, "y") + "ies"), singular
 	}
 
 	return kind.GroupVersion().WithResource(singularName + "s"), singular
+}
+
+func isVowel(ch byte) bool {
+	switch ch {
+	case 'a', 'e', 'i', 'o', 'u':
+		return true
+	default:
+		return false
+	}
 }
 
 // ResourceSingularizer implements RESTMapper

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper_test.go
@@ -448,6 +448,9 @@ func TestKindToResource(t *testing.T) {
 
 		// Add "ies" when ending with "y"
 		{Kind: "ImageRepository", Plural: "imagerepositories", Singular: "imagerepository"},
+		// Add "s" when ending with vowel + "y"
+		{Kind: "Gateway", Plural: "gateways", Singular: "gateway"},
+		{Kind: "Array", Plural: "arrays", Singular: "array"},
 		// Add "es" when ending with "s"
 		{Kind: "miss", Plural: "misses", Singular: "miss"},
 		// Add "s" otherwise

--- a/staging/src/k8s.io/client-go/dynamic/fake/simple_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/fake/simple_test.go
@@ -377,6 +377,39 @@ func TestListWithNoFixturesAndTypedScheme(t *testing.T) {
 	}
 }
 
+func TestListWithVowelYKindAndTypedScheme(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gateways"}
+	gvk := gvr.GroupVersion().WithKind("Gateway")
+
+	listGVK := gvk
+	listGVK.Kind += "List"
+
+	u := unstructured.Unstructured{}
+	u.SetGroupVersionKind(gvk)
+	u.SetName("name")
+	u.SetNamespace("namespace")
+
+	typedScheme := runtime.NewScheme()
+	typedScheme.AddKnownTypeWithName(gvk, &mockResource{})
+	typedScheme.AddKnownTypeWithName(listGVK, &mockResourceList{})
+
+	client := NewSimpleDynamicClient(typedScheme, &u)
+	list, err := client.Resource(gvr).Namespace("namespace").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatal("error listing", err)
+	}
+
+	expectedList := &unstructured.UnstructuredList{}
+	expectedList.SetGroupVersionKind(listGVK)
+	expectedList.SetResourceVersion("2") // One object created so far, initial value is 1.
+	expectedList.SetContinue("")
+	expectedList.Items = append(expectedList.Items, u)
+
+	if diff := cmp.Diff(expectedList, list); diff != "" {
+		t.Fatal("unexpected diff (-want, +got): ", diff)
+	}
+}
+
 // This test ensures list works when the dynamic client is seeded with an empty scheme and
 // unstructured typed fixtures
 func TestListWithNoScheme(t *testing.T) {


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

I ran into this while writing tests for a controller that works with Gateway API resources. The fake dynamic client panics when you try to `List` gateways because `UnsafeGuessKindToResource` turns `Gateway` into `gatewaies` instead of `gateways`.

The root cause is pretty straightforward — the pluralization logic sees a trailing `y` and always does the `-y → -ies` replacement, but that's only correct for consonant+y words (like `Policy → Policies`). For vowel+y words, English just appends `s`:

- gateway → gateways ✓ (not gatewaies)
- array → arrays ✓ (not arraies)
- key → keys ✓ (not keies)

This fix adds a check for whether the character before `y` is a vowel, and if so, just appends `s` instead of doing the `-ies` swap.

### Which issue(s) this PR fixes:

Fixes #134751

### Special notes for your reviewer:

I kept the change minimal:
- Added a small unexported `isVowel` helper that checks the preceding byte — works fine here since resource names are always ASCII
- None of the built-in Kubernetes types end in vowel+y, so existing pluralization is unaffected
- Added test cases for `Gateway` and `Array` in the existing `TestKindToResource` table
- Also added a regression test in `client-go/dynamic/fake` since that's the package where this actually blows up in practice

Happy to drop the fake client test if reviewers feel the apimachinery unit test is sufficient.

### Does this PR introduce a user-facing change?

```release-note
NONE
```