### PR TITLE
feat(ccm): add labels to route_sync_total metric

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -6245,6 +6245,15 @@
   componentEndpoints:
   - component: kube-controller-manager
     endpoint: /metrics
+- name: route_corrections_total
+  subsystem: route_controller
+  help: A metric counting the number of periodically-triggered reconciles that resulted
+    in at least one route being created or deleted.
+  type: Counter
+  stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
 - name: route_sync_total
   subsystem: route_controller
   help: A metric counting the amount of times routes have been synced with the cloud

--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -6245,21 +6245,16 @@
   componentEndpoints:
   - component: kube-controller-manager
     endpoint: /metrics
-- name: route_corrections_total
-  subsystem: route_controller
-  help: A metric counting the number of periodically-triggered reconciles that resulted
-    in at least one route being created or deleted.
-  type: Counter
-  stabilityLevel: ALPHA
-  componentEndpoints:
-  - component: cloud-controller-manager
-    endpoint: /metrics
 - name: route_sync_total
   subsystem: route_controller
-  help: A metric counting the amount of times routes have been synced with the cloud
-    provider.
+  help: A metric counting the number of route reconciles with the cloud provider,
+    labeled by the trigger (periodic or node_change) and the outcome (changed if at
+    least one route was created or deleted, otherwise noop).
   type: Counter
   stabilityLevel: ALPHA
+  labels:
+  - outcome
+  - trigger
   componentEndpoints:
   - component: cloud-controller-manager
     endpoint: /metrics

--- a/staging/src/k8s.io/cloud-provider/controllers/route/metrics.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/metrics.go
@@ -41,7 +41,7 @@ var (
 	routeCorrectionsCount = metrics.NewCounter(&metrics.CounterOpts{
 		Name:           "route_corrections_total",
 		Subsystem:      subsystem,
-		Help:           "A metric counting the amount of times routes required adjustment after a periodic reconcile.",
+		Help:           "A metric counting the number of periodically-triggered reconciles that resulted in at least one route being created or deleted.",
 		StabilityLevel: metrics.ALPHA,
 	})
 )

--- a/staging/src/k8s.io/cloud-provider/controllers/route/metrics.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/metrics.go
@@ -30,25 +30,25 @@ const (
 
 var registration sync.Once
 
-var (
-	routeSyncCount = metrics.NewCounter(&metrics.CounterOpts{
-		Name:           "route_sync_total",
-		Subsystem:      subsystem,
-		Help:           "A metric counting the amount of times routes have been synced with the cloud provider.",
-		StabilityLevel: metrics.ALPHA,
-	})
-
-	routeCorrectionsCount = metrics.NewCounter(&metrics.CounterOpts{
-		Name:           "route_corrections_total",
-		Subsystem:      subsystem,
-		Help:           "A metric counting the number of periodically-triggered reconciles that resulted in at least one route being created or deleted.",
-		StabilityLevel: metrics.ALPHA,
-	})
-)
+var routeSyncCount = metrics.NewCounterVec(&metrics.CounterOpts{
+	Name:           "route_sync_total",
+	Subsystem:      subsystem,
+	Help:           "A metric counting the number of route reconciles with the cloud provider, labeled by the trigger (periodic or node_change) and the outcome (changed if at least one route was created or deleted, otherwise noop).",
+	StabilityLevel: metrics.ALPHA,
+}, []string{"outcome", "trigger"})
 
 func registerMetrics() {
 	registration.Do(func() {
 		legacyregistry.MustRegister(routeSyncCount)
-		legacyregistry.MustRegister(routeCorrectionsCount)
 	})
+}
+
+// recordRouteSync increments route_sync_total for a completed reconcile,
+// deriving the outcome label from whether any route was created or deleted.
+func recordRouteSync(routesChanged bool, trigger string) {
+	outcome := "noop"
+	if routesChanged {
+		outcome = "changed"
+	}
+	routeSyncCount.WithLabelValues(outcome, trigger).Inc()
 }

--- a/staging/src/k8s.io/cloud-provider/controllers/route/metrics.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/metrics.go
@@ -37,10 +37,18 @@ var (
 		Help:           "A metric counting the amount of times routes have been synced with the cloud provider.",
 		StabilityLevel: metrics.ALPHA,
 	})
+
+	routeCorrectionsCount = metrics.NewCounter(&metrics.CounterOpts{
+		Name:           "route_corrections_total",
+		Subsystem:      subsystem,
+		Help:           "A metric counting the amount of times routes required adjustment after a periodic reconcile.",
+		StabilityLevel: metrics.ALPHA,
+	})
 )
 
 func registerMetrics() {
 	registration.Do(func() {
 		legacyregistry.MustRegister(routeSyncCount)
+		legacyregistry.MustRegister(routeCorrectionsCount)
 	})
 }

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
@@ -269,11 +269,11 @@ func (rc *RouteController) reconcileNodeRoutes(ctx context.Context) (bool, error
 
 	routeList, err := rc.routes.ListRoutes(ctx, rc.clusterName)
 	if err != nil {
-		return false, fmt.Errorf("error listing routes: %v", err)
+		return false, fmt.Errorf("error listing routes: %w", err)
 	}
 	nodes, err := rc.nodeLister.List(labels.Everything())
 	if err != nil {
-		return false, fmt.Errorf("error listing nodes: %v", err)
+		return false, fmt.Errorf("error listing nodes: %w", err)
 	}
 	return rc.reconcile(ctx, nodes, routeList)
 }

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
@@ -65,8 +65,8 @@ const (
 	// routesSyncKey and routeCorrectionsKey are workqueue keys that both trigger a
 	// full-cluster route reconcile. They identify the trigger reason so we can
 	// attribute the outcome.
-	routesSyncKey       = "routes"
-	routeCorrectionsKey = "route-corrections"
+	routesSyncKey       = "node_change"
+	routeCorrectionsKey = "periodic"
 )
 
 var updateNetworkConditionBackoff = wait.Backoff{
@@ -167,7 +167,8 @@ func (rc *RouteController) handleNodeUpdate(oldObj, newObj interface{}) {
 	// In these cases, the old and new Node objects are identical. We use this event as a signal to perform
 	// a route reconciliation — our regular cleanup process — as described in the KEP 5237.
 	// We use a separate key to measure the amount of route reconciles due to a
-	// periodic reconcile. This is tracked in the metric `route_controller_route_corrections_total`
+	// periodic reconcile. This is tracked in the metric
+	// `route_controller_route_sync_total` via the `trigger="periodic"` label.
 	if oldNode.GetResourceVersion() == newNode.GetResourceVersion() {
 		rc.workqueue.AddRateLimited(routeCorrectionsKey)
 	}
@@ -206,9 +207,14 @@ func (rc *RouteController) Run(ctx context.Context, syncPeriod time.Duration, co
 		go wait.UntilWithContext(ctx, rc.runWorker, time.Second)
 	} else {
 		go wait.NonSlidingUntil(func() {
-			if _, err := rc.reconcileNodeRoutes(ctx); err != nil {
+			routesChanged, err := rc.reconcileNodeRoutes(ctx)
+			if err != nil {
 				klog.Errorf("Couldn't reconcile node routes: %v", err)
+				return
 			}
+			// Without the workqueue, reconciles are only driven by the
+			// syncPeriod timer, so the trigger is always periodic.
+			recordRouteSync(routesChanged, "periodic")
 		}, syncPeriod, ctx.Done())
 	}
 
@@ -250,9 +256,8 @@ func (rc *RouteController) processNextWorkItem(ctx context.Context) bool {
 			klog.Infof("Couldn't reconcile node routes: %v, requeuing", err)
 			return fmt.Errorf("couldn't reconcile node routes: %w, requeuing", err)
 		}
-		if key == routeCorrectionsKey && routesChanged {
-			routeCorrectionsCount.Inc()
-		}
+
+		recordRouteSync(routesChanged, key)
 
 		return nil
 	}(obj)
@@ -265,8 +270,6 @@ func (rc *RouteController) processNextWorkItem(ctx context.Context) bool {
 }
 
 func (rc *RouteController) reconcileNodeRoutes(ctx context.Context) (bool, error) {
-	routeSyncCount.Inc()
-
 	routeList, err := rc.routes.ListRoutes(ctx, rc.clusterName)
 	if err != nil {
 		return false, fmt.Errorf("error listing routes: %w", err)

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"reflect"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/time/rate"
@@ -60,6 +61,9 @@ const (
 	// The 10s interval was defined in KEP 5237, it is equivalent to the default
 	// sync period of the route controller.
 	minRouteResyncInterval time.Duration = 10 * time.Second
+
+	routesSyncKey       = "routes"
+	routeCorrectionsKey = "route-corrections"
 )
 
 var updateNetworkConditionBackoff = wait.Backoff{
@@ -137,11 +141,10 @@ func New(
 
 // enqueueClusterReconcile enqueues a route reconciliation of the cluster.
 func (rc *RouteController) enqueueClusterReconcile(_ interface{}) {
-	rc.workqueue.AddRateLimited("routes")
+	rc.workqueue.AddRateLimited(routesSyncKey)
 }
 
 func (rc *RouteController) handleNodeUpdate(oldObj, newObj interface{}) {
-
 	oldNode, oldOk := oldObj.(*v1.Node)
 	newNode, newOk := newObj.(*v1.Node)
 
@@ -149,15 +152,21 @@ func (rc *RouteController) handleNodeUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
-	// The Node informer triggers a periodic update event.
-	// In these cases, the old and new Node objects are identical. We use this event as a signal to perform
-	// a route reconciliation — our regular cleanup process — as described in the KEP 5237.
-	resync := oldNode.GetResourceVersion() == newNode.GetResourceVersion()
 	diffInPodCIDR := !reflect.DeepEqual(oldNode.Spec.PodCIDRs, newNode.Spec.PodCIDRs)
 	diffInNodeAddresses := !reflect.DeepEqual(oldNode.Status.Addresses, newNode.Status.Addresses)
 
-	if diffInPodCIDR || diffInNodeAddresses || resync {
-		rc.enqueueClusterReconcile(newObj)
+	if diffInPodCIDR || diffInNodeAddresses {
+		rc.workqueue.AddRateLimited(routesSyncKey)
+		return
+	}
+
+	// The Node informer triggers a periodic update event.
+	// In these cases, the old and new Node objects are identical. We use this event as a signal to perform
+	// a route reconciliation — our regular cleanup process — as described in the KEP 5237.
+	// We use a separate key to measure the amount of route reconciles due to a
+	// periodic reconcile. This is tracked in the metric `route_controller_route_corrections_total`
+	if oldNode.GetResourceVersion() == newNode.GetResourceVersion() {
+		rc.workqueue.AddRateLimited(routeCorrectionsKey)
 	}
 }
 
@@ -194,7 +203,7 @@ func (rc *RouteController) Run(ctx context.Context, syncPeriod time.Duration, co
 		go wait.UntilWithContext(ctx, rc.runWorker, time.Second)
 	} else {
 		go wait.NonSlidingUntil(func() {
-			if err := rc.reconcileNodeRoutes(ctx); err != nil {
+			if _, err := rc.reconcileNodeRoutes(ctx); err != nil {
 				klog.Errorf("Couldn't reconcile node routes: %v", err)
 			}
 		}, syncPeriod, ctx.Done())
@@ -231,16 +240,19 @@ func (rc *RouteController) processNextWorkItem(ctx context.Context) bool {
 		defer rc.workqueue.Done(key)
 
 		// Run the route reconciliation
-		if err := rc.reconcileNodeRoutes(ctx); err != nil {
+		routesChanged, err := rc.reconcileNodeRoutes(ctx)
+		if err != nil {
 			// Put the item back on the workqueue to handle any transient errors.
 			rc.workqueue.AddRateLimited(key)
 			klog.Infof("Couldn't reconcile node routes: %v, requeuing", err)
 			return fmt.Errorf("couldn't reconcile node routes: %w, requeuing", err)
 		}
+		if key == routeCorrectionsKey && routesChanged {
+			routeCorrectionsCount.Inc()
+		}
 
 		return nil
 	}(obj)
-
 	if err != nil {
 		utilruntime.HandleError(err)
 		return true
@@ -249,16 +261,16 @@ func (rc *RouteController) processNextWorkItem(ctx context.Context) bool {
 	return true
 }
 
-func (rc *RouteController) reconcileNodeRoutes(ctx context.Context) error {
+func (rc *RouteController) reconcileNodeRoutes(ctx context.Context) (bool, error) {
 	routeSyncCount.Inc()
 
 	routeList, err := rc.routes.ListRoutes(ctx, rc.clusterName)
 	if err != nil {
-		return fmt.Errorf("error listing routes: %v", err)
+		return false, fmt.Errorf("error listing routes: %v", err)
 	}
 	nodes, err := rc.nodeLister.List(labels.Everything())
 	if err != nil {
-		return fmt.Errorf("error listing nodes: %v", err)
+		return false, fmt.Errorf("error listing nodes: %v", err)
 	}
 	return rc.reconcile(ctx, nodes, routeList)
 }
@@ -279,13 +291,14 @@ type routeNode struct {
 	cidrWithActions *map[string]routeAction
 }
 
-func (rc *RouteController) reconcile(ctx context.Context, nodes []*v1.Node, routes []*cloudprovider.Route) error {
+func (rc *RouteController) reconcile(ctx context.Context, nodes []*v1.Node, routes []*cloudprovider.Route) (bool, error) {
 	var l sync.Mutex
 	// routeMap includes info about a target Node and its addresses, routes and a map between Pod CIDRs and actions.
 	// If action is add/remove, the route will be added/removed.
 	// If action is keep, the route will not be touched.
 	// If action is update, the route will be deleted and then added.
 	routeMap := make(map[types.NodeName]routeNode)
+	var routesChanged atomic.Bool
 
 	// Put current routes into routeMap.
 	for _, route := range routes {
@@ -379,6 +392,7 @@ func (rc *RouteController) reconcile(ctx context.Context, nodes []*v1.Node, rout
 				if err := rc.routes.DeleteRoute(ctx, rc.clusterName, route); err != nil {
 					klog.Errorf("Could not delete route %s %s after %v: %v", route.Name, route.DestinationCIDR, time.Since(startTime), err)
 				} else {
+					routesChanged.Store(true)
 					klog.Infof("Deleted route %s %s after %v", route.Name, route.DestinationCIDR, time.Since(startTime))
 				}
 				<-rateLimiter
@@ -423,7 +437,8 @@ func (rc *RouteController) reconcile(ctx context.Context, nodes []*v1.Node, rout
 			wg.Add(1)
 			go func(nodeName types.NodeName, nameHint string, route *cloudprovider.Route) {
 				defer wg.Done()
-				err := clientretry.RetryOnConflict(updateNetworkConditionBackoff, func() error {
+
+				createRouteFunc := func() error {
 					startTime := time.Now()
 					// Ensure that we don't have more than maxConcurrentRouteOperations
 					// CreateRoute calls in flight.
@@ -441,18 +456,22 @@ func (rc *RouteController) reconcile(ctx context.Context, nodes []*v1.Node, rout
 									Name:       string(nodeName),
 									UID:        node.UID,
 									Namespace:  "",
-								}, v1.EventTypeWarning, "FailedToCreateRoute", "%s", msg)
+								}, v1.EventTypeWarning, "FailedToCreateRoute", "%s", msg,
+							)
 							klog.V(4).Info(msg)
 							return err
 						}
 					}
+					routesChanged.Store(true)
 					l.Lock()
 					// Mark the route action as done (keep)
 					(*routeMap[nodeName].cidrWithActions)[route.DestinationCIDR] = keep
 					l.Unlock()
 					klog.Infof("Created route for node %s %s with hint %s after %v", nodeName, route.DestinationCIDR, nameHint, time.Since(startTime))
 					return nil
-				})
+				}
+
+				err := clientretry.RetryOnConflict(updateNetworkConditionBackoff, createRouteFunc)
 				if err != nil {
 					klog.Errorf("Could not create route %s %s for node %s: %v", nameHint, route.DestinationCIDR, nodeName, err)
 				}
@@ -497,11 +516,12 @@ func (rc *RouteController) reconcile(ctx context.Context, nodes []*v1.Node, rout
 		}(node)
 	}
 	wg.Wait()
-	return nil
+
+	return routesChanged.Load(), nil
 }
 
 func (rc *RouteController) updateNetworkingCondition(node *v1.Node, routesCreated bool) error {
-	_, condition := nodeutil.GetNodeCondition(&(node.Status), v1.NodeNetworkUnavailable)
+	_, condition := nodeutil.GetNodeCondition(&node.Status, v1.NodeNetworkUnavailable)
 	if routesCreated && condition != nil && condition.Status == v1.ConditionFalse && condition.Reason == "RouteCreated" {
 		klog.V(2).Infof("set node %v with NodeNetworkUnavailable=false was canceled because it is already set", node.Name)
 		return nil
@@ -543,7 +563,6 @@ func (rc *RouteController) updateNetworkingCondition(node *v1.Node, routesCreate
 		}
 		return err
 	})
-
 	if err != nil {
 		klog.Errorf("Error updating node %s: %v", node.Name, err)
 	}

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
@@ -62,6 +62,9 @@ const (
 	// sync period of the route controller.
 	minRouteResyncInterval time.Duration = 10 * time.Second
 
+	// routesSyncKey and routeCorrectionsKey are workqueue keys that both trigger a
+	// full-cluster route reconcile. They identify the trigger reason so we can
+	// attribute the outcome.
 	routesSyncKey       = "routes"
 	routeCorrectionsKey = "route-corrections"
 )

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller_test.go
@@ -473,7 +473,8 @@ func TestReconcile(t *testing.T) {
 			defer e.Stop()
 
 			rc.nodeListerSynced = alwaysReady
-			require.NoError(t, rc.reconcile(ctx, testCase.nodes, testCase.initialRoutes), "failed to reconcile")
+			_, err = rc.reconcile(ctx, testCase.nodes, testCase.initialRoutes)
+			require.NoError(t, err, "failed to reconcile")
 			for _, action := range testCase.clientset.Actions() {
 				if action.GetVerb() == "update" && action.GetResource().Resource == "nodes" {
 					node := action.(core.UpdateAction).GetObject().(*v1.Node)

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller_test.go
@@ -537,13 +537,13 @@ func TestHandleNodeUpdate(t *testing.T) {
 			description:           "internal IP updated",
 			clientset:             fake.NewClientset(&v1.NodeList{Items: []v1.Node{node}}),
 			updatedNode:           v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", UID: "01"}, Spec: v1.NodeSpec{PodCIDR: "10.120.0.0/24", PodCIDRs: []string{"10.120.0.0/24"}}, Status: v1.NodeStatus{Addresses: []v1.NodeAddress{{Type: v1.NodeInternalIP, Address: "10.0.1.2"}}}},
-			expectedWorkqueueItem: "routes",
+			expectedWorkqueueItem: routesSyncKey,
 		},
 		{
 			description:           "pod CIDR updated",
 			clientset:             fake.NewClientset(&v1.NodeList{Items: []v1.Node{node}}),
 			updatedNode:           v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", UID: "01"}, Spec: v1.NodeSpec{PodCIDR: "10.121.0.0/24", PodCIDRs: []string{"10.121.0.0/24"}}, Status: v1.NodeStatus{Addresses: []v1.NodeAddress{{Type: v1.NodeInternalIP, Address: "10.0.1.1"}}}},
-			expectedWorkqueueItem: "routes",
+			expectedWorkqueueItem: routesSyncKey,
 		},
 		{
 			description: "node object not updated",


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds two labels, `trigger` and `outcome`, to the existing ALPHA metric `route_controller_route_sync_total`, so operators can see not just how many route reconciles run, but why they ran and whether they actually changed anything.

- `trigger` distinguishes reconciles caused by an observed node change (`node_change`) from those caused by the informer's periodic resync (`periodic`). Per KEP 5237, the route controller uses the resync (events where the old and new Node are identical) as a signal to run its regular cleanup reconcile.
- `outcome` records whether the reconcile created or deleted at least one route (`changed`) or was a no-op (`noop`).

Previously the metric only counted total reconciles, with no way to tell periodic cleanup passes from node-change-driven ones, or whether those periodic passes were just no-ops or routinely fixing drift. The new labels give operators visibility into how often periodic reconciliation is actually correcting route drift.

#### Which issue(s) this PR is related to:

- Implementation of KEP extension: https://github.com/kubernetes/enhancements/pull/6115

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
The route controller ALPHA metric `route_controller_route_sync_total` now carries two labels: `trigger` (`periodic` or `node_change`) and `outcome` (`changed` or `noop`). This lets operators observe how often periodic reconciliation is correcting route drift versus running as a no-op.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- KEP: https://github.com/kubernetes/enhancements/issues/5237
