### PR TITLE
nodelifecycle: mark pods not ready on false to unknown transition

### DIFF
--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -750,11 +750,15 @@ func (nc *Controller) monitorNodeHealth(ctx context.Context) error {
 		}
 
 		if currentReadyCondition != nil {
+			transitionedToNotReady := currentReadyCondition.Status != v1.ConditionTrue && observedReadyCondition.Status == v1.ConditionTrue
+			transitionedToUnreachable := currentReadyCondition.Status == v1.ConditionUnknown && observedReadyCondition.Status == v1.ConditionFalse
+			shouldMarkNotReady := transitionedToNotReady || transitionedToUnreachable
+
 			pods, err := nc.getPodsAssignedToNode(node.Name)
 			if err != nil {
 				utilruntime.HandleErrorWithContext(ctx, err, "Unable to list pods of node", node.Name)
-				if currentReadyCondition.Status != v1.ConditionTrue && observedReadyCondition.Status == v1.ConditionTrue {
-					// If error happened during node status transition (Ready -> NotReady)
+				if shouldMarkNotReady {
+					// If error happened during node status transition (Ready -> NotReady/Unknown)
 					// we need to mark node for retry to force MarkPodsNotReady execution
 					// in the next iteration.
 					nc.nodesToRetry.Store(node.Name, struct{}{})
@@ -763,13 +767,14 @@ func (nc *Controller) monitorNodeHealth(ctx context.Context) error {
 			}
 			nc.processTaintBaseEviction(ctx, node, currentReadyCondition)
 
-			_, needsRetry := nc.nodesToRetry.Load(node.Name)
-			switch {
-			case currentReadyCondition.Status != v1.ConditionTrue && observedReadyCondition.Status == v1.ConditionTrue:
-				// Report node event only once when status changed.
+			if currentReadyCondition.Status == v1.ConditionUnknown && observedReadyCondition.Status != v1.ConditionUnknown {
+				controllerutil.RecordNodeStatusChange(logger, nc.recorder, node, "NodeUnreachable")
+			} else if currentReadyCondition.Status == v1.ConditionFalse && observedReadyCondition.Status == v1.ConditionTrue {
 				controllerutil.RecordNodeStatusChange(logger, nc.recorder, node, "NodeNotReady")
-				fallthrough
-			case needsRetry && observedReadyCondition.Status != v1.ConditionTrue:
+			}
+
+			_, needsRetry := nc.nodesToRetry.Load(node.Name)
+			if shouldMarkNotReady || (needsRetry && observedReadyCondition.Status != v1.ConditionTrue) {
 				if err = controllerutil.MarkPodsNotReady(ctx, nc.kubeClient, nc.recorder, pods, node.Name); err != nil {
 					utilruntime.HandleErrorWithContext(ctx, err, "Unable to mark all pods NotReady on node; queuing for retry", "node", node.Name)
 					nc.nodesToRetry.Store(node.Name, struct{}{})

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
@@ -2127,6 +2127,53 @@ func TestMonitorNodeHealthMarkPodsNotReady(t *testing.T) {
 			},
 			expectedPodStatusUpdate: true,
 		},
+		// Node status updated to False. Then grace period passes and it goes to Unknown.
+		// Expect pods status updated.
+		{
+			fakeNodeHandler: &testutil.FakeNodeHandler{
+				Existing: []*v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "node0",
+							CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+						},
+						Status: v1.NodeStatus{
+							Conditions: []v1.NodeCondition{
+								{
+									Type:               v1.NodeReady,
+									Status:             v1.ConditionFalse,
+									LastHeartbeatTime:  fakeNow,
+									LastTransitionTime: fakeNow,
+								},
+							},
+							Capacity: v1.ResourceList{
+								v1.ResourceName(v1.ResourceCPU):    resource.MustParse("10"),
+								v1.ResourceName(v1.ResourceMemory): resource.MustParse("10G"),
+							},
+						},
+					},
+				},
+				Clientset: fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{*testutil.NewPod("pod0", "node0")}}),
+			},
+			timeToPass: 1 * time.Minute,
+			// newNodeStatus represents the input status in the fake client before monitorNodeHealth runs.
+			// The heartbeat is expired, so the controller will transition the status to Unknown.
+			newNodeStatus: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					{
+						Type:               v1.NodeReady,
+						Status:             v1.ConditionFalse,
+						LastHeartbeatTime:  fakeNow,
+						LastTransitionTime: fakeNow,
+					},
+				},
+				Capacity: v1.ResourceList{
+					v1.ResourceName(v1.ResourceCPU):    resource.MustParse("10"),
+					v1.ResourceName(v1.ResourceMemory): resource.MustParse("10G"),
+				},
+			},
+			expectedPodStatusUpdate: true,
+		},
 	}
 
 	tCtx := ktesting.Init(t)
@@ -2427,6 +2474,63 @@ func TestMonitorNodeHealthMarkPodsNotReadyRetry(t *testing.T) {
 				{
 					timeToPass: 1 * time.Minute,
 					newNodes:   makeNodes(v1.ConditionFalse, timePlusTwoMinutes, timePlusTwoMinutes),
+				},
+			},
+			expectedPodStatusUpdates: 1,
+		},
+		// Node created long time ago, with status updated by kubelet exceeds grace period.
+		// First monitorNodeHealth check will fail to list pods (with False -> Unknown transition).
+		// Second monitorNodeHealth check will update pod status to NotReady (retry).
+		{
+			desc: "unsuccessful pod list on false -> unknown transition, retry required",
+			fakeNodeHandler: &testutil.FakeNodeHandler{
+				Existing: []*v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "node0",
+							CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+						},
+						Status: v1.NodeStatus{
+							Conditions: []v1.NodeCondition{
+								{
+									Type:               v1.NodeReady,
+									Status:             v1.ConditionFalse,
+									LastHeartbeatTime:  timeNow,
+									LastTransitionTime: timeNow,
+								},
+							},
+							Capacity: v1.ResourceList{
+								v1.ResourceName(v1.ResourceCPU):    resource.MustParse("10"),
+								v1.ResourceName(v1.ResourceMemory): resource.MustParse("10G"),
+							},
+						},
+					},
+				},
+				Clientset: fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{*testutil.NewPod("pod0", "node0")}}),
+			},
+			fakeGetPodsAssignedToNode: func(c *fake.Clientset) func(string) ([]*v1.Pod, error) {
+				i := 0
+				f := fakeGetPodsAssignedToNode(c)
+				return func(nodeName string) ([]*v1.Pod, error) {
+					i++
+					if i == 1 {
+						return nil, fmt.Errorf("fake error")
+					}
+					return f(nodeName)
+				}
+			},
+			nodeIterations: []nodeIteration{
+				{
+					timeToPass: 0,
+					newNodes:   makeNodes(v1.ConditionFalse, timeNow, timeNow),
+				},
+				{
+					timeToPass: 1 * time.Minute,
+					newNodes:   makeNodes(v1.ConditionFalse, timeNow, timeNow),
+				},
+				{
+					timeToPass: 1 * time.Minute,
+					newNodes:   makeNodes(v1.ConditionFalse, timeNow, timeNow),
 				},
 			},
 			expectedPodStatusUpdates: 1,
@@ -4093,5 +4197,122 @@ func TestProcessPodMarkPodNotReady(t *testing.T) {
 				t.Errorf("expect pod status updated to be %v, but got %v", item.expectedPodStatusUpdate, podStatusUpdated)
 			}
 		})
+	}
+}
+
+func TestNodeStatusChangeEventGeneration(t *testing.T) {
+	fakeNow := metav1.Date(2016, 9, 10, 12, 0, 0, 0, time.UTC)
+	fakeNodeHandler := &testutil.FakeNodeHandler{
+		Existing: []*v1.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "node0",
+					UID:               "1234567890",
+					CreationTimestamp: metav1.Date(2015, 8, 10, 0, 0, 0, 0, time.UTC),
+				},
+				Status: v1.NodeStatus{
+					Conditions: []v1.NodeCondition{
+						{
+							Type:               v1.NodeReady,
+							Status:             v1.ConditionTrue,
+							LastHeartbeatTime:  fakeNow,
+							LastTransitionTime: fakeNow,
+						},
+					},
+				},
+			},
+		},
+		Clientset: fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{*testutil.NewPod("pod0", "node0")}}),
+	}
+
+	tCtx := ktesting.Init(t)
+	nodeController, _ := newNodeLifecycleControllerFromClient(
+		tCtx,
+		fakeNodeHandler,
+		testRateLimiterQPS,
+		testRateLimiterQPS,
+		testLargeClusterThreshold,
+		testUnhealthyThreshold,
+		testNodeMonitorGracePeriod,
+		testNodeMonitorGracePeriod,
+		testNodeMonitorPeriod,
+	)
+	nodeController.now = func() metav1.Time { return fakeNow }
+	fakeRecorder := testutil.NewFakeRecorder()
+	nodeController.recorder = fakeRecorder
+	nodeController.getPodsAssignedToNode = fakeGetPodsAssignedToNode(fakeNodeHandler.Clientset)
+
+	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// First run to populate nodeHealthMap
+	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := nodeController.monitorNodeHealth(tCtx); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Clear events (RegisteredNode event is recorded on first run)
+	fakeRecorder.Events = []*v1.Event{}
+
+	// 1. Transition True -> Unknown (via heartbeat expiration)
+	nodeController.now = func() metav1.Time { return metav1.Time{Time: fakeNow.Add(10 * time.Minute)} } // Exceeds grace period
+	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := nodeController.monitorNodeHealth(tCtx); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Expect NodeUnreachable event
+	foundUnreachable := false
+	for _, event := range fakeRecorder.Events {
+		if event.Reason == "NodeUnreachable" {
+			foundUnreachable = true
+			break
+		}
+	}
+	if !foundUnreachable {
+		t.Errorf("Expected NodeUnreachable event not found. Events: %v", fakeRecorder.Events)
+	}
+
+	// Clear events and reset node for False -> Unknown test
+	fakeRecorder.Events = []*v1.Event{}
+	nodeController.now = func() metav1.Time { return fakeNow }
+	fakeNodeHandler.UpdatedNodes = nil
+	fakeNodeHandler.UpdatedNodeStatuses = nil
+	fakeNodeHandler.Existing[0].Status.Conditions[0].Status = v1.ConditionFalse
+	fakeNodeHandler.Existing[0].Status.Conditions[0].LastHeartbeatTime = fakeNow
+	fakeNodeHandler.Existing[0].Status.Conditions[0].LastTransitionTime = fakeNow
+	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	// Run once to update nodeHealthMap with False status
+	if err := nodeController.monitorNodeHealth(tCtx); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	fakeRecorder.Events = []*v1.Event{}
+
+	// 2. Transition False -> Unknown (via heartbeat expiration)
+	nodeController.now = func() metav1.Time { return metav1.Time{Time: fakeNow.Add(10 * time.Minute)} } // Exceeds grace period
+	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := nodeController.monitorNodeHealth(tCtx); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Expect NodeUnreachable event
+	foundUnreachable = false
+	for _, event := range fakeRecorder.Events {
+		if event.Reason == "NodeUnreachable" {
+			foundUnreachable = true
+			break
+		}
+	}
+	if !foundUnreachable {
+		t.Errorf("Expected NodeUnreachable event not found. Events: %v", fakeRecorder.Events)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When a node transitions from a failed state to an unreachable state (i.e. `Ready=False` to `Ready=Unknown`, such as when containerd crashes making the node `False`, and subsequently the kubelet also loses connectivity and stops posting status), the node lifecycle controller was not calling `MarkPodsNotReady`. As a result, pods on the unreachable node remained `Ready=True`, and the control plane continued routing network traffic to them.

The previous logic in `monitorNodeHealth` only checked for transitions starting from `Ready=True` when deciding to call `MarkPodsNotReady` and update pod statuses. This missed the `False -> Unknown` transition entirely.

This PR refactors the transition checks to handle both:
1. `True -> False/Unknown` transitions (`transitionedToNotReady`)
2. `False -> Unknown` transitions (`transitionedToUnreachable`)

Additionally, it introduces a new `NodeUnreachable` status change event that is recorded specifically when a node transitions to the `Unknown` Ready status (instead of duplicate `NodeNotReady` events).

#### Which issue(s) this PR is related to:
Fixes #112733

#### Special notes for your reviewer:
- The transition checking logic has been consolidated into local variables:
  ```go
  transitionedToNotReady := currentReadyCondition.Status != v1.ConditionTrue && observedReadyCondition.Status == v1.ConditionTrue
  transitionedToUnreachable := currentReadyCondition.Status == v1.ConditionUnknown && observedReadyCondition.Status == v1.ConditionFalse
  shouldMarkNotReady := transitionedToNotReady || transitionedToUnreachable

Does this PR introduce a user-facing change?
```release-note
Fix: node lifecycle controller now calls MarkPodsNotReady when a node transitions from NotReady (false) to Unreachable (unknown), preventing pods from incorrectly remaining Ready when kubelet stops after a prior node failure. Additionally, it now records a NodeUnreachable status change event specifically on transitions to Ready=Unknown.
```