### PR TITLE
Reduce allocations for unfiltered list requests served from the watch cache

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -780,45 +780,64 @@ func (c *Cacher) GetList(ctx context.Context, key string, opts storage.ListOptio
 		return err
 	}
 	span.AddEvent("Listed items from cache", attribute.Int("count", len(resp.Items)))
-	// store pointer of eligible objects,
-	// Why not directly put object in the items of listObj?
-	//   the elements in ListObject are Struct type, making slice will bring excessive memory consumption.
-	//   so we try to delay this action as much as possible
-	var selectedObjects []runtime.Object
 	var lastSelectedObjectKey string
 	var hasMoreListItems bool
 	limit := computeListLimit(opts)
-	for i, obj := range resp.Items {
-		elem, ok := obj.(*store.Element)
-		if !ok {
-			return fmt.Errorf("non *store.Element returned from storage: %v", obj)
+	if opts.Predicate.Empty() {
+		// Every item matches, so the result size is known upfront and items can be
+		// copied directly into the result list without an intermediate slice.
+		count := len(resp.Items)
+		if limit > 0 && int64(count) > limit {
+			count = int(limit)
+			hasMoreListItems = true
 		}
-		shardMatch := true
-		if utilfeature.DefaultFeatureGate.Enabled(features.ShardedListAndWatch) {
-			var err error
-			shardMatch, err = opts.Predicate.MatchesSharding(elem.Object)
-			if err != nil {
-				return fmt.Errorf("shard matching failed: %w", err)
+		listVal.Set(reflect.MakeSlice(listVal.Type(), count, count))
+		for i, obj := range resp.Items[:count] {
+			elem, ok := obj.(*store.Element)
+			if !ok {
+				return fmt.Errorf("non *store.Element returned from storage: %v", obj)
 			}
-		}
-		if shardMatch && opts.Predicate.MatchesObjectAttributes(elem.Labels, elem.Fields) {
-			selectedObjects = append(selectedObjects, elem.Object)
+			listVal.Index(i).Set(reflect.ValueOf(elem.Object).Elem())
 			lastSelectedObjectKey = elem.Key
 		}
-		if limit > 0 && int64(len(selectedObjects)) >= limit {
-			hasMoreListItems = i < len(resp.Items)-1
-			break
-		}
-	}
-	if len(selectedObjects) == 0 {
-		// Ensure that we never return a nil Items pointer in the result for consistency.
-		listVal.Set(reflect.MakeSlice(listVal.Type(), 0, 0))
 	} else {
-		// Resize the slice appropriately, since we already know that size of result set
-		listVal.Set(reflect.MakeSlice(listVal.Type(), len(selectedObjects), len(selectedObjects)))
-		span.AddEvent("Resized result")
-		for i, o := range selectedObjects {
-			listVal.Index(i).Set(reflect.ValueOf(o).Elem())
+		// store pointer of eligible objects,
+		// Why not directly put object in the items of listObj?
+		//   the elements in ListObject are Struct type, making slice will bring excessive memory consumption.
+		//   so we try to delay this action as much as possible
+		var selectedObjects []runtime.Object
+		for i, obj := range resp.Items {
+			elem, ok := obj.(*store.Element)
+			if !ok {
+				return fmt.Errorf("non *store.Element returned from storage: %v", obj)
+			}
+			shardMatch := true
+			if utilfeature.DefaultFeatureGate.Enabled(features.ShardedListAndWatch) {
+				var err error
+				shardMatch, err = opts.Predicate.MatchesSharding(elem.Object)
+				if err != nil {
+					return fmt.Errorf("shard matching failed: %w", err)
+				}
+			}
+			if shardMatch && opts.Predicate.MatchesObjectAttributes(elem.Labels, elem.Fields) {
+				selectedObjects = append(selectedObjects, elem.Object)
+				lastSelectedObjectKey = elem.Key
+			}
+			if limit > 0 && int64(len(selectedObjects)) >= limit {
+				hasMoreListItems = i < len(resp.Items)-1
+				break
+			}
+		}
+		if len(selectedObjects) == 0 {
+			// Ensure that we never return a nil Items pointer in the result for consistency.
+			listVal.Set(reflect.MakeSlice(listVal.Type(), 0, 0))
+		} else {
+			// Resize the slice appropriately, since we already know that size of result set
+			listVal.Set(reflect.MakeSlice(listVal.Type(), len(selectedObjects), len(selectedObjects)))
+			span.AddEvent("Resized result")
+			for i, o := range selectedObjects {
+				listVal.Index(i).Set(reflect.ValueOf(o).Elem())
+			}
 		}
 	}
 	span.AddEvent("Filtered items", attribute.Int("count", listVal.Len()))

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -2429,6 +2429,64 @@ func BenchmarkCacher_GetList(b *testing.B) {
 	}
 }
 
+func benchmarkPods(n int) []example.Pod {
+	pods := make([]example.Pod, n)
+	for i := range pods {
+		pods[i].Namespace = "default"
+		pods[i].Name = fmt.Sprintf("pod-%d", i)
+		pods[i].ResourceVersion = strconv.Itoa(i)
+		// Give each pod ~2KB of unique payload so the benchmark operates on
+		// realistically sized objects.
+		data := make([]byte, 1024*2)
+		rand.Read(data)
+		pods[i].Spec.NodeSelector = map[string]string{
+			"key": string(data),
+		}
+	}
+	return pods
+}
+
+func newDelegatorWithPods(tb testing.TB, pods []example.Pod) *CacheDelegator {
+	store := &cachertesting.MockStorage{
+		GetListFn: func(_ context.Context, _ string, _ storage.ListOptions, listObj runtime.Object) error {
+			podList := listObj.(*example.PodList)
+			podList.ListMeta = metav1.ListMeta{ResourceVersion: "12345"}
+			podList.Items = pods
+			return nil
+		},
+		GetRVFn: func(_ context.Context) (uint64, error) { return 12345, nil },
+	}
+	cacher, _, err := newTestCacher(store)
+	if err != nil {
+		tb.Fatalf("new cacher: %v", err)
+	}
+	tb.Cleanup(cacher.Stop)
+	delegator := NewCacheDelegator(cacher, store)
+	tb.Cleanup(delegator.Stop)
+	return delegator
+}
+
+func BenchmarkCacher_GetList_AllPods(b *testing.B) {
+	totalObjectNum := 10_000
+	delegator := newDelegatorWithPods(b, benchmarkPods(totalObjectNum))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result := &example.PodList{}
+		err := delegator.GetList(context.TODO(), "/pods/", storage.ListOptions{
+			Predicate:       storage.Everything,
+			Recursive:       true,
+			ResourceVersion: "12345",
+		}, result)
+		if err != nil {
+			b.Fatalf("GetList cache: %v", err)
+		}
+		if len(result.Items) != totalObjectNum {
+			b.Fatalf("expect %d but got %d", totalObjectNum, len(result.Items))
+		}
+	}
+}
+
 // TestWatchListIsSynchronisedWhenNoEventsFromStoreReceived makes sure that
 // a bookmark event will be delivered even if the cacher has not received an event.
 func TestWatchListIsSynchronisedWhenNoEventsFromStoreReceived(t *testing.T) {
@@ -3150,8 +3208,6 @@ func TestWatchListSemanticsSimple(t *testing.T) {
 	}
 }
 
-// --- Sharding unit tests for filterWithAttrsAndPrefixFunction ---
-
 // selectorIncludingUID builds a shard selector whose range contains the hash of uid.
 func selectorIncludingUID(uid string) sharding.Selector {
 	hash := "0x" + sharding.HashField(uid)
@@ -3381,5 +3437,99 @@ func TestFilterWithAttrsAndPrefixFunction_NamespaceShardingMismatch(t *testing.T
 
 	if filter("/pods/other-namespace/pod-ns2", labels.Set{}, fields.Set{"metadata.name": "pod-ns2", "metadata.namespace": ns}, pod) {
 		t.Error("expected filter to reject: namespace hash doesn't fall in shard range")
+	}
+}
+
+// --- Sharding unit tests for Cacher.GetList ---
+
+// selectorExcludingOnlyUID builds a shard selector covering the entire hash
+// space except the hash of uid, so it matches every object but that one.
+func selectorExcludingOnlyUID(uid string) sharding.Selector {
+	hash := "0x" + sharding.HashField(uid)
+	return sharding.NewSelector(
+		sharding.ShardRangeRequirement{
+			Key:   "object.metadata.uid",
+			Start: "0x0000000000000000",
+			End:   hash,
+		},
+		sharding.ShardRangeRequirement{
+			Key:   "object.metadata.uid",
+			Start: incrementHex(hash),
+			End:   "0x10000000000000000",
+		},
+	)
+}
+
+func shardTestPods(n int) []example.Pod {
+	pods := make([]example.Pod, n)
+	for i := range pods {
+		pods[i].Namespace = "default"
+		pods[i].Name = fmt.Sprintf("pod-%d", i)
+		pods[i].UID = types.UID(fmt.Sprintf("uid-%d", i))
+		pods[i].ResourceVersion = strconv.Itoa(i + 1)
+	}
+	return pods
+}
+
+func TestGetListWithShardedListAndWatch(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ShardedListAndWatch, true)
+	delegator := newDelegatorWithPods(t, shardTestPods(3))
+
+	testCases := map[string]struct {
+		shardSelector   sharding.Selector
+		expectPodNames  []string
+		expectShardInfo bool
+	}{
+		"nil shard selector returns all items": {
+			shardSelector:  nil,
+			expectPodNames: []string{"pod-0", "pod-1", "pod-2"},
+		},
+		"empty shard selector returns all items": {
+			shardSelector:  sharding.Everything(),
+			expectPodNames: []string{"pod-0", "pod-1", "pod-2"},
+		},
+		"shard selector returns only the matching shard": {
+			shardSelector:   selectorIncludingUID("uid-1"),
+			expectPodNames:  []string{"pod-1"},
+			expectShardInfo: true,
+		},
+		"shard selector excludes items outside the shard": {
+			shardSelector:   selectorExcludingOnlyUID("uid-1"),
+			expectPodNames:  []string{"pod-0", "pod-2"},
+			expectShardInfo: true,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			result := &example.PodList{}
+			err := delegator.GetList(context.TODO(), "/pods/", storage.ListOptions{
+				Predicate: storage.SelectionPredicate{
+					Label:         labels.Everything(),
+					Field:         fields.Everything(),
+					ShardSelector: tc.shardSelector,
+				},
+				Recursive:       true,
+				ResourceVersion: "12345",
+			}, result)
+			if err != nil {
+				t.Fatalf("GetList failed: %v", err)
+			}
+			gotNames := make([]string, 0, len(result.Items))
+			for _, pod := range result.Items {
+				gotNames = append(gotNames, pod.Name)
+			}
+			if !reflect.DeepEqual(tc.expectPodNames, gotNames) {
+				t.Errorf("expected pods %v, got %v", tc.expectPodNames, gotNames)
+			}
+			if tc.expectShardInfo {
+				if result.ShardInfo == nil {
+					t.Error("expected ShardInfo to be set on the list")
+				} else if want := tc.shardSelector.String(); result.ShardInfo.Selector != want {
+					t.Errorf("expected ShardInfo selector %q, got %q", want, result.ShardInfo.Selector)
+				}
+			} else if result.ShardInfo != nil {
+				t.Errorf("expected no ShardInfo on the list, got %+v", result.ShardInfo)
+			}
+		})
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/continue_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/continue_test.go
@@ -21,6 +21,16 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/sharding"
+	"k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/utils/ptr"
 )
 
 func encodeContinueOrDie(apiVersion string, resourceVersion int64, nextKey string) string {
@@ -108,6 +118,69 @@ func Test_decodeContinue(t *testing.T) {
 			}
 			if gotRv != tt.wantRv {
 				t.Errorf("decodeContinue() gotRv = %v, want %v", gotRv, tt.wantRv)
+			}
+		})
+	}
+}
+
+func TestPrepareContinueTokenRemainingItemCount(t *testing.T) {
+	tests := []struct {
+		name                      string
+		enableShardedListAndWatch bool
+		label                     labels.Selector
+		field                     fields.Selector
+		shardSelector             sharding.Selector
+		wantRemaining             *int64
+	}{
+		{
+			name:          "empty predicate reports remaining count",
+			label:         labels.Everything(),
+			field:         fields.Everything(),
+			wantRemaining: ptr.To[int64](3),
+		},
+		{
+			name:          "label selector omits remaining count",
+			label:         labels.SelectorFromSet(labels.Set{"name": "foo"}),
+			field:         fields.Everything(),
+			wantRemaining: nil,
+		},
+		{
+			name:                      "shard selector omits remaining count when ShardedListAndWatch enabled",
+			enableShardedListAndWatch: true,
+			label:                     labels.Everything(),
+			field:                     fields.Everything(),
+			shardSelector:             shardSelectorMatchingEverything(),
+			wantRemaining:             nil,
+		},
+		{
+			name:                      "shard selector reports remaining count when ShardedListAndWatch disabled",
+			enableShardedListAndWatch: false,
+			label:                     labels.Everything(),
+			field:                     fields.Everything(),
+			shardSelector:             shardSelectorMatchingEverything(),
+			wantRemaining:             ptr.To[int64](3),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ShardedListAndWatch, tt.enableShardedListAndWatch)
+			opts := ListOptions{
+				Predicate: SelectionPredicate{
+					Label:         tt.label,
+					Field:         tt.field,
+					ShardSelector: tt.shardSelector,
+					Limit:         2,
+				},
+			}
+			continueValue, remaining, err := PrepareContinueToken("/test/pod-2", "/test/", 12345, 5, true, opts)
+			if err != nil {
+				t.Fatalf("PrepareContinueToken() returned unexpected error: %v", err)
+			}
+			if len(continueValue) == 0 {
+				t.Error("PrepareContinueToken() returned empty continue token")
+			}
+			if diff := cmp.Diff(tt.wantRemaining, remaining); diff != "" {
+				t.Errorf("PrepareContinueToken() unexpected remainingItemCount (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -35,6 +35,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/sharding"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/apis/example"
 	"k8s.io/apiserver/pkg/features"
@@ -627,4 +630,98 @@ func initStoreData(ctx context.Context, store storage.Interface) ([]interface{},
 		created = append(created, item.key)
 	}
 	return created, nil
+}
+
+func TestWatchWithShardSelector(t *testing.T) {
+	// The shard [boundary, 2^64) contains exactly the higher of the two UID hashes.
+	uidA, uidB := "uid-a", "uid-b"
+	hashA, hashB := "0x"+sharding.HashField(uidA), "0x"+sharding.HashField(uidB)
+	inShardUID, outOfShardUID, boundary := uidA, uidB, hashA
+	if sharding.HexLess(hashA, hashB) {
+		inShardUID, outOfShardUID, boundary = uidB, uidA, hashB
+	}
+	shardSelector := sharding.NewSelector(sharding.ShardRangeRequirement{
+		Key:   "object.metadata.uid",
+		Start: boundary,
+		End:   "0x10000000000000000",
+	})
+
+	newPod := func(name, uid string) *example.Pod {
+		return &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "test-ns", UID: types.UID(uid)}}
+	}
+	expectAddedEvent := func(t *testing.T, w watch.Interface, name string) {
+		t.Helper()
+		select {
+		case event := <-w.ResultChan():
+			if event.Type != watch.Added {
+				t.Fatalf("expected %s event, got %s", watch.Added, event.Type)
+			}
+			pod, ok := event.Object.(*example.Pod)
+			if !ok {
+				t.Fatalf("expected *example.Pod, got %T", event.Object)
+			}
+			if pod.Name != name {
+				t.Fatalf("expected event for pod %q, got %q", name, pod.Name)
+			}
+		case <-time.After(wait.ForeverTestTimeout):
+			t.Fatalf("timed out waiting for event for pod %q", name)
+		}
+	}
+
+	testCases := []struct {
+		name                  string
+		gateEnabled           bool
+		expectOutOfShardEvent bool
+	}{
+		{
+			name:                  "gate enabled filters out-of-shard events",
+			gateEnabled:           true,
+			expectOutOfShardEvent: false,
+		},
+		{
+			name:                  "gate disabled ignores the shard selector",
+			gateEnabled:           false,
+			expectOutOfShardEvent: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ShardedListAndWatch, tc.gateEnabled)
+			ctx, store, _ := testSetup(t)
+
+			marker := &example.Pod{}
+			if err := store.Create(ctx, "/pods/test-ns/marker", newPod("marker", "uid-marker"), marker, 0); err != nil {
+				t.Fatalf("Create marker failed: %v", err)
+			}
+
+			w, err := store.Watch(ctx, "/pods", storage.ListOptions{
+				ResourceVersion: marker.ResourceVersion,
+				Recursive:       true,
+				Predicate: storage.SelectionPredicate{
+					Label:         labels.Everything(),
+					Field:         fields.Everything(),
+					GetAttrs:      storage.DefaultNamespaceScopedAttr,
+					ShardSelector: shardSelector,
+				},
+			})
+			if err != nil {
+				t.Fatalf("Watch failed: %v", err)
+			}
+			defer w.Stop()
+
+			// pod-out is created first so that receiving pod-in's event first
+			// proves pod-out's event was filtered rather than still in flight.
+			if err := store.Create(ctx, "/pods/test-ns/pod-out", newPod("pod-out", outOfShardUID), &example.Pod{}, 0); err != nil {
+				t.Fatalf("Create pod-out failed: %v", err)
+			}
+			if err := store.Create(ctx, "/pods/test-ns/pod-in", newPod("pod-in", inShardUID), &example.Pod{}, 0); err != nil {
+				t.Fatalf("Create pod-in failed: %v", err)
+			}
+
+			if tc.expectOutOfShardEvent {
+				expectAddedEvent(t, w, "pod-out")
+			}
+			expectAddedEvent(t, w, "pod-in")
+		})
+	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/selection_predicate.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/selection_predicate.go
@@ -99,7 +99,7 @@ func (s *SelectionPredicate) Matches(obj runtime.Object) (bool, error) {
 			return matched, err
 		}
 	}
-	if s.Empty() {
+	if s.labelFieldEmpty() {
 		return true, nil
 	}
 	labels, fields, err := s.GetAttrs(obj)
@@ -153,7 +153,17 @@ func (s *SelectionPredicate) MatchesSingle() (string, bool) {
 
 // Empty returns true if the predicate performs no filtering.
 func (s *SelectionPredicate) Empty() bool {
-	return s.Label.Empty() && s.Field.Empty()
+	// Check the selector before the feature gate: Empty is called per event on
+	// watch paths, and the nil check is free while the gate lookup is not.
+	if s.ShardSelector != nil && !s.ShardSelector.Empty() &&
+		utilfeature.DefaultFeatureGate.Enabled(features.ShardedListAndWatch) {
+		return false
+	}
+	return s.labelFieldEmpty()
+}
+
+func (s *SelectionPredicate) labelFieldEmpty() bool {
+	return (s.Label == nil || s.Label.Empty()) && (s.Field == nil || s.Field.Empty())
 }
 
 // For any index defined by IndexFields, if a matcher can match only (a subset)

--- a/staging/src/k8s.io/apiserver/pkg/storage/selection_predicate_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/selection_predicate_test.go
@@ -22,11 +22,17 @@ import (
 	"reflect"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/sharding"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 )
 
 type Ignored struct {
@@ -120,6 +126,157 @@ func TestSelectionPredicate(t *testing.T) {
 				t.Errorf("%v: expected %v, got %v", name, e, a)
 			}
 		}
+	}
+}
+
+// shardSelectorMatchingEverything matches all objects but, unlike
+// sharding.Everything(), is not Empty().
+func shardSelectorMatchingEverything() sharding.Selector {
+	return sharding.NewSelector(sharding.ShardRangeRequirement{
+		Key:   "object.metadata.uid",
+		Start: "0x0000000000000000",
+		End:   "0x10000000000000000",
+	})
+}
+
+func shardSelectorExcludingUID(uid string) sharding.Selector {
+	return sharding.NewSelector(sharding.ShardRangeRequirement{
+		Key:   "object.metadata.uid",
+		Start: "0x0000000000000000",
+		End:   "0x" + sharding.HashField(uid),
+	})
+}
+
+func TestSelectionPredicateEmpty(t *testing.T) {
+	mustParseLabel := func(s string) labels.Selector {
+		parsed, err := labels.Parse(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return parsed
+	}
+	testCases := map[string]struct {
+		enableShardedListAndWatch bool
+		label                     labels.Selector
+		field                     fields.Selector
+		shardSelector             sharding.Selector
+		expectEmpty               bool
+	}{
+		"no selectors, gate off": {
+			enableShardedListAndWatch: false,
+			label:                     labels.Everything(),
+			field:                     fields.Everything(),
+			expectEmpty:               true,
+		},
+		"nil selectors, gate off": {
+			enableShardedListAndWatch: false,
+			expectEmpty:               true,
+		},
+		"nil selectors, gate on": {
+			enableShardedListAndWatch: true,
+			expectEmpty:               true,
+		},
+		"no selectors, gate on": {
+			enableShardedListAndWatch: true,
+			label:                     labels.Everything(),
+			field:                     fields.Everything(),
+			expectEmpty:               true,
+		},
+		"empty shard selector, gate on": {
+			enableShardedListAndWatch: true,
+			label:                     labels.Everything(),
+			field:                     fields.Everything(),
+			shardSelector:             sharding.Everything(),
+			expectEmpty:               true,
+		},
+		"non-empty shard selector, gate on": {
+			enableShardedListAndWatch: true,
+			label:                     labels.Everything(),
+			field:                     fields.Everything(),
+			shardSelector:             shardSelectorMatchingEverything(),
+			expectEmpty:               false,
+		},
+		"non-empty shard selector, gate off": {
+			enableShardedListAndWatch: false,
+			label:                     labels.Everything(),
+			field:                     fields.Everything(),
+			shardSelector:             shardSelectorMatchingEverything(),
+			expectEmpty:               true,
+		},
+		"label selector, gate on": {
+			enableShardedListAndWatch: true,
+			label:                     mustParseLabel("name=foo"),
+			field:                     fields.Everything(),
+			expectEmpty:               false,
+		},
+		"field selector, gate off": {
+			enableShardedListAndWatch: false,
+			label:                     labels.Everything(),
+			field:                     fields.OneTermEqualSelector("metadata.name", "foo"),
+			expectEmpty:               false,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ShardedListAndWatch, tc.enableShardedListAndWatch)
+			sp := &SelectionPredicate{
+				Label:         tc.label,
+				Field:         tc.field,
+				ShardSelector: tc.shardSelector,
+			}
+			if got := sp.Empty(); got != tc.expectEmpty {
+				t.Errorf("Empty() = %v, want %v", got, tc.expectEmpty)
+			}
+		})
+	}
+}
+
+func TestSelectionPredicateMatchesShardOnly(t *testing.T) {
+	uid := "shard-only-uid"
+	obj := &metav1.PartialObjectMetadata{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID(uid)},
+	}
+	testCases := map[string]struct {
+		enableShardedListAndWatch bool
+		shardSelector             sharding.Selector
+		expectMatch               bool
+	}{
+		"in shard, gate on": {
+			enableShardedListAndWatch: true,
+			shardSelector:             shardSelectorMatchingEverything(),
+			expectMatch:               true,
+		},
+		"out of shard, gate on": {
+			enableShardedListAndWatch: true,
+			shardSelector:             shardSelectorExcludingUID(uid),
+			expectMatch:               false,
+		},
+		"out of shard, gate off": {
+			enableShardedListAndWatch: false,
+			shardSelector:             shardSelectorExcludingUID(uid),
+			expectMatch:               true,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ShardedListAndWatch, tc.enableShardedListAndWatch)
+			sp := &SelectionPredicate{
+				Label:         labels.Everything(),
+				Field:         fields.Everything(),
+				ShardSelector: tc.shardSelector,
+				GetAttrs: func(runtime.Object) (labels.Set, fields.Set, error) {
+					t.Error("GetAttrs must not be called for empty label/field selectors")
+					return nil, nil, errors.New("GetAttrs must not be called")
+				},
+			}
+			match, err := sp.Matches(obj)
+			if err != nil {
+				t.Fatalf("Matches() returned unexpected error: %v", err)
+			}
+			if match != tc.expectMatch {
+				t.Errorf("Matches() = %v, want %v", match, tc.expectMatch)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:

Builds on https://github.com/kubernetes/kubernetes/pull/140513

This reduces allocations when serving *unfiltered* LIST requests by preallocating when loading data from the watch cache B tree.

```
goos: linux
goarch: amd64
pkg: k8s.io/apiserver/pkg/storage/cacher
cpu: Intel(R) Xeon(R) CPU @ 2.20GHz
                         │ master                                        │PR                                          │
                         │                    sec/op                     │       sec/op         vs base               │
Cacher_GetList_AllPods-8                                    5.130m ± 41%          3.536m ± 18%  -31.08% (p=0.002 n=6)

                         │ master                                        │PR                                          │
                         │                     B/op                      │        B/op          vs base               │
Cacher_GetList_AllPods-8                                    6.006Mi ± 0%          4.892Mi ± 0%  -18.55% (p=0.002 n=6)

                         │ master                                        │PR                                          │
                         │                   allocs/op                   │      allocs/op       vs base               │
Cacher_GetList_AllPods-8                                      67.00 ± 1%            33.00 ± 0%  -50.75% (p=0.002 n=6)
```


```release-note
NONE
```
