### PR TITLE
Fix VAP/MAP params to consistently used the typed representation when available

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_dispatcher.go
@@ -26,6 +26,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -34,6 +35,7 @@ import (
 	webhookgeneric "k8s.io/apiserver/pkg/admission/plugin/webhook/generic"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/informers"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -452,7 +454,28 @@ func getParamDirectly(
 		resourceClient = dynamicClient.Resource(mapping.Resource)
 	}
 
-	return resourceClient.Get(ctx, paramRef.Name, metav1.GetOptions{})
+	param, err := resourceClient.Get(ctx, paramRef.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return convertParamToInformerRepresentation(gvk, param)
+}
+
+// convertParamToInformerRepresentation makes a get response object look like an informer object by
+// representing it as unstructured and without TypeMeta. This ensures that CEL expressions
+// receive param objects identically regardless of if the object was received via the informer
+// or if an informer cache miss resulted in a get request to fetch the object.
+func convertParamToInformerRepresentation(gvk schema.GroupVersionKind, param *unstructured.Unstructured) (runtime.Object, error) {
+	typed, err := clientgoscheme.Scheme.New(gvk)
+	if err != nil {
+		// The kind has no typed representation, so its informer also serves unstructured objects.
+		return param, nil
+	}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(param.UnstructuredContent(), typed); err != nil {
+		return nil, fmt.Errorf("failed to convert param %v to typed object: %w", gvk, err)
+	}
+	typed.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{})
+	return typed, nil
 }
 
 var _ webhookgeneric.VersionedAttributeAccessor = &versionedAttributeAccessor{}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_dispatcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_dispatcher_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// TestConvertParamToInformerRepresentation verifies that params fetched with the
+// dynamic client fallback are converted to the same representation the param
+// informer returns, so that policy evaluation behaves identically regardless of
+// which path resolved the param.
+func TestConvertParamToInformerRepresentation(t *testing.T) {
+	tests := []struct {
+		name          string
+		gvk           schema.GroupVersionKind
+		param         *unstructured.Unstructured
+		wantObject    runtime.Object
+		wantUnchanged bool
+		wantErr       bool
+	}{
+		{
+			name: "typed kind converts to typed object with empty TypeMeta",
+			gvk:  schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
+			param: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name":      "test-param",
+						"namespace": "default",
+					},
+					"data": map[string]interface{}{
+						"maxReplicas": "3",
+					},
+				},
+			},
+			// Typed informers cache objects decoded by client-go, which have an empty TypeMeta.
+			wantObject: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-param",
+					Namespace: "default",
+				},
+				Data: map[string]string{
+					"maxReplicas": "3",
+				},
+			},
+		},
+		{
+			name: "unknown kind stays unstructured",
+			gvk:  schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "TestParam"},
+			param: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "example.com/v1",
+					"kind":       "TestParam",
+					"metadata": map[string]interface{}{
+						"name":      "test-param",
+						"namespace": "default",
+					},
+					"spec": map[string]interface{}{
+						"maxReplicas": int64(3),
+					},
+				},
+			},
+			wantUnchanged: true,
+		},
+		{
+			name: "typed kind with mismatched data errors",
+			gvk:  schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
+			param: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name": "test-param",
+					},
+					"data": "not-a-map",
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			converted, err := convertParamToInformerRepresentation(tt.gvk, tt.param)
+			if tt.wantErr {
+				require.Error(t, err, "expected conversion error for malformed data")
+				return
+			}
+			require.NoError(t, err, "unexpected error during conversion")
+			if tt.wantUnchanged {
+				require.Same(t, tt.param, converted, "expected the unstructured param to be returned unchanged")
+				return
+			}
+			require.Equal(t, tt.wantObject, converted)
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -361,6 +362,15 @@ func TestCollectParamsHandlesCacheMiss(t *testing.T) {
 	require.NoError(t, err, "CollectParams should succeed by falling back to direct client Get")
 	require.Len(t, params, 1, "should have retrieved the param")
 	require.NotNil(t, params[0], "param should not be nil")
+
+	// Ensure fallback to get returns the same representation the informer cache would have
+	// returned for the same object.
+	cmParam, ok := params[0].(*corev1.ConfigMap)
+	require.Truef(t, ok, "expected fallback to return *corev1.ConfigMap, got %T", params[0])
+	require.Empty(t, cmParam.APIVersion, "typed param should have empty apiVersion, like informer-cached objects")
+	require.Empty(t, cmParam.Kind, "typed param should have empty kind, like informer-cached objects")
+	require.Equal(t, "test-param", cmParam.Name)
+	require.Equal(t, map[string]string{"maxReplicas": "3"}, cmParam.Data)
 
 	// Without the client fallback fix: the above would fail with NotFound error
 	// because the informer cache doesn't have the ConfigMap yet


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This fixes a bug where slight differences in the typed and unstructured representation of objects, such as quantity being a string vs. being a typed object, would be observable to CEL expressions *only* when a informer cache miss resulted in a direct object lookup using the dynamic client.

We expect cache hits for the informer to be more common, so expectation is that developers will have authored CEL expressions against the cache hit behavior. For this reason, and because the typed representation used by infromers is generally preferred, we fix this by converting to the cache miss get responses to the structured type.

Because this code path is uncommon, no performance impact is expected.

#### Which issue(s) this PR is related to:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug where ValidatingAdmissionPolicy and MutatingAdmissionPolicy evaluation could observe subtle differences (particularly around quantity fields and type meta fields) in object representation. The bug could occur when a parameter object was loaded via an alternative path, due to a cache miss. CEL expressions now behave deterministically against params.
```
