### PR TITLE
Fix: prevent panic for pending allocations in DRA

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -491,13 +491,11 @@ func (pl *DynamicResources) PreFilter(ctx context.Context, state fwk.CycleState,
 		}
 
 		if claim.Status.Allocation != nil {
-			if claim.Status.Allocation.NodeSelector != nil {
-				nodeSelector, err := nodeaffinity.NewNodeSelector(claim.Status.Allocation.NodeSelector)
-				if err != nil {
-					return nil, statusError(logger, err)
-				}
-				s.informationsForClaim[index].availableOnNodes = nodeSelector
+			nodeSelector, err := nodeSelectorFromAllocation(claim.Status.Allocation)
+			if err != nil {
+				return nil, statusError(logger, err)
 			}
+			s.informationsForClaim[index].availableOnNodes = nodeSelector
 		} else {
 			numClaimsToAllocate++
 
@@ -524,7 +522,7 @@ func (pl *DynamicResources) PreFilter(ctx context.Context, state fwk.CycleState,
 			if podGroupState != nil && podGroupState.pendingAllocations.Has(claim.UID) {
 				if pendingAllocation := pl.draManager.ResourceClaims().GetPendingAllocation(claim.UID); pendingAllocation != nil {
 					s.informationsForClaim[index].allocation = pendingAllocation
-					nodeSelector, err := nodeaffinity.NewNodeSelector(pendingAllocation.NodeSelector)
+					nodeSelector, err := nodeSelectorFromAllocation(pendingAllocation)
 					if err != nil {
 						return nil, statusError(logger, err)
 					}
@@ -1921,4 +1919,13 @@ func formatBCStatusOneLine(devs []BindingConditionsStatus) string {
 		parts = append(parts, base)
 	}
 	return strings.Join(parts, "; ")
+}
+
+// nodeSelectorFromAllocation returns a NodeSelector for the given allocation,
+// or nil if the allocation has no NodeSelector (meaning available on all nodes).
+func nodeSelectorFromAllocation(allocation *resourceapi.AllocationResult) (*nodeaffinity.NodeSelector, error) {
+	if allocation.NodeSelector == nil {
+		return nil, nil
+	}
+	return nodeaffinity.NewNodeSelector(allocation.NodeSelector)
 }

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -1222,6 +1222,69 @@ type testPluginCase struct {
 func TestPlugin(t *testing.T) {
 	testPlugin(ktesting.Init(t))
 }
+
+func TestPreFilterReusesPendingAllocationWithNilNodeSelector(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	featuregatetesting.SetFeatureGatesDuringTest(tCtx, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+		features.DRAWorkloadResourceClaims: true,
+		features.GenericWorkload:           true,
+	})
+
+	feats := feature.Features{
+		EnableDRAAdminAccess:               true,
+		EnableDRADeviceBindingConditions:   true,
+		EnableDRAResourceClaimDeviceStatus: true,
+		EnableDRASchedulerFilterTimeout:    true,
+		EnableDynamicResourceAllocation:    true,
+		EnableDRAWorkloadResourceClaims:    true,
+	}
+	testCtx := setup(tCtx, nil, []*v1.Node{workerNode}, []*resourceapi.ResourceClaim{pendingPodGroupClaim}, []*resourceapi.DeviceClass{deviceClass}, []*schedulingapi.PodGroup{podGroupWithClaimName}, []apiruntime.Object{workerNodeSlice}, feats, false, nil)
+
+	pendingClaim, err := testCtx.draManager.ResourceClaims().Get(namespace, claimName)
+	if err != nil {
+		t.Fatalf("Get claim: %v", err)
+	}
+	allocatedClaim := pendingClaim.DeepCopy()
+	allocatedClaim.Status.Allocation = allocationResult.DeepCopy()
+	allocatedClaim.Status.Allocation.NodeSelector = nil
+	tCtx.ExpectNoError(testCtx.draManager.ResourceClaims().SignalClaimPendingAllocation(allocatedClaim.UID, allocatedClaim))
+
+	podGroupCycleState := framework.NewCycleState()
+	podGroupCycleState.Write(stateKey, &podGroupStateData{
+		pendingAllocations: sets.New(allocatedClaim.UID),
+	})
+	cycleState := framework.NewCycleState()
+	cycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
+	testCtx.state = cycleState
+
+	nodeInfo := framework.NewNodeInfo()
+	nodeInfo.SetNode(workerNode)
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("PreFilter panicked: %v", r)
+			}
+		}()
+		_, status := testCtx.p.PreFilter(tCtx, testCtx.state, groupedPodWithClaimName, []fwk.NodeInfo{nodeInfo})
+		if !status.IsSuccess() {
+			t.Errorf("PreFilter status: %v", status)
+		}
+	}()
+
+	pluginState, err := getStateData(testCtx.state)
+	if err != nil {
+		t.Fatalf("getStateData: %v", err)
+	}
+	if pluginState.informationsForClaim[0].allocation != allocatedClaim.Status.Allocation {
+		t.Errorf("allocation pointer mismatch: got %p, want %p",
+			pluginState.informationsForClaim[0].allocation, allocatedClaim.Status.Allocation)
+	}
+	if pluginState.informationsForClaim[0].availableOnNodes != nil {
+		t.Errorf("availableOnNodes should be nil, got %v", pluginState.informationsForClaim[0].availableOnNodes)
+	}
+}
+
 func testPlugin(tCtx ktesting.TContext) {
 	testcases := map[string]testPluginCase{
 		"empty": {


### PR DESCRIPTION
 

#### What type of PR is this?

 
/kind bug
 

#### What this PR does / why we need it:


add nil guard for pending allocations in DRA.


When GenericWorkload and DRAWorkloadResourceClaims are enabled, two or more Pods can belong to same PodGroup and share same ResourceClaim.

  If selected devices come from a ResourceSlice with spec.allNodes: true:

```
  apiVersion: resource.k8s.io/v1
  kind: ResourceSlice
  metadata:
    name: global-gpu-slice
  spec:
    driver: example.com/dra
    allNodes: true    # key condition
    ...
```

  then allocator can produce an AllocationResult with NodeSelector == nil, because nil means allocated resources are available on all nodes.

  After first Pod reaches Reserve phase, scheduler records pending allocation with:

  pendingAllocation.NodeSelector == nil

  Then second Pod in same PodGroup scheduling cycle enters PreFilter and reuses that pending allocation. The PR-added code calls:

  nodeaffinity.NewNodeSelector(pendingAllocation.NodeSelector)

  This panics because pendingAllocation.NodeSelector is nil:

```
nodeaffinity.NewNodeSelector(pendingAllocation.NodeSelector)
	--->  func NewNodeSelector(ns *v1.NodeSelector, opts ...field.PathOption) (*NodeSelector, error) {
			lazy := NewLazyErrorNodeSelector(ns, opts...)
			----> func NewLazyErrorNodeSelector(ns *v1.NodeSelector, opts ...field.PathOption) *LazyErrorNodeSelector {
				   parsedTerms := make([]nodeSelectorTerm, 0, len(ns.NodeSelectorTerms))  --- > panic when len(nil)
				   }
	}
```


For reference, same function already handles persisted allocations correctly: the claim.Status.Allocation.NodeSelector path has a nil check.

```
// https://github.com/weizhoublue/kubernetes/blob/master/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
// line 493-500
  if pendingAllocation.NodeSelector != nil {
        nodeSelector, err := nodeaffinity.NewNodeSelector(pendingAllocation.NodeSelector)
        if err != nil {
                return nil, statusError(logger, err)
        }
        s.informationsForClaim[index].availableOnNodes = nodeSelector
  }
```






#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
