### PR TITLE
DRA E2E: use context-aware discovery

### DIFF
--- a/test/e2e/dra/utils/deploy.go
+++ b/test/e2e/dra/utils/deploy.go
@@ -768,8 +768,8 @@ func (d *Driver) removeFile(tCtx ktesting.TContext, pod *v1.Pod, name string) er
 
 func (d *Driver) createFromYAML(tCtx ktesting.TContext, content []byte, namespace string) {
 	// Not caching the discovery result isn't very efficient, but good enough.
-	discoveryCache := memory.NewMemCacheClient(tCtx.Client().Discovery())
-	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryCache)
+	discoveryCache := memory.NewMemCacheClientWithContext(tCtx.Client().Discovery())
+	restMapper := restmapper.NewDeferredDiscoveryRESTMapperWithContext(discoveryCache)
 
 	for _, content := range bytes.Split(content, []byte("---\n")) {
 		if len(content) == 0 {
@@ -783,7 +783,7 @@ func (d *Driver) createFromYAML(tCtx ktesting.TContext, content []byte, namespac
 		tCtx.ExpectNoError(err, fmt.Sprintf("extract group+version from object %q", klog.KObj(obj)))
 		gk := schema.GroupKind{Group: gv.Group, Kind: obj.GetKind()}
 
-		mapping, err := restMapper.RESTMapping(gk, gv.Version)
+		mapping, err := restMapper.RESTMappingWithContext(tCtx, gk, gv.Version)
 		tCtx.ExpectNoError(err, fmt.Sprintf("map %q to resource", gk))
 
 		resourceClient := tCtx.Dynamic().Resource(mapping.Resource)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The context-aware variants support contextual logging and cancellation.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Follow-up to https://github.com/kubernetes/kubernetes/pull/129109.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @bart0sh 