### PR TITLE
scheduler: reduce scheduler PostFilter event noise

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -928,7 +928,7 @@ func (pl *DynamicResources) Filter(ctx context.Context, cs fwk.CycleState, pod *
 func (pl *DynamicResources) PostFilter(ctx context.Context, cs fwk.CycleState, pod *v1.Pod, filteredNodeStatusMap fwk.NodeToStatusReader) (*fwk.PostFilterResult, *fwk.Status) {
 	logger := klog.FromContext(ctx)
 	if !pl.enabled {
-		logger.V(5).Info("plugin disabled", "pod", klog.KObj(pod))
+		logger.V(5).Info("Nothing to do in PostFilter, plugin disabled", "pod", klog.KObj(pod))
 		return nil, fwk.NewStatus(fwk.Unschedulable)
 	}
 
@@ -939,7 +939,7 @@ func (pl *DynamicResources) PostFilter(ctx context.Context, cs fwk.CycleState, p
 	// If a Pod doesn't have any resource claims attached to it, there is no need for further processing.
 	// Thus we provide a fast path for this case to avoid unnecessary computations.
 	if state.claims.empty() {
-		logger.V(5).Info("no new claims to deallocate", "pod", klog.KObj(pod))
+		logger.V(5).Info("No new claims to deallocate", "pod", klog.KObj(pod))
 		return nil, fwk.NewStatus(fwk.Unschedulable)
 	}
 	extendedResourceClaim := state.claims.extendedResourceClaim()

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -926,11 +926,12 @@ func (pl *DynamicResources) Filter(ctx context.Context, cs fwk.CycleState, pod *
 // requests its deallocation.  This only gets called when filtering found no
 // suitable node.
 func (pl *DynamicResources) PostFilter(ctx context.Context, cs fwk.CycleState, pod *v1.Pod, filteredNodeStatusMap fwk.NodeToStatusReader) (*fwk.PostFilterResult, *fwk.Status) {
+	logger := klog.FromContext(ctx)
 	if !pl.enabled {
-		return nil, fwk.NewStatus(fwk.Unschedulable, "plugin disabled")
+		logger.V(5).Info("plugin disabled", "pod", klog.KObj(pod))
+		return nil, fwk.NewStatus(fwk.Unschedulable)
 	}
 
-	logger := klog.FromContext(ctx)
 	state, err := getStateData(cs)
 	if err != nil {
 		return nil, statusError(logger, err)
@@ -938,7 +939,8 @@ func (pl *DynamicResources) PostFilter(ctx context.Context, cs fwk.CycleState, p
 	// If a Pod doesn't have any resource claims attached to it, there is no need for further processing.
 	// Thus we provide a fast path for this case to avoid unnecessary computations.
 	if state.claims.empty() {
-		return nil, fwk.NewStatus(fwk.Unschedulable, "no new claims to deallocate")
+		logger.V(5).Info("no new claims to deallocate", "pod", klog.KObj(pod))
+		return nil, fwk.NewStatus(fwk.Unschedulable)
 	}
 	extendedResourceClaim := state.claims.extendedResourceClaim()
 
@@ -991,7 +993,7 @@ func (pl *DynamicResources) PostFilter(ctx context.Context, cs fwk.CycleState, p
 		}
 	}
 
-	return nil, fwk.NewStatus(fwk.Unschedulable, "still not schedulable")
+	return nil, fwk.NewStatus(fwk.Unschedulable)
 }
 
 func (pl *DynamicResources) unreservePodGroupClaims(ctx context.Context, pod *v1.Pod) *fwk.Status {

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -80,6 +80,27 @@ func init() {
 	metrics.InitMetrics()
 }
 
+func TestPostFilterNoOpStatusHasNoUserVisibleReason(t *testing.T) {
+	pod := st.MakePod().Name("pod").Namespace("default").Obj()
+
+	t.Run("plugin disabled", func(t *testing.T) {
+		_, status := (&DynamicResources{}).PostFilter(context.Background(), framework.NewCycleState(), pod, nil)
+
+		require.Equal(t, fwk.Unschedulable, status.Code())
+		assert.Empty(t, status.Reasons())
+	})
+
+	t.Run("no claims", func(t *testing.T) {
+		state := framework.NewCycleState()
+		state.Write(stateKey, &stateData{})
+
+		_, status := (&DynamicResources{enabled: true}).PostFilter(context.Background(), state, pod, nil)
+
+		require.Equal(t, fwk.Unschedulable, status.Code())
+		assert.Empty(t, status.Reasons())
+	})
+}
+
 var (
 	podKind      = v1.SchemeGroupVersion.WithKind("Pod")
 	podGroupKind = schedulingapi.SchemeGroupVersion.WithKind("PodGroup")
@@ -1396,7 +1417,7 @@ func testPlugin(tCtx ktesting.TContext) {
 					},
 				},
 				postfilter: result{
-					status: fwk.NewStatus(fwk.Unschedulable, `still not schedulable`),
+					status: fwk.NewStatus(fwk.Unschedulable),
 				},
 			},
 		},
@@ -1618,7 +1639,7 @@ func testPlugin(tCtx ktesting.TContext) {
 					},
 				},
 				postfilter: result{
-					status: fwk.NewStatus(fwk.Unschedulable, `still not schedulable`),
+					status: fwk.NewStatus(fwk.Unschedulable),
 				},
 			},
 		},
@@ -1643,7 +1664,7 @@ func testPlugin(tCtx ktesting.TContext) {
 				},
 				postfilter: result{
 					inFlightClaims: []metav1.Object{otherAllocatedClaim},
-					status:         fwk.NewStatus(fwk.Unschedulable, `still not schedulable`),
+					status:         fwk.NewStatus(fwk.Unschedulable),
 				},
 			},
 		},
@@ -1735,7 +1756,7 @@ func testPlugin(tCtx ktesting.TContext) {
 					},
 				},
 				postfilter: result{
-					status: fwk.NewStatus(fwk.Unschedulable, `still not schedulable`),
+					status: fwk.NewStatus(fwk.Unschedulable),
 				},
 			},
 		},
@@ -1896,7 +1917,7 @@ func testPlugin(tCtx ktesting.TContext) {
 					status: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, fmt.Sprintf("request req-1: device class %s does not exist", className)),
 				},
 				postfilter: result{
-					status: fwk.NewStatus(fwk.Unschedulable, `no new claims to deallocate`),
+					status: fwk.NewStatus(fwk.Unschedulable),
 				},
 			},
 		},
@@ -2060,7 +2081,7 @@ func testPlugin(tCtx ktesting.TContext) {
 					},
 				},
 				postfilter: result{
-					status: fwk.NewStatus(fwk.Unschedulable, `still not schedulable`),
+					status: fwk.NewStatus(fwk.Unschedulable),
 				},
 			},
 		},
@@ -2120,7 +2141,7 @@ func testPlugin(tCtx ktesting.TContext) {
 					},
 				},
 				postfilter: result{
-					status: fwk.NewStatus(fwk.Unschedulable, `still not schedulable`),
+					status: fwk.NewStatus(fwk.Unschedulable),
 				},
 			},
 		},
@@ -2180,7 +2201,7 @@ func testPlugin(tCtx ktesting.TContext) {
 					status: fwk.NewStatus(fwk.Skip),
 				},
 				postfilter: result{
-					status: fwk.NewStatus(fwk.Unschedulable, `plugin disabled`),
+					status: fwk.NewStatus(fwk.Unschedulable),
 				},
 				preBindPreFlightStatus: fwk.NewStatus(fwk.Skip),
 			},
@@ -2194,7 +2215,7 @@ func testPlugin(tCtx ktesting.TContext) {
 					status: fwk.NewStatus(fwk.Unschedulable, `request req-1: device class does-not-exist does not exist`),
 				},
 				postfilter: result{
-					status: fwk.NewStatus(fwk.Unschedulable, `no new claims to deallocate`),
+					status: fwk.NewStatus(fwk.Unschedulable),
 				},
 			},
 		},
@@ -2208,7 +2229,7 @@ func testPlugin(tCtx ktesting.TContext) {
 					status: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `claim default/my-pod-my-resource, request req-1: has subrequests, but the DRAPrioritizedList feature is disabled`),
 				},
 				postfilter: result{
-					status: fwk.NewStatus(fwk.Unschedulable, `no new claims to deallocate`),
+					status: fwk.NewStatus(fwk.Unschedulable),
 				},
 			},
 		},
@@ -2221,7 +2242,7 @@ func testPlugin(tCtx ktesting.TContext) {
 					status: fwk.NewStatus(fwk.Unschedulable, `request req-1/subreq-1: device class does-not-exist does not exist`),
 				},
 				postfilter: result{
-					status: fwk.NewStatus(fwk.Unschedulable, `no new claims to deallocate`),
+					status: fwk.NewStatus(fwk.Unschedulable),
 				},
 			},
 		},
@@ -2324,7 +2345,7 @@ func testPlugin(tCtx ktesting.TContext) {
 					},
 				},
 				postfilter: result{
-					status: fwk.NewStatus(fwk.Unschedulable, `still not schedulable`),
+					status: fwk.NewStatus(fwk.Unschedulable),
 				},
 			},
 			metrics: func(tCtx ktesting.TContext, g compbasemetrics.Gatherer) {
@@ -2559,7 +2580,7 @@ func testPlugin(tCtx ktesting.TContext) {
 					},
 				},
 				postfilter: result{
-					status: fwk.NewStatus(fwk.Unschedulable, `still not schedulable`),
+					status: fwk.NewStatus(fwk.Unschedulable),
 				},
 			},
 		},
@@ -3478,7 +3499,7 @@ func testPlugin(tCtx ktesting.TContext) {
 					workerNodeWithCapacity.Name: {status: fwk.NewStatus(fwk.Unschedulable, `Insufficient cpu`)},
 				},
 				postfilter: result{
-					status: fwk.NewStatus(fwk.Unschedulable, "still not schedulable"),
+					status: fwk.NewStatus(fwk.Unschedulable),
 				},
 			},
 		},
@@ -3499,7 +3520,7 @@ func testPlugin(tCtx ktesting.TContext) {
 					workerNodeWithCapacity.Name: {status: fwk.NewStatus(fwk.Unschedulable, `cannot allocate all claims`)},
 				},
 				postfilter: result{
-					status: fwk.NewStatus(fwk.Unschedulable, "still not schedulable"),
+					status: fwk.NewStatus(fwk.Unschedulable),
 				},
 			},
 		},

--- a/test/integration/dra/core.go
+++ b/test/integration/dra/core.go
@@ -824,7 +824,7 @@ func testInvalidResourceSlices(tCtx ktesting.TContext) {
 			expectedPodScheduledCondition: gstruct.Fields{
 				"Type":    gomega.Equal(v1.PodScheduled),
 				"Status":  gomega.Equal(v1.ConditionFalse),
-				"Message": gomega.Equal("0/8 nodes are available: 1 invalid resource pools were encountered, 7 cannot allocate all claims. still not schedulable, preemption: 0/8 nodes are available: 8 Preemption is not helpful for scheduling."),
+				"Message": gomega.Equal("0/8 nodes are available: 1 invalid resource pools were encountered, 7 cannot allocate all claims. preemption: 0/8 nodes are available: 8 Preemption is not helpful for scheduling."),
 			},
 		},
 		"invalid-for-all-nodes": {
@@ -847,7 +847,7 @@ func testInvalidResourceSlices(tCtx ktesting.TContext) {
 			expectedPodScheduledCondition: gstruct.Fields{
 				"Type":    gomega.Equal(v1.PodScheduled),
 				"Status":  gomega.Equal(v1.ConditionFalse),
-				"Message": gomega.Equal("0/8 nodes are available: 8 invalid resource pools were encountered. still not schedulable, preemption: 0/8 nodes are available: 8 Preemption is not helpful for scheduling."),
+				"Message": gomega.Equal("0/8 nodes are available: 8 invalid resource pools were encountered. preemption: 0/8 nodes are available: 8 Preemption is not helpful for scheduling."),
 			},
 		},
 	}

--- a/test/integration/dra/extendedresource.go
+++ b/test/integration/dra/extendedresource.go
@@ -83,7 +83,7 @@ func testExtendedResource(tCtx ktesting.TContext, enabled, explicit bool) {
 				"Type":    gomega.Equal(v1.PodScheduled),
 				"Status":  gomega.Equal(v1.ConditionFalse),
 				"Reason":  gomega.Equal("Unschedulable"),
-				"Message": gomega.Equal(fmt.Sprintf("0/8 nodes are available: 8 Insufficient %s. no new claims to deallocate, preemption: 0/8 nodes are available: 8 Preemption is not helpful for scheduling.", resourceName)),
+				"Message": gomega.Equal(fmt.Sprintf("0/8 nodes are available: 8 Insufficient %s. preemption: 0/8 nodes are available: 8 Preemption is not helpful for scheduling.", resourceName)),
 			}),
 		))
 	}

--- a/test/integration/dra/prioritizedlist.go
+++ b/test/integration/dra/prioritizedlist.go
@@ -61,7 +61,7 @@ func testPrioritizedList(tCtx ktesting.TContext, enabled bool) {
 			"Type":    gomega.Equal(v1.PodScheduled),
 			"Status":  gomega.Equal(v1.ConditionFalse),
 			"Reason":  gomega.Equal("Unschedulable"),
-			"Message": gomega.Equal("0/8 nodes are available: 8 cannot allocate all claims. still not schedulable, preemption: 0/8 nodes are available: 8 Preemption is not helpful for scheduling."),
+			"Message": gomega.Equal("0/8 nodes are available: 8 cannot allocate all claims. preemption: 0/8 nodes are available: 8 Preemption is not helpful for scheduling."),
 		}),
 	))
 	tCtx.Eventually(func(tCtx ktesting.TContext) (*v1.Pod, error) {


### PR DESCRIPTION
 #### What type of PR is this?

  /kind cleanup

  #### What this PR does / why we need it:

  This PR reduces noise in Pod `FailedScheduling` events from the `DynamicResources` scheduler plugin.

  `DynamicResources.PostFilter` currently returns some internal/no-op PostFilter outcomes as user-visible `Unschedulable` reasons, such as:

  - `plugin disabled`
  - `no new claims to deallocate`
  - `still not schedulable`

  These messages do not explain what users need to change to make the Pod schedulable. They can also be appended to the actual scheduling failure reason, making the event harder to
  read.

  This PR keeps the `Unschedulable` status for those no-op cases but stops exposing those internal messages as status reasons. The first two are moved to V(5) logs, while `still not
  schedulable` is dropped because it does not add useful diagnostic information.

  Actionable PostFilter messages that describe actual work, such as ResourceClaim deallocation or deletion, are preserved.

  #### Which issue(s) this PR is related to:

  N/A

  #### Special notes for your reviewer:

  This only changes the user-visible reasons returned by no-op/internal `DynamicResources.PostFilter` paths. It does not change scheduling behavior or queueing semantics.


Example user-visible change:

  Before this PR, internal `DynamicResources.PostFilter` no-op reasons could be appended to the Pod `FailedScheduling` event together with the real filter failure and preemption
  result, for example:
 
```text
0/1 nodes are available: 1 Insufficient cpu. no new claims to deallocate, preemption: 0/1 nodes are available: 1 No preemption victims found for incoming pod
```
  After this PR, the DRA no-op suffix is omitted, while the actionable filter and preemption messages remain:
 
```text
 0/1 nodes are available: 1 Insufficient cpu. preemption: 0/1 nodes are available: 1 No preemption victims found for incoming pod
```
  The removed suffix was an internal DynamicResources.PostFilter outcome and did not identify a user-actionable scheduling constraint.


  Tests added/updated:

  - `go test ./pkg/scheduler/framework/plugins/dynamicresources -run TestPostFilterNoOpStatusHasNoUserVisibleReason -count=1`
  - `go test ./pkg/scheduler/framework/plugins/dynamicresources -run TestPlugin -count=1`

  #### Does this PR introduce a user-facing change?

```release-note
  NONE
```

  #### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
  NONE
```
