### PR TITLE
Mark newly NodeConformance-tagged resize/restart/device-plugin tests as Slow

### DIFF
--- a/test/e2e/common/node/container_restart_policy.go
+++ b/test/e2e/common/node/container_restart_policy.go
@@ -173,7 +173,7 @@ var _ = SIGDescribe("Pod Extended (container restart policy)", framework.WithNod
 	})
 })
 
-var _ = SIGDescribe("Pod Extended (RestartAllContainers)", framework.WithNodeConformance(), framework.WithFeatureGate(features.ContainerRestartRules), framework.WithFeatureGate(features.RestartAllContainersOnContainerExits), func() {
+var _ = SIGDescribe("Pod Extended (RestartAllContainers)", framework.WithSlow(), framework.WithNodeConformance(), framework.WithFeatureGate(features.ContainerRestartRules), framework.WithFeatureGate(features.RestartAllContainersOnContainerExits), func() {
 	f := framework.NewDefaultFramework("pods")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 

--- a/test/e2e/common/node/pod_level_resources_resize.go
+++ b/test/e2e/common/node/pod_level_resources_resize.go
@@ -437,7 +437,7 @@ func doBurstablePodLevelResizeTests(f *framework.Framework) {
 	)
 }
 
-var _ = SIGDescribe("PLR Pod InPlace Resize", framework.WithNodeConformance(), framework.WithFeatureGate(features.InPlacePodLevelResourcesVerticalScaling), func() {
+var _ = SIGDescribe("PLR Pod InPlace Resize", framework.WithSlow(), framework.WithNodeConformance(), framework.WithFeatureGate(features.InPlacePodLevelResourcesVerticalScaling), func() {
 	f := framework.NewDefaultFramework("pod-level-resources-resize-tests")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 	ginkgo.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -879,7 +879,7 @@ var _ = SIGDescribe("Pod InPlace Resize Container", func() {
 	doPodResizeMemoryLimitDecreaseTest(f)
 })
 
-var _ = SIGDescribe("Pod InPlace Resize Init Container", framework.WithNodeConformance(), framework.WithFeatureGate(features.InPlacePodVerticalScalingInitContainers), func() {
+var _ = SIGDescribe("Pod InPlace Resize Init Container", framework.WithSlow(), framework.WithNodeConformance(), framework.WithFeatureGate(features.InPlacePodVerticalScalingInitContainers), func() {
 	f := framework.NewDefaultFramework("pod-resize-tests")
 
 	ginkgo.BeforeEach(func(ctx context.Context) {

--- a/test/e2e_node/device_plugin_failures_pod_status_test.go
+++ b/test/e2e_node/device_plugin_failures_pod_status_test.go
@@ -39,7 +39,7 @@ import (
 	"k8s.io/kubernetes/test/e2e_node/testdeviceplugin"
 )
 
-var _ = SIGDescribe("Device Plugin Failures Pod Status", framework.WithNodeConformance(), framework.WithFeatureGate(features.ResourceHealthStatus), func() {
+var _ = SIGDescribe("Device Plugin Failures Pod Status", framework.WithSlow(), framework.WithNodeConformance(), framework.WithFeatureGate(features.ResourceHealthStatus), func() {
 	f := framework.NewDefaultFramework("device-plugin-failures")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 


### PR DESCRIPTION
#### What type of PR is this?

/kind regression

#### What this PR does / why we need it:

`ci-kubernetes-node-e2e-containerd` runtime jumped from ~35m to ~55-67m
starting 2026-06-26, close to its 65m kubetest timeout and already
causing intermittent `kubetest.Timeout` failures.

Root cause: #140023 added `framework.WithNodeConformance()` to four
`SIGDescribe` blocks (PLR Pod InPlace Resize, Pod InPlace Resize Init
Container, Pod Extended container restart policy/RestartAllContainers,
Device Plugin Failures Pod Status). The job focuses on
`[NodeConformance]` and only skips `Flaky|Slow|Serial`, so these tests
started running there unconditionally, adding the extra ~20-30 minutes.

This PR adds `framework.WithSlow()` to the same four blocks so the
job's existing skip filter excludes them again, restoring prior
runtime, while keeping them running under jobs that don't skip `Slow`.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This PR was written in part with the assistance of generative AI (used
to analyze the TestGrid duration graph, bisect the regression to
#140023, and draft the `WithSlow()` edits). I reviewed and verified all
changes myself (`go build`, `gofmt`) before submitting.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
