### PR TITLE
[WIP] KEP-5491: Avoid repeated list-to-set conversion in list-aware matchAttribute/distinctAttribute constraint evaluation

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -291,10 +291,11 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 					logger = klog.LoggerWithValues(logger, "matchAttribute", matchAttribute)
 				}
 				m := &matchAttributeConstraint{
-					logger:        logger,
-					requestNames:  sets.New(constraint.Requests...),
-					attributeName: matchAttribute,
-					features:      a.features,
+					logger:            logger,
+					requestNames:      sets.New(constraint.Requests...),
+					attributeName:     matchAttribute,
+					features:          a.features,
+					attributeSetCache: newDeviceAttributeAsSetCache(matchAttribute),
 				}
 				constraints[i] = m
 			case constraint.DistinctAttribute != nil:
@@ -305,10 +306,11 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 					logger = klog.LoggerWithValues(logger, "distinctAttribute", distinctAttribute)
 				}
 				m := &distinctAttributeConstraint{
-					logger:        logger,
-					requestNames:  sets.New(constraint.Requests...),
-					attributeName: distinctAttribute,
-					features:      a.features,
+					logger:            logger,
+					requestNames:      sets.New(constraint.Requests...),
+					attributeName:     distinctAttribute,
+					features:          a.features,
+					attributeSetCache: newDeviceAttributeAsSetCache(distinctAttribute),
 				}
 				constraints[i] = m
 			default:
@@ -796,6 +798,61 @@ type deviceAttributeListAsSet struct {
 	versionValue sets.Set[string]
 }
 
+// deviceAttributeAsSetCache caches the set representation for one fixed
+// attribute name, so device ID is enough as the map key.
+type deviceAttributeAsSetCache struct {
+	attributeName resourceapi.FullyQualifiedName
+	attributeSets map[DeviceID]*deviceAttributeListAsSet
+}
+
+func newDeviceAttributeAsSetCache(attributeName resourceapi.FullyQualifiedName) *deviceAttributeAsSetCache {
+	return &deviceAttributeAsSetCache{
+		attributeName: attributeName,
+		attributeSets: make(map[DeviceID]*deviceAttributeListAsSet),
+	}
+}
+
+func (c *deviceAttributeAsSetCache) get(device *draapi.Device, deviceID DeviceID) *deviceAttributeListAsSet {
+	if c.attributeSets == nil {
+		c.attributeSets = make(map[DeviceID]*deviceAttributeListAsSet)
+	}
+
+	if attributeSet, ok := c.attributeSets[deviceID]; ok {
+		return attributeSet
+	}
+
+	attribute := lookupAttribute(device, deviceID, c.attributeName)
+	if attribute == nil {
+		c.attributeSets[deviceID] = nil
+		return nil
+	}
+
+	attributeSet := attributeAsSet(attribute)
+	c.attributeSets[deviceID] = attributeSet
+	return attributeSet
+}
+
+func (s *deviceAttributeListAsSet) clone() *deviceAttributeListAsSet {
+	if s == nil {
+		return nil
+	}
+
+	result := &deviceAttributeListAsSet{}
+	if s.intValue != nil {
+		result.intValue = s.intValue.Clone()
+	}
+	if s.boolValue != nil {
+		result.boolValue = s.boolValue.Clone()
+	}
+	if s.stringValue != nil {
+		result.stringValue = s.stringValue.Clone()
+	}
+	if s.versionValue != nil {
+		result.versionValue = s.versionValue.Clone()
+	}
+	return result
+}
+
 // intersection returns the new intersection set of two attribute sets as a new set.
 // Returns nil if there is no intersection or if the types do not match.
 func (s *deviceAttributeListAsSet) intersection(other *deviceAttributeListAsSet) *deviceAttributeListAsSet {
@@ -898,6 +955,7 @@ type matchAttributeConstraint struct {
 	// intersectionStack[len-1] is the current intersection; each add() pushes and each remove() pops,
 	// so backtracking always restores the intersection to its pre-add state.
 	intersectionStack []*deviceAttributeListAsSet
+	attributeSetCache *deviceAttributeAsSetCache
 
 	numDevices int
 }
@@ -909,24 +967,31 @@ func (m *matchAttributeConstraint) add(requestName, subRequestName string, devic
 		return true
 	}
 
-	attribute := lookupAttribute(device, deviceID, m.attributeName)
-	if attribute == nil {
-		// Doesn't have the attribute.
-		m.logger.V(7).Info("Constraint not satisfied, attribute not set")
-		return false
+	var attribute *resourceapi.DeviceAttribute
+	var attributeSet *deviceAttributeListAsSet
+	if m.features.ListTypeAttributes {
+		if m.attributeSetCache == nil {
+			m.attributeSetCache = newDeviceAttributeAsSetCache(m.attributeName)
+		}
+		attributeSet = m.attributeSetCache.get(device, deviceID)
+	} else {
+		attribute = lookupAttribute(device, deviceID, m.attributeName)
+		if attribute == nil {
+			// Doesn't have the attribute.
+			m.logger.V(7).Info("Constraint not satisfied, attribute not set")
+			return false
+		}
 	}
 
 	if m.numDevices == 0 {
 		// The first device can always get picked.
 		// Initialize either scalar attribute or list set based on the attribute type.
 		if m.features.ListTypeAttributes {
-			// Convert attribute to set representation (both scalar and list)
-			first := attributeAsSet(attribute)
-			if first == nil {
+			if attributeSet == nil {
 				m.logger.V(7).Info("Attribute type unknown")
 				return false
 			}
-			m.intersectionStack = append(m.intersectionStack, first)
+			m.intersectionStack = append(m.intersectionStack, attributeSet.clone())
 		} else {
 			// Scalar attribute: use existing behavior
 			m.attribute = attribute
@@ -938,14 +1003,12 @@ func (m *matchAttributeConstraint) add(requestName, subRequestName string, devic
 
 	// Check if we are matching with set-based logic or scalar-based logic
 	if m.features.ListTypeAttributes {
-		// Set-based matching: check if there is non-empty intersection
-		newSet := attributeAsSet(attribute)
-		if newSet == nil {
+		if attributeSet == nil {
 			m.logger.V(7).Info("Unknown attribute type")
 			return false
 		}
 		current := m.intersectionStack[m.numDevices-1]
-		narrowed := current.intersection(newSet)
+		narrowed := current.intersection(attributeSet)
 		if narrowed == nil {
 			m.logger.V(7).Info("Attribute values have no common elements")
 			return false

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/constraint.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/constraint.go
@@ -38,7 +38,10 @@ type distinctAttributeConstraint struct {
 	attributeName resourceapi.FullyQualifiedName
 	features      Features
 
-	attributes []*resourceapi.DeviceAttribute
+	attributes    []*resourceapi.DeviceAttribute
+	attributeSets []*deviceAttributeListAsSet
+
+	attributeSetCache *deviceAttributeAsSetCache
 }
 
 func (m *distinctAttributeConstraint) add(requestName, subRequestName string, device *draapi.Device, deviceID DeviceID) bool {
@@ -54,7 +57,17 @@ func (m *distinctAttributeConstraint) add(requestName, subRequestName string, de
 		return false
 	}
 
-	if !m.matchesAttribute(*attribute) {
+	if m.features.ListTypeAttributes {
+		if m.attributeSetCache == nil {
+			m.attributeSetCache = newDeviceAttributeAsSetCache(m.attributeName)
+		}
+		attributeSet := m.attributeSetCache.get(device, deviceID)
+		if !m.matchesAttributeSet(attributeSet) {
+			m.logger.V(7).Info("Constraint not satisfied, has some duplicated attributes")
+			return false
+		}
+		m.attributeSets = append(m.attributeSets, attributeSet)
+	} else if !m.matchesAttribute(*attribute) {
 		m.logger.V(7).Info("Constraint not satisfied, has some duplicated attributes")
 		return false
 	}
@@ -71,6 +84,9 @@ func (m *distinctAttributeConstraint) remove(requestName, subRequestName string,
 	}
 
 	m.attributes = m.attributes[:len(m.attributes)-1]
+	if m.features.ListTypeAttributes {
+		m.attributeSets = m.attributeSets[:len(m.attributeSets)-1]
+	}
 	m.logger.V(7).Info("Device removed from constraint set", "device", deviceID, "numDevices", len(m.attributes))
 }
 
@@ -81,6 +97,26 @@ func (m *distinctAttributeConstraint) matches(requestName, subRequestName string
 		fullSubRequestName := fmt.Sprintf("%s/%s", requestName, subRequestName)
 		return m.requestNames.Has(requestName) || m.requestNames.Has(fullSubRequestName)
 	}
+}
+
+func (m *distinctAttributeConstraint) matchesAttributeSet(newSet *deviceAttributeListAsSet) bool {
+	if newSet == nil {
+		m.logger.V(7).Info("Unknown attribute type")
+		return false
+	}
+
+	for _, existingSet := range m.attributeSets {
+		if existingSet == nil {
+			continue
+		}
+		if newSet.intersection(existingSet) != nil {
+			m.logger.V(7).Info("Constraint not satisfied, devices have common elements")
+			return false
+		}
+	}
+
+	m.logger.V(7).Info("Constraint satisfied, new device is disjoint from all existing devices")
+	return true
 }
 
 func (m *distinctAttributeConstraint) matchesAttribute(attribute resourceapi.DeviceAttribute) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

- Avoid repeated list-to-set conversion in list-aware matchAttribute/distinctAttribute constraint evaluation by introducing an internal cache for the converted attribute as set in the matchAttribute/distinctAttribute constraint struct

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes https://github.com/kubernetes/kubernetes/issues/137902
KEP: https://github.com/kubernetes/enhancements/issues/5491

#### Special notes for your reviewer:

There is no test change because it is purely refactoring, which introduces an internal cache.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
KEP-5491: Avoid repeated list-to-set conversion in matchAttribute/distinctAttribute constraint evaluation
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/issues/5491
```
