### PR TITLE
proxy: log nodePort changes for improved observability

### DIFF
--- a/pkg/proxy/endpointschangetracker.go
+++ b/pkg/proxy/endpointschangetracker.go
@@ -237,15 +237,31 @@ func (em EndpointsMap) Update(ect *EndpointsChangeTracker) UpdateEndpointsMapRes
 // Merge ensures that the current EndpointsMap contains all <service, endpoints> pairs from the EndpointsMap passed in.
 func (em EndpointsMap) merge(other EndpointsMap) {
 	for svcPortName := range other {
-		em[svcPortName] = other[svcPortName]
+		epList := other[svcPortName]
+		if _, exists := em[svcPortName]; !exists {
+			klog.V(3).InfoS("Adding new service endpoints", "portName", svcPortName, "endpoints", formatEndpointsList(epList))
+		} else {
+			klog.V(3).InfoS("Updating existing service endpoints", "portName", svcPortName, "endpoints", formatEndpointsList(epList))
+		}
+		em[svcPortName] = epList
 	}
 }
 
 // Unmerge removes the <service, endpoints> pairs from the current EndpointsMap which are contained in the EndpointsMap passed in.
 func (em EndpointsMap) unmerge(other EndpointsMap) {
 	for svcPortName := range other {
+		klog.V(3).InfoS("Removing service endpoints", "portName", svcPortName)
 		delete(em, svcPortName)
 	}
+}
+
+// formatEndpointsList returns a string list converted from an endpoints list.
+func formatEndpointsList(endpoints []Endpoint) []string {
+	var formattedList []string
+	for _, ep := range endpoints {
+		formattedList = append(formattedList, ep.String())
+	}
+	return formattedList
 }
 
 // getLocalEndpointIPs returns endpoints IPs if given endpoint is local - local means the endpoint is running in same host as kube-proxy.

--- a/pkg/proxy/endpointslicecache.go
+++ b/pkg/proxy/endpointslicecache.go
@@ -301,21 +301,10 @@ func endpointsMapFromEndpointInfo(endpointInfoBySP map[ServicePortName]map[strin
 			}
 			// Ensure endpoints are always returned in the same order to simplify diffing.
 			sort.Sort(byEndpoint(endpointsMap[svcPortName]))
-
-			klog.V(3).InfoS("Setting endpoints for service port name", "portName", svcPortName, "endpoints", formatEndpointsList(endpointsMap[svcPortName]))
 		}
 	}
 
 	return endpointsMap
-}
-
-// formatEndpointsList returns a string list converted from an endpoints list.
-func formatEndpointsList(endpoints []Endpoint) []string {
-	var formattedList []string
-	for _, ep := range endpoints {
-		formattedList = append(formattedList, ep.String())
-	}
-	return formattedList
 }
 
 // endpointSliceCacheKeys returns cache keys used for a given EndpointSlice.

--- a/pkg/proxy/servicechangetracker.go
+++ b/pkg/proxy/servicechangetracker.go
@@ -197,11 +197,17 @@ func (sm ServicePortMap) Update(sct *ServiceChangeTracker) UpdateServiceMapResul
 // In other words, if some elements in current collisions with other, update the current by other.
 func (sm *ServicePortMap) merge(other ServicePortMap) {
 	for svcPortName, info := range other {
-		_, exists := (*sm)[svcPortName]
+		existingInfo, exists := (*sm)[svcPortName]
 		if !exists {
 			klog.V(4).InfoS("Adding new service port", "portName", svcPortName, "servicePort", info)
 		} else {
 			klog.V(4).InfoS("Updating existing service port", "portName", svcPortName, "servicePort", info)
+			if existingInfo.NodePort() != 0 && info.NodePort() == 0 {
+				klog.V(4).InfoS("Clearing nodePort for service port name", "portName", svcPortName, "nodePort", existingInfo.NodePort())
+			}
+		}
+		if info.NodePort() != 0 {
+			klog.V(4).InfoS("Setting nodePort for service port name", "portName", svcPortName, "nodePort", info.NodePort())
 		}
 		(*sm)[svcPortName] = info
 	}
@@ -219,10 +225,13 @@ func (sm *ServicePortMap) filter(other ServicePortMap) {
 
 // unmerge deletes all other ServicePortMap's elements from current ServicePortMap.
 func (sm *ServicePortMap) unmerge(other ServicePortMap) {
-	for svcPortName := range other {
+	for svcPortName, info := range other {
 		_, exists := (*sm)[svcPortName]
 		if exists {
 			klog.V(4).InfoS("Removing service port", "portName", svcPortName)
+			if info.NodePort() != 0 {
+				klog.V(4).InfoS("Clearing nodePort for service port name", "portName", svcPortName, "nodePort", info.NodePort())
+			}
 			delete(*sm, svcPortName)
 		} else {
 			klog.ErrorS(nil, "Service port does not exists", "portName", svcPortName)


### PR DESCRIPTION
Logs when a nodePort is configured, cleared, or removed from a service, similar to how endpoints are logged, to improve traceability in kube-proxy.

/kind flake
```release-note
NONE
```


Help debug #139786

/sig network
/assign @danwinship @adrianmoisey 