### PR TITLE
podnodeselector: surface config decode errors instead of looping forever

### DIFF
--- a/plugin/pkg/admission/podnodeselector/admission.go
+++ b/plugin/pkg/admission/podnodeselector/admission.go
@@ -49,7 +49,10 @@ const PluginName = "PodNodeSelector"
 func Register(plugins *admission.Plugins) {
 	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
 		// TODO move this to a versioned configuration file format.
-		pluginConfig := readConfig(config)
+		pluginConfig, err := readConfig(config)
+		if err != nil {
+			return nil, err
+		}
 		plugin := NewPodNodeSelector(pluginConfig.PodNodeSelectorPluginConfig)
 		return plugin, nil
 	})
@@ -80,21 +83,21 @@ type pluginConfig struct {
 //	clusterDefaultNodeSelector: <node-selectors-labels>
 //	namespace1: <node-selectors-labels>
 //	namespace2: <node-selectors-labels>
-func readConfig(config io.Reader) *pluginConfig {
+func readConfig(config io.Reader) (*pluginConfig, error) {
 	defaultConfig := &pluginConfig{}
 	if config == nil || reflect.ValueOf(config).IsNil() {
-		return defaultConfig
+		return defaultConfig, nil
 	}
 	d := yaml.NewYAMLOrJSONDecoder(config, 4096)
 	for {
 		if err := d.Decode(defaultConfig); err != nil {
-			if err != io.EOF {
-				continue
+			if err == io.EOF {
+				break
 			}
+			return nil, fmt.Errorf("failed to decode PodNodeSelector plugin config: %w", err)
 		}
-		break
 	}
-	return defaultConfig
+	return defaultConfig, nil
 }
 
 // Admit enforces that pod and its namespace node label selectors matches at least a node in the cluster.

--- a/plugin/pkg/admission/podnodeselector/admission_test.go
+++ b/plugin/pkg/admission/podnodeselector/admission_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package podnodeselector
 
 import (
+	"bytes"
 	"context"
 	"testing"
 	"time"
@@ -191,6 +192,23 @@ func TestHandles(t *testing.T) {
 		if e, a := shouldHandle, nodeEnvionment.Handles(op); e != a {
 			t.Errorf("%v: shouldHandle=%t, handles=%t", op, e, a)
 		}
+	}
+}
+
+func TestReadConfigInvalidYAML(t *testing.T) {
+	_, err := readConfig(bytes.NewBufferString("invalid: ["))
+	if err == nil {
+		t.Errorf("expected an error when decoding invalid config, got nil")
+	}
+}
+
+func TestReadConfigNil(t *testing.T) {
+	config, err := readConfig(nil)
+	if err != nil {
+		t.Errorf("unexpected error for nil config: %v", err)
+	}
+	if config == nil {
+		t.Error("expected non-nil config for nil reader")
 	}
 }
 


### PR DESCRIPTION
`readConfig` previously continued the decode loop on any non-EOF error, which silently ignored malformed config and could spin forever. Return decode errors so the admission plugin fails loudly during registration.

/kind bug

```release-note
NONE