### PR TITLE
apimachinery: add declarative validation for Condition.Reason field

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
@@ -234,6 +234,8 @@ message Condition {
   // +kubebuilder:validation:MaxLength=1024
   // +kubebuilder:validation:MinLength=1
   // +kubebuilder:validation:Pattern=`^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$`
+  // +k8s:alpha(since: "1.37")=+k8s:required
+  // +k8s:alpha(since: "1.37")=+k8s:maxLength=1024
   optional string reason = 5;
 
   // message is a human readable message indicating details about the transition.

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -1678,6 +1678,7 @@ type Condition struct {
 	// +kubebuilder:validation:MaxLength=1024
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:Pattern=`^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$`
+	// +k8s:alpha(since: "1.37")=+k8s:required
 	Reason string `json:"reason" protobuf:"bytes,5,opt,name=reason"`
 	// message is a human readable message indicating details about the transition.
 	// This may be an empty string.

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -1679,6 +1679,7 @@ type Condition struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:Pattern=`^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$`
 	// +k8s:alpha(since: "1.37")=+k8s:required
+	// +k8s:alpha(since: "1.37")=+k8s:maxLength=1024
 	Reason string `json:"reason" protobuf:"bytes,5,opt,name=reason"`
 	// message is a human readable message indicating details about the transition.
 	// This may be an empty string.

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -365,7 +365,7 @@ func ValidateCondition(condition metav1.Condition, fldPath *field.Path) field.Er
 	}
 
 	if len(condition.Reason) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("reason"), ""))
+		allErrs = append(allErrs, field.Required(fldPath.Child("reason"), "").MarkCoveredByDeclarative())
 	} else {
 		for _, currErr := range isValidConditionReason(condition.Reason) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("reason"), condition.Reason, currErr))

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -371,7 +371,7 @@ func ValidateCondition(condition metav1.Condition, fldPath *field.Path) field.Er
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("reason"), condition.Reason, currErr))
 		}
 		if len(condition.Reason) > maxReasonLen {
-			allErrs = append(allErrs, field.TooLong(fldPath.Child("reason"), "" /*unused*/, maxReasonLen))
+			allErrs = append(allErrs, field.TooLong(fldPath.Child("reason"), "" /*unused*/, maxReasonLen).WithOrigin("maxLength").MarkCoveredByDeclarative())
 		}
 	}
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/zz_generated.validations.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/zz_generated.validations.go
@@ -156,7 +156,35 @@ func Validate_Condition(
 		errs = append(errs, fn(fldPath.Child("lastTransitionTime"), &obj.LastTransitionTime, oldVal, oldObj != nil)...)
 	}
 
-	// field v1.Condition.Reason has no validation
+	{ // field v1.Condition.Reason
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *string,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *v1.Condition) *string {
+				return &oldObj.Reason
+			})
+		errs = append(errs, fn(fldPath.Child("reason"), &obj.Reason, oldVal, oldObj != nil)...)
+	}
+
 	// field v1.Condition.Message has no validation
 	return errs
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/zz_generated.validations.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/zz_generated.validations.go
@@ -176,6 +176,9 @@ func Validate_Condition(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 1024).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1_test.go
@@ -55,6 +55,9 @@ func init() {
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"status.conditions[*].reason": {
+				{ErrorType: "FieldValueRequired"},
+			},
 			"status.conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1_test.go
@@ -57,6 +57,7 @@ func init() {
 			},
 			"status.conditions[*].reason": {
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "maxLength"},
 			},
 			"status.conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
@@ -55,6 +55,9 @@ func init() {
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"status.conditions[*].reason": {
+				{ErrorType: "FieldValueRequired"},
+			},
 			"status.conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
@@ -57,6 +57,7 @@ func init() {
 			},
 			"status.conditions[*].reason": {
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "maxLength"},
 			},
 			"status.conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
@@ -55,6 +55,9 @@ func init() {
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"status.conditions[*].reason": {
+				{ErrorType: "FieldValueRequired"},
+			},
 			"status.conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
@@ -57,6 +57,7 @@ func init() {
 			},
 			"status.conditions[*].reason": {
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "maxLength"},
 			},
 			"status.conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},

--- a/test/declarative_validation/certificates/podcertificaterequest/declarative_validation_test.go
+++ b/test/declarative_validation/certificates/podcertificaterequest/declarative_validation_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/x509"
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -294,6 +295,18 @@ func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 					},
 					ExpectedErrs: field.ErrorList{
 						field.Required(field.NewPath("status", "conditions").Index(0).Child("reason"), "").MarkAlpha(),
+					},
+				},
+				{
+					Name: "invalid too long reason",
+					Conditions: []metav1.Condition{
+						meta.MkCondition(
+							meta.TweakType(string(certificates.PodCertificateRequestConditionTypeDenied)),
+							meta.TweakReason(strings.Repeat("A", 1025)),
+						),
+					},
+					ExpectedErrs: field.ErrorList{
+						field.TooLong(field.NewPath("status", "conditions").Index(0).Child("reason"), "", 1024).WithOrigin("maxLength").MarkAlpha(),
 					},
 				},
 			}

--- a/test/declarative_validation/certificates/podcertificaterequest/declarative_validation_test.go
+++ b/test/declarative_validation/certificates/podcertificaterequest/declarative_validation_test.go
@@ -284,6 +284,18 @@ func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 						field.NotSupported(field.NewPath("status", "conditions").Child("[0]", "status"), "False", []string{"True"}).MarkFromImperative(),
 					},
 				},
+				{
+					Name: "invalid missing reason",
+					Conditions: []metav1.Condition{
+						meta.MkCondition(
+							meta.TweakType(string(certificates.PodCertificateRequestConditionTypeDenied)),
+							meta.TweakReason(""),
+						),
+					},
+					ExpectedErrs: field.ErrorList{
+						field.Required(field.NewPath("status", "conditions").Index(0).Child("reason"), "").MarkAlpha(),
+					},
+				},
 			}
 
 			for _, tc := range testCases {

--- a/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1beta1_test.go
@@ -55,6 +55,9 @@ func init() {
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"status.conditions[*].reason": {
+				{ErrorType: "FieldValueRequired"},
+			},
 			"status.conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1beta1_test.go
@@ -57,6 +57,7 @@ func init() {
 			},
 			"status.conditions[*].reason": {
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "maxLength"},
 			},
 			"status.conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},

--- a/test/declarative_validation/meta/conditions.go
+++ b/test/declarative_validation/meta/conditions.go
@@ -18,6 +18,7 @@ package meta
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -132,6 +133,22 @@ func GenerateConditionTestCases(fldPath *field.Path) []ConditionTestCase {
 			ExpectedErrs: field.ErrorList{
 				field.Required(fldPath.Index(0).Child("reason"), "").MarkAlpha(),
 			},
+		},
+		{
+			Name: "invalid too long reason",
+			Conditions: []metav1.Condition{
+				MkCondition(TweakReason(strings.Repeat("A", 1025))),
+			},
+			ExpectedErrs: field.ErrorList{
+				field.TooLong(fldPath.Index(0).Child("reason"), "", 1024).WithOrigin("maxLength").MarkAlpha(),
+			},
+		},
+		{
+			Name: "valid reason at max length",
+			Conditions: []metav1.Condition{
+				MkCondition(TweakReason(strings.Repeat("A", 1024))),
+			},
+			ExpectedErrs: nil,
 		},
 	}
 }

--- a/test/declarative_validation/meta/conditions.go
+++ b/test/declarative_validation/meta/conditions.go
@@ -124,6 +124,15 @@ func GenerateConditionTestCases(fldPath *field.Path) []ConditionTestCase {
 			},
 			ExpectedErrs: nil,
 		},
+		{
+			Name: "invalid missing reason",
+			Conditions: []metav1.Condition{
+				MkCondition(TweakReason("")),
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Required(fldPath.Index(0).Child("reason"), "").MarkAlpha(),
+			},
+		},
 	}
 }
 
@@ -178,5 +187,11 @@ func TweakObservedGeneration(gen int64) func(*metav1.Condition) {
 func TweakLastTransitionTime(t metav1.Time) func(*metav1.Condition) {
 	return func(c *metav1.Condition) {
 		c.LastTransitionTime = t
+	}
+}
+
+func TweakReason(reason string) func(*metav1.Condition) {
+	return func(c *metav1.Condition) {
+		c.Reason = reason
 	}
 }

--- a/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1_test.go
@@ -55,6 +55,9 @@ func init() {
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"status.conditions[*].reason": {
+				{ErrorType: "FieldValueRequired"},
+			},
 			"status.conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1_test.go
@@ -57,6 +57,7 @@ func init() {
 			},
 			"status.conditions[*].reason": {
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "maxLength"},
 			},
 			"status.conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},

--- a/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1beta1_test.go
@@ -55,6 +55,9 @@ func init() {
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"status.conditions[*].reason": {
+				{ErrorType: "FieldValueRequired"},
+			},
 			"status.conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1beta1_test.go
@@ -57,6 +57,7 @@ func init() {
 			},
 			"status.conditions[*].reason": {
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "maxLength"},
 			},
 			"status.conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1_test.go
@@ -59,6 +59,10 @@ func init() {
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"status.conditions[*].reason": {
+				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "maxLength"},
+			},
 			"status.conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1alpha3_test.go
@@ -61,6 +61,7 @@ func init() {
 			},
 			"status.conditions[*].reason": {
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "maxLength"},
 			},
 			"status.conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1alpha3_test.go
@@ -59,6 +59,9 @@ func init() {
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"status.conditions[*].reason": {
+				{ErrorType: "FieldValueRequired"},
+			},
 			"status.conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1beta2_test.go
@@ -61,6 +61,7 @@ func init() {
 			},
 			"status.conditions[*].reason": {
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "maxLength"},
 			},
 			"status.conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1beta2_test.go
@@ -59,6 +59,9 @@ func init() {
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"status.conditions[*].reason": {
+				{ErrorType: "FieldValueRequired"},
+			},
 			"status.conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1_test.go
@@ -189,6 +189,7 @@ func init() {
 			},
 			"status.devices[*].conditions[*].reason": {
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "maxLength"},
 			},
 			"status.devices[*].conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1_test.go
@@ -187,6 +187,9 @@ func init() {
 			"status.devices[*].conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"status.devices[*].conditions[*].reason": {
+				{ErrorType: "FieldValueRequired"},
+			},
 			"status.devices[*].conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta1_test.go
@@ -189,6 +189,7 @@ func init() {
 			},
 			"status.devices[*].conditions[*].reason": {
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "maxLength"},
 			},
 			"status.devices[*].conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta1_test.go
@@ -187,6 +187,9 @@ func init() {
 			"status.devices[*].conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"status.devices[*].conditions[*].reason": {
+				{ErrorType: "FieldValueRequired"},
+			},
 			"status.devices[*].conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta2_test.go
@@ -189,6 +189,7 @@ func init() {
 			},
 			"status.devices[*].conditions[*].reason": {
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "maxLength"},
 			},
 			"status.devices[*].conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta2_test.go
@@ -187,6 +187,9 @@ func init() {
 			"status.devices[*].conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"status.devices[*].conditions[*].reason": {
+				{ErrorType: "FieldValueRequired"},
+			},
 			"status.devices[*].conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/resourcepoolstatusrequest/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/resource/resourcepoolstatusrequest/zz_generated.validations.v1alpha3_test.go
@@ -73,6 +73,9 @@ func init() {
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"status.conditions[*].reason": {
+				{ErrorType: "FieldValueRequired"},
+			},
 			"status.conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/resourcepoolstatusrequest/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/resource/resourcepoolstatusrequest/zz_generated.validations.v1alpha3_test.go
@@ -75,6 +75,7 @@ func init() {
 			},
 			"status.conditions[*].reason": {
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "maxLength"},
 			},
 			"status.conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},

--- a/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1alpha3_test.go
@@ -128,6 +128,7 @@ func init() {
 			},
 			"status.conditions[*].reason": {
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "maxLength"},
 			},
 			"status.conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},

--- a/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1alpha3_test.go
@@ -126,6 +126,9 @@ func init() {
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"status.conditions[*].reason": {
+				{ErrorType: "FieldValueRequired"},
+			},
 			"status.conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1_test.go
@@ -55,6 +55,10 @@ func init() {
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"status.conditions[*].reason": {
+				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "maxLength"},
+			},
 			"status.conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1beta1_test.go
@@ -55,6 +55,9 @@ func init() {
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"status.conditions[*].reason": {
+				{ErrorType: "FieldValueRequired"},
+			},
 			"status.conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1beta1_test.go
@@ -57,6 +57,7 @@ func init() {
 			},
 			"status.conditions[*].reason": {
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "maxLength"},
 			},
 			"status.conditions[*].status": {
 				{ErrorType: "FieldValueNotSupported"},


### PR DESCRIPTION
## What this PR does

Migrates the hand-written `Reason` validation on `metav1.Condition` to Declarative Validation (KEP-5073), covering Batch 1 of the tracking issue:

- Added `+k8s:required` and `+k8s:maxLength=1024` tags to `Condition.Reason` in `types.go`
- Regenerated `zz_generated.validations.go` accordingly
- Marked the corresponding hand-written checks in `validation.go` as `.MarkCoveredByDeclarative()`
- Added test coverage for empty and over-length `Reason` values, including the `PodCertificateRequest`-specific test table

## Which issue(s) this PR is related to

Part of #139638 (Batch 1: `Reason`)

## Does this PR introduce a user-facing change?

```release-note
NONE
```
