### PR TITLE
Fix ResourceQuota update filter missing initial container status resource population

### DIFF
--- a/pkg/quota/v1/install/update_filter.go
+++ b/pkg/quota/v1/install/update_filter.go
@@ -21,7 +21,6 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/util/feature"
-	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/quota/v1/evaluator/core"
 	"k8s.io/utils/clock"
@@ -59,17 +58,39 @@ func DefaultUpdateFilter() func(resource schema.GroupVersionResource, oldObj, ne
 	}
 }
 
-// hasResourcesChanged function to compare resources in container statuses
+// hasResourcesChanged function to compare resources in container statuses.
+// It iterates over newPod statuses to detect both changes to existing resources
+// and the initial population of resources (when oldPod has no container statuses yet).
 func hasResourcesChanged(oldPod *v1.Pod, newPod *v1.Pod) bool {
-	for _, oldStatus := range oldPod.Status.ContainerStatuses {
-		newStatus, ok := podutil.GetContainerStatus(newPod.Status.ContainerStatuses, oldStatus.Name)
-		if ok && !apiequality.Semantic.DeepEqual(oldStatus.Resources, newStatus.Resources) {
-			return true
-		}
+	if containerStatusResourcesChanged(oldPod.Status.ContainerStatuses, newPod.Status.ContainerStatuses) {
+		return true
 	}
-	for _, oldInitContainerStatus := range oldPod.Status.InitContainerStatuses {
-		newInitContainerStatus, ok := podutil.GetContainerStatus(newPod.Status.InitContainerStatuses, oldInitContainerStatus.Name)
-		if ok && !apiequality.Semantic.DeepEqual(oldInitContainerStatus.Resources, newInitContainerStatus.Resources) {
+	if containerStatusResourcesChanged(oldPod.Status.InitContainerStatuses, newPod.Status.InitContainerStatuses) {
+		return true
+	}
+	return false
+}
+
+// containerStatusResourcesChanged returns true if any container's Resources
+// field changed between oldStatuses and newStatuses. It iterates over newStatuses
+// to detect both modifications and the initial population of Resources
+// (e.g., when a newly-created pod receives its first Kubelet status update).
+func containerStatusResourcesChanged(oldStatuses, newStatuses []v1.ContainerStatus) bool {
+	oldStatusMap := make(map[string]*v1.ContainerStatus, len(oldStatuses))
+	for i := range oldStatuses {
+		oldStatusMap[oldStatuses[i].Name] = &oldStatuses[i]
+	}
+	for i := range newStatuses {
+		newStatus := &newStatuses[i]
+		oldStatus, found := oldStatusMap[newStatus.Name]
+		if !found {
+			// Container status is new; if it has Resources populated, resources changed.
+			if newStatus.Resources != nil {
+				return true
+			}
+			continue
+		}
+		if !apiequality.Semantic.DeepEqual(oldStatus.Resources, newStatus.Resources) {
 			return true
 		}
 	}

--- a/pkg/quota/v1/install/update_filter_test.go
+++ b/pkg/quota/v1/install/update_filter_test.go
@@ -112,6 +112,8 @@ func TestHasResourcesChanged(t *testing.T) {
 		},
 	}
 
+	gpuResourceName := v1.ResourceName("nvidia.com/gpu")
+
 	tests := []struct {
 		name     string
 		oldPod   *v1.Pod
@@ -130,6 +132,151 @@ func TestHasResourcesChanged(t *testing.T) {
 			newPod:   newChangedPod,
 			expected: true,
 		},
+		{
+			name:     "both-pods-have-no-statuses",
+			oldPod:   &v1.Pod{},
+			newPod:   &v1.Pod{},
+			expected: false,
+		},
+		{
+			// This is the critical test case for issue #125134.
+			// When a pod is first created, oldPod has no ContainerStatuses.
+			// After the Kubelet reports status, newPod has ContainerStatuses
+			// with Resources populated. The old code missed this because it
+			// iterated over oldPod.Status.ContainerStatuses (which was empty).
+			name:   "old-pod-no-statuses-new-pod-has-resources-populated",
+			oldPod: &v1.Pod{},
+			newPod: &v1.Pod{
+				Status: v1.PodStatus{
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name: "foo",
+							Resources: &v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU: resource.MustParse("100m"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:   "old-pod-no-statuses-new-pod-has-nil-resources",
+			oldPod: &v1.Pod{},
+			newPod: &v1.Pod{
+				Status: v1.PodStatus{
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:      "foo",
+							Resources: nil,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "old-pod-has-resources-new-pod-nil-resources",
+			oldPod: &v1.Pod{
+				Status: v1.PodStatus{
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name: "foo",
+							Resources: &v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU: resource.MustParse("100m"),
+								},
+							},
+						},
+					},
+				},
+			},
+			newPod: &v1.Pod{
+				Status: v1.PodStatus{
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:      "foo",
+							Resources: nil,
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:   "init-container-old-pod-no-statuses-new-pod-has-resources",
+			oldPod: &v1.Pod{},
+			newPod: &v1.Pod{
+				Status: v1.PodStatus{
+					InitContainerStatuses: []v1.ContainerStatus{
+						{
+							Name: "init-foo",
+							Resources: &v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU: resource.MustParse("50m"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			// Extended resource (GPU) newly populated in status — the exact
+			// scenario from issue #125134.
+			name:   "extended-resource-gpu-newly-populated",
+			oldPod: &v1.Pod{},
+			newPod: &v1.Pod{
+				Status: v1.PodStatus{
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name: "gpu-container",
+							Resources: &v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									gpuResourceName: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "extended-resource-gpu-unchanged",
+			oldPod: &v1.Pod{
+				Status: v1.PodStatus{
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name: "gpu-container",
+							Resources: &v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									gpuResourceName: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			newPod: &v1.Pod{
+				Status: v1.PodStatus{
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name: "gpu-container",
+							Resources: &v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									gpuResourceName: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -139,3 +286,4 @@ func TestHasResourcesChanged(t *testing.T) {
 		})
 	}
 }
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes a bug in the ResourceQuota update filter (`hasResourcesChanged`) where the initial population of container status resources by the Kubelet was not detected, causing incorrect (doubled) `ResourceQuota` usage reporting for extended resources like `nvidia.com/gpu` when `InPlacePodVerticalScaling` is enabled.

**Root Cause:**

The `hasResourcesChanged` function in `pkg/quota/v1/install/update_filter.go` iterated **only** over `oldPod.Status.ContainerStatuses` to detect resource changes. When a pod was first created, `oldPod` had no container statuses (the Kubelet hadn't reported status yet), so the loop never executed and the function always returned `false`.

This meant the quota controller never re-evaluated pod usage when the Kubelet's first status update populated `ContainerStatuses[].Resources`, leading to inconsistent `ResourceQuota.Status.Used` values until the sync loop corrected them after the default `--resource-quota-sync-period` of 5 minutes.

**The Fix:**

Changed the iteration to go over `newPod.Status.ContainerStatuses` instead, looking up each container in the old pod's statuses. This detects:
- **Newly populated** container statuses with `Resources` (the bug fix case)
- **Changed** `Resources` between old and new (preserving existing behavior)
- **New statuses with nil Resources** are correctly ignored

Also refactored the comparison logic into a shared `containerStatusResourcesChanged` helper to eliminate duplication between regular and init container status checks, and removed the now-unused `podutil` import.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #125134

#### Special notes for your reviewer:

- The change is minimal and targeted: 1 production file modified (`update_filter.go`), 1 test file enhanced (`update_filter_test.go`)
- Removed the now-unused `podutil` import since `podutil.GetContainerStatus` is no longer needed
- The fix means the quota controller will do one extra quota re-evaluation on the first Kubelet status update per pod lifecycle. This is the correct behavior and has negligible performance impact.

**Test Results — all pass with zero regressions:**

| Test Suite | Command | Result |
|---|---|---|
| `pkg/quota/v1/install` (9 subtests) | `go test -v -run TestHasResourcesChanged ./pkg/quota/v1/install/...` | ✅ PASS |
| `pkg/quota/v1/evaluator/core` | `go test -v ./pkg/quota/v1/evaluator/core/...` | ✅ PASS |
| `staging/.../admission/plugin/resourcequota` | `go test -v ./staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/...` | ✅ PASS |

New test cases added:
- `both-pods-have-no-statuses` → false
- `old-pod-no-statuses-new-pod-has-resources-populated` → true **(critical fix case)**
- `old-pod-no-statuses-new-pod-has-nil-resources` → false
- `old-pod-has-resources-new-pod-nil-resources` → true
- `init-container-old-pod-no-statuses-new-pod-has-resources` → true
- `extended-resource-gpu-newly-populated` → true **(exact scenario from #125134)**
- `extended-resource-gpu-unchanged` → false

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Fix ResourceQuota reporting incorrect (doubled) usage for extended resources (e.g., nvidia.com/gpu) when InPlacePodVerticalScaling feature gate is enabled. The quota update filter now correctly detects the initial population of container status resources by the Kubelet, eliminating the ~5 minute inconsistency window.
