### PR TITLE
scheduler: skip informer registration for pod event resources

### DIFF
--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -522,8 +522,12 @@ func addAllEventHandlers(
 
 	for gvk, at := range gvkMap {
 		switch gvk {
-		case fwk.Node, fwk.Pod:
-			// Do nothing.
+		case fwk.Node:
+			// Node informer is already registered above.
+		case fwk.Pod, fwk.AssignedPod, fwk.UnscheduledPod, fwk.TargetPod:
+			// Pod informer is already registered above. AssignedPod,
+			// UnscheduledPod, and TargetPod are logical Pod event resources
+			// emitted from the Pod add/update/delete handlers.
 		case fwk.CSINode:
 			if handlerRegistration, err = informerFactory.Storage().V1().CSINodes().Informer().AddEventHandler(
 				buildEvtResHandler(at, fwk.CSINode),

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -531,6 +532,67 @@ func TestAddAllEventHandlers(t *testing.T) {
 				t.Errorf("Unexpected diff (-want, +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestAddAllEventHandlersPodEventResources(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(), 0)
+	schedulingQueue := internalqueue.NewTestQueueWithInformerFactory(ctx, nil, informerFactory)
+	testSched := Scheduler{
+		StopEverything:  ctx.Done(),
+		SchedulingQueue: schedulingQueue,
+		logger:          logger,
+	}
+
+	dynclient := dyfake.NewSimpleDynamicClient(runtime.NewScheme())
+	dynInformerFactory := dynamicinformer.NewDynamicSharedInformerFactory(dynclient, 0)
+	gvkMap := map[fwk.EventResource]fwk.ActionType{
+		fwk.AssignedPod:    fwk.Add | fwk.Update | fwk.Delete,
+		fwk.UnscheduledPod: fwk.Add | fwk.Update | fwk.Delete,
+		fwk.TargetPod:      fwk.Update,
+	}
+
+	handledErrorMessages := []string{}
+	oldErrorHandlers := utilruntime.ErrorHandlers
+	t.Cleanup(func() {
+		utilruntime.ErrorHandlers = oldErrorHandlers
+	})
+	utilruntime.ErrorHandlers = []utilruntime.ErrorHandler{
+		func(_ context.Context, _ error, msg string, _ ...interface{}) {
+			handledErrorMessages = append(handledErrorMessages, msg)
+		},
+	}
+
+	err := addAllEventHandlers(&testSched, informerFactory, dynInformerFactory, nil, nil, nil, gvkMap)
+	utilruntime.ErrorHandlers = oldErrorHandlers
+	if err != nil {
+		t.Fatalf("Add event handlers failed, error = %v", err)
+	}
+	for _, msg := range handledErrorMessages {
+		if msg == "Incorrect event registration" {
+			t.Fatalf("expected no incorrect event registration, got handled errors: %v", handledErrorMessages)
+		}
+	}
+
+	informerFactory.Start(testSched.StopEverything)
+	dynInformerFactory.Start(testSched.StopEverything)
+	staticInformers := informerFactory.WaitForCacheSync(testSched.StopEverything)
+	dynamicInformers := dynInformerFactory.WaitForCacheSync(testSched.StopEverything)
+
+	expectStaticInformers := map[reflect.Type]bool{
+		reflect.TypeFor[*v1.Pod]():       true,
+		reflect.TypeFor[*v1.Node]():      true,
+		reflect.TypeFor[*v1.Namespace](): true,
+	}
+	if diff := cmp.Diff(expectStaticInformers, staticInformers); diff != "" {
+		t.Errorf("Unexpected diff (-want, +got):\n%s", diff)
+	}
+	if len(dynamicInformers) != 0 {
+		t.Errorf("expected no dynamic informers, got %v", dynamicInformers)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

  /kind cleanup

  #### What this PR does / why we need it:

  This PR avoids reporting `Incorrect event registration` for scheduler pod event resources like `AssignedPod`, `UnscheduledPod`, and `TargetPod`.

  These resources are logical pod event resources. The scheduler already registers the pod informer, and these events are emitted from pod add/update/delete handling. They should not
  try to register another informer by GVK parsing.

  Without this change, scheduler integration tests can keep printing logs like:

  ```text
  UnhandledError: Incorrect event registration gvk=<framework.EventResource>: AssignedPod
  UnhandledError: Incorrect event registration gvk=<framework.EventResource>: UnscheduledPod
  UnhandledError: Incorrect event registration gvk=<framework.EventResource>: TargetPod
```
  This PR makes these pod event resources use the existing pod informer path, and adds a test to cover this behavior.

  #### Which issue(s) this PR is related to:
```
  N/A
```
  #### Special notes for your reviewer:

  The change should not affect plugin event handling for real API resources. It only skips extra informer registration for pod logical event resources which are already covered by the
  pod informer.

  Tested:

  go test ./pkg/scheduler -run TestAddAllEventHandlersPodEventResources -count=1 -v
  go test ./pkg/scheduler -run TestAddAllEventHandlers -count=1 -v
  go test ./pkg/scheduler -count=1

  #### Does this PR introduce a user-facing change?
```text
NONE
```
  #### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```text
NONE
```