### PR TITLE
Filter handwritten validation errors by reverse lookup against enforced declarative errors

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
@@ -409,49 +409,56 @@ func ValidateDeclarativelyWithMigrationChecks(ctx context.Context, scheme *runti
 		compareDeclarativeErrorsAndEmitMismatches(ctx, errs, mismatchCandidateErrs, validationIdentifier, betaEnabled, *cfg)
 	}
 
-	// Filter HV errors
-	errs = filterHandwrittenErrors(errs, allDeclarativeEnforced, betaEnabled)
-
-	// Append Enforced DV errors
+	// Collect the declarative errors that are enforced (i.e. surfaced to the user) in the
+	// current mode. A declarative error is enforced when any of the following holds:
+	//   - allDeclarativeEnforced is set (testing): every declarative error is enforced.
+	//   - It is an internal error: always enforced, regardless of lifecycle.
+	//   - It is a beta error and the beta gate is enabled.
+	//   - It is a standard (unprefixed) error: always enforced.
+	// Alpha errors are never enforced; they remain shadowed by handwritten validation.
+	enforcedDeclarativeErrs := make(field.ErrorList, 0, len(declarativeErrs))
 	for _, dvErr := range declarativeErrs {
-		if allDeclarativeEnforced {
-			errs = append(errs, dvErr)
-			continue
-		}
 		switch {
+		case allDeclarativeEnforced:
+			enforcedDeclarativeErrs = append(enforcedDeclarativeErrs, dvErr)
 		case dvErr.Type == field.ErrorTypeInternal:
-			errs = append(errs, dvErr)
+			enforcedDeclarativeErrs = append(enforcedDeclarativeErrs, dvErr)
 		case dvErr.IsBeta():
 			if betaEnabled {
-				errs = append(errs, dvErr)
+				enforcedDeclarativeErrs = append(enforcedDeclarativeErrs, dvErr)
 			}
 		case !dvErr.IsAlpha():
-			errs = append(errs, dvErr) // Standard
+			enforcedDeclarativeErrs = append(enforcedDeclarativeErrs, dvErr) // Standard
 		}
 	}
+
+	// Remove handwritten errors that are superseded by an enforced declarative counterpart.
+	errs = filterHandwrittenErrors(errs, enforcedDeclarativeErrs, allDeclarativeEnforced, cfg)
+
+	// Append the enforced declarative errors.
+	errs = append(errs, enforcedDeclarativeErrs...)
 
 	return errs
 }
 
-func filterHandwrittenErrors(errs field.ErrorList, allDeclarativeEnforced, betaEnabled bool) field.ErrorList {
-	// We remove HV errors that are covered by declarative validation AND are enforced.
+// filterHandwrittenErrors removes a CoveredByDeclarative handwritten error when a matching enforced
+// beta declarative error exists (matched by type, field, and origin). In allDeclarativeEnforced
+// (testing-only) mode every covered handwritten error is removed.
+func filterHandwrittenErrors(errs, enforcedDeclarativeErrs field.ErrorList, allDeclarativeEnforced bool, opts *ValidationConfigOption) field.ErrorList {
+	matcher := field.ErrorMatcher{}.ByType().ByOrigin().RequireOriginWhenInvalid().ByFieldNormalized(opts.NormalizationRules)
 	return errs.Filter(func(e error) bool {
 		var fe *field.Error
 		if !errors.As(e, &fe) || !fe.CoveredByDeclarative {
 			return false
 		}
-
 		if allDeclarativeEnforced {
 			return true
 		}
-
-		// Explicit Strategy
-		if fe.IsBeta() {
-			// Beta validations are enforced only if the Beta feature gate is enabled.
-			return betaEnabled
+		for _, dErr := range enforcedDeclarativeErrs {
+			if dErr.IsBeta() && matcher.Matches(fe, dErr) {
+				return true
+			}
 		}
-		// For Standard validations, we keep the handwritten error for now to avoid losing coverage
-		// before it is deleted from source. Alpha validations are always shadowed (kept).
 		return false
 	})
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go
@@ -708,9 +708,16 @@ func TestValidateDeclarativelyWithMigrationChecks(t *testing.T) {
 	// Additional Declarative (No HV counterpart)
 	errDVAdditional := field.Invalid(field.NewPath("spec", "additional"), "decAdditional", "declarative additional")
 
-	// Beta Lifecycle (Gated by DeclarativeValidationBeta)
-	errHVBetaCovered := field.Forbidden(field.NewPath("spec", "beta"), "imperative beta").MarkCoveredByDeclarative().MarkBeta()
-	errDVBeta := field.Invalid(field.NewPath("spec", "beta"), "decBeta", "declarative beta").MarkBeta()
+	// Beta Lifecycle (Gated by DeclarativeValidationBeta).
+	// The HV error carries no lifecycle marker; it is removed when a matching enforced beta DV
+	// error exists. The pair shares type, field, and origin, as real HV/DV counterparts do.
+	errHVBetaCovered := field.Invalid(field.NewPath("spec", "beta"), "val", "imperative beta").WithOrigin("min").MarkCoveredByDeclarative()
+	errDVBeta := field.Invalid(field.NewPath("spec", "beta"), "decBeta", "declarative beta").WithOrigin("min").MarkBeta()
+
+	// Beta Lifecycle, origin-less non-Invalid pair. Forbidden errors carry no origin, so
+	// RequireOriginWhenInvalid does not apply and the pair matches on type and field alone.
+	errHVBetaForbidden := field.Forbidden(field.NewPath("spec", "betaForbidden"), "imperative beta forbidden").MarkCoveredByDeclarative()
+	errDVBetaForbidden := field.Forbidden(field.NewPath("spec", "betaForbidden"), "declarative beta forbidden").MarkBeta()
 
 	// Alpha Lifecycle (Shadowed)
 	// Alpha rules should NOT mark HV as covered, so HV remains authoritative.
@@ -769,6 +776,22 @@ func TestValidateDeclarativelyWithMigrationChecks(t *testing.T) {
 			imperativeErrors:  field.ErrorList{errHVBetaCovered},
 			declarativeErrors: field.ErrorList{errDVBeta},
 			expectedErrors:    field.ErrorList{errHVBetaCovered},
+		},
+		{
+			name:              "Beta Gate Enabled, declarative not emitted -> HV kept",
+			dvFeatureEnabled:  true,
+			betaGateEnabled:   true,
+			imperativeErrors:  field.ErrorList{errHVBetaCovered},
+			declarativeErrors: field.ErrorList{},
+			expectedErrors:    field.ErrorList{errHVBetaCovered},
+		},
+		{
+			name:              "Beta Gate Enabled, origin-less Forbidden -> HV removed, DV returned",
+			dvFeatureEnabled:  true,
+			betaGateEnabled:   true,
+			imperativeErrors:  field.ErrorList{errHVBetaForbidden},
+			declarativeErrors: field.ErrorList{errDVBetaForbidden},
+			expectedErrors:    field.ErrorList{errDVBetaForbidden},
 		},
 		{
 			name:              "Alpha -> Shadows Alpha (HV kept, DV hidden)",


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig api-machinery

#### What this PR does / why we need it:

Reworks migration filtering in `ValidateDeclarativelyWithMigrationChecks` so a handwritten (HV) error is suppressed by matching it against the **enforced declarative (DV) error set**, instead of a per-rule stability marker on the HV side.

- **Single source of truth** — stability lives only on the tag/DV error, not duplicated on the handwritten side.
- **Works with shared validation helpers** — e.g. `ValidateCSIDriverName` (called by both graduated and non-graduated callers) needs no per-caller stability mark.
- **Graduation = flip tag + codegen** — no handwritten edits to graduate a rule alpha→beta→stable.
- **Fixes short-circuit bug** — HV is dropped only when DV actually emits a matching enforced error, so an HV error whose DV counterpart was short-circuited (ancestor failed) is correctly kept.

Matching reuses the same `field.ErrorMatcher` (type + normalized field + origin) the existing mismatch checker uses, so the filter can only drop what is already a confirmed match.

Behavior preserved: beta DV supersedes its HV counterpart only when the `DeclarativeValidationBeta` gate is on; standard (unprefixed) DV does not auto-drop its HV counterpart; alpha is always shadowed.


#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

No functional change to validation results for existing APIs; this only changes how the HV/DV de-duplication decision is made during migration. Scope is limited to two files in `apiserver/pkg/registry/rest`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```