### PR TITLE
Add a message when preemption succeeds

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -196,7 +196,7 @@ func TestPostFilter(t *testing.T) {
 				"node1": fwk.NewStatus(fwk.Unschedulable),
 			}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 			wantResult: framework.NewPostFilterResultWithNominatedNode("node1"),
-			wantStatus: fwk.NewStatus(fwk.Success),
+			wantStatus: fwk.NewStatus(fwk.Success, "preemption: found a potential placement for pod on node node1, preempting 1 victims"),
 		},
 		{
 			name: "pod with tied priority is still unschedulable",
@@ -257,7 +257,7 @@ func TestPostFilter(t *testing.T) {
 				"node2": fwk.NewStatus(fwk.Unschedulable),
 			}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 			wantResult: framework.NewPostFilterResultWithNominatedNode("node2"),
-			wantStatus: fwk.NewStatus(fwk.Success),
+			wantStatus: fwk.NewStatus(fwk.Success, "preemption: found a potential placement for pod on node node2, preempting 1 victims"),
 		},
 		{
 			name: "pod can be made schedulable on minHighestPriority node",
@@ -280,7 +280,7 @@ func TestPostFilter(t *testing.T) {
 				"node2": fwk.NewStatus(fwk.Unschedulable),
 			}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 			wantResult: framework.NewPostFilterResultWithNominatedNode("node2"),
-			wantStatus: fwk.NewStatus(fwk.Success),
+			wantStatus: fwk.NewStatus(fwk.Success, "preemption: found a potential placement for pod on node node2, preempting 1 victims"),
 		},
 		{
 			name: "preemption result filtered out by extenders",
@@ -302,7 +302,7 @@ func TestPostFilter(t *testing.T) {
 				Predicates:   []tf.FitPredicate{tf.Node1PredicateExtender},
 			},
 			wantResult: framework.NewPostFilterResultWithNominatedNode("node1"),
-			wantStatus: fwk.NewStatus(fwk.Success),
+			wantStatus: fwk.NewStatus(fwk.Success, "preemption: found a potential placement for pod on node node1, preempting 1 victims"),
 		},
 		{
 			name: "no candidate nodes found, no enough resource after removing low priority pods",
@@ -395,7 +395,7 @@ func TestPostFilter(t *testing.T) {
 				"node2": fwk.NewStatus(fwk.Unschedulable),
 			}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 			wantResult: framework.NewPostFilterResultWithNominatedNode("node2"),
-			wantStatus: fwk.NewStatus(fwk.Success),
+			wantStatus: fwk.NewStatus(fwk.Success, "preemption: found a potential placement for pod on node node2, preempting 1 victims"),
 		},
 		{
 			name: "pod with SchedulingGroup with TAS with scheduling constraint enabled should not preempt",
@@ -465,7 +465,7 @@ func TestPostFilter(t *testing.T) {
 			}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 			features:   feature.Features{EnableGenericWorkload: false, EnableTopologyAwareWorkloadScheduling: false},
 			wantResult: framework.NewPostFilterResultWithNominatedNode("node1"),
-			wantStatus: fwk.NewStatus(fwk.Success),
+			wantStatus: fwk.NewStatus(fwk.Success, "preemption: found a potential placement for pod on node node1, preempting 1 victims"),
 		},
 	}
 

--- a/pkg/scheduler/framework/preemption/preemption.go
+++ b/pkg/scheduler/framework/preemption/preemption.go
@@ -166,7 +166,7 @@ func (ev *Evaluator) Preempt(ctx context.Context, state fwk.CycleState, pod *v1.
 		return nil, status
 	}
 
-	return framework.NewPostFilterResultWithNominatedNode(bestCandidate.Name()), fwk.NewStatus(fwk.Success)
+	return framework.NewPostFilterResultWithNominatedNode(bestCandidate.Name()), fwk.NewStatus(fwk.Success, fmt.Sprintf("found a potential placement for pod on node %v, preempting %d victims", bestCandidate.Name(), len(bestCandidate.Victims().Pods)))
 }
 
 // FindCandidates calculates a slice of preemption candidates.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a message to preemption plugin status when it succeeds. Currently we only add the message from preemption when preemption fails:
```
0/1 nodes are available: 1 Insufficient cpu. preemption: 0/1 nodes are available: 1 Insufficient cpu. 
```

The problem is that when the preemption succeeds there is no preemption message at all. So till the preemption removes victim pods and schedules a preemptor pod, the event message on the pod will look like this:
```
0/1 nodes are available: 1 Insufficient cpu.
```

With the changes from this PR it will look like this:
```
0/1 nodes are available: 1 Insufficient cpu. preemption: found a potential placement for pod on node X.
```

#### Which issue(s) this PR is related to:

N/A 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
A FailedScheduling event and PodScheduled PodCondition for a pod for which the default preemption found a potential node will now contain
"preemption:  found a potential placement for pod on node <node_name>, preempting <victim_count> victims" mesage. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
