### PR TITLE
admission: handle empty runtimeClassName

### DIFF
--- a/plugin/pkg/admission/runtimeclass/admission.go
+++ b/plugin/pkg/admission/runtimeclass/admission.go
@@ -145,7 +145,7 @@ func (r *RuntimeClass) prepareObjects(ctx context.Context, attributes admission.
 		return nil, nil, apierrors.NewBadRequest("Resource was marked with kind Pod but was unable to be converted")
 	}
 
-	if pod.Spec.RuntimeClassName == nil {
+	if pod.Spec.RuntimeClassName == nil || len(*pod.Spec.RuntimeClassName) == 0 {
 		return pod, nil, nil
 	}
 

--- a/plugin/pkg/admission/runtimeclass/admission_test.go
+++ b/plugin/pkg/admission/runtimeclass/admission_test.go
@@ -487,6 +487,24 @@ func TestValidate(t *testing.T) {
 			pod:         newOverheadValidPod("no-resource-req-no-overhead", 1, core.ResourceRequirements{}, false),
 			expectError: false,
 		},
+		{
+			name: "Empty RuntimeClassName",
+			runtimeClass: &nodev1.RuntimeClass{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Handler:    "bar",
+				Overhead: &nodev1.Overhead{
+					PodFixed: corev1.ResourceList{
+						corev1.ResourceName(corev1.ResourceCPU):    resource.MustParse("100m"),
+						corev1.ResourceName(corev1.ResourceMemory): resource.MustParse("1"),
+					},
+				},
+			},
+			pod: &core.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "empty-runtimeclassname", Namespace: "test"},
+				Spec:       core.PodSpec{RuntimeClassName: new("")},
+			},
+			expectError: false,
+		},
 	}
 	rt := NewRuntimeClass()
 	o := NewObjectInterfacesForTest()


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig node

#### What this PR does / why we need it:
Our validation logic handles empty `runtimeClassName`, we require that value to be a valid DNS subdomain name. See
https://github.com/kubernetes/kubernetes/blob/b6b907fda0d598ea8c2c92bd886f4e22ae10844a/pkg/apis/core/validation/validation.go#L353. We can then just pass through in the admission and treat that as empty.

#### Which issue(s) this PR is related to:
Fixes #139462

#### Special notes for your reviewer:
/assign @tallclair 

#### Does this PR introduce a user-facing change?
```release-note
RuntimeClass admission plugin will admit Pods with an empty `spec.runtimeClassName`.
```
