### PR TITLE
apiserver: discard buffered partial response before writing fallback status

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -128,6 +128,7 @@ func SerializeObject(mediaType string, encoder runtime.Encoder, hw http.Response
 
 	// make a best effort to write the object if a failure is detected
 	utilruntime.HandleError(fmt.Errorf("apiserver was unable to write a JSON response: %v", err))
+	w.discardBufferedResponse()
 	status := ErrorToAPIStatus(err)
 	candidateStatusCode := int(status.Code)
 	// if the current status code is successful, allow the error's status code to overwrite it
@@ -210,6 +211,14 @@ func (w *deferredResponseWriter) Write(p []byte) (n int, err error) {
 		}
 		return len(p), err
 	}
+}
+
+func (w *deferredResponseWriter) discardBufferedResponse() {
+	if w.hasWritten {
+		return
+	}
+	w.hasBuffered = false
+	w.buffer = nil
 }
 
 func (w *deferredResponseWriter) unbufferedWrite(p []byte) (n int, err error) {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
@@ -134,6 +134,7 @@ func TestSerializeObject(t *testing.T) {
 
 		mediaType  string
 		out        []byte
+		partial    [][]byte
 		outErrs    []error
 		req        *http.Request
 		statusCode int
@@ -349,14 +350,35 @@ func TestSerializeObject(t *testing.T) {
 			},
 			wantBody: gzipContent([]byte(": "+string(largePayload)), gzipContentEncodingLevel),
 		},
+
+		{
+			name:               "discard buffered partial response when streaming encode fails",
+			compressionEnabled: true,
+			out:                smallPayload,
+			partial:            [][]byte{[]byte("{"), []byte(`"items":[{"name":"partial-item"}`)},
+			outErrs:            []error{errors.New("bad")},
+			mediaType:          "application/json",
+			req: &http.Request{
+				Header: http.Header{
+					"Accept-Encoding": []string{"gzip"},
+				},
+				URL: &url.URL{Path: "/path"},
+			},
+			wantCode: http.StatusInternalServerError,
+			wantHeaders: http.Header{
+				"Content-Type": []string{"application/json"},
+			},
+			wantBody: smallPayload,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.APIResponseCompression, tt.compressionEnabled)
 
 			encoder := &fakeEncoder{
-				buf:  tt.out,
-				errs: tt.outErrs,
+				buf:     tt.out,
+				partial: tt.partial,
+				errs:    tt.outErrs,
 			}
 			if tt.statusCode == 0 {
 				tt.statusCode = http.StatusOK
@@ -862,9 +884,10 @@ func (frw *fakeResponseRecorder) Write(buf []byte) (int, error) {
 }
 
 type fakeEncoder struct {
-	obj  runtime.Object
-	buf  []byte
-	errs []error
+	obj     runtime.Object
+	buf     []byte
+	partial [][]byte
+	errs    []error
 
 	encodeCalled bool
 }
@@ -874,6 +897,11 @@ func (e *fakeEncoder) Encode(obj runtime.Object, w io.Writer) error {
 	if len(e.errs) > 0 {
 		err := e.errs[0]
 		e.errs = e.errs[1:]
+		for _, chunk := range e.partial {
+			if _, werr := w.Write(chunk); werr != nil {
+				return werr
+			}
+		}
 		return err
 	}
 	_, err := w.Write(e.buf)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

When `SerializeObject`'s encoder fails after having buffered a partial response, the fallback error path appended the fallback Status to the already-buffered partial bytes. On `Close()` the writer then flushed a concatenation of the truncated object and the Status, producing an unparseable body such as `{"items":[{"name":"..."}{"kind":"Status","status":"Failure","code":500}`.

This PR adds `deferredResponseWriter.discardBufferedResponse()` and calls it before encoding the fallback Status. Because the buffered bytes have not been sent to the client yet, they can be safely dropped so the fallback Status is written into a clean buffer.


https://github.com/kubernetes/kubernetes/blob/d5c2dd81390f06f8ead9e8e932a1348ae1cc2ee2/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go#L119-L145
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
