### PR TITLE
Fix util_system_windows windows token handling

### DIFF
--- a/test/e2e_node_windows/util_system_windows.go
+++ b/test/e2e_node_windows/util_system_windows.go
@@ -21,6 +21,8 @@ package e2enodewindows
 import (
 	"fmt"
 	"runtime"
+	"sort"
+	"strings"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -103,9 +105,12 @@ func enablePrivilege(name string) error {
 	return nil
 }
 
-// duplicateSystemToken walks running processes and duplicates an impersonation
-// token from the first one running as SYSTEM whose token can be fully
-// duplicated. Returns an error if none can be obtained.
+// duplicateSystemToken duplicates an impersonation token from a SYSTEM process.
+// It prefers well-known host (session-0) SYSTEM processes: a token duplicated
+// from a process running *inside* a container silo is silo-scoped and cannot
+// open a different container's silo job object (STATUS_ACCESS_DENIED), even
+// though its user is S-1-5-18. Host processes like services.exe yield a
+// host-scoped token that can open any silo.
 func duplicateSystemToken() (windows.Token, error) {
 	systemSID, err := windows.StringToSid(systemSIDString)
 	if err != nil {
@@ -118,13 +123,33 @@ func duplicateSystemToken() (windows.Token, error) {
 	}
 	defer windows.CloseHandle(snap)
 
+	type proc struct {
+		pid  uint32
+		name string
+	}
+	var procs []proc
 	var pe windows.ProcessEntry32
 	pe.Size = uint32(unsafe.Sizeof(pe))
 	for err = windows.Process32First(snap, &pe); err == nil; err = windows.Process32Next(snap, &pe) {
 		if pe.ProcessID == 0 {
 			continue
 		}
-		if dup, ok := trySystemTokenFromPID(pe.ProcessID, systemSID); ok {
+		procs = append(procs, proc{pe.ProcessID, strings.ToLower(windows.UTF16ToString(pe.ExeFile[:]))})
+	}
+
+	// Preferred host SYSTEM processes first; then anything else as fallback.
+	preferred := map[string]int{"services.exe": 0, "winlogon.exe": 1, "wininit.exe": 2, "lsass.exe": 3}
+	sort.SliceStable(procs, func(i, j int) bool {
+		pi, oki := preferred[procs[i].name]
+		pj, okj := preferred[procs[j].name]
+		if oki != okj {
+			return oki // preferred ones sort first
+		}
+		return pi < pj
+	})
+
+	for _, p := range procs {
+		if dup, ok := trySystemTokenFromPID(p.pid, systemSID); ok {
 			return dup, nil
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change updates the Windows e2e node helper to read container job-object affinity through a host-scoped SYSTEM token instead of relying on the current elevated process context.

On Windows, an Administrator process is not enough to inspect a container silo job object in all cases. The previous approach could hit access-denied failures because the security boundary is enforced on the job object itself, and tokens from silo-scoped SYSTEM processes are still insufficient for cross-silo access.
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
