### PR TITLE
test: remove usage of testify assertion library in pkg/scheduler

### DIFF
--- a/pkg/scheduler/framework/autoscaler_contract/framework_contract_test.go
+++ b/pkg/scheduler/framework/autoscaler_contract/framework_contract_test.go
@@ -24,8 +24,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2/ktesting"
@@ -43,20 +41,24 @@ type frameworkContract interface {
 func TestFrameworkContract(t *testing.T) {
 	var f framework.Framework
 	var c frameworkContract = f
-	assert.Nil(t, c)
+	if c != nil {
+		t.Errorf("Expected contract interface to be nil, got: %v", c)
+	}
 }
 
 func TestNewFramework(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
 	var f interface{}
 	if f, _ = runtime.NewFramework(ctx, nil, nil); f != nil {
-		_, ok := f.(framework.Framework)
-		assert.True(t, ok)
+		if _, ok := f.(framework.Framework); !ok {
+			t.Error("Expected runtime.NewFramework to return a framework.Framework")
+		}
 	}
 }
 
 func TestNewCycleState(t *testing.T) {
 	var state interface{} = framework.NewCycleState()
-	_, ok := state.(*framework.CycleState)
-	assert.True(t, ok)
+	if _, ok := state.(*framework.CycleState); !ok {
+		t.Error("Expected framework.NewCycleState to return a *framework.CycleState")
+	}
 }

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -33,8 +33,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	schedulingapi "k8s.io/api/scheduling/v1alpha3"
@@ -2259,7 +2257,9 @@ func testPlugin(tCtx ktesting.TContext) {
 			want:                      want{},
 			metrics: func(tCtx ktesting.TContext, g compbasemetrics.Gatherer) {
 				_, err := testutil.GetCounterValuesFromGatherer(g, "dynamic_resource_allocation_resourceclaim_creates_total", map[string]string{}, "status")
-				require.ErrorContains(tCtx, err, "not found")
+				if err == nil || !strings.Contains(err.Error(), "not found") {
+		tCtx.Fatalf("Expected error containing 'not found', got: %v", err)
+	}
 			},
 		},
 		"extended-resource-one-device-plugin-one-dra": {
@@ -2329,7 +2329,9 @@ func testPlugin(tCtx ktesting.TContext) {
 			},
 			metrics: func(tCtx ktesting.TContext, g compbasemetrics.Gatherer) {
 				_, err := testutil.GetCounterValuesFromGatherer(g, "dynamic_resource_allocation_resourceclaim_creates_total", map[string]string{}, "status")
-				require.ErrorContains(tCtx, err, "not found")
+				if err == nil || !strings.Contains(err.Error(), "not found") {
+		tCtx.Fatalf("Expected error containing 'not found', got: %v", err)
+	}
 			},
 		},
 		"extended-resource-name-with-resources": {
@@ -2351,8 +2353,12 @@ func testPlugin(tCtx ktesting.TContext) {
 			},
 			metrics: func(tCtx ktesting.TContext, g compbasemetrics.Gatherer) {
 				metric, err := testutil.GetCounterValuesFromGatherer(g, "dynamic_resource_allocation_resourceclaim_creates_total", map[string]string{}, "status")
-				require.NoError(tCtx, err)
-				require.Equal(tCtx, 1, int(metric["success"]))
+				if err != nil {
+		tCtx.Fatalf("Unexpected error: %v", err)
+	}
+				if got := int(metric["success"]); got != 1 {
+		tCtx.Fatalf("Expected metric['success'] to be 1, got %v", got)
+	}
 			},
 		},
 		"implicit-extended-resource-name-with-resources": {
@@ -2374,8 +2380,12 @@ func testPlugin(tCtx ktesting.TContext) {
 			},
 			metrics: func(tCtx ktesting.TContext, g compbasemetrics.Gatherer) {
 				metric, err := testutil.GetCounterValuesFromGatherer(g, "dynamic_resource_allocation_resourceclaim_creates_total", map[string]string{}, "status")
-				require.NoError(tCtx, err)
-				require.Equal(tCtx, 1, int(metric["success"]))
+				if err != nil {
+		tCtx.Fatalf("Unexpected error: %v", err)
+	}
+				if got := int(metric["success"]); got != 1 {
+		tCtx.Fatalf("Expected metric['success'] to be 1, got %v", got)
+	}
 			},
 		},
 		"implicit-extended-resource-name-two-containers-with-resources": {
@@ -2397,8 +2407,12 @@ func testPlugin(tCtx ktesting.TContext) {
 			},
 			metrics: func(tCtx ktesting.TContext, g compbasemetrics.Gatherer) {
 				metric, err := testutil.GetCounterValuesFromGatherer(g, "dynamic_resource_allocation_resourceclaim_creates_total", map[string]string{}, "status")
-				require.NoError(tCtx, err)
-				require.Equal(tCtx, 1, int(metric["success"]))
+				if err != nil {
+		tCtx.Fatalf("Unexpected error: %v", err)
+	}
+				if got := int(metric["success"]); got != 1 {
+		tCtx.Fatalf("Expected metric['success'] to be 1, got %v", got)
+	}
 			},
 		},
 		"extended-resource-name-with-resources-fail-patch": {
@@ -2423,8 +2437,12 @@ func testPlugin(tCtx ktesting.TContext) {
 			},
 			metrics: func(tCtx ktesting.TContext, g compbasemetrics.Gatherer) {
 				metric, err := testutil.GetCounterValuesFromGatherer(g, "dynamic_resource_allocation_resourceclaim_creates_total", map[string]string{}, "status")
-				require.NoError(tCtx, err)
-				require.Equal(tCtx, 1, int(metric["success"]))
+				if err != nil {
+		tCtx.Fatalf("Unexpected error: %v", err)
+	}
+				if got := int(metric["success"]); got != 1 {
+		tCtx.Fatalf("Expected metric['success'] to be 1, got %v", got)
+	}
 			},
 		},
 		"extended-resource-name-with-resources-has-claim": {
@@ -2446,7 +2464,9 @@ func testPlugin(tCtx ktesting.TContext) {
 			},
 			metrics: func(tCtx ktesting.TContext, g compbasemetrics.Gatherer) {
 				_, err := testutil.GetCounterValuesFromGatherer(g, "dynamic_resource_allocation_resourceclaim_creates_total", map[string]string{}, "status")
-				require.ErrorContains(tCtx, err, "not found")
+				if err == nil || !strings.Contains(err.Error(), "not found") {
+		tCtx.Fatalf("Expected error containing 'not found', got: %v", err)
+	}
 			},
 		},
 		"extended-resource-name-with-resources-delete-claim": {
@@ -2468,7 +2488,9 @@ func testPlugin(tCtx ktesting.TContext) {
 			},
 			metrics: func(tCtx ktesting.TContext, g compbasemetrics.Gatherer) {
 				_, err := testutil.GetCounterValuesFromGatherer(g, "dynamic_resource_allocation_resourceclaim_creates_total", map[string]string{}, "status")
-				require.ErrorContains(tCtx, err, "not found")
+				if err == nil || !strings.Contains(err.Error(), "not found") {
+		tCtx.Fatalf("Expected error containing 'not found', got: %v", err)
+	}
 			},
 		},
 		"extended-resource-name-bind-failure": {
@@ -2490,8 +2512,12 @@ func testPlugin(tCtx ktesting.TContext) {
 			},
 			metrics: func(tCtx ktesting.TContext, g compbasemetrics.Gatherer) {
 				metric, err := testutil.GetCounterValuesFromGatherer(g, "dynamic_resource_allocation_resourceclaim_creates_total", map[string]string{}, "status")
-				require.NoError(tCtx, err)
-				require.Equal(tCtx, 1, int(metric["success"]))
+				if err != nil {
+		tCtx.Fatalf("Unexpected error: %v", err)
+	}
+				if got := int(metric["success"]); got != 1 {
+		tCtx.Fatalf("Expected metric['success'] to be 1, got %v", got)
+	}
 			},
 		},
 		"extended-resource-name-skip-bind": {
@@ -2507,8 +2533,12 @@ func testPlugin(tCtx ktesting.TContext) {
 			},
 			metrics: func(tCtx ktesting.TContext, g compbasemetrics.Gatherer) {
 				metric, err := testutil.GetCounterValuesFromGatherer(g, "dynamic_resource_allocation_resourceclaim_creates_total", map[string]string{}, "status")
-				require.NoError(tCtx, err)
-				require.Equal(tCtx, 1, int(metric["success"]))
+				if err != nil {
+		tCtx.Fatalf("Unexpected error: %v", err)
+	}
+				if got := int(metric["success"]); got != 1 {
+		tCtx.Fatalf("Expected metric['success'] to be 1, got %v", got)
+	}
 			},
 		},
 		"extended-resource-name-claim-creation-failure": {
@@ -2539,8 +2569,12 @@ func testPlugin(tCtx ktesting.TContext) {
 			},
 			metrics: func(tCtx ktesting.TContext, g compbasemetrics.Gatherer) {
 				metric, err := testutil.GetCounterValuesFromGatherer(g, "dynamic_resource_allocation_resourceclaim_creates_total", map[string]string{}, "status")
-				require.NoError(tCtx, err)
-				require.Equal(tCtx, 1, int(metric["failure"]))
+				if err != nil {
+		tCtx.Fatalf("Unexpected error: %v", err)
+	}
+				if got := int(metric["failure"]); got != 1 {
+		tCtx.Fatalf("Expected metric['failure'] to be 1, got %v", got)
+	}
 			},
 		},
 		"canceled": {
@@ -2798,13 +2832,17 @@ func testPlugin(tCtx ktesting.TContext) {
 					},
 					"driver", // group by driver label
 				)
-				require.NoError(tCtx, err)
+				if err != nil {
+		tCtx.Fatalf("Unexpected error: %v", err)
+	}
 
 				var totalAllocs float64
 				for _, v := range allocs {
 					totalAllocs += v
 				}
-				require.InEpsilon(tCtx, float64(1), totalAllocs, 0.1, "expected exactly one successful allocation with BindingConditions")
+				if diff := totalAllocs - float64(1); diff < -0.1 || diff > 0.1 {
+		tCtx.Fatalf("expected exactly one successful allocation with BindingConditions: expected %v, got %v (diff %v)", float64(1), totalAllocs, diff)
+	}
 
 				// Histogram: one success sample with requires_bindingconditions=true
 				hist, err := testutil.GetHistogramVecFromGatherer(
@@ -2814,8 +2852,12 @@ func testPlugin(tCtx ktesting.TContext) {
 						"status": "success",
 					},
 				)
-				require.NoError(tCtx, err)
-				require.Equal(tCtx, uint64(1), hist.GetAggregatedSampleCount(), "expected one success sample in wait duration histogram")
+				if err != nil {
+		tCtx.Fatalf("Unexpected error: %v", err)
+	}
+				if got := hist.GetAggregatedSampleCount(); got != uint64(1) {
+		tCtx.Fatalf("expected one success sample in wait duration histogram: expected %v, got %v", uint64(1), got)
+	}
 			},
 		},
 		"bound-claim-with-failed-binding": {
@@ -2942,13 +2984,17 @@ func testPlugin(tCtx ktesting.TContext) {
 					},
 					"driver",
 				)
-				require.NoError(tCtx, err)
+				if err != nil {
+		tCtx.Fatalf("Unexpected error: %v", err)
+	}
 
 				var totalTimeouts float64
 				for _, v := range timeouts {
 					totalTimeouts += v
 				}
-				require.InEpsilon(tCtx, float64(1), totalTimeouts, 0.1, "expected exactly one timeout with BindingConditions")
+				if diff := totalTimeouts - float64(1); diff < -0.1 || diff > 0.1 {
+		tCtx.Fatalf("expected exactly one timeout with BindingConditions: expected %v, got %v (diff %v)", float64(1), totalTimeouts, diff)
+	}
 
 				// Histogram: one timeout sample with requires_bindingconditions=true
 				hist, err := testutil.GetHistogramVecFromGatherer(
@@ -2958,8 +3004,12 @@ func testPlugin(tCtx ktesting.TContext) {
 						"status": "timeout",
 					},
 				)
-				require.NoError(tCtx, err)
-				require.Equal(tCtx, uint64(1), hist.GetAggregatedSampleCount(), "expected one timeout sample in wait duration histogram")
+				if err != nil {
+		tCtx.Fatalf("Unexpected error: %v", err)
+	}
+				if got := hist.GetAggregatedSampleCount(); got != uint64(1) {
+		tCtx.Fatalf("expected one timeout sample in wait duration histogram: expected %v, got %v", uint64(1), got)
+	}
 			},
 		},
 		"bound-claim-with-mixed-binding-conditions": {
@@ -3538,7 +3588,9 @@ func testPlugin(tCtx ktesting.TContext) {
 				featuregatetesting.SetFeatureGateEmulationVersionDuringTest(tCtx, utilfeature.DefaultFeatureGate, version.MustParse("1.35"))
 				featuregatetesting.SetFeatureGateDuringTest(tCtx, utilfeature.DefaultFeatureGate, features.DRAAdminAccess, false)
 
-				require.False(tCtx, tc.enableDRAWorkloadResourceClaims, "DRAWorkloadResourceClaims cannot be enabled when DRAAdminAccess is disabled")
+				if tc.enableDRAWorkloadResourceClaims {
+		tCtx.Fatalf("DRAWorkloadResourceClaims cannot be enabled when DRAAdminAccess is disabled")
+	}
 			} else {
 				// These features can't be set with pre-1.36 emulation
 				featuregatetesting.SetFeatureGatesDuringTest(tCtx, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
@@ -3572,7 +3624,9 @@ func testPlugin(tCtx ktesting.TContext) {
 			nodeInfo := framework.NewNodeInfo()
 			result, status := testCtx.p.PreFilter(tCtx, testCtx.state, tc.pod, []fwk.NodeInfo{nodeInfo})
 			tCtx.Run("prefilter", func(tCtx ktesting.TContext) {
-				assert.Equal(tCtx, tc.want.preFilterResult, result)
+				if diff := cmp.Diff(tc.want.preFilterResult, result); diff != "" {
+		tCtx.Errorf("preFilterResult does not match (-want,+got):\n%s", diff)
+	}
 				testCtx.verify(tCtx, tc.want.prefilter, initialObjects, tc.pod, result, status)
 			})
 			unschedulable := status.IsRejected()
@@ -3619,7 +3673,9 @@ func testPlugin(tCtx ktesting.TContext) {
 					score, status := testCtx.p.Score(tCtx, testCtx.state, tc.pod, potentialNode)
 					nodeName := potentialNode.Node().Name
 					tCtx.Run(fmt.Sprintf("score/%s", nodeName), func(tCtx ktesting.TContext) {
-						assert.Equal(tCtx, tc.want.scoreResult.forNode(nodeName), score)
+						if diff := cmp.Diff(tc.want.scoreResult.forNode(nodeName), score); diff != "" {
+		tCtx.Errorf("scoreResult does not match (-want,+got):\n%s", diff)
+	}
 						testCtx.verify(tCtx, tc.want.score.forNode(nodeName), initialObjects, tc.pod, nil, status)
 					})
 					scores = append(scores, fwk.NodeScore{Name: nodeName, Score: score})
@@ -3628,7 +3684,9 @@ func testPlugin(tCtx ktesting.TContext) {
 				initialObjects = testCtx.listAll(tCtx)
 				status := testCtx.p.NormalizeScore(tCtx, testCtx.state, tc.pod, scores)
 				tCtx.Run("normalizeScore", func(tCtx ktesting.TContext) {
-					assert.Equal(tCtx, tc.want.normalizeScoreResult, scores)
+					if diff := cmp.Diff(tc.want.normalizeScoreResult, scores); diff != "" {
+		tCtx.Errorf("normalizeScoreResult does not match (-want,+got):\n%s", diff)
+	}
 					testCtx.verify(tCtx, tc.want.normalizeScore, initialObjects, tc.pod, nil, status)
 				})
 			}
@@ -3680,10 +3738,15 @@ func testPlugin(tCtx ktesting.TContext) {
 					initialObjects = testCtx.updateAPIServer(tCtx, initialObjects, tc.prepare.prebind)
 					preBindPreFlightResult, preBindPreFlightStatus := testCtx.p.PreBindPreFlight(tCtx, testCtx.state, tc.pod, selectedNodeName)
 					tCtx.Run("preBindPreFlightStatus", func(tContext ktesting.TContext) {
-						assert.Equal(tCtx, tc.want.preBindPreFlightStatus, preBindPreFlightStatus)
+						if diff := cmp.Diff(tc.want.preBindPreFlightStatus, preBindPreFlightStatus); diff != "" {
+		tCtx.Errorf("preBindPreFlightStatus does not match (-want,+got):\n%s", diff)
+	}
 					})
 					tCtx.Run("preBindPreFlightResult", func(tContext ktesting.TContext) {
-						assert.Equal(tCtx, &fwk.PreBindPreFlightResult{AllowParallel: true}, preBindPreFlightResult)
+						expectedPreBindPreFlightResult := &fwk.PreBindPreFlightResult{AllowParallel: true}
+	if diff := cmp.Diff(expectedPreBindPreFlightResult, preBindPreFlightResult); diff != "" {
+		tCtx.Errorf("preBindPreFlightResult does not match (-want,+got):\n%s", diff)
+	}
 					})
 					preBindStatus := testCtx.p.PreBind(tCtx, testCtx.state, tc.pod, selectedNodeName)
 					tCtx.Run("prebind", func(tCtx ktesting.TContext) {
@@ -3705,7 +3768,9 @@ func testPlugin(tCtx ktesting.TContext) {
 				initialObjects = testCtx.updateAPIServer(tCtx, initialObjects, tc.prepare.postfilter)
 				result, status := testCtx.p.PostFilter(tCtx, testCtx.state, tc.pod, nil /* filteredNodeStatusMap not used by plugin */)
 				tCtx.Run("postfilter", func(tCtx ktesting.TContext) {
-					assert.Equal(tCtx, tc.want.postFilterResult, result)
+					if diff := cmp.Diff(tc.want.postFilterResult, result); diff != "" {
+		tCtx.Errorf("postFilterResult does not match (-want,+got):\n%s", diff)
+	}
 					testCtx.verify(tCtx, tc.want.postfilter, initialObjects, tc.pod, nil, status)
 				})
 			}
@@ -3748,12 +3813,18 @@ type testContext struct {
 func (tc *testContext) verify(tCtx ktesting.TContext, expected result, initialObjects []metav1.Object, testPod *v1.Pod, result interface{}, status *fwk.Status) {
 	tCtx.Helper()
 	if expected.status == nil {
-		assert.Nil(tCtx, status)
+		if status != nil {
+		tCtx.Errorf("Expected nil status, got: %v", status)
+	}
 	} else if actualErr := status.AsError(); actualErr != nil {
 		// Compare only the error strings.
-		assert.ErrorContains(tCtx, actualErr, expected.status.AsError().Error())
+		if actualErr == nil || !strings.Contains(actualErr.Error(), expected.status.AsError().Error()) {
+		tCtx.Errorf("Expected error containing %q, got: %v", expected.status.AsError().Error(), actualErr)
+	}
 	} else {
-		assert.Equal(tCtx, expected.status, status)
+		if diff := cmp.Diff(expected.status, status); diff != "" {
+		tCtx.Errorf("status does not match (-want,+got):\n%s", diff)
+	}
 	}
 	objects := tc.listAll(tCtx)
 	wantObjects := update(initialObjects, expected.changes)
@@ -3999,7 +4070,9 @@ func setup(tCtx ktesting.TContext, args *config.DynamicResourcesArgs, nodes []*v
 		KubeClient:             tc.client,
 	}
 	resourceSliceTracker, err := resourceslicetracker.StartTracker(tCtx, resourceSliceTrackerOpts)
-	require.NoError(tCtx, err, "couldn't start resource slice tracker")
+	if err != nil {
+		tCtx.Fatalf("couldn't start resource slice tracker: %v", err)
+	}
 	doneCheckers = append(doneCheckers, resourceSliceTracker.HasSyncedChecker())
 
 	claimsCache := assumecache.NewAssumeCache(tCtx.Logger(), tc.informerFactory.Resource().V1().ResourceClaims().Informer(), "resource claim", "", nil)
@@ -4019,7 +4092,9 @@ func setup(tCtx ktesting.TContext, args *config.DynamicResourcesArgs, nodes []*v
 	if features.EnableDRAExtendedResource {
 		cache := tc.draManager.DeviceClassResolver().(*extendedresourcecache.ExtendedResourceCache)
 		deviceClassHandlerRegistration, err := tc.informerFactory.Resource().V1().DeviceClasses().Informer().AddEventHandler(cache)
-		require.NoError(tCtx, err, "failed to add device class informer event handler")
+		if err != nil {
+		tCtx.Fatalf("failed to add device class informer event handler: %v", err)
+	}
 		doneCheckers = append(doneCheckers, deviceClassHandlerRegistration.HasSyncedChecker())
 	}
 
@@ -4787,7 +4862,9 @@ func Test_computesScore(t *testing.T) {
 			if tc.expectErr {
 				t.Fatal("expected error, got none")
 			}
-			assert.Equal(t, tc.expectedScore, score)
+			if score != tc.expectedScore {
+		t.Errorf("Expected score %v, got %v", tc.expectedScore, score)
+	}
 		})
 	}
 }
@@ -4958,7 +5035,9 @@ func TestNormalizeScore(t *testing.T) {
 			}
 			scores := tc.scores
 			_ = pl.NormalizeScore(context.Background(), nil, nil, scores)
-			assert.Equal(t, tc.expectedScores, scores)
+			if diff := cmp.Diff(tc.expectedScores, scores); diff != "" {
+		t.Errorf("scores do not match (-want,+got):\n%s", diff)
+	}
 		})
 	}
 }

--- a/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity_test.go
+++ b/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -1361,11 +1360,17 @@ func Test_isSchedulableAfterNodeChange(t *testing.T) {
 
 			actualHint, err := p.(*NodeAffinity).isSchedulableAfterNodeChange(logger, tc.pod, tc.oldObj, tc.newObj)
 			if tc.expectedErr {
-				require.Error(t, err)
+				if err == nil {
+					t.Error("Expected error, got nil")
+				}
 				return
 			}
-			require.NoError(t, err)
-			require.Equal(t, tc.expectedHint, actualHint)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.expectedHint, actualHint); diff != "" {
+				t.Errorf("Unexpected hint (-want,+got):\n%s", diff)
+			}
 		})
 	}
 }

--- a/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/assert"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -215,7 +214,10 @@ func TestBrokenLinearFunction(t *testing.T) {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
 			function := helper.BuildBrokenLinearFunction(test.points)
 			for _, assertion := range test.assertions {
-				assert.InDelta(t, assertion.expected, function(assertion.p), 0.1, "points=%v, p=%d", test.points, assertion.p)
+				got := function(assertion.p)
+				if got != assertion.expected {
+					t.Errorf("Unexpected points (points=%v, p=%d): expected %v, got %v", test.points, assertion.p, assertion.expected, got)
+				}
 			}
 		})
 	}

--- a/pkg/scheduler/framework/plugins/noderesources/resource_allocation_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/resource_allocation_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -848,15 +847,21 @@ func TestNodeMatchCaching(t *testing.T) {
 
 			// First call should be a cache miss
 			_, found1 := scorer.getCachedNodeMatch(testNode.Name, tc.nodeNameToMatch, tc.allNodesMatch, nodeSelectorStr)
-			assert.False(t, found1, "Cache should be empty initially")
+			if found1 {
+				t.Error("Cache should be empty initially")
+			}
 
 			// Simulate setting a cached result
 			scorer.setCachedNodeMatch(testNode.Name, tc.nodeNameToMatch, tc.allNodesMatch, nodeSelectorStr, tc.expectedMatch)
 
 			// Second call should be a cache hit
 			matches2, found2 := scorer.getCachedNodeMatch(testNode.Name, tc.nodeNameToMatch, tc.allNodesMatch, nodeSelectorStr)
-			assert.True(t, found2, "Result should be found in cache")
-			assert.Equal(t, tc.expectedMatch, matches2, "Cached result should match expected value")
+			if !found2 {
+				t.Error("Result should be found in cache")
+			}
+			if matches2 != tc.expectedMatch {
+				t.Errorf("Cached result should match expected value, expected %v, got %v", tc.expectedMatch, matches2)
+			}
 		})
 	}
 }

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -1257,8 +1256,12 @@ func TestVolumeBinding(t *testing.T) {
 
 			t.Logf("Verify: call PreFilter and check status")
 			gotPreFilterResult, gotPreFilterStatus := p.PreFilter(ctx, state, item.pod, nil)
-			assert.Equal(t, item.wantPreFilterStatus, gotPreFilterStatus)
-			assert.Equal(t, item.wantPreFilterResult, gotPreFilterResult)
+			if diff := cmp.Diff(item.wantPreFilterStatus, gotPreFilterStatus); diff != "" {
+				t.Errorf("PreFilter status does not match (-want,+got):\n%s", diff)
+			}
+			if diff := cmp.Diff(item.wantPreFilterResult, gotPreFilterResult); diff != "" {
+				t.Errorf("PreFilter result does not match (-want,+got):\n%s", diff)
+			}
 
 			if !gotPreFilterStatus.IsSuccess() {
 				// scheduler framework will skip Filter if PreFilter fails
@@ -1288,7 +1291,9 @@ func TestVolumeBinding(t *testing.T) {
 			t.Logf("Verify: call Filter and check status")
 			for i, nodeInfo := range nodeInfos {
 				gotStatus := p.Filter(ctx, state, item.pod, nodeInfo)
-				assert.Equal(t, item.wantFilterStatus[i], gotStatus)
+				if diff := cmp.Diff(item.wantFilterStatus[i], gotStatus); diff != "" {
+					t.Errorf("Filter status for node info does not match (-want,+got):\n%s", diff)
+				}
 			}
 
 			t.Logf("Verify: call PreScore and check status")
@@ -1369,7 +1374,10 @@ func Test_PreBindPreFlight(t *testing.T) {
 			if !status.Equal(item.wantStatus) {
 				t.Errorf("PreBindPreFlight failed - got: %v, want: %v", status, item.wantStatus)
 			}
-			assert.Equal(t, &fwk.PreBindPreFlightResult{AllowParallel: true}, result)
+			expectedResult := &fwk.PreBindPreFlightResult{AllowParallel: true}
+			if diff := cmp.Diff(expectedResult, result); diff != "" {
+				t.Errorf("PreBindPreFlightResult does not match (-want,+got):\n%s", diff)
+			}
 		})
 	}
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega"
-	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
@@ -1498,7 +1497,9 @@ func TestNewInformerFactoryTrim(t *testing.T) {
 			},
 		},
 	}}
-	require.NoError(t, cs.Tracker().Add(pd))
+	if err := cs.Tracker().Add(pd); err != nil {
+		t.Fatalf("Failed to add Pod: %v", err)
+	}
 
 	informerFactory := NewInformerFactory(cs, 0)
 	lister := informerFactory.Core().V1().Pods().Lister()
@@ -1509,6 +1510,10 @@ func TestNewInformerFactoryTrim(t *testing.T) {
 	informerFactory.WaitForCacheSync(ctx.Done())
 
 	p, err := lister.Pods("default").Get("test")
-	require.NoError(t, err)
-	require.Empty(t, p.GetManagedFields(), "expected managedFields to be trimmed by the transform")
+	if err != nil {
+		t.Fatalf("Unexpected error getting pod: %v", err)
+	}
+	if managedFields := p.GetManagedFields(); len(managedFields) != 0 {
+		t.Errorf("Expected managedFields to be empty, got: %v", managedFields)
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This PR addresses technical debt in the `pkg/scheduler` test suites by removing the usage of the third-party assertion library `github.com/stretchr/testify` (`assert` and `require`). This aligns with the [SIG Scheduling Technical and Style Guidelines](https://github.com/kubernetes/community/blob/master/sig-scheduling/CONTRIBUTING.md#technical-and-style-guidelines), which mandate avoiding assertion libraries in favor of standard Go testing idioms and `go-cmp`.

**Key Changes:**
*   **`require.NoError(t, err)` / `require.Error(t, err)`:** Replaced with explicit `if err != nil` and `if err == nil` checks using `t.Fatalf`/`t.Errorf`.
*   **`assert.Nil(t, obj)` / `assert.True(t, cond)`:** Converted to standard conditional blocks (`if obj != nil` / `if !cond`).
*   **`assert.Equal(t, expected, actual)`:** Replaced with `if diff := cmp.Diff(expected, actual); diff != "" { t.Errorf(...) }`.
*   **Special Case (`requested_to_capacity_ratio_test.go`):** Replaced `assert.InDelta` with direct integer equality (`got != expected`) because scheduling scores in `helper.BuildBrokenLinearFunction` are represented by `int64` integers.

<details>
<summary><b>Detailed Changelog of modified test files:</b></summary>

1. **`pkg/scheduler/scheduler_test.go`**
   - Removed `testify/require` import.
   - Refactored `require.NoError` and `require.Empty` checks on `cs.Tracker().Add` and `GetManagedFields()`.
2. **`pkg/scheduler/framework/autoscaler_contract/framework_contract_test.go`**
   - Removed `testify/assert` import.
   - Refactored framework and contract type assertions to standard Go conditionals.
3. **`pkg/scheduler/framework/plugins/nodeaffinity/node_affinity_test.go`**
   - Removed `testify/require` import.
   - Refactored assertions in `TestNodeAffinity` using `cmp.Diff`.
4. **`pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio_test.go`**
   - Removed `testify/assert` import.
   - Refactored delta-based assertion to strict integer comparison.
5. **`pkg/scheduler/framework/plugins/noderesources/resource_allocation_test.go`**
   - Removed `testify/assert` import.
   - Refactored cache-miss and cache-hit assertion checks.
6. **`pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go`**
   - Removed `testify/assert` import.
   - Refactored multiple `assert.Equal` statements using `cmp.Diff`.
7. **`pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go`**
   - Removed `testify/assert` and `testify/require` imports.
   - Refactored 41 assertions (handling errors, allocations, metrics, and histograms) using native Go constructs and `cmp.Diff`.

</details>

#### Which issue(s) this PR is related to:
Fixes #130407

#### Special notes for your reviewer:
All modifications were verified locally. The packages compile cleanly and all unit tests pass successfully:

*   `go test ./pkg/scheduler/...` (ok, ~3.3s)
*   `go test ./pkg/scheduler/framework/autoscaler_contract/...` (ok, ~4.2s)
*   `go test ./pkg/scheduler/framework/plugins/nodeaffinity/...` (ok, ~5.2s)
*   `go test ./pkg/scheduler/framework/plugins/noderesources/...` (ok, ~17.3s)
*   `go test ./pkg/scheduler/framework/plugins/volumebinding/...` (ok, ~32.3s)
*   `go test ./pkg/scheduler/framework/plugins/dynamicresources/...` (ok, ~56.4s)

#### Does this PR introduce a user-facing change?
```release-note
NONE