### PR TITLE
Mark session affinity timeout tests slow

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -2232,7 +2232,7 @@ var _ = common.SIGDescribe("Services", func() {
 		execAffinityTestForNonLBService(ctx, f, cs, svc)
 	})
 
-	ginkgo.It("should have session affinity timeout work for service with type clusterIP [LinuxOnly]", func(ctx context.Context) {
+	framework.It("should have session affinity timeout work for service with type clusterIP [LinuxOnly]", framework.WithSlow(), func(ctx context.Context) {
 		svc := getServeHostnameService("affinity-clusterip-timeout")
 		svc.Spec.Type = v1.ServiceTypeClusterIP
 		execAffinityTestForSessionAffinityTimeout(ctx, f, cs, svc)
@@ -2269,7 +2269,7 @@ var _ = common.SIGDescribe("Services", func() {
 		execAffinityTestForNonLBService(ctx, f, cs, svc)
 	})
 
-	ginkgo.It("should have session affinity timeout work for NodePort service [LinuxOnly]", func(ctx context.Context) {
+	framework.It("should have session affinity timeout work for NodePort service [LinuxOnly]", framework.WithSlow(), func(ctx context.Context) {
 		svc := getServeHostnameService("affinity-nodeport-timeout")
 		svc.Spec.Type = v1.ServiceTypeNodePort
 		execAffinityTestForSessionAffinityTimeout(ctx, f, cs, svc)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Marks the service session affinity timeout e2e tests as slow.

These tests intentionally wait for the configured session affinity timeout before checking that traffic can move to another backend. Recent `ci-kubernetes-e2e-kind-alpha-beta-features` JUnit results show these timeout tests sometimes exceeding the 5 minute threshold for `[Slow]` tests.

#### Which issue(s) this PR is related to:

Related to #131049

#### Special notes for your reviewer:

I checked the last 50 completed successful `ci-kubernetes-e2e-kind-alpha-beta-features` runs. The ClusterIP timeout test exceeded 300s in 4 runs, and the NodePort timeout test exceeded 300s in 2 runs.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
