### PR TITLE
emptydir: mount memory-backed emptyDir with nodev,nosuid,noexec

### DIFF
--- a/pkg/volume/emptydir/empty_dir.go
+++ b/pkg/volume/emptydir/empty_dir.go
@@ -572,6 +572,10 @@ func getVolumeSource(spec *volume.Spec) (*v1.EmptyDirVolumeSource, bool) {
 }
 
 func (ed *emptyDir) generateTmpfsMountOptions(noswapSupported bool) (options []string) {
+	// Mount tmpfs with the same default nodev/nosuid/noexec options used by
+	// other kernel-mounted tmpfs filesystems.
+	options = append(options, "nodev", "nosuid", "noexec")
+
 	// Linux system default is 50% of capacity.
 	if ed.sizeLimit != nil && ed.sizeLimit.Value() > 0 {
 		options = append(options, fmt.Sprintf("size=%d", ed.sizeLimit.Value()))

--- a/pkg/volume/emptydir/empty_dir_test.go
+++ b/pkg/volume/emptydir/empty_dir_test.go
@@ -1191,6 +1191,12 @@ func TestTmpfsMountOptions(t *testing.T) {
 
 			options := emptyDirObj.generateTmpfsMountOptions(testCase.tmpfsNoswapSupported)
 
+			for _, expected := range []string{"nodev", "nosuid", "noexec"} {
+				if !doesStringArrayContainSubstring(options, expected) {
+					t.Errorf("expected tmpfs option %q to be present. options: %v", expected, options)
+				}
+			}
+
 			if testCase.tmpfsNoswapSupported && !doesStringArrayContainSubstring(options, swap.TmpfsNoswapOption) {
 				t.Errorf("tmpfs noswap option is expected when supported. options: %v", options)
 			}


### PR DESCRIPTION
/kind bug

Fixes kubernetes/kubernetes#48912

```release-note
NONE