### PR TITLE
kubelet: log StaticPodURLHeader key names only, not values

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -370,11 +370,13 @@ func newCrashLoopBackOff(kubeCfg *kubeletconfiginternal.KubeletConfiguration) (t
 func makePodSourceConfig(ctx context.Context, kubeCfg *kubeletconfiginternal.KubeletConfiguration, kubeDeps *Dependencies, nodeName types.NodeName, nodeHasSynced func() bool) (*config.PodConfig, error) {
 	logger := klog.FromContext(ctx)
 	manifestURLHeader := make(http.Header)
+	var manifestURLHeaderKeys []string
 	if len(kubeCfg.StaticPodURLHeader) > 0 {
 		for k, v := range kubeCfg.StaticPodURLHeader {
 			for i := range v {
 				manifestURLHeader.Add(k, v[i])
 			}
+			manifestURLHeaderKeys = append(manifestURLHeaderKeys, k)
 		}
 	}
 
@@ -389,7 +391,7 @@ func makePodSourceConfig(ctx context.Context, kubeCfg *kubeletconfiginternal.Kub
 
 	// define url config source
 	if kubeCfg.StaticPodURL != "" {
-		logger.Info("Adding pod URL with HTTP header", "URL", kubeCfg.StaticPodURL, "header", manifestURLHeader)
+		logger.Info("Adding pod URL with HTTP headers", "URL", kubeCfg.StaticPodURL, "header", manifestURLHeaderKeys)
 		config.NewSourceURL(logger, kubeCfg.StaticPodURL, manifestURLHeader, nodeName, kubeCfg.HTTPCheckFrequency.Duration, cfg.Channel(ctx, kubetypes.HTTPSource))
 	}
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -367,19 +367,30 @@ func newCrashLoopBackOff(kubeCfg *kubeletconfiginternal.KubeletConfiguration) (t
 
 // makePodSourceConfig creates a config.PodConfig from the given
 // KubeletConfiguration or returns an error.
+// staticPodURLHeaderAndKeys canonicalizes the StaticPodURLHeader config map
+// into an http.Header and a sorted slice of canonicalized header key names.
+func staticPodURLHeaderAndKeys(headers map[string][]string) (http.Header, []string) {
+	manifestURLHeader := make(http.Header)
+	if len(headers) > 0 {
+		for k, v := range headers {
+			for i := range v {
+				manifestURLHeader.Add(k, v[i]) // Add canonicalizes k internally
+			}
+		}
+	}
+	// Collect keys from the header after Add has canonicalized them,
+	// avoiding the need for a separate http.CanonicalHeaderKey call.
+	keys := make([]string, 0, len(manifestURLHeader))
+	for k := range manifestURLHeader {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return manifestURLHeader, keys
+}
+
 func makePodSourceConfig(ctx context.Context, kubeCfg *kubeletconfiginternal.KubeletConfiguration, kubeDeps *Dependencies, nodeName types.NodeName, nodeHasSynced func() bool) (*config.PodConfig, error) {
 	logger := klog.FromContext(ctx)
-	manifestURLHeader := make(http.Header)
-	var manifestURLHeaderKeys []string
-	if len(kubeCfg.StaticPodURLHeader) > 0 {
-		for k, v := range kubeCfg.StaticPodURLHeader {
-			for i := range v {
-				manifestURLHeader.Add(k, v[i])
-			}
-			manifestURLHeaderKeys = append(manifestURLHeaderKeys, http.CanonicalHeaderKey(k))
-		}
-		sort.Strings(manifestURLHeaderKeys)
-	}
+	manifestURLHeader, manifestURLHeaderKeys := staticPodURLHeaderAndKeys(kubeCfg.StaticPodURLHeader)
 
 	// source of all configuration
 	cfg := config.NewPodConfig(kubeDeps.Recorder, kubeDeps.PodStartupLatencyTracker)

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -365,8 +365,6 @@ func newCrashLoopBackOff(kubeCfg *kubeletconfiginternal.KubeletConfiguration) (t
 	return boMax, boInitial
 }
 
-// makePodSourceConfig creates a config.PodConfig from the given
-// KubeletConfiguration or returns an error.
 // staticPodURLHeaderAndKeys canonicalizes the StaticPodURLHeader config map
 // into an http.Header and a sorted slice of canonicalized header key names.
 func staticPodURLHeaderAndKeys(headers map[string][]string) (http.Header, []string) {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -376,8 +376,9 @@ func makePodSourceConfig(ctx context.Context, kubeCfg *kubeletconfiginternal.Kub
 			for i := range v {
 				manifestURLHeader.Add(k, v[i])
 			}
-			manifestURLHeaderKeys = append(manifestURLHeaderKeys, k)
+			manifestURLHeaderKeys = append(manifestURLHeaderKeys, http.CanonicalHeaderKey(k))
 		}
+		sort.Strings(manifestURLHeaderKeys)
 	}
 
 	// source of all configuration

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -122,7 +122,6 @@ import (
 	"k8s.io/kubernetes/pkg/volume/util/hostutil"
 	"k8s.io/kubernetes/pkg/volume/util/subpath"
 	"k8s.io/kubernetes/test/utils/ktesting"
-	"k8s.io/kubernetes/test/utils/ktesting/initoption"
 	"k8s.io/utils/clock"
 	testingclock "k8s.io/utils/clock/testing"
 )
@@ -5370,7 +5369,7 @@ func cleanUpTempDir(t *testing.T, tempDir, originalLogsDir string) {
 	require.NoError(t, err)
 }
 
-func TestMakePodSourceConfig_DoesNotLogHeaderValues(t *testing.T) {
+func TestStaticPodURLHeaderAndKeys(t *testing.T) {
 	const secretBearer = "Bearer static-pod-url-secret-must-not-leak"
 	const secretAPIKey = "super-secret-api-key-must-not-leak"
 
@@ -5381,13 +5380,13 @@ func TestMakePodSourceConfig_DoesNotLogHeaderValues(t *testing.T) {
 		wantAbsent []string
 	}{
 		{
-			name:       "Authorization bearer not leaked",
+			name:       "Authorization bearer not leaked in keys",
 			headers:    map[string][]string{"Authorization": {secretBearer}},
 			wantKeys:   []string{"Authorization"},
 			wantAbsent: []string{secretBearer},
 		},
 		{
-			name:       "multiple sensitive headers not leaked",
+			name:       "multiple sensitive headers not leaked in keys",
 			headers:    map[string][]string{"Authorization": {secretBearer}, "X-API-Key": {secretAPIKey}},
 			wantKeys:   []string{"Authorization", "X-Api-Key"}, // http.CanonicalHeaderKey: X-API-Key → X-Api-Key
 			wantAbsent: []string{secretBearer, secretAPIKey},
@@ -5402,33 +5401,14 @@ func TestMakePodSourceConfig_DoesNotLogHeaderValues(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			// Use buffered ktesting logger — same pattern as watchdog and nodeshutdown log tests.
-			tCtx := ktesting.Init(t, initoption.BufferLogs(true))
-			logger := tCtx.Logger()
-			ctx := klog.NewContext(tCtx, logger)
+			_, keys := staticPodURLHeaderAndKeys(tc.headers)
+			require.ElementsMatch(t, tc.wantKeys, keys)
 
-			kubeCfg := &kubeletconfiginternal.KubeletConfiguration{
-				StaticPodURL:       "http://127.0.0.1:1/static-pods.yaml",
-				StaticPodURLHeader: tc.headers,
-				HTTPCheckFrequency: metav1.Duration{Duration: time.Hour},
-			}
-			deps := &Dependencies{PodStartupLatencyTracker: kubeletutil.NewPodStartupLatencyTracker()}
-
-			_, err := makePodSourceConfig(ctx, kubeCfg, deps, "node-a", func() bool { return true })
-			require.NoError(t, err)
-
-			underlier, ok := logger.GetSink().(ktesting.Underlier)
-			require.True(t, ok, "expected ktesting Underlier sink, got %T", logger.GetSink())
-			logStr := underlier.GetBuffer().String()
-
+			// Verify no secret values appear in the keys.
+			keysStr := strings.Join(keys, " ")
 			for _, absent := range tc.wantAbsent {
-				if strings.Contains(logStr, absent) {
-					t.Fatalf("log contains %q which must not be present\nlogs: %s", absent, logStr)
-				}
-			}
-			for _, want := range tc.wantKeys {
-				if !strings.Contains(logStr, want) {
-					t.Fatalf("log does not contain expected header key %q\nlogs: %s", want, logStr)
+				if strings.Contains(keysStr, absent) {
+					t.Fatalf("header keys contain %q which must not be present\ngot keys: %v", absent, keys)
 				}
 			}
 		})

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -122,6 +122,7 @@ import (
 	"k8s.io/kubernetes/pkg/volume/util/hostutil"
 	"k8s.io/kubernetes/pkg/volume/util/subpath"
 	"k8s.io/kubernetes/test/utils/ktesting"
+	"k8s.io/kubernetes/test/utils/ktesting/initoption"
 	"k8s.io/utils/clock"
 	testingclock "k8s.io/utils/clock/testing"
 )
@@ -5367,4 +5368,69 @@ func cleanUpTempDir(t *testing.T, tempDir, originalLogsDir string) {
 		time.Sleep(100 * time.Millisecond)
 	}
 	require.NoError(t, err)
+}
+
+func TestMakePodSourceConfig_DoesNotLogHeaderValues(t *testing.T) {
+	const secretBearer = "Bearer static-pod-url-secret-must-not-leak"
+	const secretAPIKey = "super-secret-api-key-must-not-leak"
+
+	tests := []struct {
+		name       string
+		headers    map[string][]string
+		wantKeys   []string
+		wantAbsent []string
+	}{
+		{
+			name:       "Authorization bearer not leaked",
+			headers:    map[string][]string{"Authorization": {secretBearer}},
+			wantKeys:   []string{"Authorization"},
+			wantAbsent: []string{secretBearer},
+		},
+		{
+			name:       "multiple sensitive headers not leaked",
+			headers:    map[string][]string{"Authorization": {secretBearer}, "X-API-Key": {secretAPIKey}},
+			wantKeys:   []string{"Authorization", "X-Api-Key"}, // http.CanonicalHeaderKey: X-API-Key → X-Api-Key
+			wantAbsent: []string{secretBearer, secretAPIKey},
+		},
+		{
+			name:       "lowercase input canonicalized",
+			headers:    map[string][]string{"authorization": {secretBearer}},
+			wantKeys:   []string{"Authorization"},
+			wantAbsent: []string{secretBearer, "authorization"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Use buffered ktesting logger — same pattern as watchdog and nodeshutdown log tests.
+			tCtx := ktesting.Init(t, initoption.BufferLogs(true))
+			logger := tCtx.Logger()
+			ctx := klog.NewContext(tCtx, logger)
+
+			kubeCfg := &kubeletconfiginternal.KubeletConfiguration{
+				StaticPodURL:       "http://127.0.0.1:1/static-pods.yaml",
+				StaticPodURLHeader: tc.headers,
+				HTTPCheckFrequency: metav1.Duration{Duration: time.Hour},
+			}
+			deps := &Dependencies{PodStartupLatencyTracker: kubeletutil.NewPodStartupLatencyTracker()}
+
+			_, err := makePodSourceConfig(ctx, kubeCfg, deps, "node-a", func() bool { return true })
+			require.NoError(t, err)
+
+			underlier, ok := logger.GetSink().(ktesting.Underlier)
+			require.True(t, ok, "expected ktesting Underlier sink, got %T", logger.GetSink())
+			logStr := underlier.GetBuffer().String()
+
+			for _, absent := range tc.wantAbsent {
+				if strings.Contains(logStr, absent) {
+					t.Fatalf("log contains %q which must not be present\nlogs: %s", absent, logStr)
+				}
+			}
+			for _, want := range tc.wantKeys {
+				if !strings.Contains(logStr, want) {
+					t.Fatalf("log does not contain expected header key %q\nlogs: %s", want, logStr)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`makePodSourceConfig` logs the full `StaticPodURLHeader` values (including credentials like `Authorization: Bearer ...`) at default verbosity when kubelet starts. The field is tagged `datapolicy:"token"` and `marshalKubeletConfigForLog` already masks it with `<masked>`, but this code path copied the values into a plain `http.Header` and logged them directly, bypassing both protections.

This PR collects only the header key names and logs those instead, matching the existing mask pattern.

**Before:** `header map[Authorization:[Bearer secret]]`  
**After:** `header [Authorization]`

`NewSourceURL` still receives the full `manifestURLHeader` unchanged — only the log call is fixed.

Added `TestMakePodSourceConfig_DoesNotLogHeaderValues` as a regression test ensuring credential values never appear in logs again. Table-driven: single bearer, multiple headers, lowercase canonicalization.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/140132

#### Special notes for your reviewer:

Verified with a custom logr sink test: secret values are no longer present in log output. Full `go test ./pkg/kubelet/...` passes. Added a dedicated regression test covering single-bearer, multi-header, and lowercase-canonicalization cases.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where kubelet logged `--manifest-url-header` credential values (e.g., Authorization tokens) to runtime logs at startup. Only header key names are now logged.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
