### PR TITLE
Use contextual logging in ResourcePoolStatusRequest controller

### DIFF
--- a/pkg/controller/resourcepoolstatusrequest/controller.go
+++ b/pkg/controller/resourcepoolstatusrequest/controller.go
@@ -110,14 +110,14 @@ func NewController(
 	metrics.Register()
 
 	// Set up event handlers for ResourcePoolStatusRequests
-	_, err := requestInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err := requestInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			c.enqueueRequest(logger, obj)
 		},
 		UpdateFunc: func(old, new interface{}) {
 			c.enqueueRequest(logger, new)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	if err != nil {
 		return nil, fmt.Errorf("failed to add request event handler: %w", err)
 	}


### PR DESCRIPTION
/kind cleanup
/sig instrumentation
/wg structured-logging

#### What this PR does / why we need it
Migrates the ResourcePoolStatusRequest controller informer handler registration to AddEventHandlerWithOptions and passes the controller logger through cache.HandlerOptions.

This is a small slice of the contextual logging migration tracked in kubernetes/kubernetes#126379.

#### Which issue(s) this PR is related to
Part of kubernetes/kubernetes#126379

#### Special notes for your reviewer
Kept the existing handler behavior and error handling; only the logger propagation path changes.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Testing
```
make test WHAT=./pkg/controller/resourcepoolstatusrequest GOFLAGS=-v
make test WHAT=./pkg/controller/resourcepoolstatusrequest/... GOFLAGS=-v
hack/verify-golangci-lint.sh -a ./pkg/controller/resourcepoolstatusrequest
hack/verify-gofmt.sh
hack/verify-boilerplate.sh
git diff --check origin/master...HEAD
```
