### PR TITLE
Daemonset-controller optimization: hoist toleration & node affinity parsing out of loop

### DIFF
--- a/pkg/controller/daemon/benchmark_test.go
+++ b/pkg/controller/daemon/benchmark_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
+)
+
+// exclusionNodeAffinity mirrors the node affinity commonly carried by
+// cluster-wide DaemonSets (log shippers, node agents) that must avoid a few
+// special node classes: a single term with several NotIn expressions.
+func exclusionNodeAffinity() *v1.Affinity {
+	return &v1.Affinity{
+		NodeAffinity: &v1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{Key: "example.com/papaya", Operator: v1.NodeSelectorOpNotIn, Values: []string{"true"}},
+						{Key: "example.com/kumquat", Operator: v1.NodeSelectorOpNotIn, Values: []string{"true"}},
+						{Key: "quince", Operator: v1.NodeSelectorOpNotIn, Values: []string{"dragonfruit"}},
+						{Key: "lychee", Operator: v1.NodeSelectorOpNotIn, Values: []string{"rambutan"}},
+						{Key: "example.com/durian", Operator: v1.NodeSelectorOpNotIn, Values: []string{"mangosteen", "tamarind", "persimmon"}},
+						{Key: "example.com/guava", Operator: v1.NodeSelectorOpNotIn, Values: []string{"starfruit"}},
+					},
+				}},
+			},
+		},
+	}
+}
+
+// BenchmarkUpdateDaemonSetStatus measures the per-node evaluation loop shared
+// by the DaemonSet controller's sync paths (updateDaemonSetStatus, manage,
+// rollingUpdate all evaluate NodeShouldRunDaemonPod for every node in the
+// cluster). The dominant per-node cost is evaluating whether the daemon pod
+// fits the node, so this approximates the controller's per-sync CPU cost on
+// an otherwise steady-state DaemonSet.
+func BenchmarkUpdateDaemonSetStatus(b *testing.B) {
+	for _, tc := range []struct {
+		name     string
+		affinity *v1.Affinity
+	}{
+		{name: "no-affinity", affinity: nil},
+		{name: "exclusion-affinity", affinity: exclusionNodeAffinity()},
+	} {
+		for _, numNodes := range []int{1000, 10000} {
+			b.Run(fmt.Sprintf("affinity=%s/nodes=%d", tc.name, numNodes), func(b *testing.B) {
+				// Silence per-iteration log output so the benchmark measures
+				// the evaluation loop, not the test logger.
+				logger := ktesting.NewLogger(b, ktesting.NewConfig(ktesting.Verbosity(0)))
+				ctx := klog.NewContext(context.Background(), logger)
+				ds := newDaemonSet("bench")
+				ds.Spec.Template.Spec.Affinity = tc.affinity
+				// Pre-set the status to the values the loop computes so that
+				// storeDaemonSetStatus short-circuits and each iteration
+				// measures only the per-node evaluation loop, not the fake
+				// client's status update.
+				ds.Status.DesiredNumberScheduled = int32(numNodes)
+				ds.Status.NumberUnavailable = int32(numNodes)
+				manager, _, _, err := newTestController(ctx, ds)
+				if err != nil {
+					b.Fatalf("error creating DaemonSets controller: %v", err)
+				}
+				if err := manager.dsStore.Add(ds); err != nil {
+					b.Fatal(err)
+				}
+				nodeList := make([]*v1.Node, 0, numNodes)
+				for i := range numNodes {
+					node := newNode(fmt.Sprintf("node-%d", i), map[string]string{
+						"kubernetes.io/hostname":        fmt.Sprintf("node-%d", i),
+						"topology.kubernetes.io/zone":   fmt.Sprintf("zone-%d", i%3),
+						"topology.kubernetes.io/region": "region-1",
+					})
+					if err := manager.nodeStore.Add(node); err != nil {
+						b.Fatal(err)
+					}
+					nodeList = append(nodeList, node)
+				}
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for range b.N {
+					if err := manager.updateDaemonSetStatus(ctx, ds, nodeList, "hash", false); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -849,9 +849,11 @@ func (dsc *DaemonSetsController) podsShouldBeOnNode(
 	nodeToDaemonPods map[string][]*v1.Pod,
 	ds *apps.DaemonSet,
 	hash string,
+	tolerations []v1.Toleration,
+	requiredNodeAffinity nodeaffinity.RequiredNodeAffinity,
 ) (nodesNeedingDaemonPods, podsToDelete []string) {
 
-	shouldRun, shouldContinueRunning := NodeShouldRunDaemonPod(logger, node, ds)
+	shouldRun, shouldContinueRunning := nodeShouldRunDaemonPod(logger, node, ds, tolerations, requiredNodeAffinity)
 	daemonPods, exists := nodeToDaemonPods[node.Name]
 
 	switch {
@@ -1006,9 +1008,13 @@ func (dsc *DaemonSetsController) manage(ctx context.Context, ds *apps.DaemonSet,
 	// pod. If the node is supposed to run the daemon pod, but isn't, create the daemon pod on the node.
 	logger := klog.FromContext(ctx)
 	var nodesNeedingDaemonPods, podsToDelete []string
+	// The daemon pod tolerations and the parsed required node affinity are
+	// the same for every node; build them once instead of once per node.
+	tolerations := daemonPodTolerations(ds)
+	requiredNodeAffinity := nodeaffinity.NewRequiredNodeAffinity(ds.Spec.Template.Spec.NodeSelector, ds.Spec.Template.Spec.Affinity)
 	for _, node := range nodeList {
 		nodesNeedingDaemonPodsOnNode, podsToDeleteOnNode := dsc.podsShouldBeOnNode(
-			logger, node, nodeToDaemonPods, ds, hash)
+			logger, node, nodeToDaemonPods, ds, hash, tolerations, requiredNodeAffinity)
 
 		nodesNeedingDaemonPods = append(nodesNeedingDaemonPods, nodesNeedingDaemonPodsOnNode...)
 		podsToDelete = append(podsToDelete, podsToDeleteOnNode...)
@@ -1209,8 +1215,10 @@ func (dsc *DaemonSetsController) updateDaemonSetStatus(ctx context.Context, ds *
 
 	var desiredNumberScheduled, currentNumberScheduled, numberMisscheduled, numberReady, updatedNumberScheduled, numberAvailable int
 	now := dsc.failedPodsBackoff.Clock.Now()
+	tolerations := daemonPodTolerations(ds)
+	requiredNodeAffinity := nodeaffinity.NewRequiredNodeAffinity(ds.Spec.Template.Spec.NodeSelector, ds.Spec.Template.Spec.Affinity)
 	for _, node := range nodeList {
-		shouldRun, _ := NodeShouldRunDaemonPod(logger, node, ds)
+		shouldRun, _ := nodeShouldRunDaemonPod(logger, node, ds, tolerations, requiredNodeAffinity)
 		scheduled := len(nodeToDaemonPods[node.Name]) > 0
 
 		if shouldRun {
@@ -1379,22 +1387,41 @@ func (dsc *DaemonSetsController) syncDaemonSet(ctx context.Context, key string) 
 //     Returns true when a daemonset should continue running on a node if a daemonset pod is already
 //     running on that node.
 func NodeShouldRunDaemonPod(logger klog.Logger, node *v1.Node, ds *apps.DaemonSet) (bool, bool) {
-	pod := NewPod(ds, node.Name)
+	return nodeShouldRunDaemonPod(logger, node, ds, daemonPodTolerations(ds),
+		nodeaffinity.NewRequiredNodeAffinity(ds.Spec.Template.Spec.NodeSelector, ds.Spec.Template.Spec.Affinity))
+}
 
+// daemonPodTolerations returns the tolerations of the pods this DaemonSet
+// creates: the template's tolerations plus the defaults every daemon pod
+// gets. The template is not modified.
+func daemonPodTolerations(ds *apps.DaemonSet) []v1.Toleration {
+	spec := ds.Spec.Template.Spec
+	util.AddOrUpdateDaemonPodTolerations(&spec)
+	return spec.Tolerations
+}
+
+// nodeShouldRunDaemonPod is NodeShouldRunDaemonPod for callers that evaluate
+// many nodes against the same DaemonSet: tolerations and requiredNodeAffinity
+// depend only on ds — daemonPodTolerations(ds) and the parsing result of the
+// pod template's nodeSelector and affinity — so per-node loops build them
+// once instead of once per node. Parsing the required node affinity
+// dominates the cost of this check, and the sync paths run it for every node
+// in the cluster.
+func nodeShouldRunDaemonPod(logger klog.Logger, node *v1.Node, ds *apps.DaemonSet, tolerations []v1.Toleration, requiredNodeAffinity nodeaffinity.RequiredNodeAffinity) (bool, bool) {
 	// If the daemon set specifies a node name, check that it matches with node.Name.
 	if !(ds.Spec.Template.Spec.NodeName == "" || ds.Spec.Template.Spec.NodeName == node.Name) {
 		return false, false
 	}
 
 	taints := node.Spec.Taints
-	fitsNodeName, fitsNodeAffinity, fitsTaints := predicates(logger, pod, node, taints)
-	if !fitsNodeName || !fitsNodeAffinity {
+	fitsNodeAffinity, fitsTaints := predicates(logger, node, taints, tolerations, requiredNodeAffinity)
+	if !fitsNodeAffinity {
 		return false, false
 	}
 
 	if !fitsTaints {
 		// Scheduled daemon pods should continue running if they tolerate NoExecute taint.
-		_, hasUntoleratedTaint := v1helper.FindMatchingUntoleratedTaint(logger, taints, pod.Spec.Tolerations, func(t *v1.Taint) bool {
+		_, hasUntoleratedTaint := v1helper.FindMatchingUntoleratedTaint(logger, taints, tolerations, func(t *v1.Taint) bool {
 			return t.Effect == v1.TaintEffectNoExecute
 		}, utilfeature.DefaultFeatureGate.Enabled(features.TaintTolerationComparisonOperators))
 		return false, !hasUntoleratedTaint
@@ -1403,12 +1430,13 @@ func NodeShouldRunDaemonPod(logger klog.Logger, node *v1.Node, ds *apps.DaemonSe
 	return true, true
 }
 
-// predicates checks if a DaemonSet's pod can run on a node.
-func predicates(logger klog.Logger, pod *v1.Pod, node *v1.Node, taints []v1.Taint) (fitsNodeName, fitsNodeAffinity, fitsTaints bool) {
-	fitsNodeName = len(pod.Spec.NodeName) == 0 || pod.Spec.NodeName == node.Name
+// predicates checks if a DaemonSet's pod can run on a node. tolerations and
+// requiredNodeAffinity must be derived from the DaemonSet's pod template
+// (see NodeShouldRunDaemonPod).
+func predicates(logger klog.Logger, node *v1.Node, taints []v1.Taint, tolerations []v1.Toleration, requiredNodeAffinity nodeaffinity.RequiredNodeAffinity) (fitsNodeAffinity, fitsTaints bool) {
 	// Ignore parsing errors for backwards compatibility.
-	fitsNodeAffinity, _ = nodeaffinity.GetRequiredNodeAffinity(pod).Match(node)
-	_, hasUntoleratedTaint := v1helper.FindMatchingUntoleratedTaint(logger, taints, pod.Spec.Tolerations, func(t *v1.Taint) bool {
+	fitsNodeAffinity, _ = requiredNodeAffinity.Match(node)
+	_, hasUntoleratedTaint := v1helper.FindMatchingUntoleratedTaint(logger, taints, tolerations, func(t *v1.Taint) bool {
 		return t.Effect == v1.TaintEffectNoExecute || t.Effect == v1.TaintEffectNoSchedule
 	}, utilfeature.DefaultFeatureGate.Enabled(features.TaintTolerationComparisonOperators))
 	fitsTaints = !hasUntoleratedTaint

--- a/pkg/controller/daemon/update.go
+++ b/pkg/controller/daemon/update.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/daemon/util"
@@ -148,6 +149,10 @@ func (dsc *DaemonSetsController) rollingUpdate(ctx context.Context, ds *apps.Dae
 	var numSurge int
 	var numAvailable int
 
+	// The daemon pod tolerations and the parsed required node affinity are
+	// the same for every node; build them once instead of once per node.
+	tolerations := daemonPodTolerations(ds)
+	requiredNodeAffinity := nodeaffinity.NewRequiredNodeAffinity(ds.Spec.Template.Spec.NodeSelector, ds.Spec.Template.Spec.Affinity)
 	for nodeName, pods := range nodeToDaemonPods {
 		newPod, oldPod, ok := findUpdatedPodsOnNode(ds, pods, hash)
 		if !ok {
@@ -179,7 +184,7 @@ func (dsc *DaemonSetsController) rollingUpdate(ctx context.Context, ds *apps.Dae
 				if err != nil {
 					return fmt.Errorf("couldn't get node for nodeName %q: %v", nodeName, err)
 				}
-				if shouldRun, _ := NodeShouldRunDaemonPod(logger, node, ds); !shouldRun {
+				if shouldRun, _ := nodeShouldRunDaemonPod(logger, node, ds, tolerations, requiredNodeAffinity); !shouldRun {
 					logger.V(5).Info("DaemonSet pod on node is not available and does not match scheduling constraints, remove old pod", "daemonset", klog.KObj(ds), "node", nodeName, "oldPod", klog.KObj(oldPod))
 					oldPodsToDelete = append(oldPodsToDelete, oldPod.Name)
 					continue
@@ -196,7 +201,7 @@ func (dsc *DaemonSetsController) rollingUpdate(ctx context.Context, ds *apps.Dae
 				if err != nil {
 					return fmt.Errorf("couldn't get node for nodeName %q: %v", nodeName, err)
 				}
-				if shouldRun, _ := NodeShouldRunDaemonPod(logger, node, ds); !shouldRun {
+				if shouldRun, _ := nodeShouldRunDaemonPod(logger, node, ds, tolerations, requiredNodeAffinity); !shouldRun {
 					shouldNotRunPodsToDelete = append(shouldNotRunPodsToDelete, oldPod.Name)
 					continue
 				}
@@ -584,9 +589,11 @@ func (dsc *DaemonSetsController) snapshot(ctx context.Context, ds *apps.DaemonSe
 func (dsc *DaemonSetsController) updatedDesiredNodeCounts(ctx context.Context, ds *apps.DaemonSet, nodeList []*v1.Node, nodeToDaemonPods map[string][]*v1.Pod) (int, int, int, error) {
 	var desiredNumberScheduled int
 	logger := klog.FromContext(ctx)
+	tolerations := daemonPodTolerations(ds)
+	requiredNodeAffinity := nodeaffinity.NewRequiredNodeAffinity(ds.Spec.Template.Spec.NodeSelector, ds.Spec.Template.Spec.Affinity)
 	for i := range nodeList {
 		node := nodeList[i]
-		wantToRun, _ := NodeShouldRunDaemonPod(logger, node, ds)
+		wantToRun, _ := nodeShouldRunDaemonPod(logger, node, ds, tolerations, requiredNodeAffinity)
 		if !wantToRun {
 			continue
 		}

--- a/staging/src/k8s.io/component-helpers/scheduling/corev1/nodeaffinity/nodeaffinity.go
+++ b/staging/src/k8s.io/component-helpers/scheduling/corev1/nodeaffinity/nodeaffinity.go
@@ -304,18 +304,26 @@ type RequiredNodeAffinity struct {
 
 // GetRequiredNodeAffinity returns the parsing result of pod's nodeSelector and nodeAffinity.
 func GetRequiredNodeAffinity(pod *v1.Pod) RequiredNodeAffinity {
+	return NewRequiredNodeAffinity(pod.Spec.NodeSelector, pod.Spec.Affinity)
+}
+
+// NewRequiredNodeAffinity returns the parsing result of the given nodeSelector
+// and affinity. It is equivalent to GetRequiredNodeAffinity for a pod carrying
+// them, for callers that have a pod spec's fields but no pod object (e.g.
+// workload controllers evaluating a pod template).
+func NewRequiredNodeAffinity(nodeSelector map[string]string, affinity *v1.Affinity) RequiredNodeAffinity {
 	var selector labels.Selector
-	if len(pod.Spec.NodeSelector) > 0 {
-		selector = labels.SelectorFromSet(pod.Spec.NodeSelector)
+	if len(nodeSelector) > 0 {
+		selector = labels.SelectorFromSet(nodeSelector)
 	}
 	// Use LazyErrorNodeSelector for backwards compatibility of parsing errors.
-	var affinity *LazyErrorNodeSelector
-	if pod.Spec.Affinity != nil &&
-		pod.Spec.Affinity.NodeAffinity != nil &&
-		pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
-		affinity = NewLazyErrorNodeSelector(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
+	var lazyNodeSelector *LazyErrorNodeSelector
+	if affinity != nil &&
+		affinity.NodeAffinity != nil &&
+		affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+		lazyNodeSelector = NewLazyErrorNodeSelector(affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
 	}
-	return RequiredNodeAffinity{labelSelector: selector, nodeSelector: affinity}
+	return RequiredNodeAffinity{labelSelector: selector, nodeSelector: lazyNodeSelector}
 }
 
 // Match checks whether the pod is schedulable onto nodes according to


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency

/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This PR improves performance in the daemonset controller by hoisting the toleration & node-affinity logic outside of the loop over nodes. In large clusters this can lead to significant CPU savings.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

N/A

#### Special notes for your reviewer:

- This PR was written in part with the assistance of generative AI

- We were previously extracting the tolerations & node affinity from a pod that was materialized from the daemonset podspec template. I migrated those to grab it directly from the template without materializing a pod at all. I think this is equivalent, but calling it out explicitly.

Benchmark results, in `benchstat` format:
```
│      old      │                 new                 │
                                                                 │    sec/op     │   sec/op     vs base                │
UpdateDaemonSetStatus/affinity=no-affinity/nodes=1000-96           2199.08µ ± 2%   46.68µ ± 1%  -97.88% (p=0.000 n=10)
UpdateDaemonSetStatus/affinity=no-affinity/nodes=10000-96          17471.1µ ± 1%   503.7µ ± 1%  -97.12% (p=0.000 n=10)
UpdateDaemonSetStatus/affinity=exclusion-affinity/nodes=1000-96     9809.0µ ± 1%   280.8µ ± 1%  -97.14% (p=0.000 n=10)
UpdateDaemonSetStatus/affinity=exclusion-affinity/nodes=10000-96    92.725m ± 1%   2.657m ± 0%  -97.13% (p=0.000 n=10)
geomean                                                              13.67m        363.9µ       -97.34%

                                                                 │       old        │                 new                  │
                                                                 │       B/op       │     B/op      vs base                │
UpdateDaemonSetStatus/affinity=no-affinity/nodes=1000-96            5305.247Ki ± 0%   5.387Ki ± 0%  -99.90% (p=0.000 n=10)
UpdateDaemonSetStatus/affinity=no-affinity/nodes=10000-96          52706.982Ki ± 0%   5.363Ki ± 0%  -99.99% (p=0.000 n=10)
UpdateDaemonSetStatus/affinity=exclusion-affinity/nodes=1000-96       9560.6Ki ± 0%   339.5Ki ± 0%  -96.45% (p=0.000 n=10)
UpdateDaemonSetStatus/affinity=exclusion-affinity/nodes=10000-96      92.773Mi ± 0%   3.220Mi ± 0%  -96.53% (p=0.000 n=10)
geomean                                                                21.92Mi        75.41Ki       -99.66%

                                                                 │      old       │                 new                 │
                                                                 │   allocs/op    │  allocs/op   vs base                │
UpdateDaemonSetStatus/affinity=no-affinity/nodes=1000-96            24031.00 ± 0%    51.00 ± 0%  -99.79% (p=0.000 n=10)
UpdateDaemonSetStatus/affinity=no-affinity/nodes=10000-96          240033.00 ± 0%    51.00 ± 0%  -99.98% (p=0.000 n=10)
UpdateDaemonSetStatus/affinity=exclusion-affinity/nodes=1000-96     100.036k ± 0%   2.125k ± 0%  -97.88% (p=0.000 n=10)
UpdateDaemonSetStatus/affinity=exclusion-affinity/nodes=10000-96    1000.06k ± 0%   20.12k ± 0%  -97.99% (p=0.000 n=10)
geomean                                                               155.0k         577.5       -99.63%
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

