### PR TITLE
Datapolicy-based Redaction for configz and Logging

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -82,6 +82,7 @@ import (
 	"k8s.io/component-base/featuregate"
 	"k8s.io/component-base/logs"
 	logsapi "k8s.io/component-base/logs/api/v1"
+	"k8s.io/component-base/logs/datapol"
 	"k8s.io/component-base/metrics"
 	metricsfeatures "k8s.io/component-base/metrics/features"
 	"k8s.io/component-base/metrics/legacyregistry"
@@ -263,7 +264,11 @@ is checked every 20 seconds (also configurable with a flag).`,
 
 			// We always validate the local configuration (command line + config file).
 			if err := kubeletconfigvalidation.ValidateKubeletConfiguration(kubeletConfig, utilfeature.DefaultFeatureGate); err != nil {
-				return fmt.Errorf("failed to validate kubelet configuration, error: %w, path: %s", err, kubeletConfig)
+				safeConfig := kubeletConfig.DeepCopy()
+				if redactErr := datapol.Redact(safeConfig); redactErr != nil {
+					return fmt.Errorf("failed to validate kubelet configuration, error: %w (config redaction also failed: %w)", err, redactErr)
+				}
+				return fmt.Errorf("failed to validate kubelet configuration, error: %w, path: %s", err, safeConfig)
 			}
 
 			if (kubeletConfig.KubeletCgroups != "" && kubeletConfig.KubeReservedCgroup != "") && (strings.Index(kubeletConfig.KubeletCgroups, kubeletConfig.KubeReservedCgroup) != 0) {
@@ -581,13 +586,12 @@ func setConfigz(cz *configz.Config, kc *kubeletconfiginternal.KubeletConfigurati
 }
 
 // marshalKubeletConfigForLog renders the effective KubeletConfiguration as a human-readable
-// YAML string for startup logging. The output mirrors what /configz serves except the
-// sensitive field StaticPodURLHeader is masked while /configz outputs it.
+// YAML string for startup logging. Fields tagged with `datapolicy` (e.g. the credential-bearing
+// StaticPodURLHeader) are redacted via datapol.Redact so secrets are not written to the log.
 func marshalKubeletConfigForLog(kc *kubeletconfiginternal.KubeletConfiguration) (string, error) {
-	// Make the config safe for logging without mutating the caller's copy.
 	safe := kc.DeepCopy()
-	for k := range safe.StaticPodURLHeader {
-		safe.StaticPodURLHeader[k] = []string{"<masked>"}
+	if err := datapol.Redact(safe); err != nil {
+		return "", fmt.Errorf("failed to redact sensitive fields: %w", err)
 	}
 	versioned, err := convertToVersionedKubeletConfig(safe)
 	if err != nil {

--- a/cmd/kubelet/app/server_test.go
+++ b/cmd/kubelet/app/server_test.go
@@ -28,6 +28,7 @@ import (
 	yaml "go.yaml.in/yaml/v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/component-base/logs/datapol"
 	"k8s.io/kubernetes/cmd/kubelet/app/options"
 	kubeletconfiginternal "k8s.io/kubernetes/pkg/kubelet/apis/config"
 )
@@ -580,10 +581,35 @@ func TestMarshalKubeletConfigForLog(t *testing.T) {
 	require.Contains(t, out, "failSwapOn: false")
 	require.Contains(t, out, "memory.available: 200Mi")
 
-	// (3) Sensitive StaticPodURLHeader values are masked, never leaked.
-	require.Contains(t, out, "<masked>")
+	// (3) Sensitive StaticPodURLHeader values are redacted via datapolicy tags, never leaked.
+	require.Contains(t, out, "CLASSIFIED")
 	require.NotContains(t, out, "super-secret-token")
 
-	// The helper must not mutate the caller's config when masking.
+	// The helper must not mutate the caller's config when redacting.
 	require.Equal(t, []string{"Bearer super-secret-token"}, kc.StaticPodURLHeader["Authorization"])
+}
+
+// TestConfigzVersionedConfigIsRedactable guards the /configz path: setConfigz
+// stores the *versioned* (v1beta1) KubeletConfiguration, and configz.MarshalJSON
+// redacts that stored object via datapol.Redact. The datapolicy tag therefore
+// must live on the v1beta1 type as well as the internal type, otherwise the
+// StaticPodURLHeader credentials leak over /configz (kubernetes#140101).
+func TestConfigzVersionedConfigIsRedactable(t *testing.T) {
+	kc := &kubeletconfiginternal.KubeletConfiguration{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KubeletConfiguration",
+			APIVersion: "kubelet.config.k8s.io/v1beta1",
+		},
+		StaticPodURLHeader: map[string][]string{
+			"Authorization": {"Bearer super-secret-token"},
+		},
+	}
+
+	// Mirror what setConfigz stores and what configz.MarshalJSON serializes.
+	versioned, err := convertToVersionedKubeletConfig(kc)
+	require.NoError(t, err)
+	require.NoError(t, datapol.Redact(versioned))
+
+	require.Equal(t, []string{"CLASSIFIED"}, versioned.StaticPodURLHeader["Authorization"],
+		"versioned StaticPodURLHeader must be redacted; the datapolicy tag must exist on the v1beta1 type")
 }

--- a/staging/src/k8s.io/component-base/configz/configz.go
+++ b/staging/src/k8s.io/component-base/configz/configz.go
@@ -58,6 +58,7 @@ import (
 	"sync"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/component-base/logs/datapol"
 )
 
 const DefaultConfigzPath = "/configz"
@@ -104,7 +105,9 @@ func Delete(name string) {
 	delete(configs, name)
 }
 
-// Set sets the ComponentConfig for this Config.
+// Set sets the ComponentConfig for this Config. It stores a redacted deep copy
+// so that any field tagged with `datapolicy` (e.g. credentials) is not served
+// over the "/configz" endpoint.
 func (v *Config) Set(val runtime.Object) error {
 	configsGuard.Lock()
 	defer configsGuard.Unlock()
@@ -121,11 +124,15 @@ func (v *Config) Set(val runtime.Object) error {
 	if gvk.Version == runtime.APIVersionInternal {
 		return fmt.Errorf("val must specify an external version")
 	}
-	v.val = val
+	redacted := val.DeepCopyObject()
+	if err := datapol.Redact(redacted); err != nil {
+		return fmt.Errorf("failed to redact sensitive fields: %w", err)
+	}
+	v.val = redacted
 	return nil
 }
 
-// MarshalJSON marshals the ComponentConfig as JSON data.
+// MarshalJSON marshals the already-redacted ComponentConfig as JSON data.
 func (v *Config) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.val)
 }

--- a/staging/src/k8s.io/component-base/configz/configz_test.go
+++ b/staging/src/k8s.io/component-base/configz/configz_test.go
@@ -23,9 +23,53 @@ import (
 	"strings"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+// secretConfig is a minimal runtime.Object carrying a datapolicy-tagged field,
+// used to verify that MarshalJSON redacts sensitive values.
+type secretConfig struct {
+	metav1.TypeMeta `json:",inline"`
+	Public          string              `json:"public"`
+	Token           string              `json:"token" datapolicy:"token"`
+	Headers         map[string][]string `json:"headers" datapolicy:"token"`
+}
+
+func (c *secretConfig) GetObjectKind() schema.ObjectKind { return &c.TypeMeta }
+
+func (c *secretConfig) DeepCopyObject() runtime.Object {
+	cp := &secretConfig{
+		TypeMeta: c.TypeMeta,
+		Public:   c.Public,
+		Token:    c.Token,
+	}
+	if c.Headers != nil {
+		cp.Headers = make(map[string][]string, len(c.Headers))
+		for k, v := range c.Headers {
+			vals := make([]string, len(v))
+			copy(vals, v)
+			cp.Headers[k] = vals
+		}
+	}
+	return cp
+}
+
+// unredactableConfig carries a field of a kind datapol.Redact does not know how
+// to traverse (a channel), so redaction fails closed. It is used to verify that
+// Set surfaces that error rather than storing an un-redacted value.
+type unredactableConfig struct {
+	metav1.TypeMeta `json:",inline"`
+	Ch              chan int `json:"-"`
+}
+
+func (c *unredactableConfig) GetObjectKind() schema.ObjectKind { return &c.TypeMeta }
+
+func (c *unredactableConfig) DeepCopyObject() runtime.Object {
+	return &unredactableConfig{TypeMeta: c.TypeMeta, Ch: c.Ch}
+}
 
 func TestConfigz(t *testing.T) {
 	v, err := New("testing")
@@ -123,6 +167,130 @@ func TestConfigzWithAPIVersionAndKind(t *testing.T) {
 	}
 
 	Delete("testobj")
+}
+
+func TestConfigzRedactsDatapolicyFields(t *testing.T) {
+	cfg := &secretConfig{
+		TypeMeta: metav1.TypeMeta{APIVersion: "test.k8s.io/v1", Kind: "SecretConfig"},
+		Public:   "visible",
+		Token:    "super-secret-token",
+		Headers: map[string][]string{
+			"Authorization": {"Bearer abc123"},
+		},
+	}
+
+	v, err := New("secret")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer Delete("secret")
+
+	if err := v.Set(cfg); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	s := httptest.NewServer(http.HandlerFunc(handle))
+	defer s.Close()
+
+	resp, err := http.Get(s.URL + "/configz")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	out := string(body)
+	if strings.Contains(out, "super-secret-token") {
+		t.Errorf("expected token to be redacted, got: %s", out)
+	}
+	if strings.Contains(out, "Bearer abc123") {
+		t.Errorf("expected header value to be redacted, got: %s", out)
+	}
+	if !strings.Contains(out, "CLASSIFIED") {
+		t.Errorf("expected redacted CLASSIFIED value, got: %s", out)
+	}
+	if !strings.Contains(out, "visible") {
+		t.Errorf("expected untagged field to be preserved, got: %s", out)
+	}
+
+	// The registered config must not be mutated by serialization.
+	if cfg.Token != "super-secret-token" {
+		t.Errorf("registered config was mutated: token = %q", cfg.Token)
+	}
+	if got := cfg.Headers["Authorization"]; len(got) != 1 || got[0] != "Bearer abc123" {
+		t.Errorf("registered config was mutated: headers = %v", cfg.Headers)
+	}
+}
+
+func TestConfigzSetRedactionError(t *testing.T) {
+	v, err := New("redaction-error")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer Delete("redaction-error")
+
+	cfg := &unredactableConfig{
+		TypeMeta: metav1.TypeMeta{APIVersion: "test.k8s.io/v1", Kind: "Unredactable"},
+		Ch:       make(chan int),
+	}
+
+	err = v.Set(cfg)
+	if err == nil {
+		t.Fatalf("expected error from Set, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to redact sensitive fields") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// A failed Set must not store the un-redacted value.
+	if v.val != nil {
+		t.Fatalf("expected val to remain unset after failed Set, got %v", v.val)
+	}
+}
+
+func TestConfigzSetRedactsOnce(t *testing.T) {
+	cfg := &secretConfig{
+		TypeMeta: metav1.TypeMeta{APIVersion: "test.k8s.io/v1", Kind: "SecretConfig"},
+		Public:   "visible",
+		Token:    "super-secret-token",
+	}
+
+	v, err := New("redact-once")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer Delete("redact-once")
+
+	if err := v.Set(cfg); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Redaction happens once in Set: the stored value is already redacted, so
+	// mutating the caller's object afterwards must not affect the served output.
+	stored, ok := v.val.(*secretConfig)
+	if !ok {
+		t.Fatalf("expected stored value of type *secretConfig, got %T", v.val)
+	}
+	if stored == cfg {
+		t.Fatalf("expected Set to store a copy, not the caller's object")
+	}
+	if stored.Token != "CLASSIFIED" {
+		t.Fatalf("expected stored token to be redacted at Set time, got %q", stored.Token)
+	}
+
+	cfg.Token = "mutated-after-set"
+	b, err := v.MarshalJSON()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	out := string(b)
+	if strings.Contains(out, "mutated-after-set") || strings.Contains(out, "super-secret-token") {
+		t.Fatalf("expected served output to reflect the redacted copy, got: %s", out)
+	}
+	if !strings.Contains(out, "CLASSIFIED") {
+		t.Fatalf("expected redacted CLASSIFIED value, got: %s", out)
+	}
 }
 
 func TestConfigzErrors(t *testing.T) {

--- a/staging/src/k8s.io/component-base/logs/datapol/datapol.go
+++ b/staging/src/k8s.io/component-base/logs/datapol/datapol.go
@@ -15,23 +15,402 @@ limitations under the License.
 */
 
 // Package datapol contains functions to determine if objects contain sensitive
-// data to e.g. make decisions on whether to log them or not.
+// data to e.g. make decisions on whether to log them or not, and to redact
+// datapolicy-tagged fields in place before such objects are logged or served
+// (see Redact). This package is not intended for hot paths: it uses reflection
+// to traverse arbitrary object graphs.
 package datapol
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 
 	"k8s.io/klog/v2"
 )
 
-// Verify returns a list of the datatypes contained in the argument that can be
-// considered sensitive w.r.t. to logging
-func Verify(value interface{}) []string {
+// redacted is the placeholder value written over every field tagged with
+// `datapolicy`. It matches the flagz/zpages "CLASSIFIED" convention.
+const redacted = "CLASSIFIED"
+
+// Redact walks obj via reflection and replaces the value of every field tagged
+// with `datapolicy` (regardless of the tag's value) with the string
+// "CLASSIFIED". Redaction happens in place, so callers MUST pass a pointer to a
+// deep copy of any object they do not want mutated. Fields without a datapolicy
+// tag are left untouched, but nested structs, slices, and maps are traversed so
+// that tagged fields nested arbitrarily deep are still redacted.
+func Redact(obj interface{}) (retErr error) {
 	defer func() {
 		if r := recover(); r != nil {
-			//TODO maybe export a metric
-			klog.Warningf("Error while inspecting arguments for sensitive data: %v", r)
+			retErr = fmt.Errorf("panic while redacting sensitive data: %v", r)
+		}
+	}()
+	v := reflect.ValueOf(obj)
+	if !v.IsValid() {
+		return nil // nil interface
+	}
+	if v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
+		if v.IsNil() {
+			return nil
+		}
+		v = v.Elem()
+	}
+	// A non-pointer value cannot be mutated in place; silently return rather
+	// than erroring, because the caller cannot fix the problem at runtime.
+	if !v.CanSet() {
+		return nil
+	}
+	return redactWalk(v, map[visitKey]struct{}{})
+}
+
+// visitKey identifies a value already visited during a walk. ptr is the value's
+// address via reflect.Value.Pointer(); length disambiguates slices that share a
+// backing array but span different ranges (e.g. s and s[:1]) so that aliased
+// sub-slices are still fully walked while a genuine self-referential slice is
+// still caught. For pointers and maps length is always 0.
+type visitKey struct {
+	ptr    uintptr
+	length int
+}
+
+// seen records the identity of pointers, maps, and slices already visited during
+// a walk so that a cyclic object graph short-circuits instead of recursing
+// forever. Without this guard a self-referential input (including a slice that
+// contains itself through an interface) overflows the stack, which is a fatal
+// error that Redact's recover() cannot catch. Returns true if v was already
+// visited (and records it otherwise). Only pointer, map, and slice kinds carry a
+// meaningful identity via Pointer(); other kinds return false.
+func seen(v reflect.Value, visited map[visitKey]struct{}) bool {
+	var key visitKey
+	switch v.Kind() {
+	case reflect.Pointer, reflect.Map:
+		if v.IsNil() {
+			return false
+		}
+		key = visitKey{ptr: v.Pointer()}
+	case reflect.Slice:
+		if v.IsNil() {
+			return false
+		}
+		// A slice's identity is its backing-array address plus its length: a
+		// self-referential slice repeats both, while a distinct sub-slice of a
+		// shared backing array differs in length and must still be walked.
+		key = visitKey{ptr: v.Pointer(), length: v.Len()}
+	default:
+		return false
+	}
+	if _, ok := visited[key]; ok {
+		return true
+	}
+	visited[key] = struct{}{}
+	return false
+}
+
+// redactWalk traverses untagged values looking for struct fields carrying a
+// datapolicy tag. When it finds one it hands the field to redactValue. It
+// returns an error if it encounters a value of a kind it does not know how to
+// traverse, so an unexpected shape fails closed rather than silently passing a
+// value that could hide an unredacted datapolicy-tagged field.
+func redactWalk(v reflect.Value, visited map[visitKey]struct{}) error {
+	if seen(v, visited) {
+		return nil
+	}
+	switch v.Kind() {
+	case reflect.Pointer:
+		if v.IsNil() {
+			return nil
+		}
+		return redactWalk(v.Elem(), visited)
+	case reflect.Interface:
+		if v.IsNil() {
+			return nil
+		}
+		// An interface's Elem() is not addressable, so walking it directly would
+		// leave any nested tagged fields unset (CanSet is false). Walk a settable
+		// copy and write it back so tagged fields reached through a by-value
+		// interface are still redacted.
+		ev := v.Elem()
+		cp := reflect.New(ev.Type()).Elem()
+		cp.Set(ev)
+		if err := redactWalk(cp, visited); err != nil {
+			return err
+		}
+		if v.CanSet() {
+			v.Set(cp)
+		}
+		return nil
+	case reflect.Struct:
+		t := v.Type()
+		for i := 0; i < t.NumField(); i++ {
+			fv := v.Field(i)
+			sf := t.Field(i)
+			if _, ok := sf.Tag.Lookup("datapolicy"); ok {
+				// A tagged field we cannot set (unexported) would leak its value
+				// unredacted. Fail closed rather than silently pass it through.
+				if !fv.CanSet() {
+					return fmt.Errorf("cannot redact datapolicy-tagged field %s.%s: field is unexported and cannot be set via reflection", t, sf.Name)
+				}
+				// Use a fresh visited set for the value redaction rather than
+				// sharing redactWalk's. The walk records the addresses of maps
+				// and pointers it merely traverses (without redacting); if a
+				// tagged field aliases one of those already-walked addresses,
+				// sharing the set would make seen() short-circuit and skip
+				// redaction entirely — a fail-open leak whose occurrence depends
+				// on struct field order. redactValue never re-enters redactWalk
+				// and zeroes structs instead of recursing into them, so its own
+				// cycle detection is self-contained within the fresh set.
+				if err := redactValue(fv, map[visitKey]struct{}{}); err != nil {
+					return err
+				}
+				continue
+			}
+			if !fv.CanSet() {
+				// Unexported field: reflection cannot overwrite anything beneath
+				// it, so we cannot recurse with redactWalk (which mutates). But
+				// skipping it blindly would silently leak a datapolicy-tagged
+				// field nested below. Inspect the subtree read-only and fail
+				// closed if it hides a tag we would be unable to redact.
+				if path := findDatapolicyTag(fv, sf.Name, map[reflect.Type]struct{}{}); path != "" {
+					return fmt.Errorf("cannot redact datapolicy-tagged field reached through unexported field %s.%s: found tag at %s", t, sf.Name, path)
+				}
+				continue
+			}
+			if err := redactWalk(fv, visited); err != nil {
+				return err
+			}
+		}
+		return nil
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			if err := redactWalk(v.Index(i), visited); err != nil {
+				return err
+			}
+		}
+		return nil
+	case reflect.Map:
+		iter := v.MapRange()
+		for iter.Next() {
+			// Map values are not addressable, so operate on a settable copy and
+			// write it back.
+			mv := iter.Value()
+			cp := reflect.New(mv.Type()).Elem()
+			cp.Set(mv)
+			if err := redactWalk(cp, visited); err != nil {
+				return err
+			}
+			v.SetMapIndex(iter.Key(), cp)
+		}
+		return nil
+	case reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64,
+		reflect.Complex64, reflect.Complex128,
+		reflect.String:
+		// Scalar leaf: it carries no datapolicy-tagged fields beneath it, so
+		// there is nothing to walk. A scalar reached here is untagged (tagged
+		// fields are handed to redactValue by the struct case above).
+		return nil
+	default:
+		// Chan, Func, UnsafePointer, Invalid, and any future kind we do not know
+		// how to traverse. Fail closed: error rather than silently passing a
+		// value that could hide an unredacted datapolicy-tagged field.
+		return fmt.Errorf("cannot redact value of unexpected kind %s", v.Kind())
+	}
+}
+
+// findDatapolicyTag scans v read-only for a struct field carrying a datapolicy
+// tag, descending through pointers, interfaces, structs, slices, arrays, and
+// maps. It exists to inspect subtrees that redactWalk cannot mutate — namely
+// those reached through an unexported field — so redaction can fail closed when
+// such a subtree hides a tagged field that should have been redacted. It only
+// reads values (it never calls Set or Interface), so it is safe on the
+// read-only reflect.Values that unexported fields yield, where a mutating walk
+// would panic. seenTypes bounds recursion on self-referential types: detection
+// is structural, so once a type has been fully scanned without a tag, revisiting
+// it can add nothing. It returns a dotted field path to the first tag found, or
+// "" if the subtree carries none.
+func findDatapolicyTag(v reflect.Value, path string, seenTypes map[reflect.Type]struct{}) string {
+	switch v.Kind() {
+	case reflect.Pointer, reflect.Interface:
+		if v.IsNil() {
+			return ""
+		}
+		return findDatapolicyTag(v.Elem(), path, seenTypes)
+	case reflect.Struct:
+		t := v.Type()
+		if _, ok := seenTypes[t]; ok {
+			return ""
+		}
+		seenTypes[t] = struct{}{}
+		for i := 0; i < t.NumField(); i++ {
+			sf := t.Field(i)
+			fieldPath := path + "." + sf.Name
+			if _, ok := sf.Tag.Lookup("datapolicy"); ok {
+				return fieldPath
+			}
+			if p := findDatapolicyTag(v.Field(i), fieldPath, seenTypes); p != "" {
+				return p
+			}
+		}
+		return ""
+	case reflect.Slice, reflect.Array:
+		// Walk every element: a slice/array of interfaces can hold differing
+		// dynamic types, so no single element is representative. An empty
+		// container holds no value to redact, so finding no tag is correct.
+		for i := 0; i < v.Len(); i++ {
+			if p := findDatapolicyTag(v.Index(i), path, seenTypes); p != "" {
+				return p
+			}
+		}
+		return ""
+	case reflect.Map:
+		iter := v.MapRange()
+		for iter.Next() {
+			// Match redactWalk, which only redacts map values, not keys.
+			if p := findDatapolicyTag(iter.Value(), path, seenTypes); p != "" {
+				return p
+			}
+		}
+		return ""
+	default:
+		// Scalars and other leaf kinds carry no nested tags.
+		return ""
+	}
+}
+
+// redactValue overwrites the value of a datapolicy-tagged field. Strings,
+// byte slices, and string slices are replaced with the "CLASSIFIED" sentinel;
+// maps preserve their keys but have their leaf values redacted; pointers and
+// interfaces are dereferenced; any other scalar is zeroed.
+//
+// It returns an error if it cannot actually overwrite a value it was asked to
+// redact — for example a leaf that reflection reports as not settable. Every
+// terminal write is guarded so that an un-redactable value fails closed with a
+// descriptive error instead of silently leaking (or only surfacing as a
+// recovered panic).
+func redactValue(v reflect.Value, visited map[visitKey]struct{}) error {
+	switch v.Kind() {
+	case reflect.String:
+		if !v.CanSet() {
+			return notSettableErr(v)
+		}
+		v.SetString(redacted)
+		return nil
+	case reflect.Pointer:
+		// A nil pointer holds no value to redact; leave it nil rather than
+		// materializing an empty object that was not present in the input.
+		if v.IsNil() {
+			return nil
+		}
+		// Cycle guard: a pointer that (transitively) points back to itself must
+		// not recurse forever. Redaction of the pointee mutates shared storage
+		// in place, so skipping an already-visited pointer loses nothing.
+		if seen(v, visited) {
+			return nil
+		}
+		return redactValue(v.Elem(), visited)
+	case reflect.Interface:
+		if v.IsNil() {
+			return nil
+		}
+		ev := v.Elem()
+		cp := reflect.New(ev.Type()).Elem()
+		cp.Set(ev)
+		if err := redactValue(cp, visited); err != nil {
+			return err
+		}
+		if !v.CanSet() {
+			return notSettableErr(v)
+		}
+		v.Set(cp)
+		return nil
+	case reflect.Slice:
+		switch v.Type().Elem().Kind() {
+		case reflect.Uint8:
+			// []byte — terminal replacement. This overwrites the slice header
+			// rather than mutating the shared backing array, so it must NOT be
+			// short-circuited by the seen() cycle guard: two tagged fields (or
+			// two map values) that alias the same slice each need their own
+			// replacement, otherwise the second alias leaks its original value.
+			if !v.CanSet() {
+				return notSettableErr(v)
+			}
+			v.SetBytes([]byte(redacted))
+			return nil
+		case reflect.String:
+			// []string (or a named type with string elements) — terminal
+			// replacement; same rationale as []byte above, so no seen() guard.
+			if !v.CanSet() {
+				return notSettableErr(v)
+			}
+			s := reflect.MakeSlice(v.Type(), 1, 1)
+			s.Index(0).SetString(redacted)
+			v.Set(s)
+			return nil
+		default:
+			// Recursive slice: redaction mutates each element in place through
+			// the shared backing array, so a cycle guard is both safe (aliases
+			// already share the mutation) and necessary (a self-referential
+			// slice would otherwise recurse forever).
+			if seen(v, visited) {
+				return nil
+			}
+			for i := 0; i < v.Len(); i++ {
+				if err := redactValue(v.Index(i), visited); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+	case reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			if err := redactValue(v.Index(i), visited); err != nil {
+				return err
+			}
+		}
+		return nil
+	case reflect.Map:
+		// Cycle guard: a map reachable from its own values must not recurse
+		// forever. Values are rewritten via SetMapIndex on the shared map, so
+		// skipping an already-visited map loses nothing.
+		if seen(v, visited) {
+			return nil
+		}
+		iter := v.MapRange()
+		for iter.Next() {
+			mv := iter.Value()
+			cp := reflect.New(mv.Type()).Elem()
+			cp.Set(mv)
+			if err := redactValue(cp, visited); err != nil {
+				return err
+			}
+			v.SetMapIndex(iter.Key(), cp)
+		}
+		return nil
+	default:
+		// Numbers, bools, and other scalars: clear the value.
+		if !v.CanSet() {
+			return notSettableErr(v)
+		}
+		v.Set(reflect.Zero(v.Type()))
+		return nil
+	}
+}
+
+// notSettableErr reports that reflection cannot overwrite v, so the
+// datapolicy-tagged value it holds cannot be redacted and redaction must fail
+// closed rather than leak the value.
+func notSettableErr(v reflect.Value) error {
+	return fmt.Errorf("cannot redact datapolicy-tagged value of kind %s: reflection reports it is not settable", v.Kind())
+}
+
+// Verify returns a list of the datatypes contained in the argument that can be
+// considered sensitive w.r.t. to logging
+func Verify(logger klog.Logger, value interface{}) []string {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error(nil, "Error while inspecting arguments for sensitive data", "panic", r)
 		}
 	}()
 	t := reflect.ValueOf(value)

--- a/staging/src/k8s.io/component-base/logs/datapol/datapol_test.go
+++ b/staging/src/k8s.io/component-base/logs/datapol/datapol_test.go
@@ -19,10 +19,12 @@ package datapol
 import (
 	"fmt"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/klog/v2/ktesting"
 )
 
 const (
@@ -58,6 +60,7 @@ type datapolBehindPointer struct {
 }
 
 func TestValidate(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	testcases := []struct {
 		name      string
 		value     interface{}
@@ -138,7 +141,7 @@ func TestValidate(t *testing.T) {
 		expect: []string{},
 	}}
 	for _, tc := range testcases {
-		res := Verify(tc.value)
+		res := Verify(logger, tc.value)
 		if !assert.ElementsMatch(t, tc.expect, res) {
 			t.Errorf("Wrong set of tags for %q. expect %v, got %v", tc.name, tc.expect, res)
 		}
@@ -147,6 +150,410 @@ func TestValidate(t *testing.T) {
 			if strings.Contains(formatted, marker) != (len(tc.expect) > 0) {
 				t.Errorf("Filter decision doesn't match formatted value for %q: tags: %v, format: %s", tc.name, tc.expect, formatted)
 			}
+		}
+	}
+}
+
+// The following types use exported fields because Redact mutates via
+// reflection, which can only set exported fields.
+
+type redactString struct {
+	Token  string `datapolicy:"token"`
+	Public string
+}
+
+// redactHeader mirrors the StaticPodURLHeader shape (map[string][]string) that
+// leaked credentials in kubernetes/kubernetes#140101.
+type redactHeader struct {
+	StaticPodURLHeader map[string][]string `datapolicy:"token"`
+	PublicMap          map[string][]string
+}
+
+type redactBytes struct {
+	Secret []byte `datapolicy:"secret-key"`
+}
+
+type redactStringSlice struct {
+	Secrets []string `datapolicy:"password"`
+}
+
+type redactNested struct {
+	Inner  redactString
+	Public string
+}
+
+type redactPointer struct {
+	Inner *redactString
+}
+
+type redactNoTags struct {
+	A string
+	B int
+	C map[string]string
+}
+
+// redactSharedMap has an untagged field declared before a tagged field. When
+// both alias the same map value, redaction of the tagged field must not be
+// skipped by the walk having already visited the map's address.
+type redactSharedMap struct {
+	Public map[string][]string
+	Secret map[string][]string `datapolicy:"token"`
+}
+
+// aliasedSharedMap returns a redactSharedMap whose Public and Secret fields
+// point at the same underlying map.
+func aliasedSharedMap() *redactSharedMap {
+	shared := map[string][]string{"Authorization": {"Bearer hunter2"}}
+	return &redactSharedMap{Public: shared, Secret: shared}
+}
+
+// aliasedSliceMap returns a map whose values all alias the same backing slice,
+// so redaction must replace each value independently rather than skipping
+// already-seen slice headers.
+func aliasedSliceMap() map[string][]string {
+	vals := []string{"Bearer secret"}
+	return map[string][]string{"A": vals, "B": vals}
+}
+
+func TestRedact(t *testing.T) {
+	testcases := []struct {
+		name   string
+		value  interface{}
+		expect interface{}
+	}{{
+		name:   "string field with datapolicy tag is redacted, untagged field preserved",
+		value:  &redactString{Token: marker, Public: "visible"},
+		expect: &redactString{Token: redacted, Public: "visible"},
+	}, {
+		name:   "empty tagged string is still redacted",
+		value:  &redactString{Token: "", Public: "visible"},
+		expect: &redactString{Token: redacted, Public: "visible"},
+	}, {
+		name: "map[string][]string tagged field preserves keys, redacts values",
+		value: &redactHeader{
+			StaticPodURLHeader: map[string][]string{
+				"Authorization": {"Bearer hunter2"},
+				"X-Custom":      {"a", "b"},
+			},
+			PublicMap: map[string][]string{
+				"Accept": {"application/json"},
+			},
+		},
+		expect: &redactHeader{
+			StaticPodURLHeader: map[string][]string{
+				"Authorization": {redacted},
+				"X-Custom":      {redacted},
+			},
+			PublicMap: map[string][]string{
+				"Accept": {"application/json"},
+			},
+		},
+	}, {
+		name:   "byte slice tagged field is redacted",
+		value:  &redactBytes{Secret: []byte(marker)},
+		expect: &redactBytes{Secret: []byte(redacted)},
+	}, {
+		name:   "string slice tagged field is redacted to single sentinel",
+		value:  &redactStringSlice{Secrets: []string{marker, "another"}},
+		expect: &redactStringSlice{Secrets: []string{redacted}},
+	}, {
+		name:   "nested struct with tagged field is redacted, siblings preserved",
+		value:  &redactNested{Inner: redactString{Token: marker, Public: "keep"}, Public: "top"},
+		expect: &redactNested{Inner: redactString{Token: redacted, Public: "keep"}, Public: "top"},
+	}, {
+		name:   "tagged field behind pointer is redacted",
+		value:  &redactPointer{Inner: &redactString{Token: marker, Public: "keep"}},
+		expect: &redactPointer{Inner: &redactString{Token: redacted, Public: "keep"}},
+	}, {
+		name:   "nil pointer field is left untouched",
+		value:  &redactPointer{Inner: nil},
+		expect: &redactPointer{Inner: nil},
+	}, {
+		name:   "struct with no datapolicy tags is a no-op",
+		value:  &redactNoTags{A: "a", B: 1, C: map[string]string{"k": "v"}},
+		expect: &redactNoTags{A: "a", B: 1, C: map[string]string{"k": "v"}},
+	}, {
+		name:   "tagged field inside a by-value interface is redacted",
+		value:  &struct{ V interface{} }{V: redactString{Token: marker, Public: "keep"}},
+		expect: &struct{ V interface{} }{V: redactString{Token: redacted, Public: "keep"}},
+	}, {
+		name:   "tagged field inside a pointer-in-interface is redacted",
+		value:  &struct{ V interface{} }{V: &redactString{Token: marker, Public: "keep"}},
+		expect: &struct{ V interface{} }{V: &redactString{Token: redacted, Public: "keep"}},
+	}, {
+		// Regression: the untagged Public field is walked before the tagged
+		// Secret field. Both alias the same map, so if the walk's visited set is
+		// shared with value redaction, the tagged field's seen() check would
+		// short-circuit and leave the secret unredacted (fail-open). Because the
+		// storage is genuinely shared, redacting Secret also redacts Public,
+		// which is the safe (fail-closed) direction.
+		name:   "map aliased by an untagged field walked before the tagged field is still redacted",
+		value:  aliasedSharedMap(),
+		expect: &redactSharedMap{Public: map[string][]string{"Authorization": {redacted}}, Secret: map[string][]string{"Authorization": {redacted}}},
+	}, {
+		// Regression: two map values in a tagged map alias the same []string.
+		// Terminal slice redaction replaces the slice header rather than
+		// mutating the shared backing array, so it must not be short-circuited
+		// by the seen() cycle guard — otherwise the second aliased value keeps
+		// its original secret (fail-open leak).
+		name:   "tagged map whose values alias the same string slice redacts every value",
+		value:  &redactHeader{StaticPodURLHeader: aliasedSliceMap()},
+		expect: &redactHeader{StaticPodURLHeader: map[string][]string{"A": {redacted}, "B": {redacted}}},
+	}}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := Redact(tc.value); err != nil {
+				t.Fatalf("Redact failed: %v", err)
+			}
+			assert.Equal(t, tc.expect, tc.value)
+		})
+	}
+}
+
+// TestRedactUnexpectedKind verifies that walking a value of a kind the redactor
+// does not know how to traverse (e.g. a func) fails closed with an error rather
+// than silently passing, while ordinary scalar-only inputs succeed.
+func TestRedactUnexpectedKind(t *testing.T) {
+	// A func-typed exported field is an unhandled kind and must produce an error.
+	unexpected := &struct {
+		Fn func()
+	}{Fn: func() {}}
+	if err := Redact(unexpected); err == nil {
+		t.Errorf("expected error redacting value of unexpected kind, got nil")
+	}
+
+	// A chan-typed exported field is likewise unhandled and must error.
+	unexpectedChan := &struct {
+		Ch chan int
+	}{Ch: make(chan int)}
+	if err := Redact(unexpectedChan); err == nil {
+		t.Errorf("expected error redacting value containing a channel, got nil")
+	}
+
+	// Scalar-only input has no unhandled kinds and must succeed without error.
+	scalars := &redactNoTags{A: "a", B: 1, C: map[string]string{"k": "v"}}
+	if err := Redact(scalars); err != nil {
+		t.Errorf("unexpected error redacting scalar-only value: %v", err)
+	}
+}
+
+// TestRedactValueNotSettable verifies that redactValue fails closed with an
+// error when handed a value reflection cannot overwrite, rather than silently
+// leaving the sensitive value in place. It also confirms the ability to return
+// an error propagates through the recursive kinds (pointer, interface, slice,
+// map) that wrap such a leaf, and that a settable value still redacts cleanly.
+func TestRedactValueNotSettable(t *testing.T) {
+	// reflect.ValueOf yields non-addressable (and thus non-settable) values, so
+	// each of these leaves cannot be written and must produce an error.
+	notSettable := []struct {
+		name  string
+		value reflect.Value
+	}{
+		{"string leaf", reflect.ValueOf("secret")},
+		{"int leaf", reflect.ValueOf(42)},
+		{"byte slice leaf", reflect.ValueOf([]byte("secret"))},
+		{"string slice leaf", reflect.ValueOf([]string{"secret"})},
+	}
+	for _, tc := range notSettable {
+		t.Run(tc.name+" errors", func(t *testing.T) {
+			if err := redactValue(tc.value, map[visitKey]struct{}{}); err == nil {
+				t.Errorf("expected error redacting non-settable %s, got nil", tc.name)
+			}
+		})
+	}
+
+	// A settable leaf redacts without error, proving the added error plumbing
+	// does not break the ordinary success path.
+	t.Run("settable string redacts", func(t *testing.T) {
+		s := struct {
+			Token string `datapolicy:"token"`
+		}{Token: marker}
+		fv := reflect.ValueOf(&s).Elem().Field(0)
+		if err := redactValue(fv, map[visitKey]struct{}{}); err != nil {
+			t.Fatalf("unexpected error redacting settable string: %v", err)
+		}
+		if s.Token != redacted {
+			t.Errorf("expected token redacted to %q, got %q", redacted, s.Token)
+		}
+	})
+}
+
+// hiddenTagged is an exported struct with a datapolicy-tagged field, used to
+// nest tags below unexported (unsettable) fields.
+type hiddenTagged struct {
+	Token string `datapolicy:"token"`
+}
+
+// directUnexportedTag carries a datapolicy tag directly on an unexported field.
+// Reflection cannot overwrite it, so Redact must fail closed.
+type directUnexportedTag struct {
+	secret string `datapolicy:"password"`
+}
+
+// taggedBehindUnexported nests a tagged field below an unexported struct field.
+// Reflection cannot set through the unexported field, so Redact must error.
+type taggedBehindUnexported struct {
+	inner hiddenTagged
+}
+
+// taggedInUnexportedMap hides a tagged struct inside an unexported map value,
+// exercising the map branch of the read-only tag scan.
+type taggedInUnexportedMap struct {
+	m map[string]hiddenTagged
+}
+
+// taggedInUnexportedInterface hides a tagged struct inside an unexported
+// interface field, exercising the interface branch of the read-only tag scan.
+type taggedInUnexportedInterface struct {
+	v interface{}
+}
+
+// unexportedNoTags has unexported fields — including interface and map kinds a
+// mutating walk could not traverse — but no datapolicy tags anywhere, so Redact
+// must succeed without error and without panicking.
+type unexportedNoTags struct {
+	data  interface{}
+	items map[string]string
+	name  string
+}
+
+// TestRedactUnexportedTaggedField verifies Redact fails closed when a
+// datapolicy-tagged field is reachable only through an unexported field that
+// reflection cannot overwrite, while still succeeding on unexported subtrees
+// that carry no tags.
+func TestRedactUnexportedTaggedField(t *testing.T) {
+	errorCases := []struct {
+		name  string
+		value interface{}
+	}{{
+		name:  "tag directly on unexported field",
+		value: &directUnexportedTag{secret: marker},
+	}, {
+		name:  "tag nested below an unexported struct field",
+		value: &taggedBehindUnexported{inner: hiddenTagged{Token: marker}},
+	}, {
+		name:  "tag hidden in an unexported map value",
+		value: &taggedInUnexportedMap{m: map[string]hiddenTagged{"k": {Token: marker}}},
+	}, {
+		name:  "tag hidden in an unexported interface value",
+		value: &taggedInUnexportedInterface{v: hiddenTagged{Token: marker}},
+	}, {
+		name:  "tag hidden behind a pointer in an unexported interface value",
+		value: &taggedInUnexportedInterface{v: &hiddenTagged{Token: marker}},
+	}}
+	for _, tc := range errorCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := Redact(tc.value); err == nil {
+				t.Errorf("expected error redacting %q, got nil", tc.name)
+			}
+		})
+	}
+
+	// Unexported fields with no datapolicy tags anywhere: there is nothing to
+	// redact, so Redact must succeed without error and without panicking even
+	// though the fields are unsettable interface and map kinds.
+	t.Run("unexported subtree with no tags succeeds", func(t *testing.T) {
+		v := &unexportedNoTags{
+			data:  &redactNoTags{A: "a", B: 1, C: map[string]string{"k": "v"}},
+			items: map[string]string{"k": "v"},
+			name:  "public",
+		}
+		if err := Redact(v); err != nil {
+			t.Errorf("unexpected error redacting unexported tag-free value: %v", err)
+		}
+	})
+}
+
+// TestRedactNilAndNonPointer verifies Redact does not panic on inputs it cannot
+// mutate.
+func TestRedactNilAndNonPointer(t *testing.T) {
+	// nil interface
+	if err := Redact(nil); err != nil {
+		t.Fatalf("Redact(nil) failed: %v", err)
+	}
+	// non-pointer struct cannot be mutated but must not panic
+	v := redactString{Token: marker}
+	if err := Redact(v); err != nil {
+		t.Fatalf("Redact(non-pointer) failed: %v", err)
+	}
+}
+
+// redactCyclic is a self-referential type used to prove Redact does not recurse
+// forever on a cyclic object graph. A stack overflow would be a fatal error that
+// Redact's recover() cannot catch.
+type redactCyclic struct {
+	Token string `datapolicy:"token"`
+	Self  *redactCyclic
+	Peers map[string]*redactCyclic
+}
+
+func TestRedactCyclic(t *testing.T) {
+	// Pointer cycle: node references itself.
+	node := &redactCyclic{Token: marker}
+	node.Self = node
+	node.Peers = map[string]*redactCyclic{"self": node}
+
+	if err := Redact(node); err != nil {
+		t.Fatalf("Redact failed: %v", err)
+	}
+
+	if node.Token != redacted {
+		t.Errorf("Token not redacted on cyclic input: got %q", node.Token)
+	}
+	// The cycle must have been broken (no crash) and the same node reached
+	// through the cycle is the already-redacted node.
+	if node.Self.Token != redacted {
+		t.Errorf("Token not redacted through cycle: got %q", node.Self.Token)
+	}
+}
+
+// TestRedactCyclicSlice proves a slice that references itself through an
+// interface element does not recurse forever. Slices carry identity via their
+// backing-array address; without recording that identity the walk would follow
+// the slice/interface path until a fatal stack overflow that recover() cannot
+// catch.
+func TestRedactCyclicSlice(t *testing.T) {
+	// Self-referential slice: element 0 holds the slice itself.
+	s := make([]interface{}, 1)
+	s[0] = s
+
+	// Wrap in a struct so Redact receives an addressable pointer, mirroring how
+	// configz hands it a deep-copied runtime object.
+	holder := &struct {
+		Data []interface{}
+	}{Data: s}
+
+	// Must return (break the cycle) rather than crash.
+	if err := Redact(holder); err != nil {
+		t.Fatalf("Redact failed: %v", err)
+	}
+}
+
+// TestRedactAliasedSubslice proves that two slices sharing a backing array but
+// spanning different ranges are both fully walked, so a tagged field only
+// reachable through the longer slice is still redacted. Keying the visited set
+// on the backing-array address alone (without length) would skip the longer
+// slice as "already seen" and leak the tagged field.
+func TestRedactAliasedSubslice(t *testing.T) {
+	type tagged struct {
+		Token string `datapolicy:"token"`
+	}
+	backing := []tagged{{Token: marker}, {Token: marker}}
+	holder := &struct {
+		Short []tagged
+		Full  []tagged
+	}{
+		Short: backing[:1],
+		Full:  backing,
+	}
+
+	if err := Redact(holder); err != nil {
+		t.Fatalf("Redact failed: %v", err)
+	}
+
+	for i := range backing {
+		if backing[i].Token != redacted {
+			t.Errorf("Token[%d] not redacted through aliased subslice: got %q", i, backing[i].Token)
 		}
 	}
 }

--- a/staging/src/k8s.io/kube-scheduler/config/v1/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1/types.go
@@ -400,7 +400,7 @@ type ExtenderTLSConfig struct {
 	// KeyData holds PEM-encoded bytes (typically read from a client certificate key file).
 	// KeyData takes precedence over KeyFile
 	// +listType=atomic
-	KeyData []byte `json:"keyData,omitempty"`
+	KeyData []byte `json:"keyData,omitempty" datapolicy:"security-key"`
 	// CAData holds PEM-encoded bytes (typically read from a root certificates bundle).
 	// CAData takes precedence over CAFile
 	// +listType=atomic

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -156,7 +156,7 @@ type KubeletConfiguration struct {
 	// staticPodURLHeader is a map of slices with HTTP headers to use when accessing the podURL.
 	// Default: nil
 	// +optional
-	StaticPodURLHeader map[string][]string `json:"staticPodURLHeader,omitempty"`
+	StaticPodURLHeader map[string][]string `json:"staticPodURLHeader,omitempty" datapolicy:"token"`
 	// address is the IP address for the Kubelet to serve on (set to 0.0.0.0
 	// for all interfaces).
 	// Default: "0.0.0.0"


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we negenerteed it:

Use existing datapol to redact fields in configz and logs instead of hardcoding specific fields

#### Which issue(s) this PR is related to:

- kubelet: https://github.com/kubernetes/kubernetes/issues/140101
- scheduler: https://github.com/kubernetes/kubernetes/issues/140100


#### Special notes for your reviewer:

This is a reviving of a stale code. I think it makes the most sense in light of two reported issues instead of keep hardcoding specific fields. Since we already have this attribution, it feels like a non-KEP kind of incremental change.

Some AI was used

#### Does this PR introduce a user-facing change?

```release-note
Sensitive fields are redacted out from `/configz` endpoint output
```
