### PR TITLE
Promote declarative validation API tags from alpha to beta

### DIFF
--- a/pkg/apis/admissionregistration/v1/zz_generated.validations.go
+++ b/pkg/apis/admissionregistration/v1/zz_generated.validations.go
@@ -162,7 +162,7 @@ func Validate_ValidatingAdmissionPolicyBindingSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -194,7 +194,7 @@ func Validate_ValidatingAdmissionPolicyBindingSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}

--- a/pkg/apis/admissionregistration/v1alpha1/zz_generated.validations.go
+++ b/pkg/apis/admissionregistration/v1alpha1/zz_generated.validations.go
@@ -162,7 +162,7 @@ func Validate_ValidatingAdmissionPolicyBindingSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -194,7 +194,7 @@ func Validate_ValidatingAdmissionPolicyBindingSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}

--- a/pkg/apis/admissionregistration/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/admissionregistration/v1beta1/zz_generated.validations.go
@@ -162,7 +162,7 @@ func Validate_ValidatingAdmissionPolicyBindingSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -194,7 +194,7 @@ func Validate_ValidatingAdmissionPolicyBindingSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}

--- a/pkg/apis/apps/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/apps/v1beta1/zz_generated.validations.go
@@ -219,7 +219,7 @@ func Validate_ScaleSpec(
 				}
 			}
 			// call field-attached validations
-			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkAlpha(); len(e) != 0 {
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return

--- a/pkg/apis/apps/v1beta2/zz_generated.validations.go
+++ b/pkg/apis/apps/v1beta2/zz_generated.validations.go
@@ -389,7 +389,7 @@ func Validate_ScaleSpec(
 				}
 			}
 			// call field-attached validations
-			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkAlpha(); len(e) != 0 {
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return

--- a/pkg/apis/autoscaling/v1/zz_generated.validations.go
+++ b/pkg/apis/autoscaling/v1/zz_generated.validations.go
@@ -216,7 +216,7 @@ func Validate_HorizontalPodAutoscalerSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -225,13 +225,13 @@ func Validate_HorizontalPodAutoscalerSpec(
 			if e := validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", true,
 				func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
 					return validate.Minimum(ctx, op, fldPath, obj, oldObj, 0)
-				}).MarkAlpha(); len(e) != 0 {
+				}).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			if e := validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", false,
 				func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
 					return validate.Minimum(ctx, op, fldPath, obj, oldObj, 1)
-				}).MarkAlpha(); len(e) != 0 {
+				}).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -256,14 +256,14 @@ func Validate_HorizontalPodAutoscalerSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 1).MarkAlpha(); len(e) != 0 {
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 1).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -333,7 +333,7 @@ func Validate_ScaleSpec(
 				}
 			}
 			// call field-attached validations
-			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkAlpha(); len(e) != 0 {
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return

--- a/pkg/apis/autoscaling/v2/zz_generated.validations.go
+++ b/pkg/apis/autoscaling/v2/zz_generated.validations.go
@@ -222,7 +222,7 @@ func Validate_HorizontalPodAutoscalerSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -231,13 +231,13 @@ func Validate_HorizontalPodAutoscalerSpec(
 			if e := validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", true,
 				func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
 					return validate.Minimum(ctx, op, fldPath, obj, oldObj, 0)
-				}).MarkAlpha(); len(e) != 0 {
+				}).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			if e := validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", false,
 				func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
 					return validate.Minimum(ctx, op, fldPath, obj, oldObj, 1)
-				}).MarkAlpha(); len(e) != 0 {
+				}).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -262,14 +262,14 @@ func Validate_HorizontalPodAutoscalerSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 1).MarkAlpha(); len(e) != 0 {
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 1).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return

--- a/pkg/apis/batch/v1/zz_generated.validations.go
+++ b/pkg/apis/batch/v1/zz_generated.validations.go
@@ -128,7 +128,7 @@ func Validate_CronJobSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}

--- a/pkg/apis/batch/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/batch/v1beta1/zz_generated.validations.go
@@ -113,7 +113,7 @@ func Validate_CronJobSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}

--- a/pkg/apis/certificates/v1/zz_generated.validations.go
+++ b/pkg/apis/certificates/v1/zz_generated.validations.go
@@ -114,7 +114,7 @@ func Validate_CertificateSigningRequestStatus(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -136,7 +136,7 @@ func Validate_CertificateSigningRequestStatus(
 						}
 					}
 					return false
-				}).MarkAlpha(); len(e) != 0 {
+				}).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return

--- a/pkg/apis/certificates/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/certificates/v1beta1/zz_generated.validations.go
@@ -146,7 +146,7 @@ func Validate_CertificateSigningRequestStatus(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -168,7 +168,7 @@ func Validate_CertificateSigningRequestStatus(
 						}
 					}
 					return false
-				}).MarkAlpha(); len(e) != 0 {
+				}).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return

--- a/pkg/apis/core/v1/zz_generated.validations.go
+++ b/pkg/apis/core/v1/zz_generated.validations.go
@@ -311,14 +311,14 @@ func Validate_ReplicationController(
 			func() { // cohort = "name"
 				earlyReturn := false
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "name",
-					func(o *metav1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.OptionalValue).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					func(o *metav1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.OptionalValue).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 					earlyReturn = true
 				}
 				if earlyReturn {
 					return // do not proceed
 				}
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "name",
-					func(o *metav1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.LongName).MarkAlpha(); len(e) != 0 {
+					func(o *metav1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.LongName).MarkBeta(); len(e) != 0 {
 					errs = append(errs, e...)
 				}
 			}()
@@ -377,14 +377,14 @@ func Validate_ReplicationControllerSpec(
 			// call field-attached validations
 			earlyReturn := false
 			// optional fields with default values are effectively required
-			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkAlpha(); len(e) != 0 {
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -409,7 +409,7 @@ func Validate_ReplicationControllerSpec(
 				}
 			}
 			// call field-attached validations
-			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkAlpha(); len(e) != 0 {
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return

--- a/pkg/apis/discovery/v1/zz_generated.validations.go
+++ b/pkg/apis/discovery/v1/zz_generated.validations.go
@@ -66,7 +66,7 @@ func Validate_AddressType(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *discoveryv1.AddressType) (errs field.ErrorList) {
 
-	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForAddressType, nil).MarkAlpha(); len(e) != 0 {
+	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForAddressType, nil).MarkBeta(); len(e) != 0 {
 		errs = append(errs, e...)
 	}
 
@@ -92,11 +92,11 @@ func Validate_Endpoint(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 100).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 100).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -144,11 +144,11 @@ func Validate_EndpointSlice(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -179,7 +179,7 @@ func Validate_EndpointSlice(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {

--- a/pkg/apis/discovery/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/discovery/v1beta1/zz_generated.validations.go
@@ -66,7 +66,7 @@ func Validate_AddressType(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *discoveryv1beta1.AddressType) (errs field.ErrorList) {
 
-	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForAddressType, nil).MarkAlpha(); len(e) != 0 {
+	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForAddressType, nil).MarkBeta(); len(e) != 0 {
 		errs = append(errs, e...)
 	}
 
@@ -92,11 +92,11 @@ func Validate_Endpoint(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 100).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 100).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -143,11 +143,11 @@ func Validate_EndpointSlice(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -178,7 +178,7 @@ func Validate_EndpointSlice(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {

--- a/pkg/apis/flowcontrol/v1/zz_generated.validations.go
+++ b/pkg/apis/flowcontrol/v1/zz_generated.validations.go
@@ -68,7 +68,7 @@ func Validate_LimitResponse(
 		func(obj *flowcontrolv1.LimitResponse) flowcontrolv1.LimitResponseType { return obj.Type }, validate.DirectEqualPtr,
 		func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1.QueuingConfiguration) field.ErrorList {
 			errs := field.ErrorList{}
-			errs = append(errs, validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
+			errs = append(errs, validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj).MarkBeta()...)
 			return errs
 		},
 		[]validate.DiscriminatedRule[*flowcontrolv1.QueuingConfiguration, flowcontrolv1.LimitResponseType]{
@@ -78,7 +78,7 @@ func Validate_LimitResponse(
 				Validation: func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1.QueuingConfiguration) field.ErrorList {
 					errs := field.ErrorList{}
 					earlyReturn := false
-					if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+					if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 						errs = append(errs, e...)
 						earlyReturn = true
 					}
@@ -105,7 +105,7 @@ func Validate_LimitResponse(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -134,7 +134,7 @@ func Validate_LimitResponse(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -237,7 +237,7 @@ func Validate_PriorityLevelConfigurationSpec(
 		}, validate.SemanticDeepEqual,
 		func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1.ExemptPriorityLevelConfiguration) field.ErrorList {
 			errs := field.ErrorList{}
-			errs = append(errs, validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
+			errs = append(errs, validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj).MarkBeta()...)
 			return errs
 		},
 		[]validate.DiscriminatedRule[*flowcontrolv1.ExemptPriorityLevelConfiguration, flowcontrolv1.PriorityLevelEnablement]{
@@ -247,7 +247,7 @@ func Validate_PriorityLevelConfigurationSpec(
 				Validation: func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1.ExemptPriorityLevelConfiguration) field.ErrorList {
 					errs := field.ErrorList{}
 					earlyReturn := false
-					if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+					if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 						earlyReturn = true
 					}
 					if earlyReturn {
@@ -268,7 +268,7 @@ func Validate_PriorityLevelConfigurationSpec(
 		}, validate.SemanticDeepEqual,
 		func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1.LimitedPriorityLevelConfiguration) field.ErrorList {
 			errs := field.ErrorList{}
-			errs = append(errs, validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
+			errs = append(errs, validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj).MarkBeta()...)
 			return errs
 		},
 		[]validate.DiscriminatedRule[*flowcontrolv1.LimitedPriorityLevelConfiguration, flowcontrolv1.PriorityLevelEnablement]{
@@ -278,7 +278,7 @@ func Validate_PriorityLevelConfigurationSpec(
 				Validation: func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1.LimitedPriorityLevelConfiguration) field.ErrorList {
 					errs := field.ErrorList{}
 					earlyReturn := false
-					if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+					if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 						errs = append(errs, e...)
 						earlyReturn = true
 					}
@@ -305,7 +305,7 @@ func Validate_PriorityLevelConfigurationSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -334,7 +334,7 @@ func Validate_PriorityLevelConfigurationSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -364,7 +364,7 @@ func Validate_PriorityLevelConfigurationSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {

--- a/pkg/apis/flowcontrol/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/flowcontrol/v1beta1/zz_generated.validations.go
@@ -70,7 +70,7 @@ func Validate_LimitResponse(
 		func(obj *flowcontrolv1beta1.LimitResponse) flowcontrolv1beta1.LimitResponseType { return obj.Type }, validate.DirectEqualPtr,
 		func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta1.QueuingConfiguration) field.ErrorList {
 			errs := field.ErrorList{}
-			errs = append(errs, validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
+			errs = append(errs, validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj).MarkBeta()...)
 			return errs
 		},
 		[]validate.DiscriminatedRule[*flowcontrolv1beta1.QueuingConfiguration, flowcontrolv1beta1.LimitResponseType]{
@@ -80,7 +80,7 @@ func Validate_LimitResponse(
 				Validation: func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta1.QueuingConfiguration) field.ErrorList {
 					errs := field.ErrorList{}
 					earlyReturn := false
-					if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+					if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 						errs = append(errs, e...)
 						earlyReturn = true
 					}
@@ -107,7 +107,7 @@ func Validate_LimitResponse(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -136,7 +136,7 @@ func Validate_LimitResponse(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -239,7 +239,7 @@ func Validate_PriorityLevelConfigurationSpec(
 		}, validate.SemanticDeepEqual,
 		func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta1.ExemptPriorityLevelConfiguration) field.ErrorList {
 			errs := field.ErrorList{}
-			errs = append(errs, validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
+			errs = append(errs, validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj).MarkBeta()...)
 			return errs
 		},
 		[]validate.DiscriminatedRule[*flowcontrolv1beta1.ExemptPriorityLevelConfiguration, flowcontrolv1beta1.PriorityLevelEnablement]{
@@ -249,7 +249,7 @@ func Validate_PriorityLevelConfigurationSpec(
 				Validation: func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta1.ExemptPriorityLevelConfiguration) field.ErrorList {
 					errs := field.ErrorList{}
 					earlyReturn := false
-					if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+					if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 						earlyReturn = true
 					}
 					if earlyReturn {
@@ -270,7 +270,7 @@ func Validate_PriorityLevelConfigurationSpec(
 		}, validate.SemanticDeepEqual,
 		func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta1.LimitedPriorityLevelConfiguration) field.ErrorList {
 			errs := field.ErrorList{}
-			errs = append(errs, validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
+			errs = append(errs, validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj).MarkBeta()...)
 			return errs
 		},
 		[]validate.DiscriminatedRule[*flowcontrolv1beta1.LimitedPriorityLevelConfiguration, flowcontrolv1beta1.PriorityLevelEnablement]{
@@ -280,7 +280,7 @@ func Validate_PriorityLevelConfigurationSpec(
 				Validation: func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta1.LimitedPriorityLevelConfiguration) field.ErrorList {
 					errs := field.ErrorList{}
 					earlyReturn := false
-					if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+					if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 						errs = append(errs, e...)
 						earlyReturn = true
 					}
@@ -307,7 +307,7 @@ func Validate_PriorityLevelConfigurationSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -336,7 +336,7 @@ func Validate_PriorityLevelConfigurationSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -366,7 +366,7 @@ func Validate_PriorityLevelConfigurationSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {

--- a/pkg/apis/flowcontrol/v1beta2/zz_generated.validations.go
+++ b/pkg/apis/flowcontrol/v1beta2/zz_generated.validations.go
@@ -70,7 +70,7 @@ func Validate_LimitResponse(
 		func(obj *flowcontrolv1beta2.LimitResponse) flowcontrolv1beta2.LimitResponseType { return obj.Type }, validate.DirectEqualPtr,
 		func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta2.QueuingConfiguration) field.ErrorList {
 			errs := field.ErrorList{}
-			errs = append(errs, validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
+			errs = append(errs, validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj).MarkBeta()...)
 			return errs
 		},
 		[]validate.DiscriminatedRule[*flowcontrolv1beta2.QueuingConfiguration, flowcontrolv1beta2.LimitResponseType]{
@@ -80,7 +80,7 @@ func Validate_LimitResponse(
 				Validation: func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta2.QueuingConfiguration) field.ErrorList {
 					errs := field.ErrorList{}
 					earlyReturn := false
-					if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+					if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 						errs = append(errs, e...)
 						earlyReturn = true
 					}
@@ -107,7 +107,7 @@ func Validate_LimitResponse(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -136,7 +136,7 @@ func Validate_LimitResponse(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -239,7 +239,7 @@ func Validate_PriorityLevelConfigurationSpec(
 		}, validate.SemanticDeepEqual,
 		func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta2.ExemptPriorityLevelConfiguration) field.ErrorList {
 			errs := field.ErrorList{}
-			errs = append(errs, validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
+			errs = append(errs, validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj).MarkBeta()...)
 			return errs
 		},
 		[]validate.DiscriminatedRule[*flowcontrolv1beta2.ExemptPriorityLevelConfiguration, flowcontrolv1beta2.PriorityLevelEnablement]{
@@ -249,7 +249,7 @@ func Validate_PriorityLevelConfigurationSpec(
 				Validation: func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta2.ExemptPriorityLevelConfiguration) field.ErrorList {
 					errs := field.ErrorList{}
 					earlyReturn := false
-					if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+					if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 						earlyReturn = true
 					}
 					if earlyReturn {
@@ -270,7 +270,7 @@ func Validate_PriorityLevelConfigurationSpec(
 		}, validate.SemanticDeepEqual,
 		func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta2.LimitedPriorityLevelConfiguration) field.ErrorList {
 			errs := field.ErrorList{}
-			errs = append(errs, validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
+			errs = append(errs, validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj).MarkBeta()...)
 			return errs
 		},
 		[]validate.DiscriminatedRule[*flowcontrolv1beta2.LimitedPriorityLevelConfiguration, flowcontrolv1beta2.PriorityLevelEnablement]{
@@ -280,7 +280,7 @@ func Validate_PriorityLevelConfigurationSpec(
 				Validation: func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta2.LimitedPriorityLevelConfiguration) field.ErrorList {
 					errs := field.ErrorList{}
 					earlyReturn := false
-					if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+					if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 						errs = append(errs, e...)
 						earlyReturn = true
 					}
@@ -307,7 +307,7 @@ func Validate_PriorityLevelConfigurationSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -336,7 +336,7 @@ func Validate_PriorityLevelConfigurationSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -366,7 +366,7 @@ func Validate_PriorityLevelConfigurationSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {

--- a/pkg/apis/flowcontrol/v1beta3/zz_generated.validations.go
+++ b/pkg/apis/flowcontrol/v1beta3/zz_generated.validations.go
@@ -70,7 +70,7 @@ func Validate_LimitResponse(
 		func(obj *flowcontrolv1beta3.LimitResponse) flowcontrolv1beta3.LimitResponseType { return obj.Type }, validate.DirectEqualPtr,
 		func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta3.QueuingConfiguration) field.ErrorList {
 			errs := field.ErrorList{}
-			errs = append(errs, validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
+			errs = append(errs, validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj).MarkBeta()...)
 			return errs
 		},
 		[]validate.DiscriminatedRule[*flowcontrolv1beta3.QueuingConfiguration, flowcontrolv1beta3.LimitResponseType]{
@@ -80,7 +80,7 @@ func Validate_LimitResponse(
 				Validation: func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta3.QueuingConfiguration) field.ErrorList {
 					errs := field.ErrorList{}
 					earlyReturn := false
-					if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+					if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 						errs = append(errs, e...)
 						earlyReturn = true
 					}
@@ -107,7 +107,7 @@ func Validate_LimitResponse(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -136,7 +136,7 @@ func Validate_LimitResponse(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -239,7 +239,7 @@ func Validate_PriorityLevelConfigurationSpec(
 		}, validate.SemanticDeepEqual,
 		func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta3.ExemptPriorityLevelConfiguration) field.ErrorList {
 			errs := field.ErrorList{}
-			errs = append(errs, validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
+			errs = append(errs, validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj).MarkBeta()...)
 			return errs
 		},
 		[]validate.DiscriminatedRule[*flowcontrolv1beta3.ExemptPriorityLevelConfiguration, flowcontrolv1beta3.PriorityLevelEnablement]{
@@ -249,7 +249,7 @@ func Validate_PriorityLevelConfigurationSpec(
 				Validation: func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta3.ExemptPriorityLevelConfiguration) field.ErrorList {
 					errs := field.ErrorList{}
 					earlyReturn := false
-					if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+					if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 						earlyReturn = true
 					}
 					if earlyReturn {
@@ -270,7 +270,7 @@ func Validate_PriorityLevelConfigurationSpec(
 		}, validate.SemanticDeepEqual,
 		func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta3.LimitedPriorityLevelConfiguration) field.ErrorList {
 			errs := field.ErrorList{}
-			errs = append(errs, validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
+			errs = append(errs, validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj).MarkBeta()...)
 			return errs
 		},
 		[]validate.DiscriminatedRule[*flowcontrolv1beta3.LimitedPriorityLevelConfiguration, flowcontrolv1beta3.PriorityLevelEnablement]{
@@ -280,7 +280,7 @@ func Validate_PriorityLevelConfigurationSpec(
 				Validation: func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta3.LimitedPriorityLevelConfiguration) field.ErrorList {
 					errs := field.ErrorList{}
 					earlyReturn := false
-					if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+					if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 						errs = append(errs, e...)
 						earlyReturn = true
 					}
@@ -307,7 +307,7 @@ func Validate_PriorityLevelConfigurationSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -336,7 +336,7 @@ func Validate_PriorityLevelConfigurationSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -366,7 +366,7 @@ func Validate_PriorityLevelConfigurationSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {

--- a/pkg/apis/networking/v1/zz_generated.validations.go
+++ b/pkg/apis/networking/v1/zz_generated.validations.go
@@ -140,11 +140,11 @@ func Validate_IPAddressSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -184,7 +184,7 @@ func Validate_IPBlock(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -259,7 +259,7 @@ func Validate_IngressClassParametersReference(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -288,7 +288,7 @@ func Validate_IngressClassParametersReference(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -330,7 +330,7 @@ func Validate_IngressClassSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -405,7 +405,7 @@ func Validate_NetworkPolicyEgressRule(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -448,7 +448,7 @@ func Validate_NetworkPolicyIngressRule(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -492,7 +492,7 @@ func Validate_NetworkPolicyPeer(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -533,7 +533,7 @@ func Validate_NetworkPolicySpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -565,7 +565,7 @@ func Validate_NetworkPolicySpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -609,7 +609,7 @@ func Validate_ParentReference(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -640,7 +640,7 @@ func Validate_ParentReference(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}

--- a/pkg/apis/networking/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/networking/v1beta1/zz_generated.validations.go
@@ -125,11 +125,11 @@ func Validate_IPAddressSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -205,7 +205,7 @@ func Validate_IngressClassParametersReference(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -234,7 +234,7 @@ func Validate_IngressClassParametersReference(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -276,7 +276,7 @@ func Validate_IngressClassSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -317,7 +317,7 @@ func Validate_ParentReference(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -348,7 +348,7 @@ func Validate_ParentReference(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}

--- a/pkg/apis/node/v1/zz_generated.validations.go
+++ b/pkg/apis/node/v1/zz_generated.validations.go
@@ -81,18 +81,18 @@ func Validate_RuntimeClass(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return

--- a/pkg/apis/node/v1alpha1/zz_generated.validations.go
+++ b/pkg/apis/node/v1alpha1/zz_generated.validations.go
@@ -112,18 +112,18 @@ func Validate_RuntimeClassSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return

--- a/pkg/apis/node/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/node/v1beta1/zz_generated.validations.go
@@ -81,18 +81,18 @@ func Validate_RuntimeClass(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return

--- a/pkg/apis/rbac/v1/zz_generated.validations.go
+++ b/pkg/apis/rbac/v1/zz_generated.validations.go
@@ -124,7 +124,7 @@ func Validate_ClusterRole(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -169,7 +169,7 @@ func Validate_ClusterRoleBinding(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -232,7 +232,7 @@ func Validate_PolicyRule(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -277,7 +277,7 @@ func Validate_Role(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -321,7 +321,7 @@ func Validate_RoleBinding(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -396,7 +396,7 @@ func Validate_RoleRef(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -437,7 +437,7 @@ func Validate_Subject(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}

--- a/pkg/apis/rbac/v1alpha1/zz_generated.validations.go
+++ b/pkg/apis/rbac/v1alpha1/zz_generated.validations.go
@@ -124,7 +124,7 @@ func Validate_ClusterRole(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -169,7 +169,7 @@ func Validate_ClusterRoleBinding(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -232,7 +232,7 @@ func Validate_PolicyRule(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -277,7 +277,7 @@ func Validate_Role(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -321,7 +321,7 @@ func Validate_RoleBinding(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -396,7 +396,7 @@ func Validate_RoleRef(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -437,7 +437,7 @@ func Validate_Subject(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}

--- a/pkg/apis/rbac/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/rbac/v1beta1/zz_generated.validations.go
@@ -124,7 +124,7 @@ func Validate_ClusterRole(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -169,7 +169,7 @@ func Validate_ClusterRoleBinding(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -232,7 +232,7 @@ func Validate_PolicyRule(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -277,7 +277,7 @@ func Validate_Role(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -321,7 +321,7 @@ func Validate_RoleBinding(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -396,7 +396,7 @@ func Validate_RoleRef(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -437,7 +437,7 @@ func Validate_Subject(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}

--- a/pkg/apis/resource/types.go
+++ b/pkg/apis/resource/types.go
@@ -682,7 +682,7 @@ type DeviceAttribute struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since:"1.36")=+oneOf=ValueType
+	// +oneOf=ValueType
 	// +featureGate=DRAListTypeAttributes
 	IntValues []int64
 
@@ -690,7 +690,7 @@ type DeviceAttribute struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since:"1.36")=+oneOf=ValueType
+	// +oneOf=ValueType
 	// +featureGate=DRAListTypeAttributes
 	BoolValues []bool
 
@@ -701,7 +701,7 @@ type DeviceAttribute struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since:"1.36")=+oneOf=ValueType
+	// +oneOf=ValueType
 	// +featureGate=DRAListTypeAttributes
 	StringValues []string
 
@@ -712,7 +712,7 @@ type DeviceAttribute struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since:"1.36")=+oneOf=ValueType
+	// +oneOf=ValueType
 	// +featureGate=DRAListTypeAttributes
 	VersionValues []string
 }

--- a/pkg/apis/resource/v1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1/zz_generated.validations.go
@@ -129,13 +129,13 @@ func Validate_AllocatedDeviceStatus(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.UUID(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.UUID(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -200,7 +200,7 @@ func Validate_AllocatedDeviceStatus(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -228,7 +228,7 @@ func Validate_AllocationConfigSource(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *resourcev1.AllocationConfigSource) (errs field.ErrorList) {
 
-	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForAllocationConfigSource, nil).MarkAlpha(); len(e) != 0 {
+	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForAllocationConfigSource, nil).MarkBeta(); len(e) != 0 {
 		errs = append(errs, e...)
 	}
 
@@ -287,14 +287,14 @@ func Validate_CounterSet(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -319,14 +319,14 @@ func Validate_CounterSet(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName).MarkAlpha(); len(e) != 0 {
+			if e := validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -362,7 +362,7 @@ func Validate_Device(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -396,10 +396,10 @@ func Validate_Device(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 2).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 2).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -410,7 +410,7 @@ func Validate_Device(
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
 				func(a resourcev1.DeviceCounterConsumption, b resourcev1.DeviceCounterConsumption) bool {
 					return a.CounterSet == b.CounterSet
-				}).MarkAlpha(); len(e) != 0 {
+				}).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			// iterate the list and call the type's validation function
@@ -446,7 +446,7 @@ func Validate_Device(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -480,10 +480,10 @@ func Validate_Device(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -512,10 +512,10 @@ func Validate_Device(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -555,7 +555,7 @@ func Validate_DeviceAllocationConfiguration(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -586,10 +586,10 @@ func Validate_DeviceAllocationConfiguration(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -597,7 +597,7 @@ func Validate_DeviceAllocationConfiguration(
 				return // do not proceed
 			}
 			// lists with set semantics require unique values
-			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha(); len(e) != 0 {
+			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -642,7 +642,7 @@ func Validate_DeviceAllocationMode(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *resourcev1.DeviceAllocationMode) (errs field.ErrorList) {
 
-	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceAllocationMode, nil).MarkAlpha(); len(e) != 0 {
+	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceAllocationMode, nil).MarkBeta(); len(e) != 0 {
 		errs = append(errs, e...)
 	}
 
@@ -668,10 +668,10 @@ func Validate_DeviceAllocationResult(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -704,10 +704,10 @@ func Validate_DeviceAllocationResult(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 64).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 64).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -786,7 +786,7 @@ func Validate_DeviceAttribute(
 				return false
 			}
 			return len(obj.VersionValues) != 0
-		}).MarkAlpha(); len(e) != 0 {
+		}).MarkBeta(); len(e) != 0 {
 		errs = append(errs, e...)
 	}
 
@@ -803,7 +803,7 @@ func Validate_DeviceAttribute(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -831,7 +831,7 @@ func Validate_DeviceAttribute(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -859,7 +859,7 @@ func Validate_DeviceAttribute(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -887,7 +887,7 @@ func Validate_DeviceAttribute(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -915,7 +915,7 @@ func Validate_DeviceAttribute(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -943,7 +943,7 @@ func Validate_DeviceAttribute(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -971,7 +971,7 @@ func Validate_DeviceAttribute(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1005,7 +1005,7 @@ func Validate_DeviceAttribute(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1042,10 +1042,10 @@ func Validate_DeviceClaim(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1054,7 +1054,7 @@ func Validate_DeviceClaim(
 			}
 			// lists with map semantics require unique keys
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
-				func(a resourcev1.DeviceRequest, b resourcev1.DeviceRequest) bool { return a.Name == b.Name }).MarkAlpha(); len(e) != 0 {
+				func(a resourcev1.DeviceRequest, b resourcev1.DeviceRequest) bool { return a.Name == b.Name }).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			// iterate the list and call the type's validation function
@@ -1084,10 +1084,10 @@ func Validate_DeviceClaim(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1120,10 +1120,10 @@ func Validate_DeviceClaim(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1165,10 +1165,10 @@ func Validate_DeviceClaimConfiguration(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1176,7 +1176,7 @@ func Validate_DeviceClaimConfiguration(
 				return // do not proceed
 			}
 			// lists with set semantics require unique values
-			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha(); len(e) != 0 {
+			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1236,14 +1236,14 @@ func Validate_DeviceClass(
 			func() { // cohort = "name"
 				earlyReturn := false
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "name",
-					func(o *metav1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.OptionalValue).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					func(o *metav1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.OptionalValue).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 					earlyReturn = true
 				}
 				if earlyReturn {
 					return // do not proceed
 				}
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "name",
-					func(o *metav1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.LongName).MarkAlpha(); len(e) != 0 {
+					func(o *metav1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.LongName).MarkBeta(); len(e) != 0 {
 					errs = append(errs, e...)
 				}
 			}()
@@ -1331,10 +1331,10 @@ func Validate_DeviceClassSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1363,10 +1363,10 @@ func Validate_DeviceClassSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1399,13 +1399,13 @@ func Validate_DeviceClassSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.ExtendedResourceName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.ExtendedResourceName(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1439,7 +1439,7 @@ func Validate_DeviceConfiguration(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1478,10 +1478,10 @@ func Validate_DeviceConstraint(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1489,7 +1489,7 @@ func Validate_DeviceConstraint(
 				return // do not proceed
 			}
 			// lists with set semantics require unique values
-			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha(); len(e) != 0 {
+			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1514,13 +1514,13 @@ func Validate_DeviceConstraint(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.ResourceFullyQualifiedName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.ResourceFullyQualifiedName(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1555,14 +1555,14 @@ func Validate_DeviceCounterConsumption(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1587,14 +1587,14 @@ func Validate_DeviceCounterConsumption(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName).MarkAlpha(); len(e) != 0 {
+			if e := validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1630,7 +1630,7 @@ func Validate_DeviceRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1660,10 +1660,10 @@ func Validate_DeviceRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1672,7 +1672,7 @@ func Validate_DeviceRequest(
 			}
 			// lists with map semantics require unique keys
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
-				func(a resourcev1.DeviceSubRequest, b resourcev1.DeviceSubRequest) bool { return a.Name == b.Name }).MarkAlpha(); len(e) != 0 {
+				func(a resourcev1.DeviceSubRequest, b resourcev1.DeviceSubRequest) bool { return a.Name == b.Name }).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			// iterate the list and call the type's validation function
@@ -1713,17 +1713,17 @@ func Validate_DeviceRequestAllocationResult(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkAlpha(); len(e) != 0 {
+			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1748,14 +1748,14 @@ func Validate_DeviceRequestAllocationResult(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.ResourcePoolName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.ResourcePoolName(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1783,7 +1783,7 @@ func Validate_DeviceRequestAllocationResult(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1815,10 +1815,10 @@ func Validate_DeviceRequestAllocationResult(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1847,10 +1847,10 @@ func Validate_DeviceRequestAllocationResult(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1879,13 +1879,13 @@ func Validate_DeviceRequestAllocationResult(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.UUID(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.UUID(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1922,14 +1922,14 @@ func Validate_DeviceSubRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.LongName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.LongName(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1954,10 +1954,10 @@ func Validate_DeviceSubRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1986,7 +1986,7 @@ func Validate_DeviceSubRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -2018,7 +2018,7 @@ func Validate_DeviceSubRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -2063,7 +2063,7 @@ func Validate_DeviceTaint(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -2093,7 +2093,7 @@ func Validate_DeviceTaintEffect(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *resourcev1.DeviceTaintEffect) (errs field.ErrorList) {
 
-	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTaintEffect, nil).MarkAlpha(); len(e) != 0 {
+	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTaintEffect, nil).MarkBeta(); len(e) != 0 {
 		errs = append(errs, e...)
 	}
 
@@ -2119,13 +2119,13 @@ func Validate_DeviceToleration(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.LabelKey(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.LabelKey(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -2151,7 +2151,7 @@ func Validate_DeviceToleration(
 			// call field-attached validations
 			earlyReturn := false
 			// optional fields with default values are effectively required
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -2184,7 +2184,7 @@ func Validate_DeviceToleration(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -2213,7 +2213,7 @@ func Validate_DeviceTolerationOperator(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *resourcev1.DeviceTolerationOperator) (errs field.ErrorList) {
 
-	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTolerationOperator, nil).MarkAlpha(); len(e) != 0 {
+	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTolerationOperator, nil).MarkBeta(); len(e) != 0 {
 		errs = append(errs, e...)
 	}
 
@@ -2241,10 +2241,10 @@ func Validate_ExactDeviceRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -2273,7 +2273,7 @@ func Validate_ExactDeviceRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -2306,7 +2306,7 @@ func Validate_ExactDeviceRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -2348,13 +2348,13 @@ func Validate_NetworkDeviceData(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 256).MarkAlpha(); len(e) != 0 {
+			if e := validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 256).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -2379,10 +2379,10 @@ func Validate_NetworkDeviceData(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 16).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 16).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -2390,7 +2390,7 @@ func Validate_NetworkDeviceData(
 				return // do not proceed
 			}
 			// lists with set semantics require unique values
-			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha(); len(e) != 0 {
+			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -2415,13 +2415,13 @@ func Validate_NetworkDeviceData(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 128).MarkAlpha(); len(e) != 0 {
+			if e := validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 128).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -2455,17 +2455,17 @@ func Validate_OpaqueDeviceConfiguration(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkAlpha(); len(e) != 0 {
+			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -2503,7 +2503,7 @@ func Validate_ResourceClaim(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -2596,10 +2596,10 @@ func Validate_ResourceClaimStatus(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -2630,10 +2630,10 @@ func Validate_ResourceClaimStatus(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 256).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 256).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -2644,7 +2644,7 @@ func Validate_ResourceClaimStatus(
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
 				func(a resourcev1.ResourceClaimConsumerReference, b resourcev1.ResourceClaimConsumerReference) bool {
 					return a.UID == b.UID
-				}).MarkAlpha(); len(e) != 0 {
+				}).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -2669,7 +2669,7 @@ func Validate_ResourceClaimStatus(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -2679,7 +2679,7 @@ func Validate_ResourceClaimStatus(
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
 				func(a resourcev1.AllocatedDeviceStatus, b resourcev1.AllocatedDeviceStatus) bool {
 					return a.Driver == b.Driver && a.Device == b.Device && a.Pool == b.Pool && ((a.ShareID == nil && b.ShareID == nil) || (a.ShareID != nil && b.ShareID != nil && *a.ShareID == *b.ShareID))
-				}).MarkAlpha(); len(e) != 0 {
+				}).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			// iterate the list and call the type's validation function
@@ -2827,7 +2827,7 @@ func Validate_ResourceSliceSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -2861,10 +2861,10 @@ func Validate_ResourceSliceSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -2873,7 +2873,7 @@ func Validate_ResourceSliceSpec(
 			}
 			// lists with map semantics require unique keys
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
-				func(a resourcev1.CounterSet, b resourcev1.CounterSet) bool { return a.Name == b.Name }).MarkAlpha(); len(e) != 0 {
+				func(a resourcev1.CounterSet, b resourcev1.CounterSet) bool { return a.Name == b.Name }).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			// iterate the list and call the type's validation function

--- a/pkg/apis/resource/v1alpha3/zz_generated.validations.go
+++ b/pkg/apis/resource/v1alpha3/zz_generated.validations.go
@@ -97,7 +97,7 @@ func Validate_DeviceTaint(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -127,7 +127,7 @@ func Validate_DeviceTaintEffect(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *resourcev1alpha3.DeviceTaintEffect) (errs field.ErrorList) {
 
-	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTaintEffect, nil).MarkAlpha(); len(e) != 0 {
+	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTaintEffect, nil).MarkBeta(); len(e) != 0 {
 		errs = append(errs, e...)
 	}
 

--- a/pkg/apis/resource/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta1/zz_generated.validations.go
@@ -129,13 +129,13 @@ func Validate_AllocatedDeviceStatus(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.UUID(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.UUID(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -200,7 +200,7 @@ func Validate_AllocatedDeviceStatus(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -228,7 +228,7 @@ func Validate_AllocationConfigSource(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *resourcev1beta1.AllocationConfigSource) (errs field.ErrorList) {
 
-	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForAllocationConfigSource, nil).MarkAlpha(); len(e) != 0 {
+	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForAllocationConfigSource, nil).MarkBeta(); len(e) != 0 {
 		errs = append(errs, e...)
 	}
 
@@ -287,7 +287,7 @@ func Validate_BasicDevice(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -321,10 +321,10 @@ func Validate_BasicDevice(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 2).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 2).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -335,7 +335,7 @@ func Validate_BasicDevice(
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
 				func(a resourcev1beta1.DeviceCounterConsumption, b resourcev1beta1.DeviceCounterConsumption) bool {
 					return a.CounterSet == b.CounterSet
-				}).MarkAlpha(); len(e) != 0 {
+				}).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			// iterate the list and call the type's validation function
@@ -371,7 +371,7 @@ func Validate_BasicDevice(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -405,10 +405,10 @@ func Validate_BasicDevice(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -437,10 +437,10 @@ func Validate_BasicDevice(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -480,14 +480,14 @@ func Validate_CounterSet(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -512,14 +512,14 @@ func Validate_CounterSet(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName).MarkAlpha(); len(e) != 0 {
+			if e := validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -555,7 +555,7 @@ func Validate_Device(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -594,7 +594,7 @@ func Validate_DeviceAllocationConfiguration(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -625,10 +625,10 @@ func Validate_DeviceAllocationConfiguration(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -636,7 +636,7 @@ func Validate_DeviceAllocationConfiguration(
 				return // do not proceed
 			}
 			// lists with set semantics require unique values
-			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha(); len(e) != 0 {
+			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -681,7 +681,7 @@ func Validate_DeviceAllocationMode(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *resourcev1beta1.DeviceAllocationMode) (errs field.ErrorList) {
 
-	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceAllocationMode, nil).MarkAlpha(); len(e) != 0 {
+	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceAllocationMode, nil).MarkBeta(); len(e) != 0 {
 		errs = append(errs, e...)
 	}
 
@@ -707,10 +707,10 @@ func Validate_DeviceAllocationResult(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -743,10 +743,10 @@ func Validate_DeviceAllocationResult(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 64).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 64).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -825,7 +825,7 @@ func Validate_DeviceAttribute(
 				return false
 			}
 			return len(obj.VersionValues) != 0
-		}).MarkAlpha(); len(e) != 0 {
+		}).MarkBeta(); len(e) != 0 {
 		errs = append(errs, e...)
 	}
 
@@ -842,7 +842,7 @@ func Validate_DeviceAttribute(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -870,7 +870,7 @@ func Validate_DeviceAttribute(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -898,7 +898,7 @@ func Validate_DeviceAttribute(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -926,7 +926,7 @@ func Validate_DeviceAttribute(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -954,7 +954,7 @@ func Validate_DeviceAttribute(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -982,7 +982,7 @@ func Validate_DeviceAttribute(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1010,7 +1010,7 @@ func Validate_DeviceAttribute(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1044,7 +1044,7 @@ func Validate_DeviceAttribute(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1081,10 +1081,10 @@ func Validate_DeviceClaim(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1093,7 +1093,7 @@ func Validate_DeviceClaim(
 			}
 			// lists with map semantics require unique keys
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
-				func(a resourcev1beta1.DeviceRequest, b resourcev1beta1.DeviceRequest) bool { return a.Name == b.Name }).MarkAlpha(); len(e) != 0 {
+				func(a resourcev1beta1.DeviceRequest, b resourcev1beta1.DeviceRequest) bool { return a.Name == b.Name }).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			// iterate the list and call the type's validation function
@@ -1123,10 +1123,10 @@ func Validate_DeviceClaim(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1159,10 +1159,10 @@ func Validate_DeviceClaim(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1204,10 +1204,10 @@ func Validate_DeviceClaimConfiguration(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1215,7 +1215,7 @@ func Validate_DeviceClaimConfiguration(
 				return // do not proceed
 			}
 			// lists with set semantics require unique values
-			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha(); len(e) != 0 {
+			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1275,14 +1275,14 @@ func Validate_DeviceClass(
 			func() { // cohort = "name"
 				earlyReturn := false
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "name",
-					func(o *v1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.OptionalValue).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					func(o *v1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.OptionalValue).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 					earlyReturn = true
 				}
 				if earlyReturn {
 					return // do not proceed
 				}
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "name",
-					func(o *v1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.LongName).MarkAlpha(); len(e) != 0 {
+					func(o *v1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.LongName).MarkBeta(); len(e) != 0 {
 					errs = append(errs, e...)
 				}
 			}()
@@ -1370,10 +1370,10 @@ func Validate_DeviceClassSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1402,10 +1402,10 @@ func Validate_DeviceClassSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1438,13 +1438,13 @@ func Validate_DeviceClassSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.ExtendedResourceName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.ExtendedResourceName(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1478,7 +1478,7 @@ func Validate_DeviceConfiguration(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1517,10 +1517,10 @@ func Validate_DeviceConstraint(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1528,7 +1528,7 @@ func Validate_DeviceConstraint(
 				return // do not proceed
 			}
 			// lists with set semantics require unique values
-			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha(); len(e) != 0 {
+			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1553,13 +1553,13 @@ func Validate_DeviceConstraint(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.ResourceFullyQualifiedName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.ResourceFullyQualifiedName(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1594,14 +1594,14 @@ func Validate_DeviceCounterConsumption(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1626,14 +1626,14 @@ func Validate_DeviceCounterConsumption(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName).MarkAlpha(); len(e) != 0 {
+			if e := validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1670,10 +1670,10 @@ func Validate_DeviceRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1702,7 +1702,7 @@ func Validate_DeviceRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1735,10 +1735,10 @@ func Validate_DeviceRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1749,7 +1749,7 @@ func Validate_DeviceRequest(
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
 				func(a resourcev1beta1.DeviceSubRequest, b resourcev1beta1.DeviceSubRequest) bool {
 					return a.Name == b.Name
-				}).MarkAlpha(); len(e) != 0 {
+				}).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			// iterate the list and call the type's validation function
@@ -1781,7 +1781,7 @@ func Validate_DeviceRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1825,17 +1825,17 @@ func Validate_DeviceRequestAllocationResult(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkAlpha(); len(e) != 0 {
+			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1860,14 +1860,14 @@ func Validate_DeviceRequestAllocationResult(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.ResourcePoolName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.ResourcePoolName(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1895,7 +1895,7 @@ func Validate_DeviceRequestAllocationResult(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1927,10 +1927,10 @@ func Validate_DeviceRequestAllocationResult(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1959,10 +1959,10 @@ func Validate_DeviceRequestAllocationResult(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1991,13 +1991,13 @@ func Validate_DeviceRequestAllocationResult(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.UUID(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.UUID(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -2034,14 +2034,14 @@ func Validate_DeviceSubRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.LongName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.LongName(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -2066,11 +2066,11 @@ func Validate_DeviceSubRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -2098,7 +2098,7 @@ func Validate_DeviceSubRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -2130,7 +2130,7 @@ func Validate_DeviceSubRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -2175,7 +2175,7 @@ func Validate_DeviceTaint(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -2205,7 +2205,7 @@ func Validate_DeviceTaintEffect(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *resourcev1beta1.DeviceTaintEffect) (errs field.ErrorList) {
 
-	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTaintEffect, nil).MarkAlpha(); len(e) != 0 {
+	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTaintEffect, nil).MarkBeta(); len(e) != 0 {
 		errs = append(errs, e...)
 	}
 
@@ -2231,13 +2231,13 @@ func Validate_DeviceToleration(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.LabelKey(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.LabelKey(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -2263,7 +2263,7 @@ func Validate_DeviceToleration(
 			// call field-attached validations
 			earlyReturn := false
 			// optional fields with default values are effectively required
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -2296,7 +2296,7 @@ func Validate_DeviceToleration(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -2325,7 +2325,7 @@ func Validate_DeviceTolerationOperator(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *resourcev1beta1.DeviceTolerationOperator) (errs field.ErrorList) {
 
-	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTolerationOperator, nil).MarkAlpha(); len(e) != 0 {
+	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTolerationOperator, nil).MarkBeta(); len(e) != 0 {
 		errs = append(errs, e...)
 	}
 
@@ -2351,13 +2351,13 @@ func Validate_NetworkDeviceData(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 256).MarkAlpha(); len(e) != 0 {
+			if e := validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 256).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -2382,10 +2382,10 @@ func Validate_NetworkDeviceData(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 16).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 16).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -2393,7 +2393,7 @@ func Validate_NetworkDeviceData(
 				return // do not proceed
 			}
 			// lists with set semantics require unique values
-			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha(); len(e) != 0 {
+			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -2418,13 +2418,13 @@ func Validate_NetworkDeviceData(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 128).MarkAlpha(); len(e) != 0 {
+			if e := validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 128).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -2458,17 +2458,17 @@ func Validate_OpaqueDeviceConfiguration(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkAlpha(); len(e) != 0 {
+			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -2506,7 +2506,7 @@ func Validate_ResourceClaim(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -2599,10 +2599,10 @@ func Validate_ResourceClaimStatus(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -2633,10 +2633,10 @@ func Validate_ResourceClaimStatus(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 256).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 256).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -2647,7 +2647,7 @@ func Validate_ResourceClaimStatus(
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
 				func(a resourcev1beta1.ResourceClaimConsumerReference, b resourcev1beta1.ResourceClaimConsumerReference) bool {
 					return a.UID == b.UID
-				}).MarkAlpha(); len(e) != 0 {
+				}).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -2672,7 +2672,7 @@ func Validate_ResourceClaimStatus(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -2682,7 +2682,7 @@ func Validate_ResourceClaimStatus(
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
 				func(a resourcev1beta1.AllocatedDeviceStatus, b resourcev1beta1.AllocatedDeviceStatus) bool {
 					return a.Driver == b.Driver && a.Device == b.Device && a.Pool == b.Pool && ((a.ShareID == nil && b.ShareID == nil) || (a.ShareID != nil && b.ShareID != nil && *a.ShareID == *b.ShareID))
-				}).MarkAlpha(); len(e) != 0 {
+				}).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			// iterate the list and call the type's validation function
@@ -2830,7 +2830,7 @@ func Validate_ResourceSliceSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -2864,10 +2864,10 @@ func Validate_ResourceSliceSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -2876,7 +2876,7 @@ func Validate_ResourceSliceSpec(
 			}
 			// lists with map semantics require unique keys
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
-				func(a resourcev1beta1.CounterSet, b resourcev1beta1.CounterSet) bool { return a.Name == b.Name }).MarkAlpha(); len(e) != 0 {
+				func(a resourcev1beta1.CounterSet, b resourcev1beta1.CounterSet) bool { return a.Name == b.Name }).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			// iterate the list and call the type's validation function

--- a/pkg/apis/resource/v1beta2/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta2/zz_generated.validations.go
@@ -144,13 +144,13 @@ func Validate_AllocatedDeviceStatus(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.UUID(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.UUID(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -215,7 +215,7 @@ func Validate_AllocatedDeviceStatus(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -243,7 +243,7 @@ func Validate_AllocationConfigSource(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *resourcev1beta2.AllocationConfigSource) (errs field.ErrorList) {
 
-	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForAllocationConfigSource, nil).MarkAlpha(); len(e) != 0 {
+	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForAllocationConfigSource, nil).MarkBeta(); len(e) != 0 {
 		errs = append(errs, e...)
 	}
 
@@ -302,14 +302,14 @@ func Validate_CounterSet(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -334,14 +334,14 @@ func Validate_CounterSet(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName).MarkAlpha(); len(e) != 0 {
+			if e := validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -377,7 +377,7 @@ func Validate_Device(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -411,10 +411,10 @@ func Validate_Device(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 2).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 2).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -425,7 +425,7 @@ func Validate_Device(
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
 				func(a resourcev1beta2.DeviceCounterConsumption, b resourcev1beta2.DeviceCounterConsumption) bool {
 					return a.CounterSet == b.CounterSet
-				}).MarkAlpha(); len(e) != 0 {
+				}).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			// iterate the list and call the type's validation function
@@ -461,7 +461,7 @@ func Validate_Device(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -495,10 +495,10 @@ func Validate_Device(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -527,10 +527,10 @@ func Validate_Device(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -570,7 +570,7 @@ func Validate_DeviceAllocationConfiguration(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -601,10 +601,10 @@ func Validate_DeviceAllocationConfiguration(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -612,7 +612,7 @@ func Validate_DeviceAllocationConfiguration(
 				return // do not proceed
 			}
 			// lists with set semantics require unique values
-			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha(); len(e) != 0 {
+			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -657,7 +657,7 @@ func Validate_DeviceAllocationMode(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *resourcev1beta2.DeviceAllocationMode) (errs field.ErrorList) {
 
-	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceAllocationMode, nil).MarkAlpha(); len(e) != 0 {
+	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceAllocationMode, nil).MarkBeta(); len(e) != 0 {
 		errs = append(errs, e...)
 	}
 
@@ -683,10 +683,10 @@ func Validate_DeviceAllocationResult(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -719,10 +719,10 @@ func Validate_DeviceAllocationResult(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 64).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 64).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -801,7 +801,7 @@ func Validate_DeviceAttribute(
 				return false
 			}
 			return len(obj.VersionValues) != 0
-		}).MarkAlpha(); len(e) != 0 {
+		}).MarkBeta(); len(e) != 0 {
 		errs = append(errs, e...)
 	}
 
@@ -818,7 +818,7 @@ func Validate_DeviceAttribute(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -846,7 +846,7 @@ func Validate_DeviceAttribute(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -874,7 +874,7 @@ func Validate_DeviceAttribute(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -902,7 +902,7 @@ func Validate_DeviceAttribute(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -930,7 +930,7 @@ func Validate_DeviceAttribute(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -958,7 +958,7 @@ func Validate_DeviceAttribute(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -986,7 +986,7 @@ func Validate_DeviceAttribute(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1020,7 +1020,7 @@ func Validate_DeviceAttribute(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1057,10 +1057,10 @@ func Validate_DeviceClaim(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1069,7 +1069,7 @@ func Validate_DeviceClaim(
 			}
 			// lists with map semantics require unique keys
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
-				func(a resourcev1beta2.DeviceRequest, b resourcev1beta2.DeviceRequest) bool { return a.Name == b.Name }).MarkAlpha(); len(e) != 0 {
+				func(a resourcev1beta2.DeviceRequest, b resourcev1beta2.DeviceRequest) bool { return a.Name == b.Name }).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			// iterate the list and call the type's validation function
@@ -1099,10 +1099,10 @@ func Validate_DeviceClaim(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1135,10 +1135,10 @@ func Validate_DeviceClaim(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1180,10 +1180,10 @@ func Validate_DeviceClaimConfiguration(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1191,7 +1191,7 @@ func Validate_DeviceClaimConfiguration(
 				return // do not proceed
 			}
 			// lists with set semantics require unique values
-			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha(); len(e) != 0 {
+			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1251,14 +1251,14 @@ func Validate_DeviceClass(
 			func() { // cohort = "name"
 				earlyReturn := false
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "name",
-					func(o *v1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.OptionalValue).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					func(o *v1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.OptionalValue).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 					earlyReturn = true
 				}
 				if earlyReturn {
 					return // do not proceed
 				}
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "name",
-					func(o *v1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.LongName).MarkAlpha(); len(e) != 0 {
+					func(o *v1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.LongName).MarkBeta(); len(e) != 0 {
 					errs = append(errs, e...)
 				}
 			}()
@@ -1346,10 +1346,10 @@ func Validate_DeviceClassSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1378,10 +1378,10 @@ func Validate_DeviceClassSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1414,13 +1414,13 @@ func Validate_DeviceClassSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.ExtendedResourceName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.ExtendedResourceName(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1454,7 +1454,7 @@ func Validate_DeviceConfiguration(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1493,10 +1493,10 @@ func Validate_DeviceConstraint(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1504,7 +1504,7 @@ func Validate_DeviceConstraint(
 				return // do not proceed
 			}
 			// lists with set semantics require unique values
-			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha(); len(e) != 0 {
+			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1529,13 +1529,13 @@ func Validate_DeviceConstraint(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.ResourceFullyQualifiedName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.ResourceFullyQualifiedName(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1570,14 +1570,14 @@ func Validate_DeviceCounterConsumption(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1602,14 +1602,14 @@ func Validate_DeviceCounterConsumption(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName).MarkAlpha(); len(e) != 0 {
+			if e := validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1645,7 +1645,7 @@ func Validate_DeviceRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1675,10 +1675,10 @@ func Validate_DeviceRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1689,7 +1689,7 @@ func Validate_DeviceRequest(
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
 				func(a resourcev1beta2.DeviceSubRequest, b resourcev1beta2.DeviceSubRequest) bool {
 					return a.Name == b.Name
-				}).MarkAlpha(); len(e) != 0 {
+				}).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			// iterate the list and call the type's validation function
@@ -1732,17 +1732,17 @@ func Validate_DeviceRequestAllocationResult(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkAlpha(); len(e) != 0 {
+			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1767,14 +1767,14 @@ func Validate_DeviceRequestAllocationResult(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.ResourcePoolName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.ResourcePoolName(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1802,7 +1802,7 @@ func Validate_DeviceRequestAllocationResult(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1834,10 +1834,10 @@ func Validate_DeviceRequestAllocationResult(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1866,10 +1866,10 @@ func Validate_DeviceRequestAllocationResult(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1898,13 +1898,13 @@ func Validate_DeviceRequestAllocationResult(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.UUID(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.UUID(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1941,14 +1941,14 @@ func Validate_DeviceSubRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.LongName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.LongName(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -1973,10 +1973,10 @@ func Validate_DeviceSubRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -2005,7 +2005,7 @@ func Validate_DeviceSubRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -2037,7 +2037,7 @@ func Validate_DeviceSubRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -2082,7 +2082,7 @@ func Validate_DeviceTaint(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -2112,7 +2112,7 @@ func Validate_DeviceTaintEffect(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *resourcev1beta2.DeviceTaintEffect) (errs field.ErrorList) {
 
-	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTaintEffect, nil).MarkAlpha(); len(e) != 0 {
+	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTaintEffect, nil).MarkBeta(); len(e) != 0 {
 		errs = append(errs, e...)
 	}
 
@@ -2274,13 +2274,13 @@ func Validate_DeviceToleration(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.LabelKey(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.LabelKey(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -2306,7 +2306,7 @@ func Validate_DeviceToleration(
 			// call field-attached validations
 			earlyReturn := false
 			// optional fields with default values are effectively required
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -2339,7 +2339,7 @@ func Validate_DeviceToleration(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -2368,7 +2368,7 @@ func Validate_DeviceTolerationOperator(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *resourcev1beta2.DeviceTolerationOperator) (errs field.ErrorList) {
 
-	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTolerationOperator, nil).MarkAlpha(); len(e) != 0 {
+	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTolerationOperator, nil).MarkBeta(); len(e) != 0 {
 		errs = append(errs, e...)
 	}
 
@@ -2396,10 +2396,10 @@ func Validate_ExactDeviceRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -2428,7 +2428,7 @@ func Validate_ExactDeviceRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -2461,7 +2461,7 @@ func Validate_ExactDeviceRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -2503,13 +2503,13 @@ func Validate_NetworkDeviceData(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 256).MarkAlpha(); len(e) != 0 {
+			if e := validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 256).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -2534,10 +2534,10 @@ func Validate_NetworkDeviceData(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 16).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 16).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -2545,7 +2545,7 @@ func Validate_NetworkDeviceData(
 				return // do not proceed
 			}
 			// lists with set semantics require unique values
-			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha(); len(e) != 0 {
+			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -2570,13 +2570,13 @@ func Validate_NetworkDeviceData(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 128).MarkAlpha(); len(e) != 0 {
+			if e := validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 128).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -2610,17 +2610,17 @@ func Validate_OpaqueDeviceConfiguration(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkAlpha(); len(e) != 0 {
+			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -2658,7 +2658,7 @@ func Validate_ResourceClaim(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -2751,10 +2751,10 @@ func Validate_ResourceClaimStatus(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -2785,10 +2785,10 @@ func Validate_ResourceClaimStatus(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 256).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 256).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -2799,7 +2799,7 @@ func Validate_ResourceClaimStatus(
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
 				func(a resourcev1beta2.ResourceClaimConsumerReference, b resourcev1beta2.ResourceClaimConsumerReference) bool {
 					return a.UID == b.UID
-				}).MarkAlpha(); len(e) != 0 {
+				}).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return
@@ -2824,7 +2824,7 @@ func Validate_ResourceClaimStatus(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -2834,7 +2834,7 @@ func Validate_ResourceClaimStatus(
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
 				func(a resourcev1beta2.AllocatedDeviceStatus, b resourcev1beta2.AllocatedDeviceStatus) bool {
 					return a.Driver == b.Driver && a.Device == b.Device && a.Pool == b.Pool && ((a.ShareID == nil && b.ShareID == nil) || (a.ShareID != nil && b.ShareID != nil && *a.ShareID == *b.ShareID))
-				}).MarkAlpha(); len(e) != 0 {
+				}).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			// iterate the list and call the type's validation function
@@ -2982,7 +2982,7 @@ func Validate_ResourceSliceSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -3016,10 +3016,10 @@ func Validate_ResourceSliceSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -3028,7 +3028,7 @@ func Validate_ResourceSliceSpec(
 			}
 			// lists with map semantics require unique keys
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
-				func(a resourcev1beta2.CounterSet, b resourcev1beta2.CounterSet) bool { return a.Name == b.Name }).MarkAlpha(); len(e) != 0 {
+				func(a resourcev1beta2.CounterSet, b resourcev1beta2.CounterSet) bool { return a.Name == b.Name }).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			// iterate the list and call the type's validation function

--- a/pkg/apis/storage/v1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1/zz_generated.validations.go
@@ -95,11 +95,11 @@ func Validate_StorageClass(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -128,11 +128,11 @@ func Validate_StorageClass(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -160,11 +160,11 @@ func Validate_StorageClass(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -195,11 +195,11 @@ func Validate_StorageClass(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -240,7 +240,7 @@ func Validate_VolumeAttachment(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -281,17 +281,17 @@ func Validate_VolumeAttachmentSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkAlpha(); len(e) != 0 {
+			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return

--- a/pkg/apis/storage/v1alpha1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1alpha1/zz_generated.validations.go
@@ -79,7 +79,7 @@ func Validate_VolumeAttachment(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -120,17 +120,17 @@ func Validate_VolumeAttachmentSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkAlpha(); len(e) != 0 {
+			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return

--- a/pkg/apis/storage/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1beta1/zz_generated.validations.go
@@ -95,11 +95,11 @@ func Validate_StorageClass(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -128,11 +128,11 @@ func Validate_StorageClass(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -160,11 +160,11 @@ func Validate_StorageClass(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -195,11 +195,11 @@ func Validate_StorageClass(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -240,7 +240,7 @@ func Validate_VolumeAttachment(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -281,17 +281,17 @@ func Validate_VolumeAttachmentSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkAlpha(); len(e) != 0 {
+			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkBeta(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return

--- a/staging/src/k8s.io/api/admissionregistration/v1/generated.proto
+++ b/staging/src/k8s.io/api/admissionregistration/v1/generated.proto
@@ -927,7 +927,7 @@ message ValidatingAdmissionPolicyBindingSpec {
   // If the referenced resource does not exist, this binding is considered invalid and will be ignored
   // Required.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string policyName = 1;
 
   // paramRef specifies the parameter resource used to configure the admission control policy.
@@ -986,7 +986,7 @@ message ValidatingAdmissionPolicyBindingSpec {
   // Required.
   // +listType=set
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   repeated string validationActions = 4;
 }
 

--- a/staging/src/k8s.io/api/admissionregistration/v1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1/types.go
@@ -480,7 +480,7 @@ type ValidatingAdmissionPolicyBindingSpec struct {
 	// If the referenced resource does not exist, this binding is considered invalid and will be ignored
 	// Required.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	PolicyName string `json:"policyName,omitempty" protobuf:"bytes,1,rep,name=policyName"`
 
 	// paramRef specifies the parameter resource used to configure the admission control policy.
@@ -539,7 +539,7 @@ type ValidatingAdmissionPolicyBindingSpec struct {
 	// Required.
 	// +listType=set
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	ValidationActions []ValidationAction `json:"validationActions,omitempty" protobuf:"bytes,4,rep,name=validationActions"`
 }
 

--- a/staging/src/k8s.io/api/admissionregistration/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/admissionregistration/v1alpha1/generated.proto
@@ -649,7 +649,7 @@ message ValidatingAdmissionPolicyBindingSpec {
   // If the referenced resource does not exist, this binding is considered invalid and will be ignored
   // Required.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string policyName = 1;
 
   // paramRef specifies the parameter resource used to configure the admission control policy.
@@ -708,7 +708,7 @@ message ValidatingAdmissionPolicyBindingSpec {
   // Required.
   // +listType=set
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   repeated string validationActions = 4;
 }
 

--- a/staging/src/k8s.io/api/admissionregistration/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1alpha1/types.go
@@ -420,7 +420,7 @@ type ValidatingAdmissionPolicyBindingSpec struct {
 	// If the referenced resource does not exist, this binding is considered invalid and will be ignored
 	// Required.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	PolicyName string `json:"policyName,omitempty" protobuf:"bytes,1,rep,name=policyName"`
 
 	// paramRef specifies the parameter resource used to configure the admission control policy.
@@ -479,7 +479,7 @@ type ValidatingAdmissionPolicyBindingSpec struct {
 	// Required.
 	// +listType=set
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	ValidationActions []ValidationAction `json:"validationActions,omitempty" protobuf:"bytes,4,rep,name=validationActions"`
 }
 

--- a/staging/src/k8s.io/api/admissionregistration/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/admissionregistration/v1beta1/generated.proto
@@ -875,7 +875,7 @@ message ValidatingAdmissionPolicyBindingSpec {
   // If the referenced resource does not exist, this binding is considered invalid and will be ignored
   // Required.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string policyName = 1;
 
   // paramRef specifies the parameter resource used to configure the admission control policy.
@@ -934,7 +934,7 @@ message ValidatingAdmissionPolicyBindingSpec {
   // Required.
   // +listType=set
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   repeated string validationActions = 4;
 }
 

--- a/staging/src/k8s.io/api/admissionregistration/v1beta1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1beta1/types.go
@@ -433,7 +433,7 @@ type ValidatingAdmissionPolicyBindingSpec struct {
 	// If the referenced resource does not exist, this binding is considered invalid and will be ignored
 	// Required.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	PolicyName string `json:"policyName,omitempty" protobuf:"bytes,1,rep,name=policyName"`
 
 	// paramRef specifies the parameter resource used to configure the admission control policy.
@@ -492,7 +492,7 @@ type ValidatingAdmissionPolicyBindingSpec struct {
 	// Required.
 	// +listType=set
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	ValidationActions []ValidationAction `json:"validationActions,omitempty" protobuf:"bytes,4,rep,name=validationActions"`
 }
 

--- a/staging/src/k8s.io/api/apps/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1beta1/generated.proto
@@ -332,9 +332,9 @@ message Scale {
 message ScaleSpec {
   // replicas is the number of observed instances of the scaled object.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +default=0
-  // +k8s:alpha(since: "1.36")=+k8s:minimum=0
+  // +k8s:beta(since: "1.37")=+k8s:minimum=0
   optional int32 replicas = 1;
 }
 

--- a/staging/src/k8s.io/api/apps/v1beta1/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta1/types.go
@@ -33,9 +33,9 @@ const (
 type ScaleSpec struct {
 	// replicas is the number of observed instances of the scaled object.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +default=0
-	// +k8s:alpha(since: "1.36")=+k8s:minimum=0
+	// +k8s:beta(since: "1.37")=+k8s:minimum=0
 	Replicas int32 `json:"replicas,omitempty" protobuf:"varint,1,opt,name=replicas"`
 }
 

--- a/staging/src/k8s.io/api/apps/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1beta2/generated.proto
@@ -639,9 +639,9 @@ message Scale {
 message ScaleSpec {
   // desired number of instances for the scaled object.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +default=0
-  // +k8s:alpha(since: "1.36")=+k8s:minimum=0
+  // +k8s:beta(since: "1.37")=+k8s:minimum=0
   optional int32 replicas = 1;
 }
 

--- a/staging/src/k8s.io/api/apps/v1beta2/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types.go
@@ -35,9 +35,9 @@ const (
 type ScaleSpec struct {
 	// desired number of instances for the scaled object.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +default=0
-	// +k8s:alpha(since: "1.36")=+k8s:minimum=0
+	// +k8s:beta(since: "1.37")=+k8s:minimum=0
 	Replicas int32 `json:"replicas,omitempty" protobuf:"varint,1,opt,name=replicas"`
 }
 

--- a/staging/src/k8s.io/api/autoscaling/v1/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v1/generated.proto
@@ -211,15 +211,15 @@ message HorizontalPodAutoscalerSpec {
   // metric is configured.  Scaling is active as long as at least one metric value is
   // available.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:ifEnabled(HPAScaleToZero)=+k8s:minimum=0
-  // +k8s:alpha(since: "1.36")=+k8s:ifDisabled(HPAScaleToZero)=+k8s:minimum=1
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:ifEnabled(HPAScaleToZero)=+k8s:minimum=0
+  // +k8s:beta(since: "1.37")=+k8s:ifDisabled(HPAScaleToZero)=+k8s:minimum=1
   optional int32 minReplicas = 2;
 
   // maxReplicas is the upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:minimum=1
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:minimum=1
   optional int32 maxReplicas = 3;
 
   // targetCPUUtilizationPercentage is the target average CPU utilization (represented as a percentage of requested CPU) over all the pods;
@@ -487,9 +487,9 @@ message Scale {
 message ScaleSpec {
   // replicas is the desired number of instances for the scaled object.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +default=0
-  // +k8s:alpha(since: "1.36")=+k8s:minimum=0
+  // +k8s:beta(since: "1.37")=+k8s:minimum=0
   optional int32 replicas = 1;
 }
 

--- a/staging/src/k8s.io/api/autoscaling/v1/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v1/types.go
@@ -49,15 +49,15 @@ type HorizontalPodAutoscalerSpec struct {
 	// metric is configured.  Scaling is active as long as at least one metric value is
 	// available.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:ifEnabled(HPAScaleToZero)=+k8s:minimum=0
-	// +k8s:alpha(since: "1.36")=+k8s:ifDisabled(HPAScaleToZero)=+k8s:minimum=1
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:ifEnabled(HPAScaleToZero)=+k8s:minimum=0
+	// +k8s:beta(since: "1.37")=+k8s:ifDisabled(HPAScaleToZero)=+k8s:minimum=1
 	MinReplicas *int32 `json:"minReplicas,omitempty" protobuf:"varint,2,opt,name=minReplicas"`
 
 	// maxReplicas is the upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:minimum=1
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:minimum=1
 	MaxReplicas int32 `json:"maxReplicas" protobuf:"varint,3,opt,name=maxReplicas"`
 
 	// targetCPUUtilizationPercentage is the target average CPU utilization (represented as a percentage of requested CPU) over all the pods;
@@ -148,9 +148,9 @@ type Scale struct {
 type ScaleSpec struct {
 	// replicas is the desired number of instances for the scaled object.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +default=0
-	// +k8s:alpha(since: "1.36")=+k8s:minimum=0
+	// +k8s:beta(since: "1.37")=+k8s:minimum=0
 	Replicas int32 `json:"replicas,omitempty" protobuf:"varint,1,opt,name=replicas"`
 }
 

--- a/staging/src/k8s.io/api/autoscaling/v2/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v2/generated.proto
@@ -257,16 +257,16 @@ message HorizontalPodAutoscalerSpec {
   // metric is configured.  Scaling is active as long as at least one metric value is
   // available.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:ifEnabled(HPAScaleToZero)=+k8s:minimum=0
-  // +k8s:alpha(since: "1.36")=+k8s:ifDisabled(HPAScaleToZero)=+k8s:minimum=1
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:ifEnabled(HPAScaleToZero)=+k8s:minimum=0
+  // +k8s:beta(since: "1.37")=+k8s:ifDisabled(HPAScaleToZero)=+k8s:minimum=1
   optional int32 minReplicas = 2;
 
   // maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up.
   // It cannot be less that minReplicas.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:minimum=1
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:minimum=1
   optional int32 maxReplicas = 3;
 
   // metrics contains the specifications for which to use to calculate the

--- a/staging/src/k8s.io/api/autoscaling/v2/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v2/types.go
@@ -60,16 +60,16 @@ type HorizontalPodAutoscalerSpec struct {
 	// metric is configured.  Scaling is active as long as at least one metric value is
 	// available.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:ifEnabled(HPAScaleToZero)=+k8s:minimum=0
-	// +k8s:alpha(since: "1.36")=+k8s:ifDisabled(HPAScaleToZero)=+k8s:minimum=1
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:ifEnabled(HPAScaleToZero)=+k8s:minimum=0
+	// +k8s:beta(since: "1.37")=+k8s:ifDisabled(HPAScaleToZero)=+k8s:minimum=1
 	MinReplicas *int32 `json:"minReplicas,omitempty" protobuf:"varint,2,opt,name=minReplicas"`
 
 	// maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up.
 	// It cannot be less that minReplicas.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:minimum=1
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:minimum=1
 	MaxReplicas int32 `json:"maxReplicas" protobuf:"varint,3,opt,name=maxReplicas"`
 
 	// metrics contains the specifications for which to use to calculate the

--- a/staging/src/k8s.io/api/batch/v1/generated.proto
+++ b/staging/src/k8s.io/api/batch/v1/generated.proto
@@ -63,7 +63,7 @@ message CronJobList {
 message CronJobSpec {
   // The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string schedule = 1;
 
   // The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.

--- a/staging/src/k8s.io/api/batch/v1/types.go
+++ b/staging/src/k8s.io/api/batch/v1/types.go
@@ -715,7 +715,7 @@ type CronJobSpec struct {
 
 	// The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Schedule string `json:"schedule" protobuf:"bytes,1,opt,name=schedule"`
 
 	// The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.

--- a/staging/src/k8s.io/api/batch/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/batch/v1beta1/generated.proto
@@ -64,7 +64,7 @@ message CronJobList {
 message CronJobSpec {
   // The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string schedule = 1;
 
   // The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.

--- a/staging/src/k8s.io/api/batch/v1beta1/types.go
+++ b/staging/src/k8s.io/api/batch/v1beta1/types.go
@@ -86,7 +86,7 @@ type CronJobSpec struct {
 
 	// The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Schedule string `json:"schedule" protobuf:"bytes,1,opt,name=schedule"`
 
 	// The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.

--- a/staging/src/k8s.io/api/certificates/v1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1/generated.proto
@@ -204,12 +204,12 @@ message CertificateSigningRequestStatus {
   // +listType=map
   // +listMapKey=type
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:listType=map
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=type
-  // +k8s:alpha(since: "1.36")=+k8s:customUnique
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:item(type: "Approved")=+k8s:zeroOrOneOfMember
-  // +k8s:alpha(since: "1.36")=+k8s:item(type: "Denied")=+k8s:zeroOrOneOfMember
+  // +k8s:beta(since: "1.37")=+k8s:listType=map
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=type
+  // +k8s:beta(since: "1.37")=+k8s:customUnique
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:item(type: "Approved")=+k8s:zeroOrOneOfMember
+  // +k8s:beta(since: "1.37")=+k8s:item(type: "Denied")=+k8s:zeroOrOneOfMember
   repeated CertificateSigningRequestCondition conditions = 1;
 
   // certificate is populated with an issued certificate by the signer after an Approved condition is present.

--- a/staging/src/k8s.io/api/certificates/v1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1/types.go
@@ -179,12 +179,12 @@ type CertificateSigningRequestStatus struct {
 	// +listType=map
 	// +listMapKey=type
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:listType=map
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=type
-	// +k8s:alpha(since: "1.36")=+k8s:customUnique
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:item(type: "Approved")=+k8s:zeroOrOneOfMember
-	// +k8s:alpha(since: "1.36")=+k8s:item(type: "Denied")=+k8s:zeroOrOneOfMember
+	// +k8s:beta(since: "1.37")=+k8s:listType=map
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=type
+	// +k8s:beta(since: "1.37")=+k8s:customUnique
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:item(type: "Approved")=+k8s:zeroOrOneOfMember
+	// +k8s:beta(since: "1.37")=+k8s:item(type: "Denied")=+k8s:zeroOrOneOfMember
 	Conditions []CertificateSigningRequestCondition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"`
 
 	// certificate is populated with an issued certificate by the signer after an Approved condition is present.

--- a/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
@@ -183,12 +183,12 @@ message CertificateSigningRequestStatus {
   // +listType=map
   // +listMapKey=type
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:listType=map
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=type
-  // +k8s:alpha(since: "1.36")=+k8s:customUnique
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:item(type: "Approved")=+k8s:zeroOrOneOfMember
-  // +k8s:alpha(since: "1.36")=+k8s:item(type: "Denied")=+k8s:zeroOrOneOfMember
+  // +k8s:beta(since: "1.37")=+k8s:listType=map
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=type
+  // +k8s:beta(since: "1.37")=+k8s:customUnique
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:item(type: "Approved")=+k8s:zeroOrOneOfMember
+  // +k8s:beta(since: "1.37")=+k8s:item(type: "Denied")=+k8s:zeroOrOneOfMember
   repeated CertificateSigningRequestCondition conditions = 1;
 
   // If request was approved, the controller will place the issued certificate here.

--- a/staging/src/k8s.io/api/certificates/v1beta1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1beta1/types.go
@@ -177,12 +177,12 @@ type CertificateSigningRequestStatus struct {
 	// +listType=map
 	// +listMapKey=type
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:listType=map
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=type
-	// +k8s:alpha(since: "1.36")=+k8s:customUnique
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:item(type: "Approved")=+k8s:zeroOrOneOfMember
-	// +k8s:alpha(since: "1.36")=+k8s:item(type: "Denied")=+k8s:zeroOrOneOfMember
+	// +k8s:beta(since: "1.37")=+k8s:listType=map
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=type
+	// +k8s:beta(since: "1.37")=+k8s:customUnique
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:item(type: "Approved")=+k8s:zeroOrOneOfMember
+	// +k8s:beta(since: "1.37")=+k8s:item(type: "Denied")=+k8s:zeroOrOneOfMember
 	Conditions []CertificateSigningRequestCondition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"`
 
 	// If request was approved, the controller will place the issued certificate here.

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -5362,8 +5362,8 @@ message ReplicationController {
   // be the same as the Pod(s) that the replication controller manages.
   // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:format=k8s-long-name
+  // +k8s:beta(since: "1.37")=+k8s:subfield(name)=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:subfield(name)=+k8s:format=k8s-long-name
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec defines the specification of the desired behavior of the replication controller.
@@ -5420,18 +5420,18 @@ message ReplicationControllerSpec {
   // Defaults to 1.
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#what-is-a-replicationcontroller
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +default=1
-  // +k8s:alpha(since: "1.36")=+k8s:minimum=0
+  // +k8s:beta(since: "1.37")=+k8s:minimum=0
   optional int32 replicas = 1;
 
   // Minimum number of seconds for which a newly created pod should be ready
   // without any of its container crashing, for it to be considered available.
   // Defaults to 0 (pod will be considered available as soon as it is ready)
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +default=0
-  // +k8s:alpha(since: "1.36")=+k8s:minimum=0
+  // +k8s:beta(since: "1.37")=+k8s:minimum=0
   optional int32 minReadySeconds = 4;
 
   // Selector is a label query over pods that should match the Replicas count.

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -5580,18 +5580,18 @@ type ReplicationControllerSpec struct {
 	// Defaults to 1.
 	// More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#what-is-a-replicationcontroller
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +default=1
-	// +k8s:alpha(since: "1.36")=+k8s:minimum=0
+	// +k8s:beta(since: "1.37")=+k8s:minimum=0
 	Replicas *int32 `json:"replicas,omitempty" protobuf:"varint,1,opt,name=replicas"`
 
 	// Minimum number of seconds for which a newly created pod should be ready
 	// without any of its container crashing, for it to be considered available.
 	// Defaults to 0 (pod will be considered available as soon as it is ready)
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +default=0
-	// +k8s:alpha(since: "1.36")=+k8s:minimum=0
+	// +k8s:beta(since: "1.37")=+k8s:minimum=0
 	MinReadySeconds int32 `json:"minReadySeconds,omitempty" protobuf:"varint,4,opt,name=minReadySeconds"`
 
 	// Selector is a label query over pods that should match the Replicas count.
@@ -5693,8 +5693,8 @@ type ReplicationController struct {
 	// be the same as the Pod(s) that the replication controller manages.
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:format=k8s-long-name
+	// +k8s:beta(since: "1.37")=+k8s:subfield(name)=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:subfield(name)=+k8s:format=k8s-long-name
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Spec defines the specification of the desired behavior of the replication controller.

--- a/staging/src/k8s.io/api/discovery/v1/generated.proto
+++ b/staging/src/k8s.io/api/discovery/v1/generated.proto
@@ -39,8 +39,8 @@ message Endpoint {
   // additional addresses beyond the first, and kube-proxy does not look at them.
   // +listType=set
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=100
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=100
   repeated string addresses = 1;
 
   // conditions contains information about the current status of the endpoint.
@@ -185,15 +185,15 @@ message EndpointSlice {
   // slices of addressType "IPv4" and "IPv6". No semantics are defined for
   // the "FQDN" type.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:immutable
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:immutable
   optional string addressType = 4;
 
   // endpoints is a list of unique endpoints in this slice. Each slice may
   // include a maximum of 1000 endpoints.
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated Endpoint endpoints = 2;
 
   // ports specifies the list of network ports exposed by each endpoint in

--- a/staging/src/k8s.io/api/discovery/v1/types.go
+++ b/staging/src/k8s.io/api/discovery/v1/types.go
@@ -49,15 +49,15 @@ type EndpointSlice struct {
 	// slices of addressType "IPv4" and "IPv6". No semantics are defined for
 	// the "FQDN" type.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:immutable
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:immutable
 	AddressType AddressType `json:"addressType" protobuf:"bytes,4,rep,name=addressType"`
 
 	// endpoints is a list of unique endpoints in this slice. Each slice may
 	// include a maximum of 1000 endpoints.
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Endpoints []Endpoint `json:"endpoints" protobuf:"bytes,2,rep,name=endpoints"`
 
 	// ports specifies the list of network ports exposed by each endpoint in
@@ -73,7 +73,7 @@ type EndpointSlice struct {
 
 // AddressType represents the type of address referred to by an endpoint.
 // +enum
-// +k8s:alpha(since: "1.36")=+k8s:enum
+// +k8s:beta(since: "1.37")=+k8s:enum
 type AddressType string
 
 const (
@@ -97,8 +97,8 @@ type Endpoint struct {
 	// additional addresses beyond the first, and kube-proxy does not look at them.
 	// +listType=set
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=100
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=100
 	Addresses []string `json:"addresses" protobuf:"bytes,1,rep,name=addresses"`
 
 	// conditions contains information about the current status of the endpoint.

--- a/staging/src/k8s.io/api/discovery/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/discovery/v1beta1/generated.proto
@@ -39,8 +39,8 @@ message Endpoint {
   // use the first element. Refer to: https://issue.k8s.io/106267
   // +listType=set
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=100
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=100
   repeated string addresses = 1;
 
   // conditions contains information about the current status of the endpoint.
@@ -171,14 +171,14 @@ message EndpointSlice {
   // * IPv6: Represents an IPv6 Address.
   // * FQDN: Represents a Fully Qualified Domain Name.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:immutable
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:immutable
   optional string addressType = 4;
 
   // endpoints is a list of unique endpoints in this slice. Each slice may
   // include a maximum of 1000 endpoints.
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated Endpoint endpoints = 2;
 
   // ports specifies the list of network ports exposed by each endpoint in

--- a/staging/src/k8s.io/api/discovery/v1beta1/types.go
+++ b/staging/src/k8s.io/api/discovery/v1beta1/types.go
@@ -46,14 +46,14 @@ type EndpointSlice struct {
 	// * IPv6: Represents an IPv6 Address.
 	// * FQDN: Represents a Fully Qualified Domain Name.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:immutable
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:immutable
 	AddressType AddressType `json:"addressType" protobuf:"bytes,4,rep,name=addressType"`
 
 	// endpoints is a list of unique endpoints in this slice. Each slice may
 	// include a maximum of 1000 endpoints.
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Endpoints []Endpoint `json:"endpoints" protobuf:"bytes,2,rep,name=endpoints"`
 
 	// ports specifies the list of network ports exposed by each endpoint in
@@ -68,7 +68,7 @@ type EndpointSlice struct {
 
 // AddressType represents the type of address referred to by an endpoint.
 // +enum
-// +k8s:alpha(since: "1.36")=+k8s:enum
+// +k8s:beta(since: "1.37")=+k8s:enum
 type AddressType string
 
 const (
@@ -92,8 +92,8 @@ type Endpoint struct {
 	// use the first element. Refer to: https://issue.k8s.io/106267
 	// +listType=set
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=100
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=100
 	Addresses []string `json:"addresses" protobuf:"bytes,1,rep,name=addresses"`
 
 	// conditions contains information about the current status of the endpoint.

--- a/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
@@ -431,7 +431,7 @@ message IPBlock {
   // CIDR is a string representing the IP Block
   // Valid examples are "192.168.1.0/24" or "2001:db8::/64"
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string cidr = 1;
 
   // Except is a slice of CIDRs that should not be included within an IP Block
@@ -691,7 +691,7 @@ message NetworkPolicyEgressRule {
   // allows traffic only if the traffic matches at least one item in the to list.
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated NetworkPolicyPeer to = 2;
 }
 
@@ -714,7 +714,7 @@ message NetworkPolicyIngressRule {
   // traffic matches at least one item in the from list.
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated NetworkPolicyPeer from = 2;
 }
 
@@ -753,7 +753,7 @@ message NetworkPolicyPeer {
   // IPBlock defines policy on a particular IPBlock. If this field is set then
   // neither of the other fields can be.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional IPBlock ipBlock = 3;
 }
 
@@ -797,7 +797,7 @@ message NetworkPolicySpec {
   // (and serves solely to ensure that the pods it selects are isolated by default).
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated NetworkPolicyIngressRule ingress = 2;
 
   // List of egress rules to be applied to the selected pods. Outgoing traffic is
@@ -809,7 +809,7 @@ message NetworkPolicySpec {
   // This field is beta-level in 1.8
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated NetworkPolicyEgressRule egress = 3;
 
   // List of rule types that the NetworkPolicy relates to.
@@ -1050,9 +1050,9 @@ message Scale {
 message ScaleSpec {
   // desired number of instances for the scaled object.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +default=0
-  // +k8s:alpha(since: "1.36")=+k8s:minimum=0
+  // +k8s:beta(since: "1.37")=+k8s:minimum=0
   optional int32 replicas = 1;
 }
 

--- a/staging/src/k8s.io/api/extensions/v1beta1/types.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/types.go
@@ -27,9 +27,9 @@ import (
 type ScaleSpec struct {
 	// desired number of instances for the scaled object.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +default=0
-	// +k8s:alpha(since: "1.36")=+k8s:minimum=0
+	// +k8s:beta(since: "1.37")=+k8s:minimum=0
 	Replicas int32 `json:"replicas,omitempty" protobuf:"varint,1,opt,name=replicas"`
 }
 
@@ -1110,7 +1110,7 @@ type NetworkPolicySpec struct {
 	// (and serves solely to ensure that the pods it selects are isolated by default).
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Ingress []NetworkPolicyIngressRule `json:"ingress,omitempty" protobuf:"bytes,2,rep,name=ingress"`
 
 	// List of egress rules to be applied to the selected pods. Outgoing traffic is
@@ -1122,7 +1122,7 @@ type NetworkPolicySpec struct {
 	// This field is beta-level in 1.8
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Egress []NetworkPolicyEgressRule `json:"egress,omitempty" protobuf:"bytes,3,rep,name=egress"`
 
 	// List of rule types that the NetworkPolicy relates to.
@@ -1159,7 +1159,7 @@ type NetworkPolicyIngressRule struct {
 	// traffic matches at least one item in the from list.
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	From []NetworkPolicyPeer `json:"from,omitempty" protobuf:"bytes,2,rep,name=from"`
 }
 
@@ -1184,7 +1184,7 @@ type NetworkPolicyEgressRule struct {
 	// allows traffic only if the traffic matches at least one item in the to list.
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	To []NetworkPolicyPeer `json:"to,omitempty" protobuf:"bytes,2,rep,name=to"`
 }
 
@@ -1218,7 +1218,7 @@ type IPBlock struct {
 	// CIDR is a string representing the IP Block
 	// Valid examples are "192.168.1.0/24" or "2001:db8::/64"
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	CIDR string `json:"cidr" protobuf:"bytes,1,name=cidr"`
 	// Except is a slice of CIDRs that should not be included within an IP Block
 	// Valid examples are "192.168.1.0/24" or "2001:db8::/64"
@@ -1251,7 +1251,7 @@ type NetworkPolicyPeer struct {
 	// IPBlock defines policy on a particular IPBlock. If this field is set then
 	// neither of the other fields can be.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	IPBlock *IPBlock `json:"ipBlock,omitempty" protobuf:"bytes,3,rep,name=ipBlock"`
 }
 

--- a/staging/src/k8s.io/api/flowcontrol/v1/generated.proto
+++ b/staging/src/k8s.io/api/flowcontrol/v1/generated.proto
@@ -180,15 +180,15 @@ message LimitResponse {
   // are rejected.
   // Required.
   // +unionDiscriminator
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:modeDiscriminator
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
   optional string type = 1;
 
   // `queuing` holds the configuration parameters for queuing.
   // This field may be non-empty only if `type` is `"Queue"`.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:ifMode("Queue")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:ifMode("Queue")=+k8s:required
   optional QueuingConfiguration queuing = 2;
 }
 
@@ -373,15 +373,15 @@ message PriorityLevelConfigurationSpec {
   // capacity is made available exclusively to this priority level.
   // Required.
   // +unionDiscriminator
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:modeDiscriminator
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
   optional string type = 1;
 
   // `limited` specifies how requests are handled for a Limited priority level.
   // This field must be non-empty if and only if `type` is `"Limited"`.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:ifMode("Limited")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:ifMode("Limited")=+k8s:required
   optional LimitedPriorityLevelConfiguration limited = 2;
 
   // `exempt` specifies how requests are handled for an exempt priority level.
@@ -390,8 +390,8 @@ message PriorityLevelConfigurationSpec {
   // If empty and `type` is `"Exempt"` then the default values
   // for `ExemptPriorityLevelConfiguration` apply.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:ifMode("Exempt")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:ifMode("Exempt")=+k8s:optional
   optional ExemptPriorityLevelConfiguration exempt = 3;
 }
 

--- a/staging/src/k8s.io/api/flowcontrol/v1/types.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1/types.go
@@ -431,15 +431,15 @@ type PriorityLevelConfigurationSpec struct {
 	// capacity is made available exclusively to this priority level.
 	// Required.
 	// +unionDiscriminator
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:modeDiscriminator
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
 	Type PriorityLevelEnablement `json:"type" protobuf:"bytes,1,opt,name=type"`
 
 	// `limited` specifies how requests are handled for a Limited priority level.
 	// This field must be non-empty if and only if `type` is `"Limited"`.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:ifMode("Limited")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:ifMode("Limited")=+k8s:required
 	Limited *LimitedPriorityLevelConfiguration `json:"limited,omitempty" protobuf:"bytes,2,opt,name=limited"`
 
 	// `exempt` specifies how requests are handled for an exempt priority level.
@@ -448,8 +448,8 @@ type PriorityLevelConfigurationSpec struct {
 	// If empty and `type` is `"Exempt"` then the default values
 	// for `ExemptPriorityLevelConfiguration` apply.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:ifMode("Exempt")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:ifMode("Exempt")=+k8s:optional
 	Exempt *ExemptPriorityLevelConfiguration `json:"exempt,omitempty" protobuf:"bytes,3,opt,name=exempt"`
 }
 
@@ -574,15 +574,15 @@ type LimitResponse struct {
 	// are rejected.
 	// Required.
 	// +unionDiscriminator
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:modeDiscriminator
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
 	Type LimitResponseType `json:"type" protobuf:"bytes,1,opt,name=type"`
 
 	// `queuing` holds the configuration parameters for queuing.
 	// This field may be non-empty only if `type` is `"Queue"`.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:ifMode("Queue")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:ifMode("Queue")=+k8s:required
 	Queuing *QueuingConfiguration `json:"queuing,omitempty" protobuf:"bytes,2,opt,name=queuing"`
 }
 

--- a/staging/src/k8s.io/api/flowcontrol/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta1/generated.proto
@@ -178,15 +178,15 @@ message LimitResponse {
   // are rejected.
   // Required.
   // +unionDiscriminator
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:modeDiscriminator
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
   optional string type = 1;
 
   // `queuing` holds the configuration parameters for queuing.
   // This field may be non-empty only if `type` is `"Queue"`.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:ifMode("Queue")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:ifMode("Queue")=+k8s:required
   optional QueuingConfiguration queuing = 2;
 }
 
@@ -366,15 +366,15 @@ message PriorityLevelConfigurationSpec {
   // capacity is made available exclusively to this priority level.
   // Required.
   // +unionDiscriminator
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:modeDiscriminator
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
   optional string type = 1;
 
   // `limited` specifies how requests are handled for a Limited priority level.
   // This field must be non-empty if and only if `type` is `"Limited"`.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:ifMode("Limited")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:ifMode("Limited")=+k8s:required
   optional LimitedPriorityLevelConfiguration limited = 2;
 
   // `exempt` specifies how requests are handled for an exempt priority level.
@@ -383,8 +383,8 @@ message PriorityLevelConfigurationSpec {
   // If empty and `type` is `"Exempt"` then the default values
   // for `ExemptPriorityLevelConfiguration` apply.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:ifMode("Exempt")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:ifMode("Exempt")=+k8s:optional
   optional ExemptPriorityLevelConfiguration exempt = 3;
 }
 

--- a/staging/src/k8s.io/api/flowcontrol/v1beta1/types.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta1/types.go
@@ -433,15 +433,15 @@ type PriorityLevelConfigurationSpec struct {
 	// capacity is made available exclusively to this priority level.
 	// Required.
 	// +unionDiscriminator
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:modeDiscriminator
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
 	Type PriorityLevelEnablement `json:"type" protobuf:"bytes,1,opt,name=type"`
 
 	// `limited` specifies how requests are handled for a Limited priority level.
 	// This field must be non-empty if and only if `type` is `"Limited"`.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:ifMode("Limited")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:ifMode("Limited")=+k8s:required
 	Limited *LimitedPriorityLevelConfiguration `json:"limited,omitempty" protobuf:"bytes,2,opt,name=limited"`
 
 	// `exempt` specifies how requests are handled for an exempt priority level.
@@ -450,8 +450,8 @@ type PriorityLevelConfigurationSpec struct {
 	// If empty and `type` is `"Exempt"` then the default values
 	// for `ExemptPriorityLevelConfiguration` apply.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:ifMode("Exempt")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:ifMode("Exempt")=+k8s:optional
 	Exempt *ExemptPriorityLevelConfiguration `json:"exempt,omitempty" protobuf:"bytes,3,opt,name=exempt"`
 }
 
@@ -571,15 +571,15 @@ type LimitResponse struct {
 	// are rejected.
 	// Required.
 	// +unionDiscriminator
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:modeDiscriminator
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
 	Type LimitResponseType `json:"type" protobuf:"bytes,1,opt,name=type"`
 
 	// `queuing` holds the configuration parameters for queuing.
 	// This field may be non-empty only if `type` is `"Queue"`.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:ifMode("Queue")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:ifMode("Queue")=+k8s:required
 	Queuing *QueuingConfiguration `json:"queuing,omitempty" protobuf:"bytes,2,opt,name=queuing"`
 }
 

--- a/staging/src/k8s.io/api/flowcontrol/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta2/generated.proto
@@ -178,15 +178,15 @@ message LimitResponse {
   // are rejected.
   // Required.
   // +unionDiscriminator
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:modeDiscriminator
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
   optional string type = 1;
 
   // `queuing` holds the configuration parameters for queuing.
   // This field may be non-empty only if `type` is `"Queue"`.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:ifMode("Queue")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:ifMode("Queue")=+k8s:required
   optional QueuingConfiguration queuing = 2;
 }
 
@@ -366,15 +366,15 @@ message PriorityLevelConfigurationSpec {
   // capacity is made available exclusively to this priority level.
   // Required.
   // +unionDiscriminator
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:modeDiscriminator
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
   optional string type = 1;
 
   // `limited` specifies how requests are handled for a Limited priority level.
   // This field must be non-empty if and only if `type` is `"Limited"`.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:ifMode("Limited")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:ifMode("Limited")=+k8s:required
   optional LimitedPriorityLevelConfiguration limited = 2;
 
   // `exempt` specifies how requests are handled for an exempt priority level.
@@ -383,8 +383,8 @@ message PriorityLevelConfigurationSpec {
   // If empty and `type` is `"Exempt"` then the default values
   // for `ExemptPriorityLevelConfiguration` apply.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:ifMode("Exempt")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:ifMode("Exempt")=+k8s:optional
   optional ExemptPriorityLevelConfiguration exempt = 3;
 }
 

--- a/staging/src/k8s.io/api/flowcontrol/v1beta2/types.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta2/types.go
@@ -433,15 +433,15 @@ type PriorityLevelConfigurationSpec struct {
 	// capacity is made available exclusively to this priority level.
 	// Required.
 	// +unionDiscriminator
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:modeDiscriminator
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
 	Type PriorityLevelEnablement `json:"type" protobuf:"bytes,1,opt,name=type"`
 
 	// `limited` specifies how requests are handled for a Limited priority level.
 	// This field must be non-empty if and only if `type` is `"Limited"`.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:ifMode("Limited")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:ifMode("Limited")=+k8s:required
 	Limited *LimitedPriorityLevelConfiguration `json:"limited,omitempty" protobuf:"bytes,2,opt,name=limited"`
 
 	// `exempt` specifies how requests are handled for an exempt priority level.
@@ -450,8 +450,8 @@ type PriorityLevelConfigurationSpec struct {
 	// If empty and `type` is `"Exempt"` then the default values
 	// for `ExemptPriorityLevelConfiguration` apply.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:ifMode("Exempt")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:ifMode("Exempt")=+k8s:optional
 	Exempt *ExemptPriorityLevelConfiguration `json:"exempt,omitempty" protobuf:"bytes,3,opt,name=exempt"`
 }
 
@@ -571,15 +571,15 @@ type LimitResponse struct {
 	// are rejected.
 	// Required.
 	// +unionDiscriminator
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:modeDiscriminator
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
 	Type LimitResponseType `json:"type" protobuf:"bytes,1,opt,name=type"`
 
 	// `queuing` holds the configuration parameters for queuing.
 	// This field may be non-empty only if `type` is `"Queue"`.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:ifMode("Queue")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:ifMode("Queue")=+k8s:required
 	Queuing *QueuingConfiguration `json:"queuing,omitempty" protobuf:"bytes,2,opt,name=queuing"`
 }
 

--- a/staging/src/k8s.io/api/flowcontrol/v1beta3/generated.proto
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta3/generated.proto
@@ -180,15 +180,15 @@ message LimitResponse {
   // are rejected.
   // Required.
   // +unionDiscriminator
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:modeDiscriminator
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
   optional string type = 1;
 
   // `queuing` holds the configuration parameters for queuing.
   // This field may be non-empty only if `type` is `"Queue"`.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:ifMode("Queue")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:ifMode("Queue")=+k8s:required
   optional QueuingConfiguration queuing = 2;
 }
 
@@ -368,15 +368,15 @@ message PriorityLevelConfigurationSpec {
   // capacity is made available exclusively to this priority level.
   // Required.
   // +unionDiscriminator
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:modeDiscriminator
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
   optional string type = 1;
 
   // `limited` specifies how requests are handled for a Limited priority level.
   // This field must be non-empty if and only if `type` is `"Limited"`.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:ifMode("Limited")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:ifMode("Limited")=+k8s:required
   optional LimitedPriorityLevelConfiguration limited = 2;
 
   // `exempt` specifies how requests are handled for an exempt priority level.
@@ -385,8 +385,8 @@ message PriorityLevelConfigurationSpec {
   // If empty and `type` is `"Exempt"` then the default values
   // for `ExemptPriorityLevelConfiguration` apply.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:ifMode("Exempt")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:ifMode("Exempt")=+k8s:optional
   optional ExemptPriorityLevelConfiguration exempt = 3;
 }
 

--- a/staging/src/k8s.io/api/flowcontrol/v1beta3/types.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta3/types.go
@@ -449,15 +449,15 @@ type PriorityLevelConfigurationSpec struct {
 	// capacity is made available exclusively to this priority level.
 	// Required.
 	// +unionDiscriminator
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:modeDiscriminator
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
 	Type PriorityLevelEnablement `json:"type" protobuf:"bytes,1,opt,name=type"`
 
 	// `limited` specifies how requests are handled for a Limited priority level.
 	// This field must be non-empty if and only if `type` is `"Limited"`.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:ifMode("Limited")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:ifMode("Limited")=+k8s:required
 	Limited *LimitedPriorityLevelConfiguration `json:"limited,omitempty" protobuf:"bytes,2,opt,name=limited"`
 
 	// `exempt` specifies how requests are handled for an exempt priority level.
@@ -466,8 +466,8 @@ type PriorityLevelConfigurationSpec struct {
 	// If empty and `type` is `"Exempt"` then the default values
 	// for `ExemptPriorityLevelConfiguration` apply.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:ifMode("Exempt")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:ifMode("Exempt")=+k8s:optional
 	Exempt *ExemptPriorityLevelConfiguration `json:"exempt,omitempty" protobuf:"bytes,3,opt,name=exempt"`
 }
 
@@ -587,15 +587,15 @@ type LimitResponse struct {
 	// are rejected.
 	// Required.
 	// +unionDiscriminator
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:modeDiscriminator
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
 	Type LimitResponseType `json:"type" protobuf:"bytes,1,opt,name=type"`
 
 	// `queuing` holds the configuration parameters for queuing.
 	// This field may be non-empty only if `type` is `"Queue"`.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:ifMode("Queue")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:ifMode("Queue")=+k8s:required
 	Queuing *QueuingConfiguration `json:"queuing,omitempty" protobuf:"bytes,2,opt,name=queuing"`
 }
 

--- a/staging/src/k8s.io/api/networking/v1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1/generated.proto
@@ -107,8 +107,8 @@ message IPAddressSpec {
   // ParentRef references the resource that an IPAddress is attached to.
   // An IPAddress must reference a parent object.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:immutable
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:immutable
   optional ParentReference parentRef = 1;
 }
 
@@ -119,7 +119,7 @@ message IPBlock {
   // cidr is a string representing the IPBlock
   // Valid examples are "192.168.1.0/24" or "2001:db8::/64"
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string cidr = 1;
 
   // except is a slice of CIDRs that should not be included within an IPBlock
@@ -205,12 +205,12 @@ message IngressClassParametersReference {
 
   // kind is the type of resource being referenced.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string kind = 2;
 
   // name is the name of resource being referenced.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string name = 3;
 
   // scope represents if this refers to a cluster or namespace scoped resource.
@@ -239,7 +239,7 @@ message IngressClassSpec {
   // configuration for the controller. This is optional if the controller does
   // not require extra parameters.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional IngressClassParametersReference parameters = 2;
 }
 
@@ -456,7 +456,7 @@ message NetworkPolicyEgressRule {
   // allows traffic only if the traffic matches at least one item in the to list.
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated NetworkPolicyPeer to = 2;
 }
 
@@ -479,7 +479,7 @@ message NetworkPolicyIngressRule {
   // allows traffic only if the traffic matches at least one item in the from list.
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated NetworkPolicyPeer from = 2;
 }
 
@@ -518,7 +518,7 @@ message NetworkPolicyPeer {
   // ipBlock defines policy on a particular IPBlock. If this field is set then
   // neither of the other fields can be.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional IPBlock ipBlock = 3;
 }
 
@@ -564,7 +564,7 @@ message NetworkPolicySpec {
   // solely to ensure that the pods it selects are isolated by default)
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated NetworkPolicyIngressRule ingress = 2;
 
   // egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
@@ -576,7 +576,7 @@ message NetworkPolicySpec {
   // This field is beta-level in 1.8
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated NetworkPolicyEgressRule egress = 3;
 
   // policyTypes is a list of rule types that the NetworkPolicy relates to.
@@ -602,7 +602,7 @@ message ParentReference {
 
   // Resource is the resource of the object being referenced.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string resource = 2;
 
   // Namespace is the namespace of the object being referenced.
@@ -611,7 +611,7 @@ message ParentReference {
 
   // Name is the name of the object being referenced.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string name = 4;
 }
 

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -77,7 +77,7 @@ type NetworkPolicySpec struct {
 	// solely to ensure that the pods it selects are isolated by default)
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Ingress []NetworkPolicyIngressRule `json:"ingress,omitempty" protobuf:"bytes,2,rep,name=ingress"`
 
 	// egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
@@ -89,7 +89,7 @@ type NetworkPolicySpec struct {
 	// This field is beta-level in 1.8
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Egress []NetworkPolicyEgressRule `json:"egress,omitempty" protobuf:"bytes,3,rep,name=egress"`
 
 	// policyTypes is a list of rule types that the NetworkPolicy relates to.
@@ -126,7 +126,7 @@ type NetworkPolicyIngressRule struct {
 	// allows traffic only if the traffic matches at least one item in the from list.
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	From []NetworkPolicyPeer `json:"from,omitempty" protobuf:"bytes,2,rep,name=from"`
 }
 
@@ -150,7 +150,7 @@ type NetworkPolicyEgressRule struct {
 	// allows traffic only if the traffic matches at least one item in the to list.
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	To []NetworkPolicyPeer `json:"to,omitempty" protobuf:"bytes,2,rep,name=to"`
 }
 
@@ -183,7 +183,7 @@ type IPBlock struct {
 	// cidr is a string representing the IPBlock
 	// Valid examples are "192.168.1.0/24" or "2001:db8::/64"
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	CIDR string `json:"cidr" protobuf:"bytes,1,name=cidr"`
 
 	// except is a slice of CIDRs that should not be included within an IPBlock
@@ -218,7 +218,7 @@ type NetworkPolicyPeer struct {
 	// ipBlock defines policy on a particular IPBlock. If this field is set then
 	// neither of the other fields can be.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	IPBlock *IPBlock `json:"ipBlock,omitempty" protobuf:"bytes,3,rep,name=ipBlock"`
 }
 
@@ -591,7 +591,7 @@ type IngressClassSpec struct {
 	// configuration for the controller. This is optional if the controller does
 	// not require extra parameters.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Parameters *IngressClassParametersReference `json:"parameters,omitempty" protobuf:"bytes,2,opt,name=parameters"`
 }
 
@@ -615,12 +615,12 @@ type IngressClassParametersReference struct {
 
 	// kind is the type of resource being referenced.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Kind string `json:"kind" protobuf:"bytes,2,opt,name=kind"`
 
 	// name is the name of resource being referenced.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,3,opt,name=name"`
 
 	// scope represents if this refers to a cluster or namespace scoped resource.
@@ -679,8 +679,8 @@ type IPAddressSpec struct {
 	// ParentRef references the resource that an IPAddress is attached to.
 	// An IPAddress must reference a parent object.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:immutable
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:immutable
 	ParentRef *ParentReference `json:"parentRef,omitempty" protobuf:"bytes,1,opt,name=parentRef"`
 }
 
@@ -691,14 +691,14 @@ type ParentReference struct {
 	Group string `json:"group,omitempty" protobuf:"bytes,1,opt,name=group"`
 	// Resource is the resource of the object being referenced.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Resource string `json:"resource,omitempty" protobuf:"bytes,2,opt,name=resource"`
 	// Namespace is the namespace of the object being referenced.
 	// +optional
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,3,opt,name=namespace"`
 	// Name is the name of the object being referenced.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Name string `json:"name,omitempty" protobuf:"bytes,4,opt,name=name"`
 }
 

--- a/staging/src/k8s.io/api/networking/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1beta1/generated.proto
@@ -108,8 +108,8 @@ message IPAddressSpec {
   // ParentRef references the resource that an IPAddress is attached to.
   // An IPAddress must reference a parent object.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:immutable
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:immutable
   optional ParentReference parentRef = 1;
 }
 
@@ -190,12 +190,12 @@ message IngressClassParametersReference {
 
   // kind is the type of resource being referenced.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string kind = 2;
 
   // name is the name of resource being referenced.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string name = 3;
 
   // scope represents if this refers to a cluster or namespace scoped resource.
@@ -223,7 +223,7 @@ message IngressClassSpec {
   // configuration for the controller. This is optional if the controller does
   // not require extra parameters.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional IngressClassParametersReference parameters = 2;
 }
 
@@ -405,7 +405,7 @@ message ParentReference {
 
   // Resource is the resource of the object being referenced.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string resource = 2;
 
   // Namespace is the namespace of the object being referenced.
@@ -414,7 +414,7 @@ message ParentReference {
 
   // Name is the name of the object being referenced.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string name = 4;
 }
 

--- a/staging/src/k8s.io/api/networking/v1beta1/types.go
+++ b/staging/src/k8s.io/api/networking/v1beta1/types.go
@@ -369,7 +369,7 @@ type IngressClassSpec struct {
 	// configuration for the controller. This is optional if the controller does
 	// not require extra parameters.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Parameters *IngressClassParametersReference `json:"parameters,omitempty" protobuf:"bytes,2,opt,name=parameters"`
 }
 
@@ -393,12 +393,12 @@ type IngressClassParametersReference struct {
 
 	// kind is the type of resource being referenced.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Kind string `json:"kind" protobuf:"bytes,2,opt,name=kind"`
 
 	// name is the name of resource being referenced.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,3,opt,name=name"`
 
 	// scope represents if this refers to a cluster or namespace scoped resource.
@@ -457,8 +457,8 @@ type IPAddressSpec struct {
 	// ParentRef references the resource that an IPAddress is attached to.
 	// An IPAddress must reference a parent object.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:immutable
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:immutable
 	ParentRef *ParentReference `json:"parentRef,omitempty" protobuf:"bytes,1,opt,name=parentRef"`
 }
 
@@ -469,14 +469,14 @@ type ParentReference struct {
 	Group string `json:"group,omitempty" protobuf:"bytes,1,opt,name=group"`
 	// Resource is the resource of the object being referenced.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Resource string `json:"resource,omitempty" protobuf:"bytes,2,opt,name=resource"`
 	// Namespace is the namespace of the object being referenced.
 	// +optional
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,3,opt,name=namespace"`
 	// Name is the name of the object being referenced.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Name string `json:"name,omitempty" protobuf:"bytes,4,opt,name=name"`
 }
 

--- a/staging/src/k8s.io/api/node/v1/generated.proto
+++ b/staging/src/k8s.io/api/node/v1/generated.proto
@@ -60,9 +60,9 @@ message RuntimeClass {
   // The Handler must be lowercase, conform to the DNS Label (RFC 1123) requirements,
   // and is immutable.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:format="k8s-short-name"
-  // +k8s:alpha(since: "1.36")=+k8s:immutable
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:format="k8s-short-name"
+  // +k8s:beta(since: "1.37")=+k8s:immutable
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string handler = 2;
 
   // overhead represents the resource overhead associated with running a pod for a

--- a/staging/src/k8s.io/api/node/v1/types.go
+++ b/staging/src/k8s.io/api/node/v1/types.go
@@ -51,9 +51,9 @@ type RuntimeClass struct {
 	// The Handler must be lowercase, conform to the DNS Label (RFC 1123) requirements,
 	// and is immutable.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:format="k8s-short-name"
-	// +k8s:alpha(since: "1.36")=+k8s:immutable
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:format="k8s-short-name"
+	// +k8s:beta(since: "1.37")=+k8s:immutable
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Handler string `json:"handler" protobuf:"bytes,2,opt,name=handler"`
 
 	// overhead represents the resource overhead associated with running a pod for a

--- a/staging/src/k8s.io/api/node/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/node/v1alpha1/generated.proto
@@ -82,9 +82,9 @@ message RuntimeClassSpec {
   // The runtimeHandler must be lowercase, conform to the DNS Label (RFC 1123)
   // requirements, and is immutable.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:format="k8s-short-name"
-  // +k8s:alpha(since: "1.36")=+k8s:immutable
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:format="k8s-short-name"
+  // +k8s:beta(since: "1.37")=+k8s:immutable
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string runtimeHandler = 1;
 
   // overhead represents the resource overhead associated with running a pod for a

--- a/staging/src/k8s.io/api/node/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/node/v1alpha1/types.go
@@ -61,9 +61,9 @@ type RuntimeClassSpec struct {
 	// The runtimeHandler must be lowercase, conform to the DNS Label (RFC 1123)
 	// requirements, and is immutable.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:format="k8s-short-name"
-	// +k8s:alpha(since: "1.36")=+k8s:immutable
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:format="k8s-short-name"
+	// +k8s:beta(since: "1.37")=+k8s:immutable
+	// +k8s:beta(since: "1.37")=+k8s:required
 	RuntimeHandler string `json:"runtimeHandler" protobuf:"bytes,1,opt,name=runtimeHandler"`
 
 	// overhead represents the resource overhead associated with running a pod for a

--- a/staging/src/k8s.io/api/node/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/node/v1beta1/generated.proto
@@ -60,9 +60,9 @@ message RuntimeClass {
   // The handler must be lowercase, conform to the DNS Label (RFC 1123) requirements,
   // and is immutable.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:format="k8s-short-name"
-  // +k8s:alpha(since: "1.36")=+k8s:immutable
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:format="k8s-short-name"
+  // +k8s:beta(since: "1.37")=+k8s:immutable
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string handler = 2;
 
   // overhead represents the resource overhead associated with running a pod for a

--- a/staging/src/k8s.io/api/node/v1beta1/types.go
+++ b/staging/src/k8s.io/api/node/v1beta1/types.go
@@ -52,9 +52,9 @@ type RuntimeClass struct {
 	// The handler must be lowercase, conform to the DNS Label (RFC 1123) requirements,
 	// and is immutable.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:format="k8s-short-name"
-	// +k8s:alpha(since: "1.36")=+k8s:immutable
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:format="k8s-short-name"
+	// +k8s:beta(since: "1.37")=+k8s:immutable
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Handler string `json:"handler" protobuf:"bytes,2,opt,name=handler"`
 
 	// overhead represents the resource overhead associated with running a pod for a

--- a/staging/src/k8s.io/api/rbac/v1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1/generated.proto
@@ -46,7 +46,7 @@ message ClusterRole {
   // Rules holds all the PolicyRules for this ClusterRole
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated PolicyRule rules = 2;
 
   // AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
@@ -66,7 +66,7 @@ message ClusterRoleBinding {
   // Subjects holds references to the objects the role applies to.
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated Subject subjects = 2;
 
   // RoleRef can only reference a ClusterRole in the global namespace.
@@ -102,7 +102,7 @@ message PolicyRule {
   // Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
   // +listType=atomic
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   repeated string verbs = 1;
 
   // APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
@@ -138,7 +138,7 @@ message Role {
   // Rules holds all the PolicyRules for this Role
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated PolicyRule rules = 2;
 }
 
@@ -153,7 +153,7 @@ message RoleBinding {
   // Subjects holds references to the objects the role applies to.
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated Subject subjects = 2;
 
   // RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
@@ -197,7 +197,7 @@ message RoleRef {
 
   // Name is the name of resource being referenced
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string name = 3;
 }
 
@@ -218,7 +218,7 @@ message Subject {
 
   // Name of the object being referenced.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string name = 3;
 
   // Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty

--- a/staging/src/k8s.io/api/rbac/v1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1/types.go
@@ -50,7 +50,7 @@ type PolicyRule struct {
 	// Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 	// +listType=atomic
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 
 	// APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
@@ -90,7 +90,7 @@ type Subject struct {
 	APIGroup string `json:"apiGroup,omitempty" protobuf:"bytes,2,opt,name=apiGroup"`
 	// Name of the object being referenced.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,3,opt,name=name"`
 	// Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
 	// the Authorizer should report an error.
@@ -109,7 +109,7 @@ type RoleRef struct {
 	Kind string `json:"kind" protobuf:"bytes,2,opt,name=kind"`
 	// Name is the name of resource being referenced
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,3,opt,name=name"`
 }
 
@@ -127,7 +127,7 @@ type Role struct {
 	// Rules holds all the PolicyRules for this Role
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 }
 
@@ -147,7 +147,7 @@ type RoleBinding struct {
 	// Subjects holds references to the objects the role applies to.
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
 	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
@@ -201,7 +201,7 @@ type ClusterRole struct {
 	// Rules holds all the PolicyRules for this ClusterRole
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 
 	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
@@ -236,7 +236,7 @@ type ClusterRoleBinding struct {
 	// Subjects holds references to the objects the role applies to.
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
 	// RoleRef can only reference a ClusterRole in the global namespace.

--- a/staging/src/k8s.io/api/rbac/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/generated.proto
@@ -47,7 +47,7 @@ message ClusterRole {
   // Rules holds all the PolicyRules for this ClusterRole
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated PolicyRule rules = 2;
 
   // AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
@@ -68,7 +68,7 @@ message ClusterRoleBinding {
   // Subjects holds references to the objects the role applies to.
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated Subject subjects = 2;
 
   // RoleRef can only reference a ClusterRole in the global namespace.
@@ -105,7 +105,7 @@ message PolicyRule {
   // Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
   // +listType=atomic
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   repeated string verbs = 1;
 
   // APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
@@ -142,7 +142,7 @@ message Role {
   // Rules holds all the PolicyRules for this Role
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated PolicyRule rules = 2;
 }
 
@@ -158,7 +158,7 @@ message RoleBinding {
   // Subjects holds references to the objects the role applies to.
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated Subject subjects = 2;
 
   // RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
@@ -202,7 +202,7 @@ message RoleRef {
 
   // Name is the name of resource being referenced
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string name = 3;
 }
 
@@ -223,7 +223,7 @@ message Subject {
 
   // Name of the object being referenced.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string name = 3;
 
   // Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty

--- a/staging/src/k8s.io/api/rbac/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/types.go
@@ -50,7 +50,7 @@ type PolicyRule struct {
 	// Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 	// +listType=atomic
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 
 	// APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
@@ -90,7 +90,7 @@ type Subject struct {
 	APIVersion string `json:"apiVersion,omitempty" protobuf:"bytes,2,opt,name=apiVersion"`
 	// Name of the object being referenced.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,3,opt,name=name"`
 	// Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
 	// the Authorizer should report an error.
@@ -108,7 +108,7 @@ type RoleRef struct {
 	Kind string `json:"kind" protobuf:"bytes,2,opt,name=kind"`
 	// Name is the name of resource being referenced
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,3,opt,name=name"`
 }
 
@@ -126,7 +126,7 @@ type Role struct {
 	// Rules holds all the PolicyRules for this Role
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 }
 
@@ -146,7 +146,7 @@ type RoleBinding struct {
 	// Subjects holds references to the objects the role applies to.
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
 	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
@@ -199,7 +199,7 @@ type ClusterRole struct {
 	// Rules holds all the PolicyRules for this ClusterRole
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 
 	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
@@ -234,7 +234,7 @@ type ClusterRoleBinding struct {
 	// Subjects holds references to the objects the role applies to.
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
 	// RoleRef can only reference a ClusterRole in the global namespace.

--- a/staging/src/k8s.io/api/rbac/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1beta1/generated.proto
@@ -47,7 +47,7 @@ message ClusterRole {
   // Rules holds all the PolicyRules for this ClusterRole
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated PolicyRule rules = 2;
 
   // AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
@@ -68,7 +68,7 @@ message ClusterRoleBinding {
   // Subjects holds references to the objects the role applies to.
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated Subject subjects = 2;
 
   // RoleRef can only reference a ClusterRole in the global namespace.
@@ -105,7 +105,7 @@ message PolicyRule {
   // Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
   // +listType=atomic
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   repeated string verbs = 1;
 
   // APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
@@ -143,7 +143,7 @@ message Role {
   // Rules holds all the PolicyRules for this Role
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated PolicyRule rules = 2;
 }
 
@@ -159,7 +159,7 @@ message RoleBinding {
   // Subjects holds references to the objects the role applies to.
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated Subject subjects = 2;
 
   // RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
@@ -203,7 +203,7 @@ message RoleRef {
 
   // Name is the name of resource being referenced
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string name = 3;
 }
 
@@ -223,7 +223,7 @@ message Subject {
 
   // Name of the object being referenced.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string name = 3;
 
   // Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty

--- a/staging/src/k8s.io/api/rbac/v1beta1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1beta1/types.go
@@ -50,7 +50,7 @@ type PolicyRule struct {
 	// Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 	// +listType=atomic
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 
 	// APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
@@ -90,7 +90,7 @@ type Subject struct {
 	APIGroup string `json:"apiGroup,omitempty" protobuf:"bytes,2,opt,name=apiGroup"`
 	// Name of the object being referenced.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,3,opt,name=name"`
 	// Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
 	// the Authorizer should report an error.
@@ -108,7 +108,7 @@ type RoleRef struct {
 	Kind string `json:"kind" protobuf:"bytes,2,opt,name=kind"`
 	// Name is the name of resource being referenced
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,3,opt,name=name"`
 }
 
@@ -130,7 +130,7 @@ type Role struct {
 	// Rules holds all the PolicyRules for this Role
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 }
 
@@ -154,7 +154,7 @@ type RoleBinding struct {
 	// Subjects holds references to the objects the role applies to.
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
 	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
@@ -219,7 +219,7 @@ type ClusterRole struct {
 	// Rules holds all the PolicyRules for this ClusterRole
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
 	// If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be
@@ -257,7 +257,7 @@ type ClusterRoleBinding struct {
 	// Subjects holds references to the objects the role applies to.
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
 	// RoleRef can only reference a ClusterRole in the global namespace.

--- a/staging/src/k8s.io/api/resource/v1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1/generated.proto
@@ -65,8 +65,8 @@ message AllocatedDeviceStatus {
   //
   // +optional
   // +featureGate=DRAConsumableCapacity
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-uuid
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-uuid
   optional string shareID = 7;
 
   // Conditions contains the latest observation of the device's state.
@@ -93,7 +93,7 @@ message AllocatedDeviceStatus {
   // NetworkData contains network-related information specific to the device.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional NetworkDeviceData networkData = 6;
 }
 
@@ -327,8 +327,8 @@ message CounterSet {
   // It must be a DNS label.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-short-name
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-short-name
   optional string name = 1;
 
   // Counters defines the set of counters for this CounterSet
@@ -337,8 +337,8 @@ message CounterSet {
   // The maximum number of counters is 32.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:eachKey=+k8s:format=k8s-short-name
   map<string, Counter> counters = 2;
 }
 
@@ -357,7 +357,7 @@ message Device {
   // The maximum number of attributes and capacities combined is 32.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   map<string, DeviceAttribute> attributes = 2;
 
   // Capacity defines the set of capacities for this device.
@@ -378,13 +378,13 @@ message Device {
   // device is 2.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +listType=atomic
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:unique=map
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=counterSet
+  // +k8s:beta(since: "1.37")=+k8s:unique=map
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=counterSet
   // +featureGate=DRAPartitionableDevices
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=2
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=2
   repeated DeviceCounterConsumption consumesCounters = 4;
 
   // NodeName identifies the node where the device is available.
@@ -431,7 +431,7 @@ message Device {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated DeviceTaint taints = 8;
 
   // BindsToNode indicates if the usage of an allocation involving this device
@@ -461,8 +461,8 @@ message Device {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=4
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=4
   repeated string bindingConditions = 10;
 
   // BindingFailureConditions defines the conditions for binding failure.
@@ -479,8 +479,8 @@ message Device {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=4
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=4
   repeated string bindingFailureConditions = 11;
 
   // AllowMultipleAllocations marks whether the device is allowed to be allocated to multiple DeviceRequests.
@@ -515,7 +515,7 @@ message DeviceAllocationConfiguration {
   // or from a claim.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string source = 1;
 
   // Requests lists the names of requests where the configuration applies.
@@ -527,10 +527,10 @@ message DeviceAllocationConfiguration {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:unique=set
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:unique=set
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated string requests = 2;
 
   optional DeviceConfiguration deviceConfiguration = 3;
@@ -542,8 +542,8 @@ message DeviceAllocationResult {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated DeviceRequestAllocationResult results = 1;
 
   // This field is a combination of all the claim and class configuration parameters.
@@ -556,8 +556,8 @@ message DeviceAllocationResult {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=64
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=64
   repeated DeviceAllocationConfiguration config = 2;
 }
 
@@ -566,30 +566,30 @@ message DeviceAttribute {
   // IntValue is a number.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:unionMember
   optional int64 int = 2;
 
   // BoolValue is a true/false value.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:unionMember
   optional bool bool = 3;
 
   // StringValue is a string. Must not be longer than 64 characters.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:unionMember
   optional string string = 4;
 
   // VersionValue is a semantic version according to semver.org spec 2.0.0.
   // Must not be longer than 64 characters.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:unionMember
   optional string version = 5;
 
   // IntValues is a non-empty list of numbers.
@@ -599,8 +599,8 @@ message DeviceAttribute {
   // +optional
   // +listType=atomic
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:unionMember
   // +featureGate=DRAListTypeAttributes
   repeated int64 ints = 6;
 
@@ -609,8 +609,8 @@ message DeviceAttribute {
   // +optional
   // +listType=atomic
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:unionMember
   // +featureGate=DRAListTypeAttributes
   repeated bool bools = 7;
 
@@ -622,8 +622,8 @@ message DeviceAttribute {
   // +optional
   // +listType=atomic
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:unionMember
   // +k8s:alpha(since: "1.37")=+k8s:eachVal=+k8s:maxBytes=64
   // +featureGate=DRAListTypeAttributes
   repeated string strings = 8;
@@ -636,8 +636,8 @@ message DeviceAttribute {
   // +optional
   // +listType=atomic
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:unionMember
   // +featureGate=DRAListTypeAttributes
   repeated string versions = 9;
 }
@@ -675,11 +675,11 @@ message DeviceClaim {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:unique=map
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:unique=map
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=name
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated DeviceRequest requests = 1;
 
   // These constraints must be satisfied by the set of devices that get
@@ -687,8 +687,8 @@ message DeviceClaim {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated DeviceConstraint constraints = 2;
 
   // This field holds configuration for multiple potential drivers which
@@ -697,8 +697,8 @@ message DeviceClaim {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated DeviceClaimConfiguration config = 3;
 }
 
@@ -713,10 +713,10 @@ message DeviceClaimConfiguration {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:unique=set
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:unique=set
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated string requests = 1;
 
   optional DeviceConfiguration deviceConfiguration = 2;
@@ -729,8 +729,8 @@ message DeviceClaimConfiguration {
 message DeviceClass {
   // Standard object metadata
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:format=k8s-long-name
+  // +k8s:beta(since: "1.37")=+k8s:subfield(name)=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:subfield(name)=+k8s:format=k8s-long-name
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec defines what can be allocated and how to configure it.
@@ -767,8 +767,8 @@ message DeviceClassSpec {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated DeviceSelector selectors = 1;
 
   // Config defines configuration parameters that apply to each device that is claimed via this class.
@@ -779,8 +779,8 @@ message DeviceClassSpec {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated DeviceClassConfiguration config = 2;
 
   // ExtendedResourceName is the extended resource name for the devices of this class.
@@ -794,8 +794,8 @@ message DeviceClassSpec {
   //
   // +optional
   // +featureGate=DRAExtendedResource
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-extended-resource-name
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-extended-resource-name
   optional string extendedResourceName = 4;
 }
 
@@ -807,7 +807,7 @@ message DeviceConfiguration {
   //
   // +optional
   // +oneOf=ConfigurationType
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional OpaqueDeviceConfiguration opaque = 1;
 }
 
@@ -825,10 +825,10 @@ message DeviceConstraint {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:unique=set
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:unique=set
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated string requests = 1;
 
   // MatchAttribute requires that all devices in question have this
@@ -851,8 +851,8 @@ message DeviceConstraint {
   //
   // +optional
   // +oneOf=ConstraintType
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-resource-fully-qualified-name
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-resource-fully-qualified-name
   optional string matchAttribute = 2;
 
   // DistinctAttribute requires that all devices in question have this
@@ -884,8 +884,8 @@ message DeviceCounterConsumption {
   // counters defined will be consumed.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-short-name
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-short-name
   optional string counterSet = 1;
 
   // Counters defines the counters that will be consumed by the device.
@@ -893,8 +893,8 @@ message DeviceCounterConsumption {
   // The maximum number of counters is 32.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:eachKey=+k8s:format=k8s-short-name
   map<string, Counter> counters = 2;
 }
 
@@ -924,7 +924,7 @@ message DeviceRequest {
   //
   // +optional
   // +oneOf=deviceRequestType
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional ExactDeviceRequest exactly = 2;
 
   // FirstAvailable contains subrequests, of which exactly one will be
@@ -945,11 +945,11 @@ message DeviceRequest {
   // +oneOf=deviceRequestType
   // +listType=atomic
   // +featureGate=DRAPrioritizedList
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:unique=map
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=8
+  // +k8s:beta(since: "1.37")=+k8s:unique=map
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=name
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=8
   repeated DeviceSubRequest firstAvailable = 3;
 }
 
@@ -974,9 +974,9 @@ message DeviceRequestAllocationResult {
   // vendor of the driver. It should use only lower case characters.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name-caseless
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:maxLength=63
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-long-name-caseless
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:maxLength=63
   optional string driver = 2;
 
   // This name together with the driver name and the device name field
@@ -986,8 +986,8 @@ message DeviceRequestAllocationResult {
   // DNS sub-domains separated by slashes.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-resource-pool-name
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-resource-pool-name
   optional string pool = 3;
 
   // Device references one device instance via its name in the driver's
@@ -1018,7 +1018,7 @@ message DeviceRequestAllocationResult {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated DeviceToleration tolerations = 6;
 
   // BindingConditions contains a copy of the BindingConditions
@@ -1030,8 +1030,8 @@ message DeviceRequestAllocationResult {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=4
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=4
   repeated string bindingConditions = 7;
 
   // BindingFailureConditions contains a copy of the BindingFailureConditions
@@ -1043,8 +1043,8 @@ message DeviceRequestAllocationResult {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=4
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=4
   repeated string bindingFailureConditions = 8;
 
   // ShareID uniquely identifies an individual allocation share of the device,
@@ -1054,8 +1054,8 @@ message DeviceRequestAllocationResult {
   //
   // +optional
   // +featureGate=DRAConsumableCapacity
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-uuid
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-uuid
   optional string shareID = 9;
 
   // ConsumedCapacity tracks the amount of capacity consumed per device as part of the claim request.
@@ -1112,8 +1112,8 @@ message DeviceSubRequest {
   // to reference.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-long-name
   optional string deviceClassName = 2;
 
   // Selectors define criteria which must be satisfied by a specific
@@ -1123,8 +1123,8 @@ message DeviceSubRequest {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated DeviceSelector selectors = 3;
 
   // AllocationMode and its related fields define how devices are allocated
@@ -1146,7 +1146,7 @@ message DeviceSubRequest {
   // requests with unknown modes.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional string allocationMode = 4;
 
   // Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1177,7 +1177,7 @@ message DeviceSubRequest {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated DeviceToleration tolerations = 6;
 
   // Capacity define resource requirements against each capacity.
@@ -1224,7 +1224,7 @@ message DeviceTaint {
   // Consumers must treat unknown effects like None.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string effect = 3;
 
   // TimeAdded represents the time at which the taint was added or
@@ -1251,8 +1251,8 @@ message DeviceToleration {
   // Must be a label name.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-label-key
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-label-key
   optional string key = 1;
 
   // Operator represents a key's relationship to the value.
@@ -1262,7 +1262,7 @@ message DeviceToleration {
   //
   // +optional
   // +default="Equal"
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional string operator = 2;
 
   // Value is the taint value the toleration matches to.
@@ -1276,7 +1276,7 @@ message DeviceToleration {
   // When specified, allowed values are NoSchedule and NoExecute.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional string effect = 4;
 
   // TolerationSeconds represents the period of time the toleration (which must be
@@ -1314,8 +1314,8 @@ message ExactDeviceRequest {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated DeviceSelector selectors = 2;
 
   // AllocationMode and its related fields define how devices are allocated
@@ -1338,7 +1338,7 @@ message ExactDeviceRequest {
   // requests with unknown modes.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional string allocationMode = 3;
 
   // Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1382,7 +1382,7 @@ message ExactDeviceRequest {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated DeviceToleration tolerations = 6;
 
   // Capacity define resource requirements against each capacity.
@@ -1414,8 +1414,8 @@ message NetworkDeviceData {
   // Must not be longer than 256 bytes.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxBytes=256
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxBytes=256
   optional string interfaceName = 1;
 
   // IPs lists the network addresses assigned to the device's network interface.
@@ -1426,10 +1426,10 @@ message NetworkDeviceData {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:unique=set
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=16
+  // +k8s:beta(since: "1.37")=+k8s:unique=set
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=16
   repeated string ips = 2;
 
   // HardwareAddress represents the hardware address (e.g. MAC Address) of the device's network interface.
@@ -1437,8 +1437,8 @@ message NetworkDeviceData {
   // Must not be longer than 128 bytes.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxBytes=128
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxBytes=128
   optional string hardwareAddress = 3;
 }
 
@@ -1493,9 +1493,9 @@ message OpaqueDeviceConfiguration {
   // vendor of the driver. It should use only lower case characters.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name-caseless
-  // +k8s:alpha(since: "1.36")=+k8s:maxLength=63
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-long-name-caseless
+  // +k8s:beta(since: "1.37")=+k8s:maxLength=63
   optional string driver = 1;
 
   // Parameters can contain arbitrary data. It is the responsibility of
@@ -1521,7 +1521,7 @@ message ResourceClaim {
 
   // Spec describes what is being requested and how to configure it.
   // The spec is immutable.
-  // +k8s:alpha(since: "1.36")=+k8s:immutable
+  // +k8s:beta(since: "1.37")=+k8s:immutable
   // +optional
   optional ResourceClaimSpec spec = 2;
 
@@ -1577,8 +1577,8 @@ message ResourceClaimStatus {
   // Allocation is set once the claim has been allocated successfully.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:update=NoModify
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:update=NoModify
   optional AllocationResult allocation = 1;
 
   // ReservedFor indicates which entities are currently allowed to use
@@ -1606,10 +1606,10 @@ message ResourceClaimStatus {
   // +listMapKey=uid
   // +patchStrategy=merge
   // +patchMergeKey=uid
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:listType=map
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=uid
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=256
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:listType=map
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=uid
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=256
   repeated ResourceClaimConsumerReference reservedFor = 2;
 
   // Devices contains the status of each device allocated for this
@@ -1617,18 +1617,18 @@ message ResourceClaimStatus {
   // information. Entries are owned by their respective drivers.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +listType=map
   // +listMapKey=driver
   // +listMapKey=device
   // +listMapKey=pool
   // +listMapKey=shareID
   // +featureGate=DRAResourceClaimDeviceStatus
-  // +k8s:alpha(since: "1.36")=+k8s:listType=map
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=driver
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=device
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=pool
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=shareID
+  // +k8s:beta(since: "1.37")=+k8s:listType=map
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=driver
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=device
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=pool
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=shareID
   repeated AllocatedDeviceStatus devices = 4;
 }
 
@@ -1813,7 +1813,7 @@ message ResourceSliceSpec {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +zeroOrOneOf=ResourceSliceType
   repeated Device devices = 6;
 
@@ -1839,14 +1839,14 @@ message ResourceSliceSpec {
   // The maximum number of counter sets is 8.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +listType=atomic
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:unique=map
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
+  // +k8s:beta(since: "1.37")=+k8s:unique=map
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=name
   // +featureGate=DRAPartitionableDevices
   // +zeroOrOneOf=ResourceSliceType
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=8
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=8
   repeated CounterSet sharedCounters = 8;
 }
 

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -175,7 +175,7 @@ type ResourceSliceSpec struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +zeroOrOneOf=ResourceSliceType
 	Devices []Device `json:"devices,omitempty" protobuf:"bytes,6,name=devices"`
 
@@ -201,14 +201,14 @@ type ResourceSliceSpec struct {
 	// The maximum number of counter sets is 8.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +listType=atomic
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:unique=map
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
+	// +k8s:beta(since: "1.37")=+k8s:unique=map
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=name
 	// +featureGate=DRAPartitionableDevices
 	// +zeroOrOneOf=ResourceSliceType
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=8
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=8
 	SharedCounters []CounterSet `json:"sharedCounters,omitempty" protobuf:"bytes,8,name=sharedCounters"`
 }
 
@@ -225,8 +225,8 @@ type CounterSet struct {
 	// It must be a DNS label.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-short-name
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-short-name
 	Name string `json:"name" protobuf:"bytes,1,name=name"`
 
 	// Counters defines the set of counters for this CounterSet
@@ -235,8 +235,8 @@ type CounterSet struct {
 	// The maximum number of counters is 32.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:eachKey=+k8s:format=k8s-short-name
 	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,name=counters"`
 }
 
@@ -327,7 +327,7 @@ type Device struct {
 	// The maximum number of attributes and capacities combined is 32.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Attributes map[QualifiedName]DeviceAttribute `json:"attributes,omitempty" protobuf:"bytes,2,rep,name=attributes"`
 
 	// Capacity defines the set of capacities for this device.
@@ -348,13 +348,13 @@ type Device struct {
 	// device is 2.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +listType=atomic
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:unique=map
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=counterSet
+	// +k8s:beta(since: "1.37")=+k8s:unique=map
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=counterSet
 	// +featureGate=DRAPartitionableDevices
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=2
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=2
 	ConsumesCounters []DeviceCounterConsumption `json:"consumesCounters,omitempty" protobuf:"bytes,4,rep,name=consumesCounters"`
 
 	// NodeName identifies the node where the device is available.
@@ -401,7 +401,7 @@ type Device struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Taints []DeviceTaint `json:"taints,omitempty" protobuf:"bytes,8,rep,name=taints"`
 
 	// BindsToNode indicates if the usage of an allocation involving this device
@@ -431,8 +431,8 @@ type Device struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=4
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=4
 	BindingConditions []string `json:"bindingConditions,omitempty" protobuf:"bytes,10,rep,name=bindingConditions"`
 
 	// BindingFailureConditions defines the conditions for binding failure.
@@ -449,8 +449,8 @@ type Device struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=4
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=4
 	BindingFailureConditions []string `json:"bindingFailureConditions,omitempty" protobuf:"bytes,11,rep,name=bindingFailureConditions"`
 
 	// AllowMultipleAllocations marks whether the device is allowed to be allocated to multiple DeviceRequests.
@@ -523,8 +523,8 @@ type DeviceCounterConsumption struct {
 	// counters defined will be consumed.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-short-name
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-short-name
 	CounterSet string `json:"counterSet" protobuf:"bytes,1,opt,name=counterSet"`
 
 	// Counters defines the counters that will be consumed by the device.
@@ -532,8 +532,8 @@ type DeviceCounterConsumption struct {
 	// The maximum number of counters is 32.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:eachKey=+k8s:format=k8s-short-name
 	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,opt,name=counters"`
 }
 
@@ -697,30 +697,30 @@ type DeviceAttribute struct {
 	// IntValue is a number.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:unionMember
 	IntValue *int64 `json:"int,omitempty" protobuf:"varint,2,opt,name=int"`
 
 	// BoolValue is a true/false value.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:unionMember
 	BoolValue *bool `json:"bool,omitempty" protobuf:"varint,3,opt,name=bool"`
 
 	// StringValue is a string. Must not be longer than 64 characters.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:unionMember
 	StringValue *string `json:"string,omitempty" protobuf:"bytes,4,opt,name=string"`
 
 	// VersionValue is a semantic version according to semver.org spec 2.0.0.
 	// Must not be longer than 64 characters.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:unionMember
 	VersionValue *string `json:"version,omitempty" protobuf:"bytes,5,opt,name=version"`
 
 	// IntValues is a non-empty list of numbers.
@@ -730,8 +730,8 @@ type DeviceAttribute struct {
 	// +optional
 	// +listType=atomic
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:unionMember
 	// +featureGate=DRAListTypeAttributes
 	IntValues []int64 `json:"ints,omitempty" protobuf:"varint,6,opt,name=ints"`
 
@@ -740,8 +740,8 @@ type DeviceAttribute struct {
 	// +optional
 	// +listType=atomic
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:unionMember
 	// +featureGate=DRAListTypeAttributes
 	BoolValues []bool `json:"bools,omitempty" protobuf:"varint,7,opt,name=bools"`
 
@@ -753,8 +753,8 @@ type DeviceAttribute struct {
 	// +optional
 	// +listType=atomic
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:unionMember
 	// +k8s:alpha(since: "1.37")=+k8s:eachVal=+k8s:maxBytes=64
 	// +featureGate=DRAListTypeAttributes
 	StringValues []string `json:"strings,omitempty" protobuf:"bytes,8,opt,name=strings"`
@@ -767,8 +767,8 @@ type DeviceAttribute struct {
 	// +optional
 	// +listType=atomic
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:unionMember
 	// +featureGate=DRAListTypeAttributes
 	VersionValues []string `json:"versions,omitempty" protobuf:"bytes,9,opt,name=versions"`
 }
@@ -805,7 +805,7 @@ type DeviceTaint struct {
 	// Consumers must treat unknown effects like None.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Effect DeviceTaintEffect `json:"effect" protobuf:"bytes,3,name=effect,casttype=DeviceTaintEffect"`
 
 	// ^^^^
@@ -844,7 +844,7 @@ type DeviceTaint struct {
 }
 
 // +enum
-// +k8s:alpha(since: "1.36")=+k8s:enum
+// +k8s:beta(since: "1.37")=+k8s:enum
 type DeviceTaintEffect string
 
 const (
@@ -892,7 +892,7 @@ type ResourceClaim struct {
 
 	// Spec describes what is being requested and how to configure it.
 	// The spec is immutable.
-	// +k8s:alpha(since: "1.36")=+k8s:immutable
+	// +k8s:beta(since: "1.37")=+k8s:immutable
 	// +optional
 	Spec ResourceClaimSpec `json:"spec" protobuf:"bytes,2,name=spec"`
 
@@ -921,11 +921,11 @@ type DeviceClaim struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:unique=map
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:unique=map
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=name
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Requests []DeviceRequest `json:"requests" protobuf:"bytes,1,name=requests"`
 
 	// These constraints must be satisfied by the set of devices that get
@@ -933,8 +933,8 @@ type DeviceClaim struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Constraints []DeviceConstraint `json:"constraints,omitempty" protobuf:"bytes,2,opt,name=constraints"`
 
 	// This field holds configuration for multiple potential drivers which
@@ -943,8 +943,8 @@ type DeviceClaim struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Config []DeviceClaimConfiguration `json:"config,omitempty" protobuf:"bytes,3,opt,name=config"`
 
 	// Potential future extension, ignored by older schedulers. This is
@@ -995,7 +995,7 @@ type DeviceRequest struct {
 	//
 	// +optional
 	// +oneOf=deviceRequestType
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Exactly *ExactDeviceRequest `json:"exactly,omitempty" protobuf:"bytes,2,name=exactly"`
 
 	// FirstAvailable contains subrequests, of which exactly one will be
@@ -1016,11 +1016,11 @@ type DeviceRequest struct {
 	// +oneOf=deviceRequestType
 	// +listType=atomic
 	// +featureGate=DRAPrioritizedList
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:unique=map
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=8
+	// +k8s:beta(since: "1.37")=+k8s:unique=map
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=name
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=8
 	FirstAvailable []DeviceSubRequest `json:"firstAvailable,omitempty" protobuf:"bytes,3,name=firstAvailable"`
 }
 
@@ -1048,8 +1048,8 @@ type ExactDeviceRequest struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Selectors []DeviceSelector `json:"selectors,omitempty" protobuf:"bytes,2,name=selectors"`
 
 	// AllocationMode and its related fields define how devices are allocated
@@ -1072,7 +1072,7 @@ type ExactDeviceRequest struct {
 	// requests with unknown modes.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	AllocationMode DeviceAllocationMode `json:"allocationMode,omitempty" protobuf:"bytes,3,opt,name=allocationMode"`
 
 	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1116,7 +1116,7 @@ type ExactDeviceRequest struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,6,opt,name=tolerations"`
 
 	// Capacity define resource requirements against each capacity.
@@ -1168,8 +1168,8 @@ type DeviceSubRequest struct {
 	// to reference.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-long-name
 	DeviceClassName string `json:"deviceClassName" protobuf:"bytes,2,name=deviceClassName"`
 
 	// Selectors define criteria which must be satisfied by a specific
@@ -1179,8 +1179,8 @@ type DeviceSubRequest struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Selectors []DeviceSelector `json:"selectors,omitempty" protobuf:"bytes,3,name=selectors"`
 
 	// AllocationMode and its related fields define how devices are allocated
@@ -1202,7 +1202,7 @@ type DeviceSubRequest struct {
 	// requests with unknown modes.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	AllocationMode DeviceAllocationMode `json:"allocationMode,omitempty" protobuf:"bytes,4,opt,name=allocationMode"`
 
 	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1233,7 +1233,7 @@ type DeviceSubRequest struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,6,opt,name=tolerations"`
 
 	// Capacity define resource requirements against each capacity.
@@ -1290,7 +1290,7 @@ const (
 )
 
 // +enum
-// +k8s:alpha(since: "1.36")=+k8s:enum
+// +k8s:beta(since: "1.37")=+k8s:enum
 type DeviceAllocationMode string
 
 // Valid [DeviceRequest.CountMode] values.
@@ -1426,10 +1426,10 @@ type DeviceConstraint struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:unique=set
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:unique=set
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Requests []string `json:"requests,omitempty" protobuf:"bytes,1,opt,name=requests"`
 
 	// MatchAttribute requires that all devices in question have this
@@ -1452,8 +1452,8 @@ type DeviceConstraint struct {
 	//
 	// +optional
 	// +oneOf=ConstraintType
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-resource-fully-qualified-name
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-resource-fully-qualified-name
 	MatchAttribute *FullyQualifiedName `json:"matchAttribute,omitempty" protobuf:"bytes,2,opt,name=matchAttribute"`
 
 	// Potential future extension, not part of the current design:
@@ -1499,10 +1499,10 @@ type DeviceClaimConfiguration struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:unique=set
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:unique=set
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Requests []string `json:"requests,omitempty" protobuf:"bytes,1,opt,name=requests"`
 
 	DeviceConfiguration `json:"" protobuf:"bytes,2,name=deviceConfiguration"`
@@ -1516,7 +1516,7 @@ type DeviceConfiguration struct {
 	//
 	// +optional
 	// +oneOf=ConfigurationType
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Opaque *OpaqueDeviceConfiguration `json:"opaque,omitempty" protobuf:"bytes,1,opt,name=opaque"`
 }
 
@@ -1533,9 +1533,9 @@ type OpaqueDeviceConfiguration struct {
 	// vendor of the driver. It should use only lower case characters.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name-caseless
-	// +k8s:alpha(since: "1.36")=+k8s:maxLength=63
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-long-name-caseless
+	// +k8s:beta(since: "1.37")=+k8s:maxLength=63
 	Driver string `json:"driver" protobuf:"bytes,1,name=driver"`
 
 	// Parameters can contain arbitrary data. It is the responsibility of
@@ -1561,8 +1561,8 @@ type DeviceToleration struct {
 	// Must be a label name.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-label-key
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-label-key
 	Key string `json:"key,omitempty" protobuf:"bytes,1,opt,name=key"`
 
 	// Operator represents a key's relationship to the value.
@@ -1572,7 +1572,7 @@ type DeviceToleration struct {
 	//
 	// +optional
 	// +default="Equal"
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Operator DeviceTolerationOperator `json:"operator,omitempty" protobuf:"bytes,2,opt,name=operator,casttype=DeviceTolerationOperator"`
 
 	// Value is the taint value the toleration matches to.
@@ -1586,7 +1586,7 @@ type DeviceToleration struct {
 	// When specified, allowed values are NoSchedule and NoExecute.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Effect DeviceTaintEffect `json:"effect,omitempty" protobuf:"bytes,4,opt,name=effect,casttype=DeviceTaintEffect"`
 
 	// TolerationSeconds represents the period of time the toleration (which must be
@@ -1603,7 +1603,7 @@ type DeviceToleration struct {
 // A toleration operator is the set of operators that can be used in a toleration.
 //
 // +enum
-// +k8s:alpha(since: "1.36")=+k8s:enum
+// +k8s:beta(since: "1.37")=+k8s:enum
 type DeviceTolerationOperator string
 
 const (
@@ -1617,8 +1617,8 @@ type ResourceClaimStatus struct {
 	// Allocation is set once the claim has been allocated successfully.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:update=NoModify
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:update=NoModify
 	Allocation *AllocationResult `json:"allocation,omitempty" protobuf:"bytes,1,opt,name=allocation"`
 
 	// ReservedFor indicates which entities are currently allowed to use
@@ -1646,10 +1646,10 @@ type ResourceClaimStatus struct {
 	// +listMapKey=uid
 	// +patchStrategy=merge
 	// +patchMergeKey=uid
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:listType=map
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=uid
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=256
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:listType=map
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=uid
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=256
 	ReservedFor []ResourceClaimConsumerReference `json:"reservedFor,omitempty" protobuf:"bytes,2,opt,name=reservedFor" patchStrategy:"merge" patchMergeKey:"uid"`
 
 	// DeallocationRequested is tombstoned since Kubernetes 1.32 where
@@ -1662,18 +1662,18 @@ type ResourceClaimStatus struct {
 	// information. Entries are owned by their respective drivers.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +listType=map
 	// +listMapKey=driver
 	// +listMapKey=device
 	// +listMapKey=pool
 	// +listMapKey=shareID
 	// +featureGate=DRAResourceClaimDeviceStatus
-	// +k8s:alpha(since: "1.36")=+k8s:listType=map
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=driver
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=device
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=pool
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=shareID
+	// +k8s:beta(since: "1.37")=+k8s:listType=map
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=driver
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=device
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=pool
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=shareID
 	Devices []AllocatedDeviceStatus `json:"devices,omitempty" protobuf:"bytes,4,opt,name=devices"`
 }
 
@@ -1736,8 +1736,8 @@ type DeviceAllocationResult struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Results []DeviceRequestAllocationResult `json:"results,omitempty" protobuf:"bytes,1,opt,name=results"`
 
 	// This field is a combination of all the claim and class configuration parameters.
@@ -1750,8 +1750,8 @@ type DeviceAllocationResult struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=64
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=64
 	Config []DeviceAllocationConfiguration `json:"config,omitempty" protobuf:"bytes,2,opt,name=config"`
 }
 
@@ -1780,9 +1780,9 @@ type DeviceRequestAllocationResult struct {
 	// vendor of the driver. It should use only lower case characters.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name-caseless
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:maxLength=63
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-long-name-caseless
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:maxLength=63
 	Driver string `json:"driver" protobuf:"bytes,2,name=driver"`
 
 	// This name together with the driver name and the device name field
@@ -1792,8 +1792,8 @@ type DeviceRequestAllocationResult struct {
 	// DNS sub-domains separated by slashes.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-resource-pool-name
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-resource-pool-name
 	Pool string `json:"pool" protobuf:"bytes,3,name=pool"`
 
 	// Device references one device instance via its name in the driver's
@@ -1824,7 +1824,7 @@ type DeviceRequestAllocationResult struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,6,opt,name=tolerations"`
 
 	// BindingConditions contains a copy of the BindingConditions
@@ -1836,8 +1836,8 @@ type DeviceRequestAllocationResult struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=4
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=4
 	BindingConditions []string `json:"bindingConditions,omitempty" protobuf:"bytes,7,rep,name=bindingConditions"`
 
 	// BindingFailureConditions contains a copy of the BindingFailureConditions
@@ -1849,8 +1849,8 @@ type DeviceRequestAllocationResult struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=4
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=4
 	BindingFailureConditions []string `json:"bindingFailureConditions,omitempty" protobuf:"bytes,8,rep,name=bindingFailureConditions"`
 
 	// ShareID uniquely identifies an individual allocation share of the device,
@@ -1860,8 +1860,8 @@ type DeviceRequestAllocationResult struct {
 	//
 	// +optional
 	// +featureGate=DRAConsumableCapacity
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-uuid
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-uuid
 	ShareID *types.UID `json:"shareID,omitempty" protobuf:"bytes,9,opt,name=shareID"`
 
 	// ConsumedCapacity tracks the amount of capacity consumed per device as part of the claim request.
@@ -1885,7 +1885,7 @@ type DeviceAllocationConfiguration struct {
 	// or from a claim.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Source AllocationConfigSource `json:"source" protobuf:"bytes,1,name=source"`
 
 	// Requests lists the names of requests where the configuration applies.
@@ -1897,17 +1897,17 @@ type DeviceAllocationConfiguration struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:unique=set
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:unique=set
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Requests []string `json:"requests,omitempty" protobuf:"bytes,2,opt,name=requests"`
 
 	DeviceConfiguration `json:"" protobuf:"bytes,3,name=deviceConfiguration"`
 }
 
 // +enum
-// +k8s:alpha(since: "1.36")=+k8s:enum
+// +k8s:beta(since: "1.37")=+k8s:enum
 type AllocationConfigSource string
 
 // Valid [DeviceAllocationConfiguration.Source] values.
@@ -1943,8 +1943,8 @@ type DeviceClass struct {
 	metav1.TypeMeta `json:""`
 	// Standard object metadata
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:format=k8s-long-name
+	// +k8s:beta(since: "1.37")=+k8s:subfield(name)=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:subfield(name)=+k8s:format=k8s-long-name
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Spec defines what can be allocated and how to configure it.
@@ -1966,8 +1966,8 @@ type DeviceClassSpec struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Selectors []DeviceSelector `json:"selectors,omitempty" protobuf:"bytes,1,opt,name=selectors"`
 
 	// Config defines configuration parameters that apply to each device that is claimed via this class.
@@ -1978,8 +1978,8 @@ type DeviceClassSpec struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Config []DeviceClassConfiguration `json:"config,omitempty" protobuf:"bytes,2,opt,name=config"`
 
 	// SuitableNodes is tombstoned since Kubernetes 1.32 where
@@ -1998,8 +1998,8 @@ type DeviceClassSpec struct {
 	//
 	// +optional
 	// +featureGate=DRAExtendedResource
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-extended-resource-name
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-extended-resource-name
 	ExtendedResourceName *string `json:"extendedResourceName,omitempty" protobuf:"bytes,4,opt,name=extendedResourceName"`
 }
 
@@ -2124,8 +2124,8 @@ type AllocatedDeviceStatus struct {
 	//
 	// +optional
 	// +featureGate=DRAConsumableCapacity
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-uuid
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-uuid
 	ShareID *string `json:"shareID,omitempty" protobuf:"bytes,7,opt,name=shareID"`
 
 	// Conditions contains the latest observation of the device's state.
@@ -2152,7 +2152,7 @@ type AllocatedDeviceStatus struct {
 	// NetworkData contains network-related information specific to the device.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	NetworkData *NetworkDeviceData `json:"networkData,omitempty" protobuf:"bytes,6,opt,name=networkData"`
 }
 
@@ -2167,8 +2167,8 @@ type NetworkDeviceData struct {
 	// Must not be longer than 256 bytes.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxBytes=256
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxBytes=256
 	InterfaceName string `json:"interfaceName,omitempty" protobuf:"bytes,1,opt,name=interfaceName"`
 
 	// IPs lists the network addresses assigned to the device's network interface.
@@ -2179,10 +2179,10 @@ type NetworkDeviceData struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:unique=set
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=16
+	// +k8s:beta(since: "1.37")=+k8s:unique=set
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=16
 	IPs []string `json:"ips,omitempty" protobuf:"bytes,2,opt,name=ips"`
 
 	// HardwareAddress represents the hardware address (e.g. MAC Address) of the device's network interface.
@@ -2190,7 +2190,7 @@ type NetworkDeviceData struct {
 	// Must not be longer than 128 bytes.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxBytes=128
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxBytes=128
 	HardwareAddress string `json:"hardwareAddress,omitempty" protobuf:"bytes,3,opt,name=hardwareAddress"`
 }

--- a/staging/src/k8s.io/api/resource/v1alpha3/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1alpha3/generated.proto
@@ -129,7 +129,7 @@ message DeviceTaint {
   // Consumers must treat unknown effects like None.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string effect = 3;
 
   // TimeAdded represents the time at which the taint was added or

--- a/staging/src/k8s.io/api/resource/v1alpha3/types.go
+++ b/staging/src/k8s.io/api/resource/v1alpha3/types.go
@@ -149,7 +149,7 @@ type DeviceTaint struct {
 	// Consumers must treat unknown effects like None.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Effect DeviceTaintEffect `json:"effect" protobuf:"bytes,3,name=effect,casttype=DeviceTaintEffect"`
 
 	// ^^^^
@@ -188,7 +188,7 @@ type DeviceTaint struct {
 }
 
 // +enum
-// +k8s:alpha(since: "1.36")=+k8s:enum
+// +k8s:beta(since: "1.37")=+k8s:enum
 type DeviceTaintEffect string
 
 const (

--- a/staging/src/k8s.io/api/resource/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta1/generated.proto
@@ -65,8 +65,8 @@ message AllocatedDeviceStatus {
   //
   // +optional
   // +featureGate=DRAConsumableCapacity
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-uuid
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-uuid
   optional string shareID = 7;
 
   // Conditions contains the latest observation of the device's state.
@@ -93,7 +93,7 @@ message AllocatedDeviceStatus {
   // NetworkData contains network-related information specific to the device.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional NetworkDeviceData networkData = 6;
 }
 
@@ -129,7 +129,7 @@ message BasicDevice {
   // The maximum number of attributes and capacities combined is 32.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   map<string, DeviceAttribute> attributes = 1;
 
   // Capacity defines the set of capacities for this device.
@@ -150,13 +150,13 @@ message BasicDevice {
   // device is 2.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +listType=atomic
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:unique=map
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=counterSet
+  // +k8s:beta(since: "1.37")=+k8s:unique=map
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=counterSet
   // +featureGate=DRAPartitionableDevices
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=2
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=2
   repeated DeviceCounterConsumption consumesCounters = 3;
 
   // NodeName identifies the node where the device is available.
@@ -202,7 +202,7 @@ message BasicDevice {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated DeviceTaint taints = 7;
 
   // BindsToNode indicates if the usage of an allocation involving this device
@@ -232,8 +232,8 @@ message BasicDevice {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=4
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=4
   repeated string bindingConditions = 9;
 
   // BindingFailureConditions defines the conditions for binding failure.
@@ -250,8 +250,8 @@ message BasicDevice {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=4
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=4
   repeated string bindingFailureConditions = 10;
 
   // AllowMultipleAllocations marks whether the device is allowed to be allocated to multiple DeviceRequests.
@@ -485,8 +485,8 @@ message CounterSet {
   // It must be a DNS label.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-short-name
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-short-name
   optional string name = 1;
 
   // Counters defines the set of counters for this CounterSet
@@ -495,8 +495,8 @@ message CounterSet {
   // The maximum number of counters is 32.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:eachKey=+k8s:format=k8s-short-name
   map<string, Counter> counters = 2;
 }
 
@@ -513,7 +513,7 @@ message Device {
   //
   // +optional
   // +oneOf=deviceType
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional BasicDevice basic = 2;
 }
 
@@ -524,7 +524,7 @@ message DeviceAllocationConfiguration {
   // or from a claim.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string source = 1;
 
   // Requests lists the names of requests where the configuration applies.
@@ -536,10 +536,10 @@ message DeviceAllocationConfiguration {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:unique=set
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:unique=set
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated string requests = 2;
 
   optional DeviceConfiguration deviceConfiguration = 3;
@@ -551,8 +551,8 @@ message DeviceAllocationResult {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated DeviceRequestAllocationResult results = 1;
 
   // This field is a combination of all the claim and class configuration parameters.
@@ -565,8 +565,8 @@ message DeviceAllocationResult {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=64
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=64
   repeated DeviceAllocationConfiguration config = 2;
 }
 
@@ -575,30 +575,30 @@ message DeviceAttribute {
   // IntValue is a number.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:unionMember
   optional int64 int = 2;
 
   // BoolValue is a true/false value.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:unionMember
   optional bool bool = 3;
 
   // StringValue is a string. Must not be longer than 64 characters.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:unionMember
   optional string string = 4;
 
   // VersionValue is a semantic version according to semver.org spec 2.0.0.
   // Must not be longer than 64 characters.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:unionMember
   optional string version = 5;
 
   // IntValues is a non-empty list of numbers.
@@ -607,8 +607,8 @@ message DeviceAttribute {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:unionMember
   // +featureGate=DRAListTypeAttributes
   repeated int64 ints = 6;
 
@@ -616,8 +616,8 @@ message DeviceAttribute {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:unionMember
   // +featureGate=DRAListTypeAttributes
   repeated bool bools = 7;
 
@@ -628,8 +628,8 @@ message DeviceAttribute {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:unionMember
   // +k8s:alpha(since: "1.37")=+k8s:eachVal=+k8s:maxBytes=64
   // +featureGate=DRAListTypeAttributes
   repeated string strings = 8;
@@ -641,8 +641,8 @@ message DeviceAttribute {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:unionMember
   // +featureGate=DRAListTypeAttributes
   repeated string versions = 9;
 }
@@ -680,11 +680,11 @@ message DeviceClaim {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:unique=map
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:unique=map
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=name
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated DeviceRequest requests = 1;
 
   // These constraints must be satisfied by the set of devices that get
@@ -692,8 +692,8 @@ message DeviceClaim {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated DeviceConstraint constraints = 2;
 
   // This field holds configuration for multiple potential drivers which
@@ -702,8 +702,8 @@ message DeviceClaim {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated DeviceClaimConfiguration config = 3;
 }
 
@@ -718,10 +718,10 @@ message DeviceClaimConfiguration {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:unique=set
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:unique=set
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated string requests = 1;
 
   optional DeviceConfiguration deviceConfiguration = 2;
@@ -737,8 +737,8 @@ message DeviceClaimConfiguration {
 message DeviceClass {
   // Standard object metadata
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:format=k8s-long-name
+  // +k8s:beta(since: "1.37")=+k8s:subfield(name)=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:subfield(name)=+k8s:format=k8s-long-name
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec defines what can be allocated and how to configure it.
@@ -775,8 +775,8 @@ message DeviceClassSpec {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated DeviceSelector selectors = 1;
 
   // Config defines configuration parameters that apply to each device that is claimed via this class.
@@ -787,8 +787,8 @@ message DeviceClassSpec {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated DeviceClassConfiguration config = 2;
 
   // ExtendedResourceName is the extended resource name for the devices of this class.
@@ -802,8 +802,8 @@ message DeviceClassSpec {
   //
   // +optional
   // +featureGate=DRAExtendedResource
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-extended-resource-name
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-extended-resource-name
   optional string extendedResourceName = 4;
 }
 
@@ -815,7 +815,7 @@ message DeviceConfiguration {
   //
   // +optional
   // +oneOf=ConfigurationType
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional OpaqueDeviceConfiguration opaque = 1;
 }
 
@@ -833,10 +833,10 @@ message DeviceConstraint {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:unique=set
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:unique=set
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated string requests = 1;
 
   // MatchAttribute requires that all devices in question have this
@@ -859,8 +859,8 @@ message DeviceConstraint {
   //
   // +optional
   // +oneOf=ConstraintType
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-resource-fully-qualified-name
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-resource-fully-qualified-name
   optional string matchAttribute = 2;
 
   // DistinctAttribute requires that all devices in question have this
@@ -892,8 +892,8 @@ message DeviceCounterConsumption {
   // counters defined will be consumed.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-short-name
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-short-name
   optional string counterSet = 1;
 
   // Counters defines the counters that will be consumed by the device.
@@ -901,8 +901,8 @@ message DeviceCounterConsumption {
   // The maximum number of counters is 32.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:eachKey=+k8s:format=k8s-short-name
   map<string, Counter> counters = 2;
 }
 
@@ -948,8 +948,8 @@ message DeviceRequest {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated DeviceSelector selectors = 3;
 
   // AllocationMode and its related fields define how devices are allocated
@@ -975,7 +975,7 @@ message DeviceRequest {
   // requests with unknown modes.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional string allocationMode = 4;
 
   // Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1025,11 +1025,11 @@ message DeviceRequest {
   // +oneOf=deviceRequestType
   // +listType=atomic
   // +featureGate=DRAPrioritizedList
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:unique=map
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=8
+  // +k8s:beta(since: "1.37")=+k8s:unique=map
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=name
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=8
   repeated DeviceSubRequest firstAvailable = 7;
 
   // If specified, the request's tolerations.
@@ -1056,7 +1056,7 @@ message DeviceRequest {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated DeviceToleration tolerations = 8;
 
   // Capacity define resource requirements against each capacity.
@@ -1098,9 +1098,9 @@ message DeviceRequestAllocationResult {
   // vendor of the driver. It should use only lower case characters.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name-caseless
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:maxLength=63
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-long-name-caseless
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:maxLength=63
   optional string driver = 2;
 
   // This name together with the driver name and the device name field
@@ -1110,8 +1110,8 @@ message DeviceRequestAllocationResult {
   // DNS sub-domains separated by slashes.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-resource-pool-name
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-resource-pool-name
   optional string pool = 3;
 
   // Device references one device instance via its name in the driver's
@@ -1143,7 +1143,7 @@ message DeviceRequestAllocationResult {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated DeviceToleration tolerations = 6;
 
   // BindingConditions contains a copy of the BindingConditions
@@ -1155,8 +1155,8 @@ message DeviceRequestAllocationResult {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=4
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=4
   repeated string bindingConditions = 7;
 
   // BindingFailureConditions contains a copy of the BindingFailureConditions
@@ -1168,8 +1168,8 @@ message DeviceRequestAllocationResult {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=4
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=4
   repeated string bindingFailureConditions = 8;
 
   // ShareID uniquely identifies an individual allocation share of the device,
@@ -1179,8 +1179,8 @@ message DeviceRequestAllocationResult {
   //
   // +optional
   // +featureGate=DRAConsumableCapacity
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-uuid
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-uuid
   optional string shareID = 9;
 
   // ConsumedCapacity tracks the amount of capacity consumed per device as part of the claim request.
@@ -1238,8 +1238,8 @@ message DeviceSubRequest {
   // to reference.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-long-name
   optional string deviceClassName = 2;
 
   // Selectors define criteria which must be satisfied by a specific
@@ -1249,8 +1249,8 @@ message DeviceSubRequest {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated DeviceSelector selectors = 3;
 
   // AllocationMode and its related fields define how devices are allocated
@@ -1272,7 +1272,7 @@ message DeviceSubRequest {
   // requests with unknown modes.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional string allocationMode = 4;
 
   // Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1303,7 +1303,7 @@ message DeviceSubRequest {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated DeviceToleration tolerations = 7;
 
   // Capacity define resource requirements against each capacity.
@@ -1350,7 +1350,7 @@ message DeviceTaint {
   // Consumers must treat unknown effects like None.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string effect = 3;
 
   // TimeAdded represents the time at which the taint was added or
@@ -1377,8 +1377,8 @@ message DeviceToleration {
   // Must be a label name.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-label-key
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-label-key
   optional string key = 1;
 
   // Operator represents a key's relationship to the value.
@@ -1388,7 +1388,7 @@ message DeviceToleration {
   //
   // +optional
   // +default="Equal"
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional string operator = 2;
 
   // Value is the taint value the toleration matches to.
@@ -1402,7 +1402,7 @@ message DeviceToleration {
   // When specified, allowed values are NoSchedule and NoExecute.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional string effect = 4;
 
   // TolerationSeconds represents the period of time the toleration (which must be
@@ -1427,8 +1427,8 @@ message NetworkDeviceData {
   // Must not be longer than 256 bytes.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxBytes=256
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxBytes=256
   optional string interfaceName = 1;
 
   // IPs lists the network addresses assigned to the device's network interface.
@@ -1441,10 +1441,10 @@ message NetworkDeviceData {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:unique=set
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=16
+  // +k8s:beta(since: "1.37")=+k8s:unique=set
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=16
   repeated string ips = 2;
 
   // HardwareAddress represents the hardware address (e.g. MAC Address) of the device's network interface.
@@ -1452,8 +1452,8 @@ message NetworkDeviceData {
   // Must not be longer than 128 bytes.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxBytes=128
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxBytes=128
   optional string hardwareAddress = 3;
 }
 
@@ -1508,9 +1508,9 @@ message OpaqueDeviceConfiguration {
   // vendor of the driver. It should use only lower case characters.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:maxLength=63
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name-caseless
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:maxLength=63
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-long-name-caseless
   optional string driver = 1;
 
   // Parameters can contain arbitrary data. It is the responsibility of
@@ -1539,7 +1539,7 @@ message ResourceClaim {
 
   // Spec describes what is being requested and how to configure it.
   // The spec is immutable.
-  // +k8s:alpha(since: "1.36")=+k8s:immutable
+  // +k8s:beta(since: "1.37")=+k8s:immutable
   // +optional
   optional ResourceClaimSpec spec = 2;
 
@@ -1595,8 +1595,8 @@ message ResourceClaimStatus {
   // Allocation is set once the claim has been allocated successfully.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:update=NoModify
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:update=NoModify
   optional AllocationResult allocation = 1;
 
   // ReservedFor indicates which entities are currently allowed to use
@@ -1624,10 +1624,10 @@ message ResourceClaimStatus {
   // +listMapKey=uid
   // +patchStrategy=merge
   // +patchMergeKey=uid
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:listType=map
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=uid
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=256
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:listType=map
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=uid
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=256
   repeated ResourceClaimConsumerReference reservedFor = 2;
 
   // Devices contains the status of each device allocated for this
@@ -1635,18 +1635,18 @@ message ResourceClaimStatus {
   // information. Entries are owned by their respective drivers.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +listType=map
   // +listMapKey=driver
   // +listMapKey=device
   // +listMapKey=pool
   // +listMapKey=shareID
   // +featureGate=DRAResourceClaimDeviceStatus
-  // +k8s:alpha(since: "1.36")=+k8s:listType=map
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=driver
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=device
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=pool
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=shareID
+  // +k8s:beta(since: "1.37")=+k8s:listType=map
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=driver
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=device
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=pool
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=shareID
   repeated AllocatedDeviceStatus devices = 4;
 }
 
@@ -1837,7 +1837,7 @@ message ResourceSliceSpec {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +zeroOrOneOf=ResourceSliceType
   repeated Device devices = 6;
 
@@ -1863,14 +1863,14 @@ message ResourceSliceSpec {
   // The maximum number of counter sets is 8.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +listType=atomic
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:unique=map
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
+  // +k8s:beta(since: "1.37")=+k8s:unique=map
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=name
   // +featureGate=DRAPartitionableDevices
   // +zeroOrOneOf=ResourceSliceType
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=8
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=8
   repeated CounterSet sharedCounters = 8;
 }
 

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -160,7 +160,7 @@ type ResourceSliceSpec struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +zeroOrOneOf=ResourceSliceType
 	Devices []Device `json:"devices,omitempty" protobuf:"bytes,6,name=devices"`
 
@@ -186,14 +186,14 @@ type ResourceSliceSpec struct {
 	// The maximum number of counter sets is 8.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +listType=atomic
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:unique=map
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
+	// +k8s:beta(since: "1.37")=+k8s:unique=map
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=name
 	// +featureGate=DRAPartitionableDevices
 	// +zeroOrOneOf=ResourceSliceType
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=8
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=8
 	SharedCounters []CounterSet `json:"sharedCounters,omitempty" protobuf:"bytes,8,name=sharedCounters"`
 }
 
@@ -210,8 +210,8 @@ type CounterSet struct {
 	// It must be a DNS label.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-short-name
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-short-name
 	Name string `json:"name" protobuf:"bytes,1,name=name"`
 
 	// Counters defines the set of counters for this CounterSet
@@ -220,8 +220,8 @@ type CounterSet struct {
 	// The maximum number of counters is 32.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:eachKey=+k8s:format=k8s-short-name
 	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,name=counters"`
 }
 
@@ -318,7 +318,7 @@ type Device struct {
 	//
 	// +optional
 	// +oneOf=deviceType
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Basic *BasicDevice `json:"basic,omitempty" protobuf:"bytes,2,opt,name=basic"`
 }
 
@@ -330,7 +330,7 @@ type BasicDevice struct {
 	// The maximum number of attributes and capacities combined is 32.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Attributes map[QualifiedName]DeviceAttribute `json:"attributes,omitempty" protobuf:"bytes,1,rep,name=attributes"`
 
 	// Capacity defines the set of capacities for this device.
@@ -351,13 +351,13 @@ type BasicDevice struct {
 	// device is 2.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +listType=atomic
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:unique=map
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=counterSet
+	// +k8s:beta(since: "1.37")=+k8s:unique=map
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=counterSet
 	// +featureGate=DRAPartitionableDevices
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=2
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=2
 	ConsumesCounters []DeviceCounterConsumption `json:"consumesCounters,omitempty" protobuf:"bytes,3,rep,name=consumesCounters"`
 
 	// NodeName identifies the node where the device is available.
@@ -403,7 +403,7 @@ type BasicDevice struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Taints []DeviceTaint `json:"taints,omitempty" protobuf:"bytes,7,rep,name=taints"`
 
 	// BindsToNode indicates if the usage of an allocation involving this device
@@ -433,8 +433,8 @@ type BasicDevice struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=4
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=4
 	BindingConditions []string `json:"bindingConditions,omitempty" protobuf:"bytes,9,rep,name=bindingConditions"`
 
 	// BindingFailureConditions defines the conditions for binding failure.
@@ -451,8 +451,8 @@ type BasicDevice struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=4
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=4
 	BindingFailureConditions []string `json:"bindingFailureConditions,omitempty" protobuf:"bytes,10,rep,name=bindingFailureConditions"`
 
 	// AllowMultipleAllocations marks whether the device is allowed to be allocated to multiple DeviceRequests.
@@ -525,8 +525,8 @@ type DeviceCounterConsumption struct {
 	// counters defined will be consumed.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-short-name
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-short-name
 	CounterSet string `json:"counterSet" protobuf:"bytes,1,opt,name=counterSet"`
 
 	// Counters defines the counters that will be consumed by the device.
@@ -534,8 +534,8 @@ type DeviceCounterConsumption struct {
 	// The maximum number of counters is 32.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:eachKey=+k8s:format=k8s-short-name
 	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,opt,name=counters"`
 }
 
@@ -691,30 +691,30 @@ type DeviceAttribute struct {
 	// IntValue is a number.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:unionMember
 	IntValue *int64 `json:"int,omitempty" protobuf:"varint,2,opt,name=int"`
 
 	// BoolValue is a true/false value.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:unionMember
 	BoolValue *bool `json:"bool,omitempty" protobuf:"varint,3,opt,name=bool"`
 
 	// StringValue is a string. Must not be longer than 64 characters.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:unionMember
 	StringValue *string `json:"string,omitempty" protobuf:"bytes,4,opt,name=string"`
 
 	// VersionValue is a semantic version according to semver.org spec 2.0.0.
 	// Must not be longer than 64 characters.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:unionMember
 	VersionValue *string `json:"version,omitempty" protobuf:"bytes,5,opt,name=version"`
 
 	// IntValues is a non-empty list of numbers.
@@ -723,8 +723,8 @@ type DeviceAttribute struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:unionMember
 	// +featureGate=DRAListTypeAttributes
 	IntValues []int64 `json:"ints,omitempty" protobuf:"varint,6,opt,name=ints"`
 
@@ -732,8 +732,8 @@ type DeviceAttribute struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:unionMember
 	// +featureGate=DRAListTypeAttributes
 	BoolValues []bool `json:"bools,omitempty" protobuf:"varint,7,opt,name=bools"`
 
@@ -744,8 +744,8 @@ type DeviceAttribute struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:unionMember
 	// +k8s:alpha(since: "1.37")=+k8s:eachVal=+k8s:maxBytes=64
 	// +featureGate=DRAListTypeAttributes
 	StringValues []string `json:"strings,omitempty" protobuf:"bytes,8,opt,name=strings"`
@@ -757,8 +757,8 @@ type DeviceAttribute struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:unionMember
 	// +featureGate=DRAListTypeAttributes
 	VersionValues []string `json:"versions,omitempty" protobuf:"bytes,9,opt,name=versions"`
 }
@@ -795,7 +795,7 @@ type DeviceTaint struct {
 	// Consumers must treat unknown effects like None.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Effect DeviceTaintEffect `json:"effect" protobuf:"bytes,3,name=effect,casttype=DeviceTaintEffect"`
 
 	// ^^^^
@@ -834,7 +834,7 @@ type DeviceTaint struct {
 }
 
 // +enum
-// +k8s:alpha(since: "1.36")=+k8s:enum
+// +k8s:beta(since: "1.37")=+k8s:enum
 type DeviceTaintEffect string
 
 const (
@@ -885,7 +885,7 @@ type ResourceClaim struct {
 
 	// Spec describes what is being requested and how to configure it.
 	// The spec is immutable.
-	// +k8s:alpha(since: "1.36")=+k8s:immutable
+	// +k8s:beta(since: "1.37")=+k8s:immutable
 	// +optional
 	Spec ResourceClaimSpec `json:"spec" protobuf:"bytes,2,name=spec"`
 
@@ -914,11 +914,11 @@ type DeviceClaim struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:unique=map
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:unique=map
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=name
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Requests []DeviceRequest `json:"requests" protobuf:"bytes,1,name=requests"`
 
 	// These constraints must be satisfied by the set of devices that get
@@ -926,8 +926,8 @@ type DeviceClaim struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Constraints []DeviceConstraint `json:"constraints,omitempty" protobuf:"bytes,2,opt,name=constraints"`
 
 	// This field holds configuration for multiple potential drivers which
@@ -936,8 +936,8 @@ type DeviceClaim struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Config []DeviceClaimConfiguration `json:"config,omitempty" protobuf:"bytes,3,opt,name=config"`
 
 	// Potential future extension, ignored by older schedulers. This is
@@ -1004,8 +1004,8 @@ type DeviceRequest struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Selectors []DeviceSelector `json:"selectors,omitempty" protobuf:"bytes,3,name=selectors"`
 
 	// AllocationMode and its related fields define how devices are allocated
@@ -1031,7 +1031,7 @@ type DeviceRequest struct {
 	// requests with unknown modes.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	AllocationMode DeviceAllocationMode `json:"allocationMode,omitempty" protobuf:"bytes,4,opt,name=allocationMode"`
 
 	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1081,11 +1081,11 @@ type DeviceRequest struct {
 	// +oneOf=deviceRequestType
 	// +listType=atomic
 	// +featureGate=DRAPrioritizedList
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:unique=map
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=8
+	// +k8s:beta(since: "1.37")=+k8s:unique=map
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=name
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=8
 	FirstAvailable []DeviceSubRequest `json:"firstAvailable,omitempty" protobuf:"bytes,7,name=firstAvailable"`
 
 	// If specified, the request's tolerations.
@@ -1112,7 +1112,7 @@ type DeviceRequest struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,8,opt,name=tolerations"`
 
 	// Capacity define resource requirements against each capacity.
@@ -1165,8 +1165,8 @@ type DeviceSubRequest struct {
 	// to reference.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-long-name
 	DeviceClassName string `json:"deviceClassName" protobuf:"bytes,2,name=deviceClassName"`
 
 	// Selectors define criteria which must be satisfied by a specific
@@ -1176,8 +1176,8 @@ type DeviceSubRequest struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Selectors []DeviceSelector `json:"selectors,omitempty" protobuf:"bytes,3,name=selectors"`
 
 	// AllocationMode and its related fields define how devices are allocated
@@ -1199,7 +1199,7 @@ type DeviceSubRequest struct {
 	// requests with unknown modes.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	AllocationMode DeviceAllocationMode `json:"allocationMode,omitempty" protobuf:"bytes,4,opt,name=allocationMode"`
 
 	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1230,7 +1230,7 @@ type DeviceSubRequest struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,7,opt,name=tolerations"`
 
 	// Capacity define resource requirements against each capacity.
@@ -1287,7 +1287,7 @@ const (
 )
 
 // +enum
-// +k8s:alpha(since: "1.36")=+k8s:enum
+// +k8s:beta(since: "1.37")=+k8s:enum
 type DeviceAllocationMode string
 
 // Valid [DeviceRequest.CountMode] values.
@@ -1423,10 +1423,10 @@ type DeviceConstraint struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:unique=set
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:unique=set
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Requests []string `json:"requests,omitempty" protobuf:"bytes,1,opt,name=requests"`
 
 	// MatchAttribute requires that all devices in question have this
@@ -1449,8 +1449,8 @@ type DeviceConstraint struct {
 	//
 	// +optional
 	// +oneOf=ConstraintType
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-resource-fully-qualified-name
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-resource-fully-qualified-name
 	MatchAttribute *FullyQualifiedName `json:"matchAttribute,omitempty" protobuf:"bytes,2,opt,name=matchAttribute"`
 
 	// Potential future extension, not part of the current design:
@@ -1496,10 +1496,10 @@ type DeviceClaimConfiguration struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:unique=set
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:unique=set
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Requests []string `json:"requests,omitempty" protobuf:"bytes,1,opt,name=requests"`
 
 	DeviceConfiguration `json:"" protobuf:"bytes,2,name=deviceConfiguration"`
@@ -1513,7 +1513,7 @@ type DeviceConfiguration struct {
 	//
 	// +optional
 	// +oneOf=ConfigurationType
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Opaque *OpaqueDeviceConfiguration `json:"opaque,omitempty" protobuf:"bytes,1,opt,name=opaque"`
 }
 
@@ -1530,9 +1530,9 @@ type OpaqueDeviceConfiguration struct {
 	// vendor of the driver. It should use only lower case characters.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:maxLength=63
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name-caseless
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:maxLength=63
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-long-name-caseless
 	Driver string `json:"driver" protobuf:"bytes,1,name=driver"`
 
 	// Parameters can contain arbitrary data. It is the responsibility of
@@ -1558,8 +1558,8 @@ type DeviceToleration struct {
 	// Must be a label name.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-label-key
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-label-key
 	Key string `json:"key,omitempty" protobuf:"bytes,1,opt,name=key"`
 
 	// Operator represents a key's relationship to the value.
@@ -1569,7 +1569,7 @@ type DeviceToleration struct {
 	//
 	// +optional
 	// +default="Equal"
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Operator DeviceTolerationOperator `json:"operator,omitempty" protobuf:"bytes,2,opt,name=operator,casttype=DeviceTolerationOperator"`
 
 	// Value is the taint value the toleration matches to.
@@ -1583,7 +1583,7 @@ type DeviceToleration struct {
 	// When specified, allowed values are NoSchedule and NoExecute.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Effect DeviceTaintEffect `json:"effect,omitempty" protobuf:"bytes,4,opt,name=effect,casttype=DeviceTaintEffect"`
 
 	// TolerationSeconds represents the period of time the toleration (which must be
@@ -1600,7 +1600,7 @@ type DeviceToleration struct {
 // A toleration operator is the set of operators that can be used in a toleration.
 //
 // +enum
-// +k8s:alpha(since: "1.36")=+k8s:enum
+// +k8s:beta(since: "1.37")=+k8s:enum
 type DeviceTolerationOperator string
 
 const (
@@ -1614,8 +1614,8 @@ type ResourceClaimStatus struct {
 	// Allocation is set once the claim has been allocated successfully.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:update=NoModify
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:update=NoModify
 	Allocation *AllocationResult `json:"allocation,omitempty" protobuf:"bytes,1,opt,name=allocation"`
 
 	// ReservedFor indicates which entities are currently allowed to use
@@ -1643,10 +1643,10 @@ type ResourceClaimStatus struct {
 	// +listMapKey=uid
 	// +patchStrategy=merge
 	// +patchMergeKey=uid
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:listType=map
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=uid
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=256
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:listType=map
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=uid
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=256
 	ReservedFor []ResourceClaimConsumerReference `json:"reservedFor,omitempty" protobuf:"bytes,2,opt,name=reservedFor" patchStrategy:"merge" patchMergeKey:"uid"`
 
 	// DeallocationRequested is tombstoned since Kubernetes 1.32 where
@@ -1659,18 +1659,18 @@ type ResourceClaimStatus struct {
 	// information. Entries are owned by their respective drivers.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +listType=map
 	// +listMapKey=driver
 	// +listMapKey=device
 	// +listMapKey=pool
 	// +listMapKey=shareID
 	// +featureGate=DRAResourceClaimDeviceStatus
-	// +k8s:alpha(since: "1.36")=+k8s:listType=map
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=driver
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=device
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=pool
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=shareID
+	// +k8s:beta(since: "1.37")=+k8s:listType=map
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=driver
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=device
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=pool
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=shareID
 	Devices []AllocatedDeviceStatus `json:"devices,omitempty" protobuf:"bytes,4,opt,name=devices"`
 }
 
@@ -1733,8 +1733,8 @@ type DeviceAllocationResult struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Results []DeviceRequestAllocationResult `json:"results,omitempty" protobuf:"bytes,1,opt,name=results"`
 
 	// This field is a combination of all the claim and class configuration parameters.
@@ -1747,8 +1747,8 @@ type DeviceAllocationResult struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=64
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=64
 	Config []DeviceAllocationConfiguration `json:"config,omitempty" protobuf:"bytes,2,opt,name=config"`
 }
 
@@ -1777,9 +1777,9 @@ type DeviceRequestAllocationResult struct {
 	// vendor of the driver. It should use only lower case characters.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name-caseless
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:maxLength=63
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-long-name-caseless
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:maxLength=63
 	Driver string `json:"driver" protobuf:"bytes,2,name=driver"`
 
 	// This name together with the driver name and the device name field
@@ -1789,8 +1789,8 @@ type DeviceRequestAllocationResult struct {
 	// DNS sub-domains separated by slashes.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-resource-pool-name
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-resource-pool-name
 	Pool string `json:"pool" protobuf:"bytes,3,name=pool"`
 
 	// Device references one device instance via its name in the driver's
@@ -1822,7 +1822,7 @@ type DeviceRequestAllocationResult struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,6,opt,name=tolerations"`
 
 	// BindingConditions contains a copy of the BindingConditions
@@ -1834,8 +1834,8 @@ type DeviceRequestAllocationResult struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=4
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=4
 	BindingConditions []string `json:"bindingConditions,omitempty" protobuf:"bytes,7,rep,name=bindingConditions"`
 
 	// BindingFailureConditions contains a copy of the BindingFailureConditions
@@ -1847,8 +1847,8 @@ type DeviceRequestAllocationResult struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=4
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=4
 	BindingFailureConditions []string `json:"bindingFailureConditions,omitempty" protobuf:"bytes,8,rep,name=bindingFailureConditions"`
 
 	// ShareID uniquely identifies an individual allocation share of the device,
@@ -1858,8 +1858,8 @@ type DeviceRequestAllocationResult struct {
 	//
 	// +optional
 	// +featureGate=DRAConsumableCapacity
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-uuid
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-uuid
 	ShareID *types.UID `json:"shareID,omitempty" protobuf:"bytes,9,opt,name=shareID"`
 
 	// ConsumedCapacity tracks the amount of capacity consumed per device as part of the claim request.
@@ -1883,7 +1883,7 @@ type DeviceAllocationConfiguration struct {
 	// or from a claim.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Source AllocationConfigSource `json:"source" protobuf:"bytes,1,name=source"`
 
 	// Requests lists the names of requests where the configuration applies.
@@ -1895,17 +1895,17 @@ type DeviceAllocationConfiguration struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:unique=set
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:unique=set
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Requests []string `json:"requests,omitempty" protobuf:"bytes,2,opt,name=requests"`
 
 	DeviceConfiguration `json:"" protobuf:"bytes,3,name=deviceConfiguration"`
 }
 
 // +enum
-// +k8s:alpha(since: "1.36")=+k8s:enum
+// +k8s:beta(since: "1.37")=+k8s:enum
 type AllocationConfigSource string
 
 // Valid [DeviceAllocationConfiguration.Source] values.
@@ -1944,8 +1944,8 @@ type DeviceClass struct {
 	metav1.TypeMeta `json:""`
 	// Standard object metadata
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:format=k8s-long-name
+	// +k8s:beta(since: "1.37")=+k8s:subfield(name)=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:subfield(name)=+k8s:format=k8s-long-name
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Spec defines what can be allocated and how to configure it.
@@ -1967,8 +1967,8 @@ type DeviceClassSpec struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Selectors []DeviceSelector `json:"selectors,omitempty" protobuf:"bytes,1,opt,name=selectors"`
 
 	// Config defines configuration parameters that apply to each device that is claimed via this class.
@@ -1979,8 +1979,8 @@ type DeviceClassSpec struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Config []DeviceClassConfiguration `json:"config,omitempty" protobuf:"bytes,2,opt,name=config"`
 
 	// SuitableNodes is tombstoned since Kubernetes 1.32 where
@@ -1999,8 +1999,8 @@ type DeviceClassSpec struct {
 	//
 	// +optional
 	// +featureGate=DRAExtendedResource
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-extended-resource-name
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-extended-resource-name
 	ExtendedResourceName *string `json:"extendedResourceName,omitempty" protobuf:"bytes,4,opt,name=extendedResourceName"`
 }
 
@@ -2128,8 +2128,8 @@ type AllocatedDeviceStatus struct {
 	//
 	// +optional
 	// +featureGate=DRAConsumableCapacity
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-uuid
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-uuid
 	ShareID *string `json:"shareID,omitempty" protobuf:"bytes,7,opt,name=shareID"`
 
 	// Conditions contains the latest observation of the device's state.
@@ -2156,7 +2156,7 @@ type AllocatedDeviceStatus struct {
 	// NetworkData contains network-related information specific to the device.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	NetworkData *NetworkDeviceData `json:"networkData,omitempty" protobuf:"bytes,6,opt,name=networkData"`
 }
 
@@ -2171,8 +2171,8 @@ type NetworkDeviceData struct {
 	// Must not be longer than 256 bytes.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxBytes=256
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxBytes=256
 	InterfaceName string `json:"interfaceName,omitempty" protobuf:"bytes,1,opt,name=interfaceName"`
 
 	// IPs lists the network addresses assigned to the device's network interface.
@@ -2185,10 +2185,10 @@ type NetworkDeviceData struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:unique=set
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=16
+	// +k8s:beta(since: "1.37")=+k8s:unique=set
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=16
 	IPs []string `json:"ips,omitempty" protobuf:"bytes,2,opt,name=ips"`
 
 	// HardwareAddress represents the hardware address (e.g. MAC Address) of the device's network interface.
@@ -2196,7 +2196,7 @@ type NetworkDeviceData struct {
 	// Must not be longer than 128 bytes.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxBytes=128
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxBytes=128
 	HardwareAddress string `json:"hardwareAddress,omitempty" protobuf:"bytes,3,opt,name=hardwareAddress"`
 }

--- a/staging/src/k8s.io/api/resource/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta2/generated.proto
@@ -65,8 +65,8 @@ message AllocatedDeviceStatus {
   //
   // +optional
   // +featureGate=DRAConsumableCapacity
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-uuid
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-uuid
   optional string shareID = 7;
 
   // Conditions contains the latest observation of the device's state.
@@ -93,7 +93,7 @@ message AllocatedDeviceStatus {
   // NetworkData contains network-related information specific to the device.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional NetworkDeviceData networkData = 6;
 }
 
@@ -327,8 +327,8 @@ message CounterSet {
   // It must be a DNS label.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-short-name
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-short-name
   optional string name = 1;
 
   // Counters defines the set of counters for this CounterSet
@@ -337,8 +337,8 @@ message CounterSet {
   // The maximum number of counters is 32.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:eachKey=+k8s:format=k8s-short-name
   map<string, Counter> counters = 2;
 }
 
@@ -357,7 +357,7 @@ message Device {
   // The maximum number of attributes and capacities combined is 32.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   map<string, DeviceAttribute> attributes = 2;
 
   // Capacity defines the set of capacities for this device.
@@ -378,13 +378,13 @@ message Device {
   // device is 2.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +listType=atomic
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:unique=map
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=counterSet
+  // +k8s:beta(since: "1.37")=+k8s:unique=map
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=counterSet
   // +featureGate=DRAPartitionableDevices
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=2
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=2
   repeated DeviceCounterConsumption consumesCounters = 4;
 
   // NodeName identifies the node where the device is available.
@@ -431,7 +431,7 @@ message Device {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated DeviceTaint taints = 8;
 
   // BindsToNode indicates if the usage of an allocation involving this device
@@ -461,8 +461,8 @@ message Device {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=4
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=4
   repeated string bindingConditions = 10;
 
   // BindingFailureConditions defines the conditions for binding failure.
@@ -479,8 +479,8 @@ message Device {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=4
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=4
   repeated string bindingFailureConditions = 11;
 
   // AllowMultipleAllocations marks whether the device is allowed to be allocated to multiple DeviceRequests.
@@ -515,7 +515,7 @@ message DeviceAllocationConfiguration {
   // or from a claim.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string source = 1;
 
   // Requests lists the names of requests where the configuration applies.
@@ -527,10 +527,10 @@ message DeviceAllocationConfiguration {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:unique=set
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:unique=set
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated string requests = 2;
 
   optional DeviceConfiguration deviceConfiguration = 3;
@@ -542,8 +542,8 @@ message DeviceAllocationResult {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated DeviceRequestAllocationResult results = 1;
 
   // This field is a combination of all the claim and class configuration parameters.
@@ -556,8 +556,8 @@ message DeviceAllocationResult {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=64
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=64
   repeated DeviceAllocationConfiguration config = 2;
 }
 
@@ -566,30 +566,30 @@ message DeviceAttribute {
   // IntValue is a number.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:unionMember
   optional int64 int = 2;
 
   // BoolValue is a true/false value.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:unionMember
   optional bool bool = 3;
 
   // StringValue is a string. Must not be longer than 64 characters.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:unionMember
   optional string string = 4;
 
   // VersionValue is a semantic version according to semver.org spec 2.0.0.
   // Must not be longer than 64 characters.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:unionMember
   optional string version = 5;
 
   // IntValues is a non-empty list of numbers.
@@ -599,8 +599,8 @@ message DeviceAttribute {
   // +optional
   // +listType=atomic
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:unionMember
   // +featureGate=DRAListTypeAttributes
   repeated int64 ints = 6;
 
@@ -609,8 +609,8 @@ message DeviceAttribute {
   // +optional
   // +listType=atomic
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:unionMember
   // +featureGate=DRAListTypeAttributes
   repeated bool bools = 7;
 
@@ -622,8 +622,8 @@ message DeviceAttribute {
   // +optional
   // +listType=atomic
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:unionMember
   // +k8s:alpha(since: "1.37")=+k8s:eachVal=+k8s:maxBytes=64
   // +featureGate=DRAListTypeAttributes
   repeated string strings = 8;
@@ -636,8 +636,8 @@ message DeviceAttribute {
   // +optional
   // +listType=atomic
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:unionMember
   // +featureGate=DRAListTypeAttributes
   repeated string versions = 9;
 }
@@ -675,11 +675,11 @@ message DeviceClaim {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:unique=map
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:unique=map
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=name
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated DeviceRequest requests = 1;
 
   // These constraints must be satisfied by the set of devices that get
@@ -687,8 +687,8 @@ message DeviceClaim {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated DeviceConstraint constraints = 2;
 
   // This field holds configuration for multiple potential drivers which
@@ -697,8 +697,8 @@ message DeviceClaim {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated DeviceClaimConfiguration config = 3;
 }
 
@@ -713,10 +713,10 @@ message DeviceClaimConfiguration {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:unique=set
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:unique=set
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated string requests = 1;
 
   optional DeviceConfiguration deviceConfiguration = 2;
@@ -732,8 +732,8 @@ message DeviceClaimConfiguration {
 message DeviceClass {
   // Standard object metadata
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:format=k8s-long-name
+  // +k8s:beta(since: "1.37")=+k8s:subfield(name)=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:subfield(name)=+k8s:format=k8s-long-name
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec defines what can be allocated and how to configure it.
@@ -770,8 +770,8 @@ message DeviceClassSpec {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated DeviceSelector selectors = 1;
 
   // Config defines configuration parameters that apply to each device that is claimed via this class.
@@ -782,8 +782,8 @@ message DeviceClassSpec {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated DeviceClassConfiguration config = 2;
 
   // ExtendedResourceName is the extended resource name for the devices of this class.
@@ -797,8 +797,8 @@ message DeviceClassSpec {
   //
   // +optional
   // +featureGate=DRAExtendedResource
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-extended-resource-name
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-extended-resource-name
   optional string extendedResourceName = 4;
 }
 
@@ -810,7 +810,7 @@ message DeviceConfiguration {
   //
   // +optional
   // +oneOf=ConfigurationType
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional OpaqueDeviceConfiguration opaque = 1;
 }
 
@@ -828,10 +828,10 @@ message DeviceConstraint {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:unique=set
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:unique=set
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated string requests = 1;
 
   // MatchAttribute requires that all devices in question have this
@@ -854,8 +854,8 @@ message DeviceConstraint {
   //
   // +optional
   // +oneOf=ConstraintType
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-resource-fully-qualified-name
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-resource-fully-qualified-name
   optional string matchAttribute = 2;
 
   // DistinctAttribute requires that all devices in question have this
@@ -887,8 +887,8 @@ message DeviceCounterConsumption {
   // counters defined will be consumed.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-short-name
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-short-name
   optional string counterSet = 1;
 
   // Counters defines the counters that will be consumed by the device.
@@ -896,8 +896,8 @@ message DeviceCounterConsumption {
   // The maximum number of counters is 32.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:eachKey=+k8s:format=k8s-short-name
   map<string, Counter> counters = 2;
 }
 
@@ -927,7 +927,7 @@ message DeviceRequest {
   //
   // +optional
   // +oneOf=deviceRequestType
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional ExactDeviceRequest exactly = 2;
 
   // FirstAvailable contains subrequests, of which exactly one will be
@@ -948,11 +948,11 @@ message DeviceRequest {
   // +oneOf=deviceRequestType
   // +listType=atomic
   // +featureGate=DRAPrioritizedList
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:unique=map
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=8
+  // +k8s:beta(since: "1.37")=+k8s:unique=map
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=name
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=8
   repeated DeviceSubRequest firstAvailable = 3;
 }
 
@@ -977,9 +977,9 @@ message DeviceRequestAllocationResult {
   // vendor of the driver. It should use only lower case characters.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name-caseless
-  // +k8s:alpha(since: "1.36")=+k8s:maxLength=63
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-long-name-caseless
+  // +k8s:beta(since: "1.37")=+k8s:maxLength=63
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string driver = 2;
 
   // This name together with the driver name and the device name field
@@ -989,8 +989,8 @@ message DeviceRequestAllocationResult {
   // DNS sub-domains separated by slashes.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-resource-pool-name
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-resource-pool-name
   optional string pool = 3;
 
   // Device references one device instance via its name in the driver's
@@ -1022,7 +1022,7 @@ message DeviceRequestAllocationResult {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated DeviceToleration tolerations = 6;
 
   // BindingConditions contains a copy of the BindingConditions
@@ -1034,8 +1034,8 @@ message DeviceRequestAllocationResult {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=4
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=4
   repeated string bindingConditions = 7;
 
   // BindingFailureConditions contains a copy of the BindingFailureConditions
@@ -1047,8 +1047,8 @@ message DeviceRequestAllocationResult {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=4
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=4
   repeated string bindingFailureConditions = 8;
 
   // ShareID uniquely identifies an individual allocation share of the device,
@@ -1058,8 +1058,8 @@ message DeviceRequestAllocationResult {
   //
   // +optional
   // +featureGate=DRAConsumableCapacity
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-uuid
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-uuid
   optional string shareID = 9;
 
   // ConsumedCapacity tracks the amount of capacity consumed per device as part of the claim request.
@@ -1116,8 +1116,8 @@ message DeviceSubRequest {
   // to reference.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-long-name
   optional string deviceClassName = 2;
 
   // Selectors define criteria which must be satisfied by a specific
@@ -1127,8 +1127,8 @@ message DeviceSubRequest {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated DeviceSelector selectors = 3;
 
   // AllocationMode and its related fields define how devices are allocated
@@ -1150,7 +1150,7 @@ message DeviceSubRequest {
   // requests with unknown modes.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional string allocationMode = 4;
 
   // Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1181,7 +1181,7 @@ message DeviceSubRequest {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated DeviceToleration tolerations = 6;
 
   // Capacity define resource requirements against each capacity.
@@ -1228,7 +1228,7 @@ message DeviceTaint {
   // Consumers must treat unknown effects like None.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string effect = 3;
 
   // TimeAdded represents the time at which the taint was added or
@@ -1368,8 +1368,8 @@ message DeviceToleration {
   // Must be a label name.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-label-key
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-label-key
   optional string key = 1;
 
   // Operator represents a key's relationship to the value.
@@ -1379,7 +1379,7 @@ message DeviceToleration {
   //
   // +optional
   // +default="Equal"
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional string operator = 2;
 
   // Value is the taint value the toleration matches to.
@@ -1393,7 +1393,7 @@ message DeviceToleration {
   // When specified, allowed values are NoSchedule and NoExecute.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional string effect = 4;
 
   // TolerationSeconds represents the period of time the toleration (which must be
@@ -1431,8 +1431,8 @@ message ExactDeviceRequest {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=32
   repeated DeviceSelector selectors = 2;
 
   // AllocationMode and its related fields define how devices are allocated
@@ -1455,7 +1455,7 @@ message ExactDeviceRequest {
   // requests with unknown modes.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional string allocationMode = 3;
 
   // Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1500,7 +1500,7 @@ message ExactDeviceRequest {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   repeated DeviceToleration tolerations = 6;
 
   // Capacity define resource requirements against each capacity.
@@ -1532,8 +1532,8 @@ message NetworkDeviceData {
   // Must not be longer than 256 bytes.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxBytes=256
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxBytes=256
   optional string interfaceName = 1;
 
   // IPs lists the network addresses assigned to the device's network interface.
@@ -1544,10 +1544,10 @@ message NetworkDeviceData {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:unique=set
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=16
+  // +k8s:beta(since: "1.37")=+k8s:unique=set
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=16
   repeated string ips = 2;
 
   // HardwareAddress represents the hardware address (e.g. MAC Address) of the device's network interface.
@@ -1555,8 +1555,8 @@ message NetworkDeviceData {
   // Must not be longer than 128 bytes.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxBytes=128
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:maxBytes=128
   optional string hardwareAddress = 3;
 }
 
@@ -1611,9 +1611,9 @@ message OpaqueDeviceConfiguration {
   // vendor of the driver. It should use only lower case characters.
   //
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:maxLength=63
-  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name-caseless
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:maxLength=63
+  // +k8s:beta(since: "1.37")=+k8s:format=k8s-long-name-caseless
   optional string driver = 1;
 
   // Parameters can contain arbitrary data. It is the responsibility of
@@ -1642,7 +1642,7 @@ message ResourceClaim {
 
   // Spec describes what is being requested and how to configure it.
   // The spec is immutable.
-  // +k8s:alpha(since: "1.36")=+k8s:immutable
+  // +k8s:beta(since: "1.37")=+k8s:immutable
   // +optional
   optional ResourceClaimSpec spec = 2;
 
@@ -1698,8 +1698,8 @@ message ResourceClaimStatus {
   // Allocation is set once the claim has been allocated successfully.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:update=NoModify
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:update=NoModify
   optional AllocationResult allocation = 1;
 
   // ReservedFor indicates which entities are currently allowed to use
@@ -1727,10 +1727,10 @@ message ResourceClaimStatus {
   // +listMapKey=uid
   // +patchStrategy=merge
   // +patchMergeKey=uid
-  // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:listType=map
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=uid
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=256
+  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:listType=map
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=uid
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=256
   repeated ResourceClaimConsumerReference reservedFor = 2;
 
   // Devices contains the status of each device allocated for this
@@ -1738,18 +1738,18 @@ message ResourceClaimStatus {
   // information. Entries are owned by their respective drivers.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +listType=map
   // +listMapKey=driver
   // +listMapKey=device
   // +listMapKey=pool
   // +listMapKey=shareID
   // +featureGate=DRAResourceClaimDeviceStatus
-  // +k8s:alpha(since: "1.36")=+k8s:listType=map
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=driver
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=device
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=pool
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=shareID
+  // +k8s:beta(since: "1.37")=+k8s:listType=map
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=driver
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=device
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=pool
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=shareID
   repeated AllocatedDeviceStatus devices = 4;
 }
 
@@ -1940,7 +1940,7 @@ message ResourceSliceSpec {
   //
   // +optional
   // +listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +zeroOrOneOf=ResourceSliceType
   repeated Device devices = 6;
 
@@ -1966,14 +1966,14 @@ message ResourceSliceSpec {
   // The maximum number of counter sets is 8.
   //
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:optional
   // +listType=atomic
   // +k8s:listType=atomic
-  // +k8s:alpha(since: "1.36")=+k8s:unique=map
-  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
+  // +k8s:beta(since: "1.37")=+k8s:unique=map
+  // +k8s:beta(since: "1.37")=+k8s:listMapKey=name
   // +featureGate=DRAPartitionableDevices
   // +zeroOrOneOf=ResourceSliceType
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=8
+  // +k8s:beta(since: "1.37")=+k8s:maxItems=8
   repeated CounterSet sharedCounters = 8;
 }
 

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -160,7 +160,7 @@ type ResourceSliceSpec struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +zeroOrOneOf=ResourceSliceType
 	Devices []Device `json:"devices,omitempty" protobuf:"bytes,6,name=devices"`
 
@@ -186,14 +186,14 @@ type ResourceSliceSpec struct {
 	// The maximum number of counter sets is 8.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +listType=atomic
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:unique=map
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
+	// +k8s:beta(since: "1.37")=+k8s:unique=map
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=name
 	// +featureGate=DRAPartitionableDevices
 	// +zeroOrOneOf=ResourceSliceType
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=8
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=8
 	SharedCounters []CounterSet `json:"sharedCounters,omitempty" protobuf:"bytes,8,name=sharedCounters"`
 }
 
@@ -210,8 +210,8 @@ type CounterSet struct {
 	// It must be a DNS label.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-short-name
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-short-name
 	Name string `json:"name" protobuf:"bytes,1,name=name"`
 
 	// Counters defines the set of counters for this CounterSet
@@ -220,8 +220,8 @@ type CounterSet struct {
 	// The maximum number of counters is 32.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:eachKey=+k8s:format=k8s-short-name
 	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,name=counters"`
 }
 
@@ -312,7 +312,7 @@ type Device struct {
 	// The maximum number of attributes and capacities combined is 32.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Attributes map[QualifiedName]DeviceAttribute `json:"attributes,omitempty" protobuf:"bytes,2,rep,name=attributes"`
 
 	// Capacity defines the set of capacities for this device.
@@ -333,13 +333,13 @@ type Device struct {
 	// device is 2.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +listType=atomic
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:unique=map
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=counterSet
+	// +k8s:beta(since: "1.37")=+k8s:unique=map
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=counterSet
 	// +featureGate=DRAPartitionableDevices
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=2
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=2
 	ConsumesCounters []DeviceCounterConsumption `json:"consumesCounters,omitempty" protobuf:"bytes,4,rep,name=consumesCounters"`
 
 	// NodeName identifies the node where the device is available.
@@ -386,7 +386,7 @@ type Device struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Taints []DeviceTaint `json:"taints,omitempty" protobuf:"bytes,8,rep,name=taints"`
 
 	// BindsToNode indicates if the usage of an allocation involving this device
@@ -416,8 +416,8 @@ type Device struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=4
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=4
 	BindingConditions []string `json:"bindingConditions,omitempty" protobuf:"bytes,10,rep,name=bindingConditions"`
 
 	// BindingFailureConditions defines the conditions for binding failure.
@@ -434,8 +434,8 @@ type Device struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=4
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=4
 	BindingFailureConditions []string `json:"bindingFailureConditions,omitempty" protobuf:"bytes,11,rep,name=bindingFailureConditions"`
 
 	// AllowMultipleAllocations marks whether the device is allowed to be allocated to multiple DeviceRequests.
@@ -508,8 +508,8 @@ type DeviceCounterConsumption struct {
 	// counters defined will be consumed.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-short-name
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-short-name
 	CounterSet string `json:"counterSet" protobuf:"bytes,1,opt,name=counterSet"`
 
 	// Counters defines the counters that will be consumed by the device.
@@ -517,8 +517,8 @@ type DeviceCounterConsumption struct {
 	// The maximum number of counters is 32.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:eachKey=+k8s:format=k8s-short-name
 	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,opt,name=counters"`
 }
 
@@ -682,30 +682,30 @@ type DeviceAttribute struct {
 	// IntValue is a number.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:unionMember
 	IntValue *int64 `json:"int,omitempty" protobuf:"varint,2,opt,name=int"`
 
 	// BoolValue is a true/false value.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:unionMember
 	BoolValue *bool `json:"bool,omitempty" protobuf:"varint,3,opt,name=bool"`
 
 	// StringValue is a string. Must not be longer than 64 characters.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:unionMember
 	StringValue *string `json:"string,omitempty" protobuf:"bytes,4,opt,name=string"`
 
 	// VersionValue is a semantic version according to semver.org spec 2.0.0.
 	// Must not be longer than 64 characters.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:unionMember
 	VersionValue *string `json:"version,omitempty" protobuf:"bytes,5,opt,name=version"`
 
 	// IntValues is a non-empty list of numbers.
@@ -715,8 +715,8 @@ type DeviceAttribute struct {
 	// +optional
 	// +listType=atomic
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:unionMember
 	// +featureGate=DRAListTypeAttributes
 	IntValues []int64 `json:"ints,omitempty" protobuf:"varint,6,opt,name=ints"`
 
@@ -725,8 +725,8 @@ type DeviceAttribute struct {
 	// +optional
 	// +listType=atomic
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:unionMember
 	// +featureGate=DRAListTypeAttributes
 	BoolValues []bool `json:"bools,omitempty" protobuf:"varint,7,opt,name=bools"`
 
@@ -738,8 +738,8 @@ type DeviceAttribute struct {
 	// +optional
 	// +listType=atomic
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:unionMember
 	// +k8s:alpha(since: "1.37")=+k8s:eachVal=+k8s:maxBytes=64
 	// +featureGate=DRAListTypeAttributes
 	StringValues []string `json:"strings,omitempty" protobuf:"bytes,8,opt,name=strings"`
@@ -752,8 +752,8 @@ type DeviceAttribute struct {
 	// +optional
 	// +listType=atomic
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:unionMember
 	// +featureGate=DRAListTypeAttributes
 	VersionValues []string `json:"versions,omitempty" protobuf:"bytes,9,opt,name=versions"`
 }
@@ -790,7 +790,7 @@ type DeviceTaint struct {
 	// Consumers must treat unknown effects like None.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Effect DeviceTaintEffect `json:"effect" protobuf:"bytes,3,name=effect,casttype=DeviceTaintEffect"`
 
 	// ^^^^
@@ -829,7 +829,7 @@ type DeviceTaint struct {
 }
 
 // +enum
-// +k8s:alpha(since: "1.36")=+k8s:enum
+// +k8s:beta(since: "1.37")=+k8s:enum
 type DeviceTaintEffect string
 
 const (
@@ -1034,7 +1034,7 @@ type ResourceClaim struct {
 
 	// Spec describes what is being requested and how to configure it.
 	// The spec is immutable.
-	// +k8s:alpha(since: "1.36")=+k8s:immutable
+	// +k8s:beta(since: "1.37")=+k8s:immutable
 	// +optional
 	Spec ResourceClaimSpec `json:"spec" protobuf:"bytes,2,name=spec"`
 
@@ -1063,11 +1063,11 @@ type DeviceClaim struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:unique=map
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:unique=map
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=name
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Requests []DeviceRequest `json:"requests" protobuf:"bytes,1,name=requests"`
 
 	// These constraints must be satisfied by the set of devices that get
@@ -1075,8 +1075,8 @@ type DeviceClaim struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Constraints []DeviceConstraint `json:"constraints,omitempty" protobuf:"bytes,2,opt,name=constraints"`
 
 	// This field holds configuration for multiple potential drivers which
@@ -1085,8 +1085,8 @@ type DeviceClaim struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Config []DeviceClaimConfiguration `json:"config,omitempty" protobuf:"bytes,3,opt,name=config"`
 
 	// Potential future extension, ignored by older schedulers. This is
@@ -1137,7 +1137,7 @@ type DeviceRequest struct {
 	//
 	// +optional
 	// +oneOf=deviceRequestType
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Exactly *ExactDeviceRequest `json:"exactly,omitempty" protobuf:"bytes,2,name=exactly"`
 
 	// FirstAvailable contains subrequests, of which exactly one will be
@@ -1158,11 +1158,11 @@ type DeviceRequest struct {
 	// +oneOf=deviceRequestType
 	// +listType=atomic
 	// +featureGate=DRAPrioritizedList
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:unique=map
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=8
+	// +k8s:beta(since: "1.37")=+k8s:unique=map
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=name
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=8
 	FirstAvailable []DeviceSubRequest `json:"firstAvailable,omitempty" protobuf:"bytes,3,name=firstAvailable"`
 }
 
@@ -1190,8 +1190,8 @@ type ExactDeviceRequest struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Selectors []DeviceSelector `json:"selectors,omitempty" protobuf:"bytes,2,name=selectors"`
 
 	// AllocationMode and its related fields define how devices are allocated
@@ -1214,7 +1214,7 @@ type ExactDeviceRequest struct {
 	// requests with unknown modes.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	AllocationMode DeviceAllocationMode `json:"allocationMode,omitempty" protobuf:"bytes,3,opt,name=allocationMode"`
 
 	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1259,7 +1259,7 @@ type ExactDeviceRequest struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,6,opt,name=tolerations"`
 
 	// Capacity define resource requirements against each capacity.
@@ -1311,8 +1311,8 @@ type DeviceSubRequest struct {
 	// to reference.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-long-name
 	DeviceClassName string `json:"deviceClassName" protobuf:"bytes,2,name=deviceClassName"`
 
 	// Selectors define criteria which must be satisfied by a specific
@@ -1322,8 +1322,8 @@ type DeviceSubRequest struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Selectors []DeviceSelector `json:"selectors,omitempty" protobuf:"bytes,3,name=selectors"`
 
 	// AllocationMode and its related fields define how devices are allocated
@@ -1345,7 +1345,7 @@ type DeviceSubRequest struct {
 	// requests with unknown modes.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	AllocationMode DeviceAllocationMode `json:"allocationMode,omitempty" protobuf:"bytes,4,opt,name=allocationMode"`
 
 	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1376,7 +1376,7 @@ type DeviceSubRequest struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,6,opt,name=tolerations"`
 
 	// Capacity define resource requirements against each capacity.
@@ -1433,7 +1433,7 @@ const (
 )
 
 // +enum
-// +k8s:alpha(since: "1.36")=+k8s:enum
+// +k8s:beta(since: "1.37")=+k8s:enum
 type DeviceAllocationMode string
 
 // Valid [DeviceRequest.CountMode] values.
@@ -1569,10 +1569,10 @@ type DeviceConstraint struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:unique=set
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:unique=set
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Requests []string `json:"requests,omitempty" protobuf:"bytes,1,opt,name=requests"`
 
 	// MatchAttribute requires that all devices in question have this
@@ -1595,8 +1595,8 @@ type DeviceConstraint struct {
 	//
 	// +optional
 	// +oneOf=ConstraintType
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-resource-fully-qualified-name
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-resource-fully-qualified-name
 	MatchAttribute *FullyQualifiedName `json:"matchAttribute,omitempty" protobuf:"bytes,2,opt,name=matchAttribute"`
 
 	// Potential future extension, not part of the current design:
@@ -1642,10 +1642,10 @@ type DeviceClaimConfiguration struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:unique=set
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:unique=set
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Requests []string `json:"requests,omitempty" protobuf:"bytes,1,opt,name=requests"`
 
 	DeviceConfiguration `json:"" protobuf:"bytes,2,name=deviceConfiguration"`
@@ -1659,7 +1659,7 @@ type DeviceConfiguration struct {
 	//
 	// +optional
 	// +oneOf=ConfigurationType
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Opaque *OpaqueDeviceConfiguration `json:"opaque,omitempty" protobuf:"bytes,1,opt,name=opaque"`
 }
 
@@ -1676,9 +1676,9 @@ type OpaqueDeviceConfiguration struct {
 	// vendor of the driver. It should use only lower case characters.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:maxLength=63
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name-caseless
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:maxLength=63
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-long-name-caseless
 	Driver string `json:"driver" protobuf:"bytes,1,name=driver"`
 
 	// Parameters can contain arbitrary data. It is the responsibility of
@@ -1704,8 +1704,8 @@ type DeviceToleration struct {
 	// Must be a label name.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-label-key
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-label-key
 	Key string `json:"key,omitempty" protobuf:"bytes,1,opt,name=key"`
 
 	// Operator represents a key's relationship to the value.
@@ -1715,7 +1715,7 @@ type DeviceToleration struct {
 	//
 	// +optional
 	// +default="Equal"
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Operator DeviceTolerationOperator `json:"operator,omitempty" protobuf:"bytes,2,opt,name=operator,casttype=DeviceTolerationOperator"`
 
 	// Value is the taint value the toleration matches to.
@@ -1729,7 +1729,7 @@ type DeviceToleration struct {
 	// When specified, allowed values are NoSchedule and NoExecute.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Effect DeviceTaintEffect `json:"effect,omitempty" protobuf:"bytes,4,opt,name=effect,casttype=DeviceTaintEffect"`
 
 	// TolerationSeconds represents the period of time the toleration (which must be
@@ -1746,7 +1746,7 @@ type DeviceToleration struct {
 // A toleration operator is the set of operators that can be used in a toleration.
 //
 // +enum
-// +k8s:alpha(since: "1.36")=+k8s:enum
+// +k8s:beta(since: "1.37")=+k8s:enum
 type DeviceTolerationOperator string
 
 const (
@@ -1760,8 +1760,8 @@ type ResourceClaimStatus struct {
 	// Allocation is set once the claim has been allocated successfully.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:update=NoModify
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:update=NoModify
 	Allocation *AllocationResult `json:"allocation,omitempty" protobuf:"bytes,1,opt,name=allocation"`
 
 	// ReservedFor indicates which entities are currently allowed to use
@@ -1789,10 +1789,10 @@ type ResourceClaimStatus struct {
 	// +listMapKey=uid
 	// +patchStrategy=merge
 	// +patchMergeKey=uid
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:listType=map
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=uid
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=256
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:listType=map
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=uid
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=256
 	ReservedFor []ResourceClaimConsumerReference `json:"reservedFor,omitempty" protobuf:"bytes,2,opt,name=reservedFor" patchStrategy:"merge" patchMergeKey:"uid"`
 
 	// DeallocationRequested is tombstoned since Kubernetes 1.32 where
@@ -1805,18 +1805,18 @@ type ResourceClaimStatus struct {
 	// information. Entries are owned by their respective drivers.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +listType=map
 	// +listMapKey=driver
 	// +listMapKey=device
 	// +listMapKey=pool
 	// +listMapKey=shareID
 	// +featureGate=DRAResourceClaimDeviceStatus
-	// +k8s:alpha(since: "1.36")=+k8s:listType=map
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=driver
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=device
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=pool
-	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=shareID
+	// +k8s:beta(since: "1.37")=+k8s:listType=map
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=driver
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=device
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=pool
+	// +k8s:beta(since: "1.37")=+k8s:listMapKey=shareID
 	Devices []AllocatedDeviceStatus `json:"devices,omitempty" protobuf:"bytes,4,opt,name=devices"`
 }
 
@@ -1879,8 +1879,8 @@ type DeviceAllocationResult struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Results []DeviceRequestAllocationResult `json:"results,omitempty" protobuf:"bytes,1,opt,name=results"`
 
 	// This field is a combination of all the claim and class configuration parameters.
@@ -1893,8 +1893,8 @@ type DeviceAllocationResult struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=64
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=64
 	Config []DeviceAllocationConfiguration `json:"config,omitempty" protobuf:"bytes,2,opt,name=config"`
 }
 
@@ -1923,9 +1923,9 @@ type DeviceRequestAllocationResult struct {
 	// vendor of the driver. It should use only lower case characters.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name-caseless
-	// +k8s:alpha(since: "1.36")=+k8s:maxLength=63
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-long-name-caseless
+	// +k8s:beta(since: "1.37")=+k8s:maxLength=63
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Driver string `json:"driver" protobuf:"bytes,2,name=driver"`
 
 	// This name together with the driver name and the device name field
@@ -1935,8 +1935,8 @@ type DeviceRequestAllocationResult struct {
 	// DNS sub-domains separated by slashes.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-resource-pool-name
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-resource-pool-name
 	Pool string `json:"pool" protobuf:"bytes,3,name=pool"`
 
 	// Device references one device instance via its name in the driver's
@@ -1968,7 +1968,7 @@ type DeviceRequestAllocationResult struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,6,opt,name=tolerations"`
 
 	// BindingConditions contains a copy of the BindingConditions
@@ -1980,8 +1980,8 @@ type DeviceRequestAllocationResult struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=4
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=4
 	BindingConditions []string `json:"bindingConditions,omitempty" protobuf:"bytes,7,rep,name=bindingConditions"`
 
 	// BindingFailureConditions contains a copy of the BindingFailureConditions
@@ -1993,8 +1993,8 @@ type DeviceRequestAllocationResult struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=4
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=4
 	BindingFailureConditions []string `json:"bindingFailureConditions,omitempty" protobuf:"bytes,8,rep,name=bindingFailureConditions"`
 
 	// ShareID uniquely identifies an individual allocation share of the device,
@@ -2004,8 +2004,8 @@ type DeviceRequestAllocationResult struct {
 	//
 	// +optional
 	// +featureGate=DRAConsumableCapacity
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-uuid
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-uuid
 	ShareID *types.UID `json:"shareID,omitempty" protobuf:"bytes,9,opt,name=shareID"`
 
 	// ConsumedCapacity tracks the amount of capacity consumed per device as part of the claim request.
@@ -2029,7 +2029,7 @@ type DeviceAllocationConfiguration struct {
 	// or from a claim.
 	//
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	Source AllocationConfigSource `json:"source" protobuf:"bytes,1,name=source"`
 
 	// Requests lists the names of requests where the configuration applies.
@@ -2041,17 +2041,17 @@ type DeviceAllocationConfiguration struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:unique=set
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:unique=set
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Requests []string `json:"requests,omitempty" protobuf:"bytes,2,opt,name=requests"`
 
 	DeviceConfiguration `json:"" protobuf:"bytes,3,name=deviceConfiguration"`
 }
 
 // +enum
-// +k8s:alpha(since: "1.36")=+k8s:enum
+// +k8s:beta(since: "1.37")=+k8s:enum
 type AllocationConfigSource string
 
 // Valid [DeviceAllocationConfiguration.Source] values.
@@ -2090,8 +2090,8 @@ type DeviceClass struct {
 	metav1.TypeMeta `json:""`
 	// Standard object metadata
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:format=k8s-long-name
+	// +k8s:beta(since: "1.37")=+k8s:subfield(name)=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:subfield(name)=+k8s:format=k8s-long-name
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Spec defines what can be allocated and how to configure it.
@@ -2113,8 +2113,8 @@ type DeviceClassSpec struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Selectors []DeviceSelector `json:"selectors,omitempty" protobuf:"bytes,1,opt,name=selectors"`
 
 	// Config defines configuration parameters that apply to each device that is claimed via this class.
@@ -2125,8 +2125,8 @@ type DeviceClassSpec struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=32
 	Config []DeviceClassConfiguration `json:"config,omitempty" protobuf:"bytes,2,opt,name=config"`
 
 	// SuitableNodes is tombstoned since Kubernetes 1.32 where
@@ -2145,8 +2145,8 @@ type DeviceClassSpec struct {
 	//
 	// +optional
 	// +featureGate=DRAExtendedResource
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-extended-resource-name
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-extended-resource-name
 	ExtendedResourceName *string `json:"extendedResourceName,omitempty" protobuf:"bytes,4,opt,name=extendedResourceName"`
 }
 
@@ -2274,8 +2274,8 @@ type AllocatedDeviceStatus struct {
 	//
 	// +optional
 	// +featureGate=DRAConsumableCapacity
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-uuid
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:format=k8s-uuid
 	ShareID *string `json:"shareID,omitempty" protobuf:"bytes,7,opt,name=shareID"`
 
 	// Conditions contains the latest observation of the device's state.
@@ -2302,7 +2302,7 @@ type AllocatedDeviceStatus struct {
 	// NetworkData contains network-related information specific to the device.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	NetworkData *NetworkDeviceData `json:"networkData,omitempty" protobuf:"bytes,6,opt,name=networkData"`
 }
 
@@ -2317,8 +2317,8 @@ type NetworkDeviceData struct {
 	// Must not be longer than 256 bytes.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxBytes=256
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxBytes=256
 	InterfaceName string `json:"interfaceName,omitempty" protobuf:"bytes,1,opt,name=interfaceName"`
 
 	// IPs lists the network addresses assigned to the device's network interface.
@@ -2329,10 +2329,10 @@ type NetworkDeviceData struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:alpha(since: "1.36")=+k8s:unique=set
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=16
+	// +k8s:beta(since: "1.37")=+k8s:unique=set
+	// +k8s:beta(since: "1.37")=+k8s:maxItems=16
 	IPs []string `json:"ips,omitempty" protobuf:"bytes,2,opt,name=ips"`
 
 	// HardwareAddress represents the hardware address (e.g. MAC Address) of the device's network interface.
@@ -2340,7 +2340,7 @@ type NetworkDeviceData struct {
 	// Must not be longer than 128 bytes.
 	//
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxBytes=128
+	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:maxBytes=128
 	HardwareAddress string `json:"hardwareAddress,omitempty" protobuf:"bytes,3,opt,name=hardwareAddress"`
 }

--- a/staging/src/k8s.io/api/storage/v1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1/generated.proto
@@ -455,22 +455,22 @@ message StorageClass {
 
   // provisioner indicates the type of the provisioner.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:immutable
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:immutable
   optional string provisioner = 2;
 
   // parameters holds the parameters for the provisioner that should
   // create volumes of this storage class.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:immutable
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:immutable
+  // +k8s:beta(since: "1.37")=+k8s:optional
   map<string, string> parameters = 3;
 
   // reclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class.
   // Defaults to Delete.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:immutable
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:immutable
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional string reclaimPolicy = 4;
 
   // mountOptions controls the mountOptions for dynamically provisioned PersistentVolumes of this storage class.
@@ -488,8 +488,8 @@ message StorageClass {
   // provisioned and bound.  When unset, VolumeBindingImmediate is used.
   // This field is only honored by servers that enable the VolumeScheduling feature.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:immutable
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:immutable
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional string volumeBindingMode = 7;
 
   // allowedTopologies restrict the node topologies where volumes can be dynamically provisioned.
@@ -537,7 +537,7 @@ message VolumeAttachment {
 
   // spec represents specification of the desired attach/detach volume behavior.
   // Populated by the Kubernetes system.
-  // +k8s:alpha(since: "1.36")=+k8s:immutable
+  // +k8s:beta(since: "1.37")=+k8s:immutable
   // +required
   optional VolumeAttachmentSpec spec = 2;
 
@@ -583,9 +583,9 @@ message VolumeAttachmentSpec {
   // attacher indicates the name of the volume driver that MUST handle this
   // request. This is the name returned by GetPluginName().
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:format="k8s-long-name-caseless"
-  // +k8s:alpha(since: "1.36")=+k8s:maxLength=63
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:format="k8s-long-name-caseless"
+  // +k8s:beta(since: "1.37")=+k8s:maxLength=63
   optional string attacher = 1;
 
   // source represents the volume that should be attached.

--- a/staging/src/k8s.io/api/storage/v1/types.go
+++ b/staging/src/k8s.io/api/storage/v1/types.go
@@ -42,22 +42,22 @@ type StorageClass struct {
 
 	// provisioner indicates the type of the provisioner.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:immutable
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:immutable
 	Provisioner string `json:"provisioner" protobuf:"bytes,2,opt,name=provisioner"`
 
 	// parameters holds the parameters for the provisioner that should
 	// create volumes of this storage class.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:immutable
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:immutable
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Parameters map[string]string `json:"parameters,omitempty" protobuf:"bytes,3,rep,name=parameters"`
 
 	// reclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class.
 	// Defaults to Delete.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:immutable
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:immutable
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	ReclaimPolicy *v1.PersistentVolumeReclaimPolicy `json:"reclaimPolicy,omitempty" protobuf:"bytes,4,opt,name=reclaimPolicy,casttype=k8s.io/api/core/v1.PersistentVolumeReclaimPolicy"`
 
 	// mountOptions controls the mountOptions for dynamically provisioned PersistentVolumes of this storage class.
@@ -75,8 +75,8 @@ type StorageClass struct {
 	// provisioned and bound.  When unset, VolumeBindingImmediate is used.
 	// This field is only honored by servers that enable the VolumeScheduling feature.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:immutable
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:immutable
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	VolumeBindingMode *VolumeBindingMode `json:"volumeBindingMode,omitempty" protobuf:"bytes,7,opt,name=volumeBindingMode"`
 
 	// allowedTopologies restrict the node topologies where volumes can be dynamically provisioned.
@@ -140,7 +140,7 @@ type VolumeAttachment struct {
 
 	// spec represents specification of the desired attach/detach volume behavior.
 	// Populated by the Kubernetes system.
-	// +k8s:alpha(since: "1.36")=+k8s:immutable
+	// +k8s:beta(since: "1.37")=+k8s:immutable
 	// +required
 	Spec VolumeAttachmentSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
@@ -172,9 +172,9 @@ type VolumeAttachmentSpec struct {
 	// attacher indicates the name of the volume driver that MUST handle this
 	// request. This is the name returned by GetPluginName().
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:format="k8s-long-name-caseless"
-	// +k8s:alpha(since: "1.36")=+k8s:maxLength=63
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:format="k8s-long-name-caseless"
+	// +k8s:beta(since: "1.37")=+k8s:maxLength=63
 	Attacher string `json:"attacher" protobuf:"bytes,1,opt,name=attacher"`
 
 	// source represents the volume that should be attached.

--- a/staging/src/k8s.io/api/storage/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1alpha1/generated.proto
@@ -134,7 +134,7 @@ message VolumeAttachment {
 
   // spec represents specification of the desired attach/detach volume behavior.
   // Populated by the Kubernetes system.
-  // +k8s:alpha(since: "1.36")=+k8s:immutable
+  // +k8s:beta(since: "1.37")=+k8s:immutable
   // +required
   optional VolumeAttachmentSpec spec = 2;
 
@@ -180,9 +180,9 @@ message VolumeAttachmentSpec {
   // attacher indicates the name of the volume driver that MUST handle this
   // request. This is the name returned by GetPluginName().
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:format="k8s-long-name-caseless"
-  // +k8s:alpha(since: "1.36")=+k8s:maxLength=63
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:format="k8s-long-name-caseless"
+  // +k8s:beta(since: "1.37")=+k8s:maxLength=63
   optional string attacher = 1;
 
   // source represents the volume that should be attached.

--- a/staging/src/k8s.io/api/storage/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/storage/v1alpha1/types.go
@@ -44,7 +44,7 @@ type VolumeAttachment struct {
 
 	// spec represents specification of the desired attach/detach volume behavior.
 	// Populated by the Kubernetes system.
-	// +k8s:alpha(since: "1.36")=+k8s:immutable
+	// +k8s:beta(since: "1.37")=+k8s:immutable
 	// +required
 	Spec VolumeAttachmentSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
@@ -78,9 +78,9 @@ type VolumeAttachmentSpec struct {
 	// attacher indicates the name of the volume driver that MUST handle this
 	// request. This is the name returned by GetPluginName().
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:format="k8s-long-name-caseless"
-	// +k8s:alpha(since: "1.36")=+k8s:maxLength=63
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:format="k8s-long-name-caseless"
+	// +k8s:beta(since: "1.37")=+k8s:maxLength=63
 	Attacher string `json:"attacher" protobuf:"bytes,1,opt,name=attacher"`
 
 	// source represents the volume that should be attached.

--- a/staging/src/k8s.io/api/storage/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1beta1/generated.proto
@@ -457,22 +457,22 @@ message StorageClass {
 
   // provisioner indicates the type of the provisioner.
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:immutable
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:immutable
   optional string provisioner = 2;
 
   // parameters holds the parameters for the provisioner that should
   // create volumes of this storage class.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:immutable
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:immutable
+  // +k8s:beta(since: "1.37")=+k8s:optional
   map<string, string> parameters = 3;
 
   // reclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class.
   // Defaults to Delete.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:immutable
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:immutable
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional string reclaimPolicy = 4;
 
   // mountOptions controls the mountOptions for dynamically provisioned PersistentVolumes of this storage class.
@@ -490,8 +490,8 @@ message StorageClass {
   // provisioned and bound.  When unset, VolumeBindingImmediate is used.
   // This field is only honored by servers that enable the VolumeScheduling feature.
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:immutable
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:beta(since: "1.37")=+k8s:immutable
+  // +k8s:beta(since: "1.37")=+k8s:optional
   optional string volumeBindingMode = 7;
 
   // allowedTopologies restrict the node topologies where volumes can be dynamically provisioned.
@@ -539,7 +539,7 @@ message VolumeAttachment {
 
   // spec represents specification of the desired attach/detach volume behavior.
   // Populated by the Kubernetes system.
-  // +k8s:alpha(since: "1.36")=+k8s:immutable
+  // +k8s:beta(since: "1.37")=+k8s:immutable
   // +required
   optional VolumeAttachmentSpec spec = 2;
 
@@ -585,9 +585,9 @@ message VolumeAttachmentSpec {
   // attacher indicates the name of the volume driver that MUST handle this
   // request. This is the name returned by GetPluginName().
   // +required
-  // +k8s:alpha(since: "1.36")=+k8s:required
-  // +k8s:alpha(since: "1.36")=+k8s:format="k8s-long-name-caseless"
-  // +k8s:alpha(since: "1.36")=+k8s:maxLength=63
+  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:beta(since: "1.37")=+k8s:format="k8s-long-name-caseless"
+  // +k8s:beta(since: "1.37")=+k8s:maxLength=63
   optional string attacher = 1;
 
   // source represents the volume that should be attached.

--- a/staging/src/k8s.io/api/storage/v1beta1/types.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/types.go
@@ -44,22 +44,22 @@ type StorageClass struct {
 
 	// provisioner indicates the type of the provisioner.
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:immutable
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:immutable
 	Provisioner string `json:"provisioner" protobuf:"bytes,2,opt,name=provisioner"`
 
 	// parameters holds the parameters for the provisioner that should
 	// create volumes of this storage class.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:immutable
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:immutable
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	Parameters map[string]string `json:"parameters,omitempty" protobuf:"bytes,3,rep,name=parameters"`
 
 	// reclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class.
 	// Defaults to Delete.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:immutable
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:immutable
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	ReclaimPolicy *v1.PersistentVolumeReclaimPolicy `json:"reclaimPolicy,omitempty" protobuf:"bytes,4,opt,name=reclaimPolicy,casttype=k8s.io/api/core/v1.PersistentVolumeReclaimPolicy"`
 
 	// mountOptions controls the mountOptions for dynamically provisioned PersistentVolumes of this storage class.
@@ -77,8 +77,8 @@ type StorageClass struct {
 	// provisioned and bound.  When unset, VolumeBindingImmediate is used.
 	// This field is only honored by servers that enable the VolumeScheduling feature.
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:immutable
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:beta(since: "1.37")=+k8s:immutable
+	// +k8s:beta(since: "1.37")=+k8s:optional
 	VolumeBindingMode *VolumeBindingMode `json:"volumeBindingMode,omitempty" protobuf:"bytes,7,opt,name=volumeBindingMode"`
 
 	// allowedTopologies restrict the node topologies where volumes can be dynamically provisioned.
@@ -145,7 +145,7 @@ type VolumeAttachment struct {
 
 	// spec represents specification of the desired attach/detach volume behavior.
 	// Populated by the Kubernetes system.
-	// +k8s:alpha(since: "1.36")=+k8s:immutable
+	// +k8s:beta(since: "1.37")=+k8s:immutable
 	// +required
 	Spec VolumeAttachmentSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
@@ -179,9 +179,9 @@ type VolumeAttachmentSpec struct {
 	// attacher indicates the name of the volume driver that MUST handle this
 	// request. This is the name returned by GetPluginName().
 	// +required
-	// +k8s:alpha(since: "1.36")=+k8s:required
-	// +k8s:alpha(since: "1.36")=+k8s:format="k8s-long-name-caseless"
-	// +k8s:alpha(since: "1.36")=+k8s:maxLength=63
+	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:beta(since: "1.37")=+k8s:format="k8s-long-name-caseless"
+	// +k8s:beta(since: "1.37")=+k8s:maxLength=63
 	Attacher string `json:"attacher" protobuf:"bytes,1,opt,name=attacher"`
 
 	// source represents the volume that should be attached.

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/declarative_validation_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/declarative_validation_test.go
@@ -55,13 +55,13 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"spec.policyName is required": {
 			input: mkValidBinding(tweakPolicyName("")),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "policyName"), "").MarkAlpha(),
+				field.Required(field.NewPath("spec", "policyName"), "").MarkBeta(),
 			},
 		},
 		"spec.validationActions is required": {
 			input: mkValidBinding(tweakValidateActions([]admissionregistration.ValidationAction{})),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "validationActions"), "").MarkAlpha(),
+				field.Required(field.NewPath("spec", "validationActions"), "").MarkBeta(),
 			},
 		},
 		// TODO: Add more test cases
@@ -105,14 +105,14 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			oldObj:    mkValidBinding(func(obj *admissionregistration.ValidatingAdmissionPolicyBinding) { obj.ResourceVersion = "1" }),
 			updateObj: mkValidBinding(tweakPolicyName("")),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "policyName"), "").MarkAlpha(),
+				field.Required(field.NewPath("spec", "policyName"), "").MarkBeta(),
 			},
 		},
 		"update with empty spec.validationActions": {
 			oldObj:    mkValidBinding(),
 			updateObj: mkValidBinding(tweakValidateActions([]admissionregistration.ValidationAction{})),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "validationActions"), "").MarkAlpha(),
+				field.Required(field.NewPath("spec", "validationActions"), "").MarkBeta(),
 			},
 		},
 		// TODO: Add more test cases

--- a/test/declarative_validation/apps/scale/declarative_validation_test.go
+++ b/test/declarative_validation/apps/scale/declarative_validation_test.go
@@ -48,7 +48,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 			old:    mkScale(),
 			update: mkScale(setReplicas(-1)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec.replicas"), nil, "").WithOrigin("minimum").MarkAlpha(),
+				field.Invalid(field.NewPath("spec.replicas"), nil, "").WithOrigin("minimum").MarkBeta(),
 			},
 		},
 	}

--- a/test/declarative_validation/autoscaling/horizontalpodautoscaler/declarative_validation_test.go
+++ b/test/declarative_validation/autoscaling/horizontalpodautoscaler/declarative_validation_test.go
@@ -78,19 +78,19 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"invalid: maxReplicas = 0 (required)": {
 			input: makeValidHPA(tweakMaxReplicas(0)),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "maxReplicas"), "").MarkAlpha(),
+				field.Required(field.NewPath("spec", "maxReplicas"), "").MarkBeta(),
 			},
 		},
 		"invalid: maxReplicas negative": {
 			input: makeValidHPA(tweakMaxReplicas(-1)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "maxReplicas"), int32(-1), "must be greater than or equal to 1").WithOrigin("minimum").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "maxReplicas"), int32(-1), "must be greater than or equal to 1").WithOrigin("minimum").MarkBeta(),
 			},
 		},
 		"invalid: minReplicas = 0 (gate disabled)": {
 			input: makeValidHPA(tweakMinReplicas(0), tweakMetrics(validScaleToZeroMetrics...)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "minReplicas"), int32(0), "must be greater than or equal to 1").WithOrigin("minimum").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "minReplicas"), int32(0), "must be greater than or equal to 1").WithOrigin("minimum").MarkBeta(),
 			},
 		},
 	}
@@ -160,21 +160,21 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			oldObj:    makeValidHPA(),
 			updateObj: makeValidHPA(tweakMaxReplicas(0)),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "maxReplicas"), "").MarkAlpha(),
+				field.Required(field.NewPath("spec", "maxReplicas"), "").MarkBeta(),
 			},
 		},
 		"invalid update: maxReplicas negative": {
 			oldObj:    makeValidHPA(),
 			updateObj: makeValidHPA(tweakMaxReplicas(-1)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "maxReplicas"), int32(-1), "must be greater than or equal to 1").WithOrigin("minimum").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "maxReplicas"), int32(-1), "must be greater than or equal to 1").WithOrigin("minimum").MarkBeta(),
 			},
 		},
 		"invalid update: minReplicas 1 -> 0 (gate disabled)": {
 			oldObj:    makeValidHPA(tweakMinReplicas(1), tweakMetrics(validScaleToZeroMetrics...)),
 			updateObj: makeValidHPA(tweakMinReplicas(0), tweakMetrics(validScaleToZeroMetrics...)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "minReplicas"), int32(0), "must be greater than or equal to 1").WithOrigin("minimum").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "minReplicas"), int32(0), "must be greater than or equal to 1").WithOrigin("minimum").MarkBeta(),
 			},
 		},
 		"valid update: ratcheting minReplicas=0 when gate disabled": {

--- a/test/declarative_validation/autoscaling/scale/declarative_validation_test.go
+++ b/test/declarative_validation/autoscaling/scale/declarative_validation_test.go
@@ -48,7 +48,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 			old:    mkScale(),
 			update: mkScale(setReplicas(-1)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec.replicas"), nil, "").WithOrigin("minimum").MarkAlpha(),
+				field.Invalid(field.NewPath("spec.replicas"), nil, "").WithOrigin("minimum").MarkBeta(),
 			},
 		},
 	}

--- a/test/declarative_validation/batch/cronjob/declarative_validation_test.go
+++ b/test/declarative_validation/batch/cronjob/declarative_validation_test.go
@@ -56,7 +56,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"schedule: empty": {
 			input: mkCronJob(tweakSchedule("")),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "schedule"), "").MarkAlpha(),
+				field.Required(field.NewPath("spec", "schedule"), "").MarkBeta(),
 			},
 		},
 		"jobTemplate.spec.maxFailedIndexes set without backoffLimitPerIndex": {
@@ -124,7 +124,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			old:    mkCronJob(),
 			update: mkCronJob(tweakSchedule("")),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "schedule"), "").MarkAlpha(),
+				field.Required(field.NewPath("spec", "schedule"), "").MarkBeta(),
 			},
 		},
 	}

--- a/test/declarative_validation/certificates/certificatesigningrequest/declarative_validation_test.go
+++ b/test/declarative_validation/certificates/certificatesigningrequest/declarative_validation_test.go
@@ -77,13 +77,13 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"status.conditions: Approved+Denied = invalid": {
 			input: makeValidCSR(withApprovedCondition(), withDeniedCondition()),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("status", "conditions"), nil, "").WithOrigin("zeroOrOneOf").MarkAlpha(),
+				field.Invalid(field.NewPath("status", "conditions"), nil, "").WithOrigin("zeroOrOneOf").MarkBeta(),
 			},
 		},
 		"status.conditions: Denied+Approved = invalid": {
 			input: makeValidCSR(withDeniedCondition(), withApprovedCondition()),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("status", "conditions"), nil, "").WithOrigin("zeroOrOneOf").MarkAlpha(),
+				field.Invalid(field.NewPath("status", "conditions"), nil, "").WithOrigin("zeroOrOneOf").MarkBeta(),
 			},
 		},
 	}
@@ -156,7 +156,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			old:    makeValidCSR(),
 			update: makeValidCSR(withApprovedCondition(), withDeniedCondition()),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("status", "conditions"), nil, "").WithOrigin("zeroOrOneOf").MarkAlpha(),
+				field.Invalid(field.NewPath("status", "conditions"), nil, "").WithOrigin("zeroOrOneOf").MarkBeta(),
 			},
 			subresources: []string{"/approval"}, // Can only add Approved and Denied conditions on /approval subresource
 		},

--- a/test/declarative_validation/core/replicationcontroller/declarative_validation_test.go
+++ b/test/declarative_validation/core/replicationcontroller/declarative_validation_test.go
@@ -73,7 +73,7 @@ func TestDeclarativeValidate(t *testing.T) {
 				rc.Name = "-this-is-not-a-label"
 			}),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name").MarkAlpha(),
+				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name").MarkBeta(),
 			},
 		},
 		"name: invalid subdomain format": {
@@ -81,7 +81,7 @@ func TestDeclarativeValidate(t *testing.T) {
 				rc.Name = ".this.is.not.a.subdomain"
 			}),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name").MarkAlpha(),
+				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name").MarkBeta(),
 			},
 		},
 		"name: label format with trailing dash": {
@@ -89,7 +89,7 @@ func TestDeclarativeValidate(t *testing.T) {
 				rc.Name = "this-is-a-label-"
 			}),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name").MarkAlpha(),
+				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name").MarkBeta(),
 			},
 		},
 		"name: subdomain format with trailing dash": {
@@ -97,7 +97,7 @@ func TestDeclarativeValidate(t *testing.T) {
 				rc.Name = "this.is.a.subdomain-"
 			}),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name").MarkAlpha(),
+				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name").MarkBeta(),
 			},
 		},
 		"name: long label format": {
@@ -115,7 +115,7 @@ func TestDeclarativeValidate(t *testing.T) {
 				rc.Name = strings.Repeat("x", 254)
 			}),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name").MarkAlpha(),
+				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name").MarkBeta(),
 			},
 		},
 		"name: too long subdomain format": {
@@ -123,7 +123,7 @@ func TestDeclarativeValidate(t *testing.T) {
 				rc.Name = strings.Repeat("x.", 126) + "xx"
 			}),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name").MarkAlpha(),
+				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name").MarkBeta(),
 			},
 		},
 		// metadata.generateName (note: it's is not really validated)
@@ -164,7 +164,7 @@ func TestDeclarativeValidate(t *testing.T) {
 				rc.Spec.Replicas = nil
 			}),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec.replicas"), "").MarkAlpha(),
+				field.Required(field.NewPath("spec.replicas"), "").MarkBeta(),
 			},
 		},
 		"replicas: 0": {
@@ -176,7 +176,7 @@ func TestDeclarativeValidate(t *testing.T) {
 		"replicas: negative": {
 			input: mkValidReplicationController(setSpecReplicas(-1)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec.replicas"), nil, "").WithOrigin("minimum").MarkAlpha(),
+				field.Invalid(field.NewPath("spec.replicas"), nil, "").WithOrigin("minimum").MarkBeta(),
 			},
 		},
 		// spec.minReadySeconds
@@ -189,7 +189,7 @@ func TestDeclarativeValidate(t *testing.T) {
 		"minReadySeconds: negative": {
 			input: mkValidReplicationController(setSpecMinReadySeconds(-1)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec.minReadySeconds"), nil, "").WithOrigin("minimum").MarkAlpha(),
+				field.Invalid(field.NewPath("spec.minReadySeconds"), nil, "").WithOrigin("minimum").MarkBeta(),
 			},
 		},
 		// spec.template.spec.tolerations[*].key
@@ -261,7 +261,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 				rc.Spec.Replicas = nil
 			}),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec.replicas"), "").MarkAlpha(),
+				field.Required(field.NewPath("spec.replicas"), "").MarkBeta(),
 			},
 		},
 		"replicas: 0": {
@@ -276,7 +276,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 			old:    mkValidReplicationController(),
 			update: mkValidReplicationController(setSpecReplicas(-1)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec.replicas"), nil, "").WithOrigin("minimum").MarkAlpha(),
+				field.Invalid(field.NewPath("spec.replicas"), nil, "").WithOrigin("minimum").MarkBeta(),
 			},
 		},
 		// spec.minReadySeconds
@@ -292,7 +292,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 			old:    mkValidReplicationController(),
 			update: mkValidReplicationController(setSpecMinReadySeconds(-1)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec.minReadySeconds"), nil, "").WithOrigin("minimum").MarkAlpha(),
+				field.Invalid(field.NewPath("spec.minReadySeconds"), nil, "").WithOrigin("minimum").MarkBeta(),
 			},
 		},
 	}

--- a/test/declarative_validation/discovery/endpointslice/declarative_validation_test.go
+++ b/test/declarative_validation/discovery/endpointslice/declarative_validation_test.go
@@ -62,25 +62,25 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				obj.Endpoints[0].Addresses = nil
 			}),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("endpoints").Index(0).Child("addresses"), "").MarkAlpha(),
+				field.Required(field.NewPath("endpoints").Index(0).Child("addresses"), "").MarkBeta(),
 			},
 		},
 		"invalid too many endpoint addresses": {
 			input: mkValidEndpointSlice(tweakAddresses(101)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("endpoints").Index(0).Child("addresses"), 101, 100).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("endpoints").Index(0).Child("addresses"), 101, 100).WithOrigin("maxItems").MarkBeta(),
 			},
 		},
 		"invalid missing addressType": {
 			input: mkValidEndpointSlice(tweakAddressType("")),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("addressType"), "").MarkAlpha(),
+				field.Required(field.NewPath("addressType"), "").MarkBeta(),
 			},
 		},
 		"invalid addressType not supported": {
 			input: mkValidEndpointSlice(tweakAddressType("invalid")),
 			expectedErrs: field.ErrorList{
-				field.NotSupported(field.NewPath("addressType"), discovery.AddressType("invalid"), []string{string(discovery.AddressTypeIPv4), string(discovery.AddressTypeIPv6), string(discovery.AddressTypeFQDN)}).MarkAlpha(),
+				field.NotSupported(field.NewPath("addressType"), discovery.AddressType("invalid"), []string{string(discovery.AddressTypeIPv4), string(discovery.AddressTypeIPv6), string(discovery.AddressTypeFQDN)}).MarkBeta(),
 			},
 		},
 	}
@@ -130,21 +130,21 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				obj.Endpoints[0].Addresses = nil
 			}),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("endpoints").Index(0).Child("addresses"), "").MarkAlpha(),
+				field.Required(field.NewPath("endpoints").Index(0).Child("addresses"), "").MarkBeta(),
 			},
 		},
 		"invalid update too many addresses": {
 			oldObj:    mkValidEndpointSlice(),
 			updateObj: mkValidEndpointSlice(tweakAddresses(101)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("endpoints").Index(0).Child("addresses"), 101, 100).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("endpoints").Index(0).Child("addresses"), 101, 100).WithOrigin("maxItems").MarkBeta(),
 			},
 		},
 		"invalid update addressType immutable": {
 			oldObj:    mkValidEndpointSlice(),
 			updateObj: mkValidEndpointSlice(tweakAddressType(discovery.AddressTypeIPv6)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("addressType"), discovery.AddressTypeIPv6, "field is immutable").WithOrigin("immutable").MarkAlpha(),
+				field.Invalid(field.NewPath("addressType"), discovery.AddressTypeIPv6, "field is immutable").WithOrigin("immutable").MarkBeta(),
 			},
 		},
 	}

--- a/test/declarative_validation/flowcontrol/prioritylevelconfiguration/declarative_validation_test.go
+++ b/test/declarative_validation/flowcontrol/prioritylevelconfiguration/declarative_validation_test.go
@@ -65,7 +65,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"spec.type: Limited with limited=nil": {
 			input: mkPLC(tweakLimited(nil)),
 			expectedErrs: field.ErrorList{
-				field.Required(specPath.Child("limited"), "").MarkCoveredByDeclarative().MarkAlpha(),
+				field.Required(specPath.Child("limited"), "").MarkCoveredByDeclarative().MarkBeta(),
 			},
 		},
 		"spec.type: Exempt with limited set": {
@@ -78,19 +78,19 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 			expectedErrs: field.ErrorList{
 				// Mandatory object check: spec of 'exempt' differs from bootstrap (HW-only)
 				field.Invalid(specPath, nil, "").MarkFromImperative(),
-				field.Forbidden(specPath.Child("limited"), "").MarkCoveredByDeclarative().MarkAlpha(),
+				field.Forbidden(specPath.Child("limited"), "").MarkCoveredByDeclarative().MarkBeta(),
 			},
 		},
 		"spec.type: Limited with exempt set": {
 			input: mkPLC(tweakExemptConfig(&flowcontrol.ExemptPriorityLevelConfiguration{})),
 			expectedErrs: field.ErrorList{
-				field.Forbidden(specPath.Child("exempt"), "").MarkCoveredByDeclarative().MarkAlpha(),
+				field.Forbidden(specPath.Child("exempt"), "").MarkCoveredByDeclarative().MarkBeta(),
 			},
 		},
 		"limitResponse.type: Queue with queuing=nil": {
 			input: mkPLC(tweakLimitResponseType(flowcontrol.LimitResponseTypeQueue), tweakQueuing(nil)),
 			expectedErrs: field.ErrorList{
-				field.Required(specPath.Child("limited", "limitResponse", "queuing"), "").MarkCoveredByDeclarative().MarkAlpha(),
+				field.Required(specPath.Child("limited", "limitResponse", "queuing"), "").MarkCoveredByDeclarative().MarkBeta(),
 			},
 		},
 		"limitResponse.type: Reject with queuing set": {
@@ -100,19 +100,19 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				QueueLengthLimit: 50,
 			})),
 			expectedErrs: field.ErrorList{
-				field.Forbidden(specPath.Child("limited", "limitResponse", "queuing"), "").MarkCoveredByDeclarative().MarkAlpha(),
+				field.Forbidden(specPath.Child("limited", "limitResponse", "queuing"), "").MarkCoveredByDeclarative().MarkBeta(),
 			},
 		},
 		"spec.type: empty": {
 			input: mkPLC(tweakSpecType(""), tweakLimited(nil)),
 			expectedErrs: field.ErrorList{
-				field.Required(specPath.Child("type"), "").MarkCoveredByDeclarative().MarkAlpha(),
+				field.Required(specPath.Child("type"), "").MarkCoveredByDeclarative().MarkBeta(),
 			},
 		},
 		"limitResponse.type: empty": {
 			input: mkPLC(tweakLimitResponseType("")),
 			expectedErrs: field.ErrorList{
-				field.Required(specPath.Child("limited", "limitResponse", "type"), "").MarkCoveredByDeclarative().MarkAlpha(),
+				field.Required(specPath.Child("limited", "limitResponse", "type"), "").MarkCoveredByDeclarative().MarkBeta(),
 			},
 		},
 	}
@@ -154,21 +154,21 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			old:    mkPLC(),
 			update: mkPLC(tweakLimited(nil)),
 			expectedErrs: field.ErrorList{
-				field.Required(specPath.Child("limited"), "").MarkCoveredByDeclarative().MarkAlpha(),
+				field.Required(specPath.Child("limited"), "").MarkCoveredByDeclarative().MarkBeta(),
 			},
 		},
 		"update: add exempt field to Limited PLC": {
 			old:    mkPLC(),
 			update: mkPLC(tweakExemptConfig(&flowcontrol.ExemptPriorityLevelConfiguration{})),
 			expectedErrs: field.ErrorList{
-				field.Forbidden(specPath.Child("exempt"), "").MarkCoveredByDeclarative().MarkAlpha(),
+				field.Forbidden(specPath.Child("exempt"), "").MarkCoveredByDeclarative().MarkBeta(),
 			},
 		},
 		"update: Queue with queuing set to nil": {
 			old:    mkPLC(tweakLimitResponseType(flowcontrol.LimitResponseTypeQueue)),
 			update: mkPLC(tweakLimitResponseType(flowcontrol.LimitResponseTypeQueue), tweakQueuing(nil)),
 			expectedErrs: field.ErrorList{
-				field.Required(specPath.Child("limited", "limitResponse", "queuing"), "").MarkCoveredByDeclarative().MarkAlpha(),
+				field.Required(specPath.Child("limited", "limitResponse", "queuing"), "").MarkCoveredByDeclarative().MarkBeta(),
 			},
 		},
 		"update: Reject with queuing added": {
@@ -179,7 +179,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				QueueLengthLimit: 50,
 			})),
 			expectedErrs: field.ErrorList{
-				field.Forbidden(specPath.Child("limited", "limitResponse", "queuing"), "").MarkCoveredByDeclarative().MarkAlpha(),
+				field.Forbidden(specPath.Child("limited", "limitResponse", "queuing"), "").MarkCoveredByDeclarative().MarkBeta(),
 			},
 		},
 	}

--- a/test/declarative_validation/networking/ingressclass/declarative_validation_test.go
+++ b/test/declarative_validation/networking/ingressclass/declarative_validation_test.go
@@ -60,14 +60,14 @@ func TestDeclarativeValidateParameter(t *testing.T) {
 						obj.Spec.Parameters.Name = ""
 					}),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "parameters", "name"), "").MarkAlpha()},
+						field.Required(field.NewPath("spec", "parameters", "name"), "").MarkBeta()},
 				},
 				"missing parameter kind": {
 					input: mkValidIngressClass(func(obj *networking.IngressClass) {
 						obj.Spec.Parameters.Kind = ""
 					}),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "parameters", "kind"), "").MarkAlpha(),
+						field.Required(field.NewPath("spec", "parameters", "kind"), "").MarkBeta(),
 					},
 				},
 			}
@@ -122,7 +122,7 @@ func TestDeclarativeValidateUpdateParameters(t *testing.T) {
 						obj.Spec.Parameters.Name = ""
 					}),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "parameters", "name"), "").MarkAlpha(),
+						field.Required(field.NewPath("spec", "parameters", "name"), "").MarkBeta(),
 					},
 				},
 				"update fails when parameters kind is cleared": {
@@ -134,7 +134,7 @@ func TestDeclarativeValidateUpdateParameters(t *testing.T) {
 						obj.Spec.Parameters.Kind = ""
 					}),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "parameters", "kind"), "").MarkAlpha(),
+						field.Required(field.NewPath("spec", "parameters", "kind"), "").MarkBeta(),
 					},
 				},
 			}

--- a/test/declarative_validation/networking/ipaddress/declarative_validation_test.go
+++ b/test/declarative_validation/networking/ipaddress/declarative_validation_test.go
@@ -53,19 +53,19 @@ func TestDeclarativeValidateIPAddress(t *testing.T) {
 				"missing parentRef": {
 					input: mkValidIPAddress(withNilParentRef),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "parentRef"), "").MarkAlpha(),
+						field.Required(field.NewPath("spec", "parentRef"), "").MarkBeta(),
 					},
 				},
 				"missing parentRef resource": {
 					input: mkValidIPAddress(withEmptyParentRefResource),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "parentRef", "resource"), "").MarkAlpha(),
+						field.Required(field.NewPath("spec", "parentRef", "resource"), "").MarkBeta(),
 					},
 				},
 				"missing parentRef name": {
 					input: mkValidIPAddress(withEmptyParentRefName),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "parentRef", "name"), "").MarkAlpha(),
+						field.Required(field.NewPath("spec", "parentRef", "name"), "").MarkBeta(),
 					},
 				},
 			}
@@ -114,7 +114,7 @@ func TestDeclarativeValidateIPAddressUpdate(t *testing.T) {
 							}, "field is immutable")
 							e.Origin = "immutable"
 							return e
-						}().MarkAlpha(),
+						}().MarkBeta(),
 					},
 				},
 				"set parentRef": {
@@ -132,7 +132,7 @@ func TestDeclarativeValidateIPAddressUpdate(t *testing.T) {
 							}, "field is immutable")
 							e.Origin = "immutable"
 							return e
-						}().MarkAlpha(),
+						}().MarkBeta(),
 					},
 				},
 				"unset parentRef": {
@@ -142,12 +142,12 @@ func TestDeclarativeValidateIPAddressUpdate(t *testing.T) {
 						withNilParentRef,
 					),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "parentRef"), "").MarkAlpha(),
+						field.Required(field.NewPath("spec", "parentRef"), "").MarkBeta(),
 						func() *field.Error {
 							e := field.Invalid(field.NewPath("spec", "parentRef"), nil, "field is immutable")
 							e.Origin = "immutable"
 							return e
-						}().MarkAlpha(),
+						}().MarkBeta(),
 					},
 				},
 			}

--- a/test/declarative_validation/networking/networkpolicy/declarative_validation_test.go
+++ b/test/declarative_validation/networking/networkpolicy/declarative_validation_test.go
@@ -60,7 +60,7 @@ func TestDeclarativeValidateIPBlockCIDR(t *testing.T) {
 						field.Required(
 							field.NewPath("spec", "ingress").Index(0).Child("from").Index(0).Child("ipBlock", "cidr"),
 							"",
-						).MarkAlpha(),
+						).MarkBeta(),
 					},
 				},
 				"egress rule rejects empty CIDR in ipBlock": {
@@ -69,7 +69,7 @@ func TestDeclarativeValidateIPBlockCIDR(t *testing.T) {
 						field.Required(
 							field.NewPath("spec", "egress").Index(0).Child("to").Index(0).Child("ipBlock", "cidr"),
 							"",
-						).MarkAlpha(),
+						).MarkBeta(),
 					},
 				},
 			}
@@ -130,7 +130,7 @@ func TestDeclarativeValidateIPBlockCIDRUpdate(t *testing.T) {
 						field.Required(
 							field.NewPath("spec", "ingress").Index(0).Child("from").Index(0).Child("ipBlock", "cidr"),
 							"",
-						).MarkAlpha(),
+						).MarkBeta(),
 					},
 				},
 
@@ -141,7 +141,7 @@ func TestDeclarativeValidateIPBlockCIDRUpdate(t *testing.T) {
 						field.Required(
 							field.NewPath("spec", "egress").Index(0).Child("to").Index(0).Child("ipBlock", "cidr"),
 							"",
-						).MarkAlpha(),
+						).MarkBeta(),
 					},
 				},
 			}

--- a/test/declarative_validation/node/runtimeclass/declarative_validation_test.go
+++ b/test/declarative_validation/node/runtimeclass/declarative_validation_test.go
@@ -71,7 +71,7 @@ func TestRuntimeClass_DeclarativeValidate_Create(t *testing.T) {
 						rc.Handler = ""
 					}),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("handler"), "must be a valid DNS label").MarkAlpha(),
+						field.Required(field.NewPath("handler"), "must be a valid DNS label").MarkBeta(),
 					},
 				},
 				"handler with special characters": {
@@ -80,7 +80,7 @@ func TestRuntimeClass_DeclarativeValidate_Create(t *testing.T) {
 					}),
 					expectedErrs: field.ErrorList{
 						field.Invalid(field.NewPath("handler"),
-							"", "").WithOrigin("format=k8s-short-name").MarkAlpha(),
+							"", "").WithOrigin("format=k8s-short-name").MarkBeta(),
 					},
 				},
 				"handler with uppercase and special characters": {
@@ -89,7 +89,7 @@ func TestRuntimeClass_DeclarativeValidate_Create(t *testing.T) {
 					}),
 					expectedErrs: field.ErrorList{
 						field.Invalid(field.NewPath("handler"),
-							"", "").WithOrigin("format=k8s-short-name").MarkAlpha(),
+							"", "").WithOrigin("format=k8s-short-name").MarkBeta(),
 					},
 				},
 				"handler exceeds length with invalid characters": {
@@ -98,7 +98,7 @@ func TestRuntimeClass_DeclarativeValidate_Create(t *testing.T) {
 					}),
 					expectedErrs: field.ErrorList{
 						field.Invalid(field.NewPath("handler"),
-							"", "").WithOrigin("format=k8s-short-name").MarkAlpha(),
+							"", "").WithOrigin("format=k8s-short-name").MarkBeta(),
 					},
 				},
 				"scheduling toleration with valid key": {
@@ -178,7 +178,7 @@ func TestRuntimeClass_DeclarativeValidate_Update(t *testing.T) {
 					}),
 					expectedErrs: field.ErrorList{
 						field.Invalid(field.NewPath("handler"), "",
-							"").WithOrigin("immutable").MarkAlpha(),
+							"").WithOrigin("immutable").MarkBeta(),
 					},
 				},
 			}

--- a/test/declarative_validation/rbac/clusterrole/declarative_validation_test.go
+++ b/test/declarative_validation/rbac/clusterrole/declarative_validation_test.go
@@ -51,13 +51,13 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"invalid ClusterRole missing verbs": {
 			input: mkValidClusterRole(tweakVerbs(nil)),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("rules").Index(0).Child("verbs"), "").MarkAlpha(),
+				field.Required(field.NewPath("rules").Index(0).Child("verbs"), "").MarkBeta(),
 			},
 		},
 		"invalid ClusterRole empty verbs": {
 			input: mkValidClusterRole(tweakVerbs([]string{})),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("rules").Index(0).Child("verbs"), "").MarkAlpha(),
+				field.Required(field.NewPath("rules").Index(0).Child("verbs"), "").MarkBeta(),
 			},
 		},
 		// TODO: Add more test cases
@@ -98,7 +98,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			old:    mkValidClusterRole(),
 			update: mkValidClusterRole(tweakVerbs([]string{})),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("rules").Index(0).Child("verbs"), "").MarkAlpha(),
+				field.Required(field.NewPath("rules").Index(0).Child("verbs"), "").MarkBeta(),
 			},
 		},
 		// TODO: Add more test cases

--- a/test/declarative_validation/rbac/clusterrolebinding/declarative_validation_test.go
+++ b/test/declarative_validation/rbac/clusterrolebinding/declarative_validation_test.go
@@ -51,13 +51,13 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"missing roleRef.name": {
 			input: mkValidClusterRoleBinding(tweakRoleRefName("")),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("roleRef", "name"), "").MarkAlpha(),
+				field.Required(field.NewPath("roleRef", "name"), "").MarkBeta(),
 			},
 		},
 		"missing subjects[0].name": {
 			input: mkValidClusterRoleBinding(tweakSubjectName(0, "")),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("subjects").Index(0).Child("name"), "").MarkAlpha(),
+				field.Required(field.NewPath("subjects").Index(0).Child("name"), "").MarkBeta(),
 			},
 		},
 		// TODO: Add more test cases
@@ -98,7 +98,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			old:    mkValidClusterRoleBinding(),
 			update: mkValidClusterRoleBinding(tweakSubjectName(0, "")),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("subjects").Index(0).Child("name"), "").MarkAlpha(),
+				field.Required(field.NewPath("subjects").Index(0).Child("name"), "").MarkBeta(),
 			},
 		},
 		// TODO: Add more test cases

--- a/test/declarative_validation/rbac/role/declarative_validation_test.go
+++ b/test/declarative_validation/rbac/role/declarative_validation_test.go
@@ -57,13 +57,13 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"invalid Role missing verbs": {
 			input: mkValidRole(tweakVerbs(nil)),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("rules").Index(0).Child("verbs"), "").MarkAlpha(),
+				field.Required(field.NewPath("rules").Index(0).Child("verbs"), "").MarkBeta(),
 			},
 		},
 		"invalid Role empty verbs": {
 			input: mkValidRole(tweakVerbs([]string{})),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("rules").Index(0).Child("verbs"), "").MarkAlpha(),
+				field.Required(field.NewPath("rules").Index(0).Child("verbs"), "").MarkBeta(),
 			},
 		},
 		// TODO: Add more test cases
@@ -110,7 +110,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			old:    mkValidRole(),
 			update: mkValidRole(tweakVerbs([]string{})),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("rules").Index(0).Child("verbs"), "").MarkAlpha(),
+				field.Required(field.NewPath("rules").Index(0).Child("verbs"), "").MarkBeta(),
 			},
 		},
 		// TODO: Add more test cases

--- a/test/declarative_validation/rbac/rolebinding/declarative_validation_test.go
+++ b/test/declarative_validation/rbac/rolebinding/declarative_validation_test.go
@@ -92,14 +92,14 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				Kind:     "ClusterRole",
 			})),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("roleRef", "name"), "name is required").MarkAlpha(),
+				field.Required(field.NewPath("roleRef", "name"), "name is required").MarkBeta(),
 			},
 		},
 
 		"missing subject.name": {
 			input: mkValidRoleBinding(tweakSubjectName(0, "")),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("subjects").Index(0).Child("name"), "name is required").MarkAlpha(),
+				field.Required(field.NewPath("subjects").Index(0).Child("name"), "name is required").MarkBeta(),
 			},
 		},
 		// TODO: Add more test cases

--- a/test/declarative_validation/resource/deviceclass/declarative_validation_test.go
+++ b/test/declarative_validation/resource/deviceclass/declarative_validation_test.go
@@ -66,13 +66,13 @@ func TestDeclarativeValidate(t *testing.T) {
 				"name: invalid (uppercase)": {
 					input: mkDeviceClass(tweakName("Invalid-Name")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("metadata", "name"), "Invalid-Name", "").WithOrigin("format=k8s-long-name").MarkAlpha(),
+						field.Invalid(field.NewPath("metadata", "name"), "Invalid-Name", "").WithOrigin("format=k8s-long-name").MarkBeta(),
 					},
 				},
 				"name: invalid (start with dash)": {
 					input: mkDeviceClass(tweakName("-invalid")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("metadata", "name"), "-invalid", "").WithOrigin("format=k8s-long-name").MarkAlpha(),
+						field.Invalid(field.NewPath("metadata", "name"), "-invalid", "").WithOrigin("format=k8s-long-name").MarkBeta(),
 					},
 				},
 				"name: max length": {
@@ -81,7 +81,7 @@ func TestDeclarativeValidate(t *testing.T) {
 				"name: too long": {
 					input: mkDeviceClass(tweakName(strings.Repeat("a", 254))),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("metadata", "name"), strings.Repeat("a", 254), "").WithOrigin("format=k8s-long-name").MarkAlpha(),
+						field.Invalid(field.NewPath("metadata", "name"), strings.Repeat("a", 254), "").WithOrigin("format=k8s-long-name").MarkBeta(),
 					},
 				},
 				// spec.selectors.
@@ -91,14 +91,14 @@ func TestDeclarativeValidate(t *testing.T) {
 				"too many selectors": {
 					input: mkDeviceClass(tweakSelectors(33)),
 					expectedErrs: field.ErrorList{
-						field.TooMany(field.NewPath("spec", "selectors"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+						field.TooMany(field.NewPath("spec", "selectors"), 33, 32).WithOrigin("maxItems").MarkBeta(),
 					},
 				},
 				// spec.config
 				"too many configs": {
 					input: mkDeviceClass(tweakConfig(33)),
 					expectedErrs: field.ErrorList{
-						field.TooMany(field.NewPath("spec", "config"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+						field.TooMany(field.NewPath("spec", "config"), 33, 32).WithOrigin("maxItems").MarkBeta(),
 					},
 				},
 				"valid: at limit configs": {
@@ -115,19 +115,19 @@ func TestDeclarativeValidate(t *testing.T) {
 				"invalid opaque driver, empty": {
 					input: mkDeviceClass(tweakConfigOpaqueDriver("")),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "config").Index(0).Child("opaque", "driver"), "").MarkAlpha(),
+						field.Required(field.NewPath("spec", "config").Index(0).Child("opaque", "driver"), "").MarkBeta(),
 					},
 				},
 				"invalid opaque driver, too long": {
 					input: mkDeviceClass(tweakConfigOpaqueDriver(strings.Repeat("a", 64))),
 					expectedErrs: field.ErrorList{
-						field.TooLong(field.NewPath("spec", "config").Index(0).Child("opaque", "driver"), "", 63).WithOrigin("maxLength").MarkAlpha(),
+						field.TooLong(field.NewPath("spec", "config").Index(0).Child("opaque", "driver"), "", 63).WithOrigin("maxLength").MarkBeta(),
 					},
 				},
 				"invalid opaque driver, invalid character": {
 					input: mkDeviceClass(tweakConfigOpaqueDriver("dra_example.com")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "config").Index(0).Child("opaque", "driver"), "dra_example.com", "").WithOrigin("format=k8s-long-name-caseless").MarkAlpha(),
+						field.Invalid(field.NewPath("spec", "config").Index(0).Child("opaque", "driver"), "dra_example.com", "").WithOrigin("format=k8s-long-name-caseless").MarkBeta(),
 					},
 				},
 
@@ -138,31 +138,31 @@ func TestDeclarativeValidate(t *testing.T) {
 				"invalid extended resource name": {
 					input: mkDeviceClass(tweakExtendedResourceName("invalid_name")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "extendedResourceName"), "invalid_name", "").WithOrigin("format=k8s-extended-resource-name").MarkAlpha(),
+						field.Invalid(field.NewPath("spec", "extendedResourceName"), "invalid_name", "").WithOrigin("format=k8s-extended-resource-name").MarkBeta(),
 					},
 				},
 				"invalid extended resource name, no slash": {
 					input: mkDeviceClass(tweakExtendedResourceName("noslash")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "extendedResourceName"), "noslash", "").WithOrigin("format=k8s-extended-resource-name").MarkAlpha(),
+						field.Invalid(field.NewPath("spec", "extendedResourceName"), "noslash", "").WithOrigin("format=k8s-extended-resource-name").MarkBeta(),
 					},
 				},
 				"invalid extended resource name, kubernetes.io domain": {
 					input: mkDeviceClass(tweakExtendedResourceName("kubernetes.io/foo")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "extendedResourceName"), "kubernetes.io/foo", "").WithOrigin("format=k8s-extended-resource-name").MarkAlpha(),
+						field.Invalid(field.NewPath("spec", "extendedResourceName"), "kubernetes.io/foo", "").WithOrigin("format=k8s-extended-resource-name").MarkBeta(),
 					},
 				},
 				"invalid extended resource name, requests. prefix": {
 					input: mkDeviceClass(tweakExtendedResourceName("requests.example.com/foo")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "extendedResourceName"), "requests.example.com/foo", "").WithOrigin("format=k8s-extended-resource-name").MarkAlpha(),
+						field.Invalid(field.NewPath("spec", "extendedResourceName"), "requests.example.com/foo", "").WithOrigin("format=k8s-extended-resource-name").MarkBeta(),
 					},
 				},
 				"invalid extended resource name, too long": {
 					input: mkDeviceClass(tweakExtendedResourceName("example.com/" + strings.Repeat("a", 64))),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "extendedResourceName"), "example.com/"+strings.Repeat("a", 64), "").WithOrigin("format=k8s-extended-resource-name").MarkAlpha(),
+						field.Invalid(field.NewPath("spec", "extendedResourceName"), "example.com/"+strings.Repeat("a", 64), "").WithOrigin("format=k8s-extended-resource-name").MarkBeta(),
 					},
 				},
 				// TODO: Add more test cases
@@ -218,7 +218,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkDeviceClass(),
 					update: mkDeviceClass(tweakSelectors(33)),
 					expectedErrs: field.ErrorList{
-						field.TooMany(field.NewPath("spec", "selectors"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+						field.TooMany(field.NewPath("spec", "selectors"), 33, 32).WithOrigin("maxItems").MarkBeta(),
 					},
 				},
 				"valid update: at limit configs": {
@@ -229,7 +229,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkDeviceClass(),
 					update: mkDeviceClass(tweakConfig(33)),
 					expectedErrs: field.ErrorList{
-						field.TooMany(field.NewPath("spec", "config"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+						field.TooMany(field.NewPath("spec", "config"), 33, 32).WithOrigin("maxItems").MarkBeta(),
 					},
 				},
 
@@ -242,35 +242,35 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkDeviceClass(),
 					update: mkDeviceClass(tweakExtendedResourceName("invalid_name")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "extendedResourceName"), "invalid_name", "").WithOrigin("format=k8s-extended-resource-name").MarkAlpha(),
+						field.Invalid(field.NewPath("spec", "extendedResourceName"), "invalid_name", "").WithOrigin("format=k8s-extended-resource-name").MarkBeta(),
 					},
 				},
 				"invalid extended resource name update, no slash": {
 					old:    mkDeviceClass(),
 					update: mkDeviceClass(tweakExtendedResourceName("noslash")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "extendedResourceName"), "noslash", "").WithOrigin("format=k8s-extended-resource-name").MarkAlpha(),
+						field.Invalid(field.NewPath("spec", "extendedResourceName"), "noslash", "").WithOrigin("format=k8s-extended-resource-name").MarkBeta(),
 					},
 				},
 				"invalid extended resource name update, kubernetes.io domain": {
 					old:    mkDeviceClass(),
 					update: mkDeviceClass(tweakExtendedResourceName("kubernetes.io/foo")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "extendedResourceName"), "kubernetes.io/foo", "").WithOrigin("format=k8s-extended-resource-name").MarkAlpha(),
+						field.Invalid(field.NewPath("spec", "extendedResourceName"), "kubernetes.io/foo", "").WithOrigin("format=k8s-extended-resource-name").MarkBeta(),
 					},
 				},
 				"invalid extended resource name update, requests. prefix": {
 					old:    mkDeviceClass(),
 					update: mkDeviceClass(tweakExtendedResourceName("requests.example.com/foo")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "extendedResourceName"), "requests.example.com/foo", "").WithOrigin("format=k8s-extended-resource-name").MarkAlpha(),
+						field.Invalid(field.NewPath("spec", "extendedResourceName"), "requests.example.com/foo", "").WithOrigin("format=k8s-extended-resource-name").MarkBeta(),
 					},
 				},
 				"invalid extended resource name update, too long": {
 					old:    mkDeviceClass(),
 					update: mkDeviceClass(tweakExtendedResourceName("example.com/" + strings.Repeat("a", 64))),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "extendedResourceName"), "example.com/"+strings.Repeat("a", 64), "").WithOrigin("format=k8s-extended-resource-name").MarkAlpha(),
+						field.Invalid(field.NewPath("spec", "extendedResourceName"), "example.com/"+strings.Repeat("a", 64), "").WithOrigin("format=k8s-extended-resource-name").MarkBeta(),
 					},
 				},
 				// TODO: Add more test cases

--- a/test/declarative_validation/resource/devicetaintrule/declarative_validation_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/declarative_validation_test.go
@@ -55,13 +55,13 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"missing taint.effect": {
 			input: mkValidDeviceTaintRule(tweakTaintEffect("")),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "taint", "effect"), "").MarkAlpha(),
+				field.Required(field.NewPath("spec", "taint", "effect"), "").MarkBeta(),
 			},
 		},
 		"invalid taint.effect": {
 			input: mkValidDeviceTaintRule(tweakTaintEffect("BadEffect")),
 			expectedErrs: field.ErrorList{
-				field.NotSupported(field.NewPath("spec", "taint", "effect"), resource.DeviceTaintEffect("BadEffect"), []resource.DeviceTaintEffect{}).MarkAlpha(),
+				field.NotSupported(field.NewPath("spec", "taint", "effect"), resource.DeviceTaintEffect("BadEffect"), []resource.DeviceTaintEffect{}).MarkBeta(),
 			},
 		},
 		// TODO: Add more test cases
@@ -115,14 +115,14 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			old:    mkValidDeviceTaintRule(),
 			update: mkValidDeviceTaintRule(tweakTaintEffect("")),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "taint", "effect"), "").MarkAlpha(),
+				field.Required(field.NewPath("spec", "taint", "effect"), "").MarkBeta(),
 			},
 		},
 		"invalid update with unsupported effect": {
 			old:    mkValidDeviceTaintRule(),
 			update: mkValidDeviceTaintRule(tweakTaintEffect("some-other-effect")),
 			expectedErrs: field.ErrorList{
-				field.NotSupported(field.NewPath("spec", "taint", "effect"), resource.DeviceTaintEffect("some-other-effect"), []resource.DeviceTaintEffect{resource.DeviceTaintEffectNoExecute, resource.DeviceTaintEffectNoSchedule, resource.DeviceTaintEffectNone}).MarkAlpha(),
+				field.NotSupported(field.NewPath("spec", "taint", "effect"), resource.DeviceTaintEffect("some-other-effect"), []resource.DeviceTaintEffect{resource.DeviceTaintEffectNoExecute, resource.DeviceTaintEffectNoSchedule, resource.DeviceTaintEffectNone}).MarkBeta(),
 			},
 		},
 		// TODO: Add more test cases

--- a/test/declarative_validation/resource/resourceclaim/declarative_validation_test.go
+++ b/test/declarative_validation/resource/resourceclaim/declarative_validation_test.go
@@ -87,82 +87,82 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"invalid requests, too many": {
 			input: mkValidResourceClaim(tweakDevicesRequests(33)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "devices", "requests"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("spec", "devices", "requests"), 33, 32).WithOrigin("maxItems").MarkBeta(),
 			},
 		},
 		"invalid requests, duplicate name": {
 			input: mkValidResourceClaim(tweakAddDeviceRequest(mkDeviceRequest("req-0"))),
 			expectedErrs: field.ErrorList{
-				field.Duplicate(field.NewPath("spec", "devices", "requests").Index(1), "req-0").MarkAlpha(),
+				field.Duplicate(field.NewPath("spec", "devices", "requests").Index(1), "req-0").MarkBeta(),
 			},
 		},
 		"invalid requests, too many AND duplicate name (short-circuit check)": {
 			input: mkValidResourceClaim(tweakDevicesRequests(33), tweakAddDeviceRequest(mkDeviceRequest("req-0"))),
 			expectedErrs: field.ErrorList{
 				// We expect ONLY TooMany, suppressing the Duplicate error because of short-circuiting
-				field.TooMany(field.NewPath("spec", "devices", "requests"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("spec", "devices", "requests"), 33, 32).WithOrigin("maxItems").MarkBeta(),
 			},
 		},
 		"invalid constraints, too many": {
 			input: mkValidResourceClaim(tweakDevicesConstraints(33)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "devices", "constraints"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("spec", "devices", "constraints"), 33, 32).WithOrigin("maxItems").MarkBeta(),
 			},
 		},
 		"invalid config, too many": {
 			input: mkValidResourceClaim(tweakDevicesConfigs(33)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "devices", "config"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("spec", "devices", "config"), 33, 32).WithOrigin("maxItems").MarkBeta(),
 			},
 		},
 		"invalid firstAvailable, too many": {
 			input: mkValidResourceClaim(tweakFirstAvailable(9)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable"), 9, 8).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable"), 9, 8).WithOrigin("maxItems").MarkBeta(),
 			},
 		},
 		"invalid firstAvailable, duplicate name": {
 			input: mkValidResourceClaim(tweakDuplicateFirstAvailableName("sub-0")),
 			expectedErrs: field.ErrorList{
-				field.Duplicate(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(1), "sub-0").MarkAlpha(),
+				field.Duplicate(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(1), "sub-0").MarkBeta(),
 			},
 		},
 		"invalid selectors, too many": {
 			input: mkValidResourceClaim(tweakExactlySelectors(33)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "selectors"), 33, 32).WithOrigin("maxItems").MarkCoveredByDeclarative().MarkAlpha(),
+				field.TooMany(field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "selectors"), 33, 32).WithOrigin("maxItems").MarkCoveredByDeclarative().MarkBeta(),
 			},
 		},
 		"invalid subrequest selectors, too many": {
 			input: mkValidResourceClaim(tweakSubRequestSelectors(33)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("selectors"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("selectors"), 33, 32).WithOrigin("maxItems").MarkBeta(),
 			},
 		},
 		"invalid constraint requests, too many": {
 			input: mkValidResourceClaim(tweakConstraintRequests(33)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "devices", "requests"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
-				field.TooMany(field.NewPath("spec", "devices", "constraints").Index(0).Child("requests"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("spec", "devices", "requests"), 33, 32).WithOrigin("maxItems").MarkBeta(),
+				field.TooMany(field.NewPath("spec", "devices", "constraints").Index(0).Child("requests"), 33, 32).WithOrigin("maxItems").MarkBeta(),
 			},
 		},
 		"invalid config requests, too many": {
 			input: mkValidResourceClaim(tweakConfigRequests(33)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "devices", "requests"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
-				field.TooMany(field.NewPath("spec", "devices", "config").Index(0).Child("requests"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("spec", "devices", "requests"), 33, 32).WithOrigin("maxItems").MarkBeta(),
+				field.TooMany(field.NewPath("spec", "devices", "config").Index(0).Child("requests"), 33, 32).WithOrigin("maxItems").MarkBeta(),
 			},
 		},
 		"invalid constraint requests, duplicate name": {
 			input: mkValidResourceClaim(tweakDuplicateConstraintRequest("req-0")),
 			expectedErrs: field.ErrorList{
-				field.Duplicate(field.NewPath("spec", "devices", "constraints").Index(0).Child("requests").Index(1), "req-0").MarkAlpha(),
+				field.Duplicate(field.NewPath("spec", "devices", "constraints").Index(0).Child("requests").Index(1), "req-0").MarkBeta(),
 			},
 		},
 		"invalid config requests, duplicate name": {
 			input: mkValidResourceClaim(tweakDuplicateConfigRequest("req-0")),
 			expectedErrs: field.ErrorList{
-				field.Duplicate(field.NewPath("spec", "devices", "config").Index(0).Child("requests").Index(1), "req-0").MarkAlpha(),
+				field.Duplicate(field.NewPath("spec", "devices", "config").Index(0).Child("requests").Index(1), "req-0").MarkBeta(),
 			},
 		},
 		"valid firstAvailable, max allowed": {
@@ -192,32 +192,32 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"invalid opaque driver, empty": {
 			input: mkValidResourceClaim(tweakDeviceConfigWithDriver("")),
 			expectedErrs: field.ErrorList{
-				field.Required(opaqueDriverPath, "").MarkAlpha(),
+				field.Required(opaqueDriverPath, "").MarkBeta(),
 			},
 		},
 		"invalid opaque driver, too long - 64 characters": {
 			input: mkValidResourceClaim(tweakDeviceConfigWithDriver(strings.Repeat("a", 64))),
 			expectedErrs: field.ErrorList{
-				field.TooLong(opaqueDriverPath, "", 63).MarkAlpha().WithOrigin("maxLength").MarkAlpha(),
+				field.TooLong(opaqueDriverPath, "", 63).MarkBeta().WithOrigin("maxLength").MarkBeta(),
 			},
 		},
 		"invalid opaque driver, too long - 255 characters": {
 			input: mkValidResourceClaim(tweakDeviceConfigWithDriver(strings.Repeat("a", 255))),
 			expectedErrs: field.ErrorList{
-				field.TooLong(opaqueDriverPath, "", 63).WithOrigin("maxLength").MarkAlpha(),
-				field.Invalid(opaqueDriverPath, "", "").WithOrigin("format=k8s-long-name-caseless").MarkAlpha(),
+				field.TooLong(opaqueDriverPath, "", 63).WithOrigin("maxLength").MarkBeta(),
+				field.Invalid(opaqueDriverPath, "", "").WithOrigin("format=k8s-long-name-caseless").MarkBeta(),
 			},
 		},
 		"invalid opaque driver, invalid character": {
 			input: mkValidResourceClaim(tweakDeviceConfigWithDriver("dra_example.com")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(opaqueDriverPath, "dra_example.com", "").WithOrigin("format=k8s-long-name-caseless").MarkAlpha(),
+				field.Invalid(opaqueDriverPath, "dra_example.com", "").WithOrigin("format=k8s-long-name-caseless").MarkBeta(),
 			},
 		},
 		"invalid opaque driver, invalid DNS name (leading dot)": {
 			input: mkValidResourceClaim(tweakDeviceConfigWithDriver(".example.com")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(opaqueDriverPath, ".example.com", "").WithOrigin("format=k8s-long-name-caseless").MarkAlpha(),
+				field.Invalid(opaqueDriverPath, ".example.com", "").WithOrigin("format=k8s-long-name-caseless").MarkBeta(),
 			},
 		},
 		// spec.Devices.Requests[%d].Exactly.Tolerations.Key
@@ -236,7 +236,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				{Key: "invalid_key!", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
 			})),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("key"), "invalid_key!", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("key"), "invalid_key!", "").WithOrigin("format=k8s-label-key").MarkBeta(),
 			},
 		},
 		"invalid  Exactly.Tolerations.Key - multiple slashes": {
@@ -244,7 +244,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				{Key: "a/b/c", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
 			})),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("key"), "a/b/c", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("key"), "a/b/c", "").WithOrigin("format=k8s-label-key").MarkBeta(),
 			},
 		},
 		// spec.Devices.Requests[%d].FirsAvailable[%d].Tolerations.Key
@@ -263,7 +263,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				{Key: "invalid_key!", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
 			})),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("key"), "invalid_key!", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("key"), "invalid_key!", "").WithOrigin("format=k8s-label-key").MarkBeta(),
 			},
 		},
 		"invalid FirstAvailable.Tolerations.Key - multiple slashes": {
@@ -271,7 +271,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				{Key: "a/b/c", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
 			})),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("key"), "a/b/c", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("key"), "a/b/c", "").WithOrigin("format=k8s-label-key").MarkBeta(),
 			},
 		},
 		"valid DeviceAllocationMode - All": {
@@ -284,7 +284,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 					field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "allocationMode"),
 					resource.DeviceAllocationMode("InvalidMode"),
 					[]string{"All", "ExactCount"},
-				).MarkAlpha(),
+				).MarkBeta(),
 			},
 		},
 		"valid DeviceAllocationMode - FirstAvailable": {
@@ -297,7 +297,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 					field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("allocationMode"),
 					resource.DeviceAllocationMode("InvalidMode"),
 					[]string{"All", "ExactCount"},
-				).MarkAlpha(),
+				).MarkBeta(),
 			},
 		},
 		// spec.devices.requests[%d].firstAvailable[%d].deviceClassName
@@ -308,19 +308,19 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"invalid firstAvailable class name - invalid characters": {
 			input: mkValidResourceClaim(tweakFirstAvailableDeviceClassName("Class&")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("deviceClassName"), "Class&", "").WithOrigin("format=k8s-long-name").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("deviceClassName"), "Class&", "").WithOrigin("format=k8s-long-name").MarkBeta(),
 			},
 		},
 		"invalid firstAvailable class name - long name": {
 			input: mkValidResourceClaim(tweakFirstAvailableDeviceClassName(strings.Repeat("a", 254))),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("deviceClassName"), "Class&", "").WithOrigin("format=k8s-long-name").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("deviceClassName"), "Class&", "").WithOrigin("format=k8s-long-name").MarkBeta(),
 			},
 		},
 		"invalid firstAvailable class name - empty": {
 			input: mkValidResourceClaim(tweakFirstAvailableDeviceClassName("")),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("deviceClassName"), "").MarkAlpha(),
+				field.Required(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("deviceClassName"), "").MarkBeta(),
 			},
 		},
 		"valid DeviceTolerationOperator/Effect - Exactly": {
@@ -338,7 +338,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				tweakExactlyTolerations([]resource.DeviceToleration{{Key: "key", Value: "value", Effect: resource.DeviceTaintEffectNoSchedule, Operator: ""}}),
 			),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("operator"), "").MarkAlpha(),
+				field.Required(field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("operator"), "").MarkBeta(),
 			},
 		},
 		"invalid DeviceTolerationOperator - Exactly": {
@@ -355,7 +355,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 					field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("operator"),
 					resource.DeviceTolerationOperator("InvalidOp"),
 					[]string{"Equal", "Exists"},
-				).MarkAlpha(),
+				).MarkBeta(),
 			},
 		},
 		"invalid DeviceTaintEffect - Exactly": {
@@ -372,7 +372,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 					field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("effect"),
 					resource.DeviceTaintEffect("InvalidEffect"),
 					[]string{"NoExecute", "NoSchedule"},
-				).MarkAlpha(),
+				).MarkBeta(),
 			},
 		},
 		"valid DeviceTolerationOperator/Effect - FirstAvailable": {
@@ -391,7 +391,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				tweakFirstAvailableTolerations([]resource.DeviceToleration{{Key: "key", Value: "value", Effect: resource.DeviceTaintEffectNoSchedule, Operator: ""}}),
 			),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("operator"), "").MarkAlpha(),
+				field.Required(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("operator"), "").MarkBeta(),
 			},
 		},
 		"invalid DeviceTolerationOperator - FirstAvailable": {
@@ -408,7 +408,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 					field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("operator"),
 					resource.DeviceTolerationOperator("InvalidOp"),
 					[]string{"Equal", "Exists"},
-				).MarkAlpha(),
+				).MarkBeta(),
 			},
 		},
 		"invalid DeviceTaintEffect - FirstAvailable": {
@@ -425,7 +425,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 					field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("effect"),
 					resource.DeviceTaintEffect("InvalidEffect"),
 					[]string{"NoExecute", "NoSchedule"},
-				).MarkAlpha(),
+				).MarkBeta(),
 			},
 		},
 		// Spec.Devices.Constraints[%d].MatchAttribute
@@ -434,7 +434,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				tweakMatchAttribute("invalid!"),
 			),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "invalid!", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "invalid!", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
 			},
 		},
 		"match attribute without domain": {
@@ -442,7 +442,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				tweakMatchAttribute("nodomain"),
 			),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "nodomain", "a fully qualified name must be a domain and a name separated by a slash").WithOrigin("format=k8s-resource-fully-qualified-name").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "nodomain", "a fully qualified name must be a domain and a name separated by a slash").WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
 			},
 		},
 		"match attribute empty": {
@@ -450,7 +450,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				tweakMatchAttribute(""),
 			),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
 			},
 		},
 		"match attribute with empty domain": {
@@ -458,7 +458,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				tweakMatchAttribute("/foo"),
 			),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
 			},
 		},
 		"match attribute with empty name": {
@@ -466,7 +466,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				tweakMatchAttribute("foo/"),
 			),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
 			},
 		},
 		"match attribute with invalid domain": {
@@ -474,7 +474,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				tweakMatchAttribute("invalid_domain/foo"),
 			),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "invalid_domain", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "invalid_domain", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
 			},
 		},
 		"match attribute with invalid name": {
@@ -482,7 +482,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				tweakMatchAttribute("domain/invalid-name"),
 			),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "invalid-name", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "invalid-name", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
 			},
 		},
 		"match attribute with long name": {
@@ -490,7 +490,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				tweakMatchAttribute("domain/" + strings.Repeat("a", 65)),
 			),
 			expectedErrs: field.ErrorList{
-				field.TooLong(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", 64).WithOrigin("format=k8s-resource-fully-qualified-name").MarkAlpha(),
+				field.TooLong(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", 64).WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
 			},
 		},
 		"match attribute with long domain": {
@@ -498,8 +498,8 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				tweakMatchAttribute(strings.Repeat("a", 254) + "/name"),
 			),
 			expectedErrs: field.ErrorList{
-				field.TooLong(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", 63).WithOrigin("format=k8s-resource-fully-qualified-name").MarkAlpha(),
-				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkAlpha(),
+				field.TooLong(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", 63).WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
+				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
 			},
 		},
 		// TODO: Add more test cases
@@ -744,35 +744,35 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			update: mkValidResourceClaim(tweakSpecChangeClassName("another-class")),
 			old:    validClaim,
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkAlpha(),
+				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkBeta(),
 			},
 		},
 		"spec immutable: add request": {
 			update: mkValidResourceClaim(tweakAddDeviceRequest(mkDeviceRequest("req-1"))),
 			old:    validClaim,
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkAlpha(),
+				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkBeta(),
 			},
 		},
 		"spec immutable: remove request": {
 			update: mkValidResourceClaim(tweakSpecRemoveRequest(0)),
 			old:    validClaim,
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkAlpha(),
+				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkBeta(),
 			},
 		},
 		"spec immutable: add constraint": {
 			update: mkValidResourceClaim(tweakSpecAddConstraint(mkDeviceConstraint())),
 			old:    validClaim,
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkAlpha(),
+				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkBeta(),
 			},
 		},
 		"spec immutable: short-circuits other errors (e.g. TooMany)": {
 			update: mkValidResourceClaim(tweakDevicesRequests(33)),
 			old:    mkValidResourceClaim(),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkAlpha(),
+				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkBeta(),
 			},
 		},
 		"spec immutable: add Exactly.Tolerations": {
@@ -781,7 +781,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			})),
 			old: validClaim,
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkAlpha(),
+				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkBeta(),
 			},
 		},
 		"spec immutable: change Exactly.Tolerations.Key": {
@@ -792,7 +792,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				{Key: "valid-key", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
 			})),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkAlpha(),
+				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkBeta(),
 			},
 		},
 		// spec.Devices.Requests[%d].FirsAvailable[%d].Tolerations.Key
@@ -802,7 +802,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			})),
 			old: mkValidResourceClaim(tweakFirstAvailable(1)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkAlpha(),
+				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkBeta(),
 			},
 		},
 		"spec immutable: change FirstAvailable.Tolerations.Key": {
@@ -813,14 +813,14 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				{Key: "valid-key", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
 			})),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkAlpha(),
+				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkBeta(),
 			},
 		},
 		"spec immutable: short-circuits deviceClassName error": {
 			update: mkValidResourceClaim(tweakFirstAvailableDeviceClassName("Class")),
 			old:    mkValidResourceClaim(),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkAlpha(),
+				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkBeta(),
 			},
 		},
 		// TODO: Add more test cases
@@ -889,28 +889,28 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultDriver("")),
 			expectedErrs: field.ErrorList{
-				field.Required(driverPath, "").MarkAlpha(),
+				field.Required(driverPath, "").MarkBeta(),
 			},
 		},
 		"invalid driver name, too long - 64 characters": {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultDriver(strings.Repeat("a", 64))),
 			expectedErrs: field.ErrorList{
-				field.TooLong(driverPath, "", 63).MarkAlpha().WithOrigin("maxLength"),
+				field.TooLong(driverPath, "", 63).MarkBeta().WithOrigin("maxLength"),
 			},
 		},
 		"invalid driver name, invalid character": {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultDriver("dra_example.com")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(driverPath, "dra_example.com", "").WithOrigin("format=k8s-long-name-caseless").MarkAlpha(),
+				field.Invalid(driverPath, "dra_example.com", "").WithOrigin("format=k8s-long-name-caseless").MarkBeta(),
 			},
 		},
 		"invalid driver name, invalid DNS name (leading dot)": {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultDriver(".example.com")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(driverPath, ".example.com", "").WithOrigin("format=k8s-long-name-caseless").MarkAlpha(),
+				field.Invalid(driverPath, ".example.com", "").WithOrigin("format=k8s-long-name-caseless").MarkBeta(),
 			},
 		},
 		// .Status.Allocation.Devices.Results[%d].Pool
@@ -926,42 +926,42 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultPool("")),
 			expectedErrs: field.ErrorList{
-				field.Required(poolPath, "").MarkAlpha(),
+				field.Required(poolPath, "").MarkBeta(),
 			},
 		},
 		"invalid pool name, too long": {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultPool(strings.Repeat("a", 253) + "/" + strings.Repeat("a", 253))),
 			expectedErrs: field.ErrorList{
-				field.TooLong(poolPath, "", 253).WithOrigin("format=k8s-resource-pool-name").MarkAlpha(),
+				field.TooLong(poolPath, "", 253).WithOrigin("format=k8s-resource-pool-name").MarkBeta(),
 			},
 		},
 		"invalid pool name, format": {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultPool("a/Not_Valid")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(poolPath, "Not_Valid", "").WithOrigin("format=k8s-resource-pool-name").MarkAlpha(),
+				field.Invalid(poolPath, "Not_Valid", "").WithOrigin("format=k8s-resource-pool-name").MarkBeta(),
 			},
 		},
 		"invalid pool name, leading slash": {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultPool("/a")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(poolPath, "", "").WithOrigin("format=k8s-resource-pool-name").MarkAlpha(),
+				field.Invalid(poolPath, "", "").WithOrigin("format=k8s-resource-pool-name").MarkBeta(),
 			},
 		},
 		"invalid pool name, trailing slash": {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultPool("a/")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(poolPath, "", "").WithOrigin("format=k8s-resource-pool-name").MarkAlpha(),
+				field.Invalid(poolPath, "", "").WithOrigin("format=k8s-resource-pool-name").MarkBeta(),
 			},
 		},
 		"invalid pool name, double slash": {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultPool("a//b")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(poolPath, "", "").WithOrigin("format=k8s-resource-pool-name").MarkAlpha(),
+				field.Invalid(poolPath, "", "").WithOrigin("format=k8s-resource-pool-name").MarkBeta(),
 			},
 		},
 		// .Status.Allocation.Devices.Results[%d].ShareID
@@ -973,14 +973,14 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultShareID("invalid-uid")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("status", "allocation", "devices", "results").Index(0).Child("shareID"), "invalid-uid", "").WithOrigin("format=k8s-uuid").MarkAlpha(),
+				field.Invalid(field.NewPath("status", "allocation", "devices", "results").Index(0).Child("shareID"), "invalid-uid", "").WithOrigin("format=k8s-uuid").MarkBeta(),
 			},
 		},
 		"invalid uppercase status.Allocation.Devices.Results[].ShareID ": {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultShareID("123e4567-E89b-12d3-A456-426614174000")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("status", "allocation", "devices", "results").Index(0).Child("shareID"), "invalid-uid", "").WithOrigin("format=k8s-uuid").MarkAlpha(),
+				field.Invalid(field.NewPath("status", "allocation", "devices", "results").Index(0).Child("shareID"), "invalid-uid", "").WithOrigin("format=k8s-uuid").MarkBeta(),
 			},
 		},
 		// .Status.Devices[%d].ShareID
@@ -1000,8 +1000,8 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 				tweakStatusAllocatedDeviceStatusShareID("invalid-uid"),
 			),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("status", "allocation", "devices", "results").Index(0).Child("shareID"), "invalid-uid", "must be a lowercase UUID in 8-4-4-4-12 format").WithOrigin("format=k8s-uuid").MarkAlpha(),
-				field.Invalid(field.NewPath("status", "devices").Index(0).Child("shareID"), "invalid-uid", "must be a lowercase UUID in 8-4-4-4-12 format").WithOrigin("format=k8s-uuid").MarkAlpha(),
+				field.Invalid(field.NewPath("status", "allocation", "devices", "results").Index(0).Child("shareID"), "invalid-uid", "must be a lowercase UUID in 8-4-4-4-12 format").WithOrigin("format=k8s-uuid").MarkBeta(),
+				field.Invalid(field.NewPath("status", "devices").Index(0).Child("shareID"), "invalid-uid", "must be a lowercase UUID in 8-4-4-4-12 format").WithOrigin("format=k8s-uuid").MarkBeta(),
 			},
 		},
 		"invalid upper case status.Devices[].ShareID": {
@@ -1012,8 +1012,8 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 				tweakStatusAllocatedDeviceStatusShareID("123e4567-E89b-12d3-A456-426614174000"),
 			),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("status", "allocation", "devices", "results").Index(0).Child("shareID"), "invalid-uid", "must be a lowercase UUID in 8-4-4-4-12 format").WithOrigin("format=k8s-uuid").MarkAlpha(),
-				field.Invalid(field.NewPath("status", "devices").Index(0).Child("shareID"), "invalid-uid", "must be a lowercase UUID in 8-4-4-4-12 format").WithOrigin("format=k8s-uuid").MarkAlpha(),
+				field.Invalid(field.NewPath("status", "allocation", "devices", "results").Index(0).Child("shareID"), "invalid-uid", "must be a lowercase UUID in 8-4-4-4-12 format").WithOrigin("format=k8s-uuid").MarkBeta(),
+				field.Invalid(field.NewPath("status", "devices").Index(0).Child("shareID"), "invalid-uid", "must be a lowercase UUID in 8-4-4-4-12 format").WithOrigin("format=k8s-uuid").MarkBeta(),
 			},
 		},
 		// UID in status.ReservedFor
@@ -1026,7 +1026,7 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 					resourceClaimReference(validUUID),
 				)),
 			expectedErrs: field.ErrorList{
-				field.Duplicate(field.NewPath("status", "reservedFor").Index(2), "").MarkAlpha(),
+				field.Duplicate(field.NewPath("status", "reservedFor").Index(2), "").MarkBeta(),
 			},
 		},
 		"multiple- duplicate uid in status.ReservedFor": {
@@ -1040,8 +1040,8 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 				resourceClaimReference(uuid.New().String()),
 			)),
 			expectedErrs: field.ErrorList{
-				field.Duplicate(field.NewPath("status", "reservedFor").Index(2), "").MarkAlpha(),
-				field.Duplicate(field.NewPath("status", "reservedFor").Index(4), "").MarkAlpha(),
+				field.Duplicate(field.NewPath("status", "reservedFor").Index(2), "").MarkBeta(),
+				field.Duplicate(field.NewPath("status", "reservedFor").Index(4), "").MarkBeta(),
 			},
 		},
 		"invalid status.ReservedFor, too many": {
@@ -1050,7 +1050,7 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 				tweakStatusReservedFor(generateResourceClaimReferences(257)...),
 			),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("status", "reservedFor"), 257, 256).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("status", "reservedFor"), 257, 256).WithOrigin("maxItems").MarkBeta(),
 			},
 		},
 		"valid status.ReservedFor, max items": {
@@ -1081,35 +1081,35 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 			old:    mkResourceClaimWithStatus(),
 			update: tweakStatusAllocationDevice(mkResourceClaimWithStatus(), "device-different"),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("status", "allocation"), nil, "field is immutable").WithOrigin("update").MarkAlpha(),
+				field.Invalid(field.NewPath("status", "allocation"), nil, "field is immutable").WithOrigin("update").MarkBeta(),
 			},
 		},
 		"invalid status.allocation changed driver (NoModify)": {
 			old:    mkResourceClaimWithStatus(),
 			update: tweakStatusAllocationDriver(mkResourceClaimWithStatus(), "different.example.com"),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("status", "allocation"), nil, "field is immutable").WithOrigin("update").MarkAlpha(),
+				field.Invalid(field.NewPath("status", "allocation"), nil, "field is immutable").WithOrigin("update").MarkBeta(),
 			},
 		},
 		"invalid status.allocation changed pool (NoModify)": {
 			old:    mkResourceClaimWithStatus(),
 			update: tweakStatusAllocationPool(mkResourceClaimWithStatus(), "different-pool"),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("status", "allocation"), nil, "field is immutable").WithOrigin("update").MarkAlpha(),
+				field.Invalid(field.NewPath("status", "allocation"), nil, "field is immutable").WithOrigin("update").MarkBeta(),
 			},
 		},
 		"invalid status.allocation added result (NoModify)": {
 			old:    mkResourceClaimWithStatus(),
 			update: addStatusAllocationResult(mkResourceClaimWithStatus()),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("status", "allocation"), nil, "field is immutable").WithOrigin("update").MarkAlpha(),
+				field.Invalid(field.NewPath("status", "allocation"), nil, "field is immutable").WithOrigin("update").MarkBeta(),
 			},
 		},
 		"invalid status.allocation removed result (NoModify)": {
 			old:    addStatusAllocationResult(mkResourceClaimWithStatus()),
 			update: mkResourceClaimWithStatus(),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("status", "allocation"), nil, "field is immutable").WithOrigin("update").MarkAlpha(),
+				field.Invalid(field.NewPath("status", "allocation"), nil, "field is immutable").WithOrigin("update").MarkBeta(),
 			},
 		},
 		"invalid status.allocation.devices.results, too many": {
@@ -1118,7 +1118,7 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 				tweakStatusAllocationDevicesResults(33),
 			),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("status", "allocation", "devices", "results"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("status", "allocation", "devices", "results"), 33, 32).WithOrigin("maxItems").MarkBeta(),
 			},
 		},
 		"valid status.allocation.devices.config, max items": {
@@ -1133,7 +1133,7 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 				tweakStatusAllocationDevicesConfig(65),
 			),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("status", "allocation", "devices", "config"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("status", "allocation", "devices", "config"), 33, 32).WithOrigin("maxItems").MarkBeta(),
 			},
 		},
 		"invalid status.allocation.devices.config requests, duplicate": {
@@ -1142,7 +1142,7 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 				tweakAddStatusAllocationConfigRequest("req-0"),
 			),
 			expectedErrs: field.ErrorList{
-				field.Duplicate(field.NewPath("status", "allocation", "devices", "config").Index(0).Child("requests").Index(1), "req-0").MarkAlpha(),
+				field.Duplicate(field.NewPath("status", "allocation", "devices", "config").Index(0).Child("requests").Index(1), "req-0").MarkBeta(),
 			},
 		},
 		// .Status.Allocation.Devices.Config[%d].Source
@@ -1158,14 +1158,14 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusAllocationConfigSource("")),
 			expectedErrs: field.ErrorList{
-				field.Required(configSourcePath, "").MarkCoveredByDeclarative().MarkAlpha(),
+				field.Required(configSourcePath, "").MarkCoveredByDeclarative().MarkBeta(),
 			},
 		},
 		"invalid status.allocation.devices.config source invalid": {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusAllocationConfigSource("invalid")),
 			expectedErrs: field.ErrorList{
-				field.NotSupported(configSourcePath, resource.AllocationConfigSource("invalid"), []string{string(resource.AllocationConfigSourceClaim), string(resource.AllocationConfigSourceClass)}).MarkCoveredByDeclarative().MarkAlpha(),
+				field.NotSupported(configSourcePath, resource.AllocationConfigSource("invalid"), []string{string(resource.AllocationConfigSourceClaim), string(resource.AllocationConfigSourceClass)}).MarkCoveredByDeclarative().MarkBeta(),
 			},
 		},
 		// .Status.Allocation.Devices.Config[%d].Opaque.Driver
@@ -1181,21 +1181,21 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusAllocationConfigOpaqueDriver("")),
 			expectedErrs: field.ErrorList{
-				field.Required(configOpaqueDriverPath, "").MarkAlpha(),
+				field.Required(configOpaqueDriverPath, "").MarkBeta(),
 			},
 		},
 		"invalid status.allocation.devices.config opaque driver, too long": {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusAllocationConfigOpaqueDriver(strings.Repeat("a", 64))),
 			expectedErrs: field.ErrorList{
-				field.TooLong(configOpaqueDriverPath, "", 63).WithOrigin("maxLength").MarkAlpha(),
+				field.TooLong(configOpaqueDriverPath, "", 63).WithOrigin("maxLength").MarkBeta(),
 			},
 		},
 		"invalid status.allocation.devices.config opaque driver, invalid character": {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusAllocationConfigOpaqueDriver("dra_example.com")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(configOpaqueDriverPath, "dra_example.com", "").WithOrigin("format=k8s-long-name-caseless").MarkAlpha(),
+				field.Invalid(configOpaqueDriverPath, "dra_example.com", "").WithOrigin("format=k8s-long-name-caseless").MarkBeta(),
 			},
 		},
 		// .Status.Allocation.Devices.Results[%d].Tolerations
@@ -1211,7 +1211,7 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 				{Key: "invalid_key!", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
 			})),
 			expectedErrs: field.ErrorList{
-				field.Invalid(resultTolerationPath.Child("key"), "invalid_key!", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
+				field.Invalid(resultTolerationPath.Child("key"), "invalid_key!", "").WithOrigin("format=k8s-label-key").MarkBeta(),
 			},
 		},
 		"invalid status.allocation.devices.results toleration, empty operator": {
@@ -1220,7 +1220,7 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 				{Key: "key", Value: "value", Effect: resource.DeviceTaintEffectNoSchedule, Operator: ""},
 			})),
 			expectedErrs: field.ErrorList{
-				field.Required(resultTolerationPath.Child("operator"), "").MarkAlpha(),
+				field.Required(resultTolerationPath.Child("operator"), "").MarkBeta(),
 			},
 		},
 		"invalid status.allocation.devices.results toleration, bad operator": {
@@ -1229,7 +1229,7 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 				{Key: "key", Operator: "InvalidOp", Value: "value", Effect: resource.DeviceTaintEffectNoSchedule},
 			})),
 			expectedErrs: field.ErrorList{
-				field.NotSupported(resultTolerationPath.Child("operator"), resource.DeviceTolerationOperator("InvalidOp"), []string{"Equal", "Exists"}).MarkAlpha(),
+				field.NotSupported(resultTolerationPath.Child("operator"), resource.DeviceTolerationOperator("InvalidOp"), []string{"Equal", "Exists"}).MarkBeta(),
 			},
 		},
 		"invalid status.allocation.devices.results toleration, bad effect": {
@@ -1238,7 +1238,7 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 				{Key: "key", Operator: resource.DeviceTolerationOpEqual, Value: "value", Effect: "InvalidEffect"},
 			})),
 			expectedErrs: field.ErrorList{
-				field.NotSupported(resultTolerationPath.Child("effect"), resource.DeviceTaintEffect("InvalidEffect"), []string{"NoExecute", "NoSchedule"}).MarkAlpha(),
+				field.NotSupported(resultTolerationPath.Child("effect"), resource.DeviceTaintEffect("InvalidEffect"), []string{"NoExecute", "NoSchedule"}).MarkBeta(),
 			},
 		},
 		// .Status.Devices
@@ -1280,7 +1280,7 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 				),
 			),
 			expectedErrs: field.ErrorList{
-				field.Duplicate(field.NewPath("status", "devices").Index(1), "driver1/pool1/device1").MarkAlpha(),
+				field.Duplicate(field.NewPath("status", "devices").Index(1), "driver1/pool1/device1").MarkBeta(),
 			},
 		},
 		"invalid devices, duplicate with share ID": {
@@ -1295,7 +1295,7 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 				),
 			),
 			expectedErrs: field.ErrorList{
-				field.Duplicate(field.NewPath("status", "devices").Index(1), "driver1/pool1/device1").MarkAlpha(),
+				field.Duplicate(field.NewPath("status", "devices").Index(1), "driver1/pool1/device1").MarkBeta(),
 			},
 		},
 		// .Status.Allocation.Devices.Results[%d].BindingConditions
@@ -1313,7 +1313,7 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 				tweakStatusBindingFailureConditions(1),
 			),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("status", "allocation", "devices", "results").Index(0).Child("bindingConditions"), resource.BindingConditionsMaxSize+1, resource.BindingConditionsMaxSize).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("status", "allocation", "devices", "results").Index(0).Child("bindingConditions"), resource.BindingConditionsMaxSize+1, resource.BindingConditionsMaxSize).WithOrigin("maxItems").MarkBeta(),
 			},
 		},
 		"valid binding failure conditions, max items": {
@@ -1330,7 +1330,7 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 				tweakStatusBindingFailureConditions(resource.BindingFailureConditionsMaxSize+1),
 			),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("status", "allocation", "devices", "results").Index(0).Child("bindingFailureConditions"), resource.BindingFailureConditionsMaxSize+1, resource.BindingFailureConditionsMaxSize).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("status", "allocation", "devices", "results").Index(0).Child("bindingFailureConditions"), resource.BindingFailureConditionsMaxSize+1, resource.BindingFailureConditionsMaxSize).WithOrigin("maxItems").MarkBeta(),
 			},
 		},
 		// .Status.Devices[%d].NetworkData.InterfaceName
@@ -1379,7 +1379,7 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 				),
 			),
 			expectedErrs: field.ErrorList{
-				field.TooLong(field.NewPath("status", "devices").Index(0).Child("networkData", "interfaceName"), "", resource.NetworkDeviceDataInterfaceNameMaxLength).MarkCoveredByDeclarative().WithOrigin("maxBytes").MarkAlpha(),
+				field.TooLong(field.NewPath("status", "devices").Index(0).Child("networkData", "interfaceName"), "", resource.NetworkDeviceDataInterfaceNameMaxLength).MarkCoveredByDeclarative().WithOrigin("maxBytes").MarkBeta(),
 			},
 		},
 		"invalid networkdevicedata interfacename too long with multi-byte characters repeating max bytes length times": {
@@ -1400,7 +1400,7 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 				),
 			),
 			expectedErrs: field.ErrorList{
-				field.TooLong(field.NewPath("status", "devices").Index(0).Child("networkData", "interfaceName"), "", resource.NetworkDeviceDataInterfaceNameMaxLength).MarkCoveredByDeclarative().WithOrigin("maxBytes").MarkAlpha(),
+				field.TooLong(field.NewPath("status", "devices").Index(0).Child("networkData", "interfaceName"), "", resource.NetworkDeviceDataInterfaceNameMaxLength).MarkCoveredByDeclarative().WithOrigin("maxBytes").MarkBeta(),
 			},
 		},
 		"valid status.devices.networkData.hardwareAddress": {
@@ -1448,7 +1448,7 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 				),
 			),
 			expectedErrs: field.ErrorList{
-				field.TooLong(field.NewPath("status", "devices").Index(0).Child("networkData", "hardwareAddress"), "", resource.NetworkDeviceDataHardwareAddressMaxLength).MarkCoveredByDeclarative().WithOrigin("maxBytes").MarkAlpha(),
+				field.TooLong(field.NewPath("status", "devices").Index(0).Child("networkData", "hardwareAddress"), "", resource.NetworkDeviceDataHardwareAddressMaxLength).MarkCoveredByDeclarative().WithOrigin("maxBytes").MarkBeta(),
 			},
 		},
 		"invalid status.devices.networkData.hardwareAddress too long with multi-byte characters repeating max bytes length times": {
@@ -1469,7 +1469,7 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 				),
 			),
 			expectedErrs: field.ErrorList{
-				field.TooLong(field.NewPath("status", "devices").Index(0).Child("networkData", "hardwareAddress"), "", resource.NetworkDeviceDataHardwareAddressMaxLength).MarkCoveredByDeclarative().WithOrigin("maxBytes").MarkAlpha(),
+				field.TooLong(field.NewPath("status", "devices").Index(0).Child("networkData", "hardwareAddress"), "", resource.NetworkDeviceDataHardwareAddressMaxLength).MarkCoveredByDeclarative().WithOrigin("maxBytes").MarkBeta(),
 			},
 		},
 		"invalid status.devices.networkData.ips duplicate": {
@@ -1487,7 +1487,7 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 				),
 			),
 			expectedErrs: field.ErrorList{
-				field.Duplicate(field.NewPath("status", "devices").Index(0).Child("networkData", "ips").Index(1), "1.2.3.4/32").MarkAlpha(),
+				field.Duplicate(field.NewPath("status", "devices").Index(0).Child("networkData", "ips").Index(1), "1.2.3.4/32").MarkBeta(),
 			},
 		},
 		"invalid status.allocation.devices.config.requests too many": {
@@ -1496,7 +1496,7 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 				tweakStatusAllocationConfigRequests(33),
 			),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("status", "allocation", "devices", "config").Index(0).Child("requests"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("status", "allocation", "devices", "config").Index(0).Child("requests"), 33, 32).WithOrigin("maxItems").MarkBeta(),
 			},
 		},
 		"valid status.allocation.devices.config.requests, max allowed": {
@@ -1511,7 +1511,7 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 				tweakStatusDevicesTooManyIPs(17),
 			),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("status", "devices").Index(0).Child("networkData", "ips"), 17, 16).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("status", "devices").Index(0).Child("networkData", "ips"), 17, 16).WithOrigin("maxItems").MarkBeta(),
 			},
 		},
 		"invalid status.devices.networkData.ips, max allowed": {

--- a/test/declarative_validation/resource/resourceclaimtemplate/declarative_validation_test.go
+++ b/test/declarative_validation/resource/resourceclaimtemplate/declarative_validation_test.go
@@ -75,75 +75,75 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"invalid requests, too many": {
 			input: mkValidResourceClaimTemplate(tweakDevicesRequests(33)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "spec", "devices", "requests"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("spec", "spec", "devices", "requests"), 33, 32).WithOrigin("maxItems").MarkBeta(),
 			},
 		},
 		"invalid requests, duplicate name": {
 			input: mkValidResourceClaimTemplate(tweakAddDeviceRequest(mkDeviceRequest("req-0"))),
 			expectedErrs: field.ErrorList{
-				field.Duplicate(field.NewPath("spec", "spec", "devices", "requests").Index(1), "req-0").MarkAlpha(),
+				field.Duplicate(field.NewPath("spec", "spec", "devices", "requests").Index(1), "req-0").MarkBeta(),
 			},
 		},
 		"invalid constraints, too many": {
 			input: mkValidResourceClaimTemplate(tweakDevicesConstraints(33)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "spec", "devices", "constraints"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("spec", "spec", "devices", "constraints"), 33, 32).WithOrigin("maxItems").MarkBeta(),
 			},
 		},
 		"invalid config, too many": {
 			input: mkValidResourceClaimTemplate(tweakDevicesConfigs(33)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "spec", "devices", "config"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("spec", "spec", "devices", "config"), 33, 32).WithOrigin("maxItems").MarkBeta(),
 			},
 		},
 		"invalid firstAvailable, too many": {
 			input: mkValidResourceClaimTemplate(tweakFirstAvailable(9)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable"), 9, 8).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable"), 9, 8).WithOrigin("maxItems").MarkBeta(),
 			},
 		},
 		"invalid firstAvailable, duplicate name": {
 			input: mkValidResourceClaimTemplate(tweakDuplicateFirstAvailableName("sub-0")),
 			expectedErrs: field.ErrorList{
-				field.Duplicate(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(1), "sub-0").MarkAlpha(),
+				field.Duplicate(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(1), "sub-0").MarkBeta(),
 			},
 		},
 		"invalid selectors, too many": {
 			input: mkValidResourceClaimTemplate(tweakExactlySelectors(33)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("exactly", "selectors"), 33, 32).WithOrigin("maxItems").MarkCoveredByDeclarative().MarkAlpha(),
+				field.TooMany(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("exactly", "selectors"), 33, 32).WithOrigin("maxItems").MarkCoveredByDeclarative().MarkBeta(),
 			},
 		},
 		"invalid subrequest selectors, too many": {
 			input: mkValidResourceClaimTemplate(tweakSubRequestSelectors(33)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("selectors"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("selectors"), 33, 32).WithOrigin("maxItems").MarkBeta(),
 			},
 		},
 		"invalid constraint requests, too many": {
 			input: mkValidResourceClaimTemplate(tweakConstraintRequests(33)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "spec", "devices", "requests"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
-				field.TooMany(field.NewPath("spec", "spec", "devices", "constraints").Index(0).Child("requests"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("spec", "spec", "devices", "requests"), 33, 32).WithOrigin("maxItems").MarkBeta(),
+				field.TooMany(field.NewPath("spec", "spec", "devices", "constraints").Index(0).Child("requests"), 33, 32).WithOrigin("maxItems").MarkBeta(),
 			},
 		},
 		"invalid config requests, too many": {
 			input: mkValidResourceClaimTemplate(tweakConfigRequests(33)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "spec", "devices", "requests"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
-				field.TooMany(field.NewPath("spec", "spec", "devices", "config").Index(0).Child("requests"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("spec", "spec", "devices", "requests"), 33, 32).WithOrigin("maxItems").MarkBeta(),
+				field.TooMany(field.NewPath("spec", "spec", "devices", "config").Index(0).Child("requests"), 33, 32).WithOrigin("maxItems").MarkBeta(),
 			},
 		},
 		"invalid constraint requests, duplicate name": {
 			input: mkValidResourceClaimTemplate(tweakDuplicateConstraintRequest("req-0")),
 			expectedErrs: field.ErrorList{
-				field.Duplicate(field.NewPath("spec", "spec", "devices", "constraints").Index(0).Child("requests").Index(1), "req-0").MarkAlpha(),
+				field.Duplicate(field.NewPath("spec", "spec", "devices", "constraints").Index(0).Child("requests").Index(1), "req-0").MarkBeta(),
 			},
 		},
 		"invalid config requests, duplicate name": {
 			input: mkValidResourceClaimTemplate(tweakDuplicateConfigRequest("req-0")),
 			expectedErrs: field.ErrorList{
-				field.Duplicate(field.NewPath("spec", "spec", "devices", "config").Index(0).Child("requests").Index(1), "req-0").MarkAlpha(),
+				field.Duplicate(field.NewPath("spec", "spec", "devices", "config").Index(0).Child("requests").Index(1), "req-0").MarkBeta(),
 			},
 		},
 		"valid opaque driver, lowercase": {
@@ -158,32 +158,32 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"invalid opaque driver, empty": {
 			input: mkValidResourceClaimTemplate(tweakDeviceConfigWithDriver("")),
 			expectedErrs: field.ErrorList{
-				field.Required(opaqueDriverPath, "").MarkAlpha(),
+				field.Required(opaqueDriverPath, "").MarkBeta(),
 			},
 		},
 		"invalid opaque driver, too long - 64 characters": {
 			input: mkValidResourceClaimTemplate(tweakDeviceConfigWithDriver(strings.Repeat("a", 64))),
 			expectedErrs: field.ErrorList{
-				field.TooLong(opaqueDriverPath, "", 63).WithOrigin("maxLength").MarkAlpha(),
+				field.TooLong(opaqueDriverPath, "", 63).WithOrigin("maxLength").MarkBeta(),
 			},
 		},
 		"invalid opaque driver, too long - 255 characters": {
 			input: mkValidResourceClaimTemplate(tweakDeviceConfigWithDriver(strings.Repeat("a", 255))),
 			expectedErrs: field.ErrorList{
-				field.TooLong(opaqueDriverPath, "", 63).WithOrigin("maxLength").MarkAlpha(),
-				field.Invalid(opaqueDriverPath, "", "").WithOrigin("format=k8s-long-name-caseless").MarkAlpha(),
+				field.TooLong(opaqueDriverPath, "", 63).WithOrigin("maxLength").MarkBeta(),
+				field.Invalid(opaqueDriverPath, "", "").WithOrigin("format=k8s-long-name-caseless").MarkBeta(),
 			},
 		},
 		"invalid opaque driver, invalid character": {
 			input: mkValidResourceClaimTemplate(tweakDeviceConfigWithDriver("dra_example.com")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(opaqueDriverPath, "dra_example.com", "").WithOrigin("format=k8s-long-name-caseless").MarkAlpha(),
+				field.Invalid(opaqueDriverPath, "dra_example.com", "").WithOrigin("format=k8s-long-name-caseless").MarkBeta(),
 			},
 		},
 		"invalid opaque driver, invalid DNS name (leading dot)": {
 			input: mkValidResourceClaimTemplate(tweakDeviceConfigWithDriver(".example.com")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(opaqueDriverPath, ".example.com", "").WithOrigin("format=k8s-long-name-caseless").MarkAlpha(),
+				field.Invalid(opaqueDriverPath, ".example.com", "").WithOrigin("format=k8s-long-name-caseless").MarkBeta(),
 			},
 		},
 		"valid Exactly.Tolerations.Key": {
@@ -201,7 +201,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				{Key: "invalid_key!", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
 			})),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("key"), "invalid_key!", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("key"), "invalid_key!", "").WithOrigin("format=k8s-label-key").MarkBeta(),
 			},
 		},
 		"invalid Exactly.Tolerations.Key - multiple slashes": {
@@ -209,7 +209,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				{Key: "a/b/c", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
 			})),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("key"), "a/b/c", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("key"), "a/b/c", "").WithOrigin("format=k8s-label-key").MarkBeta(),
 			},
 		},
 		"valid FirstAvailable.Tolerations.Key": {
@@ -227,7 +227,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				{Key: "invalid_key!", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
 			})),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("key"), "invalid_key!", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("key"), "invalid_key!", "").WithOrigin("format=k8s-label-key").MarkBeta(),
 			},
 		},
 		"invalid FirstAvailable.Tolerations.Key - multiple slashes": {
@@ -235,7 +235,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				{Key: "a/b/c", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
 			})),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("key"), "a/b/c", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("key"), "a/b/c", "").WithOrigin("format=k8s-label-key").MarkBeta(),
 			},
 		},
 		"valid DeviceAllocationMode - All": {
@@ -248,7 +248,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 					field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("exactly", "allocationMode"),
 					resource.DeviceAllocationMode("InvalidMode"),
 					[]string{"All", "ExactCount"},
-				).MarkAlpha(),
+				).MarkBeta(),
 			},
 		},
 		"valid DeviceAllocationMode - FirstAvailable": {
@@ -261,7 +261,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 					field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("allocationMode"),
 					resource.DeviceAllocationMode("InvalidMode"),
 					[]string{"All", "ExactCount"},
-				).MarkAlpha(),
+				).MarkBeta(),
 			},
 		},
 		"valid firstAvailable class name": {
@@ -270,13 +270,13 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"invalid firstAvailable class name - invalid characters": {
 			input: mkValidResourceClaimTemplate(tweakFirstAvailableDeviceClassName("Class&")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("deviceClassName"), "Class&", "").WithOrigin("format=k8s-long-name").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("deviceClassName"), "Class&", "").WithOrigin("format=k8s-long-name").MarkBeta(),
 			},
 		},
 		"invalid firstAvailable class name - empty": {
 			input: mkValidResourceClaimTemplate(tweakFirstAvailableDeviceClassName("")),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("deviceClassName"), "").MarkAlpha(),
+				field.Required(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("deviceClassName"), "").MarkBeta(),
 			},
 		},
 		"valid DeviceTolerationOperator/Effect - Exactly": {
@@ -294,7 +294,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				tweakExactlyTolerations([]resource.DeviceToleration{{Key: "key", Value: "value", Effect: resource.DeviceTaintEffectNoSchedule, Operator: ""}}),
 			),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("operator"), "").MarkAlpha(),
+				field.Required(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("operator"), "").MarkBeta(),
 			},
 		},
 		"invalid DeviceTolerationOperator - Exactly": {
@@ -311,7 +311,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 					field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("operator"),
 					resource.DeviceTolerationOperator("InvalidOp"),
 					[]string{"Equal", "Exists"},
-				).MarkAlpha(),
+				).MarkBeta(),
 			},
 		},
 		"invalid DeviceTaintEffect - Exactly": {
@@ -328,7 +328,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 					field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("effect"),
 					resource.DeviceTaintEffect("InvalidEffect"),
 					[]string{"NoExecute", "NoSchedule"},
-				).MarkAlpha(),
+				).MarkBeta(),
 			},
 		},
 		"valid DeviceTolerationOperator/Effect - FirstAvailable": {
@@ -347,7 +347,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				tweakFirstAvailableTolerations([]resource.DeviceToleration{{Key: "key", Value: "value", Effect: resource.DeviceTaintEffectNoSchedule, Operator: ""}}),
 			),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("operator"), "").MarkAlpha(),
+				field.Required(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("operator"), "").MarkBeta(),
 			},
 		},
 		"invalid DeviceTolerationOperator - FirstAvailable": {
@@ -364,7 +364,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 					field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("operator"),
 					resource.DeviceTolerationOperator("InvalidOp"),
 					[]string{"Equal", "Exists"},
-				).MarkAlpha(),
+				).MarkBeta(),
 			},
 		},
 		"invalid DeviceTaintEffect - FirstAvailable": {
@@ -381,25 +381,25 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 					field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("effect"),
 					resource.DeviceTaintEffect("InvalidEffect"),
 					[]string{"NoExecute", "NoSchedule"},
-				).MarkAlpha(),
+				).MarkBeta(),
 			},
 		},
 		"invalid match attribute": {
 			input: mkValidResourceClaimTemplate(tweakMatchAttribute("invalid!")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "spec", "devices", "constraints").Index(0).Child("matchAttribute"), "invalid!", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "spec", "devices", "constraints").Index(0).Child("matchAttribute"), "invalid!", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
 			},
 		},
 		"match attribute without domain": {
 			input: mkValidResourceClaimTemplate(tweakMatchAttribute("nodomain")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "spec", "devices", "constraints").Index(0).Child("matchAttribute"), "nodomain", "a fully qualified name must be a domain and a name separated by a slash").WithOrigin("format=k8s-resource-fully-qualified-name").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "spec", "devices", "constraints").Index(0).Child("matchAttribute"), "nodomain", "a fully qualified name must be a domain and a name separated by a slash").WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
 			},
 		},
 		"match attribute empty": {
 			input: mkValidResourceClaimTemplate(tweakMatchAttribute("")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
 			},
 		},
 		// TODO: Add more test cases

--- a/test/declarative_validation/resource/resourceslice/declarative_validation_test.go
+++ b/test/declarative_validation/resource/resourceslice/declarative_validation_test.go
@@ -63,7 +63,7 @@ func TestDeclarativeValidate(t *testing.T) {
 				"invalid: too many binding conditions": {
 					input: mkResourceSliceWithDevices(tweakBindingConditions(resource.BindingConditionsMaxSize + 1)),
 					expectedErrs: field.ErrorList{
-						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("bindingConditions"), resource.BindingConditionsMaxSize+1, resource.BindingConditionsMaxSize).WithOrigin("maxItems").MarkAlpha(),
+						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("bindingConditions"), resource.BindingConditionsMaxSize+1, resource.BindingConditionsMaxSize).WithOrigin("maxItems").MarkBeta(),
 					},
 				},
 				// spec.devices[%d].bindingFailureConditions
@@ -76,7 +76,7 @@ func TestDeclarativeValidate(t *testing.T) {
 				"invalid: too many binding failure conditions": {
 					input: mkResourceSliceWithDevices(tweakBindingFailureConditions(resource.BindingFailureConditionsMaxSize + 1)),
 					expectedErrs: field.ErrorList{
-						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("bindingFailureConditions"), resource.BindingFailureConditionsMaxSize+1, resource.BindingFailureConditionsMaxSize).WithOrigin("maxItems").MarkAlpha(),
+						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("bindingFailureConditions"), resource.BindingFailureConditionsMaxSize+1, resource.BindingFailureConditionsMaxSize).WithOrigin("maxItems").MarkBeta(),
 					},
 				},
 				// spec.Devices[%d].Taints[%d].Effect
@@ -91,13 +91,13 @@ func TestDeclarativeValidate(t *testing.T) {
 					expectedErrs: field.ErrorList{
 						field.NotSupported(
 							field.NewPath("spec", "devices").Index(0).Child("taints").Index(0).Child("effect"),
-							resource.DeviceTaintEffect("Invalid"), []string{}).MarkAlpha(),
+							resource.DeviceTaintEffect("Invalid"), []string{}).MarkBeta(),
 					},
 				},
 				"invalid: taint empty": {
 					input: mkResourceSliceWithDevices(tweakDeviceTaintEffect("")),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "devices").Index(0).Child("taints").Index(0).Child("effect"), "").MarkAlpha(),
+						field.Required(field.NewPath("spec", "devices").Index(0).Child("taints").Index(0).Child("effect"), "").MarkBeta(),
 					},
 				},
 				// spec.Devices[%].attribute
@@ -145,13 +145,13 @@ func TestDeclarativeValidate(t *testing.T) {
 				"invalid: device attribute with multiple values": {
 					input: mkResourceSliceWithDevices(tweakDeviceAttribute("test.io/multiple", resource.DeviceAttribute{IntValue: ptr.To[int64](123), BoolValue: ptr.To(true)})),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/multiple"), "", "").WithOrigin("union").MarkAlpha(),
+						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/multiple"), "", "").WithOrigin("union").MarkBeta(),
 					},
 				},
 				"invalid: device attribute no value": {
 					input: mkResourceSliceWithDevices(tweakDeviceAttribute("test.io/multiple", resource.DeviceAttribute{})),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/multiple"), "", "").WithOrigin("union").MarkAlpha(),
+						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/multiple"), "", "").WithOrigin("union").MarkBeta(),
 					},
 				},
 				"invalid: device attribute list with multiple value types": {
@@ -159,7 +159,7 @@ func TestDeclarativeValidate(t *testing.T) {
 					expectedErrs: field.ErrorList{
 						field.Invalid(
 							field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/list_of_multiple"), "", "",
-						).WithOrigin("union").MarkAlpha(),
+						).WithOrigin("union").MarkBeta(),
 					},
 				},
 				// spec.sharedCounters
@@ -169,7 +169,7 @@ func TestDeclarativeValidate(t *testing.T) {
 				"invalid: too many shared counters": {
 					input: mkResourceSliceWithSharedCounters(tweakSharedCounters(resource.ResourceSliceMaxCounterSets + 1)),
 					expectedErrs: field.ErrorList{
-						field.TooMany(field.NewPath("spec").Child("sharedCounters"), resource.ResourceSliceMaxCounterSets+1, resource.ResourceSliceMaxCounterSets).WithOrigin("maxItems").MarkAlpha(),
+						field.TooMany(field.NewPath("spec").Child("sharedCounters"), resource.ResourceSliceMaxCounterSets+1, resource.ResourceSliceMaxCounterSets).WithOrigin("maxItems").MarkBeta(),
 					},
 				},
 				// spec.devices.consumesCounters
@@ -179,7 +179,7 @@ func TestDeclarativeValidate(t *testing.T) {
 				"invalid: too many device consumes counters": {
 					input: mkResourceSliceWithDevices(tweakDeviceConsumesCounters(resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice + 1)),
 					expectedErrs: field.ErrorList{
-						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("consumesCounters"), resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice+1, resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice).WithOrigin("maxItems").MarkAlpha(),
+						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("consumesCounters"), resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice+1, resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice).WithOrigin("maxItems").MarkBeta(),
 					},
 				},
 				// spec.sharedCounters.name
@@ -189,13 +189,13 @@ func TestDeclarativeValidate(t *testing.T) {
 				"invalid: counter set name": {
 					input: mkResourceSliceWithSharedCounters(tweakSharedCountersName("InvalidKey")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("name"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkAlpha(),
+						field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("name"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkBeta(),
 					},
 				},
 				"invalid: counter set name not set": {
 					input: mkResourceSliceWithSharedCounters(tweakSharedCountersName("")),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "sharedCounters").Index(0).Child("name"), "").MarkAlpha(),
+						field.Required(field.NewPath("spec", "sharedCounters").Index(0).Child("name"), "").MarkBeta(),
 					},
 				},
 				// spec.devices.consumesCounters.counterSet
@@ -205,13 +205,13 @@ func TestDeclarativeValidate(t *testing.T) {
 				"invalid: device consumes counters counter set name": {
 					input: mkResourceSliceWithDevices(tweakDeviceConsumesCountersCounterSetName("InvalidKey")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counterSet"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkAlpha(),
+						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counterSet"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkBeta(),
 					},
 				},
 				"invalid: device consumes counters counter set name not set": {
 					input: mkResourceSliceWithDevices(tweakDeviceConsumesCountersCounterSetName("")),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counterSet"), "").MarkAlpha(),
+						field.Required(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counterSet"), "").MarkBeta(),
 					},
 				},
 				// spec.sharedCounters
@@ -221,7 +221,7 @@ func TestDeclarativeValidate(t *testing.T) {
 				"invalid: duplicate names for shared counters": {
 					input: mkResourceSliceWithSharedCounters(tweakSharedCountersName("duplicate-key", "duplicate-key")),
 					expectedErrs: field.ErrorList{
-						field.Duplicate(field.NewPath("spec").Child("sharedCounters").Index(1), "duplicate-key").MarkAlpha(),
+						field.Duplicate(field.NewPath("spec").Child("sharedCounters").Index(1), "duplicate-key").MarkBeta(),
 					},
 				},
 				// spec.devices.consumesCounters
@@ -231,14 +231,14 @@ func TestDeclarativeValidate(t *testing.T) {
 				"invalid: duplicate names for counter set in device counter consumption": {
 					input: mkResourceSliceWithDevices(tweakDeviceConsumesCountersCounterSetName("duplicate-key", "duplicate-key")),
 					expectedErrs: field.ErrorList{
-						field.Duplicate(field.NewPath("spec").Child("devices").Index(0).Child("consumesCounters").Index(1), "duplicate-key").MarkAlpha(),
+						field.Duplicate(field.NewPath("spec").Child("devices").Index(0).Child("consumesCounters").Index(1), "duplicate-key").MarkBeta(),
 					},
 				},
 				// spec.sharedCounters.counters
 				"invalid: shared counter key with uppercase": {
 					input: mkResourceSliceWithSharedCounters(tweakSharedCounter(counters("InvalidKey"))),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkAlpha(),
+						field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkBeta(),
 					},
 				},
 				"valid: shared counter key": {
@@ -247,14 +247,14 @@ func TestDeclarativeValidate(t *testing.T) {
 				"invalid: shared counters empty": {
 					input: mkResourceSliceWithSharedCounters(tweakSharedCounter(nil)),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "sharedCounters").Index(0).Child("counters"), "").MarkAlpha(),
+						field.Required(field.NewPath("spec", "sharedCounters").Index(0).Child("counters"), "").MarkBeta(),
 					},
 				},
 				// spec.devices.consumesCounters.counters
 				"invalid: device counter key with uppercase": {
 					input: mkResourceSliceWithDevices(tweakDeviceCounter(counters("InvalidKey"))),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkAlpha(),
+						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkBeta(),
 					},
 				},
 				"valid: device counter key": {
@@ -263,7 +263,7 @@ func TestDeclarativeValidate(t *testing.T) {
 				"invalid: device counters empty": {
 					input: mkResourceSliceWithDevices(tweakDeviceCounter(nil)),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counters"), "").MarkAlpha(),
+						field.Required(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counters"), "").MarkBeta(),
 					},
 				},
 				// TODO: Add more test cases
@@ -316,7 +316,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithDevices(),
 					update: mkResourceSliceWithDevices(tweakBindingConditions(resource.BindingConditionsMaxSize + 1)),
 					expectedErrs: field.ErrorList{
-						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("bindingConditions"), resource.BindingConditionsMaxSize+1, resource.BindingConditionsMaxSize).WithOrigin("maxItems").MarkAlpha(),
+						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("bindingConditions"), resource.BindingConditionsMaxSize+1, resource.BindingConditionsMaxSize).WithOrigin("maxItems").MarkBeta(),
 					},
 				},
 				// spec.devices[%d].bindingFailureConditions
@@ -328,7 +328,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithDevices(),
 					update: mkResourceSliceWithDevices(tweakBindingFailureConditions(resource.BindingFailureConditionsMaxSize + 1)),
 					expectedErrs: field.ErrorList{
-						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("bindingFailureConditions"), resource.BindingFailureConditionsMaxSize+1, resource.BindingFailureConditionsMaxSize).WithOrigin("maxItems").MarkAlpha(),
+						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("bindingFailureConditions"), resource.BindingFailureConditionsMaxSize+1, resource.BindingFailureConditionsMaxSize).WithOrigin("maxItems").MarkBeta(),
 					},
 				},
 				// spec.devices.taints.effect
@@ -344,14 +344,14 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithDevices(),
 					update: mkResourceSliceWithDevices(tweakDeviceTaintEffect("InvalidEffect")),
 					expectedErrs: field.ErrorList{
-						field.NotSupported(field.NewPath("spec", "devices").Index(0).Child("taints").Index(0).Child("effect"), "InvalidEffect", []string{string(resource.DeviceTaintEffectNoSchedule), string(resource.DeviceTaintEffectNoExecute)}).MarkAlpha(),
+						field.NotSupported(field.NewPath("spec", "devices").Index(0).Child("taints").Index(0).Child("effect"), "InvalidEffect", []string{string(resource.DeviceTaintEffectNoSchedule), string(resource.DeviceTaintEffectNoExecute)}).MarkBeta(),
 					},
 				},
 				"invalid update: empty taint effect": {
 					old:    mkResourceSliceWithDevices(),
 					update: mkResourceSliceWithDevices(tweakDeviceTaintEffect("")),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "devices").Index(0).Child("taints").Index(0).Child("effect"), "").MarkAlpha(),
+						field.Required(field.NewPath("spec", "devices").Index(0).Child("taints").Index(0).Child("effect"), "").MarkBeta(),
 					},
 				},
 				"valid update: device attribute": {
@@ -362,14 +362,14 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithDevices(),
 					update: mkResourceSliceWithDevices(tweakDeviceAttribute("test.io/multiple", resource.DeviceAttribute{IntValue: ptr.To[int64](123), BoolValue: ptr.To(true)})),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/multiple"), "", "").WithOrigin("union").MarkAlpha(),
+						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/multiple"), "", "").WithOrigin("union").MarkBeta(),
 					},
 				},
 				"invalid update: device attribute no value": {
 					old:    mkResourceSliceWithDevices(),
 					update: mkResourceSliceWithDevices(tweakDeviceAttribute("test.io/empty", resource.DeviceAttribute{})),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/empty"), "", "").WithOrigin("union").MarkAlpha(),
+						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/empty"), "", "").WithOrigin("union").MarkBeta(),
 					},
 				},
 				"valid update: device attribute list of strings at max bytes": {
@@ -400,7 +400,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithSharedCounters(),
 					update: mkResourceSliceWithSharedCounters(tweakSharedCounters(resource.ResourceSliceMaxCounterSets + 1)),
 					expectedErrs: field.ErrorList{
-						field.TooMany(field.NewPath("spec").Child("sharedCounters"), resource.ResourceSliceMaxCounterSets+1, resource.ResourceSliceMaxCounterSets).WithOrigin("maxItems").MarkAlpha(),
+						field.TooMany(field.NewPath("spec").Child("sharedCounters"), resource.ResourceSliceMaxCounterSets+1, resource.ResourceSliceMaxCounterSets).WithOrigin("maxItems").MarkBeta(),
 					},
 				},
 				// spec.devices.consumesCounters
@@ -412,7 +412,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithDevices(),
 					update: mkResourceSliceWithDevices(tweakDeviceConsumesCounters(resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice + 1)),
 					expectedErrs: field.ErrorList{
-						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("consumesCounters"), resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice+1, resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice).WithOrigin("maxItems").MarkAlpha(),
+						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("consumesCounters"), resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice+1, resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice).WithOrigin("maxItems").MarkBeta(),
 					},
 				},
 				// spec.sharedCounters.name
@@ -424,14 +424,14 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithSharedCounters(),
 					update: mkResourceSliceWithSharedCounters(tweakSharedCountersName("InvalidKey")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("name"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkAlpha(),
+						field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("name"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkBeta(),
 					},
 				},
 				"invalid update: counter set name not set": {
 					old:    mkResourceSliceWithSharedCounters(),
 					update: mkResourceSliceWithSharedCounters(tweakSharedCountersName("")),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "sharedCounters").Index(0).Child("name"), "").MarkAlpha(),
+						field.Required(field.NewPath("spec", "sharedCounters").Index(0).Child("name"), "").MarkBeta(),
 					},
 				},
 				// spec.devices.consumesCounters.counterSet
@@ -443,14 +443,14 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithDevices(),
 					update: mkResourceSliceWithDevices(tweakDeviceConsumesCountersCounterSetName("InvalidKey")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counterSet"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkAlpha(),
+						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counterSet"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkBeta(),
 					},
 				},
 				"invalidupdate: device consumes counters counter set name not set": {
 					old:    mkResourceSliceWithDevices(),
 					update: mkResourceSliceWithDevices(tweakDeviceConsumesCountersCounterSetName("")),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counterSet"), "").MarkAlpha(),
+						field.Required(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counterSet"), "").MarkBeta(),
 					},
 				},
 				// spec.sharedCounters
@@ -462,7 +462,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithSharedCounters(),
 					update: mkResourceSliceWithSharedCounters(tweakSharedCountersName("duplicate-key", "duplicate-key")),
 					expectedErrs: field.ErrorList{
-						field.Duplicate(field.NewPath("spec").Child("sharedCounters").Index(1), "duplicate-key").MarkAlpha(),
+						field.Duplicate(field.NewPath("spec").Child("sharedCounters").Index(1), "duplicate-key").MarkBeta(),
 					},
 				},
 				// spec.devices.consumesCounters
@@ -474,7 +474,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithDevices(),
 					update: mkResourceSliceWithDevices(tweakDeviceConsumesCountersCounterSetName("duplicate-key", "duplicate-key")),
 					expectedErrs: field.ErrorList{
-						field.Duplicate(field.NewPath("spec").Child("devices").Index(0).Child("consumesCounters").Index(1), "duplicate-key").MarkAlpha(),
+						field.Duplicate(field.NewPath("spec").Child("devices").Index(0).Child("consumesCounters").Index(1), "duplicate-key").MarkBeta(),
 					},
 				},
 				// spec.sharedCounters.counters
@@ -482,7 +482,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithSharedCounters(),
 					update: mkResourceSliceWithSharedCounters(tweakSharedCounter(counters("InvalidKey"))),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkAlpha(),
+						field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkBeta(),
 					},
 				},
 				// spec.sharedCounters.counters: nil -> invalid
@@ -490,7 +490,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithSharedCounters(tweakSharedCounter(nil)),
 					update: mkResourceSliceWithSharedCounters(tweakSharedCounter(counters("InvalidKey"))),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkAlpha(),
+						field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkBeta(),
 					},
 				},
 				// spec.devices.consumesCounters.counters
@@ -498,7 +498,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithDevices(),
 					update: mkResourceSliceWithDevices(tweakDeviceCounter(counters("InvalidKey"))),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkAlpha(),
+						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkBeta(),
 					},
 				},
 				// spec.devices.consumesCounters.counters: nil -> invalid
@@ -506,7 +506,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithDevices(tweakDeviceCounter(nil)),
 					update: mkResourceSliceWithDevices(tweakDeviceCounter(counters("InvalidKey"))),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkAlpha(),
+						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkBeta(),
 					},
 				},
 			}

--- a/test/declarative_validation/storage/storageclass/declarative_validation_test.go
+++ b/test/declarative_validation/storage/storageclass/declarative_validation_test.go
@@ -58,7 +58,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				obj.Provisioner = ""
 			}),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("provisioner"), "").MarkAlpha(),
+				field.Required(field.NewPath("provisioner"), "").MarkBeta(),
 			},
 		},
 		// TODO: Add more test cases
@@ -104,78 +104,78 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			oldObj:    mkValidStorageClass(),
 			updateObj: mkValidStorageClass(TweakProvisioner("kubernetes.io/aws-ebs")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("provisioner"), "", "").WithOrigin("immutable").MarkAlpha(),
+				field.Invalid(field.NewPath("provisioner"), "", "").WithOrigin("immutable").MarkBeta(),
 			},
 		},
 		"invalid update provisioner unset to set": {
 			oldObj:    mkValidStorageClass(TweakProvisioner("")),
 			updateObj: mkValidStorageClass(),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("provisioner"), "", "").WithOrigin("immutable").MarkAlpha(),
+				field.Invalid(field.NewPath("provisioner"), "", "").WithOrigin("immutable").MarkBeta(),
 			},
 		},
 		"invalid update provisioner set to unset": {
 			oldObj:    mkValidStorageClass(),
 			updateObj: mkValidStorageClass(TweakProvisioner("")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("provisioner"), "", "").WithOrigin("immutable").MarkAlpha(),
-				field.Required(field.NewPath("provisioner"), "").MarkAlpha(),
+				field.Invalid(field.NewPath("provisioner"), "", "").WithOrigin("immutable").MarkBeta(),
+				field.Required(field.NewPath("provisioner"), "").MarkBeta(),
 			},
 		},
 		"invalid update parameters changed": {
 			oldObj:    mkValidStorageClass(),
 			updateObj: mkValidStorageClass(TweakParameters(map[string]string{"new": "value"})),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("parameters"), nil, "").WithOrigin("immutable").MarkAlpha(),
+				field.Invalid(field.NewPath("parameters"), nil, "").WithOrigin("immutable").MarkBeta(),
 			},
 		},
 		"invalid update parameters unset to set": {
 			oldObj:    mkValidStorageClass(),
 			updateObj: mkValidStorageClass(TweakParameters(map[string]string{"foo": "bar"})),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("parameters"), nil, "").WithOrigin("immutable").MarkAlpha(),
+				field.Invalid(field.NewPath("parameters"), nil, "").WithOrigin("immutable").MarkBeta(),
 			},
 		},
 		"invalid update parameters set to unset": {
 			oldObj:    mkValidStorageClass(TweakParameters(map[string]string{"foo": "bar"})),
 			updateObj: mkValidStorageClass(),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("parameters"), nil, "").WithOrigin("immutable").MarkAlpha(),
+				field.Invalid(field.NewPath("parameters"), nil, "").WithOrigin("immutable").MarkBeta(),
 			},
 		},
 		"invalid update reclaimPolicy changed": {
 			oldObj:    mkValidStorageClass(),
 			updateObj: mkValidStorageClass(TweakReclaimPolicy(api.PersistentVolumeReclaimRetain)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("reclaimPolicy"), nil, "").WithOrigin("immutable").MarkAlpha(),
+				field.Invalid(field.NewPath("reclaimPolicy"), nil, "").WithOrigin("immutable").MarkBeta(),
 			},
 		},
 		"invalid update reclaimPolicy unset to set": {
 			oldObj:    mkValidStorageClass(TweakReclaimPolicyNil()),
 			updateObj: mkValidStorageClass(),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("reclaimPolicy"), nil, "").WithOrigin("immutable").MarkAlpha(),
+				field.Invalid(field.NewPath("reclaimPolicy"), nil, "").WithOrigin("immutable").MarkBeta(),
 			},
 		},
 		"invalid update reclaimPolicy set to unset": {
 			oldObj:    mkValidStorageClass(),
 			updateObj: mkValidStorageClass(TweakReclaimPolicyNil()),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("reclaimPolicy"), nil, "").WithOrigin("immutable").MarkAlpha(),
+				field.Invalid(field.NewPath("reclaimPolicy"), nil, "").WithOrigin("immutable").MarkBeta(),
 			},
 		},
 		"invalid update volumeBindingMode changed": {
 			oldObj:    mkValidStorageClass(),
 			updateObj: mkValidStorageClass(TweakVolumeBindingMode(storage.VolumeBindingWaitForFirstConsumer)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("volumeBindingMode"), nil, "").WithOrigin("immutable").MarkAlpha(),
+				field.Invalid(field.NewPath("volumeBindingMode"), nil, "").WithOrigin("immutable").MarkBeta(),
 			},
 		},
 		"invalid update volumeBindingMode unset to set": {
 			oldObj:    mkValidStorageClass(TweakVolumeBindingModeNil()),
 			updateObj: mkValidStorageClass(),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("volumeBindingMode"), nil, "").WithOrigin("immutable").MarkAlpha(),
+				field.Invalid(field.NewPath("volumeBindingMode"), nil, "").WithOrigin("immutable").MarkBeta(),
 			},
 		},
 		"invalid update volumeBindingMode set to unset": {
@@ -183,7 +183,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			updateObj: mkValidStorageClass(TweakVolumeBindingModeNil()),
 			expectedErrs: field.ErrorList{
 				field.Required(field.NewPath("volumeBindingMode"), "").MarkFromImperative(),
-				field.Invalid(field.NewPath("volumeBindingMode"), nil, "").WithOrigin("immutable").MarkAlpha(),
+				field.Invalid(field.NewPath("volumeBindingMode"), nil, "").WithOrigin("immutable").MarkBeta(),
 			},
 		},
 	}

--- a/test/declarative_validation/storage/volumeattachment/declarative_validation_test.go
+++ b/test/declarative_validation/storage/volumeattachment/declarative_validation_test.go
@@ -70,19 +70,19 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"invalid attacher (required)": {
 			input: mkValidVolumeAttachment(TweakAttacher("")),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "attacher"), "").MarkAlpha(),
+				field.Required(field.NewPath("spec", "attacher"), "").MarkBeta(),
 			},
 		},
 		"attacher with special characters": {
 			input: mkValidVolumeAttachment(TweakAttacher("asdadasd&@!")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "attacher"), "", "").WithOrigin("format=k8s-long-name-caseless").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "attacher"), "", "").WithOrigin("format=k8s-long-name-caseless").MarkBeta(),
 			},
 		},
 		"attacher with number of characters exceeds 63": {
 			input: mkValidVolumeAttachment(TweakAttacher(strings.Repeat("a", 64))),
 			expectedErrs: field.ErrorList{
-				field.TooLong(field.NewPath("spec", "attacher"), strings.Repeat("a", 64), 63).WithOrigin("maxLength").MarkAlpha(),
+				field.TooLong(field.NewPath("spec", "attacher"), strings.Repeat("a", 64), 63).WithOrigin("maxLength").MarkBeta(),
 			},
 		},
 	}
@@ -119,7 +119,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			oldInput: mkValidVolumeAttachment(),
 			newInput: mkValidVolumeAttachment(TweakAttacher("different.com")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec"), nil, "field is immutable").WithOrigin("immutable").MarkAlpha(),
+				field.Invalid(field.NewPath("spec"), nil, "field is immutable").WithOrigin("immutable").MarkBeta(),
 			},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
These declarative validations were introduced as alpha (`+k8s:alpha(since: "1.36")`). This PR graduates them to beta (`+k8s:beta(since: "1.37")`).

The lifecycle prefix on a declarative validation tag controls when it is enforced:
- **alpha**: always shadowed — handwritten validation remains authoritative.
- **beta**: enforced when the `DeclarativeValidationBeta` feature gate is enabled; otherwise shadowed.

So with the gate enabled, declarative validation becomes authoritative for these checks and their handwritten counterparts are suppressed. With the gate disabled, behavior is unchanged. Validations that entered alpha in 1.37 are left as-is.

No handwritten validation changes are required: #140117 makes the enforcement decision by matching handwritten errors against the declarative errors, so a graduation is just a tag change plus codegen.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
Commits are split for review:
1. `resource: drop lifecycle prefix from internal oneOf tags` — unrelated cleanup; lifecycle prefixes don't belong on internal types.
2. `Promote declarative validation tags from alpha to beta` — the tag changes on the API types.
3. `Regenerate declarative validation code` — `hack/update-codegen.sh validation` output.
4. `Update declarative validation conformance fixtures for beta` — the expected stability level in the tests.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
