### PR TITLE
scheduler: add podgroup_cache_missed_events_total metric

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -6475,6 +6475,19 @@
   componentEndpoints:
   - component: kube-scheduler
     endpoint: /metrics
+- name: podgroup_cache_missed_events_total
+  subsystem: scheduler
+  help: Number of scheduler cache operations on a pod group member that did not find
+    the expected pod group state, indicating a missed prior add/assume event. Labeled
+    by the cache operation ('update' or 'forget'). A non-zero value points to a cache
+    consistency bug.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - operation
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: podgroup_schedule_attempts_total
   subsystem: scheduler
   help: Number of attempts to schedule pod group, by the result. 'unschedulable' means

--- a/pkg/scheduler/backend/cache/cache.go
+++ b/pkg/scheduler/backend/cache/cache.go
@@ -880,6 +880,7 @@ func (cache *cacheImpl) updatePodGroupMember(logger klog.Logger, oldPod, newPod 
 	podGroupState, exists := cache.podGroupStates[key]
 	if !exists {
 		// This should not happen: the pod group state should have been already created by a prior pod add action.
+		metrics.PodGroupCacheMissedEvents.WithLabelValues("update").Inc()
 		utilruntime.HandleErrorWithLogger(logger, nil, "Pod group state not found for update, this indicates a missed add event", "pod", klog.KObj(newPod), "podGroupKey", key)
 		return
 	}
@@ -921,6 +922,7 @@ func (cache *cacheImpl) forgetPodGroupMember(logger klog.Logger, pod *v1.Pod) {
 	pgs, exists := cache.podGroupStates[key]
 	if !exists {
 		// This should not happen: the pod group state should have been already created by a prior pod add or assume action.
+		metrics.PodGroupCacheMissedEvents.WithLabelValues("forget").Inc()
 		utilruntime.HandleErrorWithLogger(logger, nil, "Pod group state not found for forget, this indicates a missed add or assume event", "pod", klog.KObj(pod), "podGroupKey", key)
 		return
 	}

--- a/pkg/scheduler/backend/cache/cache_test.go
+++ b/pkg/scheduler/backend/cache/cache_test.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
 	fwk "k8s.io/kube-scheduler/framework"
@@ -2884,4 +2885,71 @@ func (cache *cacheImpl) getNodeInfo(nodeName string) (*v1.Node, error) {
 	}
 
 	return n.info.Node(), nil
+}
+
+func TestPodGroupCacheMissedEventsMetric(t *testing.T) {
+	// In production this metric is only registered when the GenericWorkload
+	// feature gate is enabled (see metrics.Register). The package-level
+	// metrics.Register() in init() runs with the gate off, so the metric is not
+	// created and Inc() would be a no-op. Force-create it here for the test.
+	if !metrics.PodGroupCacheMissedEvents.IsCreated() {
+		metrics.RegisterMetrics(metrics.PodGroupCacheMissedEvents)
+	}
+
+	podGroupName := "pg"
+	pod := st.MakePod().Namespace("namespace").Name("member").UID("member-uid").
+		PodGroupName(podGroupName).Obj()
+
+	tests := []struct {
+		name          string
+		operation     string
+		trigger       func(cache *cacheImpl, logger klog.Logger)
+		wantIncrement float64
+	}{
+		{
+			name:      "update without prior add records a missed 'update' event",
+			operation: "update",
+			trigger: func(cache *cacheImpl, logger klog.Logger) {
+				// No AddPodGroupMember first, so the pod group state is missing.
+				cache.updatePodGroupMember(logger, pod, pod)
+			},
+			wantIncrement: 1,
+		},
+		{
+			name:      "forget without prior add/assume records a missed 'forget' event",
+			operation: "forget",
+			trigger: func(cache *cacheImpl, logger klog.Logger) {
+				// No AddPodGroupMember/assume first, so the pod group state is missing.
+				cache.forgetPodGroupMember(logger, pod)
+			},
+			wantIncrement: 1,
+		},
+		{
+			name:      "update after add does not record a missed event",
+			operation: "update",
+			trigger: func(cache *cacheImpl, logger klog.Logger) {
+				cache.addPodGroupMember(pod)
+				cache.updatePodGroupMember(logger, pod, pod)
+			},
+			wantIncrement: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics.PodGroupCacheMissedEvents.Reset()
+			logger, _ := ktesting.NewTestContext(t)
+			cache := newCache(context.Background(), time.Second, nil, true /* genericWorkloadEnabled */)
+
+			tt.trigger(cache, logger)
+
+			got, err := testutil.GetCounterMetricValue(metrics.PodGroupCacheMissedEvents.WithLabelValues(tt.operation))
+			if err != nil {
+				t.Fatalf("failed to read metric: %v", err)
+			}
+			if got != tt.wantIncrement {
+				t.Errorf("PodGroupCacheMissedEvents{operation=%q} = %v, want %v", tt.operation, got, tt.wantIncrement)
+			}
+		})
+	}
 }

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -175,6 +175,10 @@ var (
 	podGroupScheduleAttempts           *metrics.CounterVec
 	podGroupSchedulingLatency          *metrics.HistogramVec
 	PodGroupSchedulingAlgorithmLatency *metrics.Histogram
+	// PodGroupCacheMissedEvents counts scheduler cache operations on a pod group
+	// member that could not find the expected pod group state, which indicates a
+	// missed prior add/assume event. Only available when GenericWorkload is enabled.
+	PodGroupCacheMissedEvents *metrics.CounterVec
 	// The below are only available when the DRADeviceBindingConditions feature gate is enabled.
 	DRABindingConditionsAllocationsTotal *metrics.CounterVec
 	DRABindingConditionsPreBindDuration  *metrics.HistogramVec
@@ -211,6 +215,7 @@ func Register() {
 				podGroupScheduleAttempts,
 				podGroupSchedulingLatency,
 				PodGroupSchedulingAlgorithmLatency,
+				PodGroupCacheMissedEvents,
 			)
 		}
 		if utilfeature.DefaultFeatureGate.Enabled(features.DRADeviceBindingConditions) {
@@ -530,6 +535,13 @@ func InitMetrics() {
 			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
 			StabilityLevel: metrics.ALPHA,
 		})
+	PodGroupCacheMissedEvents = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      SchedulerSubsystem,
+			Name:           "podgroup_cache_missed_events_total",
+			Help:           "Number of scheduler cache operations on a pod group member that did not find the expected pod group state, indicating a missed prior add/assume event. Labeled by the cache operation ('update' or 'forget'). A non-zero value points to a cache consistency bug.",
+			StabilityLevel: metrics.ALPHA,
+		}, []string{"operation"})
 
 	metricsList = []metrics.Registerable{
 		scheduleAttempts,

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -511,7 +511,7 @@ func InitMetrics() {
 		},
 		[]string{"profile"})
 
-	// The below (podGroupScheduleAttempts, podGroupSchedulingLatency and PodGroupSchedulingAlgorithmLatency) are only available when the GenericWorkload feature gate is enabled.
+	// The below (podGroupScheduleAttempts, podGroupSchedulingLatency, PodGroupSchedulingAlgorithmLatency and PodGroupCacheMissedEvents) are only available when the GenericWorkload feature gate is enabled.
 	podGroupScheduleAttempts = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem:      SchedulerSubsystem,


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**

Adds a new ALPHA metric, `scheduler_podgroup_cache_missed_events_total`, that
surfaces PodGroup scheduler-cache consistency violations as an alertable signal
instead of a log line only.

The scheduler cache's PodGroup member operations assume the pod group state
already exists (created by a prior add/assume):

- `updatePodGroupMember` — a missing state means a **missed add event**.
- `forgetPodGroupMember` — a missing state means a **missed add or assume event**.

Both are "this should not happen" invariant violations. Today they are only
emitted via `utilruntime.HandleErrorWithLogger`. For scheduler cache
consistency issues, logs alone are weak: they are noisy, sampled/rotated, and
hard to alert on. A low-cardinality counter gives operators — and CI /
integration runs — a direct signal that the pod group cache event
ordering/state machine is broken.

This is a **diagnostic/observability** change, not a correctness fix. It does
not alter cache behavior; it only meters the existing impossible-state paths.

Why it is justified and low-risk:

- `GenericWorkload` / pod group scheduling is a newer scheduler path where this
  kind of internal-invariant visibility is most valuable.
- This cache state is internal and should be invariant-preserving; a non-zero
  value means a bug, not normal workload behavior.
- The metric is registered only when the `GenericWorkload` feature gate is
  enabled, so it does not expand the default scheduler metric surface when the
  feature is off (it sits alongside the other `podgroup_*` metrics).
- Cardinality is low: one bounded `operation` label with values `update` /
  `forget`.
- The code change is tiny and does not change cache behavior.

Metric:

```
# HELP scheduler_podgroup_cache_missed_events_total [ALPHA] Number of scheduler cache operations on a pod group member that did not find the expected pod group state, indicating a missed prior add/assume event. Labeled by the cache operation ('update' or 'forget'). A non-zero value points to a cache consistency bug.
# TYPE scheduler_podgroup_cache_missed_events_total counter
scheduler_podgroup_cache_missed_events_total{operation="update"}
scheduler_podgroup_cache_missed_events_total{operation="forget"}
```

**Which issue(s) this PR fixes**

None yet — happy to file a tracking issue if SIG Scheduling prefers. (Open to
the alternative direction of hardening/fixing the suspected missed-event path
directly instead of metering it, if that is preferred.)

**Special notes for your reviewer**

The metric is gated on `GenericWorkload`, so `.WithLabelValues(...).Inc()` is a
no-op until the gate creates it — matching the existing gated `podgroup_*`
metrics. The added unit test force-creates the metric (guarded by
`IsCreated()`) to exercise the counter, and covers both missed-event operations
plus a non-missed control case.

**Does this PR introduce a user-facing change?**

```release-note
Added a new alpha metric `scheduler_podgroup_cache_missed_events_total` (available when the `GenericWorkload` feature gate is enabled) that counts scheduler-cache pod group operations which could not find the expected pod group state, indicating a missed add/assume event.
```

/sig scheduling
/wg workload-aware-scheduling
