### PR TITLE
apiserver: Ensure controllers block in OnStartedLeading

### DIFF
--- a/pkg/controlplane/apiserver/server.go
+++ b/pkg/controlplane/apiserver/server.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	coordinationapiv1 "k8s.io/api/coordination/v1"
@@ -173,8 +174,10 @@ func (c completedConfig) New(name string, delegationTarget genericapiserver.Dele
 					lcInformer,
 				)
 				return func(ctx context.Context, workers int) {
-					go controller.Run(ctx, workers)
-					go gccontroller.Run(ctx)
+					var wg sync.WaitGroup
+					wg.Go(func() { controller.Run(ctx, workers) })
+					wg.Go(func() { gccontroller.Run(ctx) })
+					wg.Wait()
 				}, err
 			}, leaderelection.LeaderElectionTimers{
 				LeaseDuration: c.CoordinatedLeadershipLeaseDuration,

--- a/pkg/controlplane/controller/leaderelection/leaderelection_controller.go
+++ b/pkg/controlplane/controller/leaderelection/leaderelection_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sync"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -75,7 +76,9 @@ type Controller struct {
 }
 
 func (c *Controller) Run(ctx context.Context, workers int) {
+	var wg sync.WaitGroup
 	defer utilruntime.HandleCrashWithContext(ctx)
+	defer wg.Wait()
 	defer c.queue.ShutDown()
 	defer func() {
 		err := c.leaseInformer.Informer().RemoveEventHandler(c.leaseRegistration)
@@ -105,7 +108,9 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	klog.Infof("Workers: %d", workers)
 	for range workers {
 		klog.Infof("Starting worker")
-		go wait.UntilWithContext(ctx, c.runElectionWorker, time.Second)
+		wg.Go(func() {
+			wait.UntilWithContext(ctx, c.runElectionWorker, time.Second)
+		})
 	}
 	<-ctx.Done()
 }

--- a/pkg/controlplane/controller/leaderelection/leasecandidategc_controller.go
+++ b/pkg/controlplane/controller/leaderelection/leasecandidategc_controller.go
@@ -70,9 +70,7 @@ func (c *LeaseCandidateGCController) Run(ctx context.Context) {
 		return
 	}
 
-	go wait.UntilWithContext(ctx, c.gc, c.gcCheckPeriod)
-
-	<-ctx.Done()
+	wait.UntilWithContext(ctx, c.gc, c.gcCheckPeriod)
 }
 
 func (c *LeaseCandidateGCController) gc(ctx context.Context) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The coordinated leader election runner was launching controller goroutines and returning immediately. This caused OnStartedLeading to return right after starting the controllers, which will soon be incorrect when ReleaseOnCancel is set — the LeaderElector would stop renewing and release the lock.

I made sure there is no goroutine leaking and OnStartedLeading returns only when shutdown is complete.

#### Which issue(s) this PR is related to:

This is needed to unblock https://github.com/kubernetes/kubernetes/pull/139991

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A