### PR TITLE
kubelet: use ServerResourcesForGroupVersionWithContext

### DIFF
--- a/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager.go
+++ b/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	lrucache "k8s.io/apimachinery/pkg/util/cache"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -92,8 +93,8 @@ func (b *betaClusterTrustBundleHandlers) GetTrustBundle(ctb *certificatesv1beta1
 
 // Manager abstracts over the ability to get trust anchors.
 type Manager interface {
-	GetTrustAnchorsByName(name string, allowMissing bool) ([]byte, error)
-	GetTrustAnchorsBySigner(signerName string, labelSelector *metav1.LabelSelector, allowMissing bool) ([]byte, error)
+	GetTrustAnchorsByName(ctx context.Context, name string, allowMissing bool) ([]byte, error)
+	GetTrustAnchorsBySigner(ctx context.Context, signerName string, labelSelector *metav1.LabelSelector, allowMissing bool) ([]byte, error)
 }
 
 // InformerManager is the "real" manager.  It uses informers to track
@@ -197,7 +198,7 @@ func (m *InformerManager[T]) dropCacheFor(ctb *T) {
 
 // GetTrustAnchorsByName returns normalized and deduplicated trust anchors from
 // a single named ClusterTrustBundle.
-func (m *InformerManager[T]) GetTrustAnchorsByName(name string, allowMissing bool) ([]byte, error) {
+func (m *InformerManager[T]) GetTrustAnchorsByName(ctx context.Context, name string, allowMissing bool) ([]byte, error) {
 	if !m.ctbInformer.HasSynced() {
 		return nil, fmt.Errorf("ClusterTrustBundle informer has not yet synced")
 	}
@@ -228,7 +229,7 @@ func (m *InformerManager[T]) GetTrustAnchorsByName(name string, allowMissing boo
 
 // GetTrustAnchorsBySigner returns normalized and deduplicated trust anchors
 // from a set of selected ClusterTrustBundles.
-func (m *InformerManager[T]) GetTrustAnchorsBySigner(signerName string, labelSelector *metav1.LabelSelector, allowMissing bool) ([]byte, error) {
+func (m *InformerManager[T]) GetTrustAnchorsBySigner(ctx context.Context, signerName string, labelSelector *metav1.LabelSelector, allowMissing bool) ([]byte, error) {
 	if !m.ctbInformer.HasSynced() {
 		return nil, fmt.Errorf("ClusterTrustBundle informer has not yet synced")
 	}
@@ -324,12 +325,12 @@ type NoopManager struct{}
 var _ Manager = (*NoopManager)(nil)
 
 // GetTrustAnchorsByName implements Manager.
-func (m *NoopManager) GetTrustAnchorsByName(name string, allowMissing bool) ([]byte, error) {
+func (m *NoopManager) GetTrustAnchorsByName(ctx context.Context, name string, allowMissing bool) ([]byte, error) {
 	return nil, fmt.Errorf("ClusterTrustBundle projection is not supported in static kubelet mode")
 }
 
 // GetTrustAnchorsBySigner implements Manager.
-func (m *NoopManager) GetTrustAnchorsBySigner(signerName string, labelSelector *metav1.LabelSelector, allowMissing bool) ([]byte, error) {
+func (m *NoopManager) GetTrustAnchorsBySigner(ctx context.Context, signerName string, labelSelector *metav1.LabelSelector, allowMissing bool) ([]byte, error) {
 	return nil, fmt.Errorf("ClusterTrustBundle projection is not supported in static kubelet mode")
 }
 
@@ -356,18 +357,18 @@ func NewLazyInformerManager(ctx context.Context, kubeClient clientset.Interface,
 	}
 }
 
-func (m *LazyInformerManager) GetTrustAnchorsByName(name string, allowMissing bool) ([]byte, error) {
-	if err := m.ensureManagerSet(); err != nil {
+func (m *LazyInformerManager) GetTrustAnchorsByName(ctx context.Context, name string, allowMissing bool) ([]byte, error) {
+	if err := m.ensureManagerSet(ctx); err != nil {
 		return nil, fmt.Errorf("failed to ensure informer manager for ClusterTrustBundles: %w", err)
 	}
-	return m.manager.GetTrustAnchorsByName(name, allowMissing)
+	return m.manager.GetTrustAnchorsByName(ctx, name, allowMissing)
 }
 
-func (m *LazyInformerManager) GetTrustAnchorsBySigner(signerName string, labelSelector *metav1.LabelSelector, allowMissing bool) ([]byte, error) {
-	if err := m.ensureManagerSet(); err != nil {
+func (m *LazyInformerManager) GetTrustAnchorsBySigner(ctx context.Context, signerName string, labelSelector *metav1.LabelSelector, allowMissing bool) ([]byte, error) {
+	if err := m.ensureManagerSet(ctx); err != nil {
 		return nil, fmt.Errorf("failed to ensure informer manager for ClusterTrustBundles: %w", err)
 	}
-	return m.manager.GetTrustAnchorsBySigner(signerName, labelSelector, allowMissing)
+	return m.manager.GetTrustAnchorsBySigner(ctx, signerName, labelSelector, allowMissing)
 }
 
 func (m *LazyInformerManager) isManagerSet() bool {
@@ -378,7 +379,7 @@ func (m *LazyInformerManager) isManagerSet() bool {
 
 type managerConstructor func(ctx context.Context, informerFactory informers.SharedInformerFactory, cacheSize int, cacheTTL time.Duration) (Manager, error)
 
-func (m *LazyInformerManager) ensureManagerSet() error {
+func (m *LazyInformerManager) ensureManagerSet(ctx context.Context) error {
 	if m.isManagerSet() {
 		return nil
 	}
@@ -399,8 +400,9 @@ func (m *LazyInformerManager) ensureManagerSet() error {
 
 	var clusterTrustBundleManager Manager
 	var foundGV string
+	discoveryClient := discovery.ToDiscoveryInterfaceWithContext(m.client.Discovery())
 	for _, gv := range []schema.GroupVersion{certificatesv1beta1.SchemeGroupVersion, certificatesv1alpha1.SchemeGroupVersion} {
-		ctbAPIAvailable, err := clusterTrustBundlesAvailable(m.client, gv)
+		ctbAPIAvailable, err := clusterTrustBundlesAvailable(ctx, discoveryClient, gv)
 		if err != nil {
 			return fmt.Errorf("failed to determine which informer manager to choose: %w", err)
 		}
@@ -445,8 +447,8 @@ func (m *LazyInformerManager) ensureManagerSet() error {
 	return nil
 }
 
-func clusterTrustBundlesAvailable(client clientset.Interface, gv schema.GroupVersion) (bool, error) {
-	resList, err := client.Discovery().ServerResourcesForGroupVersion(gv.String())
+func clusterTrustBundlesAvailable(ctx context.Context, discoveryClient discovery.DiscoveryInterfaceWithContext, gv schema.GroupVersion) (bool, error) {
+	resList, err := discoveryClient.ServerResourcesForGroupVersionWithContext(ctx, gv.String())
 	if k8serrors.IsNotFound(err) {
 		return false, nil
 	}

--- a/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager_test.go
+++ b/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager_test.go
@@ -58,7 +58,7 @@ func TestBeforeSynced(t *testing.T) {
 
 	ctbManager, _ := NewBetaInformerManager(tCtx, informerFactory, 256, 5*time.Minute)
 
-	_, err := ctbManager.GetTrustAnchorsByName("foo", false)
+	_, err := ctbManager.GetTrustAnchorsByName(tCtx, "foo", false)
 	if err == nil {
 		t.Fatalf("Got nil error, wanted non-nil")
 	}
@@ -135,7 +135,7 @@ func testGetTrustAnchorsByName[T clusterTrustBundle](t *testing.T, b testingFunc
 		t.Fatalf("Timed out waiting for informer to sync")
 	}
 
-	gotBundle, err := ctbManager.GetTrustAnchorsByName("ctb1", false)
+	gotBundle, err := ctbManager.GetTrustAnchorsByName(tCtx, "ctb1", false)
 	if err != nil {
 		t.Fatalf("Error while calling GetTrustAnchorsByName: %v", err)
 	}
@@ -144,7 +144,7 @@ func testGetTrustAnchorsByName[T clusterTrustBundle](t *testing.T, b testingFunc
 		t.Fatalf("Got bad bundle; diff (-got +want)\n%s", diff)
 	}
 
-	gotBundle, err = ctbManager.GetTrustAnchorsByName("ctb2", false)
+	gotBundle, err = ctbManager.GetTrustAnchorsByName(tCtx, "ctb2", false)
 	if err != nil {
 		t.Fatalf("Error while calling GetTrustAnchorsByName: %v", err)
 	}
@@ -153,12 +153,12 @@ func testGetTrustAnchorsByName[T clusterTrustBundle](t *testing.T, b testingFunc
 		t.Fatalf("Got bad bundle; diff (-got +want)\n%s", diff)
 	}
 
-	_, err = ctbManager.GetTrustAnchorsByName("not-found", false)
+	_, err = ctbManager.GetTrustAnchorsByName(tCtx, "not-found", false)
 	if err == nil { // EQUALS nil
 		t.Fatalf("While looking up nonexisting ClusterTrustBundle, got nil error, wanted non-nil")
 	}
 
-	_, err = ctbManager.GetTrustAnchorsByName("not-found", true)
+	_, err = ctbManager.GetTrustAnchorsByName(tCtx, "not-found", true)
 	if err != nil {
 		t.Fatalf("Unexpected error while calling GetTrustAnchorsByName for nonexistent CTB with allowMissing: %v", err)
 	}
@@ -193,7 +193,7 @@ func testGetTrustAnchorsByNameCaching[T clusterTrustBundle](t *testing.T, b test
 	}
 
 	t.Run("foo should yield the first certificate", func(t *testing.T) {
-		gotBundle, err := ctbManager.GetTrustAnchorsByName("foo", false)
+		gotBundle, err := ctbManager.GetTrustAnchorsByName(tCtx, "foo", false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
 		}
@@ -206,7 +206,7 @@ func testGetTrustAnchorsByNameCaching[T clusterTrustBundle](t *testing.T, b test
 	})
 
 	t.Run("foo should still yield the first certificate", func(t *testing.T) {
-		gotBundle, err := ctbManager.GetTrustAnchorsByName("foo", false)
+		gotBundle, err := ctbManager.GetTrustAnchorsByName(tCtx, "foo", false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
 		}
@@ -233,7 +233,7 @@ func testGetTrustAnchorsByNameCaching[T clusterTrustBundle](t *testing.T, b test
 	time.Sleep(5 * time.Second)
 
 	t.Run("foo should yield the new certificate", func(t *testing.T) {
-		gotBundle, err := ctbManager.GetTrustAnchorsByName("foo", false)
+		gotBundle, err := ctbManager.GetTrustAnchorsByName(tCtx, "foo", false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
 		}
@@ -283,14 +283,14 @@ func testGetTrustAnchorsBySignerName[T clusterTrustBundle](t *testing.T, b testi
 			matchLabels[fmt.Sprintf("key-%d", i)] = longString.String()
 		}
 
-		_, err := ctbManager.GetTrustAnchorsBySigner("foo.bar/a", &metav1.LabelSelector{MatchLabels: matchLabels}, false)
+		_, err := ctbManager.GetTrustAnchorsBySigner(tCtx, "foo.bar/a", &metav1.LabelSelector{MatchLabels: matchLabels}, false)
 		if err == nil || !strings.Contains(err.Error(), "label selector length") {
 			t.Fatalf("Bad error, got %v, wanted it to contain \"label selector length\"", err)
 		}
 	})
 
 	t.Run("signer-a label-a should yield two sorted certificates", func(t *testing.T) {
-		gotBundle, err := ctbManager.GetTrustAnchorsBySigner("foo.bar/a", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "a"}}, false)
+		gotBundle, err := ctbManager.GetTrustAnchorsBySigner(tCtx, "foo.bar/a", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "a"}}, false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
 		}
@@ -303,7 +303,7 @@ func testGetTrustAnchorsBySignerName[T clusterTrustBundle](t *testing.T, b testi
 	})
 
 	t.Run("signer-a with nil selector should yield zero certificates", func(t *testing.T) {
-		gotBundle, err := ctbManager.GetTrustAnchorsBySigner("foo.bar/a", nil, true)
+		gotBundle, err := ctbManager.GetTrustAnchorsBySigner(tCtx, "foo.bar/a", nil, true)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
 		}
@@ -316,7 +316,7 @@ func testGetTrustAnchorsBySignerName[T clusterTrustBundle](t *testing.T, b testi
 	})
 
 	t.Run("signer-b with empty selector should yield one certificates", func(t *testing.T) {
-		gotBundle, err := ctbManager.GetTrustAnchorsBySigner("foo.bar/b", &metav1.LabelSelector{}, false)
+		gotBundle, err := ctbManager.GetTrustAnchorsBySigner(tCtx, "foo.bar/b", &metav1.LabelSelector{}, false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
 		}
@@ -327,7 +327,7 @@ func testGetTrustAnchorsBySignerName[T clusterTrustBundle](t *testing.T, b testi
 	})
 
 	t.Run("signer-a label-b should yield one certificate", func(t *testing.T) {
-		gotBundle, err := ctbManager.GetTrustAnchorsBySigner("foo.bar/a", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "b"}}, false)
+		gotBundle, err := ctbManager.GetTrustAnchorsBySigner(tCtx, "foo.bar/a", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "b"}}, false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
 		}
@@ -338,7 +338,7 @@ func testGetTrustAnchorsBySignerName[T clusterTrustBundle](t *testing.T, b testi
 	})
 
 	t.Run("signer-b label-a should yield one certificate", func(t *testing.T) {
-		gotBundle, err := ctbManager.GetTrustAnchorsBySigner("foo.bar/b", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "a"}}, false)
+		gotBundle, err := ctbManager.GetTrustAnchorsBySigner(tCtx, "foo.bar/b", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "a"}}, false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
 		}
@@ -349,7 +349,7 @@ func testGetTrustAnchorsBySignerName[T clusterTrustBundle](t *testing.T, b testi
 	})
 
 	t.Run("signer-b label-b allowMissing=true should yield zero certificates", func(t *testing.T) {
-		gotBundle, err := ctbManager.GetTrustAnchorsBySigner("foo.bar/b", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "b"}}, true)
+		gotBundle, err := ctbManager.GetTrustAnchorsBySigner(tCtx, "foo.bar/b", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "b"}}, true)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
 		}
@@ -360,7 +360,7 @@ func testGetTrustAnchorsBySignerName[T clusterTrustBundle](t *testing.T, b testi
 	})
 
 	t.Run("signer-b label-b allowMissing=false should yield zero certificates (error)", func(t *testing.T) {
-		_, err := ctbManager.GetTrustAnchorsBySigner("foo.bar/b", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "b"}}, false)
+		_, err := ctbManager.GetTrustAnchorsBySigner(tCtx, "foo.bar/b", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "b"}}, false)
 		if err == nil { // EQUALS nil
 			t.Fatalf("Got nil error while calling GetTrustAnchorsBySigner, wanted non-nil")
 		}
@@ -393,7 +393,7 @@ func testGetTrustAnchorsBySignerNameCaching[T clusterTrustBundle](t *testing.T, 
 	}
 
 	t.Run("signer-a label-a should yield one certificate", func(t *testing.T) {
-		gotBundle, err := ctbManager.GetTrustAnchorsBySigner("foo.bar/a", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "a"}}, false)
+		gotBundle, err := ctbManager.GetTrustAnchorsBySigner(tCtx, "foo.bar/a", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "a"}}, false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
 		}
@@ -406,7 +406,7 @@ func testGetTrustAnchorsBySignerNameCaching[T clusterTrustBundle](t *testing.T, 
 	})
 
 	t.Run("signer-a label-a should yield the same result when called again", func(t *testing.T) {
-		gotBundle, err := ctbManager.GetTrustAnchorsBySigner("foo.bar/a", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "a"}}, false)
+		gotBundle, err := ctbManager.GetTrustAnchorsBySigner(tCtx, "foo.bar/a", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "a"}}, false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
 		}
@@ -432,7 +432,7 @@ func testGetTrustAnchorsBySignerNameCaching[T clusterTrustBundle](t *testing.T, 
 	time.Sleep(5 * time.Second)
 
 	t.Run("signer-a label-a should return the new certificate", func(t *testing.T) {
-		gotBundle, err := ctbManager.GetTrustAnchorsBySigner("foo.bar/a", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "a"}}, false)
+		gotBundle, err := ctbManager.GetTrustAnchorsBySigner(tCtx, "foo.bar/a", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "a"}}, false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
 		}
@@ -623,7 +623,7 @@ func TestLazyInformerManager_ensureManagerSet(t *testing.T) {
 				contextWithLogger: loggerCtx,
 				logger:            logger,
 			}
-			if err := m.ensureManagerSet(); tt.wantError != (err != nil) {
+			if err := m.ensureManagerSet(loggerCtx); tt.wantError != (err != nil) {
 				t.Errorf("expected error: %t, got %v", tt.wantError, err)
 			}
 

--- a/pkg/kubelet/token/token_manager.go
+++ b/pkg/kubelet/token/token_manager.go
@@ -49,7 +49,7 @@ func NewManager(c clientset.Interface) *Manager {
 	once := &sync.Once{}
 	tokenRequestsSupported := func() bool {
 		once.Do(func() {
-			resources, err := c.Discovery().ServerResourcesForGroupVersion("v1")
+			resources, err := c.Discovery().ServerResourcesForGroupVersionWithContext(context.TODO(), ("v1"))
 			if err != nil {
 				return
 			}

--- a/pkg/kubelet/volume_host.go
+++ b/pkg/kubelet/volume_host.go
@@ -262,12 +262,12 @@ func (kvh *kubeletVolumeHost) DeleteServiceAccountTokenFunc() func(podUID types.
 	return kvh.tokenManager.DeleteServiceAccountToken
 }
 
-func (kvh *kubeletVolumeHost) GetTrustAnchorsByName(name string, allowMissing bool) ([]byte, error) {
-	return kvh.clusterTrustBundleManager.GetTrustAnchorsByName(name, allowMissing)
+func (kvh *kubeletVolumeHost) GetTrustAnchorsByName(ctx context.Context, name string, allowMissing bool) ([]byte, error) {
+	return kvh.clusterTrustBundleManager.GetTrustAnchorsByName(ctx, name, allowMissing)
 }
 
-func (kvh *kubeletVolumeHost) GetTrustAnchorsBySigner(signerName string, labelSelector *metav1.LabelSelector, allowMissing bool) ([]byte, error) {
-	return kvh.clusterTrustBundleManager.GetTrustAnchorsBySigner(signerName, labelSelector, allowMissing)
+func (kvh *kubeletVolumeHost) GetTrustAnchorsBySigner(ctx context.Context, signerName string, labelSelector *metav1.LabelSelector, allowMissing bool) ([]byte, error) {
+	return kvh.clusterTrustBundleManager.GetTrustAnchorsBySigner(ctx, signerName, labelSelector, allowMissing)
 }
 
 func (kvh *kubeletVolumeHost) GetPodCertificateCredentialBundle(ctx context.Context, namespace, podName, podUID, volumeName string, sourceIndex int) ([]byte, []byte, error) {

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -308,11 +308,11 @@ type KubeletVolumeHost interface {
 	GetHostUtil() hostutil.HostUtils
 
 	// Returns trust anchors from the named ClusterTrustBundle.
-	GetTrustAnchorsByName(name string, allowMissing bool) ([]byte, error)
+	GetTrustAnchorsByName(ctx context.Context, name string, allowMissing bool) ([]byte, error)
 
 	// Returns trust anchors from the ClusterTrustBundles selected by signer
 	// name and label selector.
-	GetTrustAnchorsBySigner(signerName string, labelSelector *metav1.LabelSelector, allowMissing bool) ([]byte, error)
+	GetTrustAnchorsBySigner(ctx context.Context, signerName string, labelSelector *metav1.LabelSelector, allowMissing bool) ([]byte, error)
 
 	// Returns the credential bundle for the specified podCertificate projected volume source.
 	GetPodCertificateCredentialBundle(ctx context.Context, namespace, podName, podUID, volumeName string, sourceIndex int) ([]byte, []byte, error)

--- a/pkg/volume/projected/projected.go
+++ b/pkg/volume/projected/projected.go
@@ -361,14 +361,14 @@ func (s *projectedVolumeMounter) collectData(mounterArgs volume.MounterArgs) (ma
 			var trustAnchors []byte
 			if source.ClusterTrustBundle.Name != nil {
 				var err error
-				trustAnchors, err = s.plugin.kvHost.GetTrustAnchorsByName(*source.ClusterTrustBundle.Name, allowEmpty)
+				trustAnchors, err = s.plugin.kvHost.GetTrustAnchorsByName(context.TODO(), *source.ClusterTrustBundle.Name, allowEmpty)
 				if err != nil {
 					errlist = append(errlist, err)
 					continue
 				}
 			} else if source.ClusterTrustBundle.SignerName != nil {
 				var err error
-				trustAnchors, err = s.plugin.kvHost.GetTrustAnchorsBySigner(*source.ClusterTrustBundle.SignerName, source.ClusterTrustBundle.LabelSelector, allowEmpty)
+				trustAnchors, err = s.plugin.kvHost.GetTrustAnchorsBySigner(context.TODO(), *source.ClusterTrustBundle.SignerName, source.ClusterTrustBundle.LabelSelector, allowEmpty)
 				if err != nil {
 					errlist = append(errlist, err)
 					continue

--- a/pkg/volume/testing/volume_host.go
+++ b/pkg/volume/testing/volume_host.go
@@ -401,8 +401,8 @@ func (f *fakeKubeletVolumeHost) GetHostUtil() hostutil.HostUtils {
 	return f.hostUtil
 }
 
-func (f *fakeKubeletVolumeHost) GetTrustAnchorsByName(name string, allowMissing bool) ([]byte, error) {
-	ctb, err := f.kubeClient.CertificatesV1beta1().ClusterTrustBundles().Get(context.Background(), name, metav1.GetOptions{})
+func (f *fakeKubeletVolumeHost) GetTrustAnchorsByName(ctx context.Context, name string, allowMissing bool) ([]byte, error) {
+	ctb, err := f.kubeClient.CertificatesV1beta1().ClusterTrustBundles().Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("while getting ClusterTrustBundle %s: %w", name, err)
 	}
@@ -411,8 +411,8 @@ func (f *fakeKubeletVolumeHost) GetTrustAnchorsByName(name string, allowMissing 
 }
 
 // Note: we do none of the deduplication and sorting that the real deal should do.
-func (f *fakeKubeletVolumeHost) GetTrustAnchorsBySigner(signerName string, labelSelector *metav1.LabelSelector, allowMissing bool) ([]byte, error) {
-	ctbList, err := f.kubeClient.CertificatesV1beta1().ClusterTrustBundles().List(context.Background(), metav1.ListOptions{})
+func (f *fakeKubeletVolumeHost) GetTrustAnchorsBySigner(ctx context.Context, signerName string, labelSelector *metav1.LabelSelector, allowMissing bool) ([]byte, error) {
+	ctbList, err := f.kubeClient.CertificatesV1beta1().ClusterTrustBundles().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("while listing all ClusterTrustBundles: %w", err)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The context-aware variant supports contextual logging and cancellation. This bubbles up the call chain into calls which manage trust.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Follow-up to https://github.com/kubernetes/kubernetes/pull/129109.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @bart0sh 