### PR TITLE
Auto-discover declarative-validation GVKs in the validation equivalence fuzz test

### DIFF
--- a/pkg/api/testing/validation.go
+++ b/pkg/api/testing/validation.go
@@ -42,6 +42,12 @@ import (
 	"sigs.k8s.io/randfill"
 )
 
+// skippedEquivalenceGroupVersions opt out of declarative validation
+// (+k8s:validation-gen=false) but share an internal type with versions that do
+// not. Only intentional opt-outs belong here; any other version missing
+// declarative validation should fail the sweep, not be skipped.
+var skippedEquivalenceGroupVersions = sets.New("extensions/v1beta1")
+
 // VerifyVersionedValidationEquivalence tests that all versions of an API return equivalent validation errors.
 // It accepts optional configuration to handle path normalization across API versions where structures differ.
 func VerifyVersionedValidationEquivalence(t *testing.T, obj, old runtime.Object, testConfigs ...ValidationTestConfig) {
@@ -55,10 +61,9 @@ func VerifyVersionedValidationEquivalence(t *testing.T, obj, old runtime.Object,
 	// Accumulate errors from all versioned validation, per version.
 	all := map[string]field.ErrorList{}
 	accumulate := func(t *testing.T, gv string, errs field.ErrorList) {
-		// Skip versions explicitly excluded from the equivalence sweep (e.g. a
-		// deprecated, unserved group whose types are intentionally not validated
-		// declaratively).
-		if opts.SkipGroupVersions.Has(gv) {
+		// Skip group/versions excluded from the equivalence sweep
+		// (see skippedEquivalenceGroupVersions).
+		if skippedEquivalenceGroupVersions.Has(gv) {
 			return
 		}
 		// If normalization rules are provided, apply them to the field paths of generated errors.
@@ -228,13 +233,6 @@ type validationOption struct {
 
 	// Fuzzer is the fuzzer to use for generating test objects.
 	Fuzzer *randfill.Filler
-
-	// SkipGroupVersions lists "group/version" strings to exclude from the
-	// versioned validation equivalence sweep. This is for kinds whose internal
-	// type is registered under a deprecated, unserved group (e.g. a workload
-	// type that also exists in extensions/v1beta1) for which declarative
-	// validation is intentionally not generated.
-	SkipGroupVersions sets.Set[string]
 }
 
 func WithSubResources(subResources ...string) ValidationTestConfig {
@@ -258,16 +256,6 @@ func WithIgnoreObjectConversionErrors() ValidationTestConfig {
 func WithFuzzer(fuzzer *randfill.Filler) ValidationTestConfig {
 	return func(o *validationOption) {
 		o.Fuzzer = fuzzer
-	}
-}
-
-// WithSkipGroupVersions excludes the given "group/version" strings from the
-// versioned validation equivalence sweep. Use it for kinds whose internal type
-// is also registered under a deprecated, unserved group (e.g. extensions/v1beta1)
-// for which declarative validation is intentionally not generated.
-func WithSkipGroupVersions(groupVersions ...string) ValidationTestConfig {
-	return func(o *validationOption) {
-		o.SkipGroupVersions = sets.New(groupVersions...)
 	}
 }
 

--- a/pkg/api/testing/validation_test.go
+++ b/pkg/api/testing/validation_test.go
@@ -18,10 +18,12 @@ package testing
 
 import (
 	"math/rand"
+	"sort"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
 	"k8s.io/apimachinery/pkg/api/apitesting/roundtrip"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -29,93 +31,71 @@ import (
 	resourcevalidation "k8s.io/kubernetes/pkg/apis/resource/validation"
 )
 
-// FIXME: Automatically finds all group/versions supporting declarative validation, or add
-// a reflexive test that verifies that they are all registered.
 func TestVersionedValidationByFuzzing(t *testing.T) {
-	typesWithDeclarativeValidation := []schema.GroupVersion{
-		// Registered group versions for versioned validation fuzz testing:
-		{Group: "", Version: "v1"},
-		{Group: "batch", Version: "v1"},
-		{Group: "batch", Version: "v1beta1"},
-		{Group: "certificates.k8s.io", Version: "v1"},
-		{Group: "certificates.k8s.io", Version: "v1alpha1"},
-		{Group: "certificates.k8s.io", Version: "v1beta1"},
-		{Group: "resource.k8s.io", Version: "v1"},
-		{Group: "resource.k8s.io", Version: "v1alpha3"},
-		{Group: "resource.k8s.io", Version: "v1beta1"},
-		{Group: "resource.k8s.io", Version: "v1beta2"},
-		{Group: "storage.k8s.io", Version: "v1"},
-		{Group: "storage.k8s.io", Version: "v1alpha1"},
-		{Group: "storage.k8s.io", Version: "v1beta1"},
-		{Group: "node.k8s.io", Version: "v1"},
-		{Group: "node.k8s.io", Version: "v1alpha1"},
-		{Group: "node.k8s.io", Version: "v1beta1"},
-		{Group: "network.k8s.io", Version: "v1"},
-		{Group: "network.k8s.io", Version: "v1beta1"},
-		{Group: "autoscaling", Version: "v1"},
-		{Group: "autoscaling", Version: "v2"},
-		{Group: "admissionregistration.k8s.io", Version: "v1"},
-		{Group: "admissionregistration.k8s.io", Version: "v1beta1"},
-		{Group: "admissionregistration.k8s.io", Version: "v1alpha1"},
-		{Group: "discovery.k8s.io", Version: "v1"},
-		{Group: "discovery.k8s.io", Version: "v1beta1"},
-		{Group: "admissionregistration.k8s.io", Version: "v1"},
-		{Group: "admissionregistration.k8s.io", Version: "v1beta1"},
-		{Group: "admissionregistration.k8s.io", Version: "v1alpha1"},
+	// Discover every served GroupVersionKind that has declarative validation, so
+	// new group/versions are covered automatically without hand maintenance.
+	var gvks []schema.GroupVersionKind
+	for gvk := range legacyscheme.Scheme.AllKnownTypes() {
+		if gvk.Version == runtime.APIVersionInternal {
+			continue
+		}
+		obj, err := legacyscheme.Scheme.New(gvk)
+		if err != nil {
+			continue
+		}
+		if !legacyscheme.Scheme.HasValidationFunc(obj) {
+			continue
+		}
+		gvks = append(gvks, gvk)
 	}
+	sort.Slice(gvks, func(i, j int) bool { return gvks[i].String() < gvks[j].String() })
 
-	// subresourceOnly specifies the subresource path for types that can only be validated
-	// as subresources (e.g. autoscaling/Scale) and do not support root-level validation.
-	// For GVKs not in this map, the test defaults to fuzzing the root resource ("").
-	// Other resources with subresources (e.g. Pod status, exec) share validation logic with
-	// the root resource, so fuzzing the root is sufficient to verify validation equivalence.
-	subresourceOnly := map[schema.GroupVersionKind]string{
-		{Group: "autoscaling", Version: "v1", Kind: "Scale"}: "scale",
-		{Group: "autoscaling", Version: "v2", Kind: "Scale"}: "scale",
+	// subresourceOnlyKinds maps a Kind to the subresource it must be validated as
+	// (e.g. Scale), since it has no root-level validation. Keyed by Kind because
+	// the same Kind is registered under several groups (autoscaling, apps). Other
+	// kinds default to the root resource (""), whose validation covers their
+	// subresources too.
+	subresourceOnlyKinds := map[string]string{
+		"Scale": "scale",
 	}
 
 	fuzzIters := *roundtrip.FuzzIters / 10 // TODO: Find a better way to manage test running time
 	f := fuzzer.FuzzerFor(FuzzerFuncs, rand.NewSource(rand.Int63()), legacyscheme.Codecs)
 
-	for _, gv := range typesWithDeclarativeValidation {
-		for kind := range legacyscheme.Scheme.KnownTypes(gv) {
-			gvk := gv.WithKind(kind)
-			t.Run(gvk.String(), func(t *testing.T) {
-				for i := 0; i < fuzzIters; i++ {
-					obj, err := legacyscheme.Scheme.New(gvk)
-					if err != nil {
-						t.Fatalf("could not create a %v: %s", kind, err)
-					}
-
-					subresource := ""
-					if specific, ok := subresourceOnly[gvk]; ok {
-						subresource = specific
-					}
-
-					var opts []ValidationTestConfig
-					// TODO(API group level configuration): Consider configuring normalization rules at the
-					// API group level to avoid potential collisions when multiple rule sets are combined.
-					// This would allow each API group to register its own normalization rules independently.
-					allRules := append([]field.NormalizationRule{}, resourcevalidation.ResourceNormalizationRules...)
-					allRules = append(allRules, nodevalidation.NodeNormalizationRules...)
-					opts = append(opts, WithNormalizationRules(allRules...), WithFuzzer(f), WithSkipGroupVersions("extensions/v1beta1"))
-
-					if subresource != "" {
-						opts = append(opts, WithSubResources(subresource))
-					}
-					// extensions/v1beta1 is unserved and does not carry declarative validation,
-					// so skip it from the versioned validation equivalence sweep.
-					opts = append(opts, WithSkipGroupVersions("extensions/v1beta1"))
-					VerifyVersionedValidationEquivalence(t, obj, nil, opts...)
-
-					old, err := legacyscheme.Scheme.New(gv.WithKind(kind))
-					if err != nil {
-						t.Fatalf("could not create a %v: %s", kind, err)
-					}
-
-					VerifyVersionedValidationEquivalence(t, obj, old, opts...)
+	for _, gvk := range gvks {
+		t.Run(gvk.String(), func(t *testing.T) {
+			for range fuzzIters {
+				obj, err := legacyscheme.Scheme.New(gvk)
+				if err != nil {
+					t.Fatalf("could not create a %v: %s", gvk.Kind, err)
 				}
-			})
-		}
+
+				subresource := ""
+				if specific, ok := subresourceOnlyKinds[gvk.Kind]; ok {
+					subresource = specific
+				}
+
+				var opts []ValidationTestConfig
+				// TODO(API group level configuration): Consider configuring normalization rules at the
+				// API group level to avoid potential collisions when multiple rule sets are combined.
+				// This would allow each API group to register its own normalization rules independently.
+				allRules := append([]field.NormalizationRule{}, resourcevalidation.ResourceNormalizationRules...)
+				allRules = append(allRules, nodevalidation.NodeNormalizationRules...)
+				opts = append(opts, WithNormalizationRules(allRules...), WithFuzzer(f))
+
+				if subresource != "" {
+					opts = append(opts, WithSubResources(subresource))
+				}
+
+				VerifyVersionedValidationEquivalence(t, obj, nil, opts...)
+
+				old, err := legacyscheme.Scheme.New(gvk)
+				if err != nil {
+					t.Fatalf("could not create a %v: %s", gvk.Kind, err)
+				}
+
+				VerifyVersionedValidationEquivalence(t, obj, old, opts...)
+			}
+		})
 	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
@@ -387,6 +387,14 @@ func (s *Scheme) ValidateUpdate(ctx context.Context, options []string, object, o
 	return nil
 }
 
+// HasValidationFunc reports whether a validation function is registered for the
+// object's type. Unlike Validate, it distinguishes "no function registered" from
+// "function ran and found no errors", which both yield a nil error list.
+func (s *Scheme) HasValidationFunc(obj Object) bool {
+	_, ok := s.validationFuncs[reflect.TypeOf(obj)]
+	return ok
+}
+
 // Convert will attempt to convert in into out. Both must be pointers. For easy
 // testing of conversion functions. Returns an error if the conversion isn't
 // possible. You can call this with types that haven't been registered (for example,

--- a/test/declarative_validation/apps/daemonset/declarative_validation_test.go
+++ b/test/declarative_validation/apps/daemonset/declarative_validation_test.go
@@ -88,13 +88,11 @@ func TestDeclarativeValidate(t *testing.T) {
 		}
 		for k, tc := range testCases {
 			t.Run(k, func(t *testing.T) {
-				apitesting.VerifyValidationEquivalence(t, ctx, tc.input, registry.Strategy, tc.expectedErrs,
-					apitesting.WithSkipGroupVersions("extensions/v1beta1"))
+				apitesting.VerifyValidationEquivalence(t, ctx, tc.input, registry.Strategy, tc.expectedErrs)
 			})
 		}
 		meta.RunObjectMetaTestCases(t, ctx, mkDaemonSet(), registry.Strategy,
 			meta.WithStringentFinalizerValidation(),
-			meta.WithValidationConfig(apitesting.WithSkipGroupVersions("extensions/v1beta1")),
 		)
 	}
 }
@@ -109,7 +107,6 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 		})
 		meta.RunObjectMetaUpdateTestCases(t, ctx, mkDaemonSet(), registry.Strategy,
 			meta.WithStringentFinalizerValidation(),
-			meta.WithValidationConfig(apitesting.WithSkipGroupVersions("extensions/v1beta1")),
 		)
 	}
 }

--- a/test/declarative_validation/apps/deployment/declarative_validation_test.go
+++ b/test/declarative_validation/apps/deployment/declarative_validation_test.go
@@ -95,13 +95,11 @@ func TestDeclarativeValidate(t *testing.T) {
 		}
 		for k, tc := range testCases {
 			t.Run(k, func(t *testing.T) {
-				apitesting.VerifyValidationEquivalence(t, ctx, tc.input, registry.Strategy, tc.expectedErrs,
-					apitesting.WithSkipGroupVersions("extensions/v1beta1"))
+				apitesting.VerifyValidationEquivalence(t, ctx, tc.input, registry.Strategy, tc.expectedErrs)
 			})
 		}
 		meta.RunObjectMetaTestCases(t, ctx, mkDeployment(), registry.Strategy,
 			meta.WithStringentFinalizerValidation(),
-			meta.WithValidationConfig(apitesting.WithSkipGroupVersions("extensions/v1beta1")),
 		)
 	}
 }
@@ -116,7 +114,6 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 		})
 		meta.RunObjectMetaUpdateTestCases(t, ctx, mkDeployment(), registry.Strategy,
 			meta.WithStringentFinalizerValidation(),
-			meta.WithValidationConfig(apitesting.WithSkipGroupVersions("extensions/v1beta1")),
 		)
 	}
 }

--- a/test/declarative_validation/apps/replicaset/declarative_validation_test.go
+++ b/test/declarative_validation/apps/replicaset/declarative_validation_test.go
@@ -87,13 +87,11 @@ func TestDeclarativeValidate(t *testing.T) {
 		}
 		for k, tc := range testCases {
 			t.Run(k, func(t *testing.T) {
-				apitesting.VerifyValidationEquivalence(t, ctx, tc.input, registry.Strategy, tc.expectedErrs,
-					apitesting.WithSkipGroupVersions("extensions/v1beta1"))
+				apitesting.VerifyValidationEquivalence(t, ctx, tc.input, registry.Strategy, tc.expectedErrs)
 			})
 		}
 		meta.RunObjectMetaTestCases(t, ctx, mkReplicaSet(), registry.Strategy,
 			meta.WithStringentFinalizerValidation(),
-			meta.WithValidationConfig(apitesting.WithSkipGroupVersions("extensions/v1beta1")),
 		)
 	}
 }
@@ -108,7 +106,6 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 		})
 		meta.RunObjectMetaUpdateTestCases(t, ctx, mkReplicaSet(), registry.Strategy,
 			meta.WithStringentFinalizerValidation(),
-			meta.WithValidationConfig(apitesting.WithSkipGroupVersions("extensions/v1beta1")),
 		)
 	}
 }

--- a/test/declarative_validation/apps/scale/declarative_validation_test.go
+++ b/test/declarative_validation/apps/scale/declarative_validation_test.go
@@ -61,7 +61,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 				t.Run(k, func(t *testing.T) {
 					tc.old.ResourceVersion = "1"
 					tc.update.ResourceVersion = "1"
-					apitesting.VerifyUpdateValidationEquivalenceFunc(t, ctx, &tc.update, &tc.old, validateScale, tc.expectedErrs, apitesting.WithSubResources("scale"), apitesting.WithSkipGroupVersions("extensions/v1beta1"))
+					apitesting.VerifyUpdateValidationEquivalenceFunc(t, ctx, &tc.update, &tc.old, validateScale, tc.expectedErrs, apitesting.WithSubResources("scale"))
 				})
 			}
 		})

--- a/test/declarative_validation/autoscaling/scale/declarative_validation_test.go
+++ b/test/declarative_validation/autoscaling/scale/declarative_validation_test.go
@@ -61,7 +61,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 				t.Run(k, func(t *testing.T) {
 					tc.old.ResourceVersion = "1"
 					tc.update.ResourceVersion = "1"
-					apitesting.VerifyUpdateValidationEquivalenceFunc(t, ctx, &tc.update, &tc.old, validateScale, tc.expectedErrs, apitesting.WithSubResources("scale"), apitesting.WithSkipGroupVersions("extensions/v1beta1"))
+					apitesting.VerifyUpdateValidationEquivalenceFunc(t, ctx, &tc.update, &tc.old, validateScale, tc.expectedErrs, apitesting.WithSubResources("scale"))
 				})
 			}
 		})

--- a/test/declarative_validation/networking/networkpolicy/declarative_validation_test.go
+++ b/test/declarative_validation/networking/networkpolicy/declarative_validation_test.go
@@ -82,9 +82,6 @@ func TestDeclarativeValidateIPBlockCIDR(t *testing.T) {
 						&tc.input,
 						registry.Strategy,
 						tc.expectedErrs,
-						// extensions/v1beta1 is unserved and no longer carries
-						// declarative validation; skip it in the version sweep.
-						apitesting.WithSkipGroupVersions("extensions/v1beta1"),
 					)
 				})
 			}
@@ -155,9 +152,6 @@ func TestDeclarativeValidateIPBlockCIDRUpdate(t *testing.T) {
 						&tc.oldObj,
 						registry.Strategy,
 						tc.expectedErrs,
-						// extensions/v1beta1 is unserved and no longer carries
-						// declarative validation; skip it in the version sweep.
-						apitesting.WithSkipGroupVersions("extensions/v1beta1"),
 					)
 				})
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig api-machinery

#### What this PR does / why we need it:

`TestVersionedValidationByFuzzing` swept a hand-maintained list of group/versions. The list had drifted: a typo (`network.k8s.io` instead of `networking.k8s.io`, so it matched nothing) and several groups missing entirely (apps, policy, rbac, flowcontrol, scheduling). This replaces it with a sweep of the scheme for served GVKs that have declarative validation, so new group/versions are covered automatically with no hand maintenance.

To support this, `Scheme.HasValidationFunc` is added: `Validate` alone can't tell "no validation function registered" from "function ran and found no errors" (both return a nil error list).

The extensions/v1beta1 skip (it opts out of declarative validation but shares an internal type with versions that don't) is now applied centrally in `VerifyVersionedValidationEquivalence` instead of via a per-call option, so every caller gets it. Any *other* version missing declarative validation now fails the sweep instead of being silently skipped.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

First commit is the apimachinery `HasValidationFunc` addition (staging API), kept separate for independent review. Second is the test refactor. The new method's only consumer is the fuzz-test enumeration — there's no other way to scope it,
since `Validate` is ambiguous by design.

#### Does this PR introduce a user-facing change?

​```release-note
Added the `HasValidationFunc` method to `runtime.Scheme` to report whether a declarative validation function is registered for a type.
```
