### PR TITLE
Fix 130069 fix context todo kubelet cm - part 4

### DIFF
--- a/pkg/kubelet/allocation/allocation_manager_test.go
+++ b/pkg/kubelet/allocation/allocation_manager_test.go
@@ -2436,7 +2436,7 @@ func makeAllocationManager(t *testing.T, runtime *containertest.FakeRuntime, all
 	statusManager := status.NewManager(&fake.Clientset{}, kubepod.NewBasicPodManager(), &statustest.FakePodDeletionSafetyProvider{}, kubeletutil.NewPodStartupLatencyTracker())
 	var containerManager *cm.FakeContainerManager
 	if nodeConfig == nil {
-		containerManager = cm.NewFakeContainerManager()
+		containerManager = cm.NewFakeContainerManager(logger)
 	} else {
 		containerManager = cm.NewFakeContainerManagerWithNodeConfig(*nodeConfig)
 	}

--- a/pkg/kubelet/apis/podresources/server_v1.go
+++ b/pkg/kubelet/apis/podresources/server_v1.go
@@ -73,7 +73,7 @@ func (p *v1PodResourcesServer) List(ctx context.Context, req *podresourcesv1.Lis
 	}
 
 	podResources := make([]*podresourcesv1.PodResources, len(pods))
-	p.devicesProvider.UpdateAllocatedDevices()
+	p.devicesProvider.UpdateAllocatedDevices(logger)
 
 	for i, pod := range pods {
 		pRes := podresourcesv1.PodResources{
@@ -105,13 +105,14 @@ func (p *v1PodResourcesServer) List(ctx context.Context, req *podresourcesv1.Lis
 
 // GetAllocatableResources returns information about all the resources known by the server - this more like the capacity, not like the current amount of free resources.
 func (p *v1PodResourcesServer) GetAllocatableResources(ctx context.Context, req *podresourcesv1.AllocatableResourcesRequest) (*podresourcesv1.AllocatableResourcesResponse, error) {
+	logger := klog.FromContext(ctx)
 	metrics.PodResourcesEndpointRequestsTotalCount.WithLabelValues("v1").Inc()
 	metrics.PodResourcesEndpointRequestsGetAllocatableCount.WithLabelValues("v1").Inc()
 
 	response := &podresourcesv1.AllocatableResourcesResponse{
-		Devices: p.devicesProvider.GetAllocatableDevices(),
+		Devices: p.devicesProvider.GetAllocatableDevices(logger),
 		CpuIds:  p.cpusProvider.GetAllocatableCPUs(),
-		Memory:  p.memoryProvider.GetAllocatableMemory(),
+		Memory:  p.memoryProvider.GetAllocatableMemory(logger),
 	}
 
 	return response, nil
@@ -160,7 +161,7 @@ func (p *v1PodResourcesServer) getContainerResources(logger klog.Logger, pod *v1
 		Name:             container.Name,
 		Devices:          p.devicesProvider.GetDevices(string(pod.UID), container.Name),
 		CpuIds:           p.cpusProvider.GetCPUs(string(pod.UID), container.Name),
-		Memory:           p.memoryProvider.GetMemory(string(pod.UID), container.Name),
+		Memory:           p.memoryProvider.GetMemory(logger, string(pod.UID), container.Name),
 		DynamicResources: p.dynamicResourcesProvider.GetDynamicResources(logger, pod, container),
 	}
 	return containerResources

--- a/pkg/kubelet/apis/podresources/server_v1_test.go
+++ b/pkg/kubelet/apis/podresources/server_v1_test.go
@@ -222,12 +222,12 @@ func TestListPodResourcesV1(t *testing.T) {
 			mockPodsProvider.EXPECT().GetActivePods().Return(tc.pods).Maybe()
 			mockDevicesProvider.EXPECT().GetDevices(string(podUID), containerName).Return(tc.devices).Maybe()
 			mockCPUsProvider.EXPECT().GetCPUs(string(podUID), containerName).Return(tc.cpus).Maybe()
-			mockMemoryProvider.EXPECT().GetMemory(string(podUID), containerName).Return(tc.memory).Maybe()
+			mockMemoryProvider.EXPECT().GetMemory(logger, string(podUID), containerName).Return(tc.memory).Maybe()
 			mockDynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pods[0], &containers[0]).Return(tc.dynamicResources).Maybe()
-			mockDevicesProvider.EXPECT().UpdateAllocatedDevices().Return().Maybe()
+			mockDevicesProvider.EXPECT().UpdateAllocatedDevices(logger).Return().Maybe()
 			mockCPUsProvider.EXPECT().GetAllocatableCPUs().Return([]int64{}).Maybe()
-			mockDevicesProvider.EXPECT().GetAllocatableDevices().Return([]*podresourcesapi.ContainerDevices{}).Maybe()
-			mockMemoryProvider.EXPECT().GetAllocatableMemory().Return([]*podresourcesapi.ContainerMemory{}).Maybe()
+			mockDevicesProvider.EXPECT().GetAllocatableDevices(logger).Return([]*podresourcesapi.ContainerDevices{}).Maybe()
+			mockMemoryProvider.EXPECT().GetAllocatableMemory(logger).Return([]*podresourcesapi.ContainerMemory{}).Maybe()
 
 			providers := PodResourcesProviders{
 				Pods:             mockPodsProvider,
@@ -375,11 +375,11 @@ func TestListPodResourcesUsesOnlyActivePodsV1(t *testing.T) {
 			mockPodsProvider.EXPECT().GetActivePods().Return(tc.activePods).Maybe()
 			mockDevicesProvider.EXPECT().GetDevices(mock.Anything, mock.Anything).Return(devs).Maybe()
 			mockCPUsProvider.EXPECT().GetCPUs(mock.Anything, mock.Anything).Return(cpus).Maybe()
-			mockMemoryProvider.EXPECT().GetMemory(mock.Anything, mock.Anything).Return(mems).Maybe()
-			mockDevicesProvider.EXPECT().UpdateAllocatedDevices().Return().Maybe()
+			mockMemoryProvider.EXPECT().GetMemory(logger, mock.Anything, mock.Anything).Return(mems).Maybe()
+			mockDevicesProvider.EXPECT().UpdateAllocatedDevices(logger).Return().Maybe()
 			mockCPUsProvider.EXPECT().GetAllocatableCPUs().Return([]int64{}).Maybe()
-			mockDevicesProvider.EXPECT().GetAllocatableDevices().Return([]*podresourcesapi.ContainerDevices{}).Maybe()
-			mockMemoryProvider.EXPECT().GetAllocatableMemory().Return([]*podresourcesapi.ContainerMemory{}).Maybe()
+			mockDevicesProvider.EXPECT().GetAllocatableDevices(logger).Return([]*podresourcesapi.ContainerDevices{}).Maybe()
+			mockMemoryProvider.EXPECT().GetAllocatableMemory(logger).Return([]*podresourcesapi.ContainerMemory{}).Maybe()
 			mockDynamicResourcesProvider.EXPECT().GetDynamicResources(logger, mock.Anything, mock.Anything).Return([]*podresourcesapi.DynamicResource{}).Maybe()
 
 			providers := PodResourcesProviders{
@@ -478,10 +478,10 @@ func TestListPodResourcesWithInitContainersV1(t *testing.T) {
 				cpusProvider *podresourcetest.MockCPUsProvider,
 				memoryProvider *podresourcetest.MockMemoryProvider,
 				dynamicResourcesProvider *podresourcetest.MockDynamicResourcesProvider) {
-				devicesProvider.EXPECT().UpdateAllocatedDevices().Return().Maybe()
+				devicesProvider.EXPECT().UpdateAllocatedDevices(logger).Return().Maybe()
 				devicesProvider.EXPECT().GetDevices(string(podUID), containerName).Return(devs).Maybe()
 				cpusProvider.EXPECT().GetCPUs(string(podUID), containerName).Return(cpus).Maybe()
-				memoryProvider.EXPECT().GetMemory(string(podUID), containerName).Return(memory).Maybe()
+				memoryProvider.EXPECT().GetMemory(logger, string(podUID), containerName).Return(memory).Maybe()
 				dynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pods[0], &pods[0].Spec.Containers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
 
 			},
@@ -529,16 +529,16 @@ func TestListPodResourcesWithInitContainersV1(t *testing.T) {
 				cpusProvider *podresourcetest.MockCPUsProvider,
 				memoryProvider *podresourcetest.MockMemoryProvider,
 				dynamicResourcesProvider *podresourcetest.MockDynamicResourcesProvider) {
-				devicesProvider.EXPECT().UpdateAllocatedDevices().Return().Maybe()
+				devicesProvider.EXPECT().UpdateAllocatedDevices(logger).Return().Maybe()
 
 				devicesProvider.EXPECT().GetDevices(string(podUID), initContainerName).Return(devs).Maybe()
 				cpusProvider.EXPECT().GetCPUs(string(podUID), initContainerName).Return(cpus).Maybe()
-				memoryProvider.EXPECT().GetMemory(string(podUID), initContainerName).Return(memory).Maybe()
+				memoryProvider.EXPECT().GetMemory(logger, string(podUID), initContainerName).Return(memory).Maybe()
 				dynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pods[0], &pods[0].Spec.InitContainers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
 
 				devicesProvider.EXPECT().GetDevices(string(podUID), containerName).Return(devs).Maybe()
 				cpusProvider.EXPECT().GetCPUs(string(podUID), containerName).Return(cpus).Maybe()
-				memoryProvider.EXPECT().GetMemory(string(podUID), containerName).Return(memory).Maybe()
+				memoryProvider.EXPECT().GetMemory(logger, string(podUID), containerName).Return(memory).Maybe()
 				dynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pods[0], &pods[0].Spec.Containers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
 
 			},
@@ -599,7 +599,7 @@ func TestListPodResourcesWithInitContainersV1(t *testing.T) {
 }
 
 func TestAllocatableResources(t *testing.T) {
-	tCtx := ktesting.Init(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 	allDevs := []*podresourcesapi.ContainerDevices{
 		{
 			ResourceName: "resource",
@@ -864,11 +864,11 @@ func TestAllocatableResources(t *testing.T) {
 
 			mockDevicesProvider.EXPECT().GetDevices("", "").Return([]*podresourcesapi.ContainerDevices{}).Maybe()
 			mockCPUsProvider.EXPECT().GetCPUs("", "").Return([]int64{}).Maybe()
-			mockMemoryProvider.EXPECT().GetMemory("", "").Return([]*podresourcesapi.ContainerMemory{}).Maybe()
-			mockDevicesProvider.EXPECT().UpdateAllocatedDevices().Return().Maybe()
-			mockDevicesProvider.EXPECT().GetAllocatableDevices().Return(tc.allDevices).Maybe()
+			mockMemoryProvider.EXPECT().GetMemory(logger, "", "").Return([]*podresourcesapi.ContainerMemory{}).Maybe()
+			mockDevicesProvider.EXPECT().UpdateAllocatedDevices(logger).Return().Maybe()
+			mockDevicesProvider.EXPECT().GetAllocatableDevices(logger).Return(tc.allDevices).Maybe()
 			mockCPUsProvider.EXPECT().GetAllocatableCPUs().Return(tc.allCPUs).Maybe()
-			mockMemoryProvider.EXPECT().GetAllocatableMemory().Return(tc.allMemory).Maybe()
+			mockMemoryProvider.EXPECT().GetAllocatableMemory(logger).Return(tc.allMemory).Maybe()
 
 			providers := PodResourcesProviders{
 				Pods:    mockPodsProvider,
@@ -1032,12 +1032,12 @@ func TestGetPodResourcesV1(t *testing.T) {
 			mockPodsProvider.EXPECT().GetPodByName(podNamespace, podName).Return(tc.pod, tc.exist).Maybe()
 			mockDevicesProvider.EXPECT().GetDevices(string(podUID), containerName).Return(tc.devices).Maybe()
 			mockCPUsProvider.EXPECT().GetCPUs(string(podUID), containerName).Return(tc.cpus).Maybe()
-			mockMemoryProvider.EXPECT().GetMemory(string(podUID), containerName).Return(tc.memory).Maybe()
+			mockMemoryProvider.EXPECT().GetMemory(logger, string(podUID), containerName).Return(tc.memory).Maybe()
 			mockDynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pod, &containers[0]).Return(tc.dynamicResources).Maybe()
-			mockDevicesProvider.EXPECT().UpdateAllocatedDevices().Return().Maybe()
+			mockDevicesProvider.EXPECT().UpdateAllocatedDevices(logger).Return().Maybe()
 			mockCPUsProvider.EXPECT().GetAllocatableCPUs().Return([]int64{}).Maybe()
-			mockDevicesProvider.EXPECT().GetAllocatableDevices().Return([]*podresourcesapi.ContainerDevices{}).Maybe()
-			mockMemoryProvider.EXPECT().GetAllocatableMemory().Return([]*podresourcesapi.ContainerMemory{}).Maybe()
+			mockDevicesProvider.EXPECT().GetAllocatableDevices(logger).Return([]*podresourcesapi.ContainerDevices{}).Maybe()
+			mockMemoryProvider.EXPECT().GetAllocatableMemory(logger).Return([]*podresourcesapi.ContainerMemory{}).Maybe()
 
 			providers := PodResourcesProviders{
 				Pods:             mockPodsProvider,
@@ -1141,10 +1141,10 @@ func TestGetPodResourcesWithInitContainersV1(t *testing.T) {
 				cpusProvider *podresourcetest.MockCPUsProvider,
 				memoryProvider *podresourcetest.MockMemoryProvider,
 				dynamicResourcesProvider *podresourcetest.MockDynamicResourcesProvider) {
-				devicesProvider.EXPECT().UpdateAllocatedDevices().Return().Maybe()
+				devicesProvider.EXPECT().UpdateAllocatedDevices(logger).Return().Maybe()
 				devicesProvider.EXPECT().GetDevices(string(podUID), containerName).Return(devs).Maybe()
 				cpusProvider.EXPECT().GetCPUs(string(podUID), containerName).Return(cpus).Maybe()
-				memoryProvider.EXPECT().GetMemory(string(podUID), containerName).Return(memory).Maybe()
+				memoryProvider.EXPECT().GetMemory(logger, string(podUID), containerName).Return(memory).Maybe()
 				dynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pod, &pod.Spec.Containers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
 
 			},
@@ -1188,16 +1188,16 @@ func TestGetPodResourcesWithInitContainersV1(t *testing.T) {
 				cpusProvider *podresourcetest.MockCPUsProvider,
 				memoryProvider *podresourcetest.MockMemoryProvider,
 				dynamicResourcesProvider *podresourcetest.MockDynamicResourcesProvider) {
-				devicesProvider.EXPECT().UpdateAllocatedDevices().Return().Maybe()
+				devicesProvider.EXPECT().UpdateAllocatedDevices(logger).Return().Maybe()
 
 				devicesProvider.EXPECT().GetDevices(string(podUID), initContainerName).Return(devs).Maybe()
 				cpusProvider.EXPECT().GetCPUs(string(podUID), initContainerName).Return(cpus).Maybe()
-				memoryProvider.EXPECT().GetMemory(string(podUID), initContainerName).Return(memory).Maybe()
+				memoryProvider.EXPECT().GetMemory(logger, string(podUID), initContainerName).Return(memory).Maybe()
 				dynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pod, &pod.Spec.InitContainers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
 
 				devicesProvider.EXPECT().GetDevices(string(podUID), containerName).Return(devs).Maybe()
 				cpusProvider.EXPECT().GetCPUs(string(podUID), containerName).Return(cpus).Maybe()
-				memoryProvider.EXPECT().GetMemory(string(podUID), containerName).Return(memory).Maybe()
+				memoryProvider.EXPECT().GetMemory(logger, string(podUID), containerName).Return(memory).Maybe()
 				dynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pod, &pod.Spec.Containers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
 			},
 			expectedResponse: &podresourcesapi.GetPodResourcesResponse{

--- a/pkg/kubelet/apis/podresources/server_v1alpha1.go
+++ b/pkg/kubelet/apis/podresources/server_v1alpha1.go
@@ -19,6 +19,7 @@ package podresources
 import (
 	"context"
 
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 
 	v1 "k8s.io/kubelet/pkg/apis/podresources/v1"
@@ -56,10 +57,11 @@ func v1DevicesToAlphaV1(alphaDevs []*v1.ContainerDevices) []*v1alpha1.ContainerD
 
 // List returns information about the resources assigned to pods on the node
 func (p *v1alpha1PodResourcesServer) List(ctx context.Context, req *v1alpha1.ListPodResourcesRequest) (*v1alpha1.ListPodResourcesResponse, error) {
+	logger := klog.FromContext(ctx)
 	metrics.PodResourcesEndpointRequestsTotalCount.WithLabelValues("v1alpha1").Inc()
 	pods := p.podsProvider.GetPods()
 	podResources := make([]*v1alpha1.PodResources, len(pods))
-	p.devicesProvider.UpdateAllocatedDevices()
+	p.devicesProvider.UpdateAllocatedDevices(logger)
 
 	for i, pod := range pods {
 		pRes := v1alpha1.PodResources{

--- a/pkg/kubelet/apis/podresources/server_v1alpha1_test.go
+++ b/pkg/kubelet/apis/podresources/server_v1alpha1_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestListPodResourcesV1alpha1(t *testing.T) {
-	tCtx := ktesting.Init(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 	podName := "pod-name"
 	podNamespace := "pod-namespace"
 	podUID := types.UID("pod-uid")
@@ -129,7 +129,7 @@ func TestListPodResourcesV1alpha1(t *testing.T) {
 
 			mockPodsProvider.EXPECT().GetPods().Return(tc.pods).Maybe()
 			mockDevicesProvider.EXPECT().GetDevices(string(podUID), containerName).Return(tc.devices).Maybe()
-			mockDevicesProvider.EXPECT().UpdateAllocatedDevices().Return().Maybe()
+			mockDevicesProvider.EXPECT().UpdateAllocatedDevices(logger).Return().Maybe()
 
 			providers := PodResourcesProviders{
 				Pods:    mockPodsProvider,

--- a/pkg/kubelet/apis/podresources/testing/mocks.go
+++ b/pkg/kubelet/apis/podresources/testing/mocks.go
@@ -55,16 +55,16 @@ func (_m *MockDevicesProvider) EXPECT() *MockDevicesProvider_Expecter {
 }
 
 // GetAllocatableDevices provides a mock function for the type MockDevicesProvider
-func (_mock *MockDevicesProvider) GetAllocatableDevices() []*v1.ContainerDevices {
-	ret := _mock.Called()
+func (_mock *MockDevicesProvider) GetAllocatableDevices(logger klog.Logger) []*v1.ContainerDevices {
+	ret := _mock.Called(logger)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetAllocatableDevices")
 	}
 
 	var r0 []*v1.ContainerDevices
-	if returnFunc, ok := ret.Get(0).(func() []*v1.ContainerDevices); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(klog.Logger) []*v1.ContainerDevices); ok {
+		r0 = returnFunc(logger)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*v1.ContainerDevices)
@@ -79,13 +79,20 @@ type MockDevicesProvider_GetAllocatableDevices_Call struct {
 }
 
 // GetAllocatableDevices is a helper method to define mock.On call
-func (_e *MockDevicesProvider_Expecter) GetAllocatableDevices() *MockDevicesProvider_GetAllocatableDevices_Call {
-	return &MockDevicesProvider_GetAllocatableDevices_Call{Call: _e.mock.On("GetAllocatableDevices")}
+//   - logger klog.Logger
+func (_e *MockDevicesProvider_Expecter) GetAllocatableDevices(logger interface{}) *MockDevicesProvider_GetAllocatableDevices_Call {
+	return &MockDevicesProvider_GetAllocatableDevices_Call{Call: _e.mock.On("GetAllocatableDevices", logger)}
 }
 
-func (_c *MockDevicesProvider_GetAllocatableDevices_Call) Run(run func()) *MockDevicesProvider_GetAllocatableDevices_Call {
+func (_c *MockDevicesProvider_GetAllocatableDevices_Call) Run(run func(logger klog.Logger)) *MockDevicesProvider_GetAllocatableDevices_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 klog.Logger
+		if args[0] != nil {
+			arg0 = args[0].(klog.Logger)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -95,7 +102,7 @@ func (_c *MockDevicesProvider_GetAllocatableDevices_Call) Return(containerDevice
 	return _c
 }
 
-func (_c *MockDevicesProvider_GetAllocatableDevices_Call) RunAndReturn(run func() []*v1.ContainerDevices) *MockDevicesProvider_GetAllocatableDevices_Call {
+func (_c *MockDevicesProvider_GetAllocatableDevices_Call) RunAndReturn(run func(logger klog.Logger) []*v1.ContainerDevices) *MockDevicesProvider_GetAllocatableDevices_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -160,8 +167,8 @@ func (_c *MockDevicesProvider_GetDevices_Call) RunAndReturn(run func(podUID stri
 }
 
 // UpdateAllocatedDevices provides a mock function for the type MockDevicesProvider
-func (_mock *MockDevicesProvider) UpdateAllocatedDevices() {
-	_mock.Called()
+func (_mock *MockDevicesProvider) UpdateAllocatedDevices(logger klog.Logger) {
+	_mock.Called(logger)
 	return
 }
 
@@ -171,13 +178,20 @@ type MockDevicesProvider_UpdateAllocatedDevices_Call struct {
 }
 
 // UpdateAllocatedDevices is a helper method to define mock.On call
-func (_e *MockDevicesProvider_Expecter) UpdateAllocatedDevices() *MockDevicesProvider_UpdateAllocatedDevices_Call {
-	return &MockDevicesProvider_UpdateAllocatedDevices_Call{Call: _e.mock.On("UpdateAllocatedDevices")}
+//   - logger klog.Logger
+func (_e *MockDevicesProvider_Expecter) UpdateAllocatedDevices(logger interface{}) *MockDevicesProvider_UpdateAllocatedDevices_Call {
+	return &MockDevicesProvider_UpdateAllocatedDevices_Call{Call: _e.mock.On("UpdateAllocatedDevices", logger)}
 }
 
-func (_c *MockDevicesProvider_UpdateAllocatedDevices_Call) Run(run func()) *MockDevicesProvider_UpdateAllocatedDevices_Call {
+func (_c *MockDevicesProvider_UpdateAllocatedDevices_Call) Run(run func(logger klog.Logger)) *MockDevicesProvider_UpdateAllocatedDevices_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 klog.Logger
+		if args[0] != nil {
+			arg0 = args[0].(klog.Logger)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -187,7 +201,7 @@ func (_c *MockDevicesProvider_UpdateAllocatedDevices_Call) Return() *MockDevices
 	return _c
 }
 
-func (_c *MockDevicesProvider_UpdateAllocatedDevices_Call) RunAndReturn(run func()) *MockDevicesProvider_UpdateAllocatedDevices_Call {
+func (_c *MockDevicesProvider_UpdateAllocatedDevices_Call) RunAndReturn(run func(logger klog.Logger)) *MockDevicesProvider_UpdateAllocatedDevices_Call {
 	_c.Run(run)
 	return _c
 }
@@ -539,16 +553,16 @@ func (_m *MockMemoryProvider) EXPECT() *MockMemoryProvider_Expecter {
 }
 
 // GetAllocatableMemory provides a mock function for the type MockMemoryProvider
-func (_mock *MockMemoryProvider) GetAllocatableMemory() []*v1.ContainerMemory {
-	ret := _mock.Called()
+func (_mock *MockMemoryProvider) GetAllocatableMemory(logger klog.Logger) []*v1.ContainerMemory {
+	ret := _mock.Called(logger)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetAllocatableMemory")
 	}
 
 	var r0 []*v1.ContainerMemory
-	if returnFunc, ok := ret.Get(0).(func() []*v1.ContainerMemory); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(klog.Logger) []*v1.ContainerMemory); ok {
+		r0 = returnFunc(logger)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*v1.ContainerMemory)
@@ -563,13 +577,20 @@ type MockMemoryProvider_GetAllocatableMemory_Call struct {
 }
 
 // GetAllocatableMemory is a helper method to define mock.On call
-func (_e *MockMemoryProvider_Expecter) GetAllocatableMemory() *MockMemoryProvider_GetAllocatableMemory_Call {
-	return &MockMemoryProvider_GetAllocatableMemory_Call{Call: _e.mock.On("GetAllocatableMemory")}
+//   - logger klog.Logger
+func (_e *MockMemoryProvider_Expecter) GetAllocatableMemory(logger interface{}) *MockMemoryProvider_GetAllocatableMemory_Call {
+	return &MockMemoryProvider_GetAllocatableMemory_Call{Call: _e.mock.On("GetAllocatableMemory", logger)}
 }
 
-func (_c *MockMemoryProvider_GetAllocatableMemory_Call) Run(run func()) *MockMemoryProvider_GetAllocatableMemory_Call {
+func (_c *MockMemoryProvider_GetAllocatableMemory_Call) Run(run func(logger klog.Logger)) *MockMemoryProvider_GetAllocatableMemory_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 klog.Logger
+		if args[0] != nil {
+			arg0 = args[0].(klog.Logger)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -579,22 +600,22 @@ func (_c *MockMemoryProvider_GetAllocatableMemory_Call) Return(containerMemorys 
 	return _c
 }
 
-func (_c *MockMemoryProvider_GetAllocatableMemory_Call) RunAndReturn(run func() []*v1.ContainerMemory) *MockMemoryProvider_GetAllocatableMemory_Call {
+func (_c *MockMemoryProvider_GetAllocatableMemory_Call) RunAndReturn(run func(logger klog.Logger) []*v1.ContainerMemory) *MockMemoryProvider_GetAllocatableMemory_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetMemory provides a mock function for the type MockMemoryProvider
-func (_mock *MockMemoryProvider) GetMemory(podUID string, containerName string) []*v1.ContainerMemory {
-	ret := _mock.Called(podUID, containerName)
+func (_mock *MockMemoryProvider) GetMemory(logger klog.Logger, podUID string, containerName string) []*v1.ContainerMemory {
+	ret := _mock.Called(logger, podUID, containerName)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetMemory")
 	}
 
 	var r0 []*v1.ContainerMemory
-	if returnFunc, ok := ret.Get(0).(func(string, string) []*v1.ContainerMemory); ok {
-		r0 = returnFunc(podUID, containerName)
+	if returnFunc, ok := ret.Get(0).(func(klog.Logger, string, string) []*v1.ContainerMemory); ok {
+		r0 = returnFunc(logger, podUID, containerName)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*v1.ContainerMemory)
@@ -609,25 +630,31 @@ type MockMemoryProvider_GetMemory_Call struct {
 }
 
 // GetMemory is a helper method to define mock.On call
+//   - logger klog.Logger
 //   - podUID string
 //   - containerName string
-func (_e *MockMemoryProvider_Expecter) GetMemory(podUID interface{}, containerName interface{}) *MockMemoryProvider_GetMemory_Call {
-	return &MockMemoryProvider_GetMemory_Call{Call: _e.mock.On("GetMemory", podUID, containerName)}
+func (_e *MockMemoryProvider_Expecter) GetMemory(logger interface{}, podUID interface{}, containerName interface{}) *MockMemoryProvider_GetMemory_Call {
+	return &MockMemoryProvider_GetMemory_Call{Call: _e.mock.On("GetMemory", logger, podUID, containerName)}
 }
 
-func (_c *MockMemoryProvider_GetMemory_Call) Run(run func(podUID string, containerName string)) *MockMemoryProvider_GetMemory_Call {
+func (_c *MockMemoryProvider_GetMemory_Call) Run(run func(logger klog.Logger, podUID string, containerName string)) *MockMemoryProvider_GetMemory_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 klog.Logger
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(klog.Logger)
 		}
 		var arg1 string
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -638,7 +665,7 @@ func (_c *MockMemoryProvider_GetMemory_Call) Return(containerMemorys []*v1.Conta
 	return _c
 }
 
-func (_c *MockMemoryProvider_GetMemory_Call) RunAndReturn(run func(podUID string, containerName string) []*v1.ContainerMemory) *MockMemoryProvider_GetMemory_Call {
+func (_c *MockMemoryProvider_GetMemory_Call) RunAndReturn(run func(logger klog.Logger, podUID string, containerName string) []*v1.ContainerMemory) *MockMemoryProvider_GetMemory_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/kubelet/apis/podresources/types.go
+++ b/pkg/kubelet/apis/podresources/types.go
@@ -26,11 +26,11 @@ import (
 // DevicesProvider knows how to provide the devices used by the given container
 type DevicesProvider interface {
 	// UpdateAllocatedDevices frees any Devices that are bound to terminated pods.
-	UpdateAllocatedDevices()
+	UpdateAllocatedDevices(logger klog.Logger)
 	// GetDevices returns information about the devices assigned to pods and containers
 	GetDevices(podUID, containerName string) []*podresourcesapi.ContainerDevices
 	// GetAllocatableDevices returns information about all the devices known to the manager
-	GetAllocatableDevices() []*podresourcesapi.ContainerDevices
+	GetAllocatableDevices(logger klog.Logger) []*podresourcesapi.ContainerDevices
 }
 
 // PodsProvider knows how to provide the pods admitted by the node
@@ -50,9 +50,9 @@ type CPUsProvider interface {
 
 type MemoryProvider interface {
 	// GetMemory returns information about the memory assigned to containers
-	GetMemory(podUID, containerName string) []*podresourcesapi.ContainerMemory
+	GetMemory(logger klog.Logger, podUID, containerName string) []*podresourcesapi.ContainerMemory
 	// GetAllocatableMemory returns the allocatable memory from the node
-	GetAllocatableMemory() []*podresourcesapi.ContainerMemory
+	GetAllocatableMemory(logger klog.Logger) []*podresourcesapi.ContainerMemory
 }
 
 type DynamicResourcesProvider interface {

--- a/pkg/kubelet/cm/container_manager.go
+++ b/pkg/kubelet/cm/container_manager.go
@@ -150,7 +150,7 @@ type ContainerManager interface {
 	PodMightNeedToUnprepareResources(UID types.UID) bool
 
 	// UpdateAllocatedResourcesStatus updates the status of allocated resources for the pod.
-	UpdateAllocatedResourcesStatus(pod *v1.Pod, status *v1.PodStatus)
+	UpdateAllocatedResourcesStatus(logger klog.Logger, pod *v1.Pod, status *v1.PodStatus)
 
 	// Updates returns a channel that receives an Update when the device changed its status.
 	Updates() <-chan resourceupdates.Update

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -296,6 +296,7 @@ func NewContainerManager(ctx context.Context, mountUtil mount.Interface, cadviso
 	}
 
 	cm.topologyManager, err = topologymanager.NewManager(
+		logger,
 		machineInfo.Topology,
 		nodeConfig.TopologyManagerPolicy,
 		nodeConfig.TopologyManagerScope,
@@ -307,7 +308,7 @@ func NewContainerManager(ctx context.Context, mountUtil mount.Interface, cadviso
 	}
 
 	logger.Info("Creating device plugin manager")
-	cm.deviceManager, err = devicemanager.NewManagerImpl(machineInfo.Topology, cm.topologyManager)
+	cm.deviceManager, err = devicemanager.NewManagerImpl(logger, machineInfo.Topology, cm.topologyManager)
 	if err != nil {
 		return nil, err
 	}
@@ -999,8 +1000,8 @@ func (cm *containerManagerImpl) GetDevices(podUID, containerName string) []*podr
 	return containerDevicesFromResourceDeviceInstances(cm.deviceManager.GetDevices(podUID, containerName))
 }
 
-func (cm *containerManagerImpl) GetAllocatableDevices() []*podresourcesapi.ContainerDevices {
-	return containerDevicesFromResourceDeviceInstances(cm.deviceManager.GetAllocatableDevices())
+func (cm *containerManagerImpl) GetAllocatableDevices(logger klog.Logger) []*podresourcesapi.ContainerDevices {
+	return containerDevicesFromResourceDeviceInstances(cm.deviceManager.GetAllocatableDevices(logger))
 }
 
 func (cm *containerManagerImpl) GetCPUs(podUID, containerName string) []int64 {
@@ -1017,24 +1018,22 @@ func (cm *containerManagerImpl) GetAllocatableCPUs() []int64 {
 	return []int64{}
 }
 
-func (cm *containerManagerImpl) GetMemory(podUID, containerName string) []*podresourcesapi.ContainerMemory {
+func (cm *containerManagerImpl) GetMemory(logger klog.Logger, podUID, containerName string) []*podresourcesapi.ContainerMemory {
 	if cm.memoryManager == nil {
 		return []*podresourcesapi.ContainerMemory{}
 	}
 
-	// This is tempporary as part of migration of memory manager to Contextual logging.
-	// Direct context to be passed when container manager is migrated.
-	return containerMemoryFromBlock(cm.memoryManager.GetMemory(podUID, containerName))
+	return containerMemoryFromBlock(cm.memoryManager.GetMemory(logger, podUID, containerName))
 }
 
-func (cm *containerManagerImpl) GetAllocatableMemory() []*podresourcesapi.ContainerMemory {
+func (cm *containerManagerImpl) GetAllocatableMemory(logger klog.Logger) []*podresourcesapi.ContainerMemory {
 	if cm.memoryManager == nil {
 		return []*podresourcesapi.ContainerMemory{}
 	}
 
 	// This is tempporary as part of migration of memory manager to Contextual logging.
 	// Direct context to be passed when container manager is migrated.
-	return containerMemoryFromBlock(cm.memoryManager.GetAllocatableMemory())
+	return containerMemoryFromBlock(cm.memoryManager.GetAllocatableMemory(logger))
 }
 
 func (cm *containerManagerImpl) GetDynamicResources(logger klog.Logger, pod *v1.Pod, container *v1.Container) []*podresourcesapi.DynamicResource {
@@ -1080,8 +1079,8 @@ func (cm *containerManagerImpl) ShouldResetExtendedResourceCapacity() bool {
 	return cm.deviceManager.ShouldResetExtendedResourceCapacity()
 }
 
-func (cm *containerManagerImpl) UpdateAllocatedDevices() {
-	cm.deviceManager.UpdateAllocatedDevices()
+func (cm *containerManagerImpl) UpdateAllocatedDevices(logger klog.Logger) {
+	cm.deviceManager.UpdateAllocatedDevices(logger)
 }
 
 func containerMemoryFromBlock(blocks []memorymanagerstate.Block) []*podresourcesapi.ContainerMemory {
@@ -1118,15 +1117,15 @@ func (cm *containerManagerImpl) PodMightNeedToUnprepareResources(UID types.UID) 
 	return cm.draManager.PodMightNeedToUnprepareResources(UID)
 }
 
-func (cm *containerManagerImpl) UpdateAllocatedResourcesStatus(pod *v1.Pod, status *v1.PodStatus) {
+func (cm *containerManagerImpl) UpdateAllocatedResourcesStatus(logger klog.Logger, pod *v1.Pod, status *v1.PodStatus) {
 
 	// For now we only support Device Plugin
-	cm.deviceManager.UpdateAllocatedResourcesStatus(pod, status)
+	cm.deviceManager.UpdateAllocatedResourcesStatus(logger, pod, status)
 
 	// Update DRA resources if the feature is enabled and the manager exists
 	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.DynamicResourceAllocation) && cm.draManager != nil {
 		if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.ResourceHealthStatus) {
-			cm.draManager.UpdateAllocatedResourcesStatus(pod, status)
+			cm.draManager.UpdateAllocatedResourcesStatus(logger, pod, status)
 		}
 	}
 }

--- a/pkg/kubelet/cm/container_manager_stub.go
+++ b/pkg/kubelet/cm/container_manager_stub.go
@@ -141,7 +141,7 @@ func (cm *containerManagerStub) GetDevices(_, _ string) []*podresourcesapi.Conta
 	return nil
 }
 
-func (cm *containerManagerStub) GetAllocatableDevices() []*podresourcesapi.ContainerDevices {
+func (cm *containerManagerStub) GetAllocatableDevices(logger klog.Logger) []*podresourcesapi.ContainerDevices {
 	return nil
 }
 
@@ -153,7 +153,7 @@ func (cm *containerManagerStub) GetAllocateResourcesPodAdmitHandler(logger klog.
 	return topologymanager.NewFakeManager(logger)
 }
 
-func (cm *containerManagerStub) UpdateAllocatedDevices() {
+func (cm *containerManagerStub) UpdateAllocatedDevices(_ klog.Logger) {
 	return
 }
 
@@ -165,11 +165,11 @@ func (cm *containerManagerStub) GetAllocatableCPUs() []int64 {
 	return nil
 }
 
-func (cm *containerManagerStub) GetMemory(_, _ string) []*podresourcesapi.ContainerMemory {
+func (cm *containerManagerStub) GetMemory(_ klog.Logger, _, _ string) []*podresourcesapi.ContainerMemory {
 	return nil
 }
 
-func (cm *containerManagerStub) GetAllocatableMemory() []*podresourcesapi.ContainerMemory {
+func (cm *containerManagerStub) GetAllocatableMemory(_ klog.Logger) []*podresourcesapi.ContainerMemory {
 	return nil
 }
 
@@ -193,7 +193,7 @@ func (cm *containerManagerStub) PodMightNeedToUnprepareResources(UID types.UID) 
 	return false
 }
 
-func (cm *containerManagerStub) UpdateAllocatedResourcesStatus(pod *v1.Pod, status *v1.PodStatus) {
+func (cm *containerManagerStub) UpdateAllocatedResourcesStatus(logger klog.Logger, pod *v1.Pod, status *v1.PodStatus) {
 }
 
 func (cm *containerManagerStub) Updates() <-chan resourceupdates.Update {

--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -141,7 +141,9 @@ func NewContainerManager(ctx context.Context, mountUtil mount.Interface, cadviso
 
 	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.WindowsCPUAndMemoryAffinity) {
 		logger.Info("Creating topology manager")
-		cm.topologyManager, err = topologymanager.NewManager(machineInfo.Topology,
+		cm.topologyManager, err = topologymanager.NewManager(
+			logger,
+			machineInfo.Topology,
 			nodeConfig.TopologyManagerPolicy,
 			nodeConfig.TopologyManagerScope,
 			nodeConfig.TopologyManagerPolicyOptions)
@@ -186,7 +188,7 @@ func NewContainerManager(ctx context.Context, mountUtil mount.Interface, cadviso
 	}
 
 	logger.Info("Creating device plugin manager")
-	cm.deviceManager, err = devicemanager.NewManagerImpl(nil, cm.topologyManager)
+	cm.deviceManager, err = devicemanager.NewManagerImpl(logger, nil, cm.topologyManager)
 	if err != nil {
 		return nil, err
 	}
@@ -280,10 +282,10 @@ func (cm *containerManagerImpl) GetResources(ctx context.Context, pod *v1.Pod, c
 	return opts, nil
 }
 
-func (cm *containerManagerImpl) UpdateAllocatedResourcesStatus(pod *v1.Pod, status *v1.PodStatus) {
+func (cm *containerManagerImpl) UpdateAllocatedResourcesStatus(logger klog.Logger, pod *v1.Pod, status *v1.PodStatus) {
 	// For now we only support Device Plugin
 
-	cm.deviceManager.UpdateAllocatedResourcesStatus(pod, status)
+	cm.deviceManager.UpdateAllocatedResourcesStatus(logger, pod, status)
 
 	// TODO(SergeyKanzhelev, https://kep.k8s.io/4680): add support for DRA resources when DRA supports Windows
 }
@@ -309,7 +311,7 @@ func (cm *containerManagerImpl) GetDevices(podUID, containerName string) []*podr
 	return containerDevicesFromResourceDeviceInstances(cm.deviceManager.GetDevices(podUID, containerName))
 }
 
-func (cm *containerManagerImpl) GetAllocatableDevices() []*podresourcesapi.ContainerDevices {
+func (cm *containerManagerImpl) GetAllocatableDevices(_ klog.Logger) []*podresourcesapi.ContainerDevices {
 	return nil
 }
 
@@ -321,7 +323,7 @@ func (cm *containerManagerImpl) GetAllocateResourcesPodAdmitHandler(_ klog.Logge
 	return cm.topologyManager
 }
 
-func (cm *containerManagerImpl) UpdateAllocatedDevices() {
+func (cm *containerManagerImpl) UpdateAllocatedDevices(_ klog.Logger) {
 	return
 }
 
@@ -345,11 +347,11 @@ func (cm *containerManagerImpl) GetAllocatableCPUs() []int64 {
 	return nil
 }
 
-func (cm *containerManagerImpl) GetMemory(_, _ string) []*podresourcesapi.ContainerMemory {
+func (cm *containerManagerImpl) GetMemory(_ klog.Logger, _, _ string) []*podresourcesapi.ContainerMemory {
 	return nil
 }
 
-func (cm *containerManagerImpl) GetAllocatableMemory() []*podresourcesapi.ContainerMemory {
+func (cm *containerManagerImpl) GetAllocatableMemory(_ klog.Logger) []*podresourcesapi.ContainerMemory {
 	return nil
 }
 

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -131,10 +131,7 @@ func (s *sourcesReadyStub) AddSource(source string) {}
 func (s *sourcesReadyStub) AllReady() bool          { return true }
 
 // NewManagerImpl creates a new manager.
-func NewManagerImpl(topology []cadvisorapi.Node, topologyAffinityStore topologymanager.Store) (*ManagerImpl, error) {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate context when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
+func NewManagerImpl(logger klog.Logger, topology []cadvisorapi.Node, topologyAffinityStore topologymanager.Store) (*ManagerImpl, error) {
 	socketPath := pluginapi.KubeletSocket
 	if runtime.GOOS == "windows" {
 		socketPath = os.Getenv("SYSTEMDRIVE") + pluginapi.KubeletSocketWindows
@@ -577,10 +574,7 @@ func (m *ManagerImpl) getCheckpoint() (checkpoint.DeviceManagerCheckpoint, error
 }
 
 // UpdateAllocatedDevices frees any Devices that are bound to terminated pods.
-func (m *ManagerImpl) UpdateAllocatedDevices() {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate context when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
+func (m *ManagerImpl) UpdateAllocatedDevices(logger klog.Logger) {
 	activePods := m.activePods()
 	if !m.sourcesReady.AllReady() {
 		return
@@ -884,7 +878,7 @@ func (m *ManagerImpl) allocateContainerResources(ctx context.Context, pod *v1.Po
 		// Updates allocatedDevices to garbage collect any stranded resources
 		// before doing the device plugin allocation.
 		if !allocatedDevicesUpdated {
-			m.UpdateAllocatedDevices()
+			m.UpdateAllocatedDevices(logger)
 			allocatedDevicesUpdated = true
 		}
 		allocDevices, err := m.devicesToAllocate(ctx, podUID, contName, resource, needed, devicesToReuse[resource])
@@ -1134,10 +1128,7 @@ func isDRAExtendedResource(pod *v1.Pod, containerName, resourceName string) bool
 }
 
 // GetAllocatableDevices returns information about all the healthy devices known to the manager
-func (m *ManagerImpl) GetAllocatableDevices() ResourceDeviceInstances {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate context when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
+func (m *ManagerImpl) GetAllocatableDevices(logger klog.Logger) ResourceDeviceInstances {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	resp := m.allDevices.Filter(m.healthyDevices)
@@ -1156,7 +1147,7 @@ func (m *ManagerImpl) GetDevices(podUID, containerName string) ResourceDeviceIns
 	return m.podDevices.getContainerDevices(podUID, containerName)
 }
 
-func (m *ManagerImpl) UpdateAllocatedResourcesStatus(pod *v1.Pod, status *v1.PodStatus) {
+func (m *ManagerImpl) UpdateAllocatedResourcesStatus(logger klog.Logger, pod *v1.Pod, status *v1.PodStatus) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -537,7 +537,7 @@ func TestGetAllocatableDevicesMultipleResources(t *testing.T) {
 	testManager.endpoints[resourceName2] = endpointInfo{e: e2, opts: nil}
 	testManager.genericDeviceUpdateCallback(logger, resourceName2, resource2Devs)
 
-	allocatableDevs := testManager.GetAllocatableDevices()
+	allocatableDevs := testManager.GetAllocatableDevices(logger)
 	as.Len(allocatableDevs, 2)
 
 	devInstances1, ok := allocatableDevs[resourceName1]
@@ -575,7 +575,7 @@ func TestGetAllocatableDevicesHealthTransition(t *testing.T) {
 
 	testManager.genericDeviceUpdateCallback(logger, resourceName1, resource1Devs)
 
-	allocatableDevs := testManager.GetAllocatableDevices()
+	allocatableDevs := testManager.GetAllocatableDevices(logger)
 	as.Len(allocatableDevs, 1)
 	devInstances, ok := allocatableDevs[resourceName1]
 	as.True(ok)
@@ -589,7 +589,7 @@ func TestGetAllocatableDevicesHealthTransition(t *testing.T) {
 	}
 	testManager.genericDeviceUpdateCallback(logger, resourceName1, resource1Devs)
 
-	allocatableDevs = testManager.GetAllocatableDevices()
+	allocatableDevs = testManager.GetAllocatableDevices(logger)
 	as.Len(allocatableDevs, 1)
 	devInstances, ok = allocatableDevs[resourceName1]
 	as.True(ok)
@@ -1278,7 +1278,7 @@ func TestDevicesToAllocateConflictWithUpdateAllocatedDevices(t *testing.T) {
 
 	go func() {
 		<-waitSetGetPreferredAllocChan
-		testManager.UpdateAllocatedDevices()
+		testManager.UpdateAllocatedDevices(logger)
 		waitUpdateAllocatedDevicesChan <- struct{}{}
 	}()
 
@@ -1343,7 +1343,7 @@ func TestGetDeviceRunContainerOptions(t *testing.T) {
 
 	activePods = []*v1.Pod{pod2}
 	podsStub.updateActivePods(activePods)
-	testManager.UpdateAllocatedDevices()
+	testManager.UpdateAllocatedDevices(logger)
 
 	// when pod is removed from activePods,G etDeviceRunContainerOptions should return error
 	runContainerOpts, err = testManager.GetDeviceRunContainerOptions(tCtx, pod1, &pod1.Spec.Containers[0])
@@ -1959,7 +1959,7 @@ func TestUpdateAllocatedResourcesStatus(t *testing.T) {
 			},
 		},
 	}
-	testManager.UpdateAllocatedResourcesStatus(pod, status)
+	testManager.UpdateAllocatedResourcesStatus(logger, pod, status)
 
 	expectedStatus := v1.ResourceStatus{
 		Name: v1.ResourceName(resourceName),

--- a/pkg/kubelet/cm/devicemanager/plugin/v1beta1/stub.go
+++ b/pkg/kubelet/cm/devicemanager/plugin/v1beta1/stub.go
@@ -342,8 +342,8 @@ func (m *Stub) PreStartContainer(ctx context.Context, r *pluginapi.PreStartConta
 
 // ListAndWatch lists devices and update that list according to the Update call
 func (m *Stub) ListAndWatch(e *pluginapi.Empty, s pluginapi.DevicePlugin_ListAndWatchServer) error {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate context when refactoring this function to accept a logger parameter.
+	// Use klog.TODO() because this method must match the generated device
+	// plugin gRPC signature in api_grpc.pb.go, which does not accept a logger.
 	klog.TODO().Info("ListAndWatch")
 
 	s.Send(&pluginapi.ListAndWatchResponse{Devices: m.devs})

--- a/pkg/kubelet/cm/devicemanager/topology_hints.go
+++ b/pkg/kubelet/cm/devicemanager/topology_hints.go
@@ -32,7 +32,7 @@ import (
 // container are created.
 func (m *ManagerImpl) GetTopologyHints(logger klog.Logger, pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint {
 	// Garbage collect any stranded device resources before providing TopologyHints
-	m.UpdateAllocatedDevices()
+	m.UpdateAllocatedDevices(logger)
 
 	// Loop through all device resources and generate TopologyHints for them.
 	deviceHints := make(map[string][]topologymanager.TopologyHint)
@@ -84,7 +84,7 @@ func (m *ManagerImpl) GetTopologyHints(logger klog.Logger, pod *v1.Pod, containe
 // ensures the Device Manager is consulted when Topology Aware Hints for Pod are created.
 func (m *ManagerImpl) GetPodTopologyHints(logger klog.Logger, pod *v1.Pod) map[string][]topologymanager.TopologyHint {
 	// Garbage collect any stranded device resources before providing TopologyHints
-	m.UpdateAllocatedDevices()
+	m.UpdateAllocatedDevices(logger)
 
 	deviceHints := make(map[string][]topologymanager.TopologyHint)
 	accumulatedResourceRequests := m.getPodDeviceRequest(pod)

--- a/pkg/kubelet/cm/devicemanager/types.go
+++ b/pkg/kubelet/cm/devicemanager/types.go
@@ -71,10 +71,10 @@ type Manager interface {
 	GetDevices(podUID, containerName string) ResourceDeviceInstances
 
 	// UpdateAllocatedResourcesStatus updates the status of allocated resources for the pod.
-	UpdateAllocatedResourcesStatus(pod *v1.Pod, status *v1.PodStatus)
+	UpdateAllocatedResourcesStatus(logger klog.Logger, pod *v1.Pod, status *v1.PodStatus)
 
 	// GetAllocatableDevices returns information about all the devices known to the manager
-	GetAllocatableDevices() ResourceDeviceInstances
+	GetAllocatableDevices(logger klog.Logger) ResourceDeviceInstances
 
 	// ShouldResetExtendedResourceCapacity returns whether the extended resources should be reset or not,
 	// depending on the checkpoint file availability. Absence of the checkpoint file strongly indicates
@@ -93,7 +93,7 @@ type Manager interface {
 	AllocatePod(logger klog.Logger, pod *v1.Pod) error
 
 	// UpdateAllocatedDevices frees any Devices that are bound to terminated pods.
-	UpdateAllocatedDevices()
+	UpdateAllocatedDevices(logger klog.Logger)
 
 	// Updates returns a channel that receives an Update when the device changed its status.
 	Updates() <-chan resourceupdates.Update

--- a/pkg/kubelet/cm/dra/manager.go
+++ b/pkg/kubelet/cm/dra/manager.go
@@ -815,8 +815,8 @@ func (m *Manager) GetContainerClaimInfos(pod *v1.Pod, container *v1.Container) (
 }
 
 // UpdateAllocatedResourcesStatus updates the health status of allocated DRA resources in the pod's container statuses.
-func (m *Manager) UpdateAllocatedResourcesStatus(pod *v1.Pod, status *v1.PodStatus) {
-	logger := klog.FromContext(context.Background()).WithName("dra-manager")
+func (m *Manager) UpdateAllocatedResourcesStatus(logger klog.Logger, pod *v1.Pod, status *v1.PodStatus) {
+	logger = logger.WithName("dra-manager")
 	logger = klog.LoggerWithValues(logger, "pod", klog.KObj(pod))
 	enableHealthMessage := utilfeature.DefaultFeatureGate.Enabled(kubefeatures.ResourceHealthStatusMessage)
 	for i := range status.ContainerStatuses {

--- a/pkg/kubelet/cm/dra/manager_test.go
+++ b/pkg/kubelet/cm/dra/manager_test.go
@@ -2533,7 +2533,7 @@ func TestUpdateAllocatedResourcesStatus(t *testing.T) {
 			}
 
 			status := tc.initialStatus.DeepCopy()
-			manager.UpdateAllocatedResourcesStatus(tc.pod, status)
+			manager.UpdateAllocatedResourcesStatus(logger, tc.pod, status)
 
 			require.Len(t, status.ContainerStatuses, 1)
 			assert.Equal(t, tc.expectedAllocatedResourcesStatus, status.ContainerStatuses[0].AllocatedResourcesStatus)
@@ -2542,6 +2542,8 @@ func TestUpdateAllocatedResourcesStatus(t *testing.T) {
 }
 
 func TestUpdateAllocatedResourcesStatus_Subrequest(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+
 	directClaimName := "test-claim"
 
 	testCases := []struct {
@@ -2655,7 +2657,7 @@ func TestUpdateAllocatedResourcesStatus_Subrequest(t *testing.T) {
 			}
 
 			// Call UpdateAllocatedResourcesStatus
-			manager.UpdateAllocatedResourcesStatus(pod, status)
+			manager.UpdateAllocatedResourcesStatus(logger, pod, status)
 
 			// Assert results
 			require.Len(t, status.ContainerStatuses, 1)

--- a/pkg/kubelet/cm/fake_container_manager.go
+++ b/pkg/kubelet/cm/fake_container_manager.go
@@ -52,13 +52,11 @@ type FakeContainerManager struct {
 
 var _ ContainerManager = &FakeContainerManager{}
 
-func NewFakeContainerManager() *FakeContainerManager {
+func NewFakeContainerManager(logger klog.Logger) *FakeContainerManager {
 	return &FakeContainerManager{
 		PodContainerManager: NewFakePodContainerManager(),
-		// Use klog.TODO() because we currently do not have a proper logger to pass in.
-		// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-		cpuManager:    cpumanager.NewFakeManager(klog.TODO()),
-		memoryManager: memorymanager.NewFakeManager(klog.TODO()),
+		cpuManager:          cpumanager.NewFakeManager(logger),
+		memoryManager:       memorymanager.NewFakeManager(logger),
 	}
 }
 
@@ -203,7 +201,7 @@ func (cm *FakeContainerManager) GetDevices(_, _ string) []*podresourcesapi.Conta
 	return nil
 }
 
-func (cm *FakeContainerManager) GetAllocatableDevices() []*podresourcesapi.ContainerDevices {
+func (cm *FakeContainerManager) GetAllocatableDevices(_ klog.Logger) []*podresourcesapi.ContainerDevices {
 	cm.Lock()
 	defer cm.Unlock()
 	cm.CalledFunctions = append(cm.CalledFunctions, "GetAllocatableDevices")
@@ -224,7 +222,7 @@ func (cm *FakeContainerManager) GetAllocateResourcesPodAdmitHandler(logger klog.
 	return topologymanager.NewFakeManager(logger)
 }
 
-func (cm *FakeContainerManager) UpdateAllocatedDevices() {
+func (cm *FakeContainerManager) UpdateAllocatedDevices(_ klog.Logger) {
 	cm.Lock()
 	defer cm.Unlock()
 	cm.CalledFunctions = append(cm.CalledFunctions, "UpdateAllocatedDevices")
@@ -244,14 +242,14 @@ func (cm *FakeContainerManager) GetAllocatableCPUs() []int64 {
 	return nil
 }
 
-func (cm *FakeContainerManager) GetMemory(_, _ string) []*podresourcesapi.ContainerMemory {
+func (cm *FakeContainerManager) GetMemory(_ klog.Logger, _, _ string) []*podresourcesapi.ContainerMemory {
 	cm.Lock()
 	defer cm.Unlock()
 	cm.CalledFunctions = append(cm.CalledFunctions, "GetMemory")
 	return nil
 }
 
-func (cm *FakeContainerManager) GetAllocatableMemory() []*podresourcesapi.ContainerMemory {
+func (cm *FakeContainerManager) GetAllocatableMemory(_ klog.Logger) []*podresourcesapi.ContainerMemory {
 	cm.Lock()
 	defer cm.Unlock()
 	return nil
@@ -282,7 +280,7 @@ func (cm *FakeContainerManager) UnprepareDynamicResources(context.Context, *v1.P
 func (cm *FakeContainerManager) PodMightNeedToUnprepareResources(UID types.UID) bool {
 	return false
 }
-func (cm *FakeContainerManager) UpdateAllocatedResourcesStatus(pod *v1.Pod, status *v1.PodStatus) {
+func (cm *FakeContainerManager) UpdateAllocatedResourcesStatus(logger klog.Logger, pod *v1.Pod, status *v1.PodStatus) {
 }
 func (cm *FakeContainerManager) Updates() <-chan resourceupdates.Update {
 	return nil

--- a/pkg/kubelet/cm/fake_pod_container_manager.go
+++ b/pkg/kubelet/cm/fake_pod_container_manager.go
@@ -87,7 +87,7 @@ func (m *FakePodContainerManager) ReduceCPULimits(_ klog.Logger, _ CgroupName) e
 	return nil
 }
 
-func (m *FakePodContainerManager) GetAllPodsFromCgroups() (map[types.UID]CgroupName, error) {
+func (m *FakePodContainerManager) GetAllPodsFromCgroups(_ klog.Logger) (map[types.UID]CgroupName, error) {
 	m.Lock()
 	defer m.Unlock()
 	m.CalledFunctions = append(m.CalledFunctions, "GetAllPodsFromCgroups")

--- a/pkg/kubelet/cm/memorymanager/fake_memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/fake_memory_manager.go
@@ -84,15 +84,14 @@ func (m *fakeManager) State() state.Reader {
 }
 
 // GetAllocatableMemory returns the amount of allocatable memory for each NUMA node
-func (m *fakeManager) GetAllocatableMemory() []state.Block {
-	logger := klog.TODO()
+func (m *fakeManager) GetAllocatableMemory(logger klog.Logger) []state.Block {
 	logger.Info("Get Allocatable Memory")
 	return []state.Block{}
 }
 
 // GetMemory returns the memory allocated by a container from NUMA nodes
-func (m *fakeManager) GetMemory(podUID, containerName string) []state.Block {
-	logger := klog.LoggerWithValues(klog.TODO(), "podUID", podUID, "containerName", containerName)
+func (m *fakeManager) GetMemory(logger klog.Logger, podUID, containerName string) []state.Block {
+	logger = klog.LoggerWithValues(logger, "podUID", podUID, "containerName", containerName)
 	logger.Info("Get Memory")
 	return []state.Block{}
 }

--- a/pkg/kubelet/cm/memorymanager/memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager.go
@@ -91,10 +91,10 @@ type Manager interface {
 	GetMemoryNUMANodes(logger klog.Logger, pod *v1.Pod, container *v1.Container) sets.Set[int]
 
 	// GetAllocatableMemory returns the amount of allocatable memory for each NUMA node
-	GetAllocatableMemory() []state.Block
+	GetAllocatableMemory(logger klog.Logger) []state.Block
 
 	// GetMemory returns the memory allocated by a container from NUMA nodes
-	GetMemory(podUID, containerName string) []state.Block
+	GetMemory(logger klog.Logger, podUID, containerName string) []state.Block
 }
 
 type manager struct {
@@ -481,11 +481,11 @@ func getSystemReservedMemory(machineInfo *cadvisorapi.MachineInfo, nodeAllocatab
 }
 
 // GetAllocatableMemory returns the amount of allocatable memory for each NUMA node
-func (m *manager) GetAllocatableMemory() []state.Block {
+func (m *manager) GetAllocatableMemory(_ klog.Logger) []state.Block {
 	return m.allocatableMemory
 }
 
 // GetMemory returns the memory allocated by a container from NUMA nodes
-func (m *manager) GetMemory(podUID, containerName string) []state.Block {
+func (m *manager) GetMemory(_ klog.Logger, podUID, containerName string) []state.Block {
 	return m.state.GetMemoryBlocks(podUID, containerName)
 }

--- a/pkg/kubelet/cm/pod_container_manager_linux.go
+++ b/pkg/kubelet/cm/pod_container_manager_linux.go
@@ -256,10 +256,7 @@ func (m *podContainerManagerImpl) IsPodCgroup(cgroupfs string) (bool, types.UID)
 
 // GetAllPodsFromCgroups scans through all the subsystems of pod cgroups
 // Get list of pods whose cgroup still exist on the cgroup mounts
-func (m *podContainerManagerImpl) GetAllPodsFromCgroups() (map[types.UID]CgroupName, error) {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
+func (m *podContainerManagerImpl) GetAllPodsFromCgroups(logger klog.Logger) (map[types.UID]CgroupName, error) {
 	// Map for storing all the found pods on the disk
 	foundPods := make(map[types.UID]CgroupName)
 	qosContainersList := [3]CgroupName{m.qosContainersInfo.BestEffort, m.qosContainersInfo.Burstable, m.qosContainersInfo.Guaranteed}
@@ -348,7 +345,7 @@ func (m *podContainerManagerNoop) ReduceCPULimits(_ klog.Logger, _ CgroupName) e
 	return nil
 }
 
-func (m *podContainerManagerNoop) GetAllPodsFromCgroups() (map[types.UID]CgroupName, error) {
+func (m *podContainerManagerNoop) GetAllPodsFromCgroups(_ klog.Logger) (map[types.UID]CgroupName, error) {
 	return nil, nil
 }
 

--- a/pkg/kubelet/cm/pod_container_manager_stub.go
+++ b/pkg/kubelet/cm/pod_container_manager_stub.go
@@ -47,7 +47,7 @@ func (m *podContainerManagerStub) ReduceCPULimits(_ klog.Logger, _ CgroupName) e
 	return nil
 }
 
-func (m *podContainerManagerStub) GetAllPodsFromCgroups() (map[types.UID]CgroupName, error) {
+func (m *podContainerManagerStub) GetAllPodsFromCgroups(_ klog.Logger) (map[types.UID]CgroupName, error) {
 	return nil, nil
 }
 

--- a/pkg/kubelet/cm/testing/mocks.go
+++ b/pkg/kubelet/cm/testing/mocks.go
@@ -177,16 +177,16 @@ func (_c *MockContainerManager_GetAllocatableCPUs_Call) RunAndReturn(run func() 
 }
 
 // GetAllocatableDevices provides a mock function for the type MockContainerManager
-func (_mock *MockContainerManager) GetAllocatableDevices() []*v10.ContainerDevices {
-	ret := _mock.Called()
+func (_mock *MockContainerManager) GetAllocatableDevices(logger klog.Logger) []*v10.ContainerDevices {
+	ret := _mock.Called(logger)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetAllocatableDevices")
 	}
 
 	var r0 []*v10.ContainerDevices
-	if returnFunc, ok := ret.Get(0).(func() []*v10.ContainerDevices); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(klog.Logger) []*v10.ContainerDevices); ok {
+		r0 = returnFunc(logger)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*v10.ContainerDevices)
@@ -201,13 +201,20 @@ type MockContainerManager_GetAllocatableDevices_Call struct {
 }
 
 // GetAllocatableDevices is a helper method to define mock.On call
-func (_e *MockContainerManager_Expecter) GetAllocatableDevices() *MockContainerManager_GetAllocatableDevices_Call {
-	return &MockContainerManager_GetAllocatableDevices_Call{Call: _e.mock.On("GetAllocatableDevices")}
+//   - logger klog.Logger
+func (_e *MockContainerManager_Expecter) GetAllocatableDevices(logger interface{}) *MockContainerManager_GetAllocatableDevices_Call {
+	return &MockContainerManager_GetAllocatableDevices_Call{Call: _e.mock.On("GetAllocatableDevices", logger)}
 }
 
-func (_c *MockContainerManager_GetAllocatableDevices_Call) Run(run func()) *MockContainerManager_GetAllocatableDevices_Call {
+func (_c *MockContainerManager_GetAllocatableDevices_Call) Run(run func(logger klog.Logger)) *MockContainerManager_GetAllocatableDevices_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 klog.Logger
+		if args[0] != nil {
+			arg0 = args[0].(klog.Logger)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -217,22 +224,22 @@ func (_c *MockContainerManager_GetAllocatableDevices_Call) Return(containerDevic
 	return _c
 }
 
-func (_c *MockContainerManager_GetAllocatableDevices_Call) RunAndReturn(run func() []*v10.ContainerDevices) *MockContainerManager_GetAllocatableDevices_Call {
+func (_c *MockContainerManager_GetAllocatableDevices_Call) RunAndReturn(run func(logger klog.Logger) []*v10.ContainerDevices) *MockContainerManager_GetAllocatableDevices_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetAllocatableMemory provides a mock function for the type MockContainerManager
-func (_mock *MockContainerManager) GetAllocatableMemory() []*v10.ContainerMemory {
-	ret := _mock.Called()
+func (_mock *MockContainerManager) GetAllocatableMemory(logger klog.Logger) []*v10.ContainerMemory {
+	ret := _mock.Called(logger)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetAllocatableMemory")
 	}
 
 	var r0 []*v10.ContainerMemory
-	if returnFunc, ok := ret.Get(0).(func() []*v10.ContainerMemory); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(klog.Logger) []*v10.ContainerMemory); ok {
+		r0 = returnFunc(logger)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*v10.ContainerMemory)
@@ -247,13 +254,20 @@ type MockContainerManager_GetAllocatableMemory_Call struct {
 }
 
 // GetAllocatableMemory is a helper method to define mock.On call
-func (_e *MockContainerManager_Expecter) GetAllocatableMemory() *MockContainerManager_GetAllocatableMemory_Call {
-	return &MockContainerManager_GetAllocatableMemory_Call{Call: _e.mock.On("GetAllocatableMemory")}
+//   - logger klog.Logger
+func (_e *MockContainerManager_Expecter) GetAllocatableMemory(logger interface{}) *MockContainerManager_GetAllocatableMemory_Call {
+	return &MockContainerManager_GetAllocatableMemory_Call{Call: _e.mock.On("GetAllocatableMemory", logger)}
 }
 
-func (_c *MockContainerManager_GetAllocatableMemory_Call) Run(run func()) *MockContainerManager_GetAllocatableMemory_Call {
+func (_c *MockContainerManager_GetAllocatableMemory_Call) Run(run func(logger klog.Logger)) *MockContainerManager_GetAllocatableMemory_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 klog.Logger
+		if args[0] != nil {
+			arg0 = args[0].(klog.Logger)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -263,7 +277,7 @@ func (_c *MockContainerManager_GetAllocatableMemory_Call) Return(containerMemory
 	return _c
 }
 
-func (_c *MockContainerManager_GetAllocatableMemory_Call) RunAndReturn(run func() []*v10.ContainerMemory) *MockContainerManager_GetAllocatableMemory_Call {
+func (_c *MockContainerManager_GetAllocatableMemory_Call) RunAndReturn(run func(logger klog.Logger) []*v10.ContainerMemory) *MockContainerManager_GetAllocatableMemory_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -682,16 +696,16 @@ func (_c *MockContainerManager_GetHealthCheckers_Call) RunAndReturn(run func() [
 }
 
 // GetMemory provides a mock function for the type MockContainerManager
-func (_mock *MockContainerManager) GetMemory(podUID string, containerName string) []*v10.ContainerMemory {
-	ret := _mock.Called(podUID, containerName)
+func (_mock *MockContainerManager) GetMemory(logger klog.Logger, podUID string, containerName string) []*v10.ContainerMemory {
+	ret := _mock.Called(logger, podUID, containerName)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetMemory")
 	}
 
 	var r0 []*v10.ContainerMemory
-	if returnFunc, ok := ret.Get(0).(func(string, string) []*v10.ContainerMemory); ok {
-		r0 = returnFunc(podUID, containerName)
+	if returnFunc, ok := ret.Get(0).(func(klog.Logger, string, string) []*v10.ContainerMemory); ok {
+		r0 = returnFunc(logger, podUID, containerName)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*v10.ContainerMemory)
@@ -706,25 +720,31 @@ type MockContainerManager_GetMemory_Call struct {
 }
 
 // GetMemory is a helper method to define mock.On call
+//   - logger klog.Logger
 //   - podUID string
 //   - containerName string
-func (_e *MockContainerManager_Expecter) GetMemory(podUID interface{}, containerName interface{}) *MockContainerManager_GetMemory_Call {
-	return &MockContainerManager_GetMemory_Call{Call: _e.mock.On("GetMemory", podUID, containerName)}
+func (_e *MockContainerManager_Expecter) GetMemory(logger interface{}, podUID interface{}, containerName interface{}) *MockContainerManager_GetMemory_Call {
+	return &MockContainerManager_GetMemory_Call{Call: _e.mock.On("GetMemory", logger, podUID, containerName)}
 }
 
-func (_c *MockContainerManager_GetMemory_Call) Run(run func(podUID string, containerName string)) *MockContainerManager_GetMemory_Call {
+func (_c *MockContainerManager_GetMemory_Call) Run(run func(logger klog.Logger, podUID string, containerName string)) *MockContainerManager_GetMemory_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 klog.Logger
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(klog.Logger)
 		}
 		var arg1 string
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -735,7 +755,7 @@ func (_c *MockContainerManager_GetMemory_Call) Return(containerMemorys []*v10.Co
 	return _c
 }
 
-func (_c *MockContainerManager_GetMemory_Call) RunAndReturn(run func(podUID string, containerName string) []*v10.ContainerMemory) *MockContainerManager_GetMemory_Call {
+func (_c *MockContainerManager_GetMemory_Call) RunAndReturn(run func(logger klog.Logger, podUID string, containerName string) []*v10.ContainerMemory) *MockContainerManager_GetMemory_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1679,8 +1699,8 @@ func (_c *MockContainerManager_UnprepareDynamicResources_Call) RunAndReturn(run 
 }
 
 // UpdateAllocatedDevices provides a mock function for the type MockContainerManager
-func (_mock *MockContainerManager) UpdateAllocatedDevices() {
-	_mock.Called()
+func (_mock *MockContainerManager) UpdateAllocatedDevices(logger klog.Logger) {
+	_mock.Called(logger)
 	return
 }
 
@@ -1690,13 +1710,20 @@ type MockContainerManager_UpdateAllocatedDevices_Call struct {
 }
 
 // UpdateAllocatedDevices is a helper method to define mock.On call
-func (_e *MockContainerManager_Expecter) UpdateAllocatedDevices() *MockContainerManager_UpdateAllocatedDevices_Call {
-	return &MockContainerManager_UpdateAllocatedDevices_Call{Call: _e.mock.On("UpdateAllocatedDevices")}
+//   - logger klog.Logger
+func (_e *MockContainerManager_Expecter) UpdateAllocatedDevices(logger interface{}) *MockContainerManager_UpdateAllocatedDevices_Call {
+	return &MockContainerManager_UpdateAllocatedDevices_Call{Call: _e.mock.On("UpdateAllocatedDevices", logger)}
 }
 
-func (_c *MockContainerManager_UpdateAllocatedDevices_Call) Run(run func()) *MockContainerManager_UpdateAllocatedDevices_Call {
+func (_c *MockContainerManager_UpdateAllocatedDevices_Call) Run(run func(logger klog.Logger)) *MockContainerManager_UpdateAllocatedDevices_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 klog.Logger
+		if args[0] != nil {
+			arg0 = args[0].(klog.Logger)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -1706,14 +1733,14 @@ func (_c *MockContainerManager_UpdateAllocatedDevices_Call) Return() *MockContai
 	return _c
 }
 
-func (_c *MockContainerManager_UpdateAllocatedDevices_Call) RunAndReturn(run func()) *MockContainerManager_UpdateAllocatedDevices_Call {
+func (_c *MockContainerManager_UpdateAllocatedDevices_Call) RunAndReturn(run func(logger klog.Logger)) *MockContainerManager_UpdateAllocatedDevices_Call {
 	_c.Run(run)
 	return _c
 }
 
 // UpdateAllocatedResourcesStatus provides a mock function for the type MockContainerManager
-func (_mock *MockContainerManager) UpdateAllocatedResourcesStatus(pod *v1.Pod, status1 *v1.PodStatus) {
-	_mock.Called(pod, status1)
+func (_mock *MockContainerManager) UpdateAllocatedResourcesStatus(logger klog.Logger, pod *v1.Pod, status1 *v1.PodStatus) {
+	_mock.Called(logger, pod, status1)
 	return
 }
 
@@ -1723,25 +1750,31 @@ type MockContainerManager_UpdateAllocatedResourcesStatus_Call struct {
 }
 
 // UpdateAllocatedResourcesStatus is a helper method to define mock.On call
+//   - logger klog.Logger
 //   - pod *v1.Pod
 //   - status1 *v1.PodStatus
-func (_e *MockContainerManager_Expecter) UpdateAllocatedResourcesStatus(pod interface{}, status1 interface{}) *MockContainerManager_UpdateAllocatedResourcesStatus_Call {
-	return &MockContainerManager_UpdateAllocatedResourcesStatus_Call{Call: _e.mock.On("UpdateAllocatedResourcesStatus", pod, status1)}
+func (_e *MockContainerManager_Expecter) UpdateAllocatedResourcesStatus(logger interface{}, pod interface{}, status1 interface{}) *MockContainerManager_UpdateAllocatedResourcesStatus_Call {
+	return &MockContainerManager_UpdateAllocatedResourcesStatus_Call{Call: _e.mock.On("UpdateAllocatedResourcesStatus", logger, pod, status1)}
 }
 
-func (_c *MockContainerManager_UpdateAllocatedResourcesStatus_Call) Run(run func(pod *v1.Pod, status1 *v1.PodStatus)) *MockContainerManager_UpdateAllocatedResourcesStatus_Call {
+func (_c *MockContainerManager_UpdateAllocatedResourcesStatus_Call) Run(run func(logger klog.Logger, pod *v1.Pod, status1 *v1.PodStatus)) *MockContainerManager_UpdateAllocatedResourcesStatus_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *v1.Pod
+		var arg0 klog.Logger
 		if args[0] != nil {
-			arg0 = args[0].(*v1.Pod)
+			arg0 = args[0].(klog.Logger)
 		}
-		var arg1 *v1.PodStatus
+		var arg1 *v1.Pod
 		if args[1] != nil {
-			arg1 = args[1].(*v1.PodStatus)
+			arg1 = args[1].(*v1.Pod)
+		}
+		var arg2 *v1.PodStatus
+		if args[2] != nil {
+			arg2 = args[2].(*v1.PodStatus)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -1752,7 +1785,7 @@ func (_c *MockContainerManager_UpdateAllocatedResourcesStatus_Call) Return() *Mo
 	return _c
 }
 
-func (_c *MockContainerManager_UpdateAllocatedResourcesStatus_Call) RunAndReturn(run func(pod *v1.Pod, status1 *v1.PodStatus)) *MockContainerManager_UpdateAllocatedResourcesStatus_Call {
+func (_c *MockContainerManager_UpdateAllocatedResourcesStatus_Call) RunAndReturn(run func(logger klog.Logger, pod *v1.Pod, status1 *v1.PodStatus)) *MockContainerManager_UpdateAllocatedResourcesStatus_Call {
 	_c.Run(run)
 	return _c
 }
@@ -2104,8 +2137,8 @@ func (_c *MockPodContainerManager_Exists_Call) RunAndReturn(run func(pod *v1.Pod
 }
 
 // GetAllPodsFromCgroups provides a mock function for the type MockPodContainerManager
-func (_mock *MockPodContainerManager) GetAllPodsFromCgroups() (map[types.UID]cm.CgroupName, error) {
-	ret := _mock.Called()
+func (_mock *MockPodContainerManager) GetAllPodsFromCgroups(logger klog.Logger) (map[types.UID]cm.CgroupName, error) {
+	ret := _mock.Called(logger)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetAllPodsFromCgroups")
@@ -2113,18 +2146,18 @@ func (_mock *MockPodContainerManager) GetAllPodsFromCgroups() (map[types.UID]cm.
 
 	var r0 map[types.UID]cm.CgroupName
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (map[types.UID]cm.CgroupName, error)); ok {
-		return returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(klog.Logger) (map[types.UID]cm.CgroupName, error)); ok {
+		return returnFunc(logger)
 	}
-	if returnFunc, ok := ret.Get(0).(func() map[types.UID]cm.CgroupName); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(klog.Logger) map[types.UID]cm.CgroupName); ok {
+		r0 = returnFunc(logger)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[types.UID]cm.CgroupName)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
+	if returnFunc, ok := ret.Get(1).(func(klog.Logger) error); ok {
+		r1 = returnFunc(logger)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2137,13 +2170,20 @@ type MockPodContainerManager_GetAllPodsFromCgroups_Call struct {
 }
 
 // GetAllPodsFromCgroups is a helper method to define mock.On call
-func (_e *MockPodContainerManager_Expecter) GetAllPodsFromCgroups() *MockPodContainerManager_GetAllPodsFromCgroups_Call {
-	return &MockPodContainerManager_GetAllPodsFromCgroups_Call{Call: _e.mock.On("GetAllPodsFromCgroups")}
+//   - logger klog.Logger
+func (_e *MockPodContainerManager_Expecter) GetAllPodsFromCgroups(logger interface{}) *MockPodContainerManager_GetAllPodsFromCgroups_Call {
+	return &MockPodContainerManager_GetAllPodsFromCgroups_Call{Call: _e.mock.On("GetAllPodsFromCgroups", logger)}
 }
 
-func (_c *MockPodContainerManager_GetAllPodsFromCgroups_Call) Run(run func()) *MockPodContainerManager_GetAllPodsFromCgroups_Call {
+func (_c *MockPodContainerManager_GetAllPodsFromCgroups_Call) Run(run func(logger klog.Logger)) *MockPodContainerManager_GetAllPodsFromCgroups_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 klog.Logger
+		if args[0] != nil {
+			arg0 = args[0].(klog.Logger)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -2153,7 +2193,7 @@ func (_c *MockPodContainerManager_GetAllPodsFromCgroups_Call) Return(uIDToCgroup
 	return _c
 }
 
-func (_c *MockPodContainerManager_GetAllPodsFromCgroups_Call) RunAndReturn(run func() (map[types.UID]cm.CgroupName, error)) *MockPodContainerManager_GetAllPodsFromCgroups_Call {
+func (_c *MockPodContainerManager_GetAllPodsFromCgroups_Call) RunAndReturn(run func(logger klog.Logger) (map[types.UID]cm.CgroupName, error)) *MockPodContainerManager_GetAllPodsFromCgroups_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/kubelet/cm/topologymanager/topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager.go
@@ -162,11 +162,7 @@ func (th *TopologyHint) LessThan(other TopologyHint) bool {
 var _ Manager = &manager{}
 
 // NewManager creates a new TopologyManager based on provided policy and scope
-func NewManager(topology []cadvisorapi.Node, topologyPolicyName string, topologyScopeName string, topologyPolicyOptions map[string]string) (Manager, error) {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
-
+func NewManager(logger klog.Logger, topology []cadvisorapi.Node, topologyPolicyName string, topologyScopeName string, topologyPolicyOptions map[string]string) (Manager, error) {
 	// When policy is none, the scope is not relevant, so we can short circuit here.
 	if topologyPolicyName == PolicyNone {
 		logger.Info("Creating topology manager with none policy")

--- a/pkg/kubelet/cm/topologymanager/topology_manager_test.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager_test.go
@@ -39,6 +39,7 @@ func NewTestBitMask(sockets ...int) bitmask.BitMask {
 }
 
 func TestNewManager(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	numaDistanceErr := "error getting NUMA distances from cadvisor"
 	if runtime.GOOS == "windows" {
 		numaDistanceErr = fmt.Sprintf("the %q policy option is not supported on Windows because NUMA node distances are not available", PreferClosestNUMANodes)
@@ -150,7 +151,7 @@ func TestNewManager(t *testing.T) {
 	for _, tc := range tcases {
 		topology := tc.topology
 
-		mngr, err := NewManager(topology, tc.policyName, "container", tc.policyOptions)
+		mngr, err := NewManager(logger, topology, tc.policyName, "container", tc.policyOptions)
 		if tc.expectedError != nil {
 			if !strings.Contains(err.Error(), tc.expectedError.Error()) {
 				t.Errorf("Unexpected error message. Have: %s wants %s", err.Error(), tc.expectedError.Error())
@@ -171,6 +172,7 @@ func TestNewManager(t *testing.T) {
 }
 
 func TestManagerScope(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	tcases := []struct {
 		description   string
 		scopeName     string
@@ -195,7 +197,7 @@ func TestManagerScope(t *testing.T) {
 	}
 
 	for _, tc := range tcases {
-		mngr, err := NewManager(nil, "best-effort", tc.scopeName, nil)
+		mngr, err := NewManager(logger, nil, "best-effort", tc.scopeName, nil)
 
 		if tc.expectedError != nil {
 			if !strings.Contains(err.Error(), tc.expectedError.Error()) {

--- a/pkg/kubelet/cm/types.go
+++ b/pkg/kubelet/cm/types.go
@@ -125,7 +125,7 @@ type PodContainerManager interface {
 	ReduceCPULimits(logger klog.Logger, name CgroupName) error
 
 	// GetAllPodsFromCgroups enumerates the set of pod uids to their associated cgroup based on state of cgroupfs system.
-	GetAllPodsFromCgroups() (map[types.UID]CgroupName, error)
+	GetAllPodsFromCgroups(logger klog.Logger) (map[types.UID]CgroupName, error)
 
 	// IsPodCgroup returns true if the literal cgroupfs name corresponds to a pod
 	IsPodCgroup(cgroupfs string) (bool, types.UID)

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1226,7 +1226,7 @@ func (kl *Kubelet) HandlePodCleanups(ctx context.Context) error {
 	)
 	if kl.cgroupsPerQOS {
 		pcm := kl.containerManager.NewPodContainerManager()
-		cgroupPods, err = pcm.GetAllPodsFromCgroups()
+		cgroupPods, err = pcm.GetAllPodsFromCgroups(logger)
 		if err != nil {
 			return fmt.Errorf("failed to get list of pods that still exist on cgroup mounts: %v", err)
 		}
@@ -1963,7 +1963,7 @@ func (kl *Kubelet) generateAPIPodStatus(ctx context.Context, pod *v1.Pod, podSta
 
 	// update the allocated resources status
 	if utilfeature.DefaultFeatureGate.Enabled(features.ResourceHealthStatus) {
-		kl.containerManager.UpdateAllocatedResourcesStatus(pod, s)
+		kl.containerManager.UpdateAllocatedResourcesStatus(logger, pod, s)
 	}
 
 	// preserve all conditions not owned by the kubelet

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -330,7 +330,7 @@ func newTestKubeletWithImageList(
 	kubelet.readinessManager = proberesults.NewManager()
 	kubelet.startupManager = proberesults.NewManager()
 
-	fakeContainerManager := cm.NewFakeContainerManager()
+	fakeContainerManager := cm.NewFakeContainerManager(logger)
 	kubelet.containerManager = fakeContainerManager
 	fakeNodeRef := &v1.ObjectReference{
 		Kind:      "Node",

--- a/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
@@ -106,7 +106,7 @@ func newFakeKubeRuntimeManager(ctx context.Context, runtimeService internalapi.R
 		startupManager:         proberesults.NewManager(),
 		machineInfo:            machineInfo,
 		osInterface:            osInterface,
-		containerManager:       cm.NewFakeContainerManager(),
+		containerManager:       cm.NewFakeContainerManager(logger),
 		runtimeHelper:          runtimeHelper,
 		runtimeService:         runtimeService,
 		imageService:           imageService,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR is the second part of replacing the appropriate context with the `context.TODO()` or `context.Background()` in the `./pkg/kubelet/cm/`. 
I break it down into multiple parts to keep PRs small and readable.

[First PR](https://github.com/kubernetes/kubernetes/pull/139075)
[Second PR](https://github.com/kubernetes/kubernetes/pull/139093)
[Third PR](https://github.com/kubernetes/kubernetes/pull/139713)

#### Which issue(s) this PR is related to:

Part of https://github.com/kubernetes/kubernetes/issues/130069

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

```release-note
NONE
```