### PR TITLE
scheduler/preemption: activate preemptor after async preemption to fix stuck pod in PreBind/WaitingPod path

### DIFF
--- a/pkg/scheduler/framework/preemption/executor.go
+++ b/pkg/scheduler/framework/preemption/executor.go
@@ -299,7 +299,12 @@ func (e *Executor) prepareCandidateAsync(c Candidate, preemptor ExecutorPreempto
 		e.preempting.Delete(preemptor.UID())
 		delete(e.lastVictimsPendingPreemption, preemptor.UID())
 		e.mu.Unlock()
-
+		// Ensure the preemptor is requeued after async preemption completes.
+		// This is necessary for the CancelPod/WaitingPod path where no API
+		// delete is performed and no informer event will arrive if
+		// EventAssignedPodDelete was discarded during the race window.
+		// Activate() is a no-op if the preemptor is already in activeQ.
+		e.fh.Activate(logger, preemptor.Pods())
 		logger.V(2).Info("Async Preemption finished completely", "preemptor", klog.KObj(preemptor), "node", c.Name(), "result", result)
 	}()
 }


### PR DESCRIPTION
/kind bug
/sig scheduling

#### What this PR does / why we need it:
When SchedulerAsyncPreemption is enabled and the victim pod is in PreBind or WaitingPod state, CancelPod() is used instead of an API delete call, generating no informer delete event.

If EventAssignedPodDelete is emitted by the victim's binding cycle before preempting.Delete() completes, IsPodRunningPreemption() returns true and the event is discarded. No further events arrive and the preemptor remains stuck in unschedulableEntities indefinitely.

Fix by calling Activate() unconditionally after preempting.Delete().
Activate() is safe on the normal API-delete path since AddUnschedulablePodIfNotPresent returns early if pod is already inactiveQ. 
The existing error-path Activate() is preserved.

#### Which issue(s) this PR is related to:
Fixes #140082

#### Special notes for your reviewer:
The fix is purely additive. Activate() is called after preempting.Delete() to guarantee IsPodRunningPreemption() returns
false before the preemptor is requeued. The existing error-path defer block is untouched.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```