### PR TITLE
Simplify scale validation

### DIFF
--- a/pkg/apis/autoscaling/validation/validation.go
+++ b/pkg/apis/autoscaling/validation/validation.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/api/validate/content"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
+	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -43,6 +44,9 @@ const (
 // ValidateScale validates a Scale and returns an ErrorList with any errors.
 func ValidateScale(scale *autoscaling.Scale) field.ErrorList {
 	allErrs := field.ErrorList{}
+	// Only validate managed fields and replicas. Other metadata fields are ignored
+	// and discarded by the scale subresource handler.
+	allErrs = append(allErrs, metav1validation.ValidateManagedFields(scale.GetManagedFields(), field.NewPath("metadata").Child("managedFields"))...)
 	if scale.Spec.Replicas < 0 {
 		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(scale.Spec.Replicas), field.NewPath("spec", "replicas")).MarkCoveredByDeclarative()...)
 	}

--- a/pkg/apis/autoscaling/validation/validation.go
+++ b/pkg/apis/autoscaling/validation/validation.go
@@ -43,8 +43,6 @@ const (
 // ValidateScale validates a Scale and returns an ErrorList with any errors.
 func ValidateScale(scale *autoscaling.Scale) field.ErrorList {
 	allErrs := field.ErrorList{}
-	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&scale.ObjectMeta, true, apimachineryvalidation.NameIsDNSSubdomain, field.NewPath("metadata"))...)
-
 	if scale.Spec.Replicas < 0 {
 		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(scale.Spec.Replicas), field.NewPath("spec", "replicas")).MarkCoveredByDeclarative()...)
 	}

--- a/pkg/apis/autoscaling/validation/validation_test.go
+++ b/pkg/apis/autoscaling/validation/validation_test.go
@@ -92,6 +92,22 @@ func TestValidateScale(t *testing.T) {
 			},
 		},
 		msg: "must be greater than or equal to 0",
+	}, {
+		scale: autoscaling.Scale{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "frontend",
+				Namespace: metav1.NamespaceDefault,
+				ManagedFields: []metav1.ManagedFieldsEntry{{
+					Operation:  "InvalidOperation",
+					FieldsType: "FieldsV1",
+					APIVersion: "v1",
+				}},
+			},
+			Spec: autoscaling.ScaleSpec{
+				Replicas: 1,
+			},
+		},
+		msg: "metadata.managedFields[0].operation: Invalid value",
 	}}
 
 	for _, c := range errorCases {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR simplifies the scale validation logic by removing the redundant `ObjectMeta` validation in `ValidateScale` (`pkg/apis/autoscaling/validation/validation.go`). The underlying object only picks the limited fields from the scale object(resourceVersion, ManagedFields). Running the validations on the remaining fields is not adding  any value.

### Why this change is safe

Removing `apivalidation.ValidateObjectMeta` from `ValidateScale` is safe and technically more correct because the API server **ignores almost all metadata** sent in a `Scale` subresource payload.

1. **Ignored Metadata:** Subresource handlers only extract `Replicas`, `ResourceVersion`, `UID`, and `ManagedFields`. Validating ignored fields (like `Labels` or `Annotations`) was overly strict. The handlers explicitly copy only these few fields from the `Scale` object into the parent object, discarding the rest of the metadata:
   - [Deployments](https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/apps/deployment/storage/storage.go#L472-L479)
   - [ReplicaSets](https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/apps/replicaset/storage/storage.go#L368-L375)
   - [StatefulSets](https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/apps/statefulset/storage/storage.go#L361-L368)
   - [ReplicationControllers](https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/core/replicationcontroller/storage/storage.go#L331-L338)
   - [CustomResources](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd.go#L353-L366)
2. **ResourceVersion & UID:** `ValidateObjectMeta` does not validate these fields anyway. `ResourceVersion` concurrency is handled natively by the etcd storage layer, and `UID` is checked explicitly by precondition matchers in the handlers (e.g., [Deployment's check](https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/apps/deployment/storage/storage.go#L463-L468)).
3. **ManagedFields:** This is the only actionable metadata the handler merges into the parent object. This PR preserves safety by explicitly calling `metav1validation.ValidateManagedFields`. 


#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
