### PR TITLE
kubectl: restrict cluster-info dump file modes

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump.go
@@ -121,9 +121,9 @@ func setupOutputWriter(dir string, defaultWriter io.Writer, filename string, fil
 	}
 	fullFile := filepath.Join(dir, filename) + fileExtension
 	parent := filepath.Dir(fullFile)
-	cmdutil.CheckErr(os.MkdirAll(parent, 0755))
+	cmdutil.CheckErr(os.MkdirAll(parent, 0700))
 
-	file, err := os.Create(fullFile)
+	file, err := os.OpenFile(fullFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	cmdutil.CheckErr(err)
 	return file
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump_test.go
@@ -56,12 +56,13 @@ func TestSetupOutputWriterNoOp(t *testing.T) {
 func TestSetupOutputWriterFile(t *testing.T) {
 	file := "output"
 	extension := ".json"
-	dir, err := os.MkdirTemp(os.TempDir(), "out")
+	baseDir, err := os.MkdirTemp(os.TempDir(), "out")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
+	dir := filepath.Join(baseDir, "cluster-info")
 	fullPath := filepath.Join(dir, file) + extension
-	defer os.RemoveAll(dir)
+	defer os.RemoveAll(baseDir)
 
 	_, _, buf, _ := genericiooptions.NewTestIOStreams()
 	f := cmdtesting.NewTestFactory()
@@ -80,5 +81,21 @@ func TestSetupOutputWriterFile(t *testing.T) {
 	}
 	if string(data) != output {
 		t.Errorf("expected: %v, saw: %v", output, data)
+	}
+
+	fileInfo, err := os.Stat(fullPath)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if fileInfo.Mode().Perm() != 0600 {
+		t.Errorf("expected file mode: %v, saw: %v", os.FileMode(0600), fileInfo.Mode().Perm())
+	}
+
+	dirInfo, err := os.Stat(dir)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if dirInfo.Mode().Perm() != 0700 {
+		t.Errorf("expected directory mode: %v, saw: %v", os.FileMode(0700), dirInfo.Mode().Perm())
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kubernetes/issues/140095

`kubectl cluster-info dump --output-directory` can write pod logs and other
debug output that may include sensitive values. This changes the dump writer to
create output directories with owner-only permissions and output files as
owner-readable/writable only.

The existing writer coverage now also asserts the created file and directory
modes so this does not regress.

Tests:

- `GOCACHE=/Volumes/STOREJET/Documents/OSC/repos/kubernetes/.go-cache GOMODCACHE=/Volumes/STOREJET/Documents/OSC/repos/kubernetes/.go-mod-cache go test ./staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo -run TestSetupOutputWriterFile -count=1`
- `GOCACHE=/Volumes/STOREJET/Documents/OSC/repos/kubernetes/.go-cache GOMODCACHE=/Volumes/STOREJET/Documents/OSC/repos/kubernetes/.go-mod-cache go test ./staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo -count=1`

```release-note
kubectl cluster-info dump --output-directory now creates output directories with 0700 permissions and output files with 0600 permissions.
```
