### PR TITLE
Reduce allocations in protobuf list streaming

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections.go
@@ -21,8 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"maps"
-	"slices"
 	"sort"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -173,7 +171,10 @@ func (e *streamEncoder) encodeUnstructuredList(list *unstructured.UnstructuredLi
 	if err != nil {
 		return err
 	}
-	keys := slices.Collect(maps.Keys(list.Object))
+	keys := make([]string, 0, len(list.Object)+1)
+	for key := range list.Object {
+		keys = append(keys, key)
+	}
 	if _, exists := list.Object["items"]; !exists {
 		keys = append(keys, "items")
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections_test.go
@@ -19,6 +19,7 @@ package json
 import (
 	"bytes"
 	"fmt"
+	"math/rand"
 	"slices"
 	"testing"
 
@@ -810,7 +811,7 @@ func BenchmarkStreamEncodeCollections(b *testing.B) {
 		kvs[c.String(0)] = c.Uint64()
 		kvs[c.String(0)] = c.String(0)
 	}
-	f := randfill.New().Funcs(disableFuzzFieldsV1, fuzzMap)
+	f := randfill.New().RandSource(rand.NewSource(12345)).Funcs(disableFuzzFieldsV1, fuzzMap)
 	carpList := &testapigroupv1.CarpList{}
 	carpList.Items = make([]testapigroupv1.Carp, 1000)
 	for i := range 1000 {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/collections.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/collections.go
@@ -17,6 +17,7 @@ limitations under the License.
 package protobuf
 
 import (
+	"encoding/binary"
 	"errors"
 	"io"
 	"math/bits"
@@ -134,27 +135,23 @@ func streamingEncodeUnknownList(w io.Writer, unk runtime.Unknown, listData strea
 }
 
 func streamingEncodeList(w io.Writer, listData streamingListData, memAlloc runtime.MemoryAllocator) (size int, err error) {
+	// headerScratch escapes via w.Write, so allocate it once per call instead of once per item.
+	headerScratch := make([]byte, 1+binary.MaxVarintLen64)
 	// ListMeta; 0xa = (1 << 3) | 2; field number: 1, type: 2 (LEN). https://protobuf.dev/programming-guides/encoding/#structure
-	n, err := doEncodeWithHeader(&listData.listMeta, w, 0xa, listData.listMetaSize, memAlloc)
+	n, err := doEncodeWithHeader(&listData.listMeta, w, 0xa, listData.listMetaSize, headerScratch, memAlloc)
 	size += n
 	if err != nil {
 		return size, err
 	}
 	// Items; 0x12 = (2 << 3) | 2; field number: 2, type: 2 (LEN). https://protobuf.dev/programming-guides/encoding/#structure
 	for i, item := range listData.items {
-		n, err := doEncodeWithHeader(item, w, 0x12, listData.itemsSizes[i], memAlloc)
+		n, err := doEncodeWithHeader(item, w, 0x12, listData.itemsSizes[i], headerScratch, memAlloc)
 		size += n
 		if err != nil {
 			return size, err
 		}
 	}
 	return size, nil
-}
-
-func writeVarintGenerated(w io.Writer, v int) (int, error) {
-	buf := make([]byte, sovGenerated(uint64(v)))
-	encodeVarintGenerated(buf, len(buf), uint64(v))
-	return w.Write(buf)
 }
 
 // sovGenerated is copied from `generated.pb.go` returns size of varint.

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/collections_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/collections_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"io"
+	"math/rand"
 	"os/exec"
 	"testing"
 
@@ -328,4 +329,35 @@ func (s *countingSizer) DeepCopyObject() runtime.Object {
 
 func (s *countingSizer) GetObjectKind() schema.ObjectKind {
 	return nil
+}
+
+func BenchmarkStreamEncodeProtobufCollections(b *testing.B) {
+	disableFuzzFieldsV1 := func(field *metav1.FieldsV1, c randfill.Continue) {}
+	fuzzMap := func(kvs map[string]interface{}, c randfill.Continue) {
+		kvs[c.String(0)] = c.Bool()
+		kvs[c.String(0)] = c.Uint64()
+		kvs[c.String(0)] = c.String(0)
+	}
+	f := randfill.New().RandSource(rand.NewSource(12345)).Funcs(disableFuzzFieldsV1, fuzzMap)
+	carpList := &testapigroupv1.CarpList{}
+	carpList.Items = make([]testapigroupv1.Carp, 1000)
+	for i := range 1000 {
+		f.Fill(&carpList.Items[i])
+	}
+	carpList.Kind = "CarpList"
+	carpList.APIVersion = "testapigroup.k8s.io/v1"
+	carpList.ResourceVersion = "12345"
+
+	encoder := NewSerializerWithOptions(nil, nil, SerializerOptions{StreamingCollectionsEncoding: true})
+	b.Run("CarpList", func(b *testing.B) {
+		var buf bytes.Buffer
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			if err := encoder.Encode(carpList, &buf); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf.go
@@ -470,15 +470,12 @@ func (s *RawSerializer) doEncode(obj runtime.Object, w io.Writer, memAlloc runti
 	return err
 }
 
-func doEncodeWithHeader(obj any, w io.Writer, field byte, precomputedSize int, memAlloc runtime.MemoryAllocator) (size int, err error) {
-	// Field identifier
-	n, err := w.Write([]byte{field})
-	size += n
-	if err != nil {
-		return size, err
-	}
-	// Size
-	n, err = writeVarintGenerated(w, precomputedSize)
+func doEncodeWithHeader(obj any, w io.Writer, field byte, precomputedSize int, headerScratch []byte, memAlloc runtime.MemoryAllocator) (size int, err error) {
+	// Field identifier and size
+	header := headerScratch[:1+sovGenerated(uint64(precomputedSize))]
+	header[0] = field
+	encodeVarintGenerated(header, len(header), uint64(precomputedSize))
+	n, err := w.Write(header)
 	size += n
 	if err != nil {
 		return size, err


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:

This reduces allocs when streaming protobuf lists via some simple pre-allocations.

```
goos: linux
goarch: amd64
pkg: k8s.io/apimachinery/pkg/runtime/serializer/protobuf
cpu: Intel(R) Xeon(R) CPU @ 2.20GHz
goos: linux
goarch: amd64
pkg: k8s.io/apimachinery/pkg/runtime/serializer/protobuf
cpu: Intel(R) Xeon(R) CPU @ 2.20GHz
                                           │ master                                    │ PR                                        │
                                           │                  sec/op                   │          sec/op           vs base         │
StreamEncodeProtobufCollections/CarpList-8                                14.97m ± 17%               13.21m ± 29%  ~ (p=0.310 n=6)

                                           │ master                                    │ PR                                        │
                                           │                   B/op                    │           B/op            vs base         │
StreamEncodeProtobufCollections/CarpList-8                                3.763Mi ± 7%               3.770Mi ± 8%  ~ (p=0.699 n=6)

                                           │ master                                    │ PR                                        │
                                           │                 allocs/op                 │     allocs/op       vs base               │
StreamEncodeProtobufCollections/CarpList-8                                 4.928k ± 0%          2.945k ± 0%  -40.25% (p=0.002 n=6)
```

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
