### PR TITLE
Flatten pendingPodGroupPods as they contain entries for a single PodGroup

### DIFF
--- a/pkg/scheduler/backend/queue/pending_pod_group_pods.go
+++ b/pkg/scheduler/backend/queue/pending_pod_group_pods.go
@@ -17,93 +17,74 @@ limitations under the License.
 package queue
 
 import (
-	"slices"
+	"fmt"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
-// pendingPodGroupMemberPods stores all pending pods that wait for their corresponding pod group to be requeued.
+// pendingPodGroupMemberPods stores all pending member pods of the currently scheduling pod group.
 type pendingPodGroupMemberPods struct {
-	podGroupToPods map[string][]*framework.QueuedPodInfo
+	keyToPod map[string]*framework.QueuedPodInfo
 }
 
 func newPendingPodGroupMemberPods() *pendingPodGroupMemberPods {
 	return &pendingPodGroupMemberPods{
-		podGroupToPods: make(map[string][]*framework.QueuedPodInfo),
+		keyToPod: make(map[string]*framework.QueuedPodInfo),
 	}
 }
 
-// add adds a pod info to the specified pod group.
-func (p *pendingPodGroupMemberPods) add(pgInfoLookup framework.QueuedEntityInfo, pInfo *framework.QueuedPodInfo) {
-	pgKey := queuedEntityKeyFunc(pgInfoLookup)
-	p.podGroupToPods[pgKey] = append(p.podGroupToPods[pgKey], pInfo)
+// add adds a pod info.
+func (p *pendingPodGroupMemberPods) add(pInfo *framework.QueuedPodInfo) {
+	p.keyToPod[pendingPodKey(pInfo.Pod)] = pInfo
 }
 
-// get returns all pod infos associated with the specified pod group.
-func (p *pendingPodGroupMemberPods) get(pgInfoLookup framework.QueuedEntityInfo) []*framework.QueuedPodInfo {
-	pgKey := queuedEntityKeyFunc(pgInfoLookup)
-	return p.podGroupToPods[pgKey]
-}
-
-// has checks if the specified pod group has any pending pods.
-func (p *pendingPodGroupMemberPods) has(pgInfoLookup framework.QueuedEntityInfo) bool {
-	pgKey := queuedEntityKeyFunc(pgInfoLookup)
-	_, ok := p.podGroupToPods[pgKey]
+// has checks if the pod is tracked.
+func (p *pendingPodGroupMemberPods) has(podLookup *v1.Pod) bool {
+	_, ok := p.keyToPod[pendingPodKey(podLookup)]
 	return ok
 }
 
 // len returns the number of pending pods.
 func (p *pendingPodGroupMemberPods) len() int {
-	count := 0
-	for _, pods := range p.podGroupToPods {
-		count += len(pods)
-	}
-	return count
+	return len(p.keyToPod)
 }
 
-// getPod searches for a specific pod within the provided pod group.
-func (p *pendingPodGroupMemberPods) getPod(pgInfoLookup framework.QueuedEntityInfo, pod *v1.Pod) *framework.QueuedPodInfo {
-	pgKey := queuedEntityKeyFunc(pgInfoLookup)
-	for _, pInfo := range p.podGroupToPods[pgKey] {
-		if pInfo.Pod.Name == pod.Name && pInfo.Pod.Namespace == pod.Namespace {
-			return pInfo
-		}
-	}
-	return nil
+// get returns the queued pod info for the given pod.
+func (p *pendingPodGroupMemberPods) get(podLookup *v1.Pod) *framework.QueuedPodInfo {
+	return p.keyToPod[pendingPodKey(podLookup)]
 }
 
-// update refreshes the pod object for a member of the specified pod group.
-// It returns the updated pod info if the pod was found, nil otherwise.
-func (p *pendingPodGroupMemberPods) update(pgInfoLookup framework.QueuedEntityInfo, newPod *v1.Pod) *framework.QueuedPodInfo {
-	pgKey := queuedEntityKeyFunc(pgInfoLookup)
-	for _, pInfo := range p.podGroupToPods[pgKey] {
-		if pInfo.Pod.Name == newPod.Name && pInfo.Pod.Namespace == newPod.Namespace {
-			pInfo.Pod = newPod
-			return pInfo
-		}
+// update refreshes the pod object and returns the updated pod info if found.
+func (p *pendingPodGroupMemberPods) update(newPod *v1.Pod) *framework.QueuedPodInfo {
+	pInfo, ok := p.keyToPod[pendingPodKey(newPod)]
+	if !ok {
+		return nil
 	}
-	return nil
+	pInfo.Pod = newPod
+	return pInfo
 }
 
-// delete removes a specific pod from the tracked members of a pod group.
-// It returns the removed pod info if found, nil otherwise.
-func (p *pendingPodGroupMemberPods) delete(pgInfoLookup framework.QueuedEntityInfo, pod *v1.Pod) *framework.QueuedPodInfo {
-	pgKey := queuedEntityKeyFunc(pgInfoLookup)
-	for i, pInfo := range p.podGroupToPods[pgKey] {
-		if pInfo.Pod.Name == pod.Name && pInfo.Pod.Namespace == pod.Namespace {
-			p.podGroupToPods[pgKey] = slices.Delete(p.podGroupToPods[pgKey], i, i+1)
-			if len(p.podGroupToPods[pgKey]) == 0 {
-				delete(p.podGroupToPods, pgKey)
-			}
-			return pInfo
-		}
+// delete removes a specific pod and returns its pod info if found.
+func (p *pendingPodGroupMemberPods) delete(podLookup *v1.Pod) *framework.QueuedPodInfo {
+	pInfo, ok := p.keyToPod[pendingPodKey(podLookup)]
+	if !ok {
+		return nil
 	}
-	return nil
+	delete(p.keyToPod, pendingPodKey(podLookup))
+	return pInfo
 }
 
-// clear removes all pods associated with the specified pod group.
-func (p *pendingPodGroupMemberPods) clear(pgInfoLookup framework.QueuedEntityInfo) {
-	pgKey := queuedEntityKeyFunc(pgInfoLookup)
-	delete(p.podGroupToPods, pgKey)
+// clear removes all tracked pods and returns them.
+func (p *pendingPodGroupMemberPods) clear() []*framework.QueuedPodInfo {
+	pods := make([]*framework.QueuedPodInfo, 0, len(p.keyToPod))
+	for _, pInfo := range p.keyToPod {
+		pods = append(pods, pInfo)
+	}
+	p.keyToPod = make(map[string]*framework.QueuedPodInfo)
+	return pods
+}
+
+func pendingPodKey(pod *v1.Pod) string {
+	return fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
 }

--- a/pkg/scheduler/backend/queue/pending_pod_group_pods_test.go
+++ b/pkg/scheduler/backend/queue/pending_pod_group_pods_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 )
@@ -29,31 +30,27 @@ import (
 func TestPendingPodGroupMemberPods_Add(t *testing.T) {
 	pod1 := st.MakePod().Name("pod1").Namespace("ns1").PodGroupName("pg1").Obj()
 	pod2 := st.MakePod().Name("pod2").Namespace("ns1").PodGroupName("pg1").Obj()
-	pod3 := st.MakePod().Name("pod3").Namespace("ns1").PodGroupName("pg3").Obj()
 	pInfo1 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod1)}
 	pInfo2 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod2)}
-	pInfo3 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod3)}
-	pgInfo1 := newQueuedPodGroupInfoForLookup(pod1)
-	pgInfo3 := newQueuedPodGroupInfoForLookup(pod3)
 
 	tests := []struct {
 		name      string
 		podsToAdd []*framework.QueuedPodInfo
-		want      map[*framework.QueuedPodGroupInfo][]*framework.QueuedPodInfo
+		want      map[string]*framework.QueuedPodInfo
 	}{
 		{
-			name:      "pod group with multiple pods",
+			name:      "multiple pods",
 			podsToAdd: []*framework.QueuedPodInfo{pInfo1, pInfo2},
-			want: map[*framework.QueuedPodGroupInfo][]*framework.QueuedPodInfo{
-				pgInfo1: {pInfo1, pInfo2},
+			want: map[string]*framework.QueuedPodInfo{
+				"ns1/pod1": pInfo1,
+				"ns1/pod2": pInfo2,
 			},
 		},
 		{
-			name:      "two pod groups",
-			podsToAdd: []*framework.QueuedPodInfo{pInfo1, pInfo3},
-			want: map[*framework.QueuedPodGroupInfo][]*framework.QueuedPodInfo{
-				pgInfo1: {pInfo1},
-				pgInfo3: {pInfo3},
+			name:      "add existing pod",
+			podsToAdd: []*framework.QueuedPodInfo{pInfo1, pInfo1},
+			want: map[string]*framework.QueuedPodInfo{
+				"ns1/pod1": pInfo1,
 			},
 		},
 	}
@@ -62,50 +59,46 @@ func TestPendingPodGroupMemberPods_Add(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ppm := newPendingPodGroupMemberPods()
 			for _, pInfo := range tt.podsToAdd {
-				ppm.add(newQueuedPodGroupInfoForLookup(pInfo.Pod), pInfo)
+				ppm.add(pInfo)
 			}
 
-			for pgInfo, wantPods := range tt.want {
-				if !ppm.has(pgInfo) {
-					t.Errorf("Expected pod group %s to be present", pgInfo.Name)
+			for _, pInfo := range tt.podsToAdd {
+				if !ppm.has(pInfo.Pod) {
+					t.Errorf("Expected pod %s to be present", pInfo.Pod.Name)
 				}
-				gotPods := ppm.get(pgInfo)
-				if diff := cmp.Diff(wantPods, gotPods, cmpopts.IgnoreUnexported(framework.PodInfo{})); diff != "" {
-					t.Errorf("Unexpected pods for pod group %s (-want,+got)\n%s", pgInfo.Name, diff)
+				gotPod := ppm.get(pInfo.Pod)
+				if diff := cmp.Diff(pInfo, gotPod, cmpopts.IgnoreUnexported(framework.PodInfo{})); diff != "" {
+					t.Errorf("Unexpected pod info for %s (-want,+got)\n%s", pInfo.Pod.Name, diff)
 				}
 			}
 		})
 	}
 }
 
-func TestPendingPodGroupMemberPods_GetPod(t *testing.T) {
+func TestPendingPodGroupMemberPods_Get(t *testing.T) {
 	pod1 := st.MakePod().Name("pod1").Namespace("ns1").PodGroupName("pg1").Obj()
 	pod2 := st.MakePod().Name("pod2").Namespace("ns1").PodGroupName("pg1").Obj()
 	pod3 := st.MakePod().Name("pod3").Namespace("ns1").PodGroupName("pg3").Obj()
 	pInfo1 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod1)}
 	pInfo2 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod2)}
-	pgInfo1 := newQueuedPodGroupInfoForLookup(pod1)
 
 	tests := []struct {
-		name         string
-		podsToAdd    []*framework.QueuedPodInfo
-		pgInfoLookup *framework.QueuedPodGroupInfo
-		targetPod    *v1.Pod
-		want         *framework.QueuedPodInfo
+		name      string
+		podsToAdd []*framework.QueuedPodInfo
+		targetPod *v1.Pod
+		want      *framework.QueuedPodInfo
 	}{
 		{
-			name:         "find existing pod in pod group",
-			podsToAdd:    []*framework.QueuedPodInfo{pInfo1, pInfo2},
-			pgInfoLookup: pgInfo1,
-			targetPod:    pod1,
-			want:         pInfo1,
+			name:      "find existing pod",
+			podsToAdd: []*framework.QueuedPodInfo{pInfo1, pInfo2},
+			targetPod: pod1,
+			want:      pInfo1,
 		},
 		{
-			name:         "pod not in pod group",
-			podsToAdd:    []*framework.QueuedPodInfo{pInfo1, pInfo2},
-			pgInfoLookup: pgInfo1,
-			targetPod:    pod3,
-			want:         nil,
+			name:      "pod not found",
+			podsToAdd: []*framework.QueuedPodInfo{pInfo1, pInfo2},
+			targetPod: pod3,
+			want:      nil,
 		},
 	}
 
@@ -113,10 +106,10 @@ func TestPendingPodGroupMemberPods_GetPod(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ppm := newPendingPodGroupMemberPods()
 			for _, pInfo := range tt.podsToAdd {
-				ppm.add(newQueuedPodGroupInfoForLookup(pInfo.Pod), pInfo)
+				ppm.add(pInfo)
 			}
 
-			got := ppm.getPod(tt.pgInfoLookup, tt.targetPod)
+			got := ppm.get(tt.targetPod)
 			if diff := cmp.Diff(tt.want, got, cmpopts.IgnoreUnexported(framework.PodInfo{})); diff != "" {
 				t.Errorf("Unexpected pod info (-want,+got)\n%s", diff)
 			}
@@ -131,29 +124,24 @@ func TestPendingPodGroupMemberPods_Update(t *testing.T) {
 
 	pInfo1 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod1)}
 	updatedPodInfo1 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, updatedPod1)}
-	pgInfo1 := newQueuedPodGroupInfoForLookup(pod1)
 
 	tests := []struct {
-		name         string
-		podsToAdd    []*framework.QueuedPodInfo
-		pgInfoLookup *framework.QueuedPodGroupInfo
-		updatePod    *v1.Pod
-		checkPod     *v1.Pod
-		wantUpdated  *framework.QueuedPodInfo
+		name        string
+		podsToAdd   []*framework.QueuedPodInfo
+		updatePod   *v1.Pod
+		wantUpdated *framework.QueuedPodInfo
 	}{
 		{
-			name:         "update existing pod",
-			podsToAdd:    []*framework.QueuedPodInfo{pInfo1},
-			pgInfoLookup: pgInfo1,
-			updatePod:    updatedPod1,
-			wantUpdated:  updatedPodInfo1,
+			name:        "update existing pod",
+			podsToAdd:   []*framework.QueuedPodInfo{pInfo1},
+			updatePod:   updatedPod1,
+			wantUpdated: updatedPodInfo1,
 		},
 		{
-			name:         "update non-existent pod",
-			podsToAdd:    []*framework.QueuedPodInfo{pInfo1},
-			pgInfoLookup: pgInfo1,
-			updatePod:    pod2,
-			wantUpdated:  nil,
+			name:        "update non-existent pod",
+			podsToAdd:   []*framework.QueuedPodInfo{pInfo1},
+			updatePod:   pod2,
+			wantUpdated: nil,
 		},
 	}
 
@@ -161,10 +149,10 @@ func TestPendingPodGroupMemberPods_Update(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ppm := newPendingPodGroupMemberPods()
 			for _, pInfo := range tt.podsToAdd {
-				ppm.add(newQueuedPodGroupInfoForLookup(pInfo.Pod), pInfo.DeepCopy())
+				ppm.add(pInfo.DeepCopy())
 			}
 
-			pInfo := ppm.update(tt.pgInfoLookup, tt.updatePod)
+			pInfo := ppm.update(tt.updatePod)
 			if diff := cmp.Diff(tt.wantUpdated, pInfo, cmpopts.IgnoreUnexported(framework.PodInfo{})); diff != "" {
 				t.Errorf("Unexpected updated pod (-want,+got)\n%s", diff)
 			}
@@ -175,46 +163,29 @@ func TestPendingPodGroupMemberPods_Update(t *testing.T) {
 func TestPendingPodGroupMemberPods_Delete(t *testing.T) {
 	pod1 := st.MakePod().Name("pod1").Namespace("ns1").PodGroupName("pg1").Obj()
 	pod2 := st.MakePod().Name("pod2").Namespace("ns1").PodGroupName("pg1").Obj()
-	pod3 := st.MakePod().Name("pod3").Namespace("ns3").PodGroupName("pg3").Obj()
 	pInfo1 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod1)}
 	pInfo2 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod2)}
-	pgInfo1 := newQueuedPodGroupInfoForLookup(pod1)
-	pgInfo3 := newQueuedPodGroupInfoForLookup(pod3)
 
 	tests := []struct {
-		name         string
-		podsToAdd    []*framework.QueuedPodInfo
-		pgInfoLookup *framework.QueuedPodGroupInfo
-		podToDelete  *v1.Pod
-		want         []*framework.QueuedPodInfo
+		name          string
+		podsToAdd     []*framework.QueuedPodInfo
+		podToDelete   *v1.Pod
+		wantDeleted   *framework.QueuedPodInfo
+		wantRemaining sets.Set[*framework.QueuedPodInfo]
 	}{
 		{
-			name:         "delete non-existent pod from existing pod group",
-			podsToAdd:    []*framework.QueuedPodInfo{pInfo1},
-			pgInfoLookup: pgInfo1,
-			podToDelete:  pod2,
-			want:         []*framework.QueuedPodInfo{pInfo1},
+			name:          "delete existing pod",
+			podsToAdd:     []*framework.QueuedPodInfo{pInfo1, pInfo2},
+			podToDelete:   pod1,
+			wantDeleted:   pInfo1,
+			wantRemaining: sets.New(pInfo2),
 		},
 		{
-			name:         "delete pod from non-existent pod group",
-			podsToAdd:    []*framework.QueuedPodInfo{pInfo1, pInfo2},
-			pgInfoLookup: pgInfo3,
-			podToDelete:  pod3,
-			want:         nil,
-		},
-		{
-			name:         "delete one pod from pod group",
-			podsToAdd:    []*framework.QueuedPodInfo{pInfo1, pInfo2},
-			pgInfoLookup: pgInfo1,
-			podToDelete:  pod1,
-			want:         []*framework.QueuedPodInfo{pInfo2},
-		},
-		{
-			name:         "delete all pods removes pod group",
-			podsToAdd:    []*framework.QueuedPodInfo{pInfo1},
-			pgInfoLookup: pgInfo1,
-			podToDelete:  pod1,
-			want:         nil,
+			name:          "delete non-existent pod",
+			podsToAdd:     []*framework.QueuedPodInfo{pInfo1},
+			podToDelete:   pod2,
+			wantDeleted:   nil,
+			wantRemaining: sets.New(pInfo1),
 		},
 	}
 
@@ -222,19 +193,20 @@ func TestPendingPodGroupMemberPods_Delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ppm := newPendingPodGroupMemberPods()
 			for _, pInfo := range tt.podsToAdd {
-				ppm.add(newQueuedPodGroupInfoForLookup(pInfo.Pod), pInfo.DeepCopy())
+				ppm.add(pInfo)
 			}
 
-			ppm.delete(tt.pgInfoLookup, tt.podToDelete)
-
-			expectedPodGroupExists := len(tt.want) > 0
-			if exists := ppm.has(tt.pgInfoLookup); exists != expectedPodGroupExists {
-				t.Errorf("Expected pod group to exist: %v, got: %v", expectedPodGroupExists, exists)
+			gotDeleted := ppm.delete(tt.podToDelete)
+			if diff := cmp.Diff(tt.wantDeleted, gotDeleted, cmpopts.IgnoreUnexported(framework.PodInfo{})); diff != "" {
+				t.Errorf("Unexpected deleted pod (-want,+got)\n%s", diff)
 			}
 
-			gotPods := ppm.get(tt.pgInfoLookup)
-			if diff := cmp.Diff(tt.want, gotPods, cmpopts.IgnoreUnexported(framework.PodInfo{})); diff != "" {
-				t.Errorf("Unexpected pods for pod group %s (-want,+got)\n%s", tt.pgInfoLookup.Name, diff)
+			gotRemaining := sets.New[*framework.QueuedPodInfo]()
+			for _, pInfo := range ppm.keyToPod {
+				gotRemaining.Insert(pInfo)
+			}
+			if diff := cmp.Diff(tt.wantRemaining, gotRemaining, cmpopts.IgnoreUnexported(framework.PodInfo{})); diff != "" {
+				t.Errorf("Unexpected remaining pods (-want,+got)\n%s", diff)
 			}
 		})
 	}
@@ -243,30 +215,23 @@ func TestPendingPodGroupMemberPods_Delete(t *testing.T) {
 func TestPendingPodGroupMemberPods_Clear(t *testing.T) {
 	pod1 := st.MakePod().Name("pod1").Namespace("ns1").PodGroupName("pg1").Obj()
 	pod2 := st.MakePod().Name("pod2").Namespace("ns1").PodGroupName("pg1").Obj()
-	pod3 := st.MakePod().Name("pod3").Namespace("ns1").PodGroupName("pg3").Obj()
 	pInfo1 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod1)}
 	pInfo2 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod2)}
-	pInfo3 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod3)}
-	pgInfo1 := newQueuedPodGroupInfoForLookup(pod1)
-	pgInfo3 := newQueuedPodGroupInfoForLookup(pod3)
 
 	tests := []struct {
-		name        string
-		podsToAdd   []*framework.QueuedPodInfo
-		clearGroup  *framework.QueuedPodGroupInfo
-		wantPresent *framework.QueuedPodGroupInfo
+		name      string
+		podsToAdd []*framework.QueuedPodInfo
+		want      sets.Set[*framework.QueuedPodInfo]
 	}{
 		{
-			name:        "clear target pod group",
-			podsToAdd:   []*framework.QueuedPodInfo{pInfo1, pInfo2, pInfo3},
-			clearGroup:  pgInfo1,
-			wantPresent: pgInfo3,
+			name:      "clear all pods",
+			podsToAdd: []*framework.QueuedPodInfo{pInfo1, pInfo2},
+			want:      sets.New(pInfo1, pInfo2),
 		},
 		{
-			name:        "clear non-existent group",
-			podsToAdd:   []*framework.QueuedPodInfo{pInfo1, pInfo2},
-			clearGroup:  pgInfo3,
-			wantPresent: pgInfo1,
+			name:      "clear empty",
+			podsToAdd: []*framework.QueuedPodInfo{},
+			want:      nil,
 		},
 	}
 
@@ -274,16 +239,17 @@ func TestPendingPodGroupMemberPods_Clear(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ppm := newPendingPodGroupMemberPods()
 			for _, pInfo := range tt.podsToAdd {
-				ppm.add(newQueuedPodGroupInfoForLookup(pInfo.Pod), pInfo)
+				ppm.add(pInfo)
 			}
 
-			ppm.clear(tt.clearGroup)
-
-			if ppm.has(tt.clearGroup) {
-				t.Errorf("Expected pod group %s to be cleared", tt.clearGroup.Name)
+			gotCleared := ppm.clear()
+			gotClearedSet := sets.New(gotCleared...)
+			if diff := cmp.Diff(tt.want, gotClearedSet, cmpopts.IgnoreUnexported(framework.PodInfo{})); diff != "" {
+				t.Errorf("Unexpected cleared pods (-want,+got)\n%s", diff)
 			}
-			if !ppm.has(tt.wantPresent) {
-				t.Errorf("Expected pod group %s to be still present", tt.wantPresent.Name)
+
+			if ppm.len() != 0 {
+				t.Errorf("Expected map to be empty, got length %d", ppm.len())
 			}
 		})
 	}
@@ -292,10 +258,8 @@ func TestPendingPodGroupMemberPods_Clear(t *testing.T) {
 func TestPendingPodGroupMemberPods_Len(t *testing.T) {
 	pod1 := st.MakePod().Name("pod1").Namespace("ns1").PodGroupName("pg1").Obj()
 	pod2 := st.MakePod().Name("pod2").Namespace("ns1").PodGroupName("pg1").Obj()
-	pod3 := st.MakePod().Name("pod3").Namespace("ns1").PodGroupName("pg3").Obj()
 	pInfo1 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod1)}
 	pInfo2 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod2)}
-	pInfo3 := &framework.QueuedPodInfo{PodInfo: mustNewTestPodInfo(t, pod3)}
 
 	tests := []struct {
 		name      string
@@ -308,14 +272,9 @@ func TestPendingPodGroupMemberPods_Len(t *testing.T) {
 			wantLen:   0,
 		},
 		{
-			name:      "single pod group with multiple pods",
+			name:      "multiple pods",
 			podsToAdd: []*framework.QueuedPodInfo{pInfo1, pInfo2},
 			wantLen:   2,
-		},
-		{
-			name:      "multiple pod groups",
-			podsToAdd: []*framework.QueuedPodInfo{pInfo1, pInfo2, pInfo3},
-			wantLen:   3,
 		},
 	}
 
@@ -323,7 +282,7 @@ func TestPendingPodGroupMemberPods_Len(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ppm := newPendingPodGroupMemberPods()
 			for _, pInfo := range tt.podsToAdd {
-				ppm.add(newQueuedPodGroupInfoForLookup(pInfo.Pod), pInfo)
+				ppm.add(pInfo)
 			}
 
 			if got := ppm.len(); got != tt.wantLen {

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -811,7 +811,7 @@ func (p *PriorityQueue) addPodGroupMember(logger klog.Logger, pInfo *framework.Q
 	if p.activeQ.isLastPoppedEntity(pgInfoLookup) {
 		// If the last popped entity is the matching pod group, add the pod to the pending pod group pods,
 		// so it will be added to the pod group when it's requeued.
-		p.pendingPodGroupPods.add(pgInfoLookup, pInfo)
+		p.pendingPodGroupPods.add(pInfo)
 		logger.V(5).Info("Pod added to pending pod group pods, waiting for its pod group to be requeued", "podGroup", klog.KObj(pgInfoLookup), "pod", klog.KObj(pInfo))
 	} else {
 		// Create a new group as it's the first member pod in the queue.
@@ -1070,13 +1070,12 @@ func (p *PriorityQueue) AddAttemptedPodGroupIfNeeded(logger klog.Logger, pgInfo 
 
 	p.activeQ.clearPoppedEntity()
 	// Get the pending pods and put them into the pod group.
-	pendingPods := p.pendingPodGroupPods.get(pgInfo)
+	pendingPods := p.pendingPodGroupPods.clear()
 	if len(pendingPods) == 0 {
 		// No pending pods, nothing to requeue.
 		return nil
 	}
 	pgInfo.SetPods(pendingPods)
-	p.pendingPodGroupPods.clear(pgInfo)
 
 	hasErrorPods := false
 	pgInfo.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
@@ -1277,13 +1276,10 @@ func (p *PriorityQueue) Update(ctx context.Context, oldPod, newPod *v1.Pod) {
 		}
 		return
 	} else if p.isPodGroupMember(newPod) {
-		pgInfoLookup := entityLookup.(*framework.QueuedPodGroupInfo)
-		if p.pendingPodGroupPods.has(pgInfoLookup) {
-			if pInfo := p.pendingPodGroupPods.update(pgInfoLookup, newPod); pInfo != nil {
-				p.UpdateNominatedPod(logger, oldPod, pInfo.PodInfo)
-				pInfo.PodSignature = p.signPod(ctx, newPod)
-				return
-			}
+		if pInfo := p.pendingPodGroupPods.update(newPod); pInfo != nil {
+			p.UpdateNominatedPod(logger, oldPod, pInfo.PodInfo)
+			pInfo.PodSignature = p.signPod(ctx, newPod)
+			return
 		}
 	}
 	// If the entity is not in any of the queues, we add it.
@@ -1322,8 +1318,7 @@ func (p *PriorityQueue) deletePodGroupMember(logger klog.Logger, pod *v1.Pod) {
 
 	entity, strategy := p.deleteFromAnyQueue(pgInfoLookup)
 	if entity == nil {
-		pgInfoLookup := newQueuedPodGroupInfoForLookup(pod)
-		pInfo := p.pendingPodGroupPods.delete(pgInfoLookup, pod)
+		pInfo := p.pendingPodGroupPods.delete(pod)
 		if pInfo == nil {
 			return
 		}
@@ -1517,10 +1512,8 @@ func (p *PriorityQueue) PendingPodGroupPods() []*v1.Pod {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 	var result []*v1.Pod
-	for _, pInfos := range p.pendingPodGroupPods.podGroupToPods {
-		for _, pInfo := range pInfos {
-			result = append(result, pInfo.Pod)
-		}
+	for _, pInfo := range p.pendingPodGroupPods.keyToPod {
+		result = append(result, pInfo.Pod)
 	}
 	return result
 }
@@ -1559,7 +1552,7 @@ func (p *PriorityQueue) getPod(podLookup *v1.Pod, unlockedActiveQ unlockedActive
 		if !p.isPodGroupMember(podLookup) {
 			return nil
 		}
-		return p.pendingPodGroupPods.getPod(entityLookup, podLookup)
+		return p.pendingPodGroupPods.get(podLookup)
 	}
 	var foundPodInfo *framework.QueuedPodInfo
 	entity.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -3706,7 +3706,6 @@ func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {
 	pgName := "test-pg"
 	pod1 := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Priority(midPriority).PodGroupName(pgName).Obj()
 	pod2 := st.MakePod().Name("pod2").Namespace("ns1").UID("pod2").Priority(midPriority).PodGroupName(pgName).Obj()
-	pgLookup := newQueuedPodGroupInfoForLookup(pod1)
 
 	tests := []struct {
 		name                            string
@@ -3732,8 +3731,8 @@ func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {
 			setup: func(tCtx ktesting.TContext, q *PriorityQueue, pgInfo *framework.QueuedPodGroupInfo) {
 				pInfo1 := q.newQueuedPodInfo(tCtx, pod1)
 				pInfo2 := q.newQueuedPodInfo(tCtx, pod2)
-				q.pendingPodGroupPods.add(pgLookup, pInfo1)
-				q.pendingPodGroupPods.add(pgLookup, pInfo2)
+				q.pendingPodGroupPods.add(pInfo1)
+				q.pendingPodGroupPods.add(pInfo2)
 			},
 			disableBackoff:                 true,
 			expectedConsecutiveErrorsCount: 1,
@@ -3745,8 +3744,8 @@ func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {
 			setup: func(tCtx ktesting.TContext, q *PriorityQueue, pgInfo *framework.QueuedPodGroupInfo) {
 				pInfo1 := q.newQueuedPodInfo(tCtx, pod1)
 				pInfo2 := q.newQueuedPodInfo(tCtx, pod2, "fakePlugin")
-				q.pendingPodGroupPods.add(pgLookup, pInfo1)
-				q.pendingPodGroupPods.add(pgLookup, pInfo2)
+				q.pendingPodGroupPods.add(pInfo1)
+				q.pendingPodGroupPods.add(pInfo2)
 			},
 			disableBackoff:                 true,
 			expectedConsecutiveErrorsCount: 1,
@@ -3758,8 +3757,8 @@ func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {
 			setup: func(tCtx ktesting.TContext, q *PriorityQueue, pgInfo *framework.QueuedPodGroupInfo) {
 				pInfo1 := q.newQueuedPodInfo(tCtx, pod1, "fakePlugin")
 				pInfo2 := q.newQueuedPodInfo(tCtx, pod2, "fakePlugin")
-				q.pendingPodGroupPods.add(pgLookup, pInfo1)
-				q.pendingPodGroupPods.add(pgLookup, pInfo2)
+				q.pendingPodGroupPods.add(pInfo1)
+				q.pendingPodGroupPods.add(pInfo2)
 				pgInfo.ConsecutiveErrorsCount = 5 // Set to non-zero to verify reset
 			},
 			disableBackoff:             true,
@@ -3772,8 +3771,8 @@ func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {
 			setup: func(tCtx ktesting.TContext, q *PriorityQueue, pgInfo *framework.QueuedPodGroupInfo) {
 				pInfo1 := q.newQueuedPodInfo(tCtx, pod1, "fakePlugin")
 				pInfo2 := q.newQueuedPodInfo(tCtx, pod2, "fakePlugin")
-				q.pendingPodGroupPods.add(pgLookup, pInfo1)
-				q.pendingPodGroupPods.add(pgLookup, pInfo2)
+				q.pendingPodGroupPods.add(pInfo1)
+				q.pendingPodGroupPods.add(pInfo2)
 			},
 			disableBackoff:                  true,
 			blockOnPreEnqueue:               true,
@@ -3786,8 +3785,8 @@ func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {
 			setup: func(tCtx ktesting.TContext, q *PriorityQueue, pgInfo *framework.QueuedPodGroupInfo) {
 				pInfo1 := q.newQueuedPodInfo(tCtx, pod1)
 				pInfo2 := q.newQueuedPodInfo(tCtx, pod2)
-				q.pendingPodGroupPods.add(pgLookup, pInfo1)
-				q.pendingPodGroupPods.add(pgLookup, pInfo2)
+				q.pendingPodGroupPods.add(pInfo1)
+				q.pendingPodGroupPods.add(pInfo2)
 			},
 			expectedConsecutiveErrorsCount: 1,
 			expectedInBackoffQ:             true,
@@ -3798,8 +3797,8 @@ func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {
 			setup: func(tCtx ktesting.TContext, q *PriorityQueue, pgInfo *framework.QueuedPodGroupInfo) {
 				pInfo1 := q.newQueuedPodInfo(tCtx, pod1)
 				pInfo2 := q.newQueuedPodInfo(tCtx, pod2, "fakePlugin")
-				q.pendingPodGroupPods.add(pgLookup, pInfo1)
-				q.pendingPodGroupPods.add(pgLookup, pInfo2)
+				q.pendingPodGroupPods.add(pInfo1)
+				q.pendingPodGroupPods.add(pInfo2)
 			},
 			expectedConsecutiveErrorsCount: 1,
 			expectedInBackoffQ:             true,
@@ -3810,8 +3809,8 @@ func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {
 			setup: func(tCtx ktesting.TContext, q *PriorityQueue, pgInfo *framework.QueuedPodGroupInfo) {
 				pInfo1 := q.newQueuedPodInfo(tCtx, pod1, "fakePlugin")
 				pInfo2 := q.newQueuedPodInfo(tCtx, pod2, "fakePlugin")
-				q.pendingPodGroupPods.add(pgLookup, pInfo1)
-				q.pendingPodGroupPods.add(pgLookup, pInfo2)
+				q.pendingPodGroupPods.add(pInfo1)
+				q.pendingPodGroupPods.add(pInfo2)
 				pgInfo.ConsecutiveErrorsCount = 5 // Set to non-zero to verify reset
 			},
 			expectedUnschedulableCount: 1,
@@ -3823,8 +3822,8 @@ func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {
 			setup: func(tCtx ktesting.TContext, q *PriorityQueue, pgInfo *framework.QueuedPodGroupInfo) {
 				pInfo1 := q.newQueuedPodInfo(tCtx, pod1)
 				pInfo2 := q.newQueuedPodInfo(tCtx, pod2)
-				q.pendingPodGroupPods.add(pgLookup, pInfo1)
-				q.pendingPodGroupPods.add(pgLookup, pInfo2)
+				q.pendingPodGroupPods.add(pInfo1)
+				q.pendingPodGroupPods.add(pInfo2)
 			},
 			blockOnPreEnqueue:               true,
 			expectedConsecutiveErrorsCount:  1,
@@ -3876,7 +3875,7 @@ func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {
 			if isInUnschedulable := q.unschedulableEntities.get(pgInfo) != nil; isInUnschedulable != test.expectedInUnschedulableEntities {
 				tCtx.Errorf("Expected pod group to be in unschedulableEntities: %v, got %v", test.expectedInUnschedulableEntities, isInUnschedulable)
 			}
-			if len(q.pendingPodGroupPods.get(pgInfo)) != 0 {
+			if q.pendingPodGroupPods.len() != 0 {
 				tCtx.Errorf("Expected pendingPodGroupPods to be cleared")
 			}
 			if len(pgInfo.QueuedPodInfos) != test.expectedPodsInGroup {
@@ -6189,13 +6188,7 @@ func TestAddPodGroupMember(t *testing.T) {
 				}
 			}
 
-			inPending := false
-			for _, pInfo := range q.pendingPodGroupPods.get(pgLookup) {
-				if pInfo.Pod.Name == tt.incomingPod.Name {
-					inPending = true
-					break
-				}
-			}
+			inPending := q.pendingPodGroupPods.has(tt.incomingPod)
 			if inPending != tt.expectedInPendingPodGroupPods {
 				t.Errorf("Expected incoming pod in pendingPodGroupPods: %v, got %v", tt.expectedInPendingPodGroupPods, inPending)
 			}
@@ -6380,14 +6373,11 @@ func TestDeletePodGroupMember(t *testing.T) {
 				}
 			}
 
-			pendingPods := q.pendingPodGroupPods.get(pgLookup)
-			if pendingLen := len(pendingPods); pendingLen != tt.expectedPodsInPending {
+			if pendingLen := q.pendingPodGroupPods.len(); pendingLen != tt.expectedPodsInPending {
 				t.Errorf("Expected pod group to have %d pods in pendingPodGroupPods, got %d", tt.expectedPodsInPending, pendingLen)
 			}
-			for _, pInfo := range pendingPods {
-				if pInfo.Pod.Name == tt.podToDelete.Name {
-					t.Errorf("Deleted pod %s is still present in pendingPodGroupPods map", tt.podToDelete.Name)
-				}
+			if q.pendingPodGroupPods.has(tt.podToDelete) {
+				t.Errorf("Deleted pod %s is still present in pendingPodGroupPods map", tt.podToDelete.Name)
 			}
 		})
 	}
@@ -6624,23 +6614,13 @@ func TestUpdatePodGroupMember(t *testing.T) {
 				}
 			}
 
-			pendingPods := q.pendingPodGroupPods.get(pgLookup)
-			if pendingLen := len(pendingPods); pendingLen != tt.expectedPodsInPending {
+			if pendingLen := q.pendingPodGroupPods.len(); pendingLen != tt.expectedPodsInPending {
 				t.Errorf("Expected pod group to have %d pods in pendingPodGroupPods, got %d", tt.expectedPodsInPending, pendingLen)
 			}
 			if tt.expectedPodsInPending > 0 {
-				inPending := false
-				for _, pInfo := range pendingPods {
-					if pInfo.Pod.Name == tt.newPod.Name {
-						inPending = true
-						if diff := cmp.Diff(tt.newPod, pInfo.Pod); diff != "" {
-							t.Errorf("Pending member pod differs from newPod (-want +got):\n%s", diff)
-						}
-						break
-					}
-				}
-				if !inPending {
-					t.Errorf("Updated pod %s was not found in pendingPodGroupPods map", tt.newPod.Name)
+				pInfo := q.pendingPodGroupPods.get(tt.newPod)
+				if diff := cmp.Diff(tt.newPod, pInfo.Pod); diff != "" {
+					t.Errorf("Pending member pod differs from newPod (-want +got):\n%s", diff)
 				}
 			}
 			if diff := cmp.Diff(tt.expectedNominatedPods, q.nominatedPodToNode, cmpopts.EquateEmpty()); diff != "" {
@@ -6770,21 +6750,11 @@ func TestActivatePodGroupMember(t *testing.T) {
 				}
 			}
 
-			pendingPods := q.pendingPodGroupPods.get(pgLookup)
-			if pendingLen := len(pendingPods); pendingLen != tt.expectedPodsInPending {
+			if pendingLen := q.pendingPodGroupPods.len(); pendingLen != tt.expectedPodsInPending {
 				t.Errorf("Expected pod group to have %d pods in pendingPodGroupPods, got %d", tt.expectedPodsInPending, pendingLen)
 			}
-			if tt.expectedPodsInPending > 0 {
-				inPending := false
-				for _, pInfo := range pendingPods {
-					if pInfo.Pod.Name == tt.podToActivate.Name {
-						inPending = true
-						break
-					}
-				}
-				if !inPending {
-					t.Errorf("Pod %s was not found in pendingPodGroupPods map", tt.podToActivate.Name)
-				}
+			if tt.expectedPodsInPending > 0 && !q.pendingPodGroupPods.has(tt.podToActivate) {
+				t.Errorf("Pod %s was not found in pendingPodGroupPods map", tt.podToActivate.Name)
 			}
 
 			if tt.expectedForceActivateEvent {
@@ -7362,8 +7332,7 @@ func TestAddUnschedulablePodIfNotPresentPodGroupMember(t *testing.T) {
 				}
 			}
 
-			pendingPods := q.pendingPodGroupPods.get(pgLookup)
-			if pendingLen := len(pendingPods); pendingLen != tt.expectedPodsInPending {
+			if pendingLen := q.pendingPodGroupPods.len(); pendingLen != tt.expectedPodsInPending {
 				t.Errorf("Expected pod group to have %d pods in pendingPodGroupPods, got %d", tt.expectedPodsInPending, pendingLen)
 			}
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

`pendingPodGroupMemberPods` in scheduling queue was tracking pending pods by a pod group key. However, since there can be only one pending pod group at a time, keying the map by the pod group key is redundant. This PR flattens the data structure to track the pods for an in-flight pod group more directly.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
