### PR TITLE
DRA resourceslice tracker: ignore DeviceClass events

### DIFF
--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -503,7 +503,6 @@ func TestAddAllEventHandlers(t *testing.T) {
 				}
 				if opts.EnableDeviceTaintRules {
 					opts.TaintInformer = informerFactory.Resource().V1beta2().DeviceTaintRules()
-					opts.ClassInformer = informerFactory.Resource().V1().DeviceClasses()
 
 				}
 				resourceSliceTracker, err = resourceslicetracker.StartTracker(ctx, opts)

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -4058,7 +4058,6 @@ func setup(tCtx ktesting.TContext, args *config.DynamicResourcesArgs, nodes []*v
 		EnableDeviceTaintRules: true,
 		SliceInformer:          tc.informerFactory.Resource().V1().ResourceSlices(),
 		TaintInformer:          tc.informerFactory.Resource().V1beta2().DeviceTaintRules(),
-		ClassInformer:          tc.informerFactory.Resource().V1().DeviceClasses(),
 		KubeClient:             tc.client,
 	}
 	resourceSliceTracker, err := resourceslicetracker.StartTracker(tCtx, resourceSliceTrackerOpts)

--- a/pkg/scheduler/framework/plugins/noderesources/resource_allocation_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/resource_allocation_test.go
@@ -596,7 +596,6 @@ func newTestDRAManager(tCtx ktesting.TContext, objects ...apiruntime.Object) *dy
 	resourceSliceTrackerOpts := tracker.Options{
 		SliceInformer: informerFactory.Resource().V1().ResourceSlices(),
 		TaintInformer: informerFactory.Resource().V1beta2().DeviceTaintRules(),
-		ClassInformer: informerFactory.Resource().V1().DeviceClasses(),
 		KubeClient:    client,
 	}
 	resourceSliceTracker, err := tracker.StartTracker(tCtx, resourceSliceTrackerOpts)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -345,7 +345,6 @@ func New(ctx context.Context,
 		// the tracker turns into a simple wrapper around the slice informer.
 		if resourceSliceTrackerOpts.EnableDeviceTaintRules {
 			resourceSliceTrackerOpts.TaintInformer = informerFactory.Resource().V1beta2().DeviceTaintRules()
-			resourceSliceTrackerOpts.ClassInformer = informerFactory.Resource().V1().DeviceClasses()
 		}
 		resourceSliceTracker, err = resourceslicetracker.StartTracker(ctx, resourceSliceTrackerOpts)
 		if err != nil {

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go
@@ -108,8 +108,8 @@ type Options struct {
 	// EnableDeviceTaintRules controls whether DeviceTaintRules
 	// will be reflected in ResourceSlices reported by the tracker.
 	//
-	// If false, then TaintInformer and ClassInformer
-	// are not needed. The tracker turns into
+	// If false, then TaintInformer is
+	// not needed. The tracker turns into
 	// a thin wrapper around the underlying
 	// SliceInformer, with no processing of its own.
 	EnableDeviceTaintRules bool
@@ -118,7 +118,6 @@ type Options struct {
 
 	SliceInformer resourceinformers.ResourceSliceInformer
 	TaintInformer resourcebetainformers.DeviceTaintRuleInformer
-	ClassInformer resourceinformers.DeviceClassInformer
 
 	// KubeClient is used to generate Events when CEL expressions
 	// encounter runtime errors.

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go
@@ -62,8 +62,6 @@ type Tracker struct {
 	resourceSlicesHandle  cache.ResourceEventHandlerRegistration
 	deviceTaints          cache.SharedIndexInformer
 	deviceTaintsHandle    cache.ResourceEventHandlerRegistration
-	deviceClasses         cache.SharedIndexInformer
-	deviceClassesHandle   cache.ResourceEventHandlerRegistration
 	patchedResourceSlices cache.Store
 	broadcaster           record.EventBroadcaster
 	recorder              record.EventRecorder
@@ -160,7 +158,6 @@ func newTracker(ctx context.Context, opts Options) (finalT *Tracker, finalErr er
 		resourceSliceLister:    opts.SliceInformer.Lister(),
 		resourceSlices:         opts.SliceInformer.Informer(),
 		deviceTaints:           opts.TaintInformer.Informer(),
-		deviceClasses:          opts.ClassInformer.Informer(),
 		patchedResourceSlices:  cache.NewStore(cache.MetaNamespaceKeyFunc),
 		handleError:            utilruntime.HandleErrorWithContext,
 		synced:                 make(chan struct{}),
@@ -212,22 +209,12 @@ func (t *Tracker) initInformers(ctx context.Context) error {
 		return fmt.Errorf("add event handler for DeviceTaintRules: %w", err)
 	}
 
-	classHandler := cache.ResourceEventHandlerFuncs{
-		AddFunc:    t.deviceClassAdd(ctx),
-		UpdateFunc: t.deviceClassUpdate(ctx),
-		DeleteFunc: t.deviceClassDelete(ctx),
-	}
-	t.deviceClassesHandle, err = t.deviceClasses.AddEventHandler(classHandler)
-	if err != nil {
-		return fmt.Errorf("add event handler for DeviceClasses: %w", err)
-	}
-
 	// This usually short-lived goroutines monitors our upstream event handlers and
 	// closes our own synced channel when they are synced.
 	monitorCtx, cancel := context.WithCancelCause(ctx)
 	t.cancel = cancel
 	t.wg.Go(func() {
-		for _, handle := range []cache.ResourceEventHandlerRegistration{t.resourceSlicesHandle, t.deviceTaintsHandle, t.deviceClassesHandle} {
+		for _, handle := range []cache.ResourceEventHandlerRegistration{t.resourceSlicesHandle, t.deviceTaintsHandle} {
 			select {
 			case <-handle.HasSyncedChecker().Done():
 			case <-monitorCtx.Done():
@@ -283,7 +270,6 @@ func (t *Tracker) Stop() {
 	}
 	_ = t.resourceSlices.RemoveEventHandler(t.resourceSlicesHandle)
 	_ = t.deviceTaints.RemoveEventHandler(t.deviceTaintsHandle)
-	_ = t.deviceClasses.RemoveEventHandler(t.deviceClassesHandle)
 
 	t.wg.Wait()
 }
@@ -525,59 +511,6 @@ func (t *Tracker) deviceTaintDelete(ctx context.Context) func(obj any) {
 		}
 		logger.V(5).Info("DeviceTaintRule deleted", "patch", klog.KObj(patch))
 		for _, sliceName := range t.sliceNamesForPatch(ctx, patch) {
-			t.syncSlice(ctx, sliceName, false)
-		}
-	}
-}
-
-func (t *Tracker) deviceClassAdd(ctx context.Context) func(obj any) {
-	logger := klog.FromContext(ctx)
-	return func(obj any) {
-		class, ok := obj.(*resourceapi.DeviceClass)
-		if !ok {
-			return
-		}
-		logger.V(5).Info("DeviceClass add", "class", klog.KObj(class))
-		for _, sliceName := range t.resourceSlices.GetIndexer().ListKeys() {
-			t.syncSlice(ctx, sliceName, false)
-		}
-	}
-}
-
-func (t *Tracker) deviceClassUpdate(ctx context.Context) func(oldObj, newObj any) {
-	logger := klog.FromContext(ctx)
-	return func(oldObj, newObj any) {
-		oldClass, ok := oldObj.(*resourceapi.DeviceClass)
-		if !ok {
-			return
-		}
-		newClass, ok := newObj.(*resourceapi.DeviceClass)
-		if !ok {
-			return
-		}
-		if loggerV := logger.V(6); loggerV.Enabled() {
-			loggerV.Info("DeviceClass update", "class", klog.KObj(newClass), "diff", diff.Diff(oldClass, newClass))
-		} else {
-			logger.V(5).Info("DeviceClass update", "class", klog.KObj(newClass))
-		}
-		for _, sliceName := range t.resourceSlices.GetIndexer().ListKeys() {
-			t.syncSlice(ctx, sliceName, false)
-		}
-	}
-}
-
-func (t *Tracker) deviceClassDelete(ctx context.Context) func(obj any) {
-	logger := klog.FromContext(ctx)
-	return func(obj any) {
-		if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-			obj = tombstone.Obj
-		}
-		class, ok := obj.(*resourceapi.ResourceSlice)
-		if !ok {
-			return
-		}
-		logger.V(5).Info("DeviceClass delete", "class", klog.KObj(class))
-		for _, sliceName := range t.resourceSlices.GetIndexer().ListKeys() {
 			t.syncSlice(ctx, sliceName, false)
 		}
 	}

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker_test.go
@@ -523,7 +523,6 @@ func TestListPatchedResourceSlices(t *testing.T) {
 			EnableDeviceTaintRules: true,
 			SliceInformer:          informerFactory.Resource().V1().ResourceSlices(),
 			TaintInformer:          informerFactory.Resource().V1beta2().DeviceTaintRules(),
-			ClassInformer:          informerFactory.Resource().V1().DeviceClasses(),
 			KubeClient:             kubeClient,
 		}
 		tracker, err := newTracker(ctx, opts)
@@ -931,7 +930,6 @@ func BenchmarkEventHandlers(b *testing.B) {
 			EnableDeviceTaintRules: true,
 			SliceInformer:          informerFactory.Resource().V1().ResourceSlices(),
 			TaintInformer:          informerFactory.Resource().V1beta2().DeviceTaintRules(),
-			ClassInformer:          informerFactory.Resource().V1().DeviceClasses(),
 			KubeClient:             kubeClient,
 		}
 		tracker, err := newTracker(ctx, opts)

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker_test.go
@@ -132,22 +132,6 @@ func applyEventPair(tCtx *testContext, event any) {
 			require.NoError(tCtx, err)
 			tCtx.deviceTaintAdd(tCtx.Context)(pair[1])
 		}
-	case [2]*resourceapi.DeviceClass:
-		store := tCtx.deviceClasses.GetStore()
-		switch {
-		case pair[0] != nil && pair[1] != nil:
-			err := store.Update(pair[1])
-			require.NoError(tCtx, err)
-			tCtx.deviceClassUpdate(tCtx.Context)(pair[0], pair[1])
-		case pair[0] != nil:
-			err := store.Delete(pair[0])
-			require.NoError(tCtx, err)
-			tCtx.deviceClassDelete(tCtx.Context)(pair[0])
-		default:
-			err := store.Add(pair[1])
-			require.NoError(tCtx, err)
-			tCtx.deviceClassAdd(tCtx.Context)(pair[1])
-		}
 	}
 }
 
@@ -179,19 +163,6 @@ var (
 	device0Name = "device-0"
 	device1Name = "device-1"
 	device2Name = "device-2"
-
-	deviceClass1 = &resourceapi.DeviceClass{
-		ObjectMeta: metav1.ObjectMeta{Name: "device-class-1"},
-		Spec: resourceapi.DeviceClassSpec{
-			Selectors: []resourceapi.DeviceSelector{
-				{
-					CEL: &resourceapi.CELDeviceSelector{
-						Expression: `device.driver == "` + driver1 + `"`,
-					},
-				},
-			},
-		},
-	}
 
 	sliceWithDevices = func(slice *resourceapi.ResourceSlice, devices []resourceapi.Device) *resourceapi.ResourceSlice {
 		slice = slice.DeepCopy()
@@ -326,8 +297,7 @@ func TestListPatchedResourceSlices(t *testing.T) {
 	type test struct {
 		// events contains pairs of old and new objects which will
 		// be passed to event handler methods.
-		// Objects can be slices, device taint rules, and device
-		// classes.
+		// Objects can be slices and device taint rules.
 		// [add], [remove], and [update] can be used to produce
 		// such pairs.
 		//
@@ -494,7 +464,6 @@ func TestListPatchedResourceSlices(t *testing.T) {
 		},
 		"filter-all-criteria": {
 			events: []any{
-				add(deviceClass1),
 				add(
 					taintDriverDevicesRule(
 						taintPoolDevicesRule(

--- a/test/integration/scheduler_perf/dra.go
+++ b/test/integration/scheduler_perf/dra.go
@@ -292,7 +292,6 @@ func (op *allocResourceClaimsOp) run(tCtx ktesting.TContext) {
 	}
 	if resourceSliceTrackerOpts.EnableDeviceTaintRules {
 		resourceSliceTrackerOpts.TaintInformer = informerFactory.Resource().V1beta2().DeviceTaintRules()
-		resourceSliceTrackerOpts.ClassInformer = informerFactory.Resource().V1().DeviceClasses()
 	}
 	resourceSliceTracker, err := resourceslicetracker.StartTracker(tCtx, resourceSliceTrackerOpts)
 	tCtx.ExpectNoError(err, "start resource slice tracker")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This was left over from the time when device taints still allowed filtering by DeviceClass. This was removed because that filtering only worked while the DeviceClass existed. The DeviceClass events then triggered resyncs even though nothing relevant changed.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

To avoid changing the Go API of the package and thus updating various other places (scheduler, controller manager) the DeviceClass informer is kept in the options. It's simply not used.


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @nojnhuh 