### PR TITLE
scheduler: fix snapshot affinity indexes for assumed pods

### DIFF
--- a/pkg/scheduler/backend/cache/snapshot.go
+++ b/pkg/scheduler/backend/cache/snapshot.go
@@ -385,8 +385,16 @@ func (s *Snapshot) AssumePod(podInfo *framework.PodInfo) error {
 	// Since this operation only affects the snapshot,
 	// we should keep the old number to remain consistent with the cached value.
 	oldGeneration := nodeInfo.Generation
+	hadPodsWithAffinity := len(nodeInfo.PodsWithAffinity) > 0
+	hadPodsWithRequiredAntiAffinity := len(nodeInfo.PodsWithRequiredAntiAffinity) > 0
 	nodeInfo.AddPodInfo(podInfo)
 	nodeInfo.Generation = oldGeneration
+	if !hadPodsWithAffinity && len(nodeInfo.PodsWithAffinity) > 0 {
+		s.havePodsWithAffinityNodeInfoList = addNodeInfoToList(s.havePodsWithAffinityNodeInfoList, nodeInfo)
+	}
+	if !hadPodsWithRequiredAntiAffinity && len(nodeInfo.PodsWithRequiredAntiAffinity) > 0 {
+		s.havePodsWithRequiredAntiAffinityNodeInfoList = addNodeInfoToList(s.havePodsWithRequiredAntiAffinityNodeInfoList, nodeInfo)
+	}
 	s.assumedPods[key] = pod
 	// Update the pod group state in the snapshot if the pod belongs to a pod group.
 	if !s.genericWorkloadEnabled || pod.Spec.SchedulingGroup == nil {
@@ -417,11 +425,19 @@ func (s *Snapshot) ForgetPod(logger klog.Logger, pod *v1.Pod) error {
 		// Since this operation only affects the snapshot,
 		// we should keep the old number to remain consistent with the cached value.
 		oldGeneration := nodeInfo.Generation
+		hadPodsWithAffinity := len(nodeInfo.PodsWithAffinity) > 0
+		hadPodsWithRequiredAntiAffinity := len(nodeInfo.PodsWithRequiredAntiAffinity) > 0
 		err := nodeInfo.RemovePod(logger, pod)
 		if err != nil {
 			return err
 		}
 		nodeInfo.Generation = oldGeneration
+		if hadPodsWithAffinity && len(nodeInfo.PodsWithAffinity) == 0 {
+			s.havePodsWithAffinityNodeInfoList = removeNodeInfoFromList(s.havePodsWithAffinityNodeInfoList, nodeInfo)
+		}
+		if hadPodsWithRequiredAntiAffinity && len(nodeInfo.PodsWithRequiredAntiAffinity) == 0 {
+			s.havePodsWithRequiredAntiAffinityNodeInfoList = removeNodeInfoFromList(s.havePodsWithRequiredAntiAffinityNodeInfoList, nodeInfo)
+		}
 		if len(nodeInfo.Pods) == 0 && nodeInfo.Node() == nil {
 			delete(s.nodeInfoMap, nodeName)
 		}
@@ -435,6 +451,30 @@ func (s *Snapshot) ForgetPod(logger klog.Logger, pod *v1.Pod) error {
 		pgs.forgetPod(assumedPod.UID)
 	}
 	return nil
+}
+
+func addNodeInfoToList(list []fwk.NodeInfo, nodeInfo *framework.NodeInfo) []fwk.NodeInfo {
+	if nodeInfo.Node() == nil {
+		return list
+	}
+	for _, existing := range list {
+		if existing.Node() != nil && existing.Node().Name == nodeInfo.Node().Name {
+			return list
+		}
+	}
+	return append(list, nodeInfo)
+}
+
+func removeNodeInfoFromList(list []fwk.NodeInfo, nodeInfo *framework.NodeInfo) []fwk.NodeInfo {
+	if nodeInfo.Node() == nil {
+		return list
+	}
+	for i, existing := range list {
+		if existing.Node() != nil && existing.Node().Name == nodeInfo.Node().Name {
+			return append(list[:i], list[i+1:]...)
+		}
+	}
+	return list
 }
 
 // forgetAllAssumedPods forgets all assumed pods from the snapshot.

--- a/pkg/scheduler/backend/cache/snapshot_test.go
+++ b/pkg/scheduler/backend/cache/snapshot_test.go
@@ -545,6 +545,81 @@ func TestSnapshot_AssumeForget(t *testing.T) {
 	}
 }
 
+func TestSnapshotAssumeForgetUpdatesAffinityNodeInfoLists(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	node1 := st.MakeNode().Name("node-1").Label("node", "node-1").Obj()
+	node2 := st.MakeNode().Name("node-2").Label("node", "node-2").Obj()
+	podWithRequiredAntiAffinity1 := st.MakePod().Name("pod-anti-1").Namespace("ns").UID("pod-anti-1").
+		Label("anti", "anti").
+		PodAntiAffinityExists("anti", "node", st.PodAntiAffinityWithRequiredReq).
+		Node("node-1").
+		Obj()
+	podWithRequiredAntiAffinity2 := st.MakePod().Name("pod-anti-2").Namespace("ns").UID("pod-anti-2").
+		Label("anti", "anti").
+		PodAntiAffinityExists("anti", "node", st.PodAntiAffinityWithRequiredReq).
+		Node("node-1").
+		Obj()
+	podWithAffinity := st.MakePod().Name("pod-affinity").Namespace("ns").UID("pod-affinity").
+		PodAffinityExists("affinity", "node", st.PodAffinityWithRequiredReq).
+		Node("node-2").
+		Obj()
+
+	snapshot := NewSnapshot(nil, []*v1.Node{node1, node2})
+	assumePod := func(pod *v1.Pod) {
+		t.Helper()
+		podInfo, err := framework.NewPodInfo(pod)
+		if err != nil {
+			t.Fatalf("NewPodInfo failed: %v", err)
+		}
+		if err := snapshot.AssumePod(podInfo); err != nil {
+			t.Fatalf("AssumePod failed: %v", err)
+		}
+	}
+	forgetPod := func(pod *v1.Pod) {
+		t.Helper()
+		if err := snapshot.ForgetPod(logger, pod); err != nil {
+			t.Fatalf("ForgetPod failed: %v", err)
+		}
+	}
+	checkNodeNames := func(name string, got []fwk.NodeInfo, want sets.Set[string]) {
+		t.Helper()
+		gotNames := sets.New[string]()
+		for _, nodeInfo := range got {
+			gotNames.Insert(nodeInfo.Node().Name)
+		}
+		if !gotNames.Equal(want) {
+			t.Fatalf("unexpected %s node names: got %v, want %v", name, sets.List(gotNames), sets.List(want))
+		}
+	}
+	checkAffinityLists := func(wantAffinity, wantRequiredAntiAffinity sets.Set[string]) {
+		t.Helper()
+		affinityNodes, err := snapshot.HavePodsWithAffinityList()
+		if err != nil {
+			t.Fatalf("HavePodsWithAffinityList failed: %v", err)
+		}
+		checkNodeNames("affinity", affinityNodes, wantAffinity)
+		requiredAntiAffinityNodes, err := snapshot.HavePodsWithRequiredAntiAffinityList()
+		if err != nil {
+			t.Fatalf("HavePodsWithRequiredAntiAffinityList failed: %v", err)
+		}
+		checkNodeNames("required anti-affinity", requiredAntiAffinityNodes, wantRequiredAntiAffinity)
+	}
+
+	checkAffinityLists(nil, nil)
+	assumePod(podWithRequiredAntiAffinity1)
+	checkAffinityLists(sets.New("node-1"), sets.New("node-1"))
+	assumePod(podWithRequiredAntiAffinity2)
+	checkAffinityLists(sets.New("node-1"), sets.New("node-1"))
+	assumePod(podWithAffinity)
+	checkAffinityLists(sets.New("node-1", "node-2"), sets.New("node-1"))
+	forgetPod(podWithRequiredAntiAffinity1)
+	checkAffinityLists(sets.New("node-1", "node-2"), sets.New("node-1"))
+	forgetPod(podWithRequiredAntiAffinity2)
+	checkAffinityLists(sets.New("node-2"), nil)
+	forgetPod(podWithAffinity)
+	checkAffinityLists(nil, nil)
+}
+
 func TestSnapshot_Placement(t *testing.T) {
 	tt := []struct {
 		name           string


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When a pod is assumed into a scheduler snapshot, the snapshot updates the node's `NodeInfo`, but it did not update the snapshot-level node lists used by inter-pod affinity:

- `havePodsWithAffinityNodeInfoList`
- `havePodsWithRequiredAntiAffinityNodeInfoList`

As a result, a pod assumed only in the snapshot could be visible through `NodeInfo.Pods`, but the node could still be missing from the affinity indexes used by scheduler plugins.

This PR keeps those lists in sync when `Snapshot.AssumePod` and `Snapshot.ForgetPod` add or remove the first or last pod with affinity or required anti-affinity on a node.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
