### PR TITLE
resourceclaim: prevent duplicate ResourceClaim creation when informer lister falls behind during rapid Pod scale-out

### DIFF
--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -974,6 +974,28 @@ func (ec *Controller) handleClaim(ctx context.Context, pod *v1.Pod, podGroup *sc
 			}
 			logger.Error(err, "Claim that was created for the pod is no longer owned by the pod, creating a new one", "podClaim", podClaim.Name, "resourceClaim", claimName)
 		}
+
+		// When the informer lister is behind (e.g., during rapid Pod
+		// scale-out), the lister may not yet have observed the ResourceClaim
+		// create event. Normally the MutationCache covers this window, but
+		// with a large burst of claims (>100) the cache can evict the entry
+		// before the informer catches up. Directly query the API server as
+		// a final check before creating a new claim.
+		if claim == nil {
+			claim, err = ec.kubeClient.ResourceV1().ResourceClaims(pod.Namespace).Get(ctx, claimName, metav1.GetOptions{})
+			if err != nil && !apierrors.IsNotFound(err) {
+				return err
+			}
+			if claim != nil {
+				ec.claimCache.Mutation(claim)
+				if mustCheckOwner {
+					if err := resourceclaim.IsForPod(pod, claim, ec.features.WorkloadResourceClaims); err != nil {
+						return fmt.Errorf("claim %s is not for this pod: %w", claimName, err)
+					}
+				}
+				return nil
+			}
+		}
 	}
 
 	templateName := podClaim.ResourceClaimTemplateName


### PR DESCRIPTION

/kind bug

#### What this PR does / why we need it:

During rapid scale-out of DRA-enabled Pods (6000-10000), the ResourceClaim controller can create duplicate ResourceClaims for the same Pod.

**Root cause:** The controller uses two layers to check whether a claim already exists before creating one from a template:

1. The informer-based `claimLister` — may be behind if ResourceClaim events haven't been delivered yet
2. The `MutationCache` — a fixed-size (100 entries) write-through cache that covers the window between creating a claim and receiving its informer event

When more than 100 claims are created before any informer Add events arrive, the MutationCache evicts the oldest entries. After eviction, both the lister (still behind) and the cache (evicted) return NotFound, causing the controller to incorrectly create a second ResourceClaim.

**Fix:** When both the lister and mutation cache miss, and the pod status already references a claim name, do a direct API server GET as a final safety net before creating a new claim. If found, the claim is re-inserted into the MutationCache and the function returns early.

#### Which issue(s) this PR fixes:

Fixes #140217

#### Special notes for your reviewer:

- 1 file changed, 22 insertions in `pkg/controller/resourceclaim/controller.go`
- The fix only activates when: (1) the pod status has a claim name, (2) the lister returns NotFound, and (3) both caches miss
- `claimCache.Mutation()` on the direct GET result ensures future lookups hit the cache
- No behavioral change for the common case (lister or cache hit)
- Tested: all 84 existing tests pass (`go test ./pkg/controller/resourceclaim/ -v -count=1`)

#### Does this PR introduce a user-facing change?

```release-note
Fix a race condition in the DRA ResourceClaim controller where rapid creation of thousands of DRA-enabled Pods could cause duplicate ResourceClaim creation. The controller now performs a direct API server lookup when both the informer cache and mutation cache miss, preventing the duplicate.