### PR TITLE
relax restriction of parallelism on jobs if WorkloadWithJobs is disabled

### DIFF
--- a/plugin/pkg/admission/job/admission.go
+++ b/plugin/pkg/admission/job/admission.go
@@ -74,7 +74,7 @@ func (p *Plugin) InspectFeatureGates(featureGates featuregate.FeatureGate) {
 }
 
 func (p *Plugin) SetExternalKubeInformerFactory(f informers.SharedInformerFactory) {
-	if !p.genericWorkloadEnabled {
+	if !p.genericWorkloadEnabled && !p.workloadWithJobEnabled {
 		return
 	}
 	pgInformer := f.Scheduling().V1alpha3().PodGroups()
@@ -87,7 +87,7 @@ func (p *Plugin) ValidateInitialization() error {
 	if !p.inspectedFeatureGates {
 		return fmt.Errorf("%s has not inspected feature gates", PluginName)
 	}
-	if p.genericWorkloadEnabled && p.pgLister == nil {
+	if (p.genericWorkloadEnabled || p.workloadWithJobEnabled) && p.pgLister == nil {
 		return fmt.Errorf("missing PodGroup lister")
 	}
 	return nil
@@ -130,8 +130,12 @@ func (p *Plugin) validateParallelismChange(a admission.Attributes, job, oldJob *
 	}
 
 	// When SchedulingGroup is set in the template, look up that PodGroup directly.
+	// This path only applies when GenericWorkload is enabled.
 	sg := oldJob.Spec.Template.Spec.SchedulingGroup
 	if sg != nil && sg.PodGroupName != nil {
+		if !p.genericWorkloadEnabled {
+			return nil
+		}
 		pg, err := p.pgLister.PodGroups(oldJob.Namespace).Get(*sg.PodGroupName)
 		if err != nil {
 			return nil
@@ -144,6 +148,10 @@ func (p *Plugin) validateParallelismChange(a admission.Attributes, job, oldJob *
 	}
 
 	// When SchedulingGroup is not in the template, scan PodGroups in the namespace owned by this Job.
+	// This path only applies when WorkloadWithJob is enabled.
+	if !p.workloadWithJobEnabled {
+		return nil
+	}
 	pgs, err := p.pgLister.PodGroups(oldJob.Namespace).List(labels.Everything())
 	if err != nil {
 		return nil

--- a/plugin/pkg/admission/job/admission_test.go
+++ b/plugin/pkg/admission/job/admission_test.go
@@ -32,7 +32,6 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/features"
-	"k8s.io/utils/ptr"
 )
 
 func TestGangSchedulingParallelism(t *testing.T) {
@@ -73,8 +72,8 @@ func TestGangSchedulingParallelism(t *testing.T) {
 			},
 			Spec: batch.JobSpec{
 				CompletionMode: &indexedMode,
-				Completions:    ptr.To[int32](4),
-				Parallelism:    ptr.To[int32](4),
+				Completions:    new(int32(4)),
+				Parallelism:    new(int32(4)),
 			},
 		}
 		if sgName != nil {
@@ -86,72 +85,40 @@ func TestGangSchedulingParallelism(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		enableFeatureGate bool
-		oldJob            *batch.Job
-		newJob            *batch.Job
-		podGroups         []*schedulingv1alpha3.PodGroup
-		wantErr           bool
+		enableGenericWorkload bool
+		enableWorkloadWithJob bool
+		oldJob                *batch.Job
+		newJob                *batch.Job
+		podGroups             []*schedulingv1alpha3.PodGroup
+		wantErr               bool
 	}{
-		"feature gate disabled: allows parallelism change": {
-			oldJob: baseJob(ptr.To("gang-pg")),
+		"both gates disabled: allows parallelism change": {
+			oldJob: baseJob(new("gang-pg")),
 			newJob: func() *batch.Job {
-				j := baseJob(ptr.To("gang-pg"))
-				j.Spec.Parallelism = ptr.To[int32](2)
+				j := baseJob(new("gang-pg"))
+				j.Spec.Parallelism = new(int32(2))
 				return j
 			}(),
 			podGroups: []*schedulingv1alpha3.PodGroup{gangPG},
 		},
-		"no schedulingGroup: skips check (handled by validation)": {
-			enableFeatureGate: true,
-			oldJob:            baseJob(nil),
+		"only WorkloadWithJob disabled, schedulingGroup path: rejects": {
+			enableGenericWorkload: true,
+			oldJob:                baseJob(new("gang-pg")),
 			newJob: func() *batch.Job {
-				j := baseJob(nil)
-				j.Spec.Parallelism = ptr.To[int32](2)
-				return j
-			}(),
-		},
-		"parallelism unchanged: allows": {
-			enableFeatureGate: true,
-			oldJob:            baseJob(ptr.To("gang-pg")),
-			newJob:            baseJob(ptr.To("gang-pg")),
-			podGroups:         []*schedulingv1alpha3.PodGroup{gangPG},
-		},
-		"gang PodGroup: rejects parallelism change": {
-			enableFeatureGate: true,
-			oldJob:            baseJob(ptr.To("gang-pg")),
-			newJob: func() *batch.Job {
-				j := baseJob(ptr.To("gang-pg"))
-				j.Spec.Parallelism = ptr.To[int32](2)
+				j := baseJob(new("gang-pg"))
+				j.Spec.Parallelism = new(int32(2))
 				return j
 			}(),
 			podGroups: []*schedulingv1alpha3.PodGroup{gangPG},
 			wantErr:   true,
 		},
-		"basic PodGroup: allows parallelism change": {
-			enableFeatureGate: true,
-			oldJob:            baseJob(ptr.To("basic-pg")),
-			newJob: func() *batch.Job {
-				j := baseJob(ptr.To("basic-pg"))
-				j.Spec.Parallelism = ptr.To[int32](2)
-				return j
-			}(),
-			podGroups: []*schedulingv1alpha3.PodGroup{basicPG},
-		},
-		"PodGroup not found: allows parallelism change": {
-			enableFeatureGate: true,
-			oldJob:            baseJob(ptr.To("missing-pg")),
-			newJob: func() *batch.Job {
-				j := baseJob(ptr.To("missing-pg"))
-				j.Spec.Parallelism = ptr.To[int32](2)
-				return j
-			}(),
-		},
-		"controller-created gang PodGroup - rejects parallelism change": {
-			enableFeatureGate: true,
-			oldJob:            baseJob(nil),
+
+		"only WorkloadWithJob disabled, owner-ref path: allows": {
+			enableGenericWorkload: true,
+			oldJob:                baseJob(nil),
 			newJob: func() *batch.Job {
 				j := baseJob(nil)
-				j.Spec.Parallelism = ptr.To[int32](2)
+				j.Spec.Parallelism = new(int32(2))
 				return j
 			}(),
 			podGroups: []*schedulingv1alpha3.PodGroup{
@@ -165,7 +132,89 @@ func TestGangSchedulingParallelism(t *testing.T) {
 								Kind:       "Job",
 								Name:       "test-job",
 								UID:        types.UID("test-job-uid"),
-								Controller: ptr.To(true),
+								Controller: new(true),
+							},
+						},
+					},
+					Spec: schedulingv1alpha3.PodGroupSpec{
+						SchedulingPolicy: schedulingv1alpha3.PodGroupSchedulingPolicy{
+							Gang: &schedulingv1alpha3.GangSchedulingPolicy{MinCount: 4},
+						},
+					},
+				},
+			},
+		},
+		"no schedulingGroup: skips check (handled by validation)": {
+			enableGenericWorkload: true,
+			enableWorkloadWithJob: true,
+			oldJob:                baseJob(nil),
+			newJob: func() *batch.Job {
+				j := baseJob(nil)
+				j.Spec.Parallelism = new(int32(2))
+				return j
+			}(),
+		},
+		"parallelism unchanged: allows": {
+			enableGenericWorkload: true,
+			enableWorkloadWithJob: true,
+			oldJob:                baseJob(new("gang-pg")),
+			newJob:                baseJob(new("gang-pg")),
+			podGroups:             []*schedulingv1alpha3.PodGroup{gangPG},
+		},
+		"gang PodGroup: rejects parallelism change": {
+			enableGenericWorkload: true,
+			enableWorkloadWithJob: true,
+			oldJob:                baseJob(new("gang-pg")),
+			newJob: func() *batch.Job {
+				j := baseJob(new("gang-pg"))
+				j.Spec.Parallelism = new(int32(2))
+				return j
+			}(),
+			podGroups: []*schedulingv1alpha3.PodGroup{gangPG},
+			wantErr:   true,
+		},
+		"basic PodGroup: allows parallelism change": {
+			enableGenericWorkload: true,
+			enableWorkloadWithJob: true,
+			oldJob:                baseJob(new("basic-pg")),
+			newJob: func() *batch.Job {
+				j := baseJob(new("basic-pg"))
+				j.Spec.Parallelism = new(int32(2))
+				return j
+			}(),
+			podGroups: []*schedulingv1alpha3.PodGroup{basicPG},
+		},
+		"PodGroup not found: allows parallelism change": {
+			enableGenericWorkload: true,
+			enableWorkloadWithJob: true,
+			oldJob:                baseJob(new("missing-pg")),
+			newJob: func() *batch.Job {
+				j := baseJob(new("missing-pg"))
+				j.Spec.Parallelism = new(int32(2))
+				return j
+			}(),
+		},
+		"controller-created gang PodGroup - rejects parallelism change": {
+			enableGenericWorkload: true,
+			enableWorkloadWithJob: true,
+			oldJob:                baseJob(nil),
+			newJob: func() *batch.Job {
+				j := baseJob(nil)
+				j.Spec.Parallelism = new(int32(2))
+				return j
+			}(),
+			podGroups: []*schedulingv1alpha3.PodGroup{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "controller-created-pg",
+						Namespace: metav1.NamespaceDefault,
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "batch/v1",
+								Kind:       "Job",
+								Name:       "test-job",
+								UID:        types.UID("test-job-uid"),
+								Controller: new(true),
 							},
 						},
 					},
@@ -179,11 +228,12 @@ func TestGangSchedulingParallelism(t *testing.T) {
 			wantErr: true,
 		},
 		"controller-created basic PodGroup - allows parallelism change": {
-			enableFeatureGate: true,
-			oldJob:            baseJob(nil),
+			enableGenericWorkload: true,
+			enableWorkloadWithJob: true,
+			oldJob:                baseJob(nil),
 			newJob: func() *batch.Job {
 				j := baseJob(nil)
-				j.Spec.Parallelism = ptr.To[int32](2)
+				j.Spec.Parallelism = new(int32(2))
 				return j
 			}(),
 			podGroups: []*schedulingv1alpha3.PodGroup{
@@ -197,7 +247,7 @@ func TestGangSchedulingParallelism(t *testing.T) {
 								Kind:       "Job",
 								Name:       "test-job",
 								UID:        types.UID("test-job-uid"),
-								Controller: ptr.To(true),
+								Controller: new(true),
 							},
 						},
 					},
@@ -210,11 +260,12 @@ func TestGangSchedulingParallelism(t *testing.T) {
 			},
 		},
 		"gang PodGroup owned by different Job - allows parallelism change": {
-			enableFeatureGate: true,
-			oldJob:            baseJob(nil),
+			enableGenericWorkload: true,
+			enableWorkloadWithJob: true,
+			oldJob:                baseJob(nil),
 			newJob: func() *batch.Job {
 				j := baseJob(nil)
-				j.Spec.Parallelism = ptr.To[int32](2)
+				j.Spec.Parallelism = new(int32(2))
 				return j
 			}(),
 			podGroups: []*schedulingv1alpha3.PodGroup{
@@ -228,7 +279,7 @@ func TestGangSchedulingParallelism(t *testing.T) {
 								Kind:       "Job",
 								Name:       "other-job",
 								UID:        types.UID("other-job-uid"),
-								Controller: ptr.To(true),
+								Controller: new(true),
 							},
 						},
 					},
@@ -246,8 +297,8 @@ func TestGangSchedulingParallelism(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGatesDuringTest(t,
 				utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
-					features.GenericWorkload: tc.enableFeatureGate,
-					features.WorkloadWithJob: tc.enableFeatureGate,
+					features.GenericWorkload: tc.enableGenericWorkload,
+					features.WorkloadWithJob: tc.enableWorkloadWithJob,
 				})
 
 			p := NewPlugin()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
I am working on GangJobsets and I want to scale the Jobs when JobSet owns the podgroup / workload. The objects are recreated but the validation fails because job will not allow any changes to parallelism even if the WorkloadWithJob feature gate is turned off.
#### Which issue(s) this PR is related to:

Fixes: #140112
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Relax restriction of parallelism when WorkloadWithJob feature gate is turned off.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
