### PR TITLE
apiserver/pkg/handlers: add BenchmarkPerFlushGzipWriterMemory

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watchlist_compression_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watchlist_compression_test.go
@@ -20,11 +20,15 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	goruntime "runtime"
+	"runtime/debug"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,6 +37,7 @@ import (
 	"k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/klog/v2"
 )
 
 const gzipContentOrDieEncodingLevel = 1
@@ -221,6 +226,106 @@ func TestPerFlushGzipWriter(t *testing.T) {
 			require.Equal(t, scenario.expected, string(got))
 		})
 	}
+}
+
+// BenchmarkPerFlushGzipWriterMemory measures retained heap growth per watch
+// connection when compression is enabled.
+//
+// Each iteration opens numConns compressed watch connections, reads the initial
+// events and the initial-events-end bookmark, then measures heap.
+// The perFlushGzipWriter releases the gzip.Writer back to the pool on Flush,
+// so idle connections after initial events should not hold gzip state.
+func BenchmarkPerFlushGzipWriterMemory(b *testing.B) {
+	klog.SetLogger(logr.Discard())
+	featuregatetesting.SetFeatureGateDuringTest(b, utilfeature.DefaultFeatureGate, features.WatchListCompression, true)
+
+	numConns := b.N
+	numInitialEvents := 100
+	events := make([]watch.Event, 0, numInitialEvents+1)
+	for i := range numInitialEvents {
+		events = append(events, watch.Event{
+			Type: watch.Added,
+			Object: &endpointstesting.Simple{
+				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("obj-%d", i)},
+				TypeMeta:   metav1.TypeMeta{APIVersion: testGroupV2.String()},
+			},
+		})
+	}
+	events = append(events, watch.Event{
+		Type: watch.Bookmark,
+		Object: &endpointstesting.Simple{
+			ObjectMeta: metav1.ObjectMeta{
+				ResourceVersion: "100",
+				Annotations:     map[string]string{metav1.InitialEventsAnnotationKey: "true"},
+			},
+			TypeMeta: metav1.TypeMeta{APIVersion: testGroupV2.String()},
+		},
+	})
+
+	info, ok := runtime.SerializerInfoForMediaType(codecs.SupportedMediaTypes(), runtime.ContentTypeJSON)
+	require.True(b, ok)
+	require.NotNil(b, info.StreamSerializer)
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		watcher := watch.NewFakeWithOptions(watch.FakeOptions{ChannelSize: len(events)})
+		for _, event := range events {
+			watcher.Action(event.Type, event.Object)
+		}
+		defer watcher.Stop()
+		ws := &WatchServer{
+			Scope:              &RequestScope{},
+			Watching:           watcher,
+			MediaType:          "application/json",
+			Framer:             info.StreamSerializer.Framer,
+			Encoder:            testCodecV2,
+			EmbeddedEncoder:    testCodecV2,
+			TimeoutFactory:     &fakeTimeoutFactory{done: make(chan struct{})},
+			isWatchListRequest: true,
+		}
+		ws.HandleHTTP(w, req)
+	}))
+	b.Cleanup(s.Close)
+
+	oldGCPercent := debug.SetGCPercent(-1)
+	defer debug.SetGCPercent(oldGCPercent)
+
+	goruntime.GC()
+	var memStart goruntime.MemStats
+	goruntime.ReadMemStats(&memStart)
+
+	decoders := make([]*json.Decoder, numConns)
+	for j := range decoders {
+		req, err := http.NewRequestWithContext(b.Context(), http.MethodGet, s.URL, nil)
+		require.NoError(b, err)
+		req.Header.Set("Accept-Encoding", "gzip")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(b, err)
+		b.Cleanup(func() { require.NoError(b, resp.Body.Close()) })
+
+		gr, err := gzip.NewReader(resp.Body)
+		require.NoError(b, err)
+		decoders[j] = json.NewDecoder(gr)
+	}
+
+	for _, decoder := range decoders {
+		for range events {
+			var got watchJSON
+			require.NoError(b, decoder.Decode(&got))
+		}
+	}
+
+	goruntime.GC()
+	var memAfter goruntime.MemStats
+	goruntime.ReadMemStats(&memAfter)
+	// prevent GC from collecting client connections before we measure heap
+	goruntime.KeepAlive(decoders)
+
+	var heapGrowth uint64
+	if memAfter.HeapInuse > memStart.HeapInuse {
+		heapGrowth = memAfter.HeapInuse - memStart.HeapInuse
+	}
+	b.ReportMetric(float64(heapGrowth)/float64(numConns)/1024, "KB/conn")
+	b.ReportMetric(float64(heapGrowth)/1024/1024, "MB-heap-growth/op")
 }
 
 func TestWatchServerCompression(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds a benchmark that measures retained heap per idle compressed watch connection after initial events are sent.
```
goos: darwin
goarch: arm64
pkg: k8s.io/apiserver/pkg/endpoints/handlers
cpu: Apple M4 Pro
BenchmarkPerFlushGzipWriterMemory-14                  10            964342 ns/op               465.6 KB/conn             4.547 MB-heap-growth/op
BenchmarkPerFlushGzipWriterMemory-14                 100            586944 ns/op               168.6 KB/conn            16.47 MB-heap-growth/op
BenchmarkPerFlushGzipWriterMemory-14                 500            587556 ns/op               120.0 KB/conn            58.59 MB-heap-growth/op
BenchmarkPerFlushGzipWriterMemory-14                1000            601112 ns/op               114.6 KB/conn           112.0 MB-heap-growth/op
BenchmarkPerFlushGzipWriterMemory-14                3000            769113 ns/op               110.3 KB/conn           323.3 MB-heap-growth/op
```


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
