### PR TITLE
kubelet/userns: don't allocate ranges that include ID 2^32-1

### DIFF
--- a/pkg/kubelet/userns/userns_manager.go
+++ b/pkg/kubelet/userns/userns_manager.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"sync"
@@ -222,19 +223,30 @@ func (m *UsernsManager) isSet(v uint32) bool {
 // The first return value is the first ID in the user namespace, the second returns
 // the length for the user namespace range.
 func (m *UsernsManager) allocateOne(logger klog.Logger, pod types.UID) (firstID uint32, length uint32, err error) {
-	firstZero, found, err := m.used.AllocateNext()
-	if err != nil {
-		return 0, 0, err
-	}
-	if !found {
-		return 0, 0, fmt.Errorf("could not find an empty slot to allocate a user namespace")
-	}
+	for {
+		firstZero, found, err := m.used.AllocateNext()
+		if err != nil {
+			return 0, 0, err
+		}
+		if !found {
+			return 0, 0, fmt.Errorf("could not find an empty slot to allocate a user namespace")
+		}
 
-	logger.V(5).Info("new pod user namespace allocation", "podUID", pod)
+		first := uint64(firstZero+m.off) * uint64(m.userNsLength)
+		// The kernel rejects uid_map/gid_map extents that include ID 2^32-1, as
+		// the extent first+count wraps. A pod with such a range fails sandbox
+		// creation forever, so leave the range marked as used and try the next one.
+		if first+uint64(m.userNsLength) > math.MaxUint32 {
+			logger.V(2).Info("skipping user namespace range not usable for ID mappings", "firstID", first, "length", m.userNsLength)
+			continue
+		}
 
-	firstID = uint32((firstZero + m.off)) * m.userNsLength
-	m.usedBy[pod] = firstID
-	return firstID, m.userNsLength, nil
+		logger.V(5).Info("new pod user namespace allocation", "podUID", pod)
+
+		firstID = uint32(first)
+		m.usedBy[pod] = firstID
+		return firstID, m.userNsLength, nil
+	}
 }
 
 // record stores the user namespace [from; from+length] to the specified pod.

--- a/pkg/kubelet/userns/userns_manager_test.go
+++ b/pkg/kubelet/userns/userns_manager_test.go
@@ -21,6 +21,7 @@ package userns
 import (
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"testing"
 
@@ -528,4 +529,41 @@ func TestRecordBounds(t *testing.T) {
 	err = m.record(logger, types.UID(fmt.Sprintf("%d", 2)), uint32(2*65536), 65536)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "out of range")
+}
+
+func TestUserNsManagerAllocateTerminalBlock(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, true)
+
+	// Mappings that cover the end of the 32-bit ID space. The kernel rejects
+	// uid_map/gid_map extents that include ID 2^32-1 (the extent first+count
+	// wraps), so the last block [4294901760, 4294967295] can never be used to
+	// create a sandbox and must not be allocated to a pod.
+	testUserNsPodsManager := &testUserNsPodsManager{
+		mappingFirstID: 65534 * 65536,
+		mappingLen:     2 * 65536,
+		maxPods:        2,
+	}
+	m, err := MakeUserNsManager(logger, testUserNsPodsManager, nil)
+	require.NoError(t, err)
+
+	var allocs []uint32
+	for i := 0; i < 2; i++ {
+		firstID, length, err := m.allocateOne(logger, types.UID(fmt.Sprintf("pod-%d", i)))
+		if err != nil {
+			break
+		}
+		lastID := uint64(firstID) + uint64(length) - 1
+		assert.Lessf(t, lastID, uint64(math.MaxUint32),
+			"allocated range [%v, %v] includes an ID the kernel rejects in ID mappings", firstID, lastID)
+		allocs = append(allocs, firstID)
+	}
+	assert.NotEmpty(t, allocs, "at least one user namespace should be allocatable")
+
+	// A terminal range persisted by an older kubelet must still be accepted on
+	// restart, so the kubelet can start and the pod can be deleted normally.
+	m2, err := MakeUserNsManager(logger, testUserNsPodsManager, nil)
+	require.NoError(t, err)
+	err = m2.record(logger, "pod-from-disk", 65535*65536, 65536)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node

#### What this PR does / why we need it:

The kubelet's user namespace pool covers `[idsPerPod, 2^32)` by default (`getKubeletMappings`), so with the default 65536 IDs per pod the last allocatable block is `[4294901760, 4294967295]`. The kernel rejects any `uid_map`/`gid_map` extent that includes ID `2^32-1`, because `extent.first + extent.count` wraps u32 (`kernel/user_namespace.c`, `map_write`):

```c
/* Verify count is not zero and does not cause the extent to wrap */
if ((extent.first + extent.count) <= extent.first)
        goto out;
if ((extent.lower_first + extent.count) <= extent.lower_first)
        goto out;
```

Ranges are picked with a random scan, so any `hostUsers: false` pod can draw that block. When it does, the runtime can never create the sandbox (EINVAL while writing the ID mappings) and the pod stays stuck in `FailedCreatePodSandBox` until it is deleted.

This change makes `allocateOne` compute the range end in 64 bits and skip ranges whose mapping would include ID `2^32-1`. A skipped range stays marked as used, so it is never handed out again. This also covers pools provided via `getsubids` that reach (or pass) the top of the 32-bit ID space.

#### Which issue(s) this PR is related to:

Fixes #139916

#### Special notes for your reviewer:

- The guard is deliberately in `allocateOne` rather than shrinking the pool in `MakeUserNsManager`/`getKubeletMappings`: shrinking `len` would make `record()` fail with "out of range" while replaying a `userns` file persisted by an older kubelet that contains the terminal range, and `MakeUserNsManager` would then error out, i.e. the kubelet would fail to start after an upgrade on any node that still has such a (stuck) pod on disk. The added test pins that replay path.
- Computing the range in `uint64` also avoids the `uint32` multiply wrap for pools whose declared end exceeds `2^32`.
- Tested with the new unit test (fails before this change, allocating exactly `[4294901760, 4294967295]`; passes after), plus `go test ./pkg/kubelet/userns/...` with `-race` and `hack/verify-golangci-lint.sh ./pkg/kubelet/userns`.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where the kubelet could allocate a user namespace ID range ending at ID 2^32-1 to a pod with `hostUsers: false`. The kernel rejects ID mappings that include that ID, so such pods were stuck failing sandbox creation until deleted.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
