### PR TITLE
DRA: Record node selector for shared pending allocations

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -524,6 +524,11 @@ func (pl *DynamicResources) PreFilter(ctx context.Context, state fwk.CycleState,
 			if podGroupState != nil && podGroupState.pendingAllocations.Has(claim.UID) {
 				if pendingAllocation := pl.draManager.ResourceClaims().GetPendingAllocation(claim.UID); pendingAllocation != nil {
 					s.informationsForClaim[index].allocation = pendingAllocation
+					nodeSelector, err := nodeaffinity.NewNodeSelector(pendingAllocation.NodeSelector)
+					if err != nil {
+						return nil, statusError(logger, err)
+					}
+					s.informationsForClaim[index].availableOnNodes = nodeSelector
 					logger.V(5).Info("reusing pending allocation", "pod", klog.KObj(pod), "resourceclaim", klog.KObj(claim), "uid", claim.UID, "allocation", klog.Format(pendingAllocation))
 					continue
 				}

--- a/test/integration/dra/pod_group.go
+++ b/test/integration/dra/pod_group.go
@@ -139,4 +139,50 @@ func testPodGroup(tCtx ktesting.TContext) {
 			}
 		})
 	}
+
+	tCtx.Run("incompatible-node-selectors", func(tCtx ktesting.TContext) {
+		tCtx.Parallel()
+
+		namespace := createTestNamespace(tCtx, nil)
+		startScheduler(tCtx)
+
+		class, driverName := createTestClass(tCtx, namespace)
+
+		slice0 := st.MakeResourceSlice("worker-0", driverName).Devices("device-0")
+		createSlice(tCtx, slice0.Obj())
+
+		claimObj := createClaim(tCtx, namespace, "", class, claim)
+
+		podGroup := &schedulingapi.PodGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: podGroupName,
+			},
+			Spec: schedulingapi.PodGroupSpec{
+				SchedulingPolicy: schedulingapi.PodGroupSchedulingPolicy{
+					Gang: &schedulingapi.GangSchedulingPolicy{
+						MinCount: 2,
+					},
+				},
+			},
+		}
+		podGroup, err := tCtx.Client().SchedulingV1alpha3().PodGroups(namespace).Create(tCtx, podGroup, metav1.CreateOptions{})
+		tCtx.ExpectNoError(err, "create PodGroup")
+
+		schedGroup := &v1.PodSchedulingGroup{
+			PodGroupName: &podGroup.Name,
+		}
+
+		pod0 := podWithClaimName.DeepCopy()
+		pod0.Spec.SchedulingGroup = schedGroup
+		pod0.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": "worker-0"}
+		pod0 = createPod(tCtx, namespace, "-0", pod0, claimObj)
+
+		pod1 := podWithClaimName.DeepCopy()
+		pod1.Spec.SchedulingGroup = schedGroup
+		pod1.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": "worker-1"}
+		pod1 = createPod(tCtx, namespace, "-1", pod1, claimObj)
+
+		expectPodUnschedulable(tCtx, pod0, "pod group is unschedulable, minCount (2) cannot be satisfied")
+		expectPodUnschedulable(tCtx, pod1, "1 resourceclaim not available on the node")
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR fixes the issue @troychiu describes in #140087:

> When two pods in a PodGroup share a ResourceClaim, the dra scheduler plugin reuses the in-memory `pendingAllocation` created during the `Reserve` phase of the first pod (`pod0`). However, during `PreFilter` when reusing `pendingAllocation`
> 
> https://github.com/kubernetes/kubernetes/blob/a0b6070d29d7408c37ea09c8dbb46c91cb9e7c65/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go#L524-L530
> 
> , `s.informationsForClaim[index].availableOnNodes` is never set. As a result, during the `Filter` phase
> 
> https://github.com/kubernetes/kubernetes/blob/a0b6070d29d7408c37ea09c8dbb46c91cb9e7c65/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go#L763
> 
> , `availableOnNodes` evaluates to `nil`, skipping node selector validation for subsequent pods (`pod1`).
> This allows `pod1` to be successfully scheduled onto a node (`worker-1`) even if the allocated device physically resides on a different node (`worker-0`).

I think the reason that `availableOnNodes` was omitted was because #137647 didn't need it but it should have been added in #137897.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #140087

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug where Pods in a PodGroup sharing a ResourceClaim could be scheduled to Nodes where the ResourceClaim is not available.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
