### PR TITLE
Run PlacementFeasible plugins before any Pod is attempted

### DIFF
--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -185,13 +185,21 @@ type PlacementFeasiblePlugin interface {
 	fwk.Plugin
 
 	// PlacementFeasible is called after each pod in a pod group is evaluated.
-	// Use placementCycleState to accumulate the results from the evaluated pods in current cycle.
+	// placementFeasibleArgs contains information that plugins might additionally need when determining whether pod group scheduling placement is feasible.
 	// Return Wait status if the pod group cannot be scheduled in the current partially evaluated placement, but may become schedulable once more pods are evaluated.
 	// Return Unschedulable status if the pod group cannot be scheduled in the current placement.
 	// The scheduler will give up this placement and won't even evaluate remaining pods. The placement will remain eligible for preemption.
 	// Return Success status if the pod group can be scheduled in the current partially evaluated placement.
 	// After returning Success, the plugin should keep returning Success for the remaining pods.
-	PlacementFeasible(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroupInfo fwk.PodGroupInfo) *fwk.Status
+	PlacementFeasible(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroupInfo fwk.PodGroupInfo, placementFeasibleArgs PlacementFeasibleArgs) *fwk.Status
+}
+
+// PlacementFeasibleArgs contains information that plugins implementing the PlacementFeasiblePlugin
+// interface might additionally need when determining whether pod group scheduling placement is feasible.
+type PlacementFeasibleArgs struct {
+	// Evaluated denotes the number of Pods evaluated so far by the pod group scheduling cycle
+	// for a particular pod group and placement.
+	Evaluated int
 }
 
 // Framework manages the set of plugins in use by the scheduling framework.
@@ -282,7 +290,7 @@ type Framework interface {
 	// If any plugin returns invalid status, the result will be Error and the remaining plugins won't be invoked.
 	// Otherwise, if at least 1 plugin returns Unschedulable, the remaining plugins won't be invoked and the result will be Unschedulable. The placement will remain eligible for preemption.
 	// Otherwise, if at least 1 plugin returns Wait, the remaining plugins will be invoked and the result will be Wait.
-	RunPlacementFeasiblePlugins(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroupInfo fwk.PodGroupInfo) *fwk.Status
+	RunPlacementFeasiblePlugins(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroupInfo fwk.PodGroupInfo, placementFeasibleArgs PlacementFeasibleArgs) *fwk.Status
 
 	// AddWaitingPod creates a waiting pod instance and adds it to the framework.
 	// It takes the pluginsWaitTime map returned by the RunPermitPlugins.

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
@@ -238,32 +238,10 @@ func (pl *GangScheduling) Permit(ctx context.Context, state fwk.CycleState, pod 
 	return nil, 0
 }
 
-const placementFeasibleStateKey = "PlacementFeasible" + Name
-
-type placementFeasibleState struct {
-	evaluated, succeeded int
-}
-
-func (s *placementFeasibleState) Clone() fwk.StateData {
-	return &placementFeasibleState{
-		evaluated: s.evaluated,
-		succeeded: s.succeeded,
-	}
-}
-
-func getPlacementFeasibleState(placementCycleState fwk.PlacementCycleState) *placementFeasibleState {
-	state, err := placementCycleState.Read(placementFeasibleStateKey)
-	if err != nil {
-		state = &placementFeasibleState{}
-		placementCycleState.Write(placementFeasibleStateKey, state)
-	}
-	return state.(*placementFeasibleState)
-}
-
 // PlacementFeasible is responsible for enforcing the gang's MinCount constraint in the pod group scheduling cycle.
 // The function will only return success once the gang's MinCount is satisfied or if the pod group is not using gang scheduling policy.
 // In case there are not enough remaining pods to satisfy the gang's MinCount, it returns Unschedulable which will terminate the pod group scheduling cycle early.
-func (pl *GangScheduling) PlacementFeasible(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroupInfo fwk.PodGroupInfo) *fwk.Status {
+func (pl *GangScheduling) PlacementFeasible(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroupInfo fwk.PodGroupInfo, args framework.PlacementFeasibleArgs) *fwk.Status {
 	pg := podGroupInfo.GetPodGroup()
 
 	gangPolicy := pg.Spec.SchedulingPolicy.Gang
@@ -277,12 +255,8 @@ func (pl *GangScheduling) PlacementFeasible(ctx context.Context, placementCycleS
 		return fwk.AsStatus(fmt.Errorf("failed to get podGroup state for podGroup %s to compute gang feasibility: %w", klog.KObj(pg), err))
 	}
 
-	// We need to keep track of how many pods have already been evaluated in the current PodGroup scheduling cycle.
-	pgState := getPlacementFeasibleState(placementCycleState)
-	pgState.evaluated++
-
 	// remaining is the number of unscheduled pods that haven't been evaluated yet in the current PodGroup scheduling cycle.
-	remaining := len(podGroupInfo.GetUnscheduledPods()) - pgState.evaluated
+	remaining := len(podGroupInfo.GetUnscheduledPods()) - args.Evaluated
 
 	// scheduled includes the pods that are assigned or assumed in the current PodGroup scheduling cycle.
 	scheduled := podGroupState.ScheduledPodsCount()

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -735,7 +735,7 @@ func TestPlacementFeasible(t *testing.T) {
 					mockState.scheduledPodsCount++
 				}
 
-				gotStatus := pl.PlacementFeasible(ctx, cycleState, pgInfo)
+				gotStatus := pl.PlacementFeasible(ctx, cycleState, pgInfo, schedulerframework.PlacementFeasibleArgs{Evaluated: i + 1})
 
 				if gotCode := gotStatus.Code(); gotCode != tc.expectedStatuses[i] {
 					t.Errorf("Step %d: expected status %v, got %v", i, tc.expectedStatuses[i], gotCode)

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -2073,14 +2073,14 @@ func (f *frameworkImpl) runPermitPlugin(ctx context.Context, pl fwk.PermitPlugin
 // If any plugin returns invalid status, the result will be Error and the remaining plugins won't be invoked.
 // Otherwise, if at least 1 plugin returns Unschedulable, the remaining plugins won't be invoked and the result will be Unschedulable.
 // Otherwise, if at least 1 plugin returns Wait, the remaining plugins will be invoked and the result will be Wait.
-func (f *frameworkImpl) RunPlacementFeasiblePlugins(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroupInfo fwk.PodGroupInfo) (status *fwk.Status) {
+func (f *frameworkImpl) RunPlacementFeasiblePlugins(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroupInfo fwk.PodGroupInfo, args framework.PlacementFeasibleArgs) (status *fwk.Status) {
 	startTime := time.Now()
 	defer func() {
 		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PlacementFeasible, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
 	}()
 
 	for _, pl := range f.placementFeasiblePlugins {
-		plStatus := f.runPlacementFeasiblePlugin(ctx, pl, placementCycleState, podGroupInfo)
+		plStatus := f.runPlacementFeasiblePlugin(ctx, pl, placementCycleState, podGroupInfo, args)
 		if plStatus.IsSuccess() {
 			continue
 		}
@@ -2100,12 +2100,12 @@ func (f *frameworkImpl) RunPlacementFeasiblePlugins(ctx context.Context, placeme
 	return status
 }
 
-func (f *frameworkImpl) runPlacementFeasiblePlugin(ctx context.Context, pl framework.PlacementFeasiblePlugin, state fwk.PlacementCycleState, podGroup fwk.PodGroupInfo) *fwk.Status {
+func (f *frameworkImpl) runPlacementFeasiblePlugin(ctx context.Context, pl framework.PlacementFeasiblePlugin, state fwk.PlacementCycleState, podGroup fwk.PodGroupInfo, args framework.PlacementFeasibleArgs) *fwk.Status {
 	if !state.ShouldRecordPluginMetrics() {
-		return pl.PlacementFeasible(ctx, state, podGroup)
+		return pl.PlacementFeasible(ctx, state, podGroup, args)
 	}
 	startTime := time.Now()
-	status := pl.PlacementFeasible(ctx, state, podGroup)
+	status := pl.PlacementFeasible(ctx, state, podGroup, args)
 	f.metricsRecorder.ObservePluginDurationAsync(metrics.PlacementFeasible, pl.Name(), status.Code().String(), metrics.SinceInSeconds(startTime))
 	return status
 }

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -229,7 +229,7 @@ func (pl *TestPlugin) PreFilter(ctx context.Context, state fwk.CycleState, p *v1
 	return pl.inj.PreFilterResult, fwk.NewStatus(fwk.Code(pl.inj.PreFilterStatus), injectReason)
 }
 
-func (pl *TestPlugin) PlacementFeasible(ctx context.Context, state fwk.PlacementCycleState, podGroup fwk.PodGroupInfo) *fwk.Status {
+func (pl *TestPlugin) PlacementFeasible(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroup fwk.PodGroupInfo, args framework.PlacementFeasibleArgs) *fwk.Status {
 	return fwk.NewStatus(fwk.Code(pl.inj.PlacementFeasibleStatus), injectReason)
 }
 
@@ -781,7 +781,7 @@ type mockGangSchedulingWithPlacementFeasible struct {
 	mockGangScheduling
 }
 
-func (p *mockGangSchedulingWithPlacementFeasible) PlacementFeasible(_ context.Context, _ fwk.PlacementCycleState, _ fwk.PodGroupInfo) *fwk.Status {
+func (p *mockGangSchedulingWithPlacementFeasible) PlacementFeasible(_ context.Context, _ fwk.PlacementCycleState, _ fwk.PodGroupInfo, _ framework.PlacementFeasibleArgs) *fwk.Status {
 	return nil
 }
 
@@ -1194,7 +1194,7 @@ type mockPlacementFeasiblePlugin struct {
 
 func (p *mockPlacementFeasiblePlugin) Name() string { return p.name }
 
-func (p *mockPlacementFeasiblePlugin) PlacementFeasible(ctx context.Context, state fwk.PlacementCycleState, podGroup fwk.PodGroupInfo) *fwk.Status {
+func (p *mockPlacementFeasiblePlugin) PlacementFeasible(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroup fwk.PodGroupInfo, args framework.PlacementFeasibleArgs) *fwk.Status {
 	p.called = true
 	return p.status
 }
@@ -1281,7 +1281,7 @@ func TestRunPlacementFeasiblePlugins(t *testing.T) {
 				f.placementFeasiblePlugins[i] = p
 			}
 
-			status := f.RunPlacementFeasiblePlugins(ctx, framework.NewCycleState(), nil)
+			status := f.RunPlacementFeasiblePlugins(ctx, framework.NewCycleState(), nil, framework.PlacementFeasibleArgs{})
 
 			if diff := cmp.Diff(tc.expectedStatus, status, statusCmpOpts...); diff != "" {
 				t.Errorf("Unexpected status (-want, +got):\n%s", diff)
@@ -4073,7 +4073,7 @@ func TestRecordingMetrics(t *testing.T) {
 		{
 			name: "PlacementFeasible - Success",
 			action: func(ctx context.Context, f framework.Framework) {
-				f.RunPlacementFeasiblePlugins(ctx, state, nil)
+				f.RunPlacementFeasiblePlugins(ctx, state, nil, framework.PlacementFeasibleArgs{})
 			},
 			wantExtensionPoint: "PlacementFeasible",
 			wantStatus:         fwk.Success,
@@ -4158,7 +4158,7 @@ func TestRecordingMetrics(t *testing.T) {
 		{
 			name: "PlacementFeasible - Error",
 			action: func(ctx context.Context, f framework.Framework) {
-				f.RunPlacementFeasiblePlugins(ctx, state, nil)
+				f.RunPlacementFeasiblePlugins(ctx, state, nil, framework.PlacementFeasibleArgs{})
 			},
 			inject:             injectedResult{PlacementFeasibleStatus: int(fwk.Error)},
 			wantExtensionPoint: "PlacementFeasible",

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -331,6 +331,26 @@ func (sched *Scheduler) podGroupSchedulingDefaultAlgorithm(ctx context.Context, 
 	logger := klog.FromContext(ctx)
 	logger.V(5).Info("Running a pod group scheduling algorithm", "podGroup", klog.KObj(podGroupInfo), "unscheduledPodsCount", len(podGroupInfo.QueuedPodInfos))
 
+	// Run PlacementFeasible plugins to check if the pod group can meet its constraints
+	// before even attempting to schedule any pods.
+	placementFeasibleArgs := framework.PlacementFeasibleArgs{
+		Evaluated: 0,
+	}
+	placementFeasibleStatus := schedFwk.RunPlacementFeasiblePlugins(ctx, placementCycleState, podGroupInfo, placementFeasibleArgs)
+	result.status = placementFeasibleStatus
+	if placementFeasibleStatus.IsError() {
+		// Do not evaluate any pods if PlacementFeasible plugins return error or unexpected status.
+		result.status = fwk.AsStatus(fmt.Errorf("failed to evaluate placement feasibility: %w", placementFeasibleStatus.AsError()))
+		return result
+	}
+	if placementFeasibleStatus.Code() == fwk.Unschedulable {
+		// Unschedulable from PlacementFeasible plugins indicates that the pod group
+		// cannot meet its constraints, even if we succeed in scheduling all the pods.
+		// Exit early from the pod group algorithm.
+		result.status = fwk.NewStatus(fwk.Unschedulable, result.status.Reasons()...)
+		return result
+	}
+
 	requiresPreemption := false
 	anyScheduled := false
 	for _, podInfo := range podGroupInfo.QueuedPodInfos {
@@ -348,12 +368,11 @@ func (sched *Scheduler) podGroupSchedulingDefaultAlgorithm(ctx context.Context, 
 			break
 		}
 
-		// PlacementFeasible plugins check if the pod group can meet its constraints.
-		// Those plugins need to be run after each pod is scheduled.
-		placementFeasibleStatus := schedFwk.RunPlacementFeasiblePlugins(ctx, placementCycleState, podGroupInfo)
-
+		// Check if the pod group can still meet its constraints after scheduling the current pod.
+		placementFeasibleArgs.Evaluated++
+		placementFeasibleStatus := schedFwk.RunPlacementFeasiblePlugins(ctx, placementCycleState, podGroupInfo, placementFeasibleArgs)
 		if placementFeasibleStatus.IsError() {
-			// When the algorithm returns error or unexpected status, stop evaluating the rest of the pods.
+			// Stop evaluating the rest of the pods if PlacementFeasible plugins return error or unexpected status.
 			result.status = fwk.AsStatus(fmt.Errorf("failed to evaluate placement feasibility: %w", placementFeasibleStatus.AsError()))
 			break
 		}

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -110,16 +110,6 @@ func (mp *fakePodGroupPlugin) PodGroupPostFilter(ctx context.Context, pgInfo fwk
 	return &framework.PodGroupPostFilterResult{NominatedNodeNames: n}, mp.podGroupPostFilterStatus
 }
 
-type fakePlacementFeasibleState struct {
-	podCount int
-}
-
-func (s *fakePlacementFeasibleState) Clone() fwk.StateData {
-	return &fakePlacementFeasibleState{podCount: s.podCount}
-}
-
-const fakePlacementFeasibleStateKey fwk.StateKey = "fakePlacementFeasibleState"
-
 type fakePlacementFeasiblePlugin struct {
 	placementFeasibleStatuses [][]fwk.Code
 	placementCount            int
@@ -138,29 +128,17 @@ func (mp *fakePlacementFeasiblePlugin) Name() string {
 // The mock uses a 2D slice (placementFeasibleStatuses) where:
 // - The outer slice represents distinct placements (e.g., when evaluating multiple topology placements).
 // - The inner slice represents the pod-by-pod evaluation within a single placement.
-// It uses placementCycleState to track how many pods have been evaluated in the current placement.
-func (mp *fakePlacementFeasiblePlugin) PlacementFeasible(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroupInfo fwk.PodGroupInfo) *fwk.Status {
+func (mp *fakePlacementFeasiblePlugin) PlacementFeasible(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroupInfo fwk.PodGroupInfo, args framework.PlacementFeasibleArgs) *fwk.Status {
 	// If no mock statuses are configured, always succeed.
 	if len(mp.placementFeasibleStatuses) == 0 {
 		return nil
 	}
 
-	// Each placement gets a new placementCycleState. Check if this state has been initialized.
-	stateData, err := placementCycleState.Read(fakePlacementFeasibleStateKey)
-	if err != nil {
-		// We haven't considered this placement before (this is the first pod evaluated in this placement).
-		// Initialize the state and increment the placement count.
-		stateData = &fakePlacementFeasibleState{podCount: 0}
-		placementCycleState.Write(fakePlacementFeasibleStateKey, stateData)
+	if args.Evaluated == 0 {
 		mp.placementCount++
 	}
 
-	// Increment the count of pods evaluated for the current placement attempt.
-	state := stateData.(*fakePlacementFeasibleState)
-	state.podCount++
-
 	placementIndex := mp.placementCount - 1
-	podIndex := state.podCount - 1
 
 	// Ensure the indices are within the bounds of the injected statuses.
 	if placementIndex < len(mp.placementFeasibleStatuses) {
@@ -168,8 +146,8 @@ func (mp *fakePlacementFeasiblePlugin) PlacementFeasible(ctx context.Context, pl
 		if len(mp.placementFeasibleStatuses[placementIndex]) == 0 {
 			return nil
 		}
-		if podIndex < len(mp.placementFeasibleStatuses[placementIndex]) {
-			code := mp.placementFeasibleStatuses[placementIndex][podIndex]
+		if args.Evaluated < len(mp.placementFeasibleStatuses[placementIndex]) {
+			code := mp.placementFeasibleStatuses[placementIndex][args.Evaluated]
 			if code == fwk.Success {
 				return nil
 			}
@@ -771,6 +749,28 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 			},
 		},
 		{
+			name: "All pods feasible, podGroup already meeting quorum before any pod is evaluated",
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p1": nil,
+					"p2": nil,
+					"p3": nil,
+				},
+			},
+			podGroupFeasibleStatuses: []fwk.Code{
+				fwk.Success,
+				fwk.Success,
+				fwk.Success,
+				fwk.Success,
+			},
+			expectedGroupStatusCode: fwk.Success,
+			expectedPodStatus: map[string]*fwk.Status{
+				"p1": nil,
+				"p2": nil,
+				"p3": nil,
+			},
+		},
+		{
 			name: "All pods feasible, podGroup schedulable with 3 schedulable pods",
 			plugin: &fakePodGroupPlugin{
 				filterStatus: map[string]*fwk.Status{
@@ -780,6 +780,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 				},
 			},
 			podGroupFeasibleStatuses: []fwk.Code{
+				fwk.Wait,
 				fwk.Wait,
 				fwk.Wait,
 				fwk.Success,
@@ -804,6 +805,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 				fwk.Wait,
 				fwk.Wait,
 				fwk.Wait,
+				fwk.Wait,
 			},
 			expectedGroupStatusCode: fwk.Unschedulable,
 			expectedPodStatus: map[string]*fwk.Status{
@@ -822,6 +824,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 				},
 			},
 			podGroupFeasibleStatuses: []fwk.Code{
+				fwk.Wait,
 				fwk.Unschedulable,
 			},
 			expectedGroupStatusCode: fwk.Unschedulable,
@@ -840,6 +843,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 				},
 			},
 			podGroupFeasibleStatuses: []fwk.Code{
+				fwk.Wait,
 				fwk.Wait,
 				fwk.Unschedulable,
 			},
@@ -901,6 +905,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 			podGroupFeasibleStatuses: []fwk.Code{
 				fwk.Wait,
 				fwk.Wait,
+				fwk.Wait,
 				fwk.Success,
 			},
 			expectedGroupStatusCode:          fwk.Unschedulable,
@@ -960,6 +965,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 				},
 			},
 			podGroupFeasibleStatuses: []fwk.Code{
+				fwk.Wait,
 				fwk.Success,
 				fwk.Success,
 				fwk.Success,
@@ -997,6 +1003,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 				},
 			},
 			podGroupFeasibleStatuses: []fwk.Code{
+				fwk.Wait,
 				fwk.Success,
 				fwk.Error,
 			},
@@ -1005,6 +1012,40 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 				"p1": nil,
 				"p2": nil,
 				// The algorithm stopped evaluating the pods after an error occurred, so a "p3" status is not expected.
+			},
+		},
+		{
+			name: "First placementFeasible call returned Unschedulable",
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p1": nil,
+					"p2": nil,
+					"p3": nil,
+				},
+			},
+			podGroupFeasibleStatuses: []fwk.Code{
+				fwk.Unschedulable,
+			},
+			expectedGroupStatusCode: fwk.Unschedulable,
+			expectedPodStatus:       map[string]*fwk.Status{
+				// The algorithm didn't evaluate any pods whatsoever because the first call to PlacementFeasible Plugin returned Unschedulable.
+			},
+		},
+		{
+			name: "First placementFeasible call returned Error",
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p1": nil,
+					"p2": nil,
+					"p3": nil,
+				},
+			},
+			podGroupFeasibleStatuses: []fwk.Code{
+				fwk.Error,
+			},
+			expectedGroupStatusCode: fwk.Error,
+			expectedPodStatus:       map[string]*fwk.Status{
+				// The algorithm didn't evaluate any pods whatsoever because the first call to PlacementFeasible Plugin returned Error.
 			},
 		},
 		{
@@ -1039,6 +1080,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 				},
 			},
 			podGroupFeasibleStatuses: []fwk.Code{
+				fwk.Wait,
 				fwk.Success,
 				fwk.Error,
 			},
@@ -2297,8 +2339,8 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 				},
 			},
 			placementFeasibleStatuses: [][]fwk.Code{
-				{fwk.Unschedulable},
-				{fwk.Unschedulable},
+				{fwk.Wait, fwk.Unschedulable},
+				{fwk.Wait, fwk.Unschedulable},
 			},
 			expectedResult: podGroupAlgorithmResult{
 				podResults: []algorithmResult{
@@ -2357,8 +2399,8 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 				},
 			},
 			placementFeasibleStatuses: [][]fwk.Code{
-				{fwk.Success},       // placement1
-				{fwk.Unschedulable}, // placement2
+				{fwk.Wait, fwk.Success},       // placement1
+				{fwk.Wait, fwk.Unschedulable}, // placement2
 			},
 			expectedResult: podGroupAlgorithmResult{
 				podResults: []algorithmResult{


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This change changes the `PlacementFeasiblePlugin` interface and starts running plugins from this extension point before evaluating any Pod in the Pod group scheduling cycle.

#### Which issue(s) this PR is related to:

No issue is opened for that.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
