### PR TITLE
docs: fix duplicated word in agnhost README

### DIFF
--- a/test/images/agnhost/README.md
+++ b/test/images/agnhost/README.md
@@ -311,7 +311,7 @@ controlled with the time delay or via http control server.
   start endpoint as NOT_SERVING.
 - `--port` (default: `5000`) can be used to override the gRPC port number.
 - `--http-port` (default: `8080`) can be used to override the http control server port number.
-- `--service` (default: ``) can be used used to specify which service this endpoint will respond to.
+- `--service` (default: ``) can be used to specify which service this endpoint will respond to.
 - `--tls-cert-file` File containing an x509 certificate for gRPC TLS. (CA cert, if any, concatenated after server cert).
 - `--tls-private-key-file` File containing an x509 private key matching `--tls-cert-file`.
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Removes a duplicated word in the agnhost README without changing the technical meaning.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This is a documentation-only typo fix.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.

```docs
```