### PR TITLE
docs: fix duplicated word in nftables README

### DIFF
--- a/pkg/proxy/nftables/README.md
+++ b/pkg/proxy/nftables/README.md
@@ -128,7 +128,7 @@ by setting appropriate `priority` values for your base chains. In particular:
   - Service traffic that needs to be masqueraded will be SNATted on a chain of `type
     nat`, `hook postrouting`, and `priority srcnat`. (So chains in other tables that run
     before this will always see the original client IP, while chains that run after this
-    will will see masqueraded source IPs for some traffic.)
+    will see masqueraded source IPs for some traffic.)
 
   - Traffic to services with no endpoints will be dropped or rejected from a chain with
     `type filter`, `priority filter`, and any of `hook input`, `hook output`, or `hook


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Removes a duplicated word in `pkg/proxy/nftables/README.md` without changing the technical meaning.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This is a documentation-only typo fix.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.

```docs
```