### PR TITLE
fix(kubelet): parallelize container kills in SyncPod

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	cadvisorapi "github.com/google/cadvisor/lib/model"
@@ -1484,13 +1485,33 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 		}
 	} else {
 		// Step 3: kill any running containers in this pod which are not to keep.
-		for containerID, containerInfo := range podContainerChanges.ContainersToKill {
-			logger.V(3).Info("Killing unwanted container for pod", "containerName", containerInfo.name, "containerID", containerID, "pod", klog.KObj(pod))
-			killContainerResult := kubecontainer.NewSyncResult(kubecontainer.KillContainer, containerInfo.name)
-			result.AddSyncResult(killContainerResult)
-			if err := m.killContainer(ctx, pod, containerID, containerInfo.name, containerInfo.message, containerInfo.reason, nil, nil); err != nil {
-				killContainerResult.Fail(kubecontainer.ErrKillContainer, err.Error())
-				logger.Error(err, "killContainer for pod failed", "containerName", containerInfo.name, "containerID", containerID, "pod", klog.KObj(pod))
+		if len(podContainerChanges.ContainersToKill) > 0 {
+			var wg sync.WaitGroup
+			var errs []error
+			var errsMu sync.Mutex
+
+			for containerID, containerInfo := range podContainerChanges.ContainersToKill {
+				logger.V(3).Info("Killing unwanted container for pod", "containerName", containerInfo.name, "containerID", containerID, "pod", klog.KObj(pod))
+				killContainerResult := kubecontainer.NewSyncResult(kubecontainer.KillContainer, containerInfo.name)
+				result.AddSyncResult(killContainerResult)
+
+				wg.Add(1)
+				go func(cID kubecontainer.ContainerID, cInfo containerToKillInfo, kr *kubecontainer.SyncResult) {
+					defer utilruntime.HandleCrashWithContext(ctx)
+					defer wg.Done()
+
+					if err := m.killContainer(ctx, pod, cID, cInfo.name, cInfo.message, cInfo.reason, nil, nil); err != nil {
+						kr.Fail(kubecontainer.ErrKillContainer, err.Error())
+						logger.Error(err, "killContainer for pod failed", "containerName", cInfo.name, "containerID", cID, "pod", klog.KObj(pod))
+						
+						errsMu.Lock()
+						errs = append(errs, err)
+						errsMu.Unlock()
+					}
+				}(containerID, containerInfo, killContainerResult)
+			}
+			wg.Wait()
+			if len(errs) > 0 {
 				return
 			}
 		}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -62,8 +62,10 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	proberesults "k8s.io/kubernetes/pkg/kubelet/prober/results"
 	"k8s.io/kubernetes/test/utils/ktesting"
+	internalapi "k8s.io/cri-api/pkg/apis"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
+	"sync"
 )
 
 var (
@@ -755,6 +757,119 @@ func TestSyncPodWithConvertedPodSysctls(t *testing.T) {
 		assert.Equal(t, runtimeapi.ContainerState_CONTAINER_RUNNING, c.State)
 	}
 }
+
+func TestSyncPodParallelKill(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	fakeRuntime, _, m, err := createTestRuntimeManager(tCtx)
+	assert.NoError(t, err)
+
+	// 1. Create a pod with two containers
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "12345678",
+			Name:      "foo",
+			Namespace: "new",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:            "c1",
+					Image:           "busybox",
+					ImagePullPolicy: v1.PullIfNotPresent,
+				},
+				{
+					Name:            "c2",
+					Image:           "alpine",
+					ImagePullPolicy: v1.PullIfNotPresent,
+				},
+			},
+		},
+	}
+
+	// 2. Start the containers
+	backOff := flowcontrol.NewBackOff(time.Second, time.Minute)
+	result := m.SyncPod(tCtx, pod, &kubecontainer.PodStatus{}, []v1.Secret{}, backOff, false)
+	assert.NoError(t, result.Error())
+	assert.Len(t, fakeRuntime.Containers, 2)
+
+	// Get the started container statuses/IDs
+	runtimePod, err := m.GetPod(tCtx, pod.UID)
+	assert.NoError(t, err)
+	podStatus, err := m.GetPodStatus(tCtx, runtimePod)
+	assert.NoError(t, err)
+	assert.Len(t, podStatus.ContainerStatuses, 2)
+	
+	c1ID := podStatus.ContainerStatuses[0].ID
+	c2ID := podStatus.ContainerStatuses[1].ID
+
+	// 3. Mark both containers as having failed their liveness probes
+	m.livenessManager.Set(c1ID, proberesults.Failure, pod)
+	m.livenessManager.Set(c2ID, proberesults.Failure, pod)
+
+	// 4. Wrap the runtimeService to monitor and block StopContainer calls
+	stopChan := make(chan string, 2)
+	var stopWg sync.WaitGroup
+	stopWg.Add(2)
+
+	concurrentService := &concurrentStopRuntimeService{
+		RuntimeService:    m.runtimeService,
+		stopContainerChan: stopChan,
+		wg:                &stopWg,
+	}
+	m.runtimeService = concurrentService
+
+	// 5. Run SyncPod again in a separate goroutine (as it will block on StopContainer calls)
+	syncPodDone := make(chan struct{})
+	go func() {
+		defer close(syncPodDone)
+		// We pass the podStatus computed above so computePodActions knows they are running
+		m.SyncPod(tCtx, pod, podStatus, []v1.Secret{}, backOff, false)
+	}()
+
+	// 6. Wait to receive both container IDs on stopChan.
+	// If the kills were sequential, the first call would block on stopWg.Wait()
+	// and we would never receive the second container ID here (causing a deadlock/timeout).
+	// Because they are parallel, both calls enter StopContainer concurrently.
+	var stoppedContainers []string
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+
+	for i := 0; i < 2; i++ {
+		select {
+		case id := <-stopChan:
+			stoppedContainers = append(stoppedContainers, id)
+		case <-timer.C:
+			t.Fatal("Timeout waiting for parallel StopContainer calls. This indicates sequential execution or deadlock.")
+		}
+	}
+
+	// Unblock the StopContainer calls
+	stopWg.Done()
+	stopWg.Done()
+
+	// Wait for SyncPod to finish
+	select {
+	case <-syncPodDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timeout waiting for SyncPod to complete after unblocking.")
+	}
+
+	assert.ElementsMatch(t, []string{c1ID.ID, c2ID.ID}, stoppedContainers)
+}
+
+type concurrentStopRuntimeService struct {
+	internalapi.RuntimeService
+	stopContainerChan chan string
+	wg                *sync.WaitGroup
+}
+
+func (c *concurrentStopRuntimeService) StopContainer(ctx context.Context, containerID string, timeout int64) error {
+	c.stopContainerChan <- containerID
+	c.wg.Wait()
+	return c.RuntimeService.StopContainer(ctx, containerID, timeout)
+}
+
+
 
 func TestPruneInitContainers(t *testing.T) {
 	tCtx := ktesting.Init(t)


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When multiple containers in a pod fail their liveness or startup probes within a single sync loop iteration, kubelet's SyncPod kills them sequentially. Each killContainer call blocks for up to terminationGracePeriodSeconds (default 30s), stalling the entire sync loop and preventing replacement containers from starting until every failed container has finished its graceful shutdown.

This creates an unnecessary linear delay: for N failed containers, total restart time scales as O(N × gracePeriod) instead of O(gracePeriod).

This commit parallelizes Step 3 of SyncPod (killing containers not to keep) using goroutines and sync.WaitGroup, matching the existing concurrency pattern already used for whole-pod termination in killContainersWithSyncResult. All containers begin their graceful shutdown concurrently, and if any kill fails, SyncPod returns after all goroutines complete.

#### Test plan

Added TestSyncPodParallelKill in kuberuntime_manager_test.go that:
1. Creates a pod with two containers and starts them via SyncPod
2. Marks both containers as liveness-probe-failed
3. Wraps the RuntimeService to capture StopContainer calls and block them
4. Runs SyncPod in a separate goroutine
5. Verifies both StopContainer calls arrive concurrently (before either returns)
6. Unblocks both calls and confirms SyncPod completes without error

Run with: `go test -v -run TestSyncPodParallelKill ./pkg/kubelet/kuberuntime/`

#### Which issue(s) this PR fixes:

Fixes #138146

#### Special notes for your reviewer:

- 2 files changed: 1 production file (pkg/kubelet/kuberuntime/kuberuntime_manager.go), 1 test file (kuberuntime_manager_test.go)
- The concurrency pattern (goroutine + WaitGroup + error collection under mutex) is identical to killContainersWithSyncResult in the same package
- No feature gate required — this is a performance fix, not a new feature
- No behavioral change when ContainersToKill has 0 or 1 entries

#### Does this PR introduce a user-facing change?

```release-note
kubelet: parallelize container kills in SyncPod so that when multiple containers fail health checks simultaneously, all are killed concurrently rather than sequentially. This eliminates the cumulative grace-period delay and allows replacement containers to start immediately.