### PR TITLE
[InPlacePodVerticalScaling] add metrics to determine deferred resize duration and priority

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -4099,6 +4099,38 @@
   componentEndpoints:
   - component: kubelet
     endpoint: /metrics
+- name: pod_deferred_resize_duration_seconds
+  subsystem: kubelet
+  help: 'Duration in seconds that a pod resize remains deferred before completion.
+    Label ''priority_bucket'' classifies the pod priority (system-critical: >=2000000000,
+    high: 100000..1999999999, medium: 1..99999, normal: 0/default, low: -999..-1,
+    very-low: <=-1000, unknown: nil pod). Label ''resolution'' describes how the deferred
+    resize was resolved (accepted, reverted, terminated).'
+  type: Histogram
+  stabilityLevel: ALPHA
+  labels:
+  - priority_bucket
+  - resolution
+  buckets:
+  - 5
+  - 10
+  - 15
+  - 20
+  - 30
+  - 45
+  - 60
+  - 90
+  - 120
+  - 150
+  - 180
+  - 300
+  - 600
+  - 1200
+  - 1800
+  - 3600
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: pod_in_progress_resizes
   subsystem: kubelet
   help: Number of in-progress resizes for pods.
@@ -4119,10 +4151,14 @@
     endpoint: /metrics
 - name: pod_pending_resizes
   subsystem: kubelet
-  help: Number of pending resizes for pods.
+  help: 'Number of pending resizes for pods. Label ''priority_bucket'' classifies
+    the pod priority (system-critical: >=2000000000, high: 100000..1999999999, medium:
+    1..99999, normal: 0/default, low: -999..-1, very-low: <=-1000, unknown: nil pod).
+    Label ''reason'' describes the state (deferred, infeasible).'
   type: Gauge
   stabilityLevel: ALPHA
   labels:
+  - priority_bucket
   - reason
   componentEndpoints:
   - component: kubelet

--- a/hack/tools/instrumentation/documentation/documentation.md
+++ b/hack/tools/instrumentation/documentation/documentation.md
@@ -8,7 +8,7 @@ description: >-
 
 ## Metrics (v1.37)
 
-<!-- (auto-generated 2026 Jul 15) -->
+<!-- (auto-generated 2026 Jul 17) -->
 <!-- (auto-generated v1.37) -->
 This page details the metrics that different Kubernetes components export. You can query the metrics endpoint for these 
 components using an HTTP scrape, and fetch the current metrics data in Prometheus format.
@@ -250,7 +250,7 @@ Stable metrics observe strict API contracts and no labels can be added or remove
 	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">scheduler_preemption_victims</div>
-	<div class="metric_help">Number of selected preemption victims</div>
+	<div class="metric_help">Number of selected preemption victims for preemption initiated by a single pod</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
@@ -620,12 +620,26 @@ Beta metrics observe a looser API contract than its stable counterparts. No labe
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">extension_point</span><span class="metric_label">plugin</span><span class="metric_label">profile</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
+	<div class="metric_name">scheduler_plugin_execution_duration_seconds</div>
+	<div class="metric_help">Duration for running a plugin at a specific extension point.</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
+	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">extension_point</span><span class="metric_label">plugin</span><span class="metric_label">status</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">scheduler_pod_scheduling_sli_duration_seconds</div>
 	<div class="metric_help">E2e latency for a pod being scheduled, from the time the pod enters the scheduling queue and might involve multiple scheduling attempts.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">attempts</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="beta">
+	<div class="metric_name">scheduler_scheduling_algorithm_duration_seconds</div>
+	<div class="metric_help">Scheduling algorithm latency in seconds</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
+	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">scheduler_unschedulable_pods</div>
 	<div class="metric_help">The number of unschedulable pods broken down by plugin name. A pod will increment the gauge for all plugins that caused it to not schedule and so this metric have meaning only when broken down by plugin.</div>
@@ -1327,20 +1341,6 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<li data-type="timingratiohistogram"><label class="metric_detail">Type:</label> <span class="metric_type">TimingRatioHistogram</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">phase</span><span class="metric_label">request_kind</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
-	<div class="metric_name">apiserver_flowcontrol_request_concurrency_in_use</div>
-	<div class="metric_help">Concurrency (number of seats) occupied by the currently executing (initial stage for a WATCH, any stage otherwise) requests in the API Priority and Fairness subsystem</div>
-	<ul>
-	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
-	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li><li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.31.0</span></li></ul>
-	</div><div class="metric" data-stability="alpha">
-	<div class="metric_name">apiserver_flowcontrol_request_concurrency_limit</div>
-	<div class="metric_help">Nominal number of execution seats configured for each priority level</div>
-	<ul>
-	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
-	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li><li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.30.0</span></li></ul>
-	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_request_dispatch_no_accommodation_total</div>
 	<div class="metric_help">Number of times a dispatch attempt resulted in a non accommodation due to lack of available seats</div>
 	<ul>
@@ -1544,13 +1544,6 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">component</span><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">scope</span><span class="metric_label">subresource</span><span class="metric_label">verb</span><span class="metric_label">version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
-	<div class="metric_name">apiserver_request_slo_duration_seconds</div>
-	<div class="metric_help">Response latency distribution (not counting webhook duration and priority & fairness queue wait times) in seconds for each verb, group, version, resource, subresource, scope and component.</div>
-	<ul>
-	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
-	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">component</span><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">scope</span><span class="metric_label">subresource</span><span class="metric_label">verb</span><span class="metric_label">version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li><li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.27.0</span></li></ul>
-	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_request_terminations_total</div>
 	<div class="metric_help">Number of requests which apiserver terminated in self-defense.</div>
 	<ul>
@@ -1613,13 +1606,6 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
 	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
-	</div><div class="metric" data-stability="alpha">
-	<div class="metric_name">apiserver_storage_db_total_size_in_bytes</div>
-	<div class="metric_help">Total size of the storage database file physically allocated in bytes.</div>
-	<ul>
-	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
-	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">endpoint</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li><li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.28.0</span></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_storage_decode_errors_total</div>
 	<div class="metric_help">Number of stored object decode errors split by object type</div>
@@ -2776,6 +2762,13 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">retry_trigger</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">kubelet_pod_deferred_resize_duration_seconds</div>
+	<div class="metric_help">Duration in seconds that a pod resize remains deferred before completion. Label 'priority_bucket' classifies the pod priority (system-critical, high, medium, normal, low, very-low, unknown). Label 'resolution' describes how the deferred resize was resolved (accepted, reverted, terminated).</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_bucket</span><span class="metric_label">resolution</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_pod_in_progress_resizes</div>
 	<div class="metric_help">Number of in-progress resizes for pods.</div>
 	<ul>
@@ -2791,11 +2784,11 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">reason_detail</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_pod_pending_resizes</div>
-	<div class="metric_help">Number of pending resizes for pods.</div>
+	<div class="metric_help">Number of pending resizes for pods. Label 'priority_bucket' classifies the pod priority (system-critical, high, medium, normal, low, very-low, unknown). Label 'reason' describes the state (deferred, infeasible).</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">reason</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_bucket</span><span class="metric_label">reason</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_pod_resize_duration_milliseconds</div>
 	<div class="metric_help">Duration in milliseconds to actuate a pod resize</div>
@@ -3819,13 +3812,6 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">call_type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
-	<div class="metric_name">scheduler_plugin_execution_duration_seconds</div>
-	<div class="metric_help">Duration for running a plugin at a specific extension point.</div>
-	<ul>
-	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
-	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">extension_point</span><span class="metric_label">plugin</span><span class="metric_label">status</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
-	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_pod_scheduled_after_flush_total</div>
 	<div class="metric_help">Number of pods that were successfully scheduled after being flushed from unschedulableEntities due to timeout. This metric helps detect potential queueing hint misconfigurations or event handling issues.</div>
 	<ul>
@@ -3854,12 +3840,26 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">profile</span><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">scheduler_preemption_evaluation_duration_seconds</div>
+	<div class="metric_help">Duration in seconds for identifying the target preemption victims.</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">preemptor</span><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">scheduler_preemption_execution_duration_seconds</div>
+	<div class="metric_help">Duration in seconds for preempting the target preemption victims. With async preemption enabled, preemption execution does not block the scheduling of other pods.</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">preemptor</span><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_preemption_goroutines_duration_seconds</div>
 	<div class="metric_help">Duration in seconds for running goroutines for the preemption.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li><li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.37.0</span></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_preemption_goroutines_execution_total</div>
 	<div class="metric_help">Number of preemption goroutines executed.</div>
@@ -3868,19 +3868,26 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">scheduler_preemption_pdb_violations_total</div>
+	<div class="metric_help">Total number of pod disruption budget violations caused by preemption.</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">preemptor</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">scheduler_preemption_workload_disruptions</div>
+	<div class="metric_help">Number of workload preemption units being preempted. A single preemption unit can be all pods in a pod group (in case of DisruptionMode=all), or a single pod (in case of DisruptionMode=single).</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">preemptor</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_queueing_hint_execution_duration_seconds</div>
 	<div class="metric_help">Duration for running a queueing hint function of a plugin.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">event</span><span class="metric_label">hint</span><span class="metric_label">plugin</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
-	</div><div class="metric" data-stability="alpha">
-	<div class="metric_name">scheduler_scheduling_algorithm_duration_seconds</div>
-	<div class="metric_help">Scheduling algorithm latency in seconds</div>
-	<ul>
-	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
-	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_store_schedule_results_duration_seconds</div>
 	<div class="metric_help">Latency for getting a no.</div>
@@ -3902,6 +3909,20 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">scheduler_workload_preemption_attempts_total</div>
+	<div class="metric_help">Total preemption attempts initiated by workload (including pod groups) in the cluster till now.</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">scheduler_workload_preemption_victims</div>
+	<div class="metric_help">Number of pod preemption victims caused by workload preemption.</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scrape_error</div>
 	<div class="metric_help">1 if there was an error while getting container metrics, 0 otherwise</div>

--- a/pkg/kubelet/allocation/allocation_manager.go
+++ b/pkg/kubelet/allocation/allocation_manager.go
@@ -541,7 +541,7 @@ func (m *manager) handlePodResourcesResize(ctx context.Context, pod *v1.Pod) (bo
 	_, updated := m.UpdatePodFromAllocation(pod)
 	if !updated {
 		// Desired resources == allocated resources. Pod allocation does not need to be updated.
-		m.statusManager.ClearPodResizePendingCondition(pod.UID)
+		m.statusManager.ClearPodResizePendingCondition(pod.UID, metrics.DeferredResizeResolutionReverted)
 		return false, nil
 	}
 
@@ -552,7 +552,7 @@ func (m *manager) handlePodResourcesResize(ctx context.Context, pod *v1.Pod) (bo
 		if err := m.SetAllocatedResources(logger, pod); err != nil {
 			return false, err
 		}
-		m.statusManager.ClearPodResizePendingCondition(pod.UID)
+		m.statusManager.ClearPodResizePendingCondition(pod.UID, metrics.DeferredResizeResolutionAccepted)
 
 		// Clear any errors that may have been surfaced from a previous resize and update the
 		// generation of the resize in-progress condition.

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2986,7 +2986,7 @@ func (kl *Kubelet) HandlePodUpdates(ctx context.Context, pods []*v1.Pod) {
 				} else {
 					// We can hit this case if a pending resize has been reverted,
 					// so we need to clear the pending resize condition.
-					kl.statusManager.ClearPodResizePendingCondition(pod.UID)
+					kl.statusManager.ClearPodResizePendingCondition(pod.UID, metrics.DeferredResizeResolutionReverted)
 				}
 			}
 		}

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1890,7 +1890,7 @@ func (kl *Kubelet) determinePodResizeStatus(allocatedPod *v1.Pod, podIsTerminal 
 	// If pod is terminal, clear the resize status.
 	if podIsTerminal {
 		kl.statusManager.ClearPodResizeInProgressCondition(allocatedPod.UID)
-		kl.statusManager.ClearPodResizePendingCondition(allocatedPod.UID)
+		kl.statusManager.ClearPodResizePendingCondition(allocatedPod.UID, metrics.DeferredResizeResolutionTerminated)
 		return nil
 	}
 

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -5063,7 +5063,7 @@ func TestHandlePodReconcile_RetryPendingResizes(t *testing.T) {
 			kubelet.podManager.AddPod(tc.oldPod)
 			kubelet.allocationManager.PushPendingResize(logger, pendingResizeDesired.UID)
 
-			kubelet.statusManager.ClearPodResizePendingCondition(pendingResizeDesired.UID)
+			kubelet.statusManager.ClearPodResizePendingCondition(pendingResizeDesired.UID, metrics.DeferredResizeResolutionAccepted)
 			kubelet.HandlePodReconcile(tCtx, []*v1.Pod{tc.newPod})
 			require.Equal(t, tc.shouldRetryPendingResize, kubelet.statusManager.IsPodResizeDeferred(pendingResizeDesired.UID))
 

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -23,8 +23,10 @@ import (
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/kubernetes/pkg/apis/scheduling"
 	"k8s.io/kubernetes/pkg/features"
 )
 
@@ -205,6 +207,20 @@ const (
 
 	// Metric key for podsapi
 	PodWatchEventsDroppedKey = "pod_watch_events_dropped_total"
+)
+
+// PriorityBucket represents the priority bucket label value for pod resize metrics.
+type PriorityBucket string
+
+const (
+	// Priority bucket label values for pod resize metrics.
+	PriorityBucketSystemCritical PriorityBucket = "system-critical"
+	PriorityBucketHigh           PriorityBucket = "high"
+	PriorityBucketMedium         PriorityBucket = "medium"
+	PriorityBucketNormal         PriorityBucket = "normal"
+	PriorityBucketLow            PriorityBucket = "low"
+	PriorityBucketVeryLow        PriorityBucket = "very-low"
+	PriorityBucketUnknown        PriorityBucket = "unknown"
 )
 
 type imageSizeBucket struct {
@@ -1223,10 +1239,10 @@ var (
 		&metrics.GaugeOpts{
 			Subsystem:      KubeletSubsystem,
 			Name:           PodPendingResizesKey,
-			Help:           "Number of pending resizes for pods.",
+			Help:           "Number of pending resizes for pods. Label 'priority_bucket' classifies the pod priority (system-critical: >=2000000000, high: 100000..1999999999, medium: 1..99999, normal: 0/default, low: -999..-1, very-low: <=-1000, unknown: nil pod). Label 'reason' describes the state (deferred, infeasible).",
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"reason"},
+		[]string{"reason", "priority_bucket"},
 	)
 
 	// PodInfeasibleResizes tracks the number of infeasible resizes for pods.
@@ -1475,3 +1491,35 @@ func GetImageSizeBucket(sizeInBytes uint64) string {
 	// return empty string when sizeInBytes is 0 (error getting image size)
 	return ""
 }
+
+// GetPriorityBucketLabel returns the priority bucket label value for a given pod based on its priority value.
+// Mappings:
+//   - system-critical: priority >= 2000000000 (SystemCriticalPriority)
+//   - high: 100000 <= priority < 2000000000
+//   - medium: 1 <= priority < 100000
+//   - normal: priority == 0 or default (DefaultPriorityWhenNoDefaultClassExists)
+//   - low: -999 <= priority <= -1
+//   - very-low: priority <= -1000
+//   - unknown: pod is nil
+func GetPriorityBucketLabel(pod *v1.Pod) PriorityBucket {
+	if pod == nil {
+		return PriorityBucketUnknown
+	}
+	if pod.Spec.Priority == nil || *pod.Spec.Priority == scheduling.DefaultPriorityWhenNoDefaultClassExists {
+		return PriorityBucketNormal
+	}
+	p := *pod.Spec.Priority
+	switch {
+	case p >= scheduling.SystemCriticalPriority:
+		return PriorityBucketSystemCritical
+	case p >= 100000:
+		return PriorityBucketHigh
+	case p > 0:
+		return PriorityBucketMedium
+	case p > -1000:
+		return PriorityBucketLow
+	default:
+		return PriorityBucketVeryLow
+	}
+}
+

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -195,12 +195,13 @@ const (
 	DRAResourceClaimsInUseAnyDriver = "<any>"
 
 	// Metric keys for in-place pod resize operations.
-	ContainerRequestedResizesKey     = "container_requested_resizes_total"
-	PodResizeDurationMillisecondsKey = "pod_resize_duration_milliseconds"
-	PodPendingResizesKey             = "pod_pending_resizes"
-	PodInfeasibleResizesKey          = "pod_infeasible_resizes_total"
-	PodInProgressResizesKey          = "pod_in_progress_resizes"
-	PodDeferredAcceptedResizesKey    = "pod_deferred_accepted_resizes_total"
+	ContainerRequestedResizesKey        = "container_requested_resizes_total"
+	PodResizeDurationMillisecondsKey    = "pod_resize_duration_milliseconds"
+	PodPendingResizesKey                = "pod_pending_resizes"
+	PodInfeasibleResizesKey             = "pod_infeasible_resizes_total"
+	PodInProgressResizesKey             = "pod_in_progress_resizes"
+	PodDeferredAcceptedResizesKey       = "pod_deferred_accepted_resizes_total"
+	PodDeferredResizeDurationSecondsKey = "pod_deferred_resize_duration_seconds"
 
 	// Metric key for podcertificate states.
 	PodCertificateStatesKey = "podcertificate_states"
@@ -221,6 +222,16 @@ const (
 	PriorityBucketLow            PriorityBucket = "low"
 	PriorityBucketVeryLow        PriorityBucket = "very-low"
 	PriorityBucketUnknown        PriorityBucket = "unknown"
+)
+
+// DeferredResizeResolution represents the resolution status label value for pod deferred resize duration metric.
+type DeferredResizeResolution string
+
+const (
+	// Deferred resize resolution label values for pod deferred resize duration metric.
+	DeferredResizeResolutionAccepted   DeferredResizeResolution = "accepted"
+	DeferredResizeResolutionReverted   DeferredResizeResolution = "reverted"
+	DeferredResizeResolutionTerminated DeferredResizeResolution = "terminated"
 )
 
 type imageSizeBucket struct {
@@ -255,6 +266,9 @@ var (
 
 	// podResizeDurationBuckets is the bucket boundaries for pod_resize_duration_milliseconds metrics.
 	podResizeDurationBuckets = []float64{10, 50, 100, 500, 1000, 2000, 5000, 10000, 20000, 30000, 60000, 120000, 300000, 600000}
+
+	// podDeferredResizeDurationBuckets is the bucket boundaries for pod_deferred_resize_duration_seconds metrics.
+	podDeferredResizeDurationBuckets = []float64{5, 10, 15, 20, 30, 45, 60, 90, 120, 150, 180, 300, 600, 1200, 1800, 3600}
 )
 
 var (
@@ -1277,6 +1291,18 @@ var (
 		[]string{"retry_trigger"},
 	)
 
+	// PodDeferredResizeDurationSeconds tracks the duration (in seconds) that a pod remains deferred before completion.
+	PodDeferredResizeDurationSeconds = metrics.NewHistogramVec(
+		&metrics.HistogramOpts{
+			Subsystem:      KubeletSubsystem,
+			Name:           PodDeferredResizeDurationSecondsKey,
+			Help:           "Duration in seconds that a pod resize remains deferred before completion. Label 'priority_bucket' classifies the pod priority (system-critical: >=2000000000, high: 100000..1999999999, medium: 1..99999, normal: 0/default, low: -999..-1, very-low: <=-1000, unknown: nil pod). Label 'resolution' describes how the deferred resize was resolved (accepted, reverted, terminated).",
+			Buckets:        podDeferredResizeDurationBuckets,
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"resolution", "priority_bucket"},
+	)
+
 	// ResourceManagerAllocationsTotal counts the total number of exclusive resource
 	// allocations performed by a manager. The `source` label distinguishes between
 	// allocations drawn from the node-level pool versus a pre-allocated pod-level pool.
@@ -1446,6 +1472,7 @@ func Register() {
 			legacyregistry.MustRegister(PodInfeasibleResizes)
 			legacyregistry.MustRegister(PodInProgressResizes)
 			legacyregistry.MustRegister(PodDeferredAcceptedResizes)
+			legacyregistry.MustRegister(PodDeferredResizeDurationSeconds)
 		}
 
 		if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResourceManagers) {
@@ -1522,4 +1549,3 @@ func GetPriorityBucketLabel(pod *v1.Pod) PriorityBucket {
 		return PriorityBucketVeryLow
 	}
 }
-

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -188,7 +188,7 @@ type Manager interface {
 	SetPodResizeInProgressCondition(podUID types.UID, reason, message string, observedGeneration int64) (int64, bool)
 
 	// ClearPodResizePendingCondition clears the PodResizePending condition for the pod from the cache.
-	ClearPodResizePendingCondition(podUID types.UID)
+	ClearPodResizePendingCondition(podUID types.UID, resolution metrics.DeferredResizeResolution)
 
 	// ClearPodResizeInProgressCondition clears the PodResizeInProgress condition for the pod from the cache.
 	// If the condition was cleared, it returns the observedGeneration of the cleared condition and true.
@@ -369,14 +369,29 @@ func (m *manager) SetPodResizeInProgressCondition(podUID types.UID, reason, mess
 	return observedGeneration, !reflect.DeepEqual(previousCondition, m.podResizeConditions[podUID].PodResizeInProgress)
 }
 
+func (m *manager) observeDeferredResizeDuration(podUID types.UID, cond *v1.PodCondition, resolution metrics.DeferredResizeResolution) {
+	if cond == nil || cond.Reason != v1.PodReasonDeferred || cond.LastTransitionTime.IsZero() {
+		return
+	}
+	// If the pod was already removed from the pod manager (e.g. during pod deletion cleanup),
+	// GetPodByUID will return nil. GetPriorityBucketLabel(nil) will return PriorityBucketUnknown ("unknown").
+	pod, _ := m.podManager.GetPodByUID(podUID)
+	priorityBucket := metrics.GetPriorityBucketLabel(pod)
+	duration := time.Since(cond.LastTransitionTime.Time).Seconds()
+	metrics.PodDeferredResizeDurationSeconds.WithLabelValues(string(resolution), string(priorityBucket)).Observe(duration)
+}
+
 // ClearPodResizePendingCondition clears the PodResizePending condition for the pod from the cache.
-func (m *manager) ClearPodResizePendingCondition(podUID types.UID) {
+func (m *manager) ClearPodResizePendingCondition(podUID types.UID, resolution metrics.DeferredResizeResolution) {
 	m.podStatusesLock.Lock()
 	defer m.podStatusesLock.Unlock()
 
-	if m.podResizeConditions[podUID].PodResizePending == nil {
+	cond := m.podResizeConditions[podUID].PodResizePending
+	if cond == nil {
 		return
 	}
+
+	m.observeDeferredResizeDuration(podUID, cond, resolution)
 
 	m.podResizeConditions[podUID] = podResizeConditions{
 		PodResizeInProgress: m.podResizeConditions[podUID].PodResizeInProgress,
@@ -1043,7 +1058,8 @@ func (m *manager) deletePodStatus(uid types.UID) {
 	delete(m.podStatuses, uid)
 	m.podStartupLatencyHelper.DeletePodStartupState(uid)
 	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
-		if _, exists := m.podResizeConditions[uid]; exists {
+		if conds, exists := m.podResizeConditions[uid]; exists {
+			m.observeDeferredResizeDuration(uid, conds.PodResizePending, metrics.DeferredResizeResolutionTerminated)
 			delete(m.podResizeConditions, uid)
 			m.recordInProgressResizeCount()
 			m.observePendingResizeCount()
@@ -1060,7 +1076,8 @@ func (m *manager) RemoveOrphanedStatuses(logger klog.Logger, podUIDs map[types.U
 			logger.V(5).Info("Removing pod from status map", "podUID", key)
 			delete(m.podStatuses, key)
 			if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
-				if _, exists := m.podResizeConditions[key]; exists {
+				if conds, exists := m.podResizeConditions[key]; exists {
+					m.observeDeferredResizeDuration(key, conds.PodResizePending, metrics.DeferredResizeResolutionTerminated)
 					delete(m.podResizeConditions, key)
 					m.recordInProgressResizeCount()
 					m.observePendingResizeCount()

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -326,7 +326,7 @@ func (m *manager) SetPodResizePendingCondition(podUID types.UID, reason, message
 	}
 
 	if previousCondition == nil {
-		m.recordPendingResizeCount()
+		m.observePendingResizeCount()
 		return true
 	} else {
 		return previousCondition.Reason != reason || previousCondition.ObservedGeneration != observedGeneration
@@ -383,7 +383,7 @@ func (m *manager) ClearPodResizePendingCondition(podUID types.UID) {
 		PodResizePending:    nil,
 	}
 
-	m.recordPendingResizeCount()
+	m.observePendingResizeCount()
 }
 
 // ClearPodResizeInProgressCondition clears the PodResizeInProgress condition for the pod from the cache.
@@ -434,7 +434,7 @@ func (m *manager) BackfillPodResizeConditions(pods []*v1.Pod) {
 			}
 		}
 	}
-	m.recordPendingResizeCount()
+	m.observePendingResizeCount()
 	m.recordInProgressResizeCount()
 }
 
@@ -1046,7 +1046,7 @@ func (m *manager) deletePodStatus(uid types.UID) {
 		if _, exists := m.podResizeConditions[uid]; exists {
 			delete(m.podResizeConditions, uid)
 			m.recordInProgressResizeCount()
-			m.recordPendingResizeCount()
+			m.observePendingResizeCount()
 		}
 	}
 }
@@ -1063,7 +1063,7 @@ func (m *manager) RemoveOrphanedStatuses(logger klog.Logger, podUIDs map[types.U
 				if _, exists := m.podResizeConditions[key]; exists {
 					delete(m.podResizeConditions, key)
 					m.recordInProgressResizeCount()
-					m.recordPendingResizeCount()
+					m.observePendingResizeCount()
 				}
 			}
 		}
@@ -1467,18 +1467,28 @@ func updatedPodResizeCondition(conditionType v1.PodConditionType, oldCondition *
 	}
 }
 
-// recordPendingResizeCount sets the pending resize metric.
-func (m *manager) recordPendingResizeCount() {
-	pendingResizeCount := make(map[string]int)
-	for _, conditions := range m.podResizeConditions {
+// observePendingResizeCount sets the pending resize metric.
+func (m *manager) observePendingResizeCount() {
+	type pendingKey struct {
+		reason         string
+		priorityBucket metrics.PriorityBucket
+	}
+	pendingResizeCount := make(map[pendingKey]int)
+	for uid, conditions := range m.podResizeConditions {
 		if conditions.PodResizePending != nil {
-			pendingResizeCount[strings.ToLower(conditions.PodResizePending.Reason)]++
+			pod, ok := m.podManager.GetPodByUID(uid)
+			if !ok {
+				continue
+			}
+			reason := strings.ToLower(conditions.PodResizePending.Reason)
+			priorityBucket := metrics.GetPriorityBucketLabel(pod)
+			pendingResizeCount[pendingKey{reason: reason, priorityBucket: priorityBucket}]++
 		}
 	}
 
 	metrics.PodPendingResizes.Reset()
-	for reason, count := range pendingResizeCount {
-		metrics.PodPendingResizes.WithLabelValues(reason).Set(float64(count))
+	for k, count := range pendingResizeCount {
+		metrics.PodPendingResizes.WithLabelValues(k.reason, string(k.priorityBucket)).Set(float64(count))
 	}
 }
 

--- a/pkg/kubelet/status/status_manager_test.go
+++ b/pkg/kubelet/status/status_manager_test.go
@@ -2773,9 +2773,11 @@ func TestRecordInProgressResizeCount(t *testing.T) {
 
 func TestRecordPendingResizesCount(t *testing.T) {
 	metrics.Register()
+	int32Ptr := func(val int32) *int32 { return &val }
 
 	for _, tc := range []struct {
 		name               string
+		existingPods       []*v1.Pod
 		existingConditions map[types.UID]podResizeConditions
 		expected           string
 	}{
@@ -2799,6 +2801,9 @@ func TestRecordPendingResizesCount(t *testing.T) {
 		},
 		{
 			name: "one pod deferred",
+			existingPods: []*v1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "test-pod", UID: "test-pod"}},
+			},
 			existingConditions: map[types.UID]podResizeConditions{
 				"test-pod": {
 					PodResizePending: &v1.PodCondition{
@@ -2810,13 +2815,17 @@ func TestRecordPendingResizesCount(t *testing.T) {
 				},
 			},
 			expected: `
-			    # HELP kubelet_pod_pending_resizes [ALPHA] Number of pending resizes for pods.
+			    # HELP kubelet_pod_pending_resizes [ALPHA] Number of pending resizes for pods. Label 'priority_bucket' classifies the pod priority (system-critical: >=2000000000, high: 100000..1999999999, medium: 1..99999, normal: 0/default, low: -999..-1, very-low: <=-1000, unknown: nil pod). Label 'reason' describes the state (deferred, infeasible).
 				# TYPE kubelet_pod_pending_resizes gauge
-				kubelet_pod_pending_resizes{reason="deferred"} 1
+				kubelet_pod_pending_resizes{priority_bucket="normal",reason="deferred"} 1
 			`,
 		},
 		{
 			name: "2 pods infeasible, each with a different reason",
+			existingPods: []*v1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "test-pod-1", UID: "test-pod-1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "test-pod-2", UID: "test-pod-2"}},
+			},
 			existingConditions: map[types.UID]podResizeConditions{
 				"test-pod-1": {
 					PodResizePending: &v1.PodCondition{
@@ -2836,13 +2845,17 @@ func TestRecordPendingResizesCount(t *testing.T) {
 				},
 			},
 			expected: `
-			    # HELP kubelet_pod_pending_resizes [ALPHA] Number of pending resizes for pods.
+			    # HELP kubelet_pod_pending_resizes [ALPHA] Number of pending resizes for pods. Label 'priority_bucket' classifies the pod priority (system-critical: >=2000000000, high: 100000..1999999999, medium: 1..99999, normal: 0/default, low: -999..-1, very-low: <=-1000, unknown: nil pod). Label 'reason' describes the state (deferred, infeasible).
 				# TYPE kubelet_pod_pending_resizes gauge
-				kubelet_pod_pending_resizes{reason="infeasible"} 2
+				kubelet_pod_pending_resizes{priority_bucket="normal",reason="infeasible"} 2
 			`,
 		},
 		{
 			name: "one deferred, one infeasible",
+			existingPods: []*v1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "test-pod-1", UID: "test-pod-1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "test-pod-2", UID: "test-pod-2"}},
+			},
 			existingConditions: map[types.UID]podResizeConditions{
 				"test-pod-1": {
 					PodResizePending: &v1.PodCondition{
@@ -2862,10 +2875,81 @@ func TestRecordPendingResizesCount(t *testing.T) {
 				},
 			},
 			expected: `
-			    # HELP kubelet_pod_pending_resizes [ALPHA] Number of pending resizes for pods.
+			    # HELP kubelet_pod_pending_resizes [ALPHA] Number of pending resizes for pods. Label 'priority_bucket' classifies the pod priority (system-critical: >=2000000000, high: 100000..1999999999, medium: 1..99999, normal: 0/default, low: -999..-1, very-low: <=-1000, unknown: nil pod). Label 'reason' describes the state (deferred, infeasible).
 				# TYPE kubelet_pod_pending_resizes gauge
-				kubelet_pod_pending_resizes{reason="deferred"} 1
-				kubelet_pod_pending_resizes{reason="infeasible"} 1
+				kubelet_pod_pending_resizes{priority_bucket="normal",reason="deferred"} 1
+				kubelet_pod_pending_resizes{priority_bucket="normal",reason="infeasible"} 1
+			`,
+		},
+		{
+			name: "multiple pods with different priority classes",
+			existingPods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod-sys", UID: "sys-uid"},
+					Spec:       v1.PodSpec{Priority: int32Ptr(2000000000)},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod-high", UID: "high-uid"},
+					Spec:       v1.PodSpec{Priority: int32Ptr(100000)},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod-med", UID: "med-uid"},
+					Spec:       v1.PodSpec{Priority: int32Ptr(5000)},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod-low", UID: "low-uid"},
+					Spec:       v1.PodSpec{Priority: int32Ptr(-500)},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod-vlow", UID: "vlow-uid"},
+					Spec:       v1.PodSpec{Priority: int32Ptr(-1500)},
+				},
+			},
+			existingConditions: map[types.UID]podResizeConditions{
+				"sys-uid": {
+					PodResizePending: &v1.PodCondition{
+						Type:   v1.PodResizePending,
+						Status: v1.ConditionTrue,
+						Reason: v1.PodReasonDeferred,
+					},
+				},
+				"high-uid": {
+					PodResizePending: &v1.PodCondition{
+						Type:   v1.PodResizePending,
+						Status: v1.ConditionTrue,
+						Reason: v1.PodReasonDeferred,
+					},
+				},
+				"med-uid": {
+					PodResizePending: &v1.PodCondition{
+						Type:   v1.PodResizePending,
+						Status: v1.ConditionTrue,
+						Reason: v1.PodReasonInfeasible,
+					},
+				},
+				"low-uid": {
+					PodResizePending: &v1.PodCondition{
+						Type:   v1.PodResizePending,
+						Status: v1.ConditionTrue,
+						Reason: v1.PodReasonDeferred,
+					},
+				},
+				"vlow-uid": {
+					PodResizePending: &v1.PodCondition{
+						Type:   v1.PodResizePending,
+						Status: v1.ConditionTrue,
+						Reason: v1.PodReasonInfeasible,
+					},
+				},
+			},
+			expected: `
+			    # HELP kubelet_pod_pending_resizes [ALPHA] Number of pending resizes for pods. Label 'priority_bucket' classifies the pod priority (system-critical: >=2000000000, high: 100000..1999999999, medium: 1..99999, normal: 0/default, low: -999..-1, very-low: <=-1000, unknown: nil pod). Label 'reason' describes the state (deferred, infeasible).
+				# TYPE kubelet_pod_pending_resizes gauge
+				kubelet_pod_pending_resizes{priority_bucket="high",reason="deferred"} 1
+				kubelet_pod_pending_resizes{priority_bucket="low",reason="deferred"} 1
+				kubelet_pod_pending_resizes{priority_bucket="medium",reason="infeasible"} 1
+				kubelet_pod_pending_resizes{priority_bucket="system-critical",reason="deferred"} 1
+				kubelet_pod_pending_resizes{priority_bucket="very-low",reason="infeasible"} 1
 			`,
 		},
 		{
@@ -2875,8 +2959,11 @@ func TestRecordPendingResizesCount(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			manager := newTestManager(&fake.Clientset{})
+			for _, p := range tc.existingPods {
+				manager.podManager.(mutablePodManager).AddPod(p)
+			}
 			manager.podResizeConditions = tc.existingConditions
-			manager.recordPendingResizeCount()
+			manager.observePendingResizeCount()
 
 			require.NoError(t, testutil.GatherAndCompare(
 				legacyregistry.DefaultGatherer, strings.NewReader(tc.expected), "kubelet_pod_pending_resizes",
@@ -2972,6 +3059,9 @@ func TestBackfillPodResizeConditions(t *testing.T) {
 	}
 
 	manager := newTestManager(&fake.Clientset{})
+	for _, p := range pods {
+		manager.podManager.(mutablePodManager).AddPod(p)
+	}
 	manager.BackfillPodResizeConditions(pods)
 	actualResizeConditions := manager.podResizeConditions
 	expectedResizeConditions := map[types.UID]podResizeConditions{
@@ -3031,10 +3121,10 @@ func TestBackfillPodResizeConditions(t *testing.T) {
 	require.Equal(t, expectedResizeConditions, actualResizeConditions)
 
 	expectedMetrics := `
-		# HELP kubelet_pod_pending_resizes [ALPHA] Number of pending resizes for pods.
+		# HELP kubelet_pod_pending_resizes [ALPHA] Number of pending resizes for pods. Label 'priority_bucket' classifies the pod priority (system-critical: >=2000000000, high: 100000..1999999999, medium: 1..99999, normal: 0/default, low: -999..-1, very-low: <=-1000, unknown: nil pod). Label 'reason' describes the state (deferred, infeasible).
 		# TYPE kubelet_pod_pending_resizes gauge
-		kubelet_pod_pending_resizes{reason="deferred"} 1
-		kubelet_pod_pending_resizes{reason="infeasible"} 1
+		kubelet_pod_pending_resizes{priority_bucket="normal",reason="deferred"} 1
+		kubelet_pod_pending_resizes{priority_bucket="normal",reason="infeasible"} 1
 	`
 	require.NoError(t, testutil.GatherAndCompare(
 		legacyregistry.DefaultGatherer, strings.NewReader(expectedMetrics), "kubelet_pod_pending_resizes",

--- a/pkg/kubelet/status/status_manager_test.go
+++ b/pkg/kubelet/status/status_manager_test.go
@@ -2612,7 +2612,7 @@ func TestPodResizeConditions(t *testing.T) {
 		{
 			name: "clear pod resize pending condition",
 			updateFunc: func(podUID types.UID) bool {
-				m.ClearPodResizePendingCondition(podUID)
+				m.ClearPodResizePendingCondition(podUID, metrics.DeferredResizeResolutionAccepted)
 				return false
 			},
 			expected: nil,
@@ -3183,5 +3183,157 @@ func getPodStatus() v1.PodStatus {
 			},
 		},
 		Message: "Message",
+	}
+}
+
+func TestPodDeferredResizeDurationSeconds(t *testing.T) {
+	metrics.Register()
+	int32Ptr := func(val int32) *int32 { return &val }
+
+	testCases := []struct {
+		name               string
+		podUID             types.UID
+		priority           *int32
+		conditionReason    string
+		action             string // "clear", "delete", "orphan"
+		resolution         metrics.DeferredResizeResolution
+		expectedResolution metrics.DeferredResizeResolution
+		expectedPriority   metrics.PriorityBucket
+		expectedCount      int
+		podMissing         bool
+	}{
+		{
+			name:               "no condition present - no metric emitted",
+			podUID:             "pod-no-cond",
+			priority:           int32Ptr(0),
+			conditionReason:    "",
+			action:             "clear",
+			resolution:         metrics.DeferredResizeResolutionAccepted,
+			expectedResolution: metrics.DeferredResizeResolutionAccepted,
+			expectedPriority:   metrics.PriorityBucketNormal,
+			expectedCount:      0,
+		},
+		{
+			name:               "infeasible condition - no metric emitted",
+			podUID:             "pod-infeasible",
+			priority:           int32Ptr(0),
+			conditionReason:    v1.PodReasonInfeasible,
+			action:             "clear",
+			resolution:         metrics.DeferredResizeResolutionAccepted,
+			expectedResolution: metrics.DeferredResizeResolutionAccepted,
+			expectedPriority:   metrics.PriorityBucketNormal,
+			expectedCount:      0,
+		},
+		{
+			name:               "deferred condition cleared as accepted",
+			podUID:             "pod-accepted",
+			priority:           int32Ptr(100000),
+			conditionReason:    v1.PodReasonDeferred,
+			action:             "clear",
+			resolution:         metrics.DeferredResizeResolutionAccepted,
+			expectedResolution: metrics.DeferredResizeResolutionAccepted,
+			expectedPriority:   metrics.PriorityBucketHigh,
+			expectedCount:      1,
+		},
+		{
+			name:               "deferred condition cleared as reverted",
+			podUID:             "pod-reverted",
+			priority:           int32Ptr(-500),
+			conditionReason:    v1.PodReasonDeferred,
+			action:             "clear",
+			resolution:         metrics.DeferredResizeResolutionReverted,
+			expectedResolution: metrics.DeferredResizeResolutionReverted,
+			expectedPriority:   metrics.PriorityBucketLow,
+			expectedCount:      1,
+		},
+		{
+			name:               "deferred condition removed via DeletePodStatus as terminated",
+			podUID:             "pod-deleted",
+			priority:           int32Ptr(2000000000),
+			conditionReason:    v1.PodReasonDeferred,
+			action:             "delete",
+			expectedResolution: metrics.DeferredResizeResolutionTerminated,
+			expectedPriority:   metrics.PriorityBucketSystemCritical,
+			expectedCount:      1,
+		},
+		{
+			name:               "deferred condition removed via RemoveOrphanedStatuses as terminated",
+			podUID:             "pod-orphaned",
+			priority:           int32Ptr(-1500),
+			conditionReason:    v1.PodReasonDeferred,
+			action:             "orphan",
+			expectedResolution: metrics.DeferredResizeResolutionTerminated,
+			expectedPriority:   metrics.PriorityBucketVeryLow,
+			expectedCount:      1,
+		},
+		{
+			name:               "deferred condition removed via DeletePodStatus as terminated with missing pod (unknown priority)",
+			podUID:             "pod-deleted-missing",
+			priority:           int32Ptr(0), // Doesn't matter because pod is missing
+			conditionReason:    v1.PodReasonDeferred,
+			action:             "delete",
+			expectedResolution: metrics.DeferredResizeResolutionTerminated,
+			expectedPriority:   metrics.PriorityBucketUnknown,
+			expectedCount:      1,
+			podMissing:         true,
+		},
+		{
+			name:               "deferred condition removed via RemoveOrphanedStatuses as terminated with missing pod (unknown priority)",
+			podUID:             "pod-orphaned-missing",
+			priority:           int32Ptr(0), // Doesn't matter because pod is missing
+			conditionReason:    v1.PodReasonDeferred,
+			action:             "orphan",
+			expectedResolution: metrics.DeferredResizeResolutionTerminated,
+			expectedPriority:   metrics.PriorityBucketUnknown,
+			expectedCount:      1,
+			podMissing:         true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			metrics.PodDeferredResizeDurationSeconds.Reset()
+			manager := newTestManager(&fake.Clientset{})
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: string(tc.podUID), UID: tc.podUID},
+				Spec:       v1.PodSpec{Priority: tc.priority},
+			}
+			if !tc.podMissing {
+				manager.podManager.(mutablePodManager).AddPod(pod)
+			}
+
+			if tc.conditionReason != "" {
+				manager.podResizeConditions[tc.podUID] = podResizeConditions{
+					PodResizePending: &v1.PodCondition{
+						Type:               v1.PodResizePending,
+						Status:             v1.ConditionTrue,
+						Reason:             tc.conditionReason,
+						LastTransitionTime: metav1.Time{Time: time.Now().Add(-30 * time.Second)},
+					},
+				}
+			}
+			if tc.action == "delete" || tc.action == "orphan" {
+				manager.podStatuses[tc.podUID] = versionedPodStatus{
+					status: v1.PodStatus{Phase: v1.PodRunning},
+				}
+			}
+
+			switch tc.action {
+			case "clear":
+				manager.ClearPodResizePendingCondition(tc.podUID, tc.resolution)
+			case "delete":
+				manager.deletePodStatus(tc.podUID)
+			case "orphan":
+				manager.RemoveOrphanedStatuses(klog.Background(), map[types.UID]bool{})
+			}
+
+			count, err := testutil.GetHistogramMetricCount(
+				metrics.PodDeferredResizeDurationSeconds.WithLabelValues(string(tc.expectedResolution), string(tc.expectedPriority)),
+			)
+			if tc.expectedCount == 0 && err != nil {
+				count = 0
+			}
+			require.Equal(t, uint64(tc.expectedCount), count)
+		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR enhances In-Place Pod Vertical Scaling observability for resizes in the `Deferred` statuses in two commits.

1. Adds the `priority_bucket` label to the `pod_pending_resizes` gauge to track the current queue depth and backlog of pending pod resizes across priority tiers.
2. Introduces the `pod_deferred_resize_duration_seconds` histogram labeled by `resolution` (`accepted`, `reverted`, `terminated`) and `priority_bucket` to measure completion latency. This is only emitted when a deferred condition was actually present and cleared.

This is partially motivated by but does not depend on https://github.com/kubernetes/enhancements/issues/5836. It gives us an idea of how long high-priority resizes are stuck in `Deferred` status.

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
Add alpha kubelet metric `kubelet_pod_deferred_resize_duration_seconds` histogram and add `priority_bucket` label to `kubelet_pod_pending_resizes` gauge.
```

Assisted by Antigravity

/sig node instrumentation
/assign @tallclair