### PR TITLE
Fix MutatingAdmissionPolicy JSONPatch with complex values

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch/json_patch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch/json_patch_test.go
@@ -469,6 +469,110 @@ func TestJSONPatch(t *testing.T) {
 				Spec:       appsv1.DeploymentSpec{},
 			},
 		},
+		{
+			name: "jsonPatch with scalar int and bool as values",
+			expression: `[
+					JSONPatch{op: "replace", path: "/spec/replicas", value: object.spec.replicas + 2},
+					JSONPatch{op: "replace", path: "/spec/paused", value: !object.spec.paused},
+				]`,
+			gvr: deploymentGVR,
+			object: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{Replicas: ptr.To[int32](3), Paused: true},
+			},
+			expectedResult: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{Replicas: ptr.To[int32](5), Paused: false},
+			},
+		},
+		{
+			name: "jsonPatch with quantity and duration as values",
+			expression: `[
+					JSONPatch{op: "add", path: "/metadata/labels/cpu", value: quantity("100m").isGreaterThan(quantity("0")) ? "100m" : "0"},
+					JSONPatch{op: "add", path: "/spec/minReadySeconds", value: int(duration("30s")) / 1000000000},
+				]`,
+			gvr: deploymentGVR,
+			object: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"existing": "val"}},
+				Spec:       appsv1.DeploymentSpec{},
+			},
+			expectedResult: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"existing": "val", "cpu": "100m"},
+				},
+				Spec: appsv1.DeploymentSpec{
+					MinReadySeconds: 30,
+				},
+			},
+		},
+		{
+			name: "jsonPatch with slice of scalars as value",
+			expression: `[
+					JSONPatch{op: "add", path: "/spec/template/spec/containers/0/command", value: ["sh", "-c", "echo hello"]},
+				]`,
+			gvr: deploymentGVR,
+			object: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "c1"}},
+						},
+					},
+				},
+			},
+			expectedResult: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:    "c1",
+									Command: []string{"sh", "-c", "echo hello"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "jsonPatch with map of scalars as value",
+			expression: `[
+					JSONPatch{op: "add", path: "/metadata/labels", value: {"env": "prod", "tier": "frontend"}},
+				]`,
+			gvr: deploymentGVR,
+			object: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec:       appsv1.DeploymentSpec{},
+			},
+			expectedResult: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"env": "prod", "tier": "frontend"},
+				},
+				Spec: appsv1.DeploymentSpec{},
+			},
+		},
+		{
+			name: "jsonPatch with map of struct as value",
+			expression: `[
+					JSONPatch{op: "add", path: "/spec/template/spec/nodeSelector", value: {"disktype": "ssd"}},
+				]`,
+			gvr: deploymentGVR,
+			object: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{},
+					},
+				},
+			},
+			expectedResult: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							NodeSelector: map[string]string{"disktype": "ssd"},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	compiler, err := cel.NewCompositedCompiler(environment.MustBaseEnvSet(environment.DefaultCompatibilityVersion()))

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch/json_patch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch/json_patch_test.go
@@ -402,6 +402,73 @@ func TestJSONPatch(t *testing.T) {
 			}}}},
 			expectedErr: "JSON Patch: replace operation does not apply: doc is missing key: /spec/template/spec/containers/-: missing value",
 		},
+		{
+			name: "jsonPatch with complex struct as value",
+			expression: `[
+					JSONPatch{op: "add", path: "/spec/template/spec/containers/1", value: object.spec.template.spec.containers[0]},
+				]`,
+			gvr: deploymentGVR,
+			object: &appsv1.Deployment{Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "a"}},
+			}}}},
+			expectedResult: &appsv1.Deployment{Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "a"}, {Name: "a"}},
+			}}}},
+		},
+		{
+			name: "jsonPatch with large complex struct as value",
+			expression: `[
+					JSONPatch{op: "replace", path: "/spec/template/spec", value: object.spec.template.spec},
+				]`,
+			gvr: deploymentGVR,
+			object: &appsv1.Deployment{Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "a", Image: "nginx"}},
+			}}}},
+			expectedResult: &appsv1.Deployment{Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "a", Image: "nginx"}},
+			}}}},
+		},
+		{
+			name: "jsonPatch with slice of complex struct as value",
+			expression: `[
+					JSONPatch{op: "add", path: "/spec/template/spec/containers", value: object.spec.template.spec.containers},
+				]`,
+			gvr: deploymentGVR,
+			object: &appsv1.Deployment{Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "a"}},
+			}}}},
+			expectedResult: &appsv1.Deployment{Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "a"}},
+			}}}},
+		},
+		{
+			name: "jsonPatch with list concatenation operator",
+			expression: `[
+					JSONPatch{op: "add", path: "/spec/template/spec/containers", value: object.spec.template.spec.containers + [object.spec.template.spec.containers[0]]},
+				]`,
+			gvr: deploymentGVR,
+			object: &appsv1.Deployment{Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "a"}},
+			}}}},
+			expectedResult: &appsv1.Deployment{Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "a"}, {Name: "a"}},
+			}}}},
+		},
+		{
+			name: "jsonPatch with map key comprehension all predicate",
+			expression: `[
+					JSONPatch{op: "add", path: "/metadata/labels/added", value: object.metadata.labels.all(k, k != "invalid") ? "true" : "false"},
+				]`,
+			gvr: deploymentGVR,
+			object: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"env": "prod", "app": "demo"}},
+				Spec:       appsv1.DeploymentSpec{},
+			},
+			expectedResult: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"env": "prod", "app": "demo", "added": "true"}},
+				Spec:       appsv1.DeploymentSpec{},
+			},
+		},
 	}
 
 	compiler, err := cel.NewCompositedCompiler(environment.MustBaseEnvSet(environment.DefaultCompatibilityVersion()))

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/valuesschemalesstyped.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/valuesschemalesstyped.go
@@ -34,7 +34,7 @@ import (
 var (
 	structpbValueType = reflect.TypeFor[*structpb.Value]()
 	anyType           = reflect.TypeFor[any]()
-	mapStringAnyType  = reflect.TypeOf(map[string]interface{}(nil))
+	mapStringAnyType  = reflect.TypeFor[map[string]interface{}]()
 )
 
 // SchemalessTypedToVal wraps a Go value as a CEL ref.Val.
@@ -144,15 +144,12 @@ func SchemalessTypedToVal(val interface{}) ref.Val {
 	}
 }
 
-// schemalessListToNative converts a schemaless list to *structpb.Value, walking
+// schemalessListToProtoValue converts a schemaless list to *structpb.Value, walking
 // the backing reflect.Value directly so it retains no per-element ref.Val cache.
-func schemalessListToNative(v reflect.Value, typeDesc reflect.Type) (interface{}, error) {
-	if typeDesc != structpbValueType {
-		return nil, fmt.Errorf("unsupported target native type: %s", typeDesc)
-	}
+func schemalessListToProtoValue(v reflect.Value) (*structpb.Value, error) {
 	values := make([]*structpb.Value, v.Len())
 	for idx := range values {
-		native, err := SchemalessTypedToVal(v.Index(idx).Interface()).ConvertToNative(typeDesc)
+		native, err := SchemalessTypedToVal(v.Index(idx).Interface()).ConvertToNative(structpbValueType)
 		if err != nil {
 			return nil, err
 		}
@@ -165,43 +162,42 @@ func schemalessListToNative(v reflect.Value, typeDesc reflect.Type) (interface{}
 	return &structpb.Value{Kind: &structpb.Value_ListValue{ListValue: &structpb.ListValue{Values: values}}}, nil
 }
 
-// schemalessMapToNative converts the entries produced by forEachEntry to the
-// requested native type (*structpb.Value or map[string]interface{}), wrapping
-// each value directly so it populates no field cache.
-func schemalessMapToNative(typeDesc reflect.Type, forEachEntry func(func(key string, rawVal interface{}) error) error) (interface{}, error) {
-	switch typeDesc {
-	case structpbValueType:
-		fields := make(map[string]*structpb.Value)
-		if err := forEachEntry(func(key string, rawVal interface{}) error {
-			native, err := SchemalessTypedToVal(rawVal).ConvertToNative(typeDesc)
-			if err != nil {
-				return err
-			}
-			pbVal, ok := native.(*structpb.Value)
-			if !ok {
-				return fmt.Errorf("expected *structpb.Value converting field %q, got %T", key, native)
-			}
-			fields[key] = pbVal
-			return nil
-		}); err != nil {
-			return nil, err
+// schemalessMapToProtoValue converts the entries produced by forEachEntry to *structpb.Value,
+// wrapping each value directly so it populates no field cache.
+func schemalessMapToProtoValue(forEachEntry func(func(key string, rawVal interface{}) error) error) (*structpb.Value, error) {
+	fields := make(map[string]*structpb.Value)
+	if err := forEachEntry(func(key string, rawVal interface{}) error {
+		native, err := SchemalessTypedToVal(rawVal).ConvertToNative(structpbValueType)
+		if err != nil {
+			return err
 		}
-		return &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: fields}}}, nil
-	case mapStringAnyType:
-		out := make(map[string]interface{})
-		if err := forEachEntry(func(key string, rawVal interface{}) error {
-			native, err := SchemalessTypedToVal(rawVal).ConvertToNative(anyType)
-			if err != nil {
-				return err
-			}
-			out[key] = native
-			return nil
-		}); err != nil {
-			return nil, err
+		pbVal, ok := native.(*structpb.Value)
+		if !ok {
+			return fmt.Errorf("expected *structpb.Value converting field %q, got %T", key, native)
 		}
-		return out, nil
+		fields[key] = pbVal
+		return nil
+	}); err != nil {
+		return nil, err
 	}
-	return nil, fmt.Errorf("unsupported target native type: %s", typeDesc)
+	return &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: fields}}}, nil
+}
+
+// schemalessMapToMapStringAny converts the entries produced by forEachEntry to map[string]interface{},
+// wrapping each value directly so it populates no field cache.
+func schemalessMapToMapStringAny(forEachEntry func(func(key string, rawVal interface{}) error) error) (map[string]interface{}, error) {
+	out := make(map[string]interface{})
+	if err := forEachEntry(func(key string, rawVal interface{}) error {
+		native, err := SchemalessTypedToVal(rawVal).ConvertToNative(anyType)
+		if err != nil {
+			return err
+		}
+		out[key] = native
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 var _ traits.Lister = &reflectSchemalessTypedList{}
@@ -218,7 +214,10 @@ func (l *reflectSchemalessTypedList) ConvertToNative(typeDesc reflect.Type) (int
 	if typeDesc.Kind() == reflect.Slice || typeDesc == anyType {
 		return l.value.Interface(), nil
 	}
-	return schemalessListToNative(l.value, typeDesc)
+	if typeDesc == structpbValueType {
+		return schemalessListToProtoValue(l.value)
+	}
+	return nil, fmt.Errorf("unsupported target native type: %s", typeDesc)
 }
 
 func (l *reflectSchemalessTypedList) ConvertToType(typeValue ref.Type) ref.Val {
@@ -346,7 +345,13 @@ func (m *reflectSchemalessTypedMap) ConvertToNative(typeDesc reflect.Type) (inte
 	if m.value.Type().AssignableTo(typeDesc) {
 		return m.value.Interface(), nil
 	}
-	return schemalessMapToNative(typeDesc, m.forEachEntry)
+	switch typeDesc {
+	case structpbValueType:
+		return schemalessMapToProtoValue(m.forEachEntry)
+	case mapStringAnyType:
+		return schemalessMapToMapStringAny(m.forEachEntry)
+	}
+	return nil, fmt.Errorf("unsupported target native type: %s", typeDesc)
 }
 
 // forEachEntry invokes fn for each map entry with its raw Go value.
@@ -494,7 +499,13 @@ func (s *reflectSchemalessTypedStruct) ConvertToNative(typeDesc reflect.Type) (i
 	if s.value.Type().AssignableTo(typeDesc) {
 		return s.value.Interface(), nil
 	}
-	return schemalessMapToNative(typeDesc, s.forEachEntry)
+	switch typeDesc {
+	case structpbValueType:
+		return schemalessMapToProtoValue(s.forEachEntry)
+	case mapStringAnyType:
+		return schemalessMapToMapStringAny(s.forEachEntry)
+	}
+	return nil, fmt.Errorf("unsupported target native type: %s", typeDesc)
 }
 
 // forEachEntry invokes fn for each set struct field (honoring omitempty via

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/valuesschemalesstyped.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/valuesschemalesstyped.go
@@ -32,8 +32,8 @@ import (
 
 // Native Go target types recognized by the schemaless wrappers' ConvertToNative.
 var (
-	structpbValueType = reflect.TypeOf(&structpb.Value{})
-	anyType           = reflect.TypeOf((*any)(nil)).Elem()
+	structpbValueType = reflect.TypeFor[*structpb.Value]()
+	anyType           = reflect.TypeFor[any]()
 	mapStringAnyType  = reflect.TypeOf(map[string]interface{}(nil))
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/valuesschemalesstyped.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/valuesschemalesstyped.go
@@ -24,9 +24,17 @@ import (
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
+	"google.golang.org/protobuf/types/known/structpb"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/structured-merge-diff/v6/value"
+)
+
+// Native Go target types recognized by the schemaless wrappers' ConvertToNative.
+var (
+	structpbValueType = reflect.TypeOf(&structpb.Value{})
+	anyType           = reflect.TypeOf((*any)(nil)).Elem()
+	mapStringAnyType  = reflect.TypeOf(map[string]interface{}(nil))
 )
 
 // SchemalessTypedToVal wraps a Go value as a CEL ref.Val.
@@ -136,6 +144,66 @@ func SchemalessTypedToVal(val interface{}) ref.Val {
 	}
 }
 
+// schemalessListToNative converts a schemaless list to *structpb.Value, walking
+// the backing reflect.Value directly so it retains no per-element ref.Val cache.
+func schemalessListToNative(v reflect.Value, typeDesc reflect.Type) (interface{}, error) {
+	if typeDesc != structpbValueType {
+		return nil, fmt.Errorf("unsupported target native type: %s", typeDesc)
+	}
+	values := make([]*structpb.Value, v.Len())
+	for idx := range values {
+		native, err := SchemalessTypedToVal(v.Index(idx).Interface()).ConvertToNative(typeDesc)
+		if err != nil {
+			return nil, err
+		}
+		pbVal, ok := native.(*structpb.Value)
+		if !ok {
+			return nil, fmt.Errorf("expected *structpb.Value converting list element %d, got %T", idx, native)
+		}
+		values[idx] = pbVal
+	}
+	return &structpb.Value{Kind: &structpb.Value_ListValue{ListValue: &structpb.ListValue{Values: values}}}, nil
+}
+
+// schemalessMapToNative converts the entries produced by forEachEntry to the
+// requested native type (*structpb.Value or map[string]interface{}), wrapping
+// each value directly so it populates no field cache.
+func schemalessMapToNative(typeDesc reflect.Type, forEachEntry func(func(key string, rawVal interface{}) error) error) (interface{}, error) {
+	switch typeDesc {
+	case structpbValueType:
+		fields := make(map[string]*structpb.Value)
+		if err := forEachEntry(func(key string, rawVal interface{}) error {
+			native, err := SchemalessTypedToVal(rawVal).ConvertToNative(typeDesc)
+			if err != nil {
+				return err
+			}
+			pbVal, ok := native.(*structpb.Value)
+			if !ok {
+				return fmt.Errorf("expected *structpb.Value converting field %q, got %T", key, native)
+			}
+			fields[key] = pbVal
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+		return &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: fields}}}, nil
+	case mapStringAnyType:
+		out := make(map[string]interface{})
+		if err := forEachEntry(func(key string, rawVal interface{}) error {
+			native, err := SchemalessTypedToVal(rawVal).ConvertToNative(anyType)
+			if err != nil {
+				return err
+			}
+			out[key] = native
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}
+	return nil, fmt.Errorf("unsupported target native type: %s", typeDesc)
+}
+
 var _ traits.Lister = &reflectSchemalessTypedList{}
 
 // reflectSchemalessTypedList wraps a Go slice/array as a lazy CEL Lister.
@@ -147,12 +215,10 @@ type reflectSchemalessTypedList struct {
 }
 
 func (l *reflectSchemalessTypedList) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
-	switch typeDesc.Kind() {
-	case reflect.Slice:
+	if typeDesc.Kind() == reflect.Slice || typeDesc == anyType {
 		return l.value.Interface(), nil
-	default:
-		return nil, fmt.Errorf("type conversion error from '%s' to '%s'", l.Type(), typeDesc)
 	}
+	return schemalessListToNative(l.value, typeDesc)
 }
 
 func (l *reflectSchemalessTypedList) ConvertToType(typeValue ref.Type) ref.Val {
@@ -280,7 +346,22 @@ func (m *reflectSchemalessTypedMap) ConvertToNative(typeDesc reflect.Type) (inte
 	if m.value.Type().AssignableTo(typeDesc) {
 		return m.value.Interface(), nil
 	}
-	return nil, fmt.Errorf("type conversion error from '%s' to '%s'", m.Type(), typeDesc)
+	return schemalessMapToNative(typeDesc, m.forEachEntry)
+}
+
+// forEachEntry invokes fn for each map entry with its raw Go value.
+func (m *reflectSchemalessTypedMap) forEachEntry(fn func(key string, rawVal interface{}) error) error {
+	iter := m.value.MapRange()
+	for iter.Next() {
+		key := iter.Key()
+		if key.Kind() != reflect.String {
+			return fmt.Errorf("unsupported map key type: %s", key.Type())
+		}
+		if err := fn(key.String(), iter.Value().Interface()); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (m *reflectSchemalessTypedMap) ConvertToType(typeValue ref.Type) ref.Val {
@@ -413,7 +494,22 @@ func (s *reflectSchemalessTypedStruct) ConvertToNative(typeDesc reflect.Type) (i
 	if s.value.Type().AssignableTo(typeDesc) {
 		return s.value.Interface(), nil
 	}
-	return nil, fmt.Errorf("type conversion error from struct type %v to %v", s.value.Type(), typeDesc)
+	return schemalessMapToNative(typeDesc, s.forEachEntry)
+}
+
+// forEachEntry invokes fn for each set struct field (honoring omitempty via
+// CanOmit) with its raw Go value.
+func (s *reflectSchemalessTypedStruct) forEachEntry(fn func(key string, rawVal interface{}) error) error {
+	for fieldName, field := range value.TypeReflectEntryOf(s.value.Type()).Fields() {
+		e := field.GetFrom(s.value)
+		if field.CanOmit(e) {
+			continue
+		}
+		if err := fn(string(fieldName), e.Interface()); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *reflectSchemalessTypedStruct) ConvertToType(typeValue ref.Type) ref.Val {

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/valuesschemalesstyped_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/valuesschemalesstyped_test.go
@@ -214,9 +214,25 @@ func assertEquivalence(t *testing.T, val interface{}) {
 			unstrMap, expectedCEL, expectedCEL.Type(), gotCEL.Value(), gotCEL, gotCEL.Type())
 	}
 
-	// Verify inverse equality (NativeToValue.Equal(SchemalessTypedToVal)).
-	if expectedCEL.Equal(gotCEL) != types.True {
-		t.Errorf("Inverse equivalence mismatch!")
+	// Verify ConvertToNative(structpbValueType) matches the result of converting unstrMap via expectedCEL.ConvertToNative(structpbValueType).
+	gotPB, err := gotCEL.ConvertToNative(structpbValueType)
+	if err != nil {
+		t.Fatalf("SchemalessTypedToVal.ConvertToNative(structpbValueType) failed: %v", err)
+	}
+
+	expectedPB, err := expectedCEL.ConvertToNative(structpbValueType)
+	if err != nil {
+		t.Fatalf("expectedCEL.ConvertToNative(structpbValueType) failed: %v", err)
+	}
+
+	gotStructPB, ok1 := gotPB.(*structpb.Value)
+	expectedStructPB, ok2 := expectedPB.(*structpb.Value)
+	if !ok1 || !ok2 {
+		t.Fatalf("expected *structpb.Value results, got %T and %T", gotPB, expectedPB)
+	}
+
+	if !proto.Equal(gotStructPB, expectedStructPB) {
+		t.Errorf("ConvertToNative(structpbValueType) equivalence mismatch!\nGot:      %v\nExpected: %v", gotStructPB, expectedStructPB)
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/valuesschemalesstyped_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/valuesschemalesstyped_test.go
@@ -214,6 +214,12 @@ func assertEquivalence(t *testing.T, val interface{}) {
 			unstrMap, expectedCEL, expectedCEL.Type(), gotCEL.Value(), gotCEL, gotCEL.Type())
 	}
 
+	// Verify reverse-direction equivalence (expectedCEL.Equal(gotCEL)).
+	if expectedCEL.Equal(gotCEL) != types.True {
+		t.Errorf("Reverse equivalence mismatch!\nExpected: %v (Type: %T, CEL: %v)\nGot:      %v (Type: %T, CEL: %v)",
+			unstrMap, expectedCEL, expectedCEL.Type(), gotCEL.Value(), gotCEL, gotCEL.Type())
+	}
+
 	// Verify ConvertToNative(structpbValueType) matches the result of converting unstrMap via expectedCEL.ConvertToNative(structpbValueType).
 	gotPB, err := gotCEL.ConvertToNative(structpbValueType)
 	if err != nil {
@@ -1001,6 +1007,7 @@ func TestSchemalessTypedMap_Equal(t *testing.T) {
 }
 
 func TestSchemalessTyped_ConvertToNative(t *testing.T) {
+	type CustomString string
 	type SimpleStruct struct {
 		Name  string `json:"name"`
 		Value int    `json:"value"`
@@ -1077,6 +1084,15 @@ func TestSchemalessTyped_ConvertToNative(t *testing.T) {
 		{
 			name:       "map to mapStringAnyType",
 			val:        SchemalessTypedToVal(sampleMap),
+			targetType: mapStringAnyType,
+			expected: map[string]interface{}{
+				"name":  "foo",
+				"value": int64(42),
+			},
+		},
+		{
+			name:       "custom string key map to mapStringAnyType",
+			val:        SchemalessTypedToVal(map[CustomString]interface{}{"name": "foo", "value": int64(42)}),
 			targetType: mapStringAnyType,
 			expected: map[string]interface{}{
 				"name":  "foo",

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/valuesschemalesstyped_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/valuesschemalesstyped_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -977,6 +979,254 @@ func TestSchemalessTypedMap_Equal(t *testing.T) {
 			}
 			if got != tc.expected {
 				t.Errorf("expected equal result %v, got %v", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestSchemalessTyped_ConvertToNative(t *testing.T) {
+	type SimpleStruct struct {
+		Name  string `json:"name"`
+		Value int    `json:"value"`
+	}
+
+	sampleStruct := &SimpleStruct{Name: "foo", Value: 42}
+	sampleMap := map[string]interface{}{"name": "foo", "value": int64(42)}
+	sampleSlice := []interface{}{"item1", int64(10)}
+
+	type Item struct {
+		IP string `json:"ip"`
+	}
+
+	tests := []struct {
+		name       string
+		val        ref.Val
+		targetType reflect.Type
+		expected   interface{}
+	}{
+		{
+			name:       "struct to structpb.Value",
+			val:        SchemalessTypedToVal(sampleStruct),
+			targetType: structpbValueType,
+			expected: &structpb.Value{
+				Kind: &structpb.Value_StructValue{
+					StructValue: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"name":  structpb.NewStringValue("foo"),
+							"value": structpb.NewNumberValue(42),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "struct to anyType",
+			val:        SchemalessTypedToVal(sampleStruct),
+			targetType: anyType,
+			expected:   SimpleStruct{Name: "foo", Value: 42},
+		},
+		{
+			name:       "struct to mapStringAnyType",
+			val:        SchemalessTypedToVal(sampleStruct),
+			targetType: mapStringAnyType,
+			expected: map[string]interface{}{
+				"name":  "foo",
+				"value": int64(42),
+			},
+		},
+		{
+			name:       "map to structpb.Value",
+			val:        SchemalessTypedToVal(sampleMap),
+			targetType: structpbValueType,
+			expected: &structpb.Value{
+				Kind: &structpb.Value_StructValue{
+					StructValue: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"name":  structpb.NewStringValue("foo"),
+							"value": structpb.NewNumberValue(42),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "map to anyType",
+			val:        SchemalessTypedToVal(sampleMap),
+			targetType: anyType,
+			expected: map[string]interface{}{
+				"name":  "foo",
+				"value": int64(42),
+			},
+		},
+		{
+			name:       "map to mapStringAnyType",
+			val:        SchemalessTypedToVal(sampleMap),
+			targetType: mapStringAnyType,
+			expected: map[string]interface{}{
+				"name":  "foo",
+				"value": int64(42),
+			},
+		},
+		{
+			name:       "slice to structpb.Value",
+			val:        SchemalessTypedToVal(sampleSlice),
+			targetType: structpbValueType,
+			expected: &structpb.Value{
+				Kind: &structpb.Value_ListValue{
+					ListValue: &structpb.ListValue{
+						Values: []*structpb.Value{
+							structpb.NewStringValue("item1"),
+							structpb.NewNumberValue(10),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "slice to anyType",
+			val:        SchemalessTypedToVal(sampleSlice),
+			targetType: anyType,
+			expected: []interface{}{
+				"item1",
+				int64(10),
+			},
+		},
+		{
+			name:       "concatenated list to structpb.Value",
+			val:        SchemalessTypedToVal([]Item{{IP: "1.2.3.4"}}).(traits.Lister).Add(SchemalessTypedToVal([]Item{{IP: "5.6.7.8"}})),
+			targetType: structpbValueType,
+			expected: &structpb.Value{
+				Kind: &structpb.Value_ListValue{
+					ListValue: &structpb.ListValue{
+						Values: []*structpb.Value{
+							{
+								Kind: &structpb.Value_StructValue{
+									StructValue: &structpb.Struct{
+										Fields: map[string]*structpb.Value{
+											"ip": structpb.NewStringValue("1.2.3.4"),
+										},
+									},
+								},
+							},
+							{
+								Kind: &structpb.Value_StructValue{
+									StructValue: &structpb.Struct{
+										Fields: map[string]*structpb.Value{
+											"ip": structpb.NewStringValue("5.6.7.8"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := tc.val.ConvertToNative(tc.targetType)
+			if err != nil {
+				t.Fatalf("unexpected error converting to %v: %v", tc.targetType, err)
+			}
+			if res == nil {
+				t.Fatalf("expected non-nil conversion result for target type %v", tc.targetType)
+			}
+			if tc.expected != nil {
+				if pbVal, ok := res.(*structpb.Value); ok {
+					if expectedPB, ok := tc.expected.(*structpb.Value); ok {
+						if !proto.Equal(pbVal, expectedPB) {
+							t.Fatalf("unexpected converted structpb.Value:\n got:  %v\n want: %v", pbVal, expectedPB)
+						}
+					}
+				} else if !reflect.DeepEqual(res, tc.expected) {
+					t.Fatalf("unexpected converted result:\n got:  %v\n want: %v", res, tc.expected)
+				}
+			}
+		})
+	}
+}
+
+func TestSchemalessTypedStruct_OmitEmpty(t *testing.T) {
+	type SampleStruct struct {
+		FieldOmitEmpty *string `json:"fieldOmitEmpty,omitempty"`
+		FieldRequired  string  `json:"fieldRequired"`
+	}
+
+	val := "present"
+	tests := []struct {
+		name                string
+		input               *SampleStruct
+		targetField         string
+		expectedIsSet       ref.Val
+		expectedFind        bool
+		expectedSize        int64
+		expectedInNativeMap bool
+	}{
+		{
+			name:                "omitted field when nil",
+			input:               &SampleStruct{FieldRequired: "val"},
+			targetField:         "fieldOmitEmpty",
+			expectedIsSet:       types.False,
+			expectedFind:        false,
+			expectedSize:        1,
+			expectedInNativeMap: false,
+		},
+		{
+			name:                "required field when set",
+			input:               &SampleStruct{FieldRequired: "val"},
+			targetField:         "fieldRequired",
+			expectedIsSet:       types.True,
+			expectedFind:        true,
+			expectedSize:        1,
+			expectedInNativeMap: true,
+		},
+		{
+			name:                "omitted field when populated",
+			input:               &SampleStruct{FieldOmitEmpty: &val, FieldRequired: "val"},
+			targetField:         "fieldOmitEmpty",
+			expectedIsSet:       types.True,
+			expectedFind:        true,
+			expectedSize:        2,
+			expectedInNativeMap: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			celVal := SchemalessTypedToVal(tc.input)
+
+			tester, ok := celVal.(traits.FieldTester)
+			if !ok {
+				t.Fatalf("expected celVal to implement traits.FieldTester")
+			}
+			if got := tester.IsSet(types.String(tc.targetField)); got != tc.expectedIsSet {
+				t.Errorf("IsSet(%q) = %v, expected %v", tc.targetField, got, tc.expectedIsSet)
+			}
+
+			mapper, ok := celVal.(traits.Mapper)
+			if !ok {
+				t.Fatalf("expected celVal to implement traits.Mapper")
+			}
+			if _, found := mapper.Find(types.String(tc.targetField)); found != tc.expectedFind {
+				t.Errorf("Find(%q) found = %v, expected %v", tc.targetField, found, tc.expectedFind)
+			}
+			if size := mapper.Size().(types.Int); int64(size) != tc.expectedSize {
+				t.Errorf("Size() = %d, expected %d", size, tc.expectedSize)
+			}
+
+			res, err := celVal.ConvertToNative(mapStringAnyType)
+			if err != nil {
+				t.Fatalf("unexpected error converting to map[string]interface{}: %v", err)
+			}
+			m, ok := res.(map[string]interface{})
+			if !ok {
+				t.Fatalf("expected map[string]interface{}, got %T", res)
+			}
+			_, exists := m[tc.targetField]
+			if exists != tc.expectedInNativeMap {
+				t.Errorf("native map key %q exists = %v, expected %v", tc.targetField, exists, tc.expectedInNativeMap)
 			}
 		})
 	}

--- a/test/integration/apiserver/cel/mutatingadmissionpolicy_test.go
+++ b/test/integration/apiserver/cel/mutatingadmissionpolicy_test.go
@@ -123,6 +123,187 @@ func TestMutatingAdmissionPolicy(t *testing.T) {
 			},
 		},
 		{
+			name: "jsonPatch with complex struct as value",
+			policies: []*v1.MutatingAdmissionPolicy{
+				mutatingPolicy("json-patch-complex-struct", v1.NeverReinvocationPolicy, matchEndpointResources, nil, v1.Mutation{
+					PatchType: v1.PatchTypeJSONPatch,
+					JSONPatch: &v1.JSONPatch{
+						Expression: `[
+							JSONPatch{op: "add", path: "/subsets/0/addresses", value: [object.subsets[0].notReadyAddresses[0]]}
+						]`,
+					},
+				}),
+			},
+			bindings: []*v1.MutatingAdmissionPolicyBinding{
+				mutatingBinding("json-patch-complex-struct", nil, nil),
+			},
+			requestOperation: v1.Create,
+			requestResource:  corev1.SchemeGroupVersion.WithResource("endpoints"),
+			requestObject: &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "json-patch-complex-struct-object",
+					Namespace: "default",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						NotReadyAddresses: []corev1.EndpointAddress{
+							{IP: "1.2.3.4"},
+						},
+					},
+				},
+			},
+			expected: &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "json-patch-complex-struct-object",
+					Namespace: "default",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{IP: "1.2.3.4"},
+						},
+						NotReadyAddresses: []corev1.EndpointAddress{
+							{IP: "1.2.3.4"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "jsonPatch with slice of complex struct as value",
+			policies: []*v1.MutatingAdmissionPolicy{
+				mutatingPolicy("json-patch-slice-complex-struct", v1.NeverReinvocationPolicy, matchEndpointResources, nil, v1.Mutation{
+					PatchType: v1.PatchTypeJSONPatch,
+					JSONPatch: &v1.JSONPatch{
+						Expression: `[
+							JSONPatch{op: "add", path: "/subsets/0/addresses", value: object.subsets[0].notReadyAddresses}
+						]`,
+					},
+				}),
+			},
+			bindings: []*v1.MutatingAdmissionPolicyBinding{
+				mutatingBinding("json-patch-slice-complex-struct", nil, nil),
+			},
+			requestOperation: v1.Create,
+			requestResource:  corev1.SchemeGroupVersion.WithResource("endpoints"),
+			requestObject: &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "json-patch-slice-complex-struct-object",
+					Namespace: "default",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						NotReadyAddresses: []corev1.EndpointAddress{
+							{IP: "1.2.3.4"},
+						},
+					},
+				},
+			},
+			expected: &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "json-patch-slice-complex-struct-object",
+					Namespace: "default",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{IP: "1.2.3.4"},
+						},
+						NotReadyAddresses: []corev1.EndpointAddress{
+							{IP: "1.2.3.4"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "jsonPatch with list concatenation operator",
+			policies: []*v1.MutatingAdmissionPolicy{
+				mutatingPolicy("json-patch-list-concat", v1.NeverReinvocationPolicy, matchEndpointResources, nil, v1.Mutation{
+					PatchType: v1.PatchTypeJSONPatch,
+					JSONPatch: &v1.JSONPatch{
+						Expression: `[
+							JSONPatch{op: "add", path: "/subsets/0/addresses", value: object.subsets[0].notReadyAddresses + [object.subsets[0].notReadyAddresses[0]]}
+						]`,
+					},
+				}),
+			},
+			bindings: []*v1.MutatingAdmissionPolicyBinding{
+				mutatingBinding("json-patch-list-concat", nil, nil),
+			},
+			requestOperation: v1.Create,
+			requestResource:  corev1.SchemeGroupVersion.WithResource("endpoints"),
+			requestObject: &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "json-patch-list-concat-object",
+					Namespace: "default",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						NotReadyAddresses: []corev1.EndpointAddress{
+							{IP: "1.2.3.4"},
+						},
+					},
+				},
+			},
+			expected: &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "json-patch-list-concat-object",
+					Namespace: "default",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{IP: "1.2.3.4"},
+							{IP: "1.2.3.4"},
+						},
+						NotReadyAddresses: []corev1.EndpointAddress{
+							{IP: "1.2.3.4"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "jsonPatch with map key comprehension all predicate",
+			policies: []*v1.MutatingAdmissionPolicy{
+				mutatingPolicy("json-patch-map-comprehension", v1.NeverReinvocationPolicy, matchEndpointResources, nil, v1.Mutation{
+					PatchType: v1.PatchTypeJSONPatch,
+					JSONPatch: &v1.JSONPatch{
+						Expression: `[
+							JSONPatch{op: "add", path: "/metadata/labels/added", value: object.metadata.labels.all(k, k != "invalid") ? "true" : "false"}
+						]`,
+					},
+				}),
+			},
+			bindings: []*v1.MutatingAdmissionPolicyBinding{
+				mutatingBinding("json-patch-map-comprehension", nil, nil),
+			},
+			requestOperation: v1.Create,
+			requestResource:  corev1.SchemeGroupVersion.WithResource("endpoints"),
+			requestObject: &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "json-patch-map-comprehension-object",
+					Namespace: "default",
+					Labels: map[string]string{
+						"env": "prod",
+						"app": "demo",
+					},
+				},
+			},
+			expected: &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "json-patch-map-comprehension-object",
+					Namespace: "default",
+					Labels: map[string]string{
+						"env":   "prod",
+						"app":   "demo",
+						"added": "true",
+					},
+				},
+			},
+		},
+		{
 			name: "multiple policies",
 			policies: []*v1.MutatingAdmissionPolicy{
 				mutatingPolicy("multi-policy-1", v1.NeverReinvocationPolicy, matchEndpointResources, nil, v1.Mutation{
@@ -1300,6 +1481,9 @@ func withMutatingWaitReadyConstraintAndExpression(policy *v1.MutatingAdmissionPo
 		if m.ApplyConfiguration != nil {
 			bypass := `object.metadata.?labels["mutation-marker"].hasValue() ? Object{} : `
 			m.ApplyConfiguration.Expression = bypass + m.ApplyConfiguration.Expression
+		} else if m.JSONPatch != nil {
+			bypass := `object.metadata.?labels["mutation-marker"].hasValue() ? [] : `
+			m.JSONPatch.Expression = bypass + m.JSONPatch.Expression
 		}
 	}
 	policy.Spec.Mutations = append([]v1.Mutation{{


### PR DESCRIPTION

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When using MutatingAdmissionPolicy JSONPatch, CEL expressions that evaluated to complex structs, lists of structs, or maps failed to apply. This occurred because their schemaless wrappers did not properly implement `ConvertToNative` to `structpb.Value` or `anyType`.

This PR fixes the issue by extending `reflectSchemalessTypedList`, `reflectSchemalessTypedMap`, and `reflectSchemalessTypedStruct` to correctly convert their underlying values into the requested native types (e.g., `structpb.Value`, `[]interface{}`, `map[string]interface{}`). As a result, JSONPatch operations can now safely use the result of CEL expressions that return lists, maps, or structs.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
This includes new integration and unit tests covering `jsonPatch` application with complex structs, slices of complex structs, map key comprehensions, and list concatenations.

#### Does this PR introduce a user-facing change?
```release-note
Fixed an issue where MutatingAdmissionPolicy JSONPatch operations would drop or fail on complex nested values.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```