### PR TITLE
apiserver: measure event delivery latency from read from etcd to client channel enqueue

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/watch/mux.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/mux.go
@@ -221,7 +221,7 @@ func (m *Broadcaster) Action(action EventType, obj runtime.Object) error {
 	default:
 	}
 
-	m.incoming <- Event{action, obj}
+	m.incoming <- Event{Type: action, Object: obj}
 	return nil
 }
 
@@ -240,7 +240,7 @@ func (m *Broadcaster) ActionOrDrop(action EventType, obj runtime.Object) (bool, 
 	}
 
 	select {
-	case m.incoming <- Event{action, obj}:
+	case m.incoming <- Event{Type: action, Object: obj}:
 		return true, nil
 	default:
 		return false, nil

--- a/staging/src/k8s.io/apimachinery/pkg/watch/watch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/watch.go
@@ -19,6 +19,7 @@ package watch
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"k8s.io/klog/v2"
 
@@ -80,6 +81,10 @@ type Event struct {
 	//  * If Type is Error: *api.Status is recommended; other types may make sense
 	//    depending on context.
 	Object runtime.Object
+
+	// RecordTime is an internal timestamp used for telemetry to measure the propagation
+	// delay of the event. It is not serialized or exposed to the public API.
+	RecordTime time.Time `json:"-"`
 }
 
 type emptyWatch chan Event
@@ -165,27 +170,27 @@ func (f *FakeWatcher) ResultChan() <-chan Event {
 
 // Add sends an add event.
 func (f *FakeWatcher) Add(obj runtime.Object) {
-	f.result <- Event{Added, obj}
+	f.result <- Event{Type: Added, Object: obj}
 }
 
 // Modify sends a modify event.
 func (f *FakeWatcher) Modify(obj runtime.Object) {
-	f.result <- Event{Modified, obj}
+	f.result <- Event{Type: Modified, Object: obj}
 }
 
 // Delete sends a delete event.
 func (f *FakeWatcher) Delete(lastValue runtime.Object) {
-	f.result <- Event{Deleted, lastValue}
+	f.result <- Event{Type: Deleted, Object: lastValue}
 }
 
 // Error sends an Error event.
 func (f *FakeWatcher) Error(errValue runtime.Object) {
-	f.result <- Event{Error, errValue}
+	f.result <- Event{Type: Error, Object: errValue}
 }
 
 // Action sends an event of the requested type, for table-based testing.
 func (f *FakeWatcher) Action(action EventType, obj runtime.Object) {
-	f.result <- Event{action, obj}
+	f.result <- Event{Type: action, Object: obj}
 }
 
 // RaceFreeFakeWatcher lets you test anything that consumes a watch.Interface; threadsafe.
@@ -247,7 +252,7 @@ func (f *RaceFreeFakeWatcher) Add(obj runtime.Object) {
 	defer f.Unlock()
 	if !f.Stopped {
 		select {
-		case f.result <- Event{Added, obj}:
+		case f.result <- Event{Type: Added, Object: obj}:
 			return
 		default:
 			panic(fmt.Errorf("channel full"))
@@ -261,7 +266,7 @@ func (f *RaceFreeFakeWatcher) Modify(obj runtime.Object) {
 	defer f.Unlock()
 	if !f.Stopped {
 		select {
-		case f.result <- Event{Modified, obj}:
+		case f.result <- Event{Type: Modified, Object: obj}:
 			return
 		default:
 			panic(fmt.Errorf("channel full"))
@@ -275,7 +280,7 @@ func (f *RaceFreeFakeWatcher) Delete(lastValue runtime.Object) {
 	defer f.Unlock()
 	if !f.Stopped {
 		select {
-		case f.result <- Event{Deleted, lastValue}:
+		case f.result <- Event{Type: Deleted, Object: lastValue}:
 			return
 		default:
 			panic(fmt.Errorf("channel full"))
@@ -289,7 +294,7 @@ func (f *RaceFreeFakeWatcher) Error(errValue runtime.Object) {
 	defer f.Unlock()
 	if !f.Stopped {
 		select {
-		case f.result <- Event{Error, errValue}:
+		case f.result <- Event{Type: Error, Object: errValue}:
 			return
 		default:
 			panic(fmt.Errorf("channel full"))
@@ -303,7 +308,7 @@ func (f *RaceFreeFakeWatcher) Action(action EventType, obj runtime.Object) {
 	defer f.Unlock()
 	if !f.Stopped {
 		select {
-		case f.result <- Event{action, obj}:
+		case f.result <- Event{Type: action, Object: obj}:
 			return
 		default:
 			panic(fmt.Errorf("channel full"))

--- a/staging/src/k8s.io/apimachinery/pkg/watch/watch_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/watch_test.go
@@ -139,11 +139,11 @@ func TestEmpty(t *testing.T) {
 
 func TestProxyWatcher(t *testing.T) {
 	events := []Event{
-		{Added, testType("foo")},
-		{Modified, testType("qux")},
-		{Modified, testType("bar")},
-		{Deleted, testType("bar")},
-		{Error, testType("error: blah")},
+		{Type: Added, Object: testType("foo")},
+		{Type: Modified, Object: testType("qux")},
+		{Type: Modified, Object: testType("bar")},
+		{Type: Deleted, Object: testType("bar")},
+		{Type: Error, Object: testType("error: blah")},
 	}
 
 	ch := make(chan Event, len(events))

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
@@ -63,6 +63,7 @@ type cacheWatcher struct {
 	deadline            time.Time
 	allowWatchBookmarks bool
 	groupResource       schema.GroupResource
+	watcherMetrics      *metrics.WatcherMetricsObservers
 
 	// human readable identifier that helps assigning cacheWatcher
 	// instance with request
@@ -95,6 +96,7 @@ func newCacheWatcher(
 	deadline time.Time,
 	allowWatchBookmarks bool,
 	groupResource schema.GroupResource,
+	watcherMetrics *metrics.WatcherMetricsObservers,
 	identifier string,
 ) *cacheWatcher {
 	return &cacheWatcher{
@@ -108,6 +110,7 @@ func newCacheWatcher(
 		deadline:            deadline,
 		allowWatchBookmarks: allowWatchBookmarks,
 		groupResource:       groupResource,
+		watcherMetrics:      watcherMetrics,
 		identifier:          identifier,
 	}
 }
@@ -200,6 +203,9 @@ func (c *cacheWatcher) add(event *watchCacheEvent, timer *time.Timer) bool {
 			defer c.stateMutex.Unlock()
 			return c.state == cacheWatcherBookmarkReceived
 		}()
+		if !event.RecordTime.IsZero() {
+			c.watcherMetrics.ObserveTerminated(time.Since(event.RecordTime))
+		}
 		klog.V(1).Infof("Forcing %v watcher close due to unresponsiveness: %v. len(c.input) = %v, len(c.result) = %v, graceful = %v", c.groupResource.String(), c.identifier, len(c.input), len(c.result), graceful)
 		c.forget(graceful)
 	}
@@ -401,7 +407,7 @@ func (c *cacheWatcher) convertToWatchEvent(event *watchCacheEvent) *watch.Event 
 }
 
 // NOTE: sendWatchCacheEvent is assumed to not modify <event> !!!
-func (c *cacheWatcher) sendWatchCacheEvent(event *watchCacheEvent) {
+func (c *cacheWatcher) sendWatchCacheEvent(event *watchCacheEvent) (sentAt time.Time) {
 	watchEvent := c.convertToWatchEvent(event)
 	if watchEvent == nil {
 		// Watcher is not interested in that object.
@@ -429,8 +435,10 @@ func (c *cacheWatcher) sendWatchCacheEvent(event *watchCacheEvent) {
 	select {
 	case c.result <- *watchEvent:
 		c.markBookmarkAfterRvSent(event)
+		sentAt = time.Now()
 	case <-c.done:
 	}
+	return
 }
 
 func (c *cacheWatcher) processInterval(ctx context.Context, cacheInterval *watchCacheInterval, resourceVersion uint64) {
@@ -536,10 +544,19 @@ func (c *cacheWatcher) process(ctx context.Context, resourceVersion uint64) {
 			// or a bookmark event with an RV equal to resourceVersion
 			// if we haven't sent one to the client
 			if event.ResourceVersion > resourceVersion || (event.Type == watch.Bookmark && event.ResourceVersion == resourceVersion && !c.wasBookmarkAfterRvSent()) {
-				c.sendWatchCacheEvent(event)
+				sentAt := c.sendWatchCacheEvent(event)
+				if !sentAt.IsZero() {
+					c.recordLifecycleMetrics(event, sentAt)
+				}
 			}
 		case <-ctx.Done():
 			return
 		}
+	}
+}
+
+func (c *cacheWatcher) recordLifecycleMetrics(event *watchCacheEvent, sentAt time.Time) {
+	if !sentAt.IsZero() && !event.RecordTime.IsZero() {
+		c.watcherMetrics.ObserveDelivered(sentAt.Sub(event.RecordTime))
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -34,8 +35,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/storage"
+	"k8s.io/apiserver/pkg/storage/cacher/metrics"
 	"k8s.io/apiserver/pkg/storage/cacher/store"
 	utilflowcontrol "k8s.io/apiserver/pkg/util/flowcontrol"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
 	testingclock "k8s.io/utils/clock/testing"
 
 	cachertesting "k8s.io/apiserver/pkg/storage/cacher/testing"
@@ -64,7 +68,7 @@ func TestCacheWatcherCleanupNotBlockedByResult(t *testing.T) {
 	}
 	// set the size of the buffer of w.result to 0, so that the writes to
 	// w.result is blocked.
-	w = newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, time.Now(), false, schema.GroupResource{Resource: "pods"}, "")
+	w = newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, time.Now(), false, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
 	go w.processInterval(context.Background(), intervalFromEvents(initEvents), 0)
 	w.Stop()
 	if err := wait.PollImmediate(1*time.Second, 5*time.Second, func() (bool, error) {
@@ -184,7 +188,7 @@ TestCase:
 			testCase.events[j].ResourceVersion = uint64(j) + 1
 		}
 
-		w := newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, time.Now(), false, schema.GroupResource{Resource: "pods"}, "")
+		w := newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, time.Now(), false, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
 		go w.processInterval(context.Background(), intervalFromEvents(testCase.events), 0)
 
 		ch := w.ResultChan()
@@ -221,7 +225,7 @@ func TestCacheWatcherStoppedInAnotherGoroutine(t *testing.T) {
 	// timeout to zero and run the Stop goroutine concurrently.
 	// May sure that the watch will not be blocked on Stop.
 	for i := 0; i < maxRetriesToProduceTheRaceCondition; i++ {
-		w = newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, time.Now(), false, schema.GroupResource{Resource: "pods"}, "")
+		w = newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, time.Now(), false, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
 		go w.Stop()
 		select {
 		case <-done:
@@ -233,7 +237,7 @@ func TestCacheWatcherStoppedInAnotherGoroutine(t *testing.T) {
 	deadline := time.Now().Add(time.Hour)
 	// After that, verifies the cacheWatcher.process goroutine works correctly.
 	for i := 0; i < maxRetriesToProduceTheRaceCondition; i++ {
-		w = newCacheWatcher(2, filter, emptyFunc, storage.APIObjectVersioner{}, deadline, false, schema.GroupResource{Resource: "pods"}, "")
+		w = newCacheWatcher(2, filter, emptyFunc, storage.APIObjectVersioner{}, deadline, false, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
 		w.input <- &watchCacheEvent{Object: &v1.Pod{}, ResourceVersion: uint64(i + 1)}
 		ctx, cancel := context.WithDeadline(context.Background(), deadline)
 		defer cancel()
@@ -306,7 +310,7 @@ func TestResourceVersionAfterInitEvents(t *testing.T) {
 	filter := func(_ string, _ labels.Set, _ fields.Set, _ runtime.Object) bool { return true }
 	forget := func(_ bool) {}
 	deadline := time.Now().Add(time.Minute)
-	w := newCacheWatcher(numObjects+1, filter, forget, storage.APIObjectVersioner{}, deadline, true, schema.GroupResource{Resource: "pods"}, "")
+	w := newCacheWatcher(numObjects+1, filter, forget, storage.APIObjectVersioner{}, deadline, true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
 
 	// Simulate a situation when the last event will that was already in
 	// the state, wasn't yet processed by cacher and will be delivered
@@ -349,7 +353,7 @@ func TestTimeBucketWatchersBasic(t *testing.T) {
 	forget := func(bool) {}
 
 	newWatcher := func(deadline time.Time) *cacheWatcher {
-		w := newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, deadline, true, schema.GroupResource{Resource: "pods"}, "")
+		w := newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, deadline, true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
 		w.setBookmarkAfterResourceVersion(0)
 		return w
 	}
@@ -416,7 +420,7 @@ func TestCacheWatcherDraining(t *testing.T) {
 		makeWatchCacheEvent(5),
 		makeWatchCacheEvent(6),
 	}
-	w = newCacheWatcher(1, filter, forget, storage.APIObjectVersioner{}, time.Now(), true, schema.GroupResource{Resource: "pods"}, "")
+	w = newCacheWatcher(1, filter, forget, storage.APIObjectVersioner{}, time.Now(), true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
 	go w.processInterval(context.Background(), intervalFromEvents(initEvents), 1)
 	if !w.add(makeWatchCacheEvent(7), time.NewTimer(1*time.Second)) {
 		t.Fatal("failed adding an even to the watcher")
@@ -457,7 +461,7 @@ func TestCacheWatcherDrainingRequestedButNotDrained(t *testing.T) {
 		makeWatchCacheEvent(5),
 		makeWatchCacheEvent(6),
 	}
-	w = newCacheWatcher(1, filter, forget, storage.APIObjectVersioner{}, time.Now(), true, schema.GroupResource{Resource: "pods"}, "")
+	w = newCacheWatcher(1, filter, forget, storage.APIObjectVersioner{}, time.Now(), true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
 	go w.processInterval(context.Background(), intervalFromEvents(initEvents), 1)
 	if !w.add(makeWatchCacheEvent(7), time.NewTimer(1*time.Second)) {
 		t.Fatal("failed adding an even to the watcher")
@@ -494,7 +498,7 @@ func TestCacheWatcherDrainingNoBookmarkAfterResourceVersionReceived(t *testing.T
 		{Object: &v1.Pod{}},
 		{Object: &v1.Pod{}},
 	}
-	w = newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, time.Now(), true, schema.GroupResource{Resource: "pods"}, "")
+	w = newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, time.Now(), true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
 	w.setBookmarkAfterResourceVersion(10)
 	go w.processInterval(context.Background(), intervalFromEvents(initEvents), 0)
 
@@ -552,7 +556,7 @@ func TestCacheWatcherDrainingNoBookmarkAfterResourceVersionSent(t *testing.T) {
 		w.stopLocked()
 	}
 	initEvents := []*watchCacheEvent{{Object: makePod(1)}, {Object: makePod(2)}}
-	w = newCacheWatcher(2, filter, forget, storage.APIObjectVersioner{}, time.Now(), true, schema.GroupResource{Resource: "pods"}, "")
+	w = newCacheWatcher(2, filter, forget, storage.APIObjectVersioner{}, time.Now(), true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
 	w.setBookmarkAfterResourceVersion(10)
 	go w.processInterval(ctx, intervalFromEvents(initEvents), 0)
 	watchInitializationSignal.Wait()
@@ -606,7 +610,7 @@ func TestCacheWatcherDrainingNoBookmarkAfterResourceVersionSent(t *testing.T) {
 
 func TestBookmarkAfterResourceVersionWatchers(t *testing.T) {
 	newWatcher := func(id string, deadline time.Time) *cacheWatcher {
-		w := newCacheWatcher(0, func(_ string, _ labels.Set, _ fields.Set, _ runtime.Object) bool { return true }, func(bool) {}, storage.APIObjectVersioner{}, deadline, true, schema.GroupResource{Resource: "pods"}, id)
+		w := newCacheWatcher(0, func(_ string, _ labels.Set, _ fields.Set, _ runtime.Object) bool { return true }, func(bool) {}, storage.APIObjectVersioner{}, deadline, true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), id)
 		w.setBookmarkAfterResourceVersion(10)
 		return w
 	}
@@ -658,5 +662,55 @@ func TestBookmarkAfterResourceVersionWatchers(t *testing.T) {
 	ret = target.popExpiredWatchersThreadUnsafe()
 	if len(ret) != 1 || len(ret[0]) != 1 {
 		t.Fatalf("expected only one watcher to be expired")
+	}
+}
+
+func TestCacheWatcherDispatchDurationMetric(t *testing.T) {
+	metrics.Register()
+	legacyregistry.Reset()
+	t.Cleanup(legacyregistry.Reset)
+
+	w := newCacheWatcher(10, func(string, labels.Set, fields.Set, runtime.Object) bool { return true }, func(bool) {}, storage.APIObjectVersioner{}, time.Now().Add(time.Minute), false, schema.GroupResource{Resource: "pods"}, metrics.NewWatcherMetricsObservers(schema.GroupResource{Resource: "pods"}), "")
+
+	event := &watchCacheEvent{
+		Type:            watch.Added,
+		Object:          &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+		ResourceVersion: 1,
+		RecordTime:      time.Now().Add(-1 * time.Second),
+	}
+
+	w.add(event, time.NewTimer(10*time.Second))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go w.processInterval(ctx, intervalFromEvents([]*watchCacheEvent{}), 0)
+
+	<-w.ResultChan()
+	w.Stop()
+
+	expected := `
+# HELP apiserver_watch_cache_watcher_dispatch_duration_seconds [ALPHA] Histogram of latency from the time an event is received by the watch cache to when it is dispatched to a watcher's output channel, broken by resource type and outcome.
+# TYPE apiserver_watch_cache_watcher_dispatch_duration_seconds histogram
+apiserver_watch_cache_watcher_dispatch_duration_seconds_count{group="",outcome="delivered",resource="pods"} 1
+apiserver_watch_cache_watcher_dispatch_duration_seconds_count{group="",outcome="terminated",resource="pods"} 0
+`
+	if err := testutil.GatherAndCompare(gatherWithoutDurations(), strings.NewReader(expected), "apiserver_watch_cache_watcher_dispatch_duration_seconds"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func gatherWithoutDurations() testutil.GathererFunc {
+	return func() ([]*testutil.MetricFamily, error) {
+		got, err := legacyregistry.DefaultGatherer.Gather()
+		for _, mf := range got {
+			for _, m := range mf.Metric {
+				if m.Histogram == nil {
+					continue
+				}
+				m.Histogram.SampleSum = nil
+				m.Histogram.Bucket = nil
+			}
+		}
+		return got, err
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -342,6 +342,7 @@ type Cacher struct {
 	// expiredBookmarkWatchers is a list of watchers that were expired and need to be schedule for a next bookmark event
 	expiredBookmarkWatchers []*cacheWatcher
 	compactor               *compactor
+	watcherMetrics          *metrics.WatcherMetricsObservers
 }
 
 // NewCacherFromConfig creates a new Cacher responsible for servicing WATCH and LIST requests from
@@ -414,6 +415,7 @@ func NewCacherFromConfig(config Config) (*Cacher, error) {
 		clock:            config.Clock,
 		timer:            time.NewTimer(time.Duration(0)),
 		bookmarkWatchers: newTimeBucketWatchers(config.Clock, defaultBookmarkFrequency),
+		watcherMetrics:   metrics.NewWatcherMetricsObservers(config.GroupResource),
 	}
 
 	// Ensure that timer is stopped.
@@ -604,6 +606,7 @@ func (c *Cacher) Watch(ctx context.Context, key string, opts storage.ListOptions
 		deadline,
 		pred.AllowWatchBookmarks,
 		c.groupResource,
+		c.watcherMetrics,
 		identifier,
 	)
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -2474,6 +2474,7 @@ func TestForgetWatcher(t *testing.T) {
 		forgetCounter++
 		forgetWatcherFn(drainWatcher)
 	}
+	groupResource := schema.GroupResource{Resource: "pods"}
 	w := newCacheWatcher(
 		0,
 		func(_ string, _ labels.Set, _ fields.Set, _ runtime.Object) bool { return true },
@@ -2481,7 +2482,8 @@ func TestForgetWatcher(t *testing.T) {
 		storage.APIObjectVersioner{},
 		testingclock.NewFakeClock(time.Now()).Now().Add(2*time.Minute),
 		true,
-		schema.GroupResource{Resource: "pods"},
+		groupResource,
+		metrics.NewNoopWatcherMetricsObservers(),
 		"1",
 	)
 	forgetWatcherFn = forgetWatcher(cacher, w, 0, namespacedName{}, "", false)

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"sync"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/features"
@@ -28,8 +29,10 @@ import (
 )
 
 const (
-	namespace = "apiserver"
-	subsystem = "watch_cache"
+	namespace                 = "apiserver"
+	subsystem                 = "watch_cache"
+	dispatchOutcomeDelivered  = "delivered"
+	dispatchOutcomeTerminated = "terminated"
 )
 
 /*
@@ -234,6 +237,16 @@ var (
 		},
 		[]string{"group", "resource"},
 	)
+
+	dispatchDuration = compbasemetrics.NewHistogramVec(
+		&compbasemetrics.HistogramOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "watcher_dispatch_duration_seconds",
+			Help:           "Histogram of latency from the time an event is received by the watch cache to when it is dispatched to a watcher's output channel, broken by resource type and outcome.",
+			StabilityLevel: compbasemetrics.ALPHA,
+			Buckets:        []float64{0.001, 0.005, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+		}, []string{"group", "resource", "outcome"})
 )
 
 var registerMetrics sync.Once
@@ -263,6 +276,7 @@ func Register() {
 			legacyregistry.MustRegister(WatchShardsTotal)
 			legacyregistry.MustRegister(WatchFilteredEventsTotal)
 		}
+		legacyregistry.MustRegister(dispatchDuration)
 	})
 }
 
@@ -304,4 +318,46 @@ func RecordsWatchCacheCapacityChange(groupResource schema.GroupResource, old, ne
 		return
 	}
 	watchCacheCapacityDecreaseTotal.WithLabelValues(groupResource.Group, groupResource.Resource).Inc()
+}
+
+type WatcherMetricsObservers struct {
+	deliveredDuration  compbasemetrics.ObserverMetric
+	terminatedDuration compbasemetrics.ObserverMetric
+}
+
+// NewWatcherMetricsObservers creates a pre-resolved metrics observer for watch connections.
+func NewWatcherMetricsObservers(groupResource schema.GroupResource) *WatcherMetricsObservers {
+	return &WatcherMetricsObservers{
+		deliveredDuration:  dispatchDuration.WithLabelValues(groupResource.Group, groupResource.Resource, dispatchOutcomeDelivered),
+		terminatedDuration: dispatchDuration.WithLabelValues(groupResource.Group, groupResource.Resource, dispatchOutcomeTerminated),
+	}
+}
+
+func (d *WatcherMetricsObservers) ObserveDelivered(duration time.Duration) {
+	observe(d.deliveredDuration, duration)
+}
+
+func (d *WatcherMetricsObservers) ObserveTerminated(duration time.Duration) {
+	observe(d.terminatedDuration, duration)
+}
+
+func observe(m compbasemetrics.ObserverMetric, duration time.Duration) {
+	if duration < 0 {
+		duration = 0
+	}
+	m.Observe(duration.Seconds())
+}
+
+type noopObserver struct{}
+
+func (noopObserver) Observe(float64) {}
+
+var noopObs noopObserver
+
+// NewNoopWatcherMetricsObservers returns a metrics observers struct that does nothing.
+func NewNoopWatcherMetricsObservers() *WatcherMetricsObservers {
+	return &WatcherMetricsObservers{
+		deliveredDuration:  noopObs,
+		terminatedDuration: noopObs,
+	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -191,6 +191,16 @@ func (w *watchCache) Delete(obj interface{}) error {
 	return w.processEvent(event, resourceVersion)
 }
 
+// ProcessWatchEvent takes a watch.Event as an argument and processes it.
+// This implements the WatchEventReceiver interface.
+func (w *watchCache) ProcessWatchEvent(event watch.Event) error {
+	_, resourceVersion, err := w.objectToVersionedRuntimeObject(event.Object)
+	if err != nil {
+		return err
+	}
+	return w.processEvent(event, resourceVersion)
+}
+
 func (w *watchCache) objectToVersionedRuntimeObject(obj interface{}) (runtime.Object, uint64, error) {
 	object, ok := obj.(runtime.Object)
 	if !ok {
@@ -218,6 +228,11 @@ func (w *watchCache) processEvent(event watch.Event, resourceVersion uint64) err
 		return err
 	}
 
+	recordTime := event.RecordTime
+	if recordTime.IsZero() {
+		recordTime = w.config.clock.Now()
+	}
+
 	wcEvent := &watchCacheEvent{
 		Type:            event.Type,
 		Object:          elem.Object,
@@ -225,7 +240,7 @@ func (w *watchCache) processEvent(event watch.Event, resourceVersion uint64) err
 		ObjFields:       elem.Fields,
 		Key:             key,
 		ResourceVersion: resourceVersion,
-		RecordTime:      w.config.clock.Now(),
+		RecordTime:      recordTime,
 	}
 
 	// We can call w.storage.Get() outside of a critical section,

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/event.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/event.go
@@ -18,6 +18,8 @@ package etcd3
 
 import (
 	"fmt"
+	"time"
+
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
@@ -41,6 +43,7 @@ type event struct {
 	// struct field to eliminate contention
 	// between startWatching and processEvent
 	isInitialEventsEndBookmark bool
+	recordTime                 time.Time
 }
 
 // parseKV converts a KeyValue retrieved from an initial sync() listing to a synthetic isCreated event.
@@ -50,8 +53,9 @@ func parseKV(kv *mvccpb.KeyValue) *event {
 		value:     kv.Value,
 		prevValue: nil,
 		rev:       kv.ModRevision,
-		isDeleted: false,
-		isCreated: true,
+		isDeleted:  false,
+		isCreated:  true,
+		recordTime: time.Now(),
 	}
 }
 
@@ -65,8 +69,9 @@ func parseEvent(e *clientv3.Event) (*event, error) {
 		key:       string(e.Kv.Key),
 		value:     e.Kv.Value,
 		rev:       e.Kv.ModRevision,
-		isDeleted: e.Type == clientv3.EventTypeDelete,
-		isCreated: e.IsCreate(),
+		isDeleted:  e.Type == clientv3.EventTypeDelete,
+		isCreated:  e.IsCreate(),
+		recordTime: time.Now(),
 	}
 	if e.PrevKv != nil {
 		ret.prevValue = e.PrevKv.Value
@@ -78,5 +83,6 @@ func progressNotifyEvent(rev int64) *event {
 	return &event{
 		rev:              rev,
 		isProgressNotify: true,
+		recordTime:       time.Now(),
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/event_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/event_test.go
@@ -18,6 +18,7 @@ package etcd3
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -104,6 +105,7 @@ func TestParseEvent(t *testing.T) {
 				assert.ErrorContains(t, err, tc.expectedErr)
 			} else {
 				require.NoError(t, err)
+				actualEvent.recordTime = time.Time{}
 				assert.Equal(t, tc.expectedEvent, actualEvent)
 			}
 		})

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
@@ -672,30 +672,34 @@ func (wc *watchChan) transform(e *event) (res *watch.Event, err error) {
 			}
 		}
 		res = &watch.Event{
-			Type:   watch.Bookmark,
-			Object: object,
+			Type:       watch.Bookmark,
+			Object:     object,
+			RecordTime: e.recordTime,
 		}
 	case e.isDeleted:
 		if !wc.filter(oldObj) {
 			return nil, nil
 		}
 		res = &watch.Event{
-			Type:   watch.Deleted,
-			Object: oldObj,
+			Type:       watch.Deleted,
+			Object:     oldObj,
+			RecordTime: e.recordTime,
 		}
 	case e.isCreated:
 		if !wc.filter(curObj) {
 			return nil, nil
 		}
 		res = &watch.Event{
-			Type:   watch.Added,
-			Object: curObj,
+			Type:       watch.Added,
+			Object:     curObj,
+			RecordTime: e.recordTime,
 		}
 	default:
 		if wc.acceptAll() {
 			res = &watch.Event{
-				Type:   watch.Modified,
-				Object: curObj,
+				Type:       watch.Modified,
+				Object:     curObj,
+				RecordTime: e.recordTime,
 			}
 			return res, nil
 		}
@@ -704,18 +708,21 @@ func (wc *watchChan) transform(e *event) (res *watch.Event, err error) {
 		switch {
 		case curObjPasses && oldObjPasses:
 			res = &watch.Event{
-				Type:   watch.Modified,
-				Object: curObj,
+				Type:       watch.Modified,
+				Object:     curObj,
+				RecordTime: e.recordTime,
 			}
 		case curObjPasses && !oldObjPasses:
 			res = &watch.Event{
-				Type:   watch.Added,
-				Object: curObj,
+				Type:       watch.Added,
+				Object:     curObj,
+				RecordTime: e.recordTime,
 			}
 		case !curObjPasses && oldObjPasses:
 			res = &watch.Event{
-				Type:   watch.Deleted,
-				Object: oldObj,
+				Type:       watch.Deleted,
+				Object:     oldObj,
+				RecordTime: e.recordTime,
 			}
 		}
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
@@ -373,7 +374,7 @@ func TestWatchChanSyncStreamMatchesPaginated(t *testing.T) {
 	if len(stream) != len(want) {
 		t.Errorf("syncStreamRecursive queued %d events, expected %d", len(stream), len(want))
 	}
-	if diff := cmp.Diff(paginated, stream, cmp.AllowUnexported(event{})); diff != "" {
+	if diff := cmp.Diff(paginated, stream, cmp.AllowUnexported(event{}), cmpopts.IgnoreFields(event{}, "recordTime")); diff != "" {
 		t.Errorf("syncStreamRecursive and syncPaginated queued different events (-paginated +stream):\n%s", diff)
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/utils.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/utils.go
@@ -166,6 +166,7 @@ func testCheckResultFunc(t *testing.T, w watch.Interface, check func(actualEvent
 		if co, ok := obj.(runtime.CacheableObject); ok {
 			res.Object = co.GetObject()
 		}
+		res.RecordTime = time.Time{}
 		check(res)
 	case <-time.After(wait.ForeverTestTimeout):
 		t.Errorf("time out after waiting %v on ResultChan", wait.ForeverTestTimeout)
@@ -181,6 +182,7 @@ func testCheckResultWithIgnoreFunc(t *testing.T, w watch.Interface, expectedEven
 			if co, ok := obj.(runtime.CacheableObject); ok {
 				event.Object = co.GetObject()
 			}
+			event.RecordTime = time.Time{}
 			if ignore != nil && ignore(event) {
 				continue
 			}

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -1036,13 +1036,23 @@ loop:
 			resourceVersion := meta.GetResourceVersion()
 			switch event.Type {
 			case watch.Added:
-				err := store.Add(event.Object)
+				var err error
+				if receiver, ok := store.(WatchEventReceiver); ok {
+					err = receiver.ProcessWatchEvent(event)
+				} else {
+					err = store.Add(event.Object)
+				}
 				if err != nil {
 					utilruntime.HandleErrorWithContext(ctx, err, "Unable to add watch event object to store", "reflector", name, "object", event.Object)
 				}
 			case watch.Modified:
 				eventReceivedBesidesAdded = true
-				err := store.Update(event.Object)
+				var err error
+				if receiver, ok := store.(WatchEventReceiver); ok {
+					err = receiver.ProcessWatchEvent(event)
+				} else {
+					err = store.Update(event.Object)
+				}
 				if err != nil {
 					utilruntime.HandleErrorWithContext(ctx, err, "Unable to update watch event object to store", "reflector", name, "object", event.Object)
 				}
@@ -1051,7 +1061,12 @@ loop:
 				// state", which is passed in event.Object? If so, may need
 				// to change this.
 				eventReceivedBesidesAdded = true
-				err := store.Delete(event.Object)
+				var err error
+				if receiver, ok := store.(WatchEventReceiver); ok {
+					err = receiver.ProcessWatchEvent(event)
+				} else {
+					err = store.Delete(event.Object)
+				}
 				if err != nil {
 					utilruntime.HandleErrorWithContext(ctx, err, "Unable to delete watch event object from store", "reflector", name, "object", event.Object)
 				}

--- a/staging/src/k8s.io/client-go/tools/cache/store.go
+++ b/staging/src/k8s.io/client-go/tools/cache/store.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
 )
 
 // Store is a generic object storage and processing interface.  A
@@ -79,6 +80,12 @@ type Store interface {
 	// meaning in some implementations that have non-trivial
 	// additional behavior (e.g., DeltaFIFO).
 	Resync() error
+}
+
+// WatchEventReceiver is an optional interface for Store implementations that want to
+// receive the full watch.Event (including any telemetry metadata) rather than just the object.
+type WatchEventReceiver interface {
+	ProcessWatchEvent(event watch.Event) error
 }
 
 // TransactionType defines the type of a transaction operation. It is used to indicate whether


### PR DESCRIPTION
This PR introduces the 'apiserver_watch_cache_watcher_dispatch_duration_seconds' alpha metric. This metric tracks the duration from when an event is read from etcd until it is successfully written to a watcher's outgoing result channel (sentAt).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
