### PR TITLE
flake: observe scheduling attempts in ordered pod creation

### DIFF
--- a/test/integration/scheduler/podgroup/stepsframework/stepsframework.go
+++ b/test/integration/scheduler/podgroup/stepsframework/stepsframework.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/scheduler/backend/queue"
 	testutils "k8s.io/kubernetes/test/integration/util"
 )
@@ -182,6 +183,17 @@ func podInUnschedulableEntities(queue queue.SchedulingQueue, podName string) boo
 	return false
 }
 
+func podSchedulingAttempted(cs kubernetes.Interface, ns, name string) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
+		pod, err := cs.CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		_, cond := podutil.GetPodCondition(&pod.Status, v1.PodScheduled)
+		return cond != nil, nil
+	}
+}
+
 func podGroupHasScheduledCondition(cs kubernetes.Interface, ns, name string, status metav1.ConditionStatus, reason string) wait.ConditionWithContextFunc {
 	return func(ctx context.Context) (bool, error) {
 		pg, err := cs.SchedulingV1alpha3().PodGroups(ns).Get(ctx, name, metav1.GetOptions{})
@@ -230,14 +242,16 @@ func createPods(testCtx *testutils.TestContext, ns string, pods []*v1.Pod, prese
 			return fmt.Errorf("failed to create pod %s: %w", p.Name, err)
 		}
 		if preserveOrder {
-			podScheduledFn := testutils.PodScheduled(cs, ns, p.Name)
+			podSchedulingAttemptedFn := podSchedulingAttempted(cs, ns, p.Name)
 			err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 10*time.Second, false, func(ctx context.Context) (bool, error) {
 				_, ok := testCtx.Scheduler.SchedulingQueue.GetPod(p.Name, p.Namespace, p.Spec.SchedulingGroup)
 				if ok {
 					return true, nil
 				}
-				// pod may have gotten queued and scheduled between the polls
-				return podScheduledFn(ctx)
+				// The pod may have gotten queued and had a scheduling attempt between
+				// polls. A PodScheduled condition, either true or false, proves the
+				// scheduler has observed the pod.
+				return podSchedulingAttemptedFn(ctx)
 			})
 			if err != nil {
 				return fmt.Errorf("failed to ensure queueing order of pod %s: %w", p.Name, err)


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

This PR fixes a flake in the podgroup integration test:

- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-integration-master/2071943528103022592
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-integration-master/2071928171648782336
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-integration-master/2071882117066788864

`CreatePodsInOrder` creates one pod, then waits until the scheduler has observed this pod before creating the next one.

Before this PR, the helper used the scheduler queue first, and then `pod.Spec.NodeName != ""` as fallback. This is not enough for an unschedulable pod. The pod may be removed from the queue and get a scheduling attempt, but it will not get assigned to a node. Then the poll may miss the queue state and timeout.

This PR makes `CreatePodsInOrder` also treat a `PodScheduled` condition as proof that the scheduler has observed the pod. The condition can be `True` or `False`; for this helper, the important thing is that the scheduler already made a scheduling attempt.

So the test can still create all gang pods in order, and the helper no longer depends only on a short queue state or successful scheduling.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Tested:

```text
make test-integration WHAT=./test/integration/scheduler/podgroup GOFLAGS='-run=TestPodGroupScheduling/gang_pods_are_unschedulable_due_to_lack_of_space,_then_scheduled_when_minCount_is_decreased_.*true -count=1 -v'
stress -p 1 -count 20 -timeout 20m -- make test-integration WHAT=./test/integration/scheduler/podgroup GOFLAGS='-run=TestPodGroupScheduling/gang_pods_are_unschedulable_due_to_lack_of_space,_then_scheduled_when_minCount_is_decreased_.*true -count=1 -v'
make test-integration WHAT=./test/integration/scheduler/podgroup GOFLAGS='-count=1 -v'
```

Result:

```text
DONE 2 tests in 9.573s
20 runs total, 0 failures
DONE 32 tests in 157.837s
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```