### PR TITLE
DRA CEL: base cost estimate on actual types

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/cel/compile.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/cel/compile.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 
@@ -102,9 +103,8 @@ type CompilationResult struct {
 	// as used by cel.EstimateCost.
 	MaxCost uint64
 
+	typesFromEnv
 	emptyMapVal ref.Val
-
-	features Features
 }
 
 // Device defines the input values for a CEL selector expression.
@@ -119,18 +119,8 @@ type Device struct {
 }
 
 type compiler struct {
-	// deviceType is a definition for the latest type of the `device` variable.
-	// This is needed for the cost estimator.
-	// If that ever changes such as involving type-checking expressions,
-	// some additional logic might be needed to make
-	// cost estimates version-dependent.
-	deviceType *apiservercel.DeclType
-	envset     *environment.EnvSet
-
-	// attributeType is the latest attribute type, used for cost estimation.
-	attributeType *apiservercel.DeclType
-
-	features Features
+	envset        *environment.EnvSet
+	declaredTypes []*apiservercel.DeclType
 }
 
 // Options contains several additional parameters
@@ -160,7 +150,6 @@ func (c compiler) CompileCELExpression(expression string, options Options) Compi
 			},
 			Expression: expression,
 			MaxCost:    math.MaxUint64,
-			features:   c.features,
 		}
 	}
 
@@ -175,7 +164,7 @@ func (c compiler) CompileCELExpression(expression string, options Options) Compi
 		return resultError("compilation failed: "+issues.String(), apiservercel.ErrorTypeInvalid)
 	}
 
-	attributeReturnType, err := attributeTypeFromEnv(env)
+	typesFromEnv, err := c.getTypesFromEnv(env)
 	if err != nil {
 		return resultError("unexpected error loading CEL environment: "+err.Error(), apiservercel.ErrorTypeInternal)
 	}
@@ -184,7 +173,7 @@ func (c compiler) CompileCELExpression(expression string, options Options) Compi
 	// a boolean type, which then has the attribute type of this environment.
 	expectedReturnType := cel.BoolType
 	if ast.OutputType().IsExactType(expectedReturnType) ||
-		ast.OutputType().IsExactType(attributeReturnType) {
+		ast.OutputType().IsExactType(typesFromEnv.attributeType.CelType()) {
 		// Okay, is one of the acceptable types.
 	} else {
 		return resultError(fmt.Sprintf("must evaluate to %v or the unknown type, not %v", expectedReturnType.String(), ast.OutputType().String()), apiservercel.ErrorTypeInvalid)
@@ -207,19 +196,19 @@ func (c compiler) CompileCELExpression(expression string, options Options) Compi
 	}
 
 	compilationResult := CompilationResult{
-		Program:     prog,
-		Expression:  expression,
-		OutputType:  ast.OutputType(),
-		Environment: env,
-		emptyMapVal: env.CELTypeAdapter().NativeToValue(map[string]any{}),
-		MaxCost:     math.MaxUint64,
-		features:    c.features,
+		Program:      prog,
+		Expression:   expression,
+		OutputType:   ast.OutputType(),
+		Environment:  env,
+		emptyMapVal:  env.CELTypeAdapter().NativeToValue(map[string]any{}),
+		MaxCost:      math.MaxUint64,
+		typesFromEnv: typesFromEnv,
 	}
 
 	if !options.DisableCostEstimation {
 		// We don't have a SizeEstimator. The potential size of the input (= a
 		// device) is already declared in the definition of the environment.
-		estimator := c.newCostEstimator()
+		estimator := c.newCostEstimator(typesFromEnv)
 		costEst, err := env.EstimateCost(ast, estimator)
 		if err != nil {
 			compilationResult.Error = &apiservercel.Error{Type: apiservercel.ErrorTypeInternal, Detail: "cost estimation failed: " + err.Error()}
@@ -231,56 +220,73 @@ func (c compiler) CompileCELExpression(expression string, options Options) Compi
 	return compilationResult
 }
 
-func (c *compiler) newCostEstimator() checker.CostEstimator {
-	base := &library.CostEstimator{SizeEstimator: &sizeEstimator{compiler: c}}
+func (c *compiler) newCostEstimator(typesFromEnv typesFromEnv) checker.CostEstimator {
+	base := &library.CostEstimator{SizeEstimator: &sizeEstimator{typesFromEnv}}
 	return &draCostEstimator{base: base}
 }
 
-// deviceFieldTypeFromEnv resolves a device field type from the actual CEL environment.
-// This is needed so NewExpressions uses the device type selected by VersionedOptions
-// and feature gates instead of the compiler's latest device type.
-func deviceFieldTypeFromEnv(env *cel.Env, field string) (*cel.Type, bool, error) {
-	var deviceType *cel.Type
-	for _, variable := range env.Variables() {
+type typesFromEnv struct {
+	deviceType          *apiservercel.DeclType // "device"
+	outerAttributesType *apiservercel.DeclType // "device.attributes" = map to map to value
+	innerAttributesType *apiservercel.DeclType // "device.attributes[foo]" = map to value
+	attributeType       *apiservercel.DeclType // "device.attributes[foo].bar" = value
+}
+
+// getTypesFromEnv determines the actual type definitions based on
+// the environment, which reflects features and stored vs. new expression.
+func (c *compiler) getTypesFromEnv(env *cel.Env) (typesFromEnv, error) {
+	var result typesFromEnv
+
+	// Use the *latest* variable with the right name because that
+	// instance overwrites the ones before it.
+	for _, variable := range slices.Backward(env.Variables()) {
 		if variable.Name() == deviceVar {
-			deviceType = variable.Type()
+			result.deviceType = c.getDeclType(variable.Type())
 			break
 		}
 	}
-	if deviceType == nil {
-		return nil, false, fmt.Errorf("%q variable is not declared", deviceVar)
+	if result.deviceType == nil {
+		return result, fmt.Errorf("%q variable is not declared", deviceVar)
 	}
 
-	fieldType, ok := env.CELTypeProvider().FindStructFieldType(deviceType.TypeName(), field)
+	fieldType, ok := env.CELTypeProvider().FindStructFieldType(result.deviceType.TypeName(), attributesVar)
 	if !ok {
-		return nil, false, nil
+		return result, fmt.Errorf("%q variable does not declare %q field", deviceVar, attributesVar)
 	}
-	if fieldType.Type == nil {
-		return nil, true, fmt.Errorf("%q field has no type", field)
+	result.outerAttributesType = c.getDeclType(fieldType.Type)
+	if result.outerAttributesType == nil {
+		return result, fmt.Errorf("%q field has no type", attributesVar)
 	}
-	return fieldType.Type, true, nil
+
+	outerMapParams := result.outerAttributesType.CelType().Parameters()
+	if len(outerMapParams) != 2 {
+		return result, fmt.Errorf("%q field should be a map, got %s", attributesVar, result.outerAttributesType.String())
+	}
+	result.innerAttributesType = c.getDeclType(outerMapParams[1])
+	if result.innerAttributesType == nil {
+		return result, fmt.Errorf("%q field does not map to type", attributesVar)
+	}
+
+	innerMapParams := result.innerAttributesType.CelType().Parameters()
+	if len(innerMapParams) != 2 {
+		return result, fmt.Errorf("%q field values should be maps, got %s", attributesVar, result.innerAttributesType.String())
+	}
+	result.attributeType = c.getDeclType(innerMapParams[1])
+	if result.attributeType == nil {
+		return result, fmt.Errorf("%q field mapped to no type at leafs", attributesVar)
+	}
+
+	return result, nil
 }
 
-// attributeTypeFromEnv resolves the attribute value type from the actual CEL environment.
-// This keeps return-type validation aligned with the VersionedOptions selection,
-// including NewExpressions environments where feature gates affect the device type.
-func attributeTypeFromEnv(env *cel.Env) (*cel.Type, error) {
-	attributesType, ok, err := deviceFieldTypeFromEnv(env, attributesVar)
-	if err != nil {
-		return nil, err
+// getDeclType maps the cel.Type to the apiservercel.DeclType. Only works for types defined by newCompiler.
+func (c *compiler) getDeclType(t *cel.Type) *apiservercel.DeclType {
+	for _, dt := range c.declaredTypes {
+		if dt.CelType() == t {
+			return dt
+		}
 	}
-	if !ok {
-		return nil, fmt.Errorf("%q variable does not declare %q field", deviceVar, attributesVar)
-	}
-	outerMapParams := attributesType.Parameters()
-	if len(outerMapParams) != 2 {
-		return nil, fmt.Errorf("%q field should be a map, got %s", attributesVar, attributesType.String())
-	}
-	innerMapParams := outerMapParams[1].Parameters()
-	if len(innerMapParams) != 2 {
-		return nil, fmt.Errorf("%q field values should be maps, got %s", attributesVar, outerMapParams[1].String())
-	}
-	return innerMapParams[1], nil
+	return nil
 }
 
 // getAttributeValue returns the native representation of the one value that
@@ -390,49 +396,56 @@ func newCompiler(features Features) *compiler {
 		return result
 	}
 
-	attributeTypeV131 := withMaxElements(
+	// declaredTypes collects all types that we declare for the environment.
+	var declaredTypes []*apiservercel.DeclType
+	declareType := func(t *apiservercel.DeclType) *apiservercel.DeclType {
+		declaredTypes = append(declaredTypes, t)
+		return t
+	}
+
+	attributeTypeV131 := declareType(withMaxElements(
 		apiservercel.AnyType,
 		resourceapi.DeviceAttributeMaxValueLength,
-	)
-	attributeTypeV136ListTypeAttributes := withMaxElements(
+	))
+	attributeTypeV136ListTypeAttributes := declareType(withMaxElements(
 		// Use DynType so that iterate functions can work (e.g. exists, all)
 		// for list type attributes.
 		apiservercel.DynType,
 		// At compile time we don't know whether an attribute will be a scalar or list.
 		uint64(max(resourceapi.DeviceAttributeMaxValueLength, resourceapi.ResourceSliceMaxAttributeValuesPerDevice)),
-	)
+	))
 	// Each map is bound by the maximum number of different attributes.
-	innerAttributesMapTypeV131 := apiservercel.NewMapType(idType, attributeTypeV131, resourceapi.ResourceSliceMaxAttributesAndCapacitiesPerDevice)
-	outerAttributesMapTypeV131 := apiservercel.NewMapType(domainType, innerAttributesMapTypeV131, resourceapi.ResourceSliceMaxAttributesAndCapacitiesPerDevice)
-	innerAttributesMapTypeV136ListTypeAttributes := apiservercel.NewMapType(
+	innerAttributesMapTypeV131 := declareType(apiservercel.NewMapType(idType, attributeTypeV131, resourceapi.ResourceSliceMaxAttributesAndCapacitiesPerDevice))
+	outerAttributesMapTypeV131 := declareType(apiservercel.NewMapType(domainType, innerAttributesMapTypeV131, resourceapi.ResourceSliceMaxAttributesAndCapacitiesPerDevice))
+	innerAttributesMapTypeV136ListTypeAttributes := declareType(apiservercel.NewMapType(
 		idType, attributeTypeV136ListTypeAttributes, resourceapi.ResourceSliceMaxAttributesAndCapacitiesPerDevice,
-	)
-	outerAttributesMapTypeV136ListTypeAttributes := apiservercel.NewMapType(
+	))
+	outerAttributesMapTypeV136ListTypeAttributes := declareType(apiservercel.NewMapType(
 		domainType, innerAttributesMapTypeV136ListTypeAttributes, resourceapi.ResourceSliceMaxAttributesAndCapacitiesPerDevice,
-	)
+	))
 
 	fieldsV131 := []*apiservercel.DeclField{
 		field(driverVar, driverType, true),
 		field(attributesVar, outerAttributesMapTypeV131, true),
 		field(capacityVar, outerCapacityMapType, true),
 	}
-	deviceTypeV131 := apiservercel.NewObjectType("kubernetes.DRADevice", fields(fieldsV131...))
+	deviceTypeV131 := declareType(apiservercel.NewObjectType("kubernetes.DRADevice", fields(fieldsV131...)))
 
 	// One additional field, feature-gated below.
 	fieldsV134ConsumableCapacity := []*apiservercel.DeclField{field(multiAllocVar, multiAllocType, true)}
 	fieldsV134ConsumableCapacity = append(fieldsV134ConsumableCapacity, fieldsV131...)
-	deviceTypeV134ConsumableCapacity := apiservercel.NewObjectType("kubernetes.DRADevice", fields(fieldsV134ConsumableCapacity...))
+	deviceTypeV134ConsumableCapacity := declareType(apiservercel.NewObjectType("kubernetes.DRADevice", fields(fieldsV134ConsumableCapacity...)))
 
 	fieldsV136ListTypeAttributes := []*apiservercel.DeclField{
 		field(driverVar, driverType, true),
 		field(attributesVar, outerAttributesMapTypeV136ListTypeAttributes, true),
 		field(capacityVar, outerCapacityMapType, true),
 	}
-	deviceTypeV136ListTypeAttributes := apiservercel.NewObjectType("kubernetes.DRADevice", fields(fieldsV136ListTypeAttributes...))
+	deviceTypeV136ListTypeAttributes := declareType(apiservercel.NewObjectType("kubernetes.DRADevice", fields(fieldsV136ListTypeAttributes...)))
 
 	fieldsV136ConsumableCapacityListTypeAttributes := []*apiservercel.DeclField{field(multiAllocVar, multiAllocType, true)}
 	fieldsV136ConsumableCapacityListTypeAttributes = append(fieldsV136ConsumableCapacityListTypeAttributes, fieldsV136ListTypeAttributes...)
-	deviceTypeV136ConsumableCapacityListTypeAttributes := apiservercel.NewObjectType("kubernetes.DRADevice", fields(fieldsV136ConsumableCapacityListTypeAttributes...))
+	deviceTypeV136ConsumableCapacityListTypeAttributes := declareType(apiservercel.NewObjectType("kubernetes.DRADevice", fields(fieldsV136ConsumableCapacityListTypeAttributes...)))
 
 	versioned := []environment.VersionedOptions{
 		{
@@ -522,12 +535,19 @@ func newCompiler(features Features) *compiler {
 	if err != nil {
 		panic(fmt.Errorf("internal error building CEL environment: %w", err))
 	}
-	// return with newest deviceType
+
+	// Features can be still be changed before using the compiler.
+	// The FeatureEnabled checks above ensure that the environment
+	// is set up as necessary.
+	//
+	// Also, the compiler supports both stored and new expressions.
+	//
+	// Code which needs to know the actual type of items in the current
+	// expression needs to look up the type from the active environment
+	// (see deviceFieldTypeFromEnv above).
 	return &compiler{
 		envset:        envset,
-		deviceType:    deviceTypeV136ConsumableCapacityListTypeAttributes,
-		features:      features,
-		attributeType: attributeTypeV136ListTypeAttributes,
+		declaredTypes: declaredTypes,
 	}
 }
 
@@ -632,10 +652,10 @@ func (e *draCostEstimator) EstimateCallCost(function, overloadID string, target 
 //
 // sizeEstimator is derived from the sizeEstimator in k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel.
 type sizeEstimator struct {
-	compiler *compiler
+	typesFromEnv
 }
 
-func (s *sizeEstimator) EstimateSize(element checker.AstNode) *checker.SizeEstimate {
+func (s *sizeEstimator) EstimateSize(element checker.AstNode) (res *checker.SizeEstimate) {
 	path := element.Path()
 	if len(path) == 0 {
 		// Path() can return an empty list, early exit if it does since we can't
@@ -647,7 +667,7 @@ func (s *sizeEstimator) EstimateSize(element checker.AstNode) *checker.SizeEstim
 	var currentNode *apiservercel.DeclType
 	switch path[0] {
 	case deviceVar:
-		currentNode = s.compiler.deviceType
+		currentNode = s.deviceType
 	default:
 		// Unknown root, shouldn't happen.
 		return nil
@@ -672,8 +692,8 @@ func (s *sizeEstimator) EstimateSize(element checker.AstNode) *checker.SizeEstim
 				// If this is an attribute map, then we know that all elements
 				// have the same maximum size as set in attributeType, regardless
 				// of their name.
-				if currentNode.ElemType == s.compiler.attributeType {
-					currentNode = s.compiler.attributeType
+				if currentNode.ElemType == s.attributeType {
+					currentNode = s.attributeType
 					continue
 				}
 				return nil

--- a/staging/src/k8s.io/dynamic-resource-allocation/cel/compile_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/cel/compile_test.go
@@ -38,15 +38,14 @@ import (
 const maxElementsListTypeEnabled = uint64(max(resourceapi.DeviceAttributeMaxValueLength, resourceapi.ResourceSliceMaxAttributeValuesPerDevice))
 
 var testcases = map[string]struct {
-	// environment.StoredExpressions is the default (= all CEL fields and features from the current version available).
-	// environment.NewExpressions can be used to enforce that only fields and features from the previous version are available.
+	// If nil, the testcase is executed with stored and new expressions.
+	// If non-nil, it must point to environment.StoredExpressions or environment.NewExpressions
+	// to select that kind of expression.
 	envType *environment.Type
-	// The feature gate only has an effect in combination with environment.NewExpressions.
-	enableConsumableCapacity bool
-	// if enableListTypeAttributes is nil, the test will be run twice: once with it set to false and once with it set to true.
-	// This allows testing both the old and new behavior of CEL expressions without having to duplicate all test cases.
-	// If set, it controls whether the test is run with list-type attributes enabled or not.
-	enableListTypeAttributes *bool
+	// If nil, the testcase is executed with all combination of features,
+	// otherwise only with the given combination.
+	features *Features
+
 	expression               string
 	driver                   string
 	allowMultipleAllocations *bool
@@ -160,7 +159,15 @@ var testcases = map[string]struct {
 		expectMatch: true,
 		expectCost:  5,
 	},
+	"macro-compilation-error-new-expressions": {
+		features:           &Features{EnableListTypeAttributes: false},
+		envType:            new(environment.NewExpressions),
+		expression:         `device.attributes["dra.example.com"].ids.exists(id, id == 1)`,
+		driver:             "dra.example.com",
+		expectCompileError: "compilation failed",
+	},
 	"macro-exists-on-int": {
+		features:         &Features{EnableListTypeAttributes: true},
 		expression:       `device.attributes["dra.example.com"].name.exists(x, x > 0)`,
 		attributes:       map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {IntValue: new(int64(1))}},
 		driver:           "dra.example.com",
@@ -168,6 +175,7 @@ var testcases = map[string]struct {
 		expectCost:       5 + ((3 + 3) * maxElementsListTypeEnabled /* (cost(loopCondition=="not_strictly_false(!accu)") + cost(loopStep=="accu && (x > 0)")) * maxElementsListTypeEnabled */),
 	},
 	"macro-exists-on-bool": {
+		features:         &Features{EnableListTypeAttributes: true},
 		expression:       `device.attributes["dra.example.com"].name.exists(x, x == true)`,
 		attributes:       map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {BoolValue: new(true)}},
 		driver:           "dra.example.com",
@@ -175,6 +183,7 @@ var testcases = map[string]struct {
 		expectCost:       5 + ((3 + 3) * maxElementsListTypeEnabled /* (cost(loopCondition=="not_strictly_false(!accu)") + cost(loopStep=="accu && (x > 0)")) * maxElementsListTypeEnabled */),
 	},
 	"macro-exists-on-string": {
+		features:         &Features{EnableListTypeAttributes: true},
 		expression:       `device.attributes["dra.example.com"].name.exists(x, x == "fish")`,
 		attributes:       map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValue: new("fish")}},
 		driver:           "dra.example.com",
@@ -189,6 +198,7 @@ var testcases = map[string]struct {
 		expectCost:       4,
 	},
 	"includes-function-can-evaluate": {
+		features:    &Features{EnableListTypeAttributes: true},
 		expression:  `device.attributes["dra.example.com"].name.includes("fish")`,
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValues: []string{"fish", "bird"}}},
 		driver:      "dra.example.com",
@@ -224,6 +234,7 @@ var testcases = map[string]struct {
 		expectCost:  6,
 	},
 	"macro-on-list-of-int": {
+		features:    &Features{EnableListTypeAttributes: true},
 		expression:  `device.attributes["dra.example.com"].names.exists(x, x > 0)`,
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"names": {IntValues: []int64{1, 2}}},
 		driver:      "dra.example.com",
@@ -231,6 +242,7 @@ var testcases = map[string]struct {
 		expectCost:  5 + ((3 + 3) * maxElementsListTypeEnabled /* (cost(loopCondition=="not_strictly_false(!accu)") + cost(loopStep=="accu && (x > 0)")) * maxElementsListTypeEnabled */),
 	},
 	"macro-on-list-of-string": {
+		features:    &Features{EnableListTypeAttributes: true},
 		expression:  `device.attributes["dra.example.com"].names.all(x, x != "")`,
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"names": {StringValues: []string{"fish", "bird"}}},
 		driver:      "dra.example.com",
@@ -238,6 +250,7 @@ var testcases = map[string]struct {
 		expectCost:  5 + ((2 + 2) * maxElementsListTypeEnabled /* (cost(loopCondition=="not_strictly_false(accu)") + cost(loopStep=="accu && (x != "")")) * maxElementsListTypeEnabled */),
 	},
 	"macro-on-list-of-semver": {
+		features:    &Features{EnableListTypeAttributes: true},
 		expression:  `device.attributes["dra.example.com"].names.all(x, x.isGreaterThan(semver("0.0.1")))`,
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"names": {VersionValues: []string{"1.0.0", "2.0.0"}}},
 		driver:      "dra.example.com",
@@ -245,19 +258,14 @@ var testcases = map[string]struct {
 		expectCost:  5 + ((2 + 4) * maxElementsListTypeEnabled /* (cost(loopCondition=="not_strictly_false(accu)") + cost(loopStep=="accu && (x.isGreaterThan(semver("0.0.1"))")) * maxElementsListTypeEnabled */),
 	},
 	"includes-function-compilation-error": {
-		enableListTypeAttributes: new(false),
-		// "includes" is injected via VersionedOptions.FeatureEnabled.
-		// Use NewExpressions here because normal StoredExpressions ignores VersionedOptions.FeatureEnabled.
+		features:           &Features{EnableListTypeAttributes: false},
 		envType:            ptr.To(environment.NewExpressions),
 		expression:         `device.attributes["dra.example.com"].attr.includes("fish")`,
 		driver:             "dra.example.com",
 		expectCompileError: "undeclared reference to 'includes'",
 	},
 	"includes-function-compilation-and-eval-success": {
-		enableListTypeAttributes: new(true),
-		// "includes" is injected via VersionedOptions.FeatureEnabled.
-		// Use NewExpressions here because normal StoredExpressions ignores VersionedOptions.FeatureEnabled.
-		envType:     ptr.To(environment.NewExpressions),
+		features:    &Features{EnableListTypeAttributes: true},
 		expression:  `device.attributes["dra.example.com"].attr.includes("fish")`,
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"attr": {StringValue: new("fish")}},
 		driver:      "dra.example.com",
@@ -265,6 +273,7 @@ var testcases = map[string]struct {
 		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-bool-scalar-positive": {
+		features:    &Features{EnableListTypeAttributes: true},
 		expression:  `device.attributes["dra.example.com"].name.includes(true)`,
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {BoolValue: new(true)}},
 		driver:      "dra.example.com",
@@ -272,6 +281,8 @@ var testcases = map[string]struct {
 		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-bool-scalar-negative": {
+		features:    &Features{EnableListTypeAttributes: true},
+		envType:     ptr.To(environment.NewExpressions),
 		expression:  `device.attributes["dra.example.com"].name.includes(true)`,
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {BoolValue: new(false)}},
 		driver:      "dra.example.com",
@@ -279,6 +290,7 @@ var testcases = map[string]struct {
 		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-bool-list-positive": {
+		features:    &Features{EnableListTypeAttributes: true},
 		expression:  `device.attributes["dra.example.com"].name.includes(true)`,
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {BoolValues: []bool{true, false}}},
 		driver:      "dra.example.com",
@@ -286,6 +298,7 @@ var testcases = map[string]struct {
 		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-bool-list-negative": {
+		features:    &Features{EnableListTypeAttributes: true},
 		expression:  `device.attributes["dra.example.com"].name.includes(false)`,
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {BoolValues: []bool{true, true}}},
 		driver:      "dra.example.com",
@@ -293,6 +306,7 @@ var testcases = map[string]struct {
 		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-int-scalar-positive": {
+		features:    &Features{EnableListTypeAttributes: true},
 		expression:  `device.attributes["dra.example.com"].name.includes(1)`,
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {IntValue: new(int64(1))}},
 		driver:      "dra.example.com",
@@ -300,6 +314,7 @@ var testcases = map[string]struct {
 		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-int-scalar-negative": {
+		features:    &Features{EnableListTypeAttributes: true},
 		expression:  `device.attributes["dra.example.com"].name.includes(1)`,
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {IntValue: new(int64(2))}},
 		driver:      "dra.example.com",
@@ -307,6 +322,7 @@ var testcases = map[string]struct {
 		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-int-list-positive": {
+		features:    &Features{EnableListTypeAttributes: true},
 		expression:  `device.attributes["dra.example.com"].name.includes(1)`,
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {IntValues: []int64{1, 2}}},
 		driver:      "dra.example.com",
@@ -314,6 +330,7 @@ var testcases = map[string]struct {
 		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-int-list-negative": {
+		features:    &Features{EnableListTypeAttributes: true},
 		expression:  `device.attributes["dra.example.com"].name.includes(3)`,
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {IntValues: []int64{1, 2}}},
 		driver:      "dra.example.com",
@@ -321,6 +338,7 @@ var testcases = map[string]struct {
 		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-string-scalar-positive": {
+		features:    &Features{EnableListTypeAttributes: true},
 		expression:  `device.attributes["dra.example.com"].name.includes("fish")`,
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValue: new("fish")}},
 		driver:      "dra.example.com",
@@ -328,6 +346,7 @@ var testcases = map[string]struct {
 		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-string-scalar-negative": {
+		features:    &Features{EnableListTypeAttributes: true},
 		expression:  `device.attributes["dra.example.com"].name.includes("bird")`,
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValue: new("fish")}},
 		driver:      "dra.example.com",
@@ -335,6 +354,7 @@ var testcases = map[string]struct {
 		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-string-list-positive": {
+		features:    &Features{EnableListTypeAttributes: true},
 		expression:  `device.attributes["dra.example.com"].name.includes("fish")`,
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValues: []string{"fish", "bird"}}},
 		driver:      "dra.example.com",
@@ -342,6 +362,7 @@ var testcases = map[string]struct {
 		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-string-list-negative": {
+		features:    &Features{EnableListTypeAttributes: true},
 		expression:  `device.attributes["dra.example.com"].name.includes("cat")`,
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValues: []string{"fish", "bird"}}},
 		driver:      "dra.example.com",
@@ -349,6 +370,7 @@ var testcases = map[string]struct {
 		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-semver-scalar-positive": {
+		features:    &Features{EnableListTypeAttributes: true},
 		expression:  `device.attributes["dra.example.com"].name.includes(semver("1.0.0"))`,
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {VersionValue: new("1.0.0")}},
 		driver:      "dra.example.com",
@@ -356,6 +378,7 @@ var testcases = map[string]struct {
 		expectCost:  4 + 48 /* cost of "includes" is max list length */ + 1,
 	},
 	"includes-function-on-semver-scalar-negative": {
+		features:    &Features{EnableListTypeAttributes: true},
 		expression:  `device.attributes["dra.example.com"].name.includes(semver("2.0.0"))`,
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {VersionValue: new("1.0.0")}},
 		driver:      "dra.example.com",
@@ -363,6 +386,7 @@ var testcases = map[string]struct {
 		expectCost:  4 + 48 /* cost of "includes" is max list length */ + 1,
 	},
 	"includes-function-on-semver-list-positive": {
+		features:    &Features{EnableListTypeAttributes: true},
 		expression:  `device.attributes["dra.example.com"].name.includes(semver("1.0.0"))`,
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {VersionValues: []string{"1.0.0", "2.0.0"}}},
 		driver:      "dra.example.com",
@@ -370,6 +394,7 @@ var testcases = map[string]struct {
 		expectCost:  4 + 48 /* cost of "includes" is max list length */ + 1,
 	},
 	"includes-function-on-semver-list-negative": {
+		features:    &Features{EnableListTypeAttributes: true},
 		expression:  `device.attributes["dra.example.com"].name.includes(semver("3.0.0"))`,
 		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {VersionValues: []string{"1.0.0", "2.0.0"}}},
 		driver:      "dra.example.com",
@@ -377,6 +402,7 @@ var testcases = map[string]struct {
 		expectCost:  4 + 48 /* cost of "includes" is max list length */ + 1,
 	},
 	"includes-function-on-very-long-list-positive": {
+		features:   &Features{EnableListTypeAttributes: true},
 		expression: fmt.Sprintf(`device.attributes["dra.example.com"].name.includes("value-%d")`, resourceapi.ResourceSliceMaxAttributeValuesPerDevice),
 		attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValues: func() []string {
 			values := make([]string, resourceapi.ResourceSliceMaxAttributeValuesPerDevice)
@@ -390,6 +416,7 @@ var testcases = map[string]struct {
 		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-very-long-list-runtime-error": {
+		features:   &Features{EnableListTypeAttributes: true},
 		expression: fmt.Sprintf(`device.attributes["dra.example.com"].name.includes("value-%d")`, resourceapi.ResourceSliceMaxAttributeValuesPerDevice+1),
 		attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValues: func() []string {
 			values := make([]string, resourceapi.ResourceSliceMaxAttributeValuesPerDevice+1)
@@ -431,6 +458,7 @@ var testcases = map[string]struct {
 		expectCost:  7,
 	},
 	"macro-exists-on-version": {
+		features:         &Features{EnableListTypeAttributes: true},
 		expression:       `device.attributes["dra.example.com"].name.exists(x, x.isGreaterThan(semver("0.0.1")))`,
 		attributes:       map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {VersionValue: new("1.0.0")}},
 		driver:           "dra.example.com",
@@ -561,7 +589,7 @@ device.attributes["dra.example.com"]["version"].isGreaterThan(semver("0.0.1"))
 		expectCost:       85555551, // Exceed limit!
 	},
 	"allow_multiple_allocations": {
-		enableConsumableCapacity: true,
+		features:                 &Features{EnableConsumableCapacity: true},
 		expression:               `device.allowMultipleAllocations == true`,
 		allowMultipleAllocations: ptr.To(true),
 		driver:                   "dra.example.com",
@@ -569,7 +597,7 @@ device.attributes["dra.example.com"]["version"].isGreaterThan(semver("0.0.1"))
 		expectCost:               3,
 	},
 	"allow_multiple_allocations_default": {
-		enableConsumableCapacity: true,
+		features:                 &Features{EnableConsumableCapacity: true},
 		expression:               `device.allowMultipleAllocations == false`,
 		allowMultipleAllocations: nil,
 		driver:                   "dra.example.com",
@@ -577,7 +605,7 @@ device.attributes["dra.example.com"]["version"].isGreaterThan(semver("0.0.1"))
 		expectCost:               3,
 	},
 	"allow_multiple_allocations_false": {
-		enableConsumableCapacity: true,
+		features:                 &Features{EnableConsumableCapacity: true},
 		expression:               `device.allowMultipleAllocations == false`,
 		allowMultipleAllocations: ptr.To(false),
 		driver:                   "dra.example.com",
@@ -585,8 +613,7 @@ device.attributes["dra.example.com"]["version"].isGreaterThan(semver("0.0.1"))
 		expectCost:               3,
 	},
 	"allow_multiple_allocations_new": {
-		enableConsumableCapacity: true,
-		envType:                  ptr.To(environment.NewExpressions),
+		features:                 &Features{EnableConsumableCapacity: true},
 		expression:               `device.allowMultipleAllocations == false`,
 		allowMultipleAllocations: ptr.To(false),
 		driver:                   "dra.example.com",
@@ -594,8 +621,7 @@ device.attributes["dra.example.com"]["version"].isGreaterThan(semver("0.0.1"))
 		expectCost:               3,
 	},
 	"allow_multiple_allocations_enabled": {
-		envType:                  ptr.To(environment.NewExpressions),
-		enableConsumableCapacity: true,
+		features:                 &Features{EnableConsumableCapacity: true},
 		expression:               `device.allowMultipleAllocations == false`,
 		allowMultipleAllocations: ptr.To(false),
 		driver:                   "dra.example.com",
@@ -603,22 +629,19 @@ device.attributes["dra.example.com"]["version"].isGreaterThan(semver("0.0.1"))
 		expectCost:               3,
 	},
 	"allow_multiple_allocations_disabled": {
-		envType:                  ptr.To(environment.NewExpressions),
-		enableConsumableCapacity: false,
-		expression:               `device.allowMultipleAllocations == false`,
-		driver:                   "dra.example.com",
-		expectCompileError:       `undefined field 'allowMultipleAllocations'`,
+		envType:            ptr.To(environment.NewExpressions),
+		features:           &Features{EnableConsumableCapacity: false},
+		expression:         `device.allowMultipleAllocations == false`,
+		driver:             "dra.example.com",
+		expectCompileError: `undefined field 'allowMultipleAllocations'`,
 	},
 }
 
 func TestCEL(t *testing.T) {
 	for name, scenario := range testcases {
-		run := func(t *testing.T, enableListTypeAttributes bool) {
+		run := func(t *testing.T, features Features, envType environment.Type) {
 			_, ctx := ktesting.NewTestContext(t)
-			result := GetCompiler(Features{
-				EnableConsumableCapacity: scenario.enableConsumableCapacity,
-				EnableListTypeAttributes: enableListTypeAttributes,
-			}).CompileCELExpression(scenario.expression, Options{EnvType: scenario.envType})
+			result := GetCompiler(features).CompileCELExpression(scenario.expression, Options{EnvType: &envType})
 			if scenario.expectCompileError != "" && result.Error == nil {
 				t.Fatalf("FAILURE: expected compile error %q, got none", scenario.expectCompileError)
 			}
@@ -668,191 +691,30 @@ func TestCEL(t *testing.T) {
 				t.Fatalf("FAILURE: expected result %v, got %v", scenario.expectMatch, match)
 			}
 		}
+
 		t.Run(name, func(t *testing.T) {
-			if scenario.enableListTypeAttributes == nil {
-				t.Run("list-type-attributes=false", func(t *testing.T) {
-					run(t, false)
-				})
-				t.Run("list-type-attributes=true", func(t *testing.T) {
-					run(t, true)
-				})
-			} else {
-				t.Run(fmt.Sprintf("list-type-attributes=%v", *scenario.enableListTypeAttributes), func(t *testing.T) {
-					run(t, *scenario.enableListTypeAttributes)
-				})
+			stateListType := []bool{true, false}
+			stateConsumable := []bool{true, false}
+			if scenario.features != nil {
+				stateConsumable = []bool{scenario.features.EnableConsumableCapacity}
+				stateListType = []bool{scenario.features.EnableListTypeAttributes}
 			}
-		})
-	}
-}
+			envTypes := []environment.Type{environment.NewExpressions, environment.StoredExpressions}
+			if scenario.envType != nil {
+				envTypes = []environment.Type{*scenario.envType}
+			}
 
-// TestCEL's main table focuses on expression behavior. This covers the env x feature
-// matrix explicitly with small expressions tied to each feature-dependent declaration.
-func TestCELFeatureCombinations(t *testing.T) {
-	// compileExpectations lists which feature-dependent expression categories should
-	// compile for one environment and feature-gate combination.
-	type compileExpectations struct {
-		// scalarAttribute covers expressions that access a scalar attribute.
-		scalarAttribute bool
-		// listTypeAttributes covers list-valued attribute access.
-		listTypeAttributes bool
-		// includesFunc covers the includes function introduced by DRAListTypeAttributes.
-		includesFunc bool
-		// multipleAllocations covers fields introduced by DRAConsumableCapacity.
-		multipleAllocations bool
-	}
-
-	type expressionTest struct {
-		expression     string
-		device         Device
-		expectsCompile bool
-	}
-
-	// StoredExpressions ignores FeatureEnabled() in VersionedOptions,
-	// so it always compiles all expressions that are valid in the current version
-	storedExpressionsCompileExpectations := compileExpectations{
-		scalarAttribute:     true,
-		listTypeAttributes:  true,
-		includesFunc:        true,
-		multipleAllocations: true,
-	}
-
-	tests := map[string]struct {
-		envType        environment.Type
-		features       Features
-		expectsCompile compileExpectations
-	}{
-		"stored-expressions-no-features": {
-			envType:        environment.StoredExpressions,
-			expectsCompile: storedExpressionsCompileExpectations,
-		},
-		"stored-expressions-consumable-capacity": {
-			envType:        environment.StoredExpressions,
-			features:       Features{EnableConsumableCapacity: true},
-			expectsCompile: storedExpressionsCompileExpectations,
-		},
-		"stored-expressions-list-type-attributes": {
-			envType:        environment.StoredExpressions,
-			features:       Features{EnableListTypeAttributes: true},
-			expectsCompile: storedExpressionsCompileExpectations,
-		},
-		"stored-expressions-all-features": {
-			envType:        environment.StoredExpressions,
-			features:       Features{EnableConsumableCapacity: true, EnableListTypeAttributes: true},
-			expectsCompile: storedExpressionsCompileExpectations,
-		},
-		"new-expressions-no-features": {
-			envType: environment.NewExpressions,
-			expectsCompile: compileExpectations{
-				scalarAttribute: true,
-			},
-		},
-		"new-expressions-consumable-capacity": {
-			envType:  environment.NewExpressions,
-			features: Features{EnableConsumableCapacity: true},
-			expectsCompile: compileExpectations{
-				scalarAttribute:     true,
-				multipleAllocations: true,
-			},
-		},
-		"new-expressions-list-type-attributes": {
-			envType:  environment.NewExpressions,
-			features: Features{EnableListTypeAttributes: true},
-			expectsCompile: compileExpectations{
-				scalarAttribute:    true,
-				listTypeAttributes: true,
-				includesFunc:       true,
-			},
-		},
-		"new-expressions-all-features": {
-			envType:  environment.NewExpressions,
-			features: Features{EnableConsumableCapacity: true, EnableListTypeAttributes: true},
-			expectsCompile: compileExpectations{
-				scalarAttribute:     true,
-				listTypeAttributes:  true,
-				includesFunc:        true,
-				multipleAllocations: true,
-			},
-		},
-	}
-
-	expressions := func(expectsCompile compileExpectations) map[string]expressionTest {
-		return map[string]expressionTest{
-			"scalar-attribute": {
-				expression: `device.attributes["dra.example.com"].ready`,
-				device: Device{
-					Driver: "dra.example.com",
-					Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-						"ready": {BoolValue: new(true)},
-					},
-				},
-				expectsCompile: expectsCompile.scalarAttribute,
-			},
-			"list-attribute": {
-				expression: `device.attributes["dra.example.com"].ids.exists(id, id == 1)`,
-				device: Device{
-					Driver: "dra.example.com",
-					Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-						"ids": {IntValues: []int64{1, 2}},
-					},
-				},
-				expectsCompile: expectsCompile.listTypeAttributes,
-			},
-			"includes-function": {
-				expression: `device.attributes["dra.example.com"].name.includes("fish")`,
-				device: Device{
-					Driver: "dra.example.com",
-					Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-						"name": {StringValue: new("fish")},
-					},
-				},
-				expectsCompile: expectsCompile.includesFunc,
-			},
-			"multiple-allocations": {
-				expression: `device.allowMultipleAllocations`,
-				device: Device{
-					Driver:                   "dra.example.com",
-					AllowMultipleAllocations: new(true),
-					Attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{},
-				},
-				expectsCompile: expectsCompile.multipleAllocations,
-			},
-			"list-attribute-with-multiple-allocations": {
-				expression: `device.allowMultipleAllocations && device.attributes["dra.example.com"].ids.exists(id, id == 1)`,
-				device: Device{
-					Driver:                   "dra.example.com",
-					AllowMultipleAllocations: new(true),
-					Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-						"ids": {IntValues: []int64{1, 2}},
-					},
-				},
-				expectsCompile: expectsCompile.listTypeAttributes && expectsCompile.multipleAllocations,
-			},
-		}
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			for exprName, exprTC := range expressions(tc.expectsCompile) {
-				t.Run(exprName, func(t *testing.T) {
-					_, ctx := ktesting.NewTestContext(t)
-					envType := tc.envType
-					result := GetCompiler(tc.features).CompileCELExpression(exprTC.expression, Options{EnvType: &envType})
-					if result.Error != nil {
-						if exprTC.expectsCompile {
-							t.Fatalf("unexpected compile error: %v", result.Error)
-						}
-						return
-					}
-					if !exprTC.expectsCompile {
-						t.Fatalf("expected compile error")
-					}
-
-					match, _, err := result.DeviceMatches(ctx, exprTC.device)
-					if err != nil {
-						t.Fatalf("unexpected evaluation error: %v", err)
-					}
-					if !match {
-						t.Fatalf("expected match")
+			var features Features
+			for _, features.EnableListTypeAttributes = range stateListType {
+				t.Run(fmt.Sprintf("list-type-attributes=%v", features.EnableListTypeAttributes), func(t *testing.T) {
+					for _, features.EnableConsumableCapacity = range stateConsumable {
+						t.Run(fmt.Sprintf("consumable-capacity=%v", features.EnableConsumableCapacity), func(t *testing.T) {
+							for _, envType := range envTypes {
+								t.Run(string(envType), func(t *testing.T) {
+									run(t, features, envType)
+								})
+							}
+						})
 					}
 				})
 			}
@@ -912,9 +774,9 @@ func BenchmarkDeviceMatches(b *testing.B) {
 			continue
 		}
 
-		run := func(b *testing.B, enableListTypeAttributes bool) {
+		run := func(b *testing.B, features Features, envType environment.Type) {
 			_, ctx := ktesting.NewTestContext(b)
-			result := GetCompiler(Features{EnableListTypeAttributes: enableListTypeAttributes}).CompileCELExpression(scenario.expression, Options{})
+			result := GetCompiler(features).CompileCELExpression(scenario.expression, Options{EnvType: &envType})
 			if result.Error != nil {
 				b.Fatalf("unexpected compile error: %s", result.Error.Error())
 			}
@@ -945,17 +807,10 @@ func BenchmarkDeviceMatches(b *testing.B) {
 				}
 			}
 		}
-		if scenario.enableListTypeAttributes == nil {
-			b.Run(name+"-list-type-attributes-false", func(b *testing.B) {
-				run(b, false)
-			})
-			b.Run(name+"-list-type-attributes-true", func(b *testing.B) {
-				run(b, true)
-			})
-		} else {
-			b.Run(fmt.Sprintf("%s-list-type-attributes-%v", name, *scenario.enableListTypeAttributes), func(b *testing.B) {
-				run(b, *scenario.enableListTypeAttributes)
-			})
-		}
+
+		b.Run(name, func(b *testing.B) {
+			// Performance shouldn't depend on feature enablement, so don't bother testing all variants.
+			run(b, Features{ /* ignored because of stored expression */ }, environment.StoredExpressions)
+		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Previously, the most recent deviceType and attributeType (= deviceTypeV136ConsumableCapacityListTypeAttributes and attributeTypeV136ListTypeAttributes) were used for cost estimations, regardless of the actual types used in the environment. Only the attribute value type was looked up in the environment.

Now all types are derived from the active environment, which is arguably more correct. In practice, it makes no difference yet, but it could.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Follow-up to https://github.com/kubernetes/kubernetes/pull/139395

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @everpeace 