### PR TITLE
DRA: resource slice tracker informer

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go
@@ -56,9 +56,9 @@ type Tracker struct {
 	enableDeviceTaintRules bool
 
 	resourceSliceLister   resourcelisters.ResourceSliceLister
-	resourceSlices        cache.SharedIndexInformer
+	resourceSlices        resourceinformers.ResourceSliceIndexInformer
 	resourceSlicesHandle  cache.ResourceEventHandlerRegistration
-	deviceTaints          cache.SharedIndexInformer
+	deviceTaints          resourceinformers.DeviceTaintRuleIndexInformer
 	deviceTaintsHandle    cache.ResourceEventHandlerRegistration
 	patchedResourceSlices cache.Store
 	broadcaster           record.EventBroadcaster
@@ -114,8 +114,8 @@ type Options struct {
 	// EnableConsumableCapacity defines whether the CEL compiler supports the DRAConsumableCapacity feature.
 	EnableConsumableCapacity bool
 
-	SliceInformer resourceinformers.ResourceSliceInformer
-	TaintInformer resourceinformers.DeviceTaintRuleInformer
+	SliceInformer resourceinformers.TypedResourceSliceInformer
+	TaintInformer resourceinformers.TypedDeviceTaintRuleInformer
 
 	// KubeClient is used to generate Events when CEL expressions
 	// encounter runtime errors.
@@ -128,7 +128,7 @@ func StartTracker(ctx context.Context, opts Options) (finalT *Tracker, finalErr 
 		// Minimal wrapper. All public methods shortcut by calling the underlying informer.
 		return &Tracker{
 			resourceSliceLister: opts.SliceInformer.Lister(),
-			resourceSlices:      opts.SliceInformer.Informer(),
+			resourceSlices:      opts.SliceInformer.TypedInformer(),
 		}, nil
 	}
 
@@ -153,8 +153,8 @@ func newTracker(ctx context.Context, opts Options) (finalT *Tracker, finalErr er
 	t := &Tracker{
 		enableDeviceTaintRules: opts.EnableDeviceTaintRules,
 		resourceSliceLister:    opts.SliceInformer.Lister(),
-		resourceSlices:         opts.SliceInformer.Informer(),
-		deviceTaints:           opts.TaintInformer.Informer(),
+		resourceSlices:         opts.SliceInformer.TypedInformer(),
+		deviceTaints:           opts.TaintInformer.TypedInformer(),
 		patchedResourceSlices:  cache.NewStore(cache.MetaNamespaceKeyFunc),
 		handleError:            utilruntime.HandleErrorWithContext,
 		synced:                 make(chan struct{}),
@@ -167,7 +167,7 @@ func newTracker(ctx context.Context, opts Options) (finalT *Tracker, finalErr er
 			t.Stop()
 		}
 	}()
-	err := t.resourceSlices.AddIndexers(cache.Indexers{driverPoolDeviceIndexName: sliceDriverPoolDeviceIndexFunc})
+	err := t.resourceSlices.AddTypedIndexers(resourceinformers.ResourceSliceIndexers{driverPoolDeviceIndexName: sliceDriverPoolDeviceIndexFunc})
 	if err != nil {
 		return nil, fmt.Errorf("failed to add %s index to ResourceSlice informer: %w", driverPoolDeviceIndexName, err)
 	}
@@ -185,23 +185,25 @@ func newTracker(ctx context.Context, opts Options) (finalT *Tracker, finalErr er
 // initInformers adds event handlers to a tracker constructed with newTracker.
 func (t *Tracker) initInformers(ctx context.Context) error {
 	var err error
+	logger := klog.FromContext(ctx)
+	options := cache.HandlerOptions{Logger: &logger}
 
-	sliceHandler := cache.ResourceEventHandlerFuncs{
+	sliceHandler := resourceinformers.ResourceSliceHandlerFuncs{
 		AddFunc:    t.resourceSliceAdd(ctx),
 		UpdateFunc: t.resourceSliceUpdate(ctx),
 		DeleteFunc: t.resourceSliceDelete(ctx),
 	}
-	t.resourceSlicesHandle, err = t.resourceSlices.AddEventHandler(sliceHandler)
+	t.resourceSlicesHandle, err = t.resourceSlices.AddTypedEventHandler(sliceHandler, options)
 	if err != nil {
 		return fmt.Errorf("add event handler for ResourceSlices: %w", err)
 	}
 
-	taintHandler := cache.ResourceEventHandlerFuncs{
+	taintHandler := resourceinformers.DeviceTaintRuleHandlerFuncs{
 		AddFunc:    t.deviceTaintAdd(ctx),
 		UpdateFunc: t.deviceTaintUpdate(ctx),
 		DeleteFunc: t.deviceTaintDelete(ctx),
 	}
-	t.deviceTaintsHandle, err = t.deviceTaints.AddEventHandler(taintHandler)
+	t.deviceTaintsHandle, err = t.deviceTaints.AddTypedEventHandler(taintHandler, options)
 	if err != nil {
 		return fmt.Errorf("add event handler for DeviceTaintRules: %w", err)
 	}
@@ -356,8 +358,7 @@ func (t *Tracker) pushEvent(oldObj, newObj any) {
 	}
 }
 
-func sliceDriverPoolDeviceIndexFunc(obj any) ([]string, error) {
-	slice := obj.(*resourceapi.ResourceSlice)
+func sliceDriverPoolDeviceIndexFunc(slice *resourceapi.ResourceSlice) ([]string, error) {
 	drivers := []string{
 		anyDriver,
 		slice.Spec.Driver,
@@ -386,23 +387,19 @@ func driverPoolDeviceIndexPatchKey(patch *resourceapi.DeviceTaintRule) string {
 	return deviceID(driverKey, poolKey, deviceKey)
 }
 
-func (t *Tracker) sliceNamesForPatch(ctx context.Context, patch *resourceapi.DeviceTaintRule) []string {
-	patchKey := driverPoolDeviceIndexPatchKey(patch)
-	sliceNames, err := t.resourceSlices.GetIndexer().IndexKeys(driverPoolDeviceIndexName, patchKey)
+func (t *Tracker) sliceNamesForRule(ctx context.Context, rule *resourceapi.DeviceTaintRule) []string {
+	key := driverPoolDeviceIndexPatchKey(rule)
+	sliceNames, err := t.resourceSlices.GetIndexer().IndexKeys(driverPoolDeviceIndexName, key)
 	if err != nil {
-		t.handleError(ctx, err, "failed listing ResourceSlices for driver/pool/device key", "key", patchKey)
+		t.handleError(ctx, err, "failed listing ResourceSlices for driver/pool/device key", "key", key)
 		return nil
 	}
 	return sliceNames
 }
 
-func (t *Tracker) resourceSliceAdd(ctx context.Context) func(obj any) {
+func (t *Tracker) resourceSliceAdd(ctx context.Context) func(*resourceapi.ResourceSlice) {
 	logger := klog.FromContext(ctx)
-	return func(obj any) {
-		slice, ok := obj.(*resourceapi.ResourceSlice)
-		if !ok {
-			return
-		}
+	return func(slice *resourceapi.ResourceSlice) {
 		if loggerV := logger.V(6); loggerV.Enabled() {
 			loggerV.Info("ResourceSlice added", "slice", klog.Format(slice))
 		} else {
@@ -412,17 +409,9 @@ func (t *Tracker) resourceSliceAdd(ctx context.Context) func(obj any) {
 	}
 }
 
-func (t *Tracker) resourceSliceUpdate(ctx context.Context) func(oldObj, newObj any) {
+func (t *Tracker) resourceSliceUpdate(ctx context.Context) func(_, _ *resourceapi.ResourceSlice) {
 	logger := klog.FromContext(ctx)
-	return func(oldObj, newObj any) {
-		oldSlice, ok := oldObj.(*resourceapi.ResourceSlice)
-		if !ok {
-			return
-		}
-		newSlice, ok := newObj.(*resourceapi.ResourceSlice)
-		if !ok {
-			return
-		}
+	return func(oldSlice, newSlice *resourceapi.ResourceSlice) {
 		if loggerV := logger.V(6); loggerV.Enabled() {
 			// While debugging, one needs a full dump of the objects for context *and*
 			// a diff because otherwise small changes would be hard to spot.
@@ -434,50 +423,31 @@ func (t *Tracker) resourceSliceUpdate(ctx context.Context) func(oldObj, newObj a
 	}
 }
 
-func (t *Tracker) resourceSliceDelete(ctx context.Context) func(obj any) {
+func (t *Tracker) resourceSliceDelete(ctx context.Context) func(resourceinformers.DeletedResourceSlice) {
 	logger := klog.FromContext(ctx)
-	return func(obj any) {
-		if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-			obj = tombstone.Obj
-		}
-		slice, ok := obj.(*resourceapi.ResourceSlice)
-		if !ok {
-			return
-		}
-		logger.V(5).Info("ResourceSlice deleted", "slice", klog.KObj(slice))
-		t.syncSlice(ctx, slice.Name, true)
+	return func(deletedSlice resourceinformers.DeletedResourceSlice) {
+		logger.V(5).Info("ResourceSlice deleted", "slice", klog.KObj(deletedSlice))
+		t.syncSlice(ctx, deletedSlice.GetName(), true)
 	}
 }
 
-func (t *Tracker) deviceTaintAdd(ctx context.Context) func(obj any) {
+func (t *Tracker) deviceTaintAdd(ctx context.Context) func(*resourceapi.DeviceTaintRule) {
 	logger := klog.FromContext(ctx)
-	return func(obj any) {
-		rule, ok := obj.(*resourceapi.DeviceTaintRule)
-		if !ok {
-			return
-		}
+	return func(rule *resourceapi.DeviceTaintRule) {
 		if loggerV := logger.V(6); loggerV.Enabled() {
 			loggerV.Info("DeviceTaintRule added", "deviceTaintRule", klog.Format(rule))
 		} else {
 			logger.V(5).Info("DeviceTaintRule added", "deviceTaintRule", klog.KObj(rule))
 		}
-		for _, sliceName := range t.sliceNamesForPatch(ctx, rule) {
+		for _, sliceName := range t.sliceNamesForRule(ctx, rule) {
 			t.syncSlice(ctx, sliceName, false)
 		}
 	}
 }
 
-func (t *Tracker) deviceTaintUpdate(ctx context.Context) func(oldObj, newObj any) {
+func (t *Tracker) deviceTaintUpdate(ctx context.Context) func(_, _ *resourceapi.DeviceTaintRule) {
 	logger := klog.FromContext(ctx)
-	return func(oldObj, newObj any) {
-		oldRule, ok := oldObj.(*resourceapi.DeviceTaintRule)
-		if !ok {
-			return
-		}
-		newRule, ok := newObj.(*resourceapi.DeviceTaintRule)
-		if !ok {
-			return
-		}
+	return func(oldRule, newRule *resourceapi.DeviceTaintRule) {
 		if loggerV := logger.V(6); loggerV.Enabled() {
 			loggerV.Info("DeviceTaintRule updated", "diff", diff.Diff(oldRule, newRule), "deviceTaintRule", klog.KObj(newRule))
 		} else {
@@ -488,26 +458,27 @@ func (t *Tracker) deviceTaintUpdate(ctx context.Context) func(oldObj, newObj any
 		// case they no longer match the new patch and need to have the
 		// patch's changes reverted.
 		slicesToSync := sets.New[string]()
-		slicesToSync.Insert(t.sliceNamesForPatch(ctx, oldRule)...)
-		slicesToSync.Insert(t.sliceNamesForPatch(ctx, newRule)...)
+		slicesToSync.Insert(t.sliceNamesForRule(ctx, oldRule)...)
+		slicesToSync.Insert(t.sliceNamesForRule(ctx, newRule)...)
 		for _, sliceName := range slicesToSync.UnsortedList() {
 			t.syncSlice(ctx, sliceName, false)
 		}
 	}
 }
 
-func (t *Tracker) deviceTaintDelete(ctx context.Context) func(obj any) {
+func (t *Tracker) deviceTaintDelete(ctx context.Context) func(resourceinformers.DeletedDeviceTaintRule) {
 	logger := klog.FromContext(ctx)
-	return func(obj any) {
-		if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-			obj = tombstone.Obj
-		}
-		patch, ok := obj.(*resourceapi.DeviceTaintRule)
-		if !ok {
+	return func(deletedRule resourceinformers.DeletedDeviceTaintRule) {
+		logger.V(5).Info("DeviceTaintRule deleted", "deviceTaintRule", klog.KObj(deletedRule))
+		if deletedRule.OptionalObj == nil {
+			// We only need to sync slices which might have been patched
+			// because of the deleted rule. Other slices are not affected.
+			for _, sliceName := range t.patchedResourceSlices.List() {
+				t.syncSlice(ctx, sliceName.(*resourceapi.ResourceSlice).Name, false)
+			}
 			return
 		}
-		logger.V(5).Info("DeviceTaintRule deleted", "patch", klog.KObj(patch))
-		for _, sliceName := range t.sliceNamesForPatch(ctx, patch) {
+		for _, sliceName := range t.sliceNamesForRule(ctx, deletedRule.OptionalObj) {
 			t.syncSlice(ctx, sliceName, false)
 		}
 	}

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker_test.go
@@ -32,6 +32,7 @@ import (
 	resourceapi "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
+	resourceinformers "k8s.io/client-go/informers/resource/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -65,6 +66,9 @@ func remove[T any](obj *T) [2]*T {
 func update[T any](oldObj, newObj *T) [2]*T {
 	return [2]*T{oldObj, newObj}
 }
+
+// removeRule(<name>) removes a DeviceTaintRule by name.
+type removeRule string
 
 func runInputEvents(tCtx *testContext, events []any, permutation []int) {
 	for _, i := range permutation {
@@ -109,7 +113,7 @@ func applyEventPair(tCtx *testContext, event any) {
 		case pair[0] != nil:
 			err := store.Delete(pair[0])
 			require.NoError(tCtx, err)
-			tCtx.resourceSliceDelete(tCtx.Context)(pair[0])
+			tCtx.resourceSliceDelete(tCtx.Context)(resourceinformers.DeletedResourceSlice{OptionalObj: pair[0]})
 		default:
 			err := store.Add(pair[1])
 			require.NoError(tCtx, err)
@@ -125,12 +129,24 @@ func applyEventPair(tCtx *testContext, event any) {
 		case pair[0] != nil:
 			err := store.Delete(pair[0])
 			require.NoError(tCtx, err)
-			tCtx.deviceTaintDelete(tCtx.Context)(pair[0])
+			tCtx.deviceTaintDelete(tCtx.Context)(resourceinformers.DeletedDeviceTaintRule{OptionalObj: pair[0]})
 		default:
 			err := store.Add(pair[1])
 			require.NoError(tCtx, err)
 			tCtx.deviceTaintAdd(tCtx.Context)(pair[1])
 		}
+	case removeRule:
+		name := string(pair)
+		store := tCtx.deviceTaints.GetStore()
+		obj, exists, err := store.GetByKey(name)
+		require.NoError(tCtx, err)
+		if !exists {
+			tCtx.Fatalf("cannot delete %s, not found", name)
+		}
+		err = store.Delete(obj)
+		require.NoError(tCtx, err)
+		// Let's pretend we don't have it...
+		tCtx.deviceTaintDelete(tCtx.Context)(resourceinformers.DeletedDeviceTaintRule{FinalStateUnknown: &cache.DeletedFinalStateUnknown{Key: name}})
 	}
 }
 
@@ -402,6 +418,40 @@ func TestListPatchedResourceSlices(t *testing.T) {
 			expectedHandlerEvents: []handlerEvent{
 				{event: handlerEventAdd, newObj: slice1},
 				{event: handlerEventAdd, newObj: slice2Tainted},
+			},
+		},
+		"remove-patch-known-deleted-rule": {
+			events: []any{[]any{
+				add(taintPool2DevicesRule),
+				add(slice1),
+				add(slice2),
+				remove(taintPool2DevicesRule),
+			}},
+			expectedPatchedSlices: []*resourceapi.ResourceSlice{
+				slice1,
+				slice2,
+			},
+			expectedHandlerEvents: []handlerEvent{
+				{event: handlerEventAdd, newObj: slice1},
+				{event: handlerEventAdd, newObj: slice2Tainted},
+				{event: handlerEventUpdate, oldObj: slice2Tainted, newObj: slice2},
+			},
+		},
+		"remove-patch-unknown-deleted-rule": {
+			events: []any{[]any{
+				add(taintPool2DevicesRule),
+				add(slice1),
+				add(slice2),
+				removeRule(taintPool2DevicesRule.Name),
+			}},
+			expectedPatchedSlices: []*resourceapi.ResourceSlice{
+				slice1,
+				slice2,
+			},
+			expectedHandlerEvents: []handlerEvent{
+				{event: handlerEventAdd, newObj: slice1},
+				{event: handlerEventAdd, newObj: slice2Tainted},
+				{event: handlerEventUpdate, oldObj: slice2Tainted, newObj: slice2},
 			},
 		},
 		"merge-taints": {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This switches to the new type-safe informer API (https://github.com/kubernetes/kubernetes/pull/139821).
The new type-safe API simplifies the code. It also highlights a bug: when the OnDelete event occurs without the deleted DeviceTaintRule, the code which     looks up affected ResourceSlices crashed.

The scheduler recovered on restart by syncing everything, but     obviously not crashing and resyncing only patched ResourceSlices is better...

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
DRA: fixed a potential crash in the scheduler (recovered after restart) when the ResourceSlice tracker encounters an OnDelete event for DeviceTaintRule where the deleted object is unknown.
```
