### PR TITLE
feat: migrate to contextual logging - p1

### DIFF
--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -827,14 +827,14 @@ func (adc *attachDetachController) GetAttachedVolumesFromNodeStatus() (map[v1.Un
 	return map[v1.UniqueVolumeName]string{}, nil
 }
 
-func (adc *attachDetachController) GetSecretFunc() func(namespace, name string) (*v1.Secret, error) {
-	return func(_, _ string) (*v1.Secret, error) {
+func (adc *attachDetachController) GetSecretFunc() func(ctx context.Context, namespace, name string) (*v1.Secret, error) {
+	return func(_ context.Context, _, _ string) (*v1.Secret, error) {
 		return nil, fmt.Errorf("GetSecret unsupported in attachDetachController")
 	}
 }
 
-func (adc *attachDetachController) GetConfigMapFunc() func(namespace, name string) (*v1.ConfigMap, error) {
-	return func(_, _ string) (*v1.ConfigMap, error) {
+func (adc *attachDetachController) GetConfigMapFunc() func(ctx context.Context, namespace, name string) (*v1.ConfigMap, error) {
+	return func(_ context.Context, _, _ string) (*v1.ConfigMap, error) {
 		return nil, fmt.Errorf("GetConfigMap unsupported in attachDetachController")
 	}
 }

--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -465,7 +465,7 @@ func (adc *attachDetachController) populateDesiredStateOfWorld(logger klog.Logge
 					"volumeName", podVolume.Name)
 				continue
 			}
-			plugin, err := adc.volumePluginMgr.FindAttachablePluginBySpec(volumeSpec)
+			plugin, err := adc.volumePluginMgr.FindAttachablePluginBySpec(logger, volumeSpec)
 			if err != nil || plugin == nil {
 				logger.V(10).Info(
 					"Skipping volume for pod: it does not implement attacher interface",
@@ -738,7 +738,7 @@ func (adc *attachDetachController) processVolumeAttachments(logger klog.Logger) 
 		}
 
 		if plugin == nil {
-			plugin, err = volumeutil.FindDetachablePluginBySpec(volumeSpec, &adc.volumePluginMgr)
+			plugin, err = volumeutil.FindDetachablePluginBySpec(logger, volumeSpec, &adc.volumePluginMgr)
 			if err != nil || plugin == nil {
 				// Currently VA objects are created for CSI volumes only. nil plugin is unexpected, generate a warning
 				logger.Info("Skipping processing the volume on node, no attacher interface found", "node", klog.KRef("", string(nodeName)), "PV", klog.KRef("", *pvName), "err", err)
@@ -816,7 +816,7 @@ func (adc *attachDetachController) GetKubeClient() clientset.Interface {
 	return adc.kubeClient
 }
 
-func (adc *attachDetachController) NewWrapperMounter(volName string, spec volume.Spec, pod *v1.Pod) (volume.Mounter, error) {
+func (adc *attachDetachController) NewWrapperMounter(logger klog.Logger, volName string, spec volume.Spec, pod *v1.Pod) (volume.Mounter, error) {
 	return nil, fmt.Errorf("NewWrapperMounter not supported by Attach/Detach controller's VolumeHost implementation")
 }
 
@@ -828,22 +828,22 @@ func (adc *attachDetachController) GetMounter() mount.Interface {
 	return nil
 }
 
-func (adc *attachDetachController) GetNodeAllocatable() (v1.ResourceList, error) {
+func (adc *attachDetachController) GetNodeAllocatable(ctx context.Context) (v1.ResourceList, error) {
 	return v1.ResourceList{}, nil
 }
 
-func (adc *attachDetachController) GetAttachedVolumesFromNodeStatus() (map[v1.UniqueVolumeName]string, error) {
+func (adc *attachDetachController) GetAttachedVolumesFromNodeStatus(ctx context.Context) (map[v1.UniqueVolumeName]string, error) {
 	return map[v1.UniqueVolumeName]string{}, nil
 }
 
-func (adc *attachDetachController) GetSecretFunc() func(namespace, name string) (*v1.Secret, error) {
-	return func(_, _ string) (*v1.Secret, error) {
+func (adc *attachDetachController) GetSecretFunc() func(ctx context.Context, namespace, name string) (*v1.Secret, error) {
+	return func(_ context.Context, _, _ string) (*v1.Secret, error) {
 		return nil, fmt.Errorf("GetSecret unsupported in attachDetachController")
 	}
 }
 
-func (adc *attachDetachController) GetConfigMapFunc() func(namespace, name string) (*v1.ConfigMap, error) {
-	return func(_, _ string) (*v1.ConfigMap, error) {
+func (adc *attachDetachController) GetConfigMapFunc() func(ctx context.Context, namespace, name string) (*v1.ConfigMap, error) {
+	return func(_ context.Context, _, _ string) (*v1.ConfigMap, error) {
 		return nil, fmt.Errorf("GetConfigMap unsupported in attachDetachController")
 	}
 }
@@ -869,7 +869,7 @@ func (adc *attachDetachController) addNodeToDswp(node *v1.Node, nodeName types.N
 	}
 }
 
-func (adc *attachDetachController) GetNodeLabels() (map[string]string, error) {
+func (adc *attachDetachController) GetNodeLabels(ctx context.Context) (map[string]string, error) {
 	return nil, fmt.Errorf("GetNodeLabels() unsupported in Attach/Detach controller")
 }
 

--- a/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
+++ b/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
@@ -318,7 +318,7 @@ func (asw *actualStateOfWorld) AddVolumeNode(
 		if volumeSpec == nil {
 			return volumeName, fmt.Errorf("volumeSpec cannot be nil if volumeName is empty")
 		}
-		attachableVolumePlugin, err := asw.volumePluginMgr.FindAttachablePluginBySpec(volumeSpec)
+		attachableVolumePlugin, err := asw.volumePluginMgr.FindAttachablePluginBySpec(logger, volumeSpec)
 		if err != nil || attachableVolumePlugin == nil {
 			if attachableVolumePlugin == nil {
 				err = fmt.Errorf("plugin do not support attachment")

--- a/pkg/controller/volume/attachdetach/cache/actual_state_of_world_test.go
+++ b/pkg/controller/volume/attachdetach/cache/actual_state_of_world_test.go
@@ -624,7 +624,8 @@ func Test_GetAttachedVolumes_Positive_OneVolumeTwoNodes(t *testing.T) {
 	volumeSpec := controllervolumetesting.GetTestVolumeSpec(string(volumeName), volumeName)
 	node1Name := types.NodeName("node1-name")
 	devicePath := "fake/device/path"
-	plugin, err := volumePluginMgr.FindAttachablePluginBySpec(volumeSpec)
+	logger, _ := ktesting.NewTestContext(t)
+	plugin, err := volumePluginMgr.FindAttachablePluginBySpec(logger, volumeSpec)
 	if err != nil || plugin == nil {
 		t.Fatalf("Failed to get volume plugin from spec %v, %v", volumeSpec, err)
 	}
@@ -632,7 +633,6 @@ func Test_GetAttachedVolumes_Positive_OneVolumeTwoNodes(t *testing.T) {
 	if err != nil || uniqueVolumeName == "" {
 		t.Fatalf("Failed to get uniqueVolumeName from spec %v, %v", volumeSpec, err)
 	}
-	logger, _ := ktesting.NewTestContext(t)
 	generatedVolumeName1, add1Err := asw.AddVolumeNode(logger, uniqueVolumeName, volumeSpec, node1Name, devicePath, true)
 	if add1Err != nil {
 		t.Fatalf("AddVolumeNode failed. Expected: <no error> Actual: <%v>", add1Err)
@@ -1216,7 +1216,7 @@ func Test_GetAttachedVolumesForNode_Positive_OneVolumeTwoNodes(t *testing.T) {
 	node1Name := types.NodeName("node1-name")
 	devicePath := "fake/device/path"
 	logger, _ := ktesting.NewTestContext(t)
-	plugin, err := volumePluginMgr.FindAttachablePluginBySpec(volumeSpec)
+	plugin, err := volumePluginMgr.FindAttachablePluginBySpec(logger, volumeSpec)
 	if err != nil || plugin == nil {
 		t.Fatalf("Failed to get volume plugin from spec %v, %v", volumeSpec, err)
 	}
@@ -1261,7 +1261,7 @@ func Test_OneVolumeTwoNodes_TwoDevicePaths(t *testing.T) {
 	node1Name := types.NodeName("node1-name")
 	devicePath1 := "fake/device/path1"
 	logger, _ := ktesting.NewTestContext(t)
-	plugin, err := volumePluginMgr.FindAttachablePluginBySpec(volumeSpec)
+	plugin, err := volumePluginMgr.FindAttachablePluginBySpec(logger, volumeSpec)
 	if err != nil || plugin == nil {
 		t.Fatalf("Failed to get volume plugin from spec %v, %v", volumeSpec, err)
 	}
@@ -1374,6 +1374,7 @@ func Test_updateNodeStatusUpdateNeededError(t *testing.T) {
 // Verify GetAttachState returns AttachedState
 // Verify GetAttachedVolumes return this volume
 func Test_MarkVolumeAsAttached(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	// Arrange
 	volumePluginMgr, _ := volumetesting.GetTestVolumePluginMgr(t)
 	asw := NewActualStateOfWorld(volumePluginMgr)
@@ -1383,13 +1384,12 @@ func Test_MarkVolumeAsAttached(t *testing.T) {
 	nodeName := types.NodeName("node-name")
 	devicePath := "fake/device/path"
 
-	plugin, err := volumePluginMgr.FindAttachablePluginBySpec(volumeSpec)
+	plugin, err := volumePluginMgr.FindAttachablePluginBySpec(logger, volumeSpec)
 	if err != nil || plugin == nil {
 		t.Fatalf("Failed to get volume plugin from spec %v, %v", volumeSpec, err)
 	}
 
 	// Act
-	logger, _ := ktesting.NewTestContext(t)
 	err = asw.MarkVolumeAsAttached(logger, volumeName, volumeSpec, nodeName, devicePath)
 
 	// Assert
@@ -1413,6 +1413,7 @@ func Test_MarkVolumeAsAttached(t *testing.T) {
 // Verify GetAttachState returns UncertainState
 // Verify GetAttachedVolumes return this volume
 func Test_MarkVolumeAsUncertain(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	// Arrange
 	volumePluginMgr, _ := volumetesting.GetTestVolumePluginMgr(t)
 	asw := NewActualStateOfWorld(volumePluginMgr)
@@ -1420,13 +1421,12 @@ func Test_MarkVolumeAsUncertain(t *testing.T) {
 	volumeSpec := controllervolumetesting.GetTestVolumeSpec(string(volumeName), volumeName)
 	nodeName := types.NodeName("node-name")
 
-	plugin, err := volumePluginMgr.FindAttachablePluginBySpec(volumeSpec)
+	plugin, err := volumePluginMgr.FindAttachablePluginBySpec(logger, volumeSpec)
 	if err != nil || plugin == nil {
 		t.Fatalf("Failed to get volume plugin from spec %v, %v", volumeSpec, err)
 	}
 
 	// Act
-	logger, _ := ktesting.NewTestContext(t)
 	err = asw.MarkVolumeAsUncertain(logger, volumeName, volumeSpec, nodeName)
 
 	// Assert

--- a/pkg/controller/volume/attachdetach/cache/desired_state_of_world.go
+++ b/pkg/controller/volume/attachdetach/cache/desired_state_of_world.go
@@ -27,6 +27,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/pkg/volume/util/operationexecutor"
@@ -212,7 +213,10 @@ func (dsw *desiredStateOfWorld) AddPod(
 			nodeName)
 	}
 
-	attachableVolumePlugin, err := dsw.volumePluginMgr.FindAttachablePluginBySpec(volumeSpec)
+	// Use klog.TODO() because we currently do not have a proper logger to pass in.
+	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
+	logger := klog.TODO()
+	attachableVolumePlugin, err := dsw.volumePluginMgr.FindAttachablePluginBySpec(logger, volumeSpec)
 	if err != nil || attachableVolumePlugin == nil {
 		if attachableVolumePlugin == nil {
 			err = fmt.Errorf("plugin do not support attachment")

--- a/pkg/controller/volume/attachdetach/reconciler/reconciler.go
+++ b/pkg/controller/volume/attachdetach/reconciler/reconciler.go
@@ -125,23 +125,23 @@ func (rc *reconciler) reconciliationLoopFunc(ctx context.Context) func(context.C
 			logger.V(5).Info("Skipping reconciling attached volumes still attached since it is set to less than one second via the command line")
 		} else if time.Since(rc.timeOfLastSync) > rc.syncDuration {
 			logger.V(5).Info("Starting reconciling attached volumes still attached")
-			rc.sync()
+			rc.sync(logger)
 		}
 	}
 }
 
-func (rc *reconciler) sync() {
+func (rc *reconciler) sync(logger klog.Logger) {
 	defer rc.updateSyncTime()
-	rc.syncStates()
+	rc.syncStates(logger)
 }
 
 func (rc *reconciler) updateSyncTime() {
 	rc.timeOfLastSync = time.Now()
 }
 
-func (rc *reconciler) syncStates() {
+func (rc *reconciler) syncStates(logger klog.Logger) {
 	volumesPerNode := rc.actualStateOfWorld.GetAttachedVolumesPerNode()
-	rc.attacherDetacher.VerifyVolumesAreAttached(volumesPerNode, rc.actualStateOfWorld)
+	rc.attacherDetacher.VerifyVolumesAreAttached(logger, volumesPerNode, rc.actualStateOfWorld)
 }
 
 // hasOutOfServiceTaint returns true if the node has out-of-service taint present.

--- a/pkg/controller/volume/attachdetach/testing/plugin.go
+++ b/pkg/controller/volume/attachdetach/testing/plugin.go
@@ -23,6 +23,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/volume"
 )
 
@@ -88,7 +89,7 @@ func (plugin *TestPlugin) CanSupport(spec *volume.Spec) bool {
 	return true
 }
 
-func (plugin *TestPlugin) RequiresRemount(spec *volume.Spec) bool {
+func (plugin *TestPlugin) RequiresRemount(logger klog.Logger, spec *volume.Spec) bool {
 	return false
 }
 
@@ -105,7 +106,7 @@ func (plugin *TestPlugin) NewUnmounter(name string, podUID types.UID) (volume.Un
 	return nil, nil
 }
 
-func (plugin *TestPlugin) VerifyExhaustedResource(spec *volume.Spec) bool {
+func (plugin *TestPlugin) VerifyExhaustedResource(logger klog.Logger, spec *volume.Spec) bool {
 	return false
 }
 
@@ -146,7 +147,7 @@ func (plugin *TestPlugin) NewDetacher() (volume.Detacher, error) {
 	return &detacher, nil
 }
 
-func (plugin *TestPlugin) CanAttach(spec *volume.Spec) (bool, error) {
+func (plugin *TestPlugin) CanAttach(logger klog.Logger, spec *volume.Spec) (bool, error) {
 	return true, nil
 }
 
@@ -170,7 +171,7 @@ func (plugin *TestPlugin) SupportsBulkVolumeVerification() bool {
 	return false
 }
 
-func (plugin *TestPlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
+func (plugin *TestPlugin) SupportsSELinuxContextMount(logger klog.Logger, spec *volume.Spec) (bool, error) {
 	return false, nil
 }
 
@@ -232,7 +233,7 @@ func (attacher *testPluginAttacher) Attach(spec *volume.Spec, nodeName types.Nod
 	return spec.Name(), nil
 }
 
-func (attacher *testPluginAttacher) VolumesAreAttached(specs []*volume.Spec, nodeName types.NodeName) (map[*volume.Spec]bool, error) {
+func (attacher *testPluginAttacher) VolumesAreAttached(logger klog.Logger, specs []*volume.Spec, nodeName types.NodeName) (map[*volume.Spec]bool, error) {
 	return nil, nil
 }
 
@@ -257,7 +258,7 @@ func (attacher *testPluginAttacher) GetDeviceMountPath(spec *volume.Spec) (strin
 	return "", nil
 }
 
-func (attacher *testPluginAttacher) MountDevice(spec *volume.Spec, devicePath string, deviceMountPath string, _ volume.DeviceMounterArgs) error {
+func (attacher *testPluginAttacher) MountDevice(logger klog.Logger, spec *volume.Spec, devicePath string, deviceMountPath string, _ volume.DeviceMounterArgs) error {
 	attacher.pluginLock.Lock()
 	defer attacher.pluginLock.Unlock()
 	if spec == nil {

--- a/pkg/controller/volume/attachdetach/util/util.go
+++ b/pkg/controller/volume/attachdetach/util/util.go
@@ -221,7 +221,7 @@ func ProcessPodVolumes(logger klog.Logger, pod *v1.Pod, addVolumes bool, desired
 		}
 
 		attachableVolumePlugin, err :=
-			volumePluginMgr.FindAttachablePluginBySpec(volumeSpec)
+			volumePluginMgr.FindAttachablePluginBySpec(logger, volumeSpec)
 		if err != nil || attachableVolumePlugin == nil {
 			logger.V(10).Info("Skipping volume for pod, it does not implement attacher interface", "pod", klog.KObj(pod), "volumeName", podVolume.Name, "err", err)
 			continue

--- a/pkg/controller/volume/expand/expand_controller.go
+++ b/pkg/controller/volume/expand/expand_controller.go
@@ -421,14 +421,14 @@ func (expc *expandController) GetNodeAllocatable() (v1.ResourceList, error) {
 	return v1.ResourceList{}, nil
 }
 
-func (expc *expandController) GetSecretFunc() func(namespace, name string) (*v1.Secret, error) {
-	return func(_, _ string) (*v1.Secret, error) {
+func (expc *expandController) GetSecretFunc() func(ctx context.Context, namespace, name string) (*v1.Secret, error) {
+	return func(_ context.Context, _, _ string) (*v1.Secret, error) {
 		return nil, fmt.Errorf("GetSecret unsupported in expandController")
 	}
 }
 
-func (expc *expandController) GetConfigMapFunc() func(namespace, name string) (*v1.ConfigMap, error) {
-	return func(_, _ string) (*v1.ConfigMap, error) {
+func (expc *expandController) GetConfigMapFunc() func(ctx context.Context, namespace, name string) (*v1.ConfigMap, error) {
+	return func(_ context.Context, _, _ string) (*v1.ConfigMap, error) {
 		return nil, fmt.Errorf("GetConfigMap unsupported in expandController")
 	}
 }

--- a/pkg/controller/volume/expand/expand_controller.go
+++ b/pkg/controller/volume/expand/expand_controller.go
@@ -409,7 +409,7 @@ func (expc *expandController) GetKubeClient() clientset.Interface {
 	return expc.kubeClient
 }
 
-func (expc *expandController) NewWrapperMounter(volName string, spec volume.Spec, pod *v1.Pod) (volume.Mounter, error) {
+func (expc *expandController) NewWrapperMounter(logger klog.Logger, volName string, spec volume.Spec, pod *v1.Pod) (volume.Mounter, error) {
 	return nil, fmt.Errorf("NewWrapperMounter not supported by expand controller's VolumeHost implementation")
 }
 
@@ -421,23 +421,23 @@ func (expc *expandController) GetMounter() mount.Interface {
 	return nil
 }
 
-func (expc *expandController) GetNodeAllocatable() (v1.ResourceList, error) {
+func (expc *expandController) GetNodeAllocatable(ctx context.Context) (v1.ResourceList, error) {
 	return v1.ResourceList{}, nil
 }
 
-func (expc *expandController) GetSecretFunc() func(namespace, name string) (*v1.Secret, error) {
-	return func(_, _ string) (*v1.Secret, error) {
+func (expc *expandController) GetSecretFunc() func(ctx context.Context, namespace, name string) (*v1.Secret, error) {
+	return func(_ context.Context, _, _ string) (*v1.Secret, error) {
 		return nil, fmt.Errorf("GetSecret unsupported in expandController")
 	}
 }
 
-func (expc *expandController) GetConfigMapFunc() func(namespace, name string) (*v1.ConfigMap, error) {
-	return func(_, _ string) (*v1.ConfigMap, error) {
+func (expc *expandController) GetConfigMapFunc() func(ctx context.Context, namespace, name string) (*v1.ConfigMap, error) {
+	return func(_ context.Context, _, _ string) (*v1.ConfigMap, error) {
 		return nil, fmt.Errorf("GetConfigMap unsupported in expandController")
 	}
 }
 
-func (expc *expandController) GetAttachedVolumesFromNodeStatus() (map[v1.UniqueVolumeName]string, error) {
+func (expc *expandController) GetAttachedVolumesFromNodeStatus(ctx context.Context) (map[v1.UniqueVolumeName]string, error) {
 	return map[v1.UniqueVolumeName]string{}, nil
 }
 
@@ -454,7 +454,7 @@ func (expc *expandController) DeleteServiceAccountTokenFunc() func(types.UID) {
 	}
 }
 
-func (expc *expandController) GetNodeLabels() (map[string]string, error) {
+func (expc *expandController) GetNodeLabels(ctx context.Context) (map[string]string, error) {
 	return nil, fmt.Errorf("GetNodeLabels unsupported in expandController")
 }
 

--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -988,7 +988,7 @@ func (plugin *mockVolumePlugin) CanSupport(spec *volume.Spec) bool {
 	return true
 }
 
-func (plugin *mockVolumePlugin) RequiresRemount(spec *volume.Spec) bool {
+func (plugin *mockVolumePlugin) RequiresRemount(logger klog.Logger, spec *volume.Spec) bool {
 	return false
 }
 
@@ -1004,7 +1004,7 @@ func (plugin *mockVolumePlugin) ConstructVolumeSpec(volumeName, mountPath string
 	return volume.ReconstructedVolume{}, nil
 }
 
-func (plugin *mockVolumePlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
+func (plugin *mockVolumePlugin) SupportsSELinuxContextMount(logger klog.Logger, spec *volume.Spec) (bool, error) {
 	return false, nil
 }
 

--- a/pkg/controller/volume/persistentvolume/volume_host.go
+++ b/pkg/controller/volume/persistentvolume/volume_host.go
@@ -17,6 +17,7 @@ limitations under the License.
 package persistentvolume
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/klog/v2"
@@ -83,14 +84,14 @@ func (ctrl *PersistentVolumeController) GetAttachedVolumesFromNodeStatus() (map[
 	return map[v1.UniqueVolumeName]string{}, nil
 }
 
-func (ctrl *PersistentVolumeController) GetSecretFunc() func(namespace, name string) (*v1.Secret, error) {
-	return func(_, _ string) (*v1.Secret, error) {
+func (ctrl *PersistentVolumeController) GetSecretFunc() func(ctx context.Context, namespace, name string) (*v1.Secret, error) {
+	return func(_ context.Context, _, _ string) (*v1.Secret, error) {
 		return nil, fmt.Errorf("GetSecret unsupported in PersistentVolumeController")
 	}
 }
 
-func (ctrl *PersistentVolumeController) GetConfigMapFunc() func(namespace, name string) (*v1.ConfigMap, error) {
-	return func(_, _ string) (*v1.ConfigMap, error) {
+func (ctrl *PersistentVolumeController) GetConfigMapFunc() func(ctx context.Context, namespace, name string) (*v1.ConfigMap, error) {
+	return func(_ context.Context, _, _ string) (*v1.ConfigMap, error) {
 		return nil, fmt.Errorf("GetConfigMap unsupported in PersistentVolumeController")
 	}
 }

--- a/pkg/controller/volume/persistentvolume/volume_host.go
+++ b/pkg/controller/volume/persistentvolume/volume_host.go
@@ -17,6 +17,7 @@ limitations under the License.
 package persistentvolume
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/klog/v2"
@@ -63,7 +64,7 @@ func (ctrl *PersistentVolumeController) GetKubeClient() clientset.Interface {
 	return ctrl.kubeClient
 }
 
-func (ctrl *PersistentVolumeController) NewWrapperMounter(volName string, spec vol.Spec, pod *v1.Pod) (vol.Mounter, error) {
+func (ctrl *PersistentVolumeController) NewWrapperMounter(logger klog.Logger, volName string, spec vol.Spec, pod *v1.Pod) (vol.Mounter, error) {
 	return nil, fmt.Errorf("PersistentVolumeController.NewWrapperMounter is not implemented")
 }
 
@@ -75,22 +76,22 @@ func (ctrl *PersistentVolumeController) GetMounter() mount.Interface {
 	return nil
 }
 
-func (ctrl *PersistentVolumeController) GetNodeAllocatable() (v1.ResourceList, error) {
+func (ctrl *PersistentVolumeController) GetNodeAllocatable(_ context.Context) (v1.ResourceList, error) {
 	return v1.ResourceList{}, nil
 }
 
-func (ctrl *PersistentVolumeController) GetAttachedVolumesFromNodeStatus() (map[v1.UniqueVolumeName]string, error) {
+func (ctrl *PersistentVolumeController) GetAttachedVolumesFromNodeStatus(_ context.Context) (map[v1.UniqueVolumeName]string, error) {
 	return map[v1.UniqueVolumeName]string{}, nil
 }
 
-func (ctrl *PersistentVolumeController) GetSecretFunc() func(namespace, name string) (*v1.Secret, error) {
-	return func(_, _ string) (*v1.Secret, error) {
+func (ctrl *PersistentVolumeController) GetSecretFunc() func(ctx context.Context, namespace, name string) (*v1.Secret, error) {
+	return func(_ context.Context, _, _ string) (*v1.Secret, error) {
 		return nil, fmt.Errorf("GetSecret unsupported in PersistentVolumeController")
 	}
 }
 
-func (ctrl *PersistentVolumeController) GetConfigMapFunc() func(namespace, name string) (*v1.ConfigMap, error) {
-	return func(_, _ string) (*v1.ConfigMap, error) {
+func (ctrl *PersistentVolumeController) GetConfigMapFunc() func(ctx context.Context, namespace, name string) (*v1.ConfigMap, error) {
+	return func(_ context.Context, _, _ string) (*v1.ConfigMap, error) {
 		return nil, fmt.Errorf("GetConfigMap unsupported in PersistentVolumeController")
 	}
 }
@@ -108,7 +109,7 @@ func (ctrl *PersistentVolumeController) DeleteServiceAccountTokenFunc() func(typ
 	}
 }
 
-func (ctrl *PersistentVolumeController) GetNodeLabels() (map[string]string, error) {
+func (ctrl *PersistentVolumeController) GetNodeLabels(_ context.Context) (map[string]string, error) {
 	return nil, fmt.Errorf("GetNodeLabels() unsupported in PersistentVolumeController")
 }
 

--- a/pkg/controller/volume/selinuxwarning/volumehost.go
+++ b/pkg/controller/volume/selinuxwarning/volumehost.go
@@ -17,6 +17,7 @@ limitations under the License.
 package selinuxwarning
 
 import (
+	"context"
 	"fmt"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
@@ -83,14 +84,14 @@ func (c *Controller) GetAttachedVolumesFromNodeStatus() (map[v1.UniqueVolumeName
 	return map[v1.UniqueVolumeName]string{}, nil
 }
 
-func (c *Controller) GetSecretFunc() func(namespace, name string) (*v1.Secret, error) {
-	return func(_, _ string) (*v1.Secret, error) {
+func (c *Controller) GetSecretFunc() func(ctx context.Context, namespace, name string) (*v1.Secret, error) {
+	return func(_ context.Context, _, _ string) (*v1.Secret, error) {
 		return nil, fmt.Errorf("GetSecret unsupported in SELinux controller")
 	}
 }
 
-func (c *Controller) GetConfigMapFunc() func(namespace, name string) (*v1.ConfigMap, error) {
-	return func(_, _ string) (*v1.ConfigMap, error) {
+func (c *Controller) GetConfigMapFunc() func(ctx context.Context, namespace, name string) (*v1.ConfigMap, error) {
+	return func(_ context.Context, _, _ string) (*v1.ConfigMap, error) {
 		return nil, fmt.Errorf("GetConfigMap unsupported in SELinux controller")
 	}
 }

--- a/pkg/controller/volume/selinuxwarning/volumehost.go
+++ b/pkg/controller/volume/selinuxwarning/volumehost.go
@@ -17,6 +17,7 @@ limitations under the License.
 package selinuxwarning
 
 import (
+	"context"
 	"fmt"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
@@ -63,7 +64,7 @@ func (c *Controller) GetKubeClient() clientset.Interface {
 	return c.kubeClient
 }
 
-func (c *Controller) NewWrapperMounter(volName string, spec volume.Spec, pod *v1.Pod) (volume.Mounter, error) {
+func (c *Controller) NewWrapperMounter(logger klog.Logger, volName string, spec volume.Spec, pod *v1.Pod) (volume.Mounter, error) {
 	return nil, fmt.Errorf("NewWrapperMounter not supported by SELinux controller VolumeHost implementation")
 }
 
@@ -75,22 +76,22 @@ func (c *Controller) GetMounter() mount.Interface {
 	return nil
 }
 
-func (c *Controller) GetNodeAllocatable() (v1.ResourceList, error) {
+func (c *Controller) GetNodeAllocatable(_ context.Context) (v1.ResourceList, error) {
 	return v1.ResourceList{}, nil
 }
 
-func (c *Controller) GetAttachedVolumesFromNodeStatus() (map[v1.UniqueVolumeName]string, error) {
+func (c *Controller) GetAttachedVolumesFromNodeStatus(_ context.Context) (map[v1.UniqueVolumeName]string, error) {
 	return map[v1.UniqueVolumeName]string{}, nil
 }
 
-func (c *Controller) GetSecretFunc() func(namespace, name string) (*v1.Secret, error) {
-	return func(_, _ string) (*v1.Secret, error) {
+func (c *Controller) GetSecretFunc() func(ctx context.Context, namespace, name string) (*v1.Secret, error) {
+	return func(_ context.Context, _, _ string) (*v1.Secret, error) {
 		return nil, fmt.Errorf("GetSecret unsupported in SELinux controller")
 	}
 }
 
-func (c *Controller) GetConfigMapFunc() func(namespace, name string) (*v1.ConfigMap, error) {
-	return func(_, _ string) (*v1.ConfigMap, error) {
+func (c *Controller) GetConfigMapFunc() func(ctx context.Context, namespace, name string) (*v1.ConfigMap, error) {
+	return func(_ context.Context, _, _ string) (*v1.ConfigMap, error) {
 		return nil, fmt.Errorf("GetConfigMap unsupported in SELinux controller")
 	}
 }
@@ -108,7 +109,7 @@ func (c *Controller) DeleteServiceAccountTokenFunc() func(types.UID) {
 	}
 }
 
-func (c *Controller) GetNodeLabels() (map[string]string, error) {
+func (c *Controller) GetNodeLabels(_ context.Context) (map[string]string, error) {
 	return nil, fmt.Errorf("GetNodeLabels() unsupported in SELinux controller")
 }
 

--- a/pkg/kubelet/configmap/configmap_manager.go
+++ b/pkg/kubelet/configmap/configmap_manager.go
@@ -38,7 +38,7 @@ import (
 // Manager interface provides methods for Kubelet to manage ConfigMap.
 type Manager interface {
 	// Get configmap by configmap namespace and name.
-	GetConfigMap(namespace, name string) (*v1.ConfigMap, error)
+	GetConfigMap(ctx context.Context, namespace, name string) (*v1.ConfigMap, error)
 
 	// WARNING: Register/UnregisterPod functions should be efficient,
 	// i.e. should not block on network operations.
@@ -62,8 +62,8 @@ func NewSimpleConfigMapManager(kubeClient clientset.Interface) Manager {
 	return &simpleConfigMapManager{kubeClient: kubeClient}
 }
 
-func (s *simpleConfigMapManager) GetConfigMap(namespace, name string) (*v1.ConfigMap, error) {
-	return s.kubeClient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+func (s *simpleConfigMapManager) GetConfigMap(ctx context.Context, namespace, name string) (*v1.ConfigMap, error) {
+	return s.kubeClient.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
 }
 
 func (s *simpleConfigMapManager) RegisterPod(pod *v1.Pod) {
@@ -80,7 +80,7 @@ type configMapManager struct {
 	manager manager.Manager
 }
 
-func (c *configMapManager) GetConfigMap(namespace, name string) (*v1.ConfigMap, error) {
+func (c *configMapManager) GetConfigMap(ctx context.Context, namespace, name string) (*v1.ConfigMap, error) {
 	object, err := c.manager.GetObject(namespace, name)
 	if err != nil {
 		return nil, err

--- a/pkg/kubelet/configmap/fake_manager.go
+++ b/pkg/kubelet/configmap/fake_manager.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package configmap
 
-import v1 "k8s.io/api/core/v1"
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+)
 
 // fakeManager implements Manager interface for testing purposes.
 // simple operations to apiserver.
@@ -28,7 +32,7 @@ func NewFakeManager() Manager {
 	return &fakeManager{}
 }
 
-func (s *fakeManager) GetConfigMap(namespace, name string) (*v1.ConfigMap, error) {
+func (s *fakeManager) GetConfigMap(ctx context.Context, namespace, name string) (*v1.ConfigMap, error) {
 	return nil, nil
 }
 

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -132,7 +132,7 @@ type Runtime interface {
 	// and store the resulting archive to the checkpoint directory.
 	CheckpointContainer(ctx context.Context, options *runtimeapi.CheckpointContainerRequest) error
 	// Generate pod status from the CRI event
-	GeneratePodStatus(event *runtimeapi.ContainerEventResponse) *PodStatus
+	GeneratePodStatus(ctx context.Context, event *runtimeapi.ContainerEventResponse) *PodStatus
 	// ListMetricDescriptors gets the descriptors for the metrics that will be returned in ListPodSandboxMetrics.
 	// This list should be static at startup: either the client and server restart together when
 	// adding or removing metrics descriptors, or they should not change.

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -133,7 +133,7 @@ type Runtime interface {
 	// and store the resulting archive to the checkpoint directory.
 	CheckpointContainer(ctx context.Context, options *runtimeapi.CheckpointContainerRequest) error
 	// Generate pod status from the CRI event
-	GeneratePodStatus(event *runtimeapi.ContainerEventResponse) *PodStatus
+	GeneratePodStatus(ctx context.Context, event *runtimeapi.ContainerEventResponse) *PodStatus
 	// ListMetricDescriptors gets the descriptors for the metrics that will be returned in ListPodSandboxMetrics.
 	// This list should be static at startup: either the client and server restart together when
 	// adding or removing metrics descriptors, or they should not change.

--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -316,7 +316,7 @@ func (f *FakeRuntime) KillContainerInPod(container v1.Container, pod *v1.Pod) er
 	return f.Err
 }
 
-func (f *FakeRuntime) GeneratePodStatus(event *runtimeapi.ContainerEventResponse) *kubecontainer.PodStatus {
+func (f *FakeRuntime) GeneratePodStatus(_ context.Context, event *runtimeapi.ContainerEventResponse) *kubecontainer.PodStatus {
 	f.Lock()
 	defer f.Unlock()
 

--- a/pkg/kubelet/container/testing/mocks.go
+++ b/pkg/kubelet/container/testing/mocks.go
@@ -302,16 +302,16 @@ func (_c *MockRuntime_GarbageCollect_Call) RunAndReturn(run func(ctx context.Con
 }
 
 // GeneratePodStatus provides a mock function for the type MockRuntime
-func (_mock *MockRuntime) GeneratePodStatus(event *v1.ContainerEventResponse) *container.PodStatus {
-	ret := _mock.Called(event)
+func (_mock *MockRuntime) GeneratePodStatus(ctx context.Context, event *v1.ContainerEventResponse) *container.PodStatus {
+	ret := _mock.Called(ctx, event)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GeneratePodStatus")
 	}
 
 	var r0 *container.PodStatus
-	if returnFunc, ok := ret.Get(0).(func(*v1.ContainerEventResponse) *container.PodStatus); ok {
-		r0 = returnFunc(event)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *v1.ContainerEventResponse) *container.PodStatus); ok {
+		r0 = returnFunc(ctx, event)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*container.PodStatus)
@@ -326,19 +326,25 @@ type MockRuntime_GeneratePodStatus_Call struct {
 }
 
 // GeneratePodStatus is a helper method to define mock.On call
+//   - ctx context.Context
 //   - event *v1.ContainerEventResponse
-func (_e *MockRuntime_Expecter) GeneratePodStatus(event interface{}) *MockRuntime_GeneratePodStatus_Call {
-	return &MockRuntime_GeneratePodStatus_Call{Call: _e.mock.On("GeneratePodStatus", event)}
+func (_e *MockRuntime_Expecter) GeneratePodStatus(ctx interface{}, event interface{}) *MockRuntime_GeneratePodStatus_Call {
+	return &MockRuntime_GeneratePodStatus_Call{Call: _e.mock.On("GeneratePodStatus", ctx, event)}
 }
 
-func (_c *MockRuntime_GeneratePodStatus_Call) Run(run func(event *v1.ContainerEventResponse)) *MockRuntime_GeneratePodStatus_Call {
+func (_c *MockRuntime_GeneratePodStatus_Call) Run(run func(ctx context.Context, event *v1.ContainerEventResponse)) *MockRuntime_GeneratePodStatus_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *v1.ContainerEventResponse
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(*v1.ContainerEventResponse)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *v1.ContainerEventResponse
+		if args[1] != nil {
+			arg1 = args[1].(*v1.ContainerEventResponse)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -349,7 +355,7 @@ func (_c *MockRuntime_GeneratePodStatus_Call) Return(podStatus *container.PodSta
 	return _c
 }
 
-func (_c *MockRuntime_GeneratePodStatus_Call) RunAndReturn(run func(event *v1.ContainerEventResponse) *container.PodStatus) *MockRuntime_GeneratePodStatus_Call {
+func (_c *MockRuntime_GeneratePodStatus_Call) RunAndReturn(run func(ctx context.Context, event *v1.ContainerEventResponse) *container.PodStatus) *MockRuntime_GeneratePodStatus_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -666,11 +666,11 @@ func NewMainKubelet(ctx context.Context,
 	if klet.kubeClient != nil {
 		switch kubeCfg.ConfigMapAndSecretChangeDetectionStrategy {
 		case kubeletconfiginternal.WatchChangeDetectionStrategy:
-			secretManager = secret.NewWatchingSecretManager(klet.kubeClient, klet.resyncInterval)
+			secretManager = secret.NewWatchingSecretManager(ctx, klet.kubeClient, klet.resyncInterval)
 			configMapManager = configmap.NewWatchingConfigMapManager(klet.kubeClient, klet.resyncInterval)
 		case kubeletconfiginternal.TTLCacheChangeDetectionStrategy:
 			secretManager = secret.NewCachingSecretManager(
-				klet.kubeClient, manager.GetObjectTTLFromNodeFunc(ctx, klet.GetNode))
+				ctx, klet.kubeClient, manager.GetObjectTTLFromNodeFunc(ctx, klet.GetNode))
 			configMapManager = configmap.NewCachingConfigMapManager(
 				klet.kubeClient, manager.GetObjectTTLFromNodeFunc(ctx, klet.GetNode))
 		case kubeletconfiginternal.GetChangeDetectionStrategy:
@@ -2230,7 +2230,7 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	}
 
 	// Fetch the pull secrets for the pod
-	pullSecrets, missingPullSecretNames := kl.getPullSecretsForPod(logger, pod)
+	pullSecrets, missingPullSecretNames := kl.getPullSecretsForPod(ctx, pod)
 
 	// Ensure the pod is being probed
 	kl.probeManager.AddPod(ctx, pod)

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -686,11 +686,11 @@ func NewMainKubelet(ctx context.Context,
 	if klet.kubeClient != nil {
 		switch kubeCfg.ConfigMapAndSecretChangeDetectionStrategy {
 		case kubeletconfiginternal.WatchChangeDetectionStrategy:
-			secretManager = secret.NewWatchingSecretManager(klet.kubeClient, klet.resyncInterval)
+			secretManager = secret.NewWatchingSecretManager(ctx, klet.kubeClient, klet.resyncInterval)
 			configMapManager = configmap.NewWatchingConfigMapManager(klet.kubeClient, klet.resyncInterval)
 		case kubeletconfiginternal.TTLCacheChangeDetectionStrategy:
 			secretManager = secret.NewCachingSecretManager(
-				klet.kubeClient, manager.GetObjectTTLFromNodeFunc(ctx, klet.GetNode))
+				ctx, klet.kubeClient, manager.GetObjectTTLFromNodeFunc(ctx, klet.GetNode))
 			configMapManager = configmap.NewCachingConfigMapManager(
 				klet.kubeClient, manager.GetObjectTTLFromNodeFunc(ctx, klet.GetNode))
 		case kubeletconfiginternal.GetChangeDetectionStrategy:
@@ -2247,7 +2247,7 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	kl.containerRuntime.InitializeActuatedPod(logger, pod)
 
 	// Fetch the pull secrets for the pod
-	pullSecrets, missingPullSecretNames := kl.getPullSecretsForPod(logger, pod)
+	pullSecrets, missingPullSecretNames := kl.getPullSecretsForPod(ctx, pod)
 
 	// Ensure the pod is being probed
 	kl.probeManager.AddPod(ctx, pod)

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -798,7 +798,7 @@ func (kl *Kubelet) makeEnvironmentVariables(ctx context.Context, pod *v1.Pod, co
 					return result, fmt.Errorf("couldn't get configMap %v/%v, no kubeClient defined", pod.Namespace, name)
 				}
 				optional := cm.Optional != nil && *cm.Optional
-				configMap, err = kl.configMapManager.GetConfigMap(pod.Namespace, name)
+				configMap, err = kl.configMapManager.GetConfigMap(ctx, pod.Namespace, name)
 				if err != nil {
 					if errors.IsNotFound(err) && optional {
 						// ignore error when marked optional
@@ -826,7 +826,7 @@ func (kl *Kubelet) makeEnvironmentVariables(ctx context.Context, pod *v1.Pod, co
 					return result, fmt.Errorf("couldn't get secret %v/%v, no kubeClient defined", pod.Namespace, name)
 				}
 				optional := s.Optional != nil && *s.Optional
-				secret, err = kl.secretManager.GetSecret(pod.Namespace, name)
+				secret, err = kl.secretManager.GetSecret(ctx, pod.Namespace, name)
 				if err != nil {
 					if errors.IsNotFound(err) && optional {
 						// ignore error when marked optional
@@ -892,7 +892,7 @@ func (kl *Kubelet) makeEnvironmentVariables(ctx context.Context, pod *v1.Pod, co
 					if kl.kubeClient == nil {
 						return result, fmt.Errorf("couldn't get configMap %v/%v, no kubeClient defined", pod.Namespace, name)
 					}
-					configMap, err = kl.configMapManager.GetConfigMap(pod.Namespace, name)
+					configMap, err = kl.configMapManager.GetConfigMap(ctx, pod.Namespace, name)
 					if err != nil {
 						if errors.IsNotFound(err) && optional {
 							// ignore error when marked optional
@@ -919,7 +919,7 @@ func (kl *Kubelet) makeEnvironmentVariables(ctx context.Context, pod *v1.Pod, co
 					if kl.kubeClient == nil {
 						return result, fmt.Errorf("couldn't get secret %v/%v, no kubeClient defined", pod.Namespace, name)
 					}
-					secret, err = kl.secretManager.GetSecret(pod.Namespace, name)
+					secret, err = kl.secretManager.GetSecret(ctx, pod.Namespace, name)
 					if err != nil {
 						if errors.IsNotFound(err) && optional {
 							// ignore error when marked optional
@@ -1084,7 +1084,8 @@ func (kl *Kubelet) makePodDataDirs(pod *v1.Pod) error {
 // getPullSecretsForPod inspects the Pod and retrieves the referenced pull
 // secrets. The names of secrets that cannot be found are returned so we can
 // emit an event later if the image pull fails too.
-func (kl *Kubelet) getPullSecretsForPod(logger klog.Logger, pod *v1.Pod) ([]v1.Secret, []string) {
+func (kl *Kubelet) getPullSecretsForPod(ctx context.Context, pod *v1.Pod) ([]v1.Secret, []string) {
+	logger := klog.FromContext(ctx)
 	pullSecrets := []v1.Secret{}
 	missingPullSecretNames := []string{}
 
@@ -1094,7 +1095,7 @@ func (kl *Kubelet) getPullSecretsForPod(logger klog.Logger, pod *v1.Pod) ([]v1.S
 			// Ignore to avoid unnecessary warnings.
 			continue
 		}
-		secret, err := kl.secretManager.GetSecret(pod.Namespace, secretRef.Name)
+		secret, err := kl.secretManager.GetSecret(ctx, pod.Namespace, secretRef.Name)
 		if err != nil {
 			logger.Info("Unable to retrieve pull secret, the image pull may not succeed.", "pod", klog.KObj(pod), "secret", klog.KRef(pod.Namespace, secretRef.Name), "err", err)
 			missingPullSecretNames = append(missingPullSecretNames, secretRef.Name)

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -805,7 +805,7 @@ func (kl *Kubelet) makeEnvironmentVariables(ctx context.Context, pod *v1.Pod, co
 					return result, fmt.Errorf("couldn't get configMap %v/%v, no kubeClient defined", pod.Namespace, name)
 				}
 				optional := cm.Optional != nil && *cm.Optional
-				configMap, err = kl.configMapManager.GetConfigMap(pod.Namespace, name)
+				configMap, err = kl.configMapManager.GetConfigMap(ctx, pod.Namespace, name)
 				if err != nil {
 					if errors.IsNotFound(err) && optional {
 						// ignore error when marked optional
@@ -833,7 +833,7 @@ func (kl *Kubelet) makeEnvironmentVariables(ctx context.Context, pod *v1.Pod, co
 					return result, fmt.Errorf("couldn't get secret %v/%v, no kubeClient defined", pod.Namespace, name)
 				}
 				optional := s.Optional != nil && *s.Optional
-				secret, err = kl.secretManager.GetSecret(pod.Namespace, name)
+				secret, err = kl.secretManager.GetSecret(ctx, pod.Namespace, name)
 				if err != nil {
 					if errors.IsNotFound(err) && optional {
 						// ignore error when marked optional
@@ -899,7 +899,7 @@ func (kl *Kubelet) makeEnvironmentVariables(ctx context.Context, pod *v1.Pod, co
 					if kl.kubeClient == nil {
 						return result, fmt.Errorf("couldn't get configMap %v/%v, no kubeClient defined", pod.Namespace, name)
 					}
-					configMap, err = kl.configMapManager.GetConfigMap(pod.Namespace, name)
+					configMap, err = kl.configMapManager.GetConfigMap(ctx, pod.Namespace, name)
 					if err != nil {
 						if errors.IsNotFound(err) && optional {
 							// ignore error when marked optional
@@ -926,7 +926,7 @@ func (kl *Kubelet) makeEnvironmentVariables(ctx context.Context, pod *v1.Pod, co
 					if kl.kubeClient == nil {
 						return result, fmt.Errorf("couldn't get secret %v/%v, no kubeClient defined", pod.Namespace, name)
 					}
-					secret, err = kl.secretManager.GetSecret(pod.Namespace, name)
+					secret, err = kl.secretManager.GetSecret(ctx, pod.Namespace, name)
 					if err != nil {
 						if errors.IsNotFound(err) && optional {
 							// ignore error when marked optional
@@ -1091,7 +1091,8 @@ func (kl *Kubelet) makePodDataDirs(pod *v1.Pod) error {
 // getPullSecretsForPod inspects the Pod and retrieves the referenced pull
 // secrets. The names of secrets that cannot be found are returned so we can
 // emit an event later if the image pull fails too.
-func (kl *Kubelet) getPullSecretsForPod(logger klog.Logger, pod *v1.Pod) ([]v1.Secret, []string) {
+func (kl *Kubelet) getPullSecretsForPod(ctx context.Context, pod *v1.Pod) ([]v1.Secret, []string) {
+	logger := klog.FromContext(ctx)
 	pullSecrets := []v1.Secret{}
 	missingPullSecretNames := []string{}
 
@@ -1101,7 +1102,7 @@ func (kl *Kubelet) getPullSecretsForPod(logger klog.Logger, pod *v1.Pod) ([]v1.S
 			// Ignore to avoid unnecessary warnings.
 			continue
 		}
-		secret, err := kl.secretManager.GetSecret(pod.Namespace, secretRef.Name)
+		secret, err := kl.secretManager.GetSecret(ctx, pod.Namespace, secretRef.Name)
 		if err != nil {
 			logger.Info("Unable to retrieve pull secret, the image pull may not succeed.", "pod", klog.KObj(pod), "secret", klog.KRef(pod.Namespace, secretRef.Name), "err", err)
 			missingPullSecretNames = append(missingPullSecretNames, secretRef.Name)

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -8387,7 +8387,7 @@ func testMetric(t *testing.T, metricName string, expectedMetric string) {
 }
 
 func TestGetNonExistentImagePullSecret(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	secrets := make([]*v1.Secret, 0)
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	testKubelet.kubelet.secretManager = secret.NewFakeManagerWithSecrets(secrets)
@@ -8406,7 +8406,7 @@ func TestGetNonExistentImagePullSecret(t *testing.T) {
 		},
 	}
 
-	pullSecrets, missingPullSecrets := testKubelet.kubelet.getPullSecretsForPod(logger, testPod)
+	pullSecrets, missingPullSecrets := testKubelet.kubelet.getPullSecretsForPod(tCtx, testPod)
 	assert.Empty(t, pullSecrets)
 	assert.Equal(t, []string{"secretFoo"}, missingPullSecrets)
 }

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -8469,7 +8469,7 @@ func testMetric(t *testing.T, metricName string, expectedMetric string) {
 }
 
 func TestGetNonExistentImagePullSecret(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	secrets := make([]*v1.Secret, 0)
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	testKubelet.kubelet.secretManager = secret.NewFakeManagerWithSecrets(secrets)
@@ -8488,7 +8488,7 @@ func TestGetNonExistentImagePullSecret(t *testing.T) {
 		},
 	}
 
-	pullSecrets, missingPullSecrets := testKubelet.kubelet.getPullSecretsForPod(logger, testPod)
+	pullSecrets, missingPullSecrets := testKubelet.kubelet.getPullSecretsForPod(tCtx, testPod)
 	assert.Empty(t, pullSecrets)
 	assert.Equal(t, []string{"secretFoo"}, missingPullSecrets)
 }
@@ -8699,11 +8699,11 @@ func (tvm *testVolumeMounter) GetMetrics() (*volume.Metrics, error) {
 	return &volume.Metrics{}, nil
 }
 
-func (tvm *testVolumeMounter) SetUp(mounterArgs volume.MounterArgs) error {
+func (tvm *testVolumeMounter) SetUp(ctx context.Context, mounterArgs volume.MounterArgs) error {
 	return nil
 }
 
-func (tvm *testVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterArgs) error {
+func (tvm *testVolumeMounter) SetUpAt(ctx context.Context, dir string, mounterArgs volume.MounterArgs) error {
 	return nil
 }
 

--- a/pkg/kubelet/kubelet_volumes_test.go
+++ b/pkg/kubelet/kubelet_volumes_test.go
@@ -700,11 +700,11 @@ func (f *stubVolume) GetAttributes() volume.Attributes {
 	return f.attributes
 }
 
-func (f *stubVolume) SetUp(mounterArgs volume.MounterArgs) error {
+func (f *stubVolume) SetUp(ctx context.Context, mounterArgs volume.MounterArgs) error {
 	return nil
 }
 
-func (f *stubVolume) SetUpAt(dir string, mounterArgs volume.MounterArgs) error {
+func (f *stubVolume) SetUpAt(ctx context.Context, dir string, mounterArgs volume.MounterArgs) error {
 	return nil
 }
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -964,14 +964,12 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 		var err error
 		// At upsizing, limits should expand prior to requests in order to keep "requests <= limits".
 		if newPodCgLimValue > currPodCgLimValue {
-			// TODO: Pass logger from context once contextual logging migration is complete
-			if err = setPodCgroupConfig(klog.TODO(), rName, true); err != nil {
+			if err = setPodCgroupConfig(logger, rName, true); err != nil {
 				return err
 			}
 		}
 		if newPodCgReqValue > currPodCgReqValue {
-			// TODO: Pass logger from context once contextual logging migration is complete
-			if err = setPodCgroupConfig(klog.TODO(), rName, false); err != nil {
+			if err = setPodCgroupConfig(logger, rName, false); err != nil {
 				return err
 			}
 		}
@@ -984,14 +982,12 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 
 		// At downsizing, requests should shrink prior to limits in order to keep "requests <= limits".
 		if newPodCgReqValue < currPodCgReqValue {
-			// TODO: Pass logger from context once contextual logging migration is complete
-			if err = setPodCgroupConfig(klog.TODO(), rName, false); err != nil {
+			if err = setPodCgroupConfig(logger, rName, false); err != nil {
 				return err
 			}
 		}
 		if newPodCgLimValue < currPodCgLimValue {
-			// TODO(#127825): Pass logger from context once contextual logging migration is complete
-			if err = setPodCgroupConfig(klog.TODO(), rName, true); err != nil {
+			if err = setPodCgroupConfig(logger, rName, true); err != nil {
 				return err
 			}
 		}
@@ -2005,8 +2001,7 @@ func (m *kubeGenericRuntimeManager) killPodWithSyncResult(ctx context.Context, p
 	return
 }
 
-func (m *kubeGenericRuntimeManager) GeneratePodStatus(event *runtimeapi.ContainerEventResponse) *kubecontainer.PodStatus {
-	ctx := context.TODO() // This context will be passed as parameter in the future
+func (m *kubeGenericRuntimeManager) GeneratePodStatus(ctx context.Context, event *runtimeapi.ContainerEventResponse) *kubecontainer.PodStatus {
 	podUID := kubetypes.UID(event.PodSandboxStatus.Metadata.Uid)
 	podIPs := m.determinePodSandboxIPs(ctx, event.PodSandboxStatus.Metadata.Namespace, event.PodSandboxStatus.Metadata.Name, event.PodSandboxStatus)
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1046,14 +1046,12 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 		var err error
 		// At upsizing, limits should expand prior to requests in order to keep "requests <= limits".
 		if newPodCgLimValue > currPodCgLimValue {
-			// TODO: Pass logger from context once contextual logging migration is complete
-			if err = setPodCgroupConfig(klog.TODO(), rName, true); err != nil {
+			if err = setPodCgroupConfig(logger, rName, true); err != nil {
 				return err
 			}
 		}
 		if newPodCgReqValue > currPodCgReqValue {
-			// TODO: Pass logger from context once contextual logging migration is complete
-			if err = setPodCgroupConfig(klog.TODO(), rName, false); err != nil {
+			if err = setPodCgroupConfig(logger, rName, false); err != nil {
 				return err
 			}
 		}
@@ -1066,14 +1064,12 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 
 		// At downsizing, requests should shrink prior to limits in order to keep "requests <= limits".
 		if newPodCgReqValue < currPodCgReqValue {
-			// TODO: Pass logger from context once contextual logging migration is complete
-			if err = setPodCgroupConfig(klog.TODO(), rName, false); err != nil {
+			if err = setPodCgroupConfig(logger, rName, false); err != nil {
 				return err
 			}
 		}
 		if newPodCgLimValue < currPodCgLimValue {
-			// TODO(#127825): Pass logger from context once contextual logging migration is complete
-			if err = setPodCgroupConfig(klog.TODO(), rName, true); err != nil {
+			if err = setPodCgroupConfig(logger, rName, true); err != nil {
 				return err
 			}
 		}
@@ -2137,8 +2133,7 @@ func (m *kubeGenericRuntimeManager) killPodWithSyncResult(ctx context.Context, p
 	return
 }
 
-func (m *kubeGenericRuntimeManager) GeneratePodStatus(event *runtimeapi.ContainerEventResponse) *kubecontainer.PodStatus {
-	ctx := context.TODO() // This context will be passed as parameter in the future
+func (m *kubeGenericRuntimeManager) GeneratePodStatus(ctx context.Context, event *runtimeapi.ContainerEventResponse) *kubecontainer.PodStatus {
 	podUID := kubetypes.UID(event.PodSandboxStatus.Metadata.Uid)
 	podIPs := m.determinePodSandboxIPs(ctx, event.PodSandboxStatus.Metadata.Namespace, event.PodSandboxStatus.Metadata.Name, event.PodSandboxStatus)
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -51,7 +51,6 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	apitest "k8s.io/cri-api/pkg/apis/testing"
 	crierror "k8s.io/cri-api/pkg/errors"
-	"k8s.io/klog/v2"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/features"
@@ -4862,8 +4861,7 @@ func TestDoPodResizeAction(t *testing.T) {
 				CPUQuota:  ptr.To(cm.MilliCPUToQuota(podCPULimit, cm.QuotaPeriod)),
 			}, nil).Maybe()
 			if tc.expectPodCgroupUpdates > 0 {
-				// TODO: Update to use proper logger once contextual logging migration is complete
-				call := mockPCM.EXPECT().SetPodCgroupConfig(klog.TODO(), mock.Anything, mock.Anything)
+				call := mockPCM.EXPECT().SetPodCgroupConfig(logger, mock.Anything, mock.Anything)
 				if tc.injectPodUpdateCgroupsError != nil {
 					call.Return(tc.injectPodUpdateCgroupsError).Times(1)
 				} else {

--- a/pkg/kubelet/pleg/evented.go
+++ b/pkg/kubelet/pleg/evented.go
@@ -211,10 +211,11 @@ func (e *EventedPLEG) watchEventsChannel(ctx context.Context) {
 	}()
 
 	if isEventedPLEGInUse() {
-		e.processCRIEvents(logger, containerEventsResponseCh)
+		e.processCRIEvents(ctx, containerEventsResponseCh)
 	}
 }
-func (e *EventedPLEG) processCRIEvents(logger klog.Logger, containerEventsResponseCh chan *runtimeapi.ContainerEventResponse) {
+func (e *EventedPLEG) processCRIEvents(ctx context.Context, containerEventsResponseCh chan *runtimeapi.ContainerEventResponse) {
+	logger := klog.FromContext(ctx)
 	for event := range containerEventsResponseCh {
 		// Ignore the event if PodSandboxStatus is nil.
 		// This might happen under some race condition where the podSandbox has
@@ -232,7 +233,7 @@ func (e *EventedPLEG) processCRIEvents(logger klog.Logger, containerEventsRespon
 		podID := types.UID(event.PodSandboxStatus.Metadata.Uid)
 		shouldSendPLEGEvent := false
 
-		status := e.runtime.GeneratePodStatus(event)
+		status := e.runtime.GeneratePodStatus(ctx, event)
 		if klogV := logger.V(6); klogV.Enabled() {
 			logger.Info("Evented PLEG: Generated pod status from the received event", "podUID", podID, "podStatus", status)
 		} else {

--- a/pkg/kubelet/pleg/evented_test.go
+++ b/pkg/kubelet/pleg/evented_test.go
@@ -247,7 +247,7 @@ func TestProcessCRIEventsRequestsRelistOnlyForStoppedEvents(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			podRelister := newFakePodRelister()
 			eventedPleg := newTestEventedPLEG(podRelister)
-			logger := ktesting.NewLogger(t, ktesting.DefaultConfig)
+			logger, _ := ktesting.NewTestContext(t)
 			eventsCh := make(chan *v1.ContainerEventResponse, 1)
 			eventsCh <- test.event
 			close(eventsCh)

--- a/pkg/kubelet/secret/fake_manager.go
+++ b/pkg/kubelet/secret/fake_manager.go
@@ -17,6 +17,7 @@ limitations under the License.
 package secret
 
 import (
+	"context"
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
@@ -42,7 +43,7 @@ func NewFakeManagerWithSecrets(secrets []*v1.Secret) Manager {
 
 // GetSecret function returns the searched secret if it was provided during the manager initialization, otherwise, it returns an error.
 // If the manager was initialized without any secrets, it returns a nil secret."
-func (s *fakeManager) GetSecret(namespace, name string) (*v1.Secret, error) {
+func (s *fakeManager) GetSecret(_ context.Context, namespace, name string) (*v1.Secret, error) {
 	if s.secrets == nil {
 		return nil, nil
 	}

--- a/pkg/kubelet/secret/secret_manager.go
+++ b/pkg/kubelet/secret/secret_manager.go
@@ -39,7 +39,7 @@ import (
 // secrets or registering/unregistering them via Pods.
 type Manager interface {
 	// Get secret by secret namespace and name.
-	GetSecret(namespace, name string) (*v1.Secret, error)
+	GetSecret(ctx context.Context, namespace, name string) (*v1.Secret, error)
 
 	// WARNING: Register/UnregisterPod functions should be efficient,
 	// i.e. should not block on network operations.
@@ -63,8 +63,8 @@ func NewSimpleSecretManager(kubeClient clientset.Interface) Manager {
 	return &simpleSecretManager{kubeClient: kubeClient}
 }
 
-func (s *simpleSecretManager) GetSecret(namespace, name string) (*v1.Secret, error) {
-	return s.kubeClient.CoreV1().Secrets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+func (s *simpleSecretManager) GetSecret(ctx context.Context, namespace, name string) (*v1.Secret, error) {
+	return s.kubeClient.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
 }
 
 func (s *simpleSecretManager) RegisterPod(pod *v1.Pod) {
@@ -81,7 +81,7 @@ type secretManager struct {
 	manager manager.Manager
 }
 
-func (s *secretManager) GetSecret(namespace, name string) (*v1.Secret, error) {
+func (s *secretManager) GetSecret(_ context.Context, namespace, name string) (*v1.Secret, error) {
 	object, err := s.manager.GetObject(namespace, name)
 	if err != nil {
 		return nil, err
@@ -121,9 +121,9 @@ const (
 //   - every GetObject() call tries to fetch the value from local cache; if it is
 //     not there, invalidated or too old, we fetch it from apiserver and refresh the
 //     value in cache; otherwise it is just fetched from cache
-func NewCachingSecretManager(kubeClient clientset.Interface, getTTL manager.GetObjectTTLFunc) Manager {
+func NewCachingSecretManager(ctx context.Context, kubeClient clientset.Interface, getTTL manager.GetObjectTTLFunc) Manager {
 	getSecret := func(namespace, name string, opts metav1.GetOptions) (runtime.Object, error) {
-		return kubeClient.CoreV1().Secrets(namespace).Get(context.TODO(), name, opts)
+		return kubeClient.CoreV1().Secrets(namespace).Get(ctx, name, opts)
 	}
 	secretStore := manager.NewObjectStore(getSecret, clock.RealClock{}, getTTL, defaultTTL)
 	return &secretManager{
@@ -137,12 +137,12 @@ func NewCachingSecretManager(kubeClient clientset.Interface, getTTL manager.GetO
 //   - whenever a pod is created or updated, we start individual watches for all
 //     referenced objects that aren't referenced from other registered pods
 //   - every GetObject() returns a value from local cache propagated via watches
-func NewWatchingSecretManager(kubeClient clientset.Interface, resyncInterval time.Duration) Manager {
+func NewWatchingSecretManager(ctx context.Context, kubeClient clientset.Interface, resyncInterval time.Duration) Manager {
 	listSecret := func(namespace string, opts metav1.ListOptions) (runtime.Object, error) {
-		return kubeClient.CoreV1().Secrets(namespace).List(context.TODO(), opts)
+		return kubeClient.CoreV1().Secrets(namespace).List(ctx, opts)
 	}
 	watchSecret := func(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
-		return kubeClient.CoreV1().Secrets(namespace).Watch(context.TODO(), opts)
+		return kubeClient.CoreV1().Secrets(namespace).Watch(ctx, opts)
 	}
 	newSecret := func() runtime.Object {
 		return &v1.Secret{}

--- a/pkg/kubelet/volume_host.go
+++ b/pkg/kubelet/volume_host.go
@@ -236,20 +236,20 @@ func (kvh *kubeletVolumeHost) GetNodeAllocatable() (v1.ResourceList, error) {
 	return node.Status.Allocatable, nil
 }
 
-func (kvh *kubeletVolumeHost) GetSecretFunc() func(namespace, name string) (*v1.Secret, error) {
+func (kvh *kubeletVolumeHost) GetSecretFunc() func(ctx context.Context, namespace, name string) (*v1.Secret, error) {
 	if kvh.secretManager != nil {
 		return kvh.secretManager.GetSecret
 	}
-	return func(namespace, name string) (*v1.Secret, error) {
+	return func(ctx context.Context, namespace, name string) (*v1.Secret, error) {
 		return nil, fmt.Errorf("not supported due to running kubelet in standalone mode")
 	}
 }
 
-func (kvh *kubeletVolumeHost) GetConfigMapFunc() func(namespace, name string) (*v1.ConfigMap, error) {
+func (kvh *kubeletVolumeHost) GetConfigMapFunc() func(ctx context.Context, namespace, name string) (*v1.ConfigMap, error) {
 	if kvh.configMapManager != nil {
 		return kvh.configMapManager.GetConfigMap
 	}
-	return func(namespace, name string) (*v1.ConfigMap, error) {
+	return func(ctx context.Context, namespace, name string) (*v1.ConfigMap, error) {
 		return nil, fmt.Errorf("not supported due to running kubelet in standalone mode")
 	}
 }

--- a/pkg/kubelet/volume_host.go
+++ b/pkg/kubelet/volume_host.go
@@ -173,10 +173,7 @@ func (kvh *kubeletVolumeHost) CSIDriversSynced() cache.InformerSynced {
 }
 
 // WaitForCacheSync is a helper function that waits for cache sync for CSIDriverLister
-func (kvh *kubeletVolumeHost) WaitForCacheSync() error {
-	// Use context.TODO() because we currently do not have a proper context to pass in.
-	// Replace this with an appropriate context when refactoring this function to accept a context parameter.
-	logger := klog.FromContext(context.TODO())
+func (kvh *kubeletVolumeHost) WaitForCacheSync(logger klog.Logger) error {
 	if kvh.csiDriversSynced == nil {
 		logger.Error(nil, "CsiDriversSynced not found on KubeletVolumeHost")
 		return fmt.Errorf("csiDriversSynced not found on KubeletVolumeHost")
@@ -192,12 +189,10 @@ func (kvh *kubeletVolumeHost) WaitForCacheSync() error {
 }
 
 func (kvh *kubeletVolumeHost) NewWrapperMounter(
+	logger klog.Logger,
 	volName string,
 	spec volume.Spec,
 	pod *v1.Pod) (volume.Mounter, error) {
-	// Use context.TODO() because we currently do not have a proper context to pass in.
-	// Replace this with an appropriate context when refactoring this function to accept a context parameter.
-	logger := klog.FromContext(context.TODO())
 
 	// The name of wrapper volume is set to "wrapped_{wrapped_volume_name}"
 	wrapperVolumeName := "wrapped_" + volName
@@ -227,29 +222,28 @@ func (kvh *kubeletVolumeHost) GetMounter() mount.Interface {
 	return kvh.kubelet.mounter
 }
 
-func (kvh *kubeletVolumeHost) GetNodeAllocatable() (v1.ResourceList, error) {
-	// TODO: Pass proper context when VolumeHost interface methods support context parameters
-	node, err := kvh.kubelet.getNodeAnyWay(context.TODO())
+func (kvh *kubeletVolumeHost) GetNodeAllocatable(ctx context.Context) (v1.ResourceList, error) {
+	node, err := kvh.kubelet.getNodeAnyWay(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving node: %v", err)
 	}
 	return node.Status.Allocatable, nil
 }
 
-func (kvh *kubeletVolumeHost) GetSecretFunc() func(namespace, name string) (*v1.Secret, error) {
+func (kvh *kubeletVolumeHost) GetSecretFunc() func(ctx context.Context, namespace, name string) (*v1.Secret, error) {
 	if kvh.secretManager != nil {
 		return kvh.secretManager.GetSecret
 	}
-	return func(namespace, name string) (*v1.Secret, error) {
+	return func(ctx context.Context, namespace, name string) (*v1.Secret, error) {
 		return nil, fmt.Errorf("not supported due to running kubelet in standalone mode")
 	}
 }
 
-func (kvh *kubeletVolumeHost) GetConfigMapFunc() func(namespace, name string) (*v1.ConfigMap, error) {
+func (kvh *kubeletVolumeHost) GetConfigMapFunc() func(ctx context.Context, namespace, name string) (*v1.ConfigMap, error) {
 	if kvh.configMapManager != nil {
 		return kvh.configMapManager.GetConfigMap
 	}
-	return func(namespace, name string) (*v1.ConfigMap, error) {
+	return func(ctx context.Context, namespace, name string) (*v1.ConfigMap, error) {
 		return nil, fmt.Errorf("not supported due to running kubelet in standalone mode")
 	}
 }
@@ -274,18 +268,16 @@ func (kvh *kubeletVolumeHost) GetPodCertificateCredentialBundle(ctx context.Cont
 	return kvh.podCertificateManager.GetPodCertificateCredentialBundle(ctx, namespace, podName, podUID, volumeName, sourceIndex)
 }
 
-func (kvh *kubeletVolumeHost) GetNodeLabels() (map[string]string, error) {
-	// TODO: Pass proper context when VolumeHost interface methods support context parameters
-	node, err := kvh.kubelet.GetNode(context.TODO())
+func (kvh *kubeletVolumeHost) GetNodeLabels(ctx context.Context) (map[string]string, error) {
+	node, err := kvh.kubelet.GetNode(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving node: %v", err)
 	}
 	return node.Labels, nil
 }
 
-func (kvh *kubeletVolumeHost) GetAttachedVolumesFromNodeStatus() (map[v1.UniqueVolumeName]string, error) {
-	// TODO: Pass proper context when VolumeHost interface methods support context parameters
-	node, err := kvh.kubelet.GetNode(context.TODO())
+func (kvh *kubeletVolumeHost) GetAttachedVolumesFromNodeStatus(ctx context.Context) (map[v1.UniqueVolumeName]string, error) {
+	node, err := kvh.kubelet.GetNode(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving node: %v", err)
 	}

--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
@@ -392,7 +392,7 @@ func (asw *actualStateOfWorld) MarkVolumeAsAttached(
 	volumeName v1.UniqueVolumeName, volumeSpec *volume.Spec, _ types.NodeName, devicePath string) error {
 
 	pluginIsAttachable := volumeAttachabilityFalse
-	if attachablePlugin, err := asw.volumePluginMgr.FindAttachablePluginBySpec(volumeSpec); err == nil && attachablePlugin != nil {
+	if attachablePlugin, err := asw.volumePluginMgr.FindAttachablePluginBySpec(logger, volumeSpec); err == nil && attachablePlugin != nil {
 		pluginIsAttachable = volumeAttachabilityTrue
 	}
 
@@ -894,7 +894,7 @@ func (asw *actualStateOfWorld) MarkRemountRequired(
 				continue
 			}
 
-			if volumePlugin.RequiresRemount(podObj.volumeSpec) {
+			if volumePlugin.RequiresRemount(logger, podObj.volumeSpec) {
 				podObj.remountRequired = true
 				asw.attachedVolumes[volumeName].mountedPods[podName] = podObj
 			}

--- a/pkg/kubelet/volumemanager/cache/desired_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/desired_state_of_world.go
@@ -359,7 +359,7 @@ func (dsw *desiredStateOfWorld) AddPodToVolume(
 	mountRequestTime := time.Now()
 	var outerVolumeSpecNames []string
 	if ok {
-		if !volumePlugin.RequiresRemount(volumeSpec) {
+		if !volumePlugin.RequiresRemount(logger, volumeSpec) {
 			mountRequestTime = oldPodMount.mountRequestTime
 		}
 		outerVolumeSpecNames = oldPodMount.outerVolumeSpecNames

--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
@@ -206,7 +206,7 @@ func (dswp *desiredStateOfWorldPopulator) findAndRemoveDeletedPods(logger klog.L
 
 			// check if the attachability has changed for this volume
 			if volumeToMount.PluginIsAttachable {
-				attachableVolumePlugin, err := dswp.volumePluginMgr.FindAttachablePluginBySpec(volumeToMount.VolumeSpec)
+				attachableVolumePlugin, err := dswp.volumePluginMgr.FindAttachablePluginBySpec(logger, volumeToMount.VolumeSpec)
 				// only this means the plugin is truly non-attachable
 				if err == nil && attachableVolumePlugin == nil {
 					// It is not possible right now for a CSI plugin to be both attachable and non-deviceMountable

--- a/pkg/kubelet/volumemanager/reconciler/reconciler.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler.go
@@ -45,7 +45,7 @@ func (rc *reconciler) reconcile(ctx context.Context) {
 	// attach if kubelet is responsible for attaching volumes.
 	// If underlying PVC was resized while in-use then this function also handles volume
 	// resizing.
-	rc.mountOrAttachVolumes(logger)
+	rc.mountOrAttachVolumes(ctx)
 
 	// Unmount volumes only when DSW and ASW are fully populated to prevent unmounting a volume
 	// that is still needed, but it did not reach DSW yet.

--- a/pkg/kubelet/volumemanager/reconciler/reconciler_common.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler_common.go
@@ -166,7 +166,8 @@ func (rc *reconciler) unmountVolumes(logger klog.Logger) {
 	}
 }
 
-func (rc *reconciler) mountOrAttachVolumes(logger klog.Logger) {
+func (rc *reconciler) mountOrAttachVolumes(ctx context.Context) {
+	logger := klog.FromContext(ctx)
 	// Ensure volumes that should be attached/mounted are attached/mounted.
 	for _, volumeToMount := range rc.desiredStateOfWorld.GetVolumesToMount() {
 		if rc.operationExecutor.IsOperationPending(volumeToMount.VolumeName, nestedpendingoperations.EmptyUniquePodName, nestedpendingoperations.EmptyNodeName) {
@@ -181,9 +182,9 @@ func (rc *reconciler) mountOrAttachVolumes(logger klog.Logger) {
 			rc.desiredStateOfWorld.AddErrorToPod(volumeToMount.PodName, err.Error())
 			continue
 		} else if cache.IsVolumeNotAttachedError(err) {
-			rc.waitForVolumeAttach(logger, volumeToMount)
+			rc.waitForVolumeAttach(ctx, volumeToMount)
 		} else if !volMounted || cache.IsRemountRequiredError(err) {
-			rc.mountAttachedVolumes(logger, volumeToMount, err)
+			rc.mountAttachedVolumes(ctx, volumeToMount, err)
 		} else if cache.IsFSResizeRequiredError(err) {
 			fsResizeRequiredErr, _ := err.(cache.FsResizeRequiredError)
 			rc.expandVolume(logger, volumeToMount, fsResizeRequiredErr.CurrentSize)
@@ -204,7 +205,8 @@ func (rc *reconciler) expandVolume(logger klog.Logger, volumeToMount cache.Volum
 	}
 }
 
-func (rc *reconciler) mountAttachedVolumes(logger klog.Logger, volumeToMount cache.VolumeToMount, podExistError error) {
+func (rc *reconciler) mountAttachedVolumes(ctx context.Context, volumeToMount cache.VolumeToMount, podExistError error) {
+	logger := klog.FromContext(ctx)
 	// Volume is not mounted, or is already mounted, but requires remounting
 	remountingLogStr := ""
 	isRemount := cache.IsRemountRequiredError(podExistError)
@@ -213,6 +215,7 @@ func (rc *reconciler) mountAttachedVolumes(logger klog.Logger, volumeToMount cac
 	}
 	logger.V(4).Info(volumeToMount.GenerateMsgDetailed("Starting operationExecutor.MountVolume", remountingLogStr), "pod", klog.KObj(volumeToMount.Pod))
 	err := rc.operationExecutor.MountVolume(
+		ctx,
 		rc.waitForAttachTimeout,
 		volumeToMount.VolumeToMount,
 		rc.actualStateOfWorld,
@@ -229,7 +232,8 @@ func (rc *reconciler) mountAttachedVolumes(logger klog.Logger, volumeToMount cac
 	}
 }
 
-func (rc *reconciler) waitForVolumeAttach(logger klog.Logger, volumeToMount cache.VolumeToMount) {
+func (rc *reconciler) waitForVolumeAttach(ctx context.Context, volumeToMount cache.VolumeToMount) {
+	logger := klog.FromContext(ctx)
 	if rc.controllerAttachDetachEnabled || !volumeToMount.PluginIsAttachable {
 		//// lets not spin a goroutine and unnecessarily trigger exponential backoff if this happens
 		if volumeToMount.PluginIsAttachable && !volumeToMount.ReportedInUse {
@@ -240,7 +244,7 @@ func (rc *reconciler) waitForVolumeAttach(logger klog.Logger, volumeToMount cach
 		// for controller to finish attaching volume.
 		logger.V(5).Info(volumeToMount.GenerateMsgDetailed("Starting operationExecutor.VerifyControllerAttachedVolume", ""), "pod", klog.KObj(volumeToMount.Pod))
 		err := rc.operationExecutor.VerifyControllerAttachedVolume(
-			logger,
+			ctx,
 			volumeToMount.VolumeToMount,
 			rc.nodeName,
 			rc.actualStateOfWorld)

--- a/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
@@ -28,6 +28,7 @@ import (
 
 	csitrans "k8s.io/csi-translation-lib"
 	"k8s.io/kubernetes/pkg/volume/csimigration"
+	"k8s.io/kubernetes/test/utils/ktesting"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/mount-utils"
@@ -41,8 +42,6 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/klog/v2/ktesting"
-	_ "k8s.io/klog/v2/ktesting/init"
 	"k8s.io/kubernetes/pkg/kubelet/volumemanager/cache"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetesting "k8s.io/kubernetes/pkg/volume/testing"
@@ -71,7 +70,7 @@ func hasAddedPods() bool { return true }
 // Calls Run()
 // Verifies there are no calls to attach, detach, mount, unmount, etc.
 func Test_Run_Positive_DoNothing(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	// Arrange
 	volumePluginMgr, fakePlugin := volumetesting.GetTestKubeletVolumePluginMgr(t)
 	seLinuxTranslator := util.NewFakeSELinuxLabelTranslator()
@@ -102,7 +101,7 @@ func Test_Run_Positive_DoNothing(t *testing.T) {
 		kubeletPodsDir)
 
 	// Act
-	runReconciler(ctx, reconciler)
+	runReconciler(tCtx, reconciler)
 
 	// Assert
 	assert.NoError(t, volumetesting.VerifyZeroAttachCalls(fakePlugin))
@@ -1113,6 +1112,7 @@ func Test_Run_Positive_VolumeUnmapControllerAttachEnabled(t *testing.T) {
 }
 
 func Test_GenerateMapVolumeFunc_Plugin_Not_Found(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	testCases := map[string]struct {
 		volumePlugins  []volume.VolumePlugin
 		expectErr      bool
@@ -1153,7 +1153,7 @@ func Test_GenerateMapVolumeFunc_Plugin_Not_Found(t *testing.T) {
 			volumeToMount := operationexecutor.VolumeToMount{
 				Pod:        pod,
 				VolumeSpec: tmpSpec}
-			err := oex.MountVolume(waitForAttachTimeout, volumeToMount, asw, false)
+			err := oex.MountVolume(tCtx, waitForAttachTimeout, volumeToMount, asw, false)
 			// Assert
 			if assert.Error(t, err) {
 				assert.ErrorContains(t, err, tc.expectedErrMsg)

--- a/pkg/kubelet/volumemanager/reconciler/reconstruct.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconstruct.go
@@ -62,7 +62,7 @@ func (rc *reconciler) reconstructVolumes(logger klog.Logger) {
 			// There is nothing to reconstruct
 			continue
 		}
-		reconstructedVolume, err := rc.reconstructVolume(volume)
+		reconstructedVolume, err := rc.reconstructVolume(logger, volume)
 		if err != nil {
 			logger.Info("Could not construct volume information", "podName", volume.podName, "volumeSpecName", volume.volumeSpecName, "err", err)
 			// We can't reconstruct the volume. Remember to check DSW after it's fully populated and force unmount the volume when it's orphaned.

--- a/pkg/kubelet/volumemanager/reconciler/reconstruct_common.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconstruct_common.go
@@ -249,7 +249,7 @@ func getVolumesFromPodDir(logger klog.Logger, podDir string) ([]podVolume, error
 }
 
 // Reconstruct volume data structure by reading the pod's volume directories
-func (rc *reconciler) reconstructVolume(volume podVolume) (rvolume *reconstructedVolume, rerr error) {
+func (rc *reconciler) reconstructVolume(logger klog.Logger, volume podVolume) (rvolume *reconstructedVolume, rerr error) {
 	metrics.ReconstructVolumeOperationsTotal.Inc()
 	defer func() {
 		if rerr != nil {
@@ -312,7 +312,7 @@ func (rc *reconciler) reconstructVolume(volume podVolume) (rvolume *reconstructe
 		// FindAttachablePluginBySpec for CSI volumes - it needs a connection to the API server,
 		// but it may not be available at this stage of kubelet startup.
 		// All CSI volumes are device-mountable, so they won't reach this code.
-		attachablePlugin, err := rc.volumePluginMgr.FindAttachablePluginBySpec(volumeSpec)
+		attachablePlugin, err := rc.volumePluginMgr.FindAttachablePluginBySpec(logger, volumeSpec)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -467,12 +467,12 @@ func (vm *volumeManager) WaitForAttachAndMount(ctx context.Context, pod *v1.Pod)
 
 		if utilfeature.DefaultFeatureGate.Enabled(features.MutableCSINodeAllocatableCount) {
 			for _, volumeToMount := range unattachedVolumeMounts {
-				attachablePlugin, findErr := vm.volumePluginMgr.FindAttachablePluginBySpec(volumeToMount.VolumeSpec)
+				attachablePlugin, findErr := vm.volumePluginMgr.FindAttachablePluginBySpec(logger, volumeToMount.VolumeSpec)
 				if findErr != nil || attachablePlugin == nil {
 					// This volume type doesn't support the attachable interface, so we can skip our check.
 					continue
 				}
-				if attachablePlugin.VerifyExhaustedResource(volumeToMount.VolumeSpec) {
+				if attachablePlugin.VerifyExhaustedResource(logger, volumeToMount.VolumeSpec) {
 					// Return error to the kubelet, which will then trigger the pod termination logic.
 					return &VolumeAttachLimitExceededError{
 						UnmountedVolumes:  unmountedVolumes,

--- a/pkg/volume/configmap/configmap.go
+++ b/pkg/volume/configmap/configmap.go
@@ -17,6 +17,7 @@ limitations under the License.
 package configmap
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/klog/v2"
@@ -43,7 +44,7 @@ const (
 // configMapPlugin implements the VolumePlugin interface.
 type configMapPlugin struct {
 	host         volume.VolumeHost
-	getConfigMap func(namespace, name string) (*v1.ConfigMap, error)
+	getConfigMap func(ctx context.Context, namespace, name string) (*v1.ConfigMap, error)
 }
 
 var _ volume.VolumePlugin = &configMapPlugin{}
@@ -150,7 +151,7 @@ type configMapVolumeMounter struct {
 
 	source       v1.ConfigMapVolumeSource
 	pod          v1.Pod
-	getConfigMap func(namespace, name string) (*v1.ConfigMap, error)
+	getConfigMap func(ctx context.Context, namespace, name string) (*v1.ConfigMap, error)
 }
 
 var _ volume.Mounter = &configMapVolumeMounter{}
@@ -187,7 +188,7 @@ func (b *configMapVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterA
 	}
 
 	optional := b.source.Optional != nil && *b.source.Optional
-	configMap, err := b.getConfigMap(b.pod.Namespace, b.source.Name)
+	configMap, err := b.getConfigMap(context.TODO(), b.pod.Namespace, b.source.Name)
 	if err != nil {
 		if !(errors.IsNotFound(err) && optional) {
 			klog.Errorf("Couldn't get configMap %v/%v: %v", b.pod.Namespace, b.source.Name, err)

--- a/pkg/volume/configmap/configmap.go
+++ b/pkg/volume/configmap/configmap.go
@@ -17,6 +17,7 @@ limitations under the License.
 package configmap
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/klog/v2"
@@ -45,7 +46,7 @@ const (
 // configMapPlugin implements the VolumePlugin interface.
 type configMapPlugin struct {
 	host         volume.VolumeHost
-	getConfigMap func(namespace, name string) (*v1.ConfigMap, error)
+	getConfigMap func(ctx context.Context, namespace, name string) (*v1.ConfigMap, error)
 }
 
 var _ volume.VolumePlugin = &configMapPlugin{}
@@ -80,7 +81,7 @@ func (plugin *configMapPlugin) CanSupport(spec *volume.Spec) bool {
 	return spec.Volume != nil && spec.Volume.ConfigMap != nil
 }
 
-func (plugin *configMapPlugin) RequiresRemount(spec *volume.Spec) bool {
+func (plugin *configMapPlugin) RequiresRemount(logger klog.Logger, spec *volume.Spec) bool {
 	return true
 }
 
@@ -88,7 +89,7 @@ func (plugin *configMapPlugin) SupportsMountOption() bool {
 	return false
 }
 
-func (plugin *configMapPlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
+func (plugin *configMapPlugin) SupportsSELinuxContextMount(logger klog.Logger, spec *volume.Spec) (bool, error) {
 	return false, nil
 }
 
@@ -152,7 +153,7 @@ type configMapVolumeMounter struct {
 
 	source       v1.ConfigMapVolumeSource
 	pod          v1.Pod
-	getConfigMap func(namespace, name string) (*v1.ConfigMap, error)
+	getConfigMap func(ctx context.Context, namespace, name string) (*v1.ConfigMap, error)
 }
 
 var _ volume.Mounter = &configMapVolumeMounter{}
@@ -175,21 +176,22 @@ func wrappedVolumeSpec() volume.Spec {
 	}
 }
 
-func (b *configMapVolumeMounter) SetUp(mounterArgs volume.MounterArgs) error {
-	return b.SetUpAt(b.GetPath(), mounterArgs)
+func (b *configMapVolumeMounter) SetUp(ctx context.Context, mounterArgs volume.MounterArgs) error {
+	return b.SetUpAt(ctx, b.GetPath(), mounterArgs)
 }
 
-func (b *configMapVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterArgs) error {
+func (b *configMapVolumeMounter) SetUpAt(ctx context.Context, dir string, mounterArgs volume.MounterArgs) error {
+	logger := klog.FromContext(ctx)
 	klog.V(3).Infof("Setting up volume %v for pod %v at %v", b.volName, b.pod.UID, dir)
 
 	// Wrap EmptyDir, let it do the setup.
-	wrapped, err := b.plugin.host.NewWrapperMounter(b.volName, wrappedVolumeSpec(), &b.pod)
+	wrapped, err := b.plugin.host.NewWrapperMounter(logger, b.volName, wrappedVolumeSpec(), &b.pod)
 	if err != nil {
 		return err
 	}
 
 	optional := b.source.Optional != nil && *b.source.Optional
-	configMap, err := b.getConfigMap(b.pod.Namespace, b.source.Name)
+	configMap, err := b.getConfigMap(context.TODO(), b.pod.Namespace, b.source.Name)
 	if err != nil {
 		if !(errors.IsNotFound(err) && optional) {
 			klog.Errorf("Couldn't get configMap %v/%v: %v", b.pod.Namespace, b.source.Name, err)
@@ -216,7 +218,7 @@ func (b *configMapVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterA
 	}
 
 	setupSuccess := false
-	if err := wrapped.SetUpAt(dir, mounterArgs); err != nil {
+	if err := wrapped.SetUpAt(ctx, dir, mounterArgs); err != nil {
 		return err
 	}
 	if err := volumeutil.MakeNestedMountpoints(b.volName, dir, b.pod); err != nil {

--- a/pkg/volume/configmap/configmap_test.go
+++ b/pkg/volume/configmap/configmap_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/kubernetes/pkg/volume/emptydir"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 	"k8s.io/kubernetes/pkg/volume/util"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 func TestMakePayload(t *testing.T) {
@@ -465,6 +466,7 @@ func TestCanSupport(t *testing.T) {
 }
 
 func TestPlugin(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	var (
 		testPodUID     = types.UID("test_pod_uid")
 		testVolumeName = "test_volume_name"
@@ -511,7 +513,7 @@ func TestPlugin(t *testing.T) {
 	var mounterArgs volume.MounterArgs
 	group := int64(1001)
 	mounterArgs.FsGroup = &group
-	err = mounter.SetUp(mounterArgs)
+	err = mounter.SetUp(tCtx, mounterArgs)
 	if err != nil {
 		t.Errorf("Failed to setup volume: %v", err)
 	}
@@ -531,6 +533,7 @@ func TestPlugin(t *testing.T) {
 // mountpoint, which is the state the system will be in after reboot.  The dir
 // should be mounter and the configMap data written to it.
 func TestPluginReboot(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	var (
 		testPodUID     = types.UID("test_pod_uid3")
 		testVolumeName = "test_volume_name"
@@ -571,7 +574,7 @@ func TestPluginReboot(t *testing.T) {
 	var mounterArgs volume.MounterArgs
 	group := int64(1001)
 	mounterArgs.FsGroup = &group
-	err = mounter.SetUp(mounterArgs)
+	err = mounter.SetUp(tCtx, mounterArgs)
 	if err != nil {
 		t.Errorf("Failed to setup volume: %v", err)
 	}
@@ -588,6 +591,7 @@ func TestPluginReboot(t *testing.T) {
 }
 
 func TestPluginOptional(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	var (
 		testPodUID     = types.UID("test_pod_uid")
 		testVolumeName = "test_volume_name"
@@ -635,7 +639,7 @@ func TestPluginOptional(t *testing.T) {
 	var mounterArgs volume.MounterArgs
 	group := int64(1001)
 	mounterArgs.FsGroup = &group
-	err = mounter.SetUp(mounterArgs)
+	err = mounter.SetUp(tCtx, mounterArgs)
 	if err != nil {
 		t.Errorf("Failed to setup volume: %v", err)
 	}
@@ -680,6 +684,7 @@ func TestPluginOptional(t *testing.T) {
 }
 
 func TestPluginKeysOptional(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	var (
 		testPodUID     = types.UID("test_pod_uid")
 		testVolumeName = "test_volume_name"
@@ -734,7 +739,7 @@ func TestPluginKeysOptional(t *testing.T) {
 	var mounterArgs volume.MounterArgs
 	group := int64(1001)
 	mounterArgs.FsGroup = &group
-	err = mounter.SetUp(mounterArgs)
+	err = mounter.SetUp(tCtx, mounterArgs)
 	if err != nil {
 		t.Errorf("Failed to setup volume: %v", err)
 	}
@@ -765,6 +770,7 @@ func volumeSpec(volumeName, configMapName string, defaultMode int32) *v1.Volume 
 }
 
 func TestInvalidConfigMapSetup(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	var (
 		testPodUID     = types.UID("test_pod_uid")
 		testVolumeName = "test_volume_name"
@@ -814,7 +820,7 @@ func TestInvalidConfigMapSetup(t *testing.T) {
 	var mounterArgs volume.MounterArgs
 	group := int64(1001)
 	mounterArgs.FsGroup = &group
-	err = mounter.SetUp(mounterArgs)
+	err = mounter.SetUp(tCtx, mounterArgs)
 	if err == nil {
 		t.Errorf("Expected setup to fail")
 	}

--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -195,7 +195,7 @@ func (c *csiAttacher) waitForVolumeAttachmentWithLister(spec *volume.Spec, volum
 	return c.waitForVolumeAttachDetachStatusWithLister(spec, volumeHandle, attachID, timeout, verifyStatus, "Attach")
 }
 
-func (c *csiAttacher) VolumesAreAttached(specs []*volume.Spec, nodeName types.NodeName) (map[*volume.Spec]bool, error) {
+func (c *csiAttacher) VolumesAreAttached(logger klog.Logger, specs []*volume.Spec, nodeName types.NodeName) (map[*volume.Spec]bool, error) {
 	klog.V(4).Info(log("probing attachment status for %d volume(s) ", len(specs)))
 
 	attached := make(map[*volume.Spec]bool)
@@ -214,7 +214,7 @@ func (c *csiAttacher) VolumesAreAttached(specs []*volume.Spec, nodeName types.No
 		driverName := pvSrc.Driver
 		volumeHandle := pvSrc.VolumeHandle
 
-		skip, err := c.plugin.skipAttach(driverName)
+		skip, err := c.plugin.skipAttach(logger, driverName)
 		if err != nil {
 			klog.Error(log("Failed to check CSIDriver for %s: %s", driverName, err))
 		} else {
@@ -261,7 +261,7 @@ func (c *csiAttacher) GetDeviceMountPath(spec *volume.Spec) (string, error) {
 	return deviceMountPath, nil
 }
 
-func (c *csiAttacher) MountDevice(spec *volume.Spec, devicePath string, deviceMountPath string, deviceMounterArgs volume.DeviceMounterArgs) error {
+func (c *csiAttacher) MountDevice(logger klog.Logger, spec *volume.Spec, devicePath string, deviceMountPath string, deviceMounterArgs volume.DeviceMounterArgs) error {
 	klog.V(4).Info(log("attacher.MountDevice(%s, %s)", devicePath, deviceMountPath))
 
 	if deviceMountPath == "" {
@@ -298,7 +298,7 @@ func (c *csiAttacher) MountDevice(spec *volume.Spec, devicePath string, deviceMo
 
 	// Get secrets and publish context required for mountDevice
 	nodeName := string(c.plugin.host.GetNodeName())
-	publishContext, err := c.plugin.getPublishContext(c.k8s, csiSource.VolumeHandle, csiSource.Driver, nodeName)
+	publishContext, err := c.plugin.getPublishContext(ctx, c.k8s, csiSource.VolumeHandle, csiSource.Driver, nodeName)
 
 	if err != nil {
 		return volumetypes.NewTransientOperationFailure(err.Error())
@@ -323,7 +323,7 @@ func (c *csiAttacher) MountDevice(spec *volume.Spec, devicePath string, deviceMo
 
 	var seLinuxSupported bool
 	if utilfeature.DefaultFeatureGate.Enabled(features.SELinuxMountReadWriteOncePod) {
-		support, err := c.plugin.SupportsSELinuxContextMount(spec)
+		support, err := c.plugin.SupportsSELinuxContextMount(logger, spec)
 		if err != nil {
 			return errors.New(log("failed to query for SELinuxMount support: %s", err))
 		}

--- a/pkg/volume/csi/csi_attacher_test.go
+++ b/pkg/volume/csi/csi_attacher_test.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/kubernetes/pkg/volume"
 	fakecsi "k8s.io/kubernetes/pkg/volume/csi/fake"
 	volumetypes "k8s.io/kubernetes/pkg/volume/util/types"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 const (
@@ -329,6 +330,7 @@ func TestAttacherAttachWithInline(t *testing.T) {
 }
 
 func TestAttacherWithCSIDriver(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	tests := []struct {
 		name                   string
 		driver                 string
@@ -374,7 +376,7 @@ func TestAttacherWithCSIDriver(t *testing.T) {
 			csiAttacher := getCsiAttacherFromVolumeAttacher(attacher, test.watchTimeout)
 			spec := volume.NewSpecFromPersistentVolume(makeTestPV("test-pv", 10, test.driver, "test-vol"), false)
 
-			pluginCanAttach, err := plug.CanAttach(spec)
+			pluginCanAttach, err := plug.CanAttach(logger, spec)
 			if err != nil {
 				t.Fatalf("attacher.CanAttach failed: %s", err)
 			}
@@ -416,6 +418,9 @@ func TestAttacherWaitForVolumeAttachmentWithCSIDriver(t *testing.T) {
 	// In order to detect if the volume plugin would skip WaitForAttach for non-attachable drivers,
 	// we do not instantiate any VolumeAttachment. So if the plugin does not skip attach,  WaitForVolumeAttachment
 	// will return an error that volume attachment was not found.
+
+	logger, _ := ktesting.NewTestContext(t)
+
 	tests := []struct {
 		name         string
 		driver       string
@@ -467,7 +472,7 @@ func TestAttacherWaitForVolumeAttachmentWithCSIDriver(t *testing.T) {
 			csiAttacher := getCsiAttacherFromVolumeAttacher(attacher, test.watchTimeout)
 			spec := volume.NewSpecFromPersistentVolume(makeTestPV("test-pv", 10, test.driver, "test-vol"), false)
 
-			pluginCanAttach, err := plug.CanAttach(spec)
+			pluginCanAttach, err := plug.CanAttach(logger, spec)
 			if err != nil {
 				t.Fatalf("plugin.CanAttach test failed: %s", err)
 			}
@@ -650,6 +655,7 @@ func TestAttacherWaitForAttachWithInline(t *testing.T) {
 }
 
 func TestAttacherVolumesAreAttached(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	type attachedSpec struct {
 		volName  string
 		spec     *volume.Spec
@@ -720,7 +726,7 @@ func TestAttacherVolumesAreAttached(t *testing.T) {
 			}
 
 			// retrieve attached status
-			stats, err := csiAttacher.VolumesAreAttached(specs, types.NodeName(nodeName))
+			stats, err := csiAttacher.VolumesAreAttached(logger, specs, types.NodeName(nodeName))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -743,6 +749,7 @@ func TestAttacherVolumesAreAttached(t *testing.T) {
 }
 
 func TestAttacherVolumesAreAttachedWithInline(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	type attachedSpec struct {
 		volName  string
 		spec     *volume.Spec
@@ -791,7 +798,7 @@ func TestAttacherVolumesAreAttachedWithInline(t *testing.T) {
 			}
 
 			// retrieve attached status
-			stats, err := csiAttacher.VolumesAreAttached(specs, types.NodeName(nodeName))
+			stats, err := csiAttacher.VolumesAreAttached(logger, specs, types.NodeName(nodeName))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -980,6 +987,7 @@ func TestAttacherMountDevice(t *testing.T) {
 	var testFSGroup int64 = 3000
 	nonFinalError := volumetypes.NewUncertainProgressError("")
 	transientError := volumetypes.NewTransientOperationFailure("")
+	logger, _ := ktesting.NewTestContext(t)
 
 	testCases := []struct {
 		testName                       string
@@ -1221,6 +1229,7 @@ func TestAttacherMountDevice(t *testing.T) {
 
 			// Run
 			err := csiAttacher.MountDevice(
+				logger,
 				tc.spec,
 				tc.devicePath,
 				tc.deviceMountPath,
@@ -1301,6 +1310,7 @@ func TestAttacherMountDevice(t *testing.T) {
 func TestAttacherMountDeviceWithInline(t *testing.T) {
 	pvName := "test-pv"
 	var testFSGroup int64 = 3000
+	logger, _ := ktesting.NewTestContext(t)
 	testCases := []struct {
 		testName                 string
 		volName                  string
@@ -1427,6 +1437,7 @@ func TestAttacherMountDeviceWithInline(t *testing.T) {
 
 			// Run
 			err = csiAttacher.MountDevice(
+				logger,
 				tc.spec,
 				tc.devicePath,
 				tc.deviceMountPath,

--- a/pkg/volume/csi/csi_block.go
+++ b/pkg/volume/csi/csi_block.go
@@ -211,6 +211,7 @@ func (m *csiBlockMapper) publishVolumeForBlock(
 	csiSource *v1.CSIPersistentVolumeSource,
 	attachment *storage.VolumeAttachment,
 ) (string, error) {
+	logger := klog.FromContext(ctx)
 	klog.V(4).Info(log("blockMapper.publishVolumeForBlock called"))
 
 	publishVolumeInfo := map[string]string{}
@@ -220,7 +221,7 @@ func (m *csiBlockMapper) publishVolumeForBlock(
 
 	// Inject pod information into volume_attributes
 	volAttribs := csiSource.VolumeAttributes
-	podInfoEnabled, err := m.plugin.podInfoEnabled(string(m.driverName))
+	podInfoEnabled, err := m.plugin.podInfoEnabled(logger, string(m.driverName))
 	if err != nil {
 		return "", volumetypes.NewTransientOperationFailure(log("blockMapper.publishVolumeForBlock failed to assemble volume attributes: %v", err))
 	}
@@ -277,7 +278,7 @@ func (m *csiBlockMapper) publishVolumeForBlock(
 }
 
 // SetUpDevice ensures the device is attached returns path where the device is located.
-func (m *csiBlockMapper) SetUpDevice() (string, error) {
+func (m *csiBlockMapper) SetUpDevice(logger klog.Logger) (string, error) {
 	klog.V(4).Info(log("blockMapper.SetUpDevice called"))
 
 	// Get csiSource from spec
@@ -291,7 +292,7 @@ func (m *csiBlockMapper) SetUpDevice() (string, error) {
 	}
 
 	driverName := csiSource.Driver
-	skip, err := m.plugin.skipAttach(driverName)
+	skip, err := m.plugin.skipAttach(logger, driverName)
 	if err != nil {
 		return "", errors.New(log("blockMapper.SetupDevice failed to check CSIDriver for %s: %v", driverName, err))
 	}
@@ -339,7 +340,7 @@ func (m *csiBlockMapper) SetUpDevice() (string, error) {
 	return stagingPath, nil
 }
 
-func (m *csiBlockMapper) MapPodDevice() (string, error) {
+func (m *csiBlockMapper) MapPodDevice(logger klog.Logger) (string, error) {
 	klog.V(4).Info(log("blockMapper.MapPodDevice called"))
 
 	// Get csiSource from spec
@@ -353,7 +354,7 @@ func (m *csiBlockMapper) MapPodDevice() (string, error) {
 	}
 
 	driverName := csiSource.Driver
-	skip, err := m.plugin.skipAttach(driverName)
+	skip, err := m.plugin.skipAttach(logger, driverName)
 	if err != nil {
 		return "", errors.New(log("blockMapper.MapPodDevice failed to check CSIDriver for %s: %v", driverName, err))
 	}

--- a/pkg/volume/csi/csi_block_test.go
+++ b/pkg/volume/csi/csi_block_test.go
@@ -27,6 +27,7 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"k8s.io/klog/v2/ktesting"
 
 	api "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -203,6 +204,8 @@ func TestBlockMapperSetupDevice(t *testing.T) {
 	plug, tmpDir := newTestPlugin(t, nil)
 	defer os.RemoveAll(tmpDir)
 
+	logger, _ := ktesting.NewTestContext(t)
+
 	csiMapper, _, pv, err := prepareBlockMapperTest(plug, "test-pv", t)
 	if err != nil {
 		t.Fatalf("Failed to make a new Mapper: %v", err)
@@ -222,7 +225,7 @@ func TestBlockMapperSetupDevice(t *testing.T) {
 	}
 	t.Log("created attachment ", attachID)
 
-	stagingPath, err := csiMapper.SetUpDevice()
+	stagingPath, err := csiMapper.SetUpDevice(logger)
 	if err != nil {
 		t.Fatalf("mapper failed to SetupDevice: %v", err)
 	}
@@ -241,6 +244,8 @@ func TestBlockMapperSetupDevice(t *testing.T) {
 func TestBlockMapperSetupDeviceError(t *testing.T) {
 	plug, tmpDir := newTestPlugin(t, nil)
 	defer os.RemoveAll(tmpDir)
+
+	logger, _ := ktesting.NewTestContext(t)
 
 	csiMapper, _, pv, err := prepareBlockMapperTest(plug, "test-pv", t)
 	if err != nil {
@@ -263,7 +268,7 @@ func TestBlockMapperSetupDeviceError(t *testing.T) {
 	}
 	t.Log("created attachment ", attachID)
 
-	stagingPath, err := csiMapper.SetUpDevice()
+	stagingPath, err := csiMapper.SetUpDevice(logger)
 	if err == nil {
 		t.Fatal("mapper unexpectedly succeeded")
 	}
@@ -288,6 +293,8 @@ func TestBlockMapperSetupDeviceNoClientError(t *testing.T) {
 	transientError := volumetypes.NewTransientOperationFailure("")
 	plug, tmpDir := newTestPlugin(t, nil)
 	defer os.RemoveAll(tmpDir)
+
+	logger, _ := ktesting.NewTestContext(t)
 
 	csiMapper, _, pv, err := prepareBlockMapperTest(plug, "test-pv", t)
 	if err != nil {
@@ -315,7 +322,7 @@ func TestBlockMapperSetupDeviceNoClientError(t *testing.T) {
 	// Note that prepareBlockMapperTest above will create a driver with a name of "test-driver"
 	csiMapper.csiClientGetter.driverName = "unknown-driver"
 
-	_, err = csiMapper.SetUpDevice()
+	_, err = csiMapper.SetUpDevice(logger)
 	if err == nil {
 		t.Errorf("test should fail, but no error occurred")
 	} else if reflect.TypeOf(transientError) != reflect.TypeOf(err) {
@@ -326,6 +333,8 @@ func TestBlockMapperSetupDeviceNoClientError(t *testing.T) {
 func TestBlockMapperMapPodDevice(t *testing.T) {
 	plug, tmpDir := newTestPlugin(t, nil)
 	defer os.RemoveAll(tmpDir)
+
+	logger, _ := ktesting.NewTestContext(t)
 
 	csiMapper, _, pv, err := prepareBlockMapperTest(plug, "test-pv", t)
 	if err != nil {
@@ -347,7 +356,7 @@ func TestBlockMapperMapPodDevice(t *testing.T) {
 	t.Log("created attachment ", attachID)
 
 	// Map device to global and pod device map path
-	path, err := csiMapper.MapPodDevice()
+	path, err := csiMapper.MapPodDevice(logger)
 	if err != nil {
 		t.Fatalf("mapper failed to GetGlobalMapPath: %v", err)
 	}
@@ -369,6 +378,7 @@ func TestBlockMapperMapPodDevice(t *testing.T) {
 }
 
 func TestBlockMapperMapPodDeviceNotSupportAttach(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	fakeClient := fakeclient.NewSimpleClientset()
 	attachRequired := false
 	fakeDriver := &storagev1.CSIDriver{
@@ -397,7 +407,7 @@ func TestBlockMapperMapPodDeviceNotSupportAttach(t *testing.T) {
 	csiMapper.csiClient = setupClient(t, true)
 
 	// Map device to global and pod device map path
-	path, err := csiMapper.MapPodDevice()
+	path, err := csiMapper.MapPodDevice(logger)
 	if err != nil {
 		t.Fatalf("mapper failed to GetGlobalMapPath: %v", err)
 	}
@@ -408,6 +418,7 @@ func TestBlockMapperMapPodDeviceNotSupportAttach(t *testing.T) {
 }
 
 func TestBlockMapperMapPodDeviceWithPodInfo(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	fakeClient := fakeclient.NewSimpleClientset()
 	attachRequired := false
 	podInfo := true
@@ -438,7 +449,7 @@ func TestBlockMapperMapPodDeviceWithPodInfo(t *testing.T) {
 	csiMapper.csiClient = setupClient(t, true)
 
 	// Map device to global and pod device map path
-	_, err = csiMapper.MapPodDevice()
+	_, err = csiMapper.MapPodDevice(logger)
 	if err != nil {
 		t.Fatalf("mapper failed to GetGlobalMapPath: %v", err)
 	}
@@ -454,6 +465,7 @@ func TestBlockMapperMapPodDeviceWithPodInfo(t *testing.T) {
 }
 
 func TestBlockMapperMapPodDeviceNoClientError(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	transientError := volumetypes.NewTransientOperationFailure("")
 	plug, tmpDir := newTestPlugin(t, nil)
 	defer os.RemoveAll(tmpDir)
@@ -484,7 +496,7 @@ func TestBlockMapperMapPodDeviceNoClientError(t *testing.T) {
 	// Note that prepareBlockMapperTest above will create a driver with a name of "test-driver"
 	csiMapper.csiClientGetter.driverName = "unknown-driver"
 
-	_, err = csiMapper.MapPodDevice()
+	_, err = csiMapper.MapPodDevice(logger)
 	if err == nil {
 		t.Errorf("test should fail, but no error occurred")
 	} else if reflect.TypeOf(transientError) != reflect.TypeOf(err) {
@@ -493,6 +505,7 @@ func TestBlockMapperMapPodDeviceNoClientError(t *testing.T) {
 }
 
 func TestBlockMapperMapPodDeviceGetStageSecretsError(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	transientError := volumetypes.NewTransientOperationFailure("")
 	plug, tmpDir := newTestPlugin(t, nil)
 	defer func() {
@@ -524,7 +537,7 @@ func TestBlockMapperMapPodDeviceGetStageSecretsError(t *testing.T) {
 	}
 	t.Log("created attachment ", attachID)
 
-	_, err = csiMapper.MapPodDevice()
+	_, err = csiMapper.MapPodDevice(logger)
 	if err == nil {
 		t.Errorf("test should fail, but no error occurred")
 	} else if !errors.As(err, &transientError) {
@@ -650,6 +663,8 @@ func TestVolumeSetupTeardown(t *testing.T) {
 	// Follow volume setup + teardown sequences at top of cs_block.go and set up / clean up one CSI block device.
 	// Focus on testing that there were no leftover files present after the cleanup.
 
+	logger, _ := ktesting.NewTestContext(t)
+
 	plug, tmpDir := newTestPlugin(t, nil)
 	defer os.RemoveAll(tmpDir)
 
@@ -672,7 +687,7 @@ func TestVolumeSetupTeardown(t *testing.T) {
 	}
 	t.Log("created attachment ", attachID)
 
-	stagingPath, err := csiMapper.SetUpDevice()
+	stagingPath, err := csiMapper.SetUpDevice(logger)
 	if err != nil {
 		t.Fatalf("mapper failed to SetupDevice: %v", err)
 	}
@@ -686,7 +701,7 @@ func TestVolumeSetupTeardown(t *testing.T) {
 		t.Errorf("csi server expected device path %s, got %s", stagingPath, svol.Path)
 	}
 
-	path, err := csiMapper.MapPodDevice()
+	path, err := csiMapper.MapPodDevice(logger)
 	if err != nil {
 		t.Fatalf("mapper failed to GetGlobalMapPath: %v", err)
 	}
@@ -764,6 +779,7 @@ func TestVolumeSetupTeardown(t *testing.T) {
 }
 
 func TestUnmapPodDeviceNoClientError(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	transientError := volumetypes.NewTransientOperationFailure("")
 	plug, tmpDir := newTestPlugin(t, nil)
 	defer os.RemoveAll(tmpDir)
@@ -787,7 +803,7 @@ func TestUnmapPodDeviceNoClientError(t *testing.T) {
 	}
 	t.Log("created attachment ", attachID)
 
-	stagingPath, err := csiMapper.SetUpDevice()
+	stagingPath, err := csiMapper.SetUpDevice(logger)
 	if err != nil {
 		t.Fatalf("mapper failed to SetupDevice: %v", err)
 	}
@@ -801,7 +817,7 @@ func TestUnmapPodDeviceNoClientError(t *testing.T) {
 		t.Errorf("csi server expected device path %s, got %s", stagingPath, svol.Path)
 	}
 
-	path, err := csiMapper.MapPodDevice()
+	path, err := csiMapper.MapPodDevice(logger)
 	if err != nil {
 		t.Fatalf("mapper failed to GetGlobalMapPath: %v", err)
 	}

--- a/pkg/volume/csi/csi_mounter.go
+++ b/pkg/volume/csi/csi_mounter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package csi
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
@@ -96,11 +97,12 @@ func getTargetPath(uid types.UID, specVolumeID string, host volume.VolumeHost) s
 // volume.Mounter methods
 var _ volume.Mounter = &csiMountMgr{}
 
-func (c *csiMountMgr) SetUp(mounterArgs volume.MounterArgs) error {
-	return c.SetUpAt(c.GetPath(), mounterArgs)
+func (c *csiMountMgr) SetUp(ctx context.Context, mounterArgs volume.MounterArgs) error {
+	return c.SetUpAt(ctx, c.GetPath(), mounterArgs)
 }
 
-func (c *csiMountMgr) SetUpAt(dir string, mounterArgs volume.MounterArgs) error {
+func (c *csiMountMgr) SetUpAt(ctx context.Context, dir string, mounterArgs volume.MounterArgs) error {
+	logger := klog.FromContext(ctx)
 	klog.V(4).Info(log("Mounter.SetUpAt(%s)", dir))
 
 	csi, err := c.csiClientGetter.Get()
@@ -120,11 +122,11 @@ func (c *csiMountMgr) SetUpAt(dir string, mounterArgs volume.MounterArgs) error 
 
 	// Check CSIDriver.Spec.Mode to ensure that the CSI driver
 	// supports the current volumeLifecycleMode.
-	if err := c.supportsVolumeLifecycleMode(); err != nil {
+	if err := c.supportsVolumeLifecycleMode(logger); err != nil {
 		return volumetypes.NewTransientOperationFailure(log("mounter.SetupAt failed to check volume lifecycle mode: %s", err))
 	}
 
-	fsGroupPolicy, err := c.getFSGroupPolicy()
+	fsGroupPolicy, err := c.getFSGroupPolicy(logger)
 	if err != nil {
 		return volumetypes.NewTransientOperationFailure(log("mounter.SetupAt failed to check fsGroup policy: %s", err))
 	}
@@ -196,7 +198,7 @@ func (c *csiMountMgr) SetUpAt(dir string, mounterArgs volume.MounterArgs) error 
 		// search for attachment by VolumeAttachment.Spec.Source.PersistentVolumeName
 		if c.publishContext == nil {
 			nodeName := string(c.plugin.host.GetNodeName())
-			c.publishContext, err = c.plugin.getPublishContext(c.k8s, volumeHandle, string(driverName), nodeName)
+			c.publishContext, err = c.plugin.getPublishContext(ctx, c.k8s, volumeHandle, string(driverName), nodeName)
 			if err != nil {
 				// we could have a transient error associated with fetching publish context
 				return volumetypes.NewTransientOperationFailure(log("mounter.SetUpAt failed to fetch publishContext: %v", err))
@@ -226,7 +228,7 @@ func (c *csiMountMgr) SetUpAt(dir string, mounterArgs volume.MounterArgs) error 
 	}
 
 	// Inject pod information into volume_attributes
-	podInfoEnabled, err := c.plugin.podInfoEnabled(string(c.driverName))
+	podInfoEnabled, err := c.plugin.podInfoEnabled(logger, string(c.driverName))
 	if err != nil {
 		return volumetypes.NewTransientOperationFailure(log("mounter.SetUpAt failed to assemble volume attributes: %v", err))
 	}
@@ -262,7 +264,7 @@ func (c *csiMountMgr) SetUpAt(dir string, mounterArgs volume.MounterArgs) error 
 
 	var selinuxLabelMount bool
 	if utilfeature.DefaultFeatureGate.Enabled(features.SELinuxMountReadWriteOncePod) {
-		support, err := c.plugin.SupportsSELinuxContextMount(c.spec)
+		support, err := c.plugin.SupportsSELinuxContextMount(logger, c.spec)
 		if err != nil {
 			return errors.New(log("failed to query for SELinuxMount support: %s", err))
 		}
@@ -506,13 +508,13 @@ func (c *csiMountMgr) supportsFSGroup(fsType string, fsGroup *int64, driverPolic
 
 // getFSGroupPolicy returns if the CSI driver supports a volume in the given mode.
 // An error indicates that it isn't supported and explains why.
-func (c *csiMountMgr) getFSGroupPolicy() (storage.FSGroupPolicy, error) {
+func (c *csiMountMgr) getFSGroupPolicy(logger klog.Logger) (storage.FSGroupPolicy, error) {
 	// Retrieve CSIDriver. It's not an error if the driver isn't found
 	// (CSIDriver is optional)
 	var csiDriver *storage.CSIDriver
 	driver := string(c.driverName)
 	if c.plugin.csiDriverLister != nil {
-		c, err := c.plugin.getCSIDriver(driver)
+		c, err := c.plugin.getCSIDriver(logger, driver)
 		if err != nil && !apierrors.IsNotFound(err) {
 			// Some internal error.
 			return storage.ReadWriteOnceWithFSTypeFSGroupPolicy, err
@@ -533,13 +535,13 @@ func (c *csiMountMgr) getFSGroupPolicy() (storage.FSGroupPolicy, error) {
 
 // supportsVolumeMode checks whether the CSI driver supports a volume in the given mode.
 // An error indicates that it isn't supported and explains why.
-func (c *csiMountMgr) supportsVolumeLifecycleMode() error {
+func (c *csiMountMgr) supportsVolumeLifecycleMode(logger klog.Logger) error {
 	// Retrieve CSIDriver. It's not an error if the driver isn't found
 	// (CSIDriver is optional), but then only persistent volumes are supported.
 	var csiDriver *storage.CSIDriver
 	driver := string(c.driverName)
 	if c.plugin.csiDriverLister != nil {
-		c, err := c.plugin.getCSIDriver(driver)
+		c, err := c.plugin.getCSIDriver(logger, driver)
 		if err != nil && !apierrors.IsNotFound(err) {
 			// Some internal error.
 			return err

--- a/pkg/volume/csi/csi_mounter_test.go
+++ b/pkg/volume/csi/csi_mounter_test.go
@@ -50,6 +50,7 @@ import (
 	"k8s.io/kubernetes/pkg/volume"
 	fakecsi "k8s.io/kubernetes/pkg/volume/csi/fake"
 	volumetypes "k8s.io/kubernetes/pkg/volume/util/types"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/mount-utils"
 	testingexec "k8s.io/utils/exec/testing"
 	"k8s.io/utils/ptr"
@@ -128,6 +129,7 @@ func TestMounterGetPath(t *testing.T) {
 }
 
 func TestMounterSetUp(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	tests := []struct {
 		name                     string
 		driver                   string
@@ -302,7 +304,7 @@ func TestMounterSetUp(t *testing.T) {
 				expectedMountOptions = append(expectedMountOptions, test.expectedSELinuxContext)
 			}
 
-			if err := csiMounter.SetUp(mounterArgs); err != nil {
+			if err := csiMounter.SetUp(tCtx, mounterArgs); err != nil {
 				t.Fatalf("mounter.Setup failed: %v", err)
 			}
 			//Test the default value of file system type is not overridden
@@ -385,6 +387,7 @@ func (m *mockVolumeOwnershipChanger) AddProgressNotifier(pod *corev1.Pod, record
 }
 
 func TestMounterSetupJsonFileHandling(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	testCases := []struct {
 		name                string
 		volumeID            string
@@ -468,7 +471,7 @@ func TestMounterSetupJsonFileHandling(t *testing.T) {
 			dataDir := filepath.Dir(mounter.GetPath())
 
 			// Mounter.SetUp()
-			err = csiMounter.SetUp(mounterArgs)
+			err = csiMounter.SetUp(tCtx, mounterArgs)
 			if tc.setupShouldFail {
 				if err == nil {
 					t.Error("test should fail, but no error occurred")
@@ -496,6 +499,7 @@ func TestMounterSetupJsonFileHandling(t *testing.T) {
 }
 
 func TestMounterSetUpSimple(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	fakeClient := fakeclient.NewSimpleClientset()
 	plug, tmpDir := newTestPlugin(t, fakeClient)
 	transientError := volumetypes.NewTransientOperationFailure("")
@@ -607,7 +611,7 @@ func TestMounterSetUpSimple(t *testing.T) {
 			}
 
 			// Mounter.SetUp()
-			err = csiMounter.SetUp(volume.MounterArgs{})
+			err = csiMounter.SetUp(tCtx, volume.MounterArgs{})
 			if tc.setupShouldFail {
 				if err != nil {
 					if tc.exitError != nil && reflect.TypeOf(tc.exitError) != reflect.TypeOf(err) {
@@ -686,6 +690,7 @@ func TestMounterSetUpSimple(t *testing.T) {
 }
 
 func TestMounterSetupWithStatusTracking(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	fakeClient := fakeclient.NewSimpleClientset()
 	plug, tmpDir := newTestPlugin(t, fakeClient)
 	defer os.RemoveAll(tmpDir)
@@ -774,7 +779,7 @@ func TestMounterSetupWithStatusTracking(t *testing.T) {
 					t.Fatalf("failed to setup VolumeAttachment: %v", err)
 				}
 			}
-			err = csiMounter.SetUp(volume.MounterArgs{})
+			err = csiMounter.SetUp(tCtx, volume.MounterArgs{})
 
 			if tc.exitError != nil && reflect.TypeOf(tc.exitError) != reflect.TypeOf(err) {
 				t.Fatalf("expected exitError: %+v got: %+v", tc.exitError, err)
@@ -792,6 +797,7 @@ func TestMounterSetupWithStatusTracking(t *testing.T) {
 }
 
 func TestMounterSetUpWithInline(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	testCases := []struct {
 		name       string
 		podUID     types.UID
@@ -887,7 +893,7 @@ func TestMounterSetUpWithInline(t *testing.T) {
 			}
 
 			// Mounter.SetUp()
-			if err := csiMounter.SetUp(volume.MounterArgs{}); err != nil {
+			if err := csiMounter.SetUp(tCtx, volume.MounterArgs{}); err != nil {
 				t.Fatalf("mounter.Setup failed: %v", err)
 			}
 
@@ -931,6 +937,7 @@ func TestMounterSetUpWithInline(t *testing.T) {
 }
 
 func TestMounterSetUpWithFSGroup(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	fakeClient := fakeclient.NewSimpleClientset()
 	plug, tmpDir := newTestPlugin(t, fakeClient)
 	defer os.RemoveAll(tmpDir)
@@ -1155,7 +1162,7 @@ func TestMounterSetUpWithFSGroup(t *testing.T) {
 			fsGroupPtr = &fsGroup
 		}
 		mounterArgs.FsGroup = fsGroupPtr
-		if err := csiMounter.SetUp(mounterArgs); err != nil {
+		if err := csiMounter.SetUp(tCtx, mounterArgs); err != nil {
 			t.Fatalf("mounter.Setup failed: %v", err)
 		}
 
@@ -1176,6 +1183,7 @@ func TestMounterSetUpWithFSGroup(t *testing.T) {
 }
 
 func TestMounterSetUpFWithNodePublishFinalError(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	testCases := []struct {
 		name                 string
 		podUID               types.UID
@@ -1263,7 +1271,7 @@ func TestMounterSetUpFWithNodePublishFinalError(t *testing.T) {
 			csiMounter.csiClient.(*fakeCsiDriverClient).nodeClient.SetNextError(status.Errorf(codes.InvalidArgument, "mount failed"))
 
 			// Mounter.SetUp()
-			if err := csiMounter.SetUp(volume.MounterArgs{
+			if err := csiMounter.SetUp(tCtx, volume.MounterArgs{
 				ReconstructedVolume: tc.reconstructedVolume,
 				IsRemount:           tc.isRemount,
 			}); err == nil {
@@ -1397,6 +1405,7 @@ func TestUnmounterTeardownNoClientError(t *testing.T) {
 }
 
 func TestPodServiceAccountTokenAttrs(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	scheme := runtime.NewScheme()
 	utilruntime.Must(pkgauthenticationv1.RegisterDefaults(scheme))
 	utilruntime.Must(pkgstoragev1.RegisterDefaults(scheme))
@@ -1511,7 +1520,7 @@ func TestPodServiceAccountTokenAttrs(t *testing.T) {
 
 			csiMounter := mounter.(*csiMountMgr)
 			csiMounter.csiClient = setupClient(t, false)
-			if err := csiMounter.SetUp(volume.MounterArgs{}); err != nil {
+			if err := csiMounter.SetUp(tCtx, volume.MounterArgs{}); err != nil {
 				t.Fatalf("mounter.Setup failed: %v", err)
 			}
 
@@ -1679,6 +1688,7 @@ func Test_csiMountMgr_supportsFSGroup(t *testing.T) {
 }
 
 func TestMounterGetFSGroupPolicy(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	defaultPolicy := storage.ReadWriteOnceWithFSTypeFSGroupPolicy
 	testCases := []struct {
 		name                  string
@@ -1728,7 +1738,7 @@ func TestMounterGetFSGroupPolicy(t *testing.T) {
 		csiMounter := mounter.(*csiMountMgr)
 
 		// Check to see if we can obtain the CSIDriver, along with examining its FSGroupPolicy
-		fsGroup, err := csiMounter.getFSGroupPolicy()
+		fsGroup, err := csiMounter.getFSGroupPolicy(logger)
 		if err != nil {
 			t.Fatalf("Error attempting to obtain FSGroupPolicy: %v", err)
 		}

--- a/pkg/volume/csi/csi_plugin.go
+++ b/pkg/volume/csi/csi_plugin.go
@@ -189,7 +189,7 @@ func updateCSIDriver(pluginName string) error {
 	return nil
 }
 
-func (p *csiPlugin) VerifyExhaustedResource(spec *volume.Spec) bool {
+func (p *csiPlugin) VerifyExhaustedResource(logger klog.Logger, spec *volume.Spec) bool {
 	if spec == nil || spec.PersistentVolume == nil || spec.PersistentVolume.Spec.CSI == nil {
 		klog.ErrorS(nil, "Invalid volume spec for CSI")
 		return false
@@ -197,7 +197,7 @@ func (p *csiPlugin) VerifyExhaustedResource(spec *volume.Spec) bool {
 
 	pluginName := spec.PersistentVolume.Spec.CSI.Driver
 
-	driver, err := p.getCSIDriver(pluginName)
+	driver, err := p.getCSIDriver(logger, pluginName)
 	if err != nil {
 		klog.ErrorS(err, "Failed to retrieve CSIDriver", "pluginName", pluginName)
 		return false
@@ -352,13 +352,15 @@ func (p *csiPlugin) Init(host volume.VolumeHost) error {
 
 	// This function prevents Kubelet from posting Ready status until CSINode
 	// is both installed and initialized
-	if err := initializeCSINode(host, p.csiDriverInformer); err != nil {
+	// Use context.TODO() because we currently do not have a proper context to pass in.
+	// This should be replaced with an appropriate context when refactoring this function to accept a context parameter.
+	if err := initializeCSINode(context.TODO(), host, p.csiDriverInformer); err != nil {
 		return errors.New(log("failed to initialize CSINode: %v", err))
 	}
 	return nil
 }
 
-func initializeCSINode(host volume.VolumeHost, csiDriverInformer cache.SharedIndexInformer) error {
+func initializeCSINode(ctx context.Context, host volume.VolumeHost, csiDriverInformer cache.SharedIndexInformer) error {
 	kvh, ok := host.(volume.KubeletVolumeHost)
 	if !ok {
 		klog.V(4).Info("Cast from VolumeHost to KubeletVolumeHost failed. Skipping CSINode initialization, not running on kubelet")
@@ -378,7 +380,7 @@ func initializeCSINode(host volume.VolumeHost, csiDriverInformer cache.SharedInd
 
 		// First wait indefinitely to talk to Kube APIServer
 		nodeName := host.GetNodeName()
-		err := waitForAPIServerForever(kubeClient, nodeName)
+		err := waitForAPIServerForever(ctx, kubeClient, nodeName)
 		if err != nil {
 			klog.Fatalf("Failed to initialize CSINode while waiting for API server to report ok: %v", err)
 		}
@@ -454,7 +456,7 @@ func (p *csiPlugin) CanSupport(spec *volume.Spec) bool {
 		(spec.Volume != nil && spec.Volume.CSI != nil)
 }
 
-func (p *csiPlugin) RequiresRemount(spec *volume.Spec) bool {
+func (p *csiPlugin) RequiresRemount(logger klog.Logger, spec *volume.Spec) bool {
 	if p.csiDriverLister == nil {
 		return false
 	}
@@ -463,7 +465,7 @@ func (p *csiPlugin) RequiresRemount(spec *volume.Spec) bool {
 		klog.V(5).Info(log("Failed to mark %q as republish required, err: %v", spec.Name(), err))
 		return false
 	}
-	csiDriver, err := p.getCSIDriver(driverName)
+	csiDriver, err := p.getCSIDriver(logger, driverName)
 	if err != nil {
 		klog.V(5).Info(log("Failed to mark %q as republish required, err: %v", spec.Name(), err))
 		return false
@@ -634,13 +636,13 @@ func (p *csiPlugin) SupportsMountOption() bool {
 	return true
 }
 
-func (p *csiPlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
+func (p *csiPlugin) SupportsSELinuxContextMount(logger klog.Logger, spec *volume.Spec) (bool, error) {
 	if utilfeature.DefaultFeatureGate.Enabled(features.SELinuxMountReadWriteOncePod) {
 		driver, err := GetCSIDriverName(spec)
 		if err != nil {
 			return false, err
 		}
-		csiDriver, err := p.getCSIDriver(driver)
+		csiDriver, err := p.getCSIDriver(logger, driver)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return false, nil
@@ -672,7 +674,7 @@ func (p *csiPlugin) NewDetacher() (volume.Detacher, error) {
 	return p.newAttacherDetacher()
 }
 
-func (p *csiPlugin) CanAttach(spec *volume.Spec) (bool, error) {
+func (p *csiPlugin) CanAttach(logger klog.Logger, spec *volume.Spec) (bool, error) {
 	volumeLifecycleMode, err := p.getVolumeLifecycleMode(spec)
 	if err != nil {
 		return false, err
@@ -690,7 +692,7 @@ func (p *csiPlugin) CanAttach(spec *volume.Spec) (bool, error) {
 
 	driverName := pvSrc.Driver
 
-	skipAttach, err := p.skipAttach(driverName)
+	skipAttach, err := p.skipAttach(logger, driverName)
 	if err != nil {
 		return false, err
 	}
@@ -855,8 +857,8 @@ func (p *csiPlugin) ConstructBlockVolumeSpec(podUID types.UID, specVolName, mapP
 
 // skipAttach looks up CSIDriver object associated with driver name
 // to determine if driver requires attachment volume operation
-func (p *csiPlugin) skipAttach(driver string) (bool, error) {
-	csiDriver, err := p.getCSIDriver(driver)
+func (p *csiPlugin) skipAttach(logger klog.Logger, driver string) (bool, error) {
+	csiDriver, err := p.getCSIDriver(logger, driver)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// Don't skip attach if CSIDriver does not exist
@@ -870,10 +872,10 @@ func (p *csiPlugin) skipAttach(driver string) (bool, error) {
 	return false, nil
 }
 
-func (p *csiPlugin) getCSIDriver(driver string) (*storage.CSIDriver, error) {
+func (p *csiPlugin) getCSIDriver(logger klog.Logger, driver string) (*storage.CSIDriver, error) {
 	kletHost, ok := p.host.(volume.KubeletVolumeHost)
 	if ok {
-		if err := kletHost.WaitForCacheSync(); err != nil {
+		if err := kletHost.WaitForCacheSync(logger); err != nil {
 			return nil, err
 		}
 	}
@@ -903,8 +905,9 @@ func (p *csiPlugin) getVolumeLifecycleMode(spec *volume.Spec) (storage.VolumeLif
 	return storage.VolumeLifecyclePersistent, nil
 }
 
-func (p *csiPlugin) getPublishContext(client clientset.Interface, handle, driver, nodeName string) (map[string]string, error) {
-	skip, err := p.skipAttach(driver)
+func (p *csiPlugin) getPublishContext(ctx context.Context, client clientset.Interface, handle, driver, nodeName string) (map[string]string, error) {
+	logger := klog.FromContext(ctx)
+	skip, err := p.skipAttach(logger, driver)
 	if err != nil {
 		return nil, err
 	}
@@ -915,7 +918,7 @@ func (p *csiPlugin) getPublishContext(client clientset.Interface, handle, driver
 	attachID := getAttachmentName(handle, driver, nodeName)
 
 	// search for attachment by VolumeAttachment.Spec.Source.PersistentVolumeName
-	attachment, err := client.StorageV1().VolumeAttachments().Get(context.TODO(), attachID, meta.GetOptions{})
+	attachment, err := client.StorageV1().VolumeAttachments().Get(ctx, attachID, meta.GetOptions{})
 	if err != nil {
 		return nil, err // This err already has enough context ("VolumeAttachment xyz not found")
 	}
@@ -941,8 +944,8 @@ func (p *csiPlugin) newAttacherDetacher() (*csiAttacher, error) {
 }
 
 // podInfoEnabled  check CSIDriver enabled pod info flag
-func (p *csiPlugin) podInfoEnabled(driverName string) (bool, error) {
-	csiDriver, err := p.getCSIDriver(driverName)
+func (p *csiPlugin) podInfoEnabled(logger klog.Logger, driverName string) (bool, error) {
+	csiDriver, err := p.getCSIDriver(logger, driverName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			klog.V(4).Info(log("CSIDriver %q not found, not adding pod information", driverName))
@@ -971,7 +974,7 @@ func unregisterDriver(driverName string) error {
 
 // waitForAPIServerForever waits forever to get a CSINode instance as a proxy
 // for a healthy APIServer
-func waitForAPIServerForever(client clientset.Interface, nodeName types.NodeName) error {
+func waitForAPIServerForever(ctx context.Context, client clientset.Interface, nodeName types.NodeName) error {
 	var lastErr error
 	// Served object is discarded so no risk to have stale object with benefit to
 	// reduce the load on APIServer and etcd.
@@ -982,7 +985,7 @@ func waitForAPIServerForever(client clientset.Interface, nodeName types.NodeName
 		// and 2) it has enough permissions. Kubelet may have restricted permissions
 		// when it's bootstrapping TLS.
 		// https://kubernetes.io/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/
-		_, lastErr = client.StorageV1().CSINodes().Get(context.TODO(), string(nodeName), opts)
+		_, lastErr = client.StorageV1().CSINodes().Get(ctx, string(nodeName), opts)
 		if lastErr == nil || apierrors.IsNotFound(lastErr) {
 			// API server contacted
 			return true, nil

--- a/pkg/volume/csi/csi_plugin_test.go
+++ b/pkg/volume/csi/csi_plugin_test.go
@@ -36,6 +36,7 @@ import (
 	fakeclient "k8s.io/client-go/kubernetes/fake"
 	utiltesting "k8s.io/client-go/util/testing"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
@@ -862,6 +863,7 @@ func TestPluginNewDetacher(t *testing.T) {
 }
 
 func TestPluginCanAttach(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	tests := []struct {
 		name       string
 		driverName string
@@ -903,7 +905,7 @@ func TestPluginCanAttach(t *testing.T) {
 			plug, tmpDir := newTestPlugin(t, fakeCSIClient)
 			defer os.RemoveAll(tmpDir)
 
-			pluginCanAttach, err := plug.CanAttach(test.spec)
+			pluginCanAttach, err := plug.CanAttach(logger, test.spec)
 			if err != nil && !test.shouldFail {
 				t.Fatalf("unexpected plugin.CanAttach error: %s", err)
 			}
@@ -915,6 +917,7 @@ func TestPluginCanAttach(t *testing.T) {
 }
 
 func TestPluginFindAttachablePlugin(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	tests := []struct {
 		name       string
 		driverName string
@@ -978,7 +981,7 @@ func TestPluginFindAttachablePlugin(t *testing.T) {
 
 			plugMgr := host.GetPluginMgr()
 
-			plugin, err := plugMgr.FindAttachablePluginBySpec(test.spec)
+			plugin, err := plugMgr.FindAttachablePluginBySpec(logger, test.spec)
 			if err != nil && !test.shouldFail {
 				t.Fatalf("unexpected error calling pluginMgr.FindAttachablePluginBySpec: %s", err)
 			}

--- a/pkg/volume/csi/csi_test.go
+++ b/pkg/volume/csi/csi_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/informers"
 	fakeclient "k8s.io/client-go/kubernetes/fake"
 	utiltesting "k8s.io/client-go/util/testing"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 )
@@ -41,6 +42,7 @@ import (
 // based on operations from the volume manager/reconciler/operation executor
 func TestCSI_VolumeAll(t *testing.T) {
 	defaultFSGroupPolicy := storage.ReadWriteOnceWithFSTypeFSGroupPolicy
+	logger, tCtx := ktesting.NewTestContext(t)
 
 	tests := []struct {
 		name                 string
@@ -276,7 +278,7 @@ func TestCSI_VolumeAll(t *testing.T) {
 			// *************** Attach/Mount volume resources ****************//
 			// attach volume
 			t.Log("csiTest.VolumeAll Attaching volume...")
-			attachPlug, err := attachDetachPlugMgr.FindAttachablePluginBySpec(volSpec)
+			attachPlug, err := attachDetachPlugMgr.FindAttachablePluginBySpec(logger, volSpec)
 			if err != nil {
 				if !test.findPluginShouldFail {
 					t.Fatalf("csiTest.VolumeAll PluginManager.FindAttachablePluginBySpec failed: %v", err)
@@ -375,7 +377,7 @@ func TestCSI_VolumeAll(t *testing.T) {
 				if err != nil {
 					t.Fatalf("csiTest.VolumeAll deviceMounter.GetdeviceMountPath failed %s", err)
 				}
-				if err := csiDevMounter.MountDevice(volSpec, devicePath, devMountPath, volume.DeviceMounterArgs{}); err != nil {
+				if err := csiDevMounter.MountDevice(logger, volSpec, devicePath, devMountPath, volume.DeviceMounterArgs{}); err != nil {
 					t.Fatalf("csiTest.VolumeAll deviceMounter.MountDevice failed: %v", err)
 				}
 				t.Log("csiTest.VolumeAll device mounted at path:", devMountPath)
@@ -412,7 +414,7 @@ func TestCSI_VolumeAll(t *testing.T) {
 			csiMounter.csiClient = csiClient
 			var mounterArgs volume.MounterArgs
 			mounterArgs.FsGroup = fsGroup
-			err = csiMounter.SetUp(mounterArgs)
+			err = csiMounter.SetUp(tCtx, mounterArgs)
 			if test.isInline && (test.driverSpec == nil || !containsVolumeMode(test.driverSpec.VolumeLifecycleModes, storage.VolumeLifecycleEphemeral)) {
 				// This *must* fail because a CSIDriver.Spec.VolumeLifecycleModes entry "ephemeral"
 				// is required.
@@ -548,7 +550,7 @@ func TestCSI_VolumeAll(t *testing.T) {
 
 			// detach volume
 			t.Log("csiTest.VolumeAll Detaching volume...")
-			attachPlug, err = attachDetachPlugMgr.FindAttachablePluginBySpec(volSpec)
+			attachPlug, err = attachDetachPlugMgr.FindAttachablePluginBySpec(logger, volSpec)
 			if err != nil {
 				t.Fatalf("csiTest.VolumeAll PluginManager.FindAttachablePluginBySpec failed: %v", err)
 			}

--- a/pkg/volume/csi/csi_util_test.go
+++ b/pkg/volume/csi/csi_util_test.go
@@ -19,7 +19,6 @@ package csi
 import (
 	"bytes"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -30,7 +29,6 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/volume"
 )
 
@@ -38,7 +36,6 @@ import (
 // Surfaces klog flags by default to enable
 // go test -v ./ --args <klog flags>
 func TestMain(m *testing.M) {
-	klog.InitFlags(flag.CommandLine)
 	os.Exit(m.Run())
 }
 

--- a/pkg/volume/csi/expander.go
+++ b/pkg/volume/csi/expander.go
@@ -31,11 +31,11 @@ import (
 
 var _ volume.NodeExpandableVolumePlugin = &csiPlugin{}
 
-func (c *csiPlugin) RequiresFSResize() bool {
+func (p *csiPlugin) RequiresFSResize() bool {
 	return true
 }
 
-func (c *csiPlugin) NodeExpand(resizeOptions volume.NodeResizeOptions) (bool, error) {
+func (p *csiPlugin) NodeExpand(resizeOptions volume.NodeResizeOptions) (bool, error) {
 	klog.V(4).Info(log("Expander.NodeExpand(%s)", resizeOptions.DeviceMountPath))
 	csiSource, err := getCSISourceFromSpec(resizeOptions.VolumeSpec)
 	if err != nil {
@@ -53,10 +53,10 @@ func (c *csiPlugin) NodeExpand(resizeOptions volume.NodeResizeOptions) (bool, er
 		return false, errors.New(log("Expander.NodeExpand failed to check VolumeMode of source: %v", err))
 	}
 
-	return c.nodeExpandWithClient(resizeOptions, csiSource, csClient, fsVolume)
+	return p.nodeExpandWithClient(resizeOptions, csiSource, csClient, fsVolume)
 }
 
-func (c *csiPlugin) nodeExpandWithClient(
+func (p *csiPlugin) nodeExpandWithClient(
 	resizeOptions volume.NodeResizeOptions,
 	csiSource *api.CSIPersistentVolumeSource,
 	csClient csiClient,
@@ -77,10 +77,10 @@ func (c *csiPlugin) nodeExpandWithClient(
 
 	pv := resizeOptions.VolumeSpec.PersistentVolume
 	if pv == nil {
-		return false, fmt.Errorf("Expander.NodeExpand failed to find associated PersistentVolume for plugin %s", c.GetPluginName())
+		return false, fmt.Errorf("Expander.NodeExpand failed to find associated PersistentVolume for plugin %s", p.GetPluginName())
 	}
 	nodeExpandSecrets := map[string]string{}
-	expandClient := c.host.GetKubeClient()
+	expandClient := p.host.GetKubeClient()
 
 	if csiSource.NodeExpandSecretRef != nil {
 		nodeExpandSecrets, err = getCredentialsFromSecret(expandClient, csiSource.NodeExpandSecretRef)

--- a/pkg/volume/downwardapi/downwardapi.go
+++ b/pkg/volume/downwardapi/downwardapi.go
@@ -17,6 +17,7 @@ limitations under the License.
 package downwardapi
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 
@@ -80,7 +81,7 @@ func (plugin *downwardAPIPlugin) CanSupport(spec *volume.Spec) bool {
 	return spec.Volume != nil && spec.Volume.DownwardAPI != nil
 }
 
-func (plugin *downwardAPIPlugin) RequiresRemount(spec *volume.Spec) bool {
+func (plugin *downwardAPIPlugin) RequiresRemount(logger klog.Logger, spec *volume.Spec) bool {
 	return true
 }
 
@@ -88,7 +89,7 @@ func (plugin *downwardAPIPlugin) SupportsMountOption() bool {
 	return false
 }
 
-func (plugin *downwardAPIPlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
+func (plugin *downwardAPIPlugin) SupportsSELinuxContextMount(logger klog.Logger, spec *volume.Spec) (bool, error) {
 	return false, nil
 }
 
@@ -163,27 +164,28 @@ func (d *downwardAPIVolume) GetAttributes() volume.Attributes {
 // This function is not idempotent by design. We want the data to be refreshed periodically.
 // The internal sync interval of kubelet will drive the refresh of data.
 // TODO: Add volume specific ticker and refresh loop
-func (b *downwardAPIVolumeMounter) SetUp(mounterArgs volume.MounterArgs) error {
-	return b.SetUpAt(b.GetPath(), mounterArgs)
+func (b *downwardAPIVolumeMounter) SetUp(ctx context.Context, mounterArgs volume.MounterArgs) error {
+	return b.SetUpAt(ctx, b.GetPath(), mounterArgs)
 }
 
-func (b *downwardAPIVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterArgs) error {
+func (b *downwardAPIVolumeMounter) SetUpAt(ctx context.Context, dir string, mounterArgs volume.MounterArgs) error {
+	logger := klog.FromContext(ctx)
 	klog.V(3).Infof("Setting up a downwardAPI volume %v for pod %v/%v at %v", b.volName, b.pod.Namespace, b.pod.Name, dir)
 	// Wrap EmptyDir. Here we rely on the idempotency of the wrapped plugin to avoid repeatedly mounting
-	wrapped, err := b.plugin.host.NewWrapperMounter(b.volName, wrappedVolumeSpec(), b.pod)
+	wrapped, err := b.plugin.host.NewWrapperMounter(logger, b.volName, wrappedVolumeSpec(), b.pod)
 	if err != nil {
 		klog.Errorf("Couldn't setup downwardAPI volume %v for pod %v/%v: %s", b.volName, b.pod.Namespace, b.pod.Name, err.Error())
 		return err
 	}
 
-	data, err := CollectData(b.source.Items, b.pod, b.plugin.host, b.source.DefaultMode, b.source.DefaultUser)
+	data, err := CollectData(ctx, b.source.Items, b.pod, b.plugin.host, b.source.DefaultMode, b.source.DefaultUser)
 	if err != nil {
 		klog.Errorf("Error preparing data for downwardAPI volume %v for pod %v/%v: %s", b.volName, b.pod.Namespace, b.pod.Name, err.Error())
 		return err
 	}
 
 	setupSuccess := false
-	if err := wrapped.SetUpAt(dir, mounterArgs); err != nil {
+	if err := wrapped.SetUpAt(ctx, dir, mounterArgs); err != nil {
 		klog.Errorf("Unable to setup downwardAPI volume %v for pod %v/%v: %s", b.volName, b.pod.Namespace, b.pod.Name, err.Error())
 		return err
 	}
@@ -235,7 +237,7 @@ func (b *downwardAPIVolumeMounter) SetUpAt(dir string, mounterArgs volume.Mounte
 // Map's value is the (sorted) content of the field to be dumped in the file.
 //
 // Note: this function is exported so that it can be called from the projection volume driver
-func CollectData(items []v1.DownwardAPIVolumeFile, pod *v1.Pod, host volume.VolumeHost, defaultMode *int32, defaultUser *int64) (map[string]volumeutil.FileProjection, error) {
+func CollectData(ctx context.Context, items []v1.DownwardAPIVolumeFile, pod *v1.Pod, host volume.VolumeHost, defaultMode *int32, defaultUser *int64) (map[string]volumeutil.FileProjection, error) {
 	if defaultMode == nil {
 		return nil, fmt.Errorf("no defaultMode used, not even the default value for it")
 	}
@@ -262,7 +264,7 @@ func CollectData(items []v1.DownwardAPIVolumeFile, pod *v1.Pod, host volume.Volu
 			}
 		} else if fileInfo.ResourceFieldRef != nil {
 			containerName := fileInfo.ResourceFieldRef.ContainerName
-			nodeAllocatable, err := host.GetNodeAllocatable()
+			nodeAllocatable, err := host.GetNodeAllocatable(ctx)
 			if err != nil {
 				errlist = append(errlist, err)
 			} else if values, err := resource.ExtractResourceValueByContainerNameAndNodeAllocatable(fileInfo.ResourceFieldRef, pod, containerName, nodeAllocatable); err != nil {

--- a/pkg/volume/downwardapi/downwardapi_test.go
+++ b/pkg/volume/downwardapi/downwardapi_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/kubernetes/pkg/volume/emptydir"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 	"k8s.io/kubernetes/pkg/volume/util"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 const (
@@ -203,6 +204,7 @@ func TestDownwardAPI(t *testing.T) {
 }
 
 func TestCollectDataWithUser(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	caseMappingUser1 := int64(1001)
 	caseMappingUser2 := int64(1002)
 
@@ -305,7 +307,7 @@ func TestCollectDataWithUser(t *testing.T) {
 			}
 		}()
 
-		actualPayload, err := CollectData(tc.mappings, &pod, host, &tc.mode, tc.user)
+		actualPayload, err := CollectData(tCtx, tc.mappings, &pod, host, &tc.mode, tc.user)
 		if err != nil {
 			t.Errorf("%v: unexpected failure making payload: %v", tc.name, err)
 			continue
@@ -327,6 +329,7 @@ type downwardAPITest struct {
 }
 
 func newDownwardAPITest(t *testing.T, name string, volumeFiles, podLabels, podAnnotations map[string]string, modes map[string]int32) *downwardAPITest {
+	tCtx := ktesting.Init(t)
 	defaultMode := int32(0644)
 	var files []v1.DownwardAPIVolumeFile
 	for path, fieldPath := range volumeFiles {
@@ -378,7 +381,7 @@ func newDownwardAPITest(t *testing.T, name string, volumeFiles, podLabels, podAn
 
 	volumePath := mounter.GetPath()
 
-	err = mounter.SetUp(volume.MounterArgs{})
+	err = mounter.SetUp(tCtx, volume.MounterArgs{})
 	if err != nil {
 		t.Errorf("Failed to setup volume: %v", err)
 	}
@@ -495,6 +498,7 @@ type reSetUp struct {
 }
 
 func (step reSetUp) run(test *downwardAPITest) {
+	tCtx := ktesting.Init(test.t)
 	if step.newLabels != nil {
 		test.pod.ObjectMeta.Labels = step.newLabels
 	}
@@ -505,7 +509,7 @@ func (step reSetUp) run(test *downwardAPITest) {
 	}
 
 	// now re-run Setup
-	if err = test.mounter.SetUp(volume.MounterArgs{}); err != nil {
+	if err = test.mounter.SetUp(tCtx, volume.MounterArgs{}); err != nil {
 		test.t.Errorf("Failed to re-setup volume: %v", err)
 	}
 

--- a/pkg/volume/emptydir/empty_dir.go
+++ b/pkg/volume/emptydir/empty_dir.go
@@ -17,15 +17,15 @@ limitations under the License.
 package emptydir
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/util/swap"
-
-	"k8s.io/klog/v2"
 	"k8s.io/mount-utils"
 	utilstrings "k8s.io/utils/strings"
 
@@ -107,7 +107,7 @@ func (plugin *emptyDirPlugin) CanSupport(spec *volume.Spec) bool {
 	return spec.Volume != nil && spec.Volume.EmptyDir != nil
 }
 
-func (plugin *emptyDirPlugin) RequiresRemount(spec *volume.Spec) bool {
+func (plugin *emptyDirPlugin) RequiresRemount(logger klog.Logger, spec *volume.Spec) bool {
 	// The kuberuntime_manager is responsible for resizing memory-backed emptyDir volumes,
 	// so we never remount them from within the volume plugin.
 	return false
@@ -117,7 +117,7 @@ func (plugin *emptyDirPlugin) SupportsMountOption() bool {
 	return false
 }
 
-func (plugin *emptyDirPlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
+func (plugin *emptyDirPlugin) SupportsSELinuxContextMount(logger klog.Logger, spec *volume.Spec) (bool, error) {
 	return false, nil
 }
 
@@ -160,7 +160,9 @@ func (plugin *emptyDirPlugin) newMounterInternal(spec *volume.Spec, pod *v1.Pod,
 	if spec.Volume.EmptyDir != nil { // Support a non-specified source as EmptyDir.
 		medium = spec.Volume.EmptyDir.Medium
 		if medium == v1.StorageMediumMemory {
-			nodeAllocatable, err := plugin.host.GetNodeAllocatable()
+			// Use context.TODO() because we currently do not have a proper context to pass in.
+			// This should be replaced with an appropriate context when refactoring this function to accept a context parameter.
+			nodeAllocatable, err := plugin.host.GetNodeAllocatable(context.TODO())
 			if err != nil {
 				return nil, err
 			}
@@ -246,12 +248,12 @@ func (ed *emptyDir) GetAttributes() volume.Attributes {
 }
 
 // SetUp creates new directory.
-func (ed *emptyDir) SetUp(mounterArgs volume.MounterArgs) error {
-	return ed.SetUpAt(ed.GetPath(), mounterArgs)
+func (ed *emptyDir) SetUp(ctx context.Context, mounterArgs volume.MounterArgs) error {
+	return ed.SetUpAt(ctx, ed.GetPath(), mounterArgs)
 }
 
 // SetUpAt creates new directory.
-func (ed *emptyDir) SetUpAt(dir string, mounterArgs volume.MounterArgs) error {
+func (ed *emptyDir) SetUpAt(ctx context.Context, dir string, mounterArgs volume.MounterArgs) error {
 	notMnt, err := ed.mounter.IsLikelyNotMountPoint(dir)
 	// Getting an os.IsNotExist err from is a contingency; the directory
 	// may not exist yet, in which case, setup should run.

--- a/pkg/volume/emptydir/empty_dir_test.go
+++ b/pkg/volume/emptydir/empty_dir_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package emptydir
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -42,6 +43,7 @@ import (
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/mount-utils"
 	"k8s.io/utils/ptr"
 )
@@ -216,8 +218,9 @@ func doTestPlugin(t *testing.T, config pluginTestConfig) {
 		}
 	}
 
+	tCtx := ktesting.Init(t)
 	// Stat the directory and check the permission bits
-	testSetUp(mounter, metadataDir, volPath)
+	_ = testSetUp(tCtx, mounter, metadataDir, volPath)
 
 	log := physicalMounter.GetLog()
 	// Check the number of mounts performed during setup
@@ -268,8 +271,8 @@ func doTestPlugin(t *testing.T, config pluginTestConfig) {
 	physicalMounter.ResetLog()
 }
 
-func testSetUp(mounter volume.Mounter, metadataDir, volPath string) error {
-	if err := mounter.SetUp(volume.MounterArgs{}); err != nil {
+func testSetUp(tCtx context.Context, mounter volume.Mounter, metadataDir, volPath string) error {
+	if err := mounter.SetUp(tCtx, volume.MounterArgs{}); err != nil {
 		return fmt.Errorf("expected success, got: %w", err)
 	}
 	// Stat the directory and check the permission bits
@@ -1352,6 +1355,8 @@ func TestResizeEphemeralVolume(t *testing.T) {
 func TestEmptyDirVolumeMode(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EmptyDirVolumeMode, true)
 
+	tCtx := ktesting.Init(t)
+
 	testCases := []struct {
 		name         string
 		mode         *int32
@@ -1409,7 +1414,7 @@ func TestEmptyDirVolumeMode(t *testing.T) {
 				t.Fatalf("Failed to make a new Mounter: %v", err)
 			}
 
-			if err := mounter.SetUp(volume.MounterArgs{}); err != nil {
+			if err := mounter.SetUp(tCtx, volume.MounterArgs{}); err != nil {
 				t.Fatalf("SetUp failed: %v", err)
 			}
 
@@ -1434,6 +1439,8 @@ func TestEmptyDirVolumeMode(t *testing.T) {
 
 func TestEmptyDirVolumeModeFeatureGateDisabled(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EmptyDirVolumeMode, false)
+
+	tCtx := ktesting.Init(t)
 
 	basePath, err := utiltesting.MkTmpdir("emptydir_mode_gate_test")
 	if err != nil {
@@ -1467,7 +1474,7 @@ func TestEmptyDirVolumeModeFeatureGateDisabled(t *testing.T) {
 		t.Fatalf("Failed to make a new Mounter: %v", err)
 	}
 
-	if err := mounter.SetUp(volume.MounterArgs{}); err != nil {
+	if err := mounter.SetUp(tCtx, volume.MounterArgs{}); err != nil {
 		t.Fatalf("SetUp failed: %v", err)
 	}
 

--- a/pkg/volume/emptydir/empty_dir_windows_test.go
+++ b/pkg/volume/emptydir/empty_dir_windows_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/mount-utils"
 )
 
@@ -46,6 +47,8 @@ func (fake *fakeMountDetector) GetMountMedium(path string, requestedMedium v1.St
 
 func TestEmptyDirVolumeModeWindows(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EmptyDirVolumeMode, true)
+
+	tCtx := ktesting.Init(t)
 
 	basePath, err := utiltesting.MkTmpdir("emptydir_mode_windows_test")
 	if err != nil {
@@ -84,7 +87,7 @@ func TestEmptyDirVolumeModeWindows(t *testing.T) {
 		t.Fatalf("Failed to make a new Mounter: %v", err)
 	}
 
-	if err := mounter.SetUp(volume.MounterArgs{}); err != nil {
+	if err := mounter.SetUp(tCtx, volume.MounterArgs{}); err != nil {
 		t.Fatalf("SetUp should not fail on Windows with mode set, got: %v", err)
 	}
 

--- a/pkg/volume/fc/attacher.go
+++ b/pkg/volume/fc/attacher.go
@@ -66,7 +66,7 @@ func (attacher *fcAttacher) Attach(spec *volume.Spec, nodeName types.NodeName) (
 	return "", nil
 }
 
-func (attacher *fcAttacher) VolumesAreAttached(specs []*volume.Spec, nodeName types.NodeName) (map[*volume.Spec]bool, error) {
+func (attacher *fcAttacher) VolumesAreAttached(logger klog.Logger, specs []*volume.Spec, nodeName types.NodeName) (map[*volume.Spec]bool, error) {
 	volumesAttachedCheck := make(map[*volume.Spec]bool)
 	for _, spec := range specs {
 		volumesAttachedCheck[spec] = true
@@ -75,7 +75,7 @@ func (attacher *fcAttacher) VolumesAreAttached(specs []*volume.Spec, nodeName ty
 	return volumesAttachedCheck, nil
 }
 
-func (plugin *fcPlugin) VerifyExhaustedResource(spec *volume.Spec) bool {
+func (plugin *fcPlugin) VerifyExhaustedResource(_ klog.Logger, _ *volume.Spec) bool {
 	return false
 }
 
@@ -99,7 +99,7 @@ func (attacher *fcAttacher) GetDeviceMountPath(
 	return attacher.manager.MakeGlobalPDName(*mounter.fcDisk), nil
 }
 
-func (attacher *fcAttacher) MountDevice(spec *volume.Spec, devicePath string, deviceMountPath string, mountArgs volume.DeviceMounterArgs) error {
+func (attacher *fcAttacher) MountDevice(logger klog.Logger, spec *volume.Spec, devicePath string, deviceMountPath string, mountArgs volume.DeviceMounterArgs) error {
 	mounter := attacher.host.GetMounter()
 	notMnt, err := mounter.IsLikelyNotMountPoint(deviceMountPath)
 	if err != nil {
@@ -205,7 +205,7 @@ func (detacher *fcDetacher) UnmountDevice(deviceMountPath string) error {
 	return nil
 }
 
-func (plugin *fcPlugin) CanAttach(spec *volume.Spec) (bool, error) {
+func (plugin *fcPlugin) CanAttach(logger klog.Logger, spec *volume.Spec) (bool, error) {
 	return true, nil
 }
 

--- a/pkg/volume/fc/fc.go
+++ b/pkg/volume/fc/fc.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fc
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -89,7 +90,7 @@ func (plugin *fcPlugin) CanSupport(spec *volume.Spec) bool {
 	return (spec.Volume != nil && spec.Volume.FC != nil) || (spec.PersistentVolume != nil && spec.PersistentVolume.Spec.FC != nil)
 }
 
-func (plugin *fcPlugin) RequiresRemount(spec *volume.Spec) bool {
+func (plugin *fcPlugin) RequiresRemount(logger klog.Logger, spec *volume.Spec) bool {
 	return false
 }
 
@@ -97,7 +98,7 @@ func (plugin *fcPlugin) SupportsMountOption() bool {
 	return true
 }
 
-func (plugin *fcPlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
+func (plugin *fcPlugin) SupportsSELinuxContextMount(logger klog.Logger, spec *volume.Spec) (bool, error) {
 	return true, nil
 }
 
@@ -392,11 +393,11 @@ func (b *fcDiskMounter) GetAttributes() volume.Attributes {
 	}
 }
 
-func (b *fcDiskMounter) SetUp(mounterArgs volume.MounterArgs) error {
-	return b.SetUpAt(b.GetPath(), mounterArgs)
+func (b *fcDiskMounter) SetUp(ctx context.Context, mounterArgs volume.MounterArgs) error {
+	return b.SetUpAt(ctx, b.GetPath(), mounterArgs)
 }
 
-func (b *fcDiskMounter) SetUpAt(dir string, mounterArgs volume.MounterArgs) error {
+func (b *fcDiskMounter) SetUpAt(ctx context.Context, dir string, mounterArgs volume.MounterArgs) error {
 	// diskSetUp checks mountpoints and prevent repeated calls
 	err := diskSetUp(b.manager, *b, dir, b.mounter, mounterArgs.FsGroup, mounterArgs.FSGroupChangePolicy)
 	if err != nil {

--- a/pkg/volume/fc/fc_test.go
+++ b/pkg/volume/fc/fc_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/mount-utils"
 	testingexec "k8s.io/utils/exec/testing"
 
@@ -146,6 +147,7 @@ func (fake *fakeDiskManager) DetachBlockFCDisk(c fcDiskUnmapper, mapPath, device
 }
 
 func doTestPlugin(t *testing.T, spec *volume.Spec) {
+	tCtx := ktesting.Init(t)
 	tmpDir, err := utiltesting.MkTmpdir("fc_test")
 	if err != nil {
 		t.Fatalf("error creating temp dir: %v", err)
@@ -177,7 +179,7 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 		t.Errorf("Unexpected path, expected %q, got: %q", expectedPath, path)
 	}
 
-	if err := mounter.SetUp(volume.MounterArgs{}); err != nil {
+	if err := mounter.SetUp(tCtx, volume.MounterArgs{}); err != nil {
 		t.Errorf("Expected success, got: %v", err)
 	}
 	if _, err := os.Stat(path); err != nil {

--- a/pkg/volume/flexvolume/attacher.go
+++ b/pkg/volume/flexvolume/attacher.go
@@ -70,7 +70,7 @@ func (a *flexVolumeAttacher) GetDeviceMountPath(spec *volume.Spec) (string, erro
 }
 
 // MountDevice is part of the volume.Attacher interface
-func (a *flexVolumeAttacher) MountDevice(spec *volume.Spec, devicePath string, deviceMountPath string, _ volume.DeviceMounterArgs) error {
+func (a *flexVolumeAttacher) MountDevice(logger klog.Logger, spec *volume.Spec, devicePath string, deviceMountPath string, _ volume.DeviceMounterArgs) error {
 	// Mount only once.
 	alreadyMounted, err := prepareForMount(a.plugin.host.GetMounter(), deviceMountPath)
 	if err != nil {
@@ -97,7 +97,7 @@ func (a *flexVolumeAttacher) MountDevice(spec *volume.Spec, devicePath string, d
 	return err
 }
 
-func (a *flexVolumeAttacher) VolumesAreAttached(specs []*volume.Spec, nodeName types.NodeName) (map[*volume.Spec]bool, error) {
+func (a *flexVolumeAttacher) VolumesAreAttached(logger klog.Logger, specs []*volume.Spec, nodeName types.NodeName) (map[*volume.Spec]bool, error) {
 	volumesAttachedCheck := make(map[*volume.Spec]bool)
 	for _, spec := range specs {
 		volumesAttachedCheck[spec] = true

--- a/pkg/volume/flexvolume/attacher_test.go
+++ b/pkg/volume/flexvolume/attacher_test.go
@@ -23,6 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/test/utils/harness"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 func TestAttach(tt *testing.T) {
@@ -61,6 +62,8 @@ func TestMountDevice(tt *testing.T) {
 	t := harness.For(tt)
 	defer t.Close()
 
+	logger, _ := ktesting.NewTestContext(tt)
+
 	spec := fakeVolumeSpec()
 
 	plugin, rootDir := testPlugin(t)
@@ -70,10 +73,11 @@ func TestMountDevice(tt *testing.T) {
 	)
 
 	a, _ := plugin.NewAttacher()
-	a.MountDevice(spec, "/dev/sdx", rootDir+"/mount-dir", volume.DeviceMounterArgs{})
+	_ = a.MountDevice(logger, spec, "/dev/sdx", rootDir+"/mount-dir", volume.DeviceMounterArgs{})
 }
 
 func TestIsVolumeAttached(tt *testing.T) {
+	logger, _ := ktesting.NewTestContext(tt)
 	t := harness.For(tt)
 	defer t.Close()
 
@@ -85,5 +89,5 @@ func TestIsVolumeAttached(tt *testing.T) {
 	)
 	a, _ := plugin.NewAttacher()
 	specs := []*volume.Spec{spec}
-	a.VolumesAreAttached(specs, "localhost")
+	_, _ = a.VolumesAreAttached(logger, specs, "localhost")
 }

--- a/pkg/volume/flexvolume/mounter.go
+++ b/pkg/volume/flexvolume/mounter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package flexvolume
 
 import (
+	"context"
 	"os"
 	"strconv"
 
@@ -40,12 +41,12 @@ var _ volume.Mounter = &flexVolumeMounter{}
 // Mounter interface
 
 // SetUp creates new directory.
-func (f *flexVolumeMounter) SetUp(mounterArgs volume.MounterArgs) error {
-	return f.SetUpAt(f.GetPath(), mounterArgs)
+func (f *flexVolumeMounter) SetUp(ctx context.Context, mounterArgs volume.MounterArgs) error {
+	return f.SetUpAt(ctx, f.GetPath(), mounterArgs)
 }
 
 // SetUpAt creates new directory.
-func (f *flexVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterArgs) error {
+func (f *flexVolumeMounter) SetUpAt(ctx context.Context, dir string, mounterArgs volume.MounterArgs) error {
 	// Mount only once.
 	alreadyMounted, err := prepareForMount(f.mounter, dir)
 	if err != nil {

--- a/pkg/volume/flexvolume/mounter_test.go
+++ b/pkg/volume/flexvolume/mounter_test.go
@@ -19,6 +19,7 @@ package flexvolume
 import (
 	"testing"
 
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/mount-utils"
 
 	v1 "k8s.io/api/core/v1"
@@ -31,6 +32,8 @@ import (
 func TestSetUpAt(tt *testing.T) {
 	t := harness.For(tt)
 	defer t.Close()
+
+	tCtx := ktesting.Init(tt)
 
 	spec := fakeVolumeSpec()
 	pod := &v1.Pod{
@@ -72,9 +75,9 @@ func TestSetUpAt(tt *testing.T) {
 
 	m, _ := plugin.newMounterInternal(spec, pod, mounter, plugin.runner)
 	var mounterArgs volume.MounterArgs
-	m.SetUpAt(rootDir+"/mount-dir", mounterArgs)
+	_ = m.SetUpAt(tCtx, rootDir+"/mount-dir", mounterArgs)
 
 	group := int64(42)
 	mounterArgs.FsGroup = &group
-	m.SetUpAt(rootDir+"/mount-dir", mounterArgs)
+	_ = m.SetUpAt(tCtx, rootDir+"/mount-dir", mounterArgs)
 }

--- a/pkg/volume/flexvolume/plugin.go
+++ b/pkg/volume/flexvolume/plugin.go
@@ -102,7 +102,7 @@ func (plugin *flexVolumePlugin) Init(host volume.VolumeHost) error {
 	return nil
 }
 
-func (plugin *flexVolumePlugin) VerifyExhaustedResource(spec *volume.Spec) bool {
+func (plugin *flexVolumePlugin) VerifyExhaustedResource(_ klog.Logger, _ *volume.Spec) bool {
 	return false
 }
 
@@ -153,7 +153,7 @@ func (plugin *flexVolumePlugin) CanSupport(spec *volume.Spec) bool {
 }
 
 // RequiresRemount is part of the volume.VolumePlugin interface.
-func (plugin *flexVolumePlugin) RequiresRemount(spec *volume.Spec) bool {
+func (plugin *flexVolumePlugin) RequiresRemount(logger klog.Logger, spec *volume.Spec) bool {
 	return false
 }
 
@@ -256,7 +256,7 @@ func (plugin *flexVolumeAttachablePlugin) NewDeviceUnmounter() (volume.DeviceUnm
 	return plugin.NewDetacher()
 }
 
-func (plugin *flexVolumeAttachablePlugin) CanAttach(spec *volume.Spec) (bool, error) {
+func (plugin *flexVolumeAttachablePlugin) CanAttach(logger klog.Logger, spec *volume.Spec) (bool, error) {
 	return true, nil
 }
 
@@ -290,7 +290,7 @@ func (plugin *flexVolumePlugin) unsupported(commands ...string) {
 	plugin.unsupportedCommands = append(plugin.unsupportedCommands, commands...)
 }
 
-func (plugin *flexVolumePlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
+func (plugin *flexVolumePlugin) SupportsSELinuxContextMount(logger klog.Logger, spec *volume.Spec) (bool, error) {
 	return false, nil
 }
 

--- a/pkg/volume/git_repo/git_repo.go
+++ b/pkg/volume/git_repo/git_repo.go
@@ -17,6 +17,7 @@ limitations under the License.
 package git_repo
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -25,6 +26,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/volume"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
@@ -79,7 +81,7 @@ func (plugin *gitRepoPlugin) CanSupport(spec *volume.Spec) bool {
 	return spec.Volume != nil && spec.Volume.GitRepo != nil
 }
 
-func (plugin *gitRepoPlugin) RequiresRemount(spec *volume.Spec) bool {
+func (plugin *gitRepoPlugin) RequiresRemount(logger klog.Logger, spec *volume.Spec) bool {
 	return false
 }
 
@@ -87,7 +89,7 @@ func (plugin *gitRepoPlugin) SupportsMountOption() bool {
 	return false
 }
 
-func (plugin *gitRepoPlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
+func (plugin *gitRepoPlugin) SupportsSELinuxContextMount(logger klog.Logger, spec *volume.Spec) (bool, error) {
 	return false, nil
 }
 
@@ -170,26 +172,27 @@ func (b *gitRepoVolumeMounter) GetAttributes() volume.Attributes {
 }
 
 // SetUp creates new directory and clones a git repo.
-func (b *gitRepoVolumeMounter) SetUp(mounterArgs volume.MounterArgs) error {
+func (b *gitRepoVolumeMounter) SetUp(ctx context.Context, mounterArgs volume.MounterArgs) error {
 	if !utilfeature.DefaultFeatureGate.Enabled(features.GitRepoVolumeDriver) {
 		return fmt.Errorf("git-repo volume plugin has been disabled; if necessary, it may be re-enabled by enabling the feature-gate `GitRepoVolumeDriver`")
 	}
 
-	return b.SetUpAt(b.GetPath(), mounterArgs)
+	return b.SetUpAt(ctx, b.GetPath(), mounterArgs)
 }
 
 // SetUpAt creates new directory and clones a git repo.
-func (b *gitRepoVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterArgs) error {
+func (b *gitRepoVolumeMounter) SetUpAt(ctx context.Context, dir string, mounterArgs volume.MounterArgs) error {
+	logger := klog.FromContext(ctx)
 	if volumeutil.IsReady(b.getMetaDir()) {
 		return nil
 	}
 
 	// Wrap EmptyDir, let it do the setup.
-	wrapped, err := b.plugin.host.NewWrapperMounter(b.volName, wrappedVolumeSpec(), &b.pod)
+	wrapped, err := b.plugin.host.NewWrapperMounter(logger, b.volName, wrappedVolumeSpec(), &b.pod)
 	if err != nil {
 		return err
 	}
-	if err := wrapped.SetUpAt(dir, mounterArgs); err != nil {
+	if err := wrapped.SetUpAt(ctx, dir, mounterArgs); err != nil {
 		return err
 	}
 

--- a/pkg/volume/git_repo/git_repo_test.go
+++ b/pkg/volume/git_repo/git_repo_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/emptydir"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/exec"
 	fakeexec "k8s.io/utils/exec/testing"
 )
@@ -485,7 +486,7 @@ func doTestPlugin(t *testing.T, sc scenario) []error {
 	}
 
 	// Test setUp()
-	setUpErrs := doTestSetUp(sc, mounter)
+	setUpErrs := doTestSetUp(t, sc, mounter)
 	allErrs = append(allErrs, setUpErrs...)
 
 	if _, err := os.Stat(path); err != nil {
@@ -540,9 +541,11 @@ func doTestPlugin(t *testing.T, sc scenario) []error {
 	return allErrs
 }
 
-func doTestSetUp(sc scenario, mounter volume.Mounter) []error {
+func doTestSetUp(t *testing.T, sc scenario, mounter volume.Mounter) []error {
 	expecteds := sc.expecteds
 	allErrs := []error{}
+
+	tCtx := ktesting.Init(t)
 
 	// Construct combined outputs from expected commands
 	var fakeOutputs []fakeexec.FakeAction
@@ -589,7 +592,7 @@ func doTestSetUp(sc scenario, mounter volume.Mounter) []error {
 	g := mounter.(*gitRepoVolumeMounter)
 	g.exec = fake
 
-	err := g.SetUp(volume.MounterArgs{})
+	err := g.SetUp(tCtx, volume.MounterArgs{})
 	if err != nil {
 		allErrs = append(allErrs, err)
 	}

--- a/pkg/volume/hostpath/host_path.go
+++ b/pkg/volume/hostpath/host_path.go
@@ -17,6 +17,7 @@ limitations under the License.
 package hostpath
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"regexp"
@@ -100,7 +101,7 @@ func (plugin *hostPathPlugin) CanSupport(spec *volume.Spec) bool {
 		(spec.Volume != nil && spec.Volume.HostPath != nil)
 }
 
-func (plugin *hostPathPlugin) RequiresRemount(spec *volume.Spec) bool {
+func (plugin *hostPathPlugin) RequiresRemount(logger klog.Logger, spec *volume.Spec) bool {
 	return false
 }
 
@@ -108,7 +109,7 @@ func (plugin *hostPathPlugin) SupportsMountOption() bool {
 	return false
 }
 
-func (plugin *hostPathPlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
+func (plugin *hostPathPlugin) SupportsSELinuxContextMount(logger klog.Logger, spec *volume.Spec) (bool, error) {
 	return false, nil
 }
 
@@ -238,7 +239,7 @@ func (b *hostPathMounter) GetAttributes() volume.Attributes {
 }
 
 // SetUp does nothing.
-func (b *hostPathMounter) SetUp(mounterArgs volume.MounterArgs) error {
+func (b *hostPathMounter) SetUp(ctx context.Context, mounterArgs volume.MounterArgs) error {
 	err := validation.ValidatePathNoBacksteps(b.GetPath())
 	if err != nil {
 		return fmt.Errorf("invalid HostPath `%s`: %v", b.GetPath(), err)
@@ -255,7 +256,7 @@ func (b *hostPathMounter) SetUp(mounterArgs volume.MounterArgs) error {
 }
 
 // SetUpAt does not make sense for host paths - probably programmer error.
-func (b *hostPathMounter) SetUpAt(dir string, mounterArgs volume.MounterArgs) error {
+func (b *hostPathMounter) SetUpAt(ctx context.Context, dir string, mounterArgs volume.MounterArgs) error {
 	return fmt.Errorf("SetUpAt() does not make sense for host paths")
 }
 

--- a/pkg/volume/hostpath/host_path_test.go
+++ b/pkg/volume/hostpath/host_path_test.go
@@ -27,7 +27,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/klog/v2/ktesting"
+	"k8s.io/kubernetes/test/utils/ktesting"
+
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 	"k8s.io/kubernetes/pkg/volume/util/hostutil"
@@ -204,6 +205,7 @@ func TestProvisioner(t *testing.T) {
 }
 
 func TestInvalidHostPath(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(volume.VolumeConfig{}), nil /* prober */, volumetest.NewFakeKubeletVolumeHost(t, "fake", nil, nil))
 
@@ -221,7 +223,7 @@ func TestInvalidHostPath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = mounter.SetUp(volume.MounterArgs{})
+	err = mounter.SetUp(tCtx, volume.MounterArgs{})
 	expectedMsg := "invalid HostPath `/no/backsteps/allowed/..`: must not contain '..'"
 	if err.Error() != expectedMsg {
 		t.Fatalf("expected error `%s` but got `%s`", expectedMsg, err)
@@ -229,6 +231,7 @@ func TestInvalidHostPath(t *testing.T) {
 }
 
 func TestPlugin(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(volume.VolumeConfig{}), nil /* prober */, volumetest.NewFakeKubeletVolumeHost(t, "fake", nil, nil))
 
@@ -257,7 +260,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Got unexpected path: %s", path)
 	}
 
-	if err := mounter.SetUp(volume.MounterArgs{}); err != nil {
+	if err := mounter.SetUp(tCtx, volume.MounterArgs{}); err != nil {
 		t.Errorf("Expected success, got: %v", err)
 	}
 

--- a/pkg/volume/image/image.go
+++ b/pkg/volume/image/image.go
@@ -17,10 +17,12 @@ limitations under the License.
 package image
 
 import (
+	"context"
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/volume"
 )
 
@@ -80,15 +82,19 @@ func (o *imagePlugin) GetAttributes() volume.Attributes {
 	}
 }
 
-func (o *imagePlugin) GetPath() string                                             { return "" }
-func (o *imagePlugin) RequiresFSResize() bool                                      { return false }
-func (o *imagePlugin) RequiresRemount(spec *volume.Spec) bool                      { return false }
-func (o *imagePlugin) SetUp(mounterArgs volume.MounterArgs) error                  { return nil }
-func (o *imagePlugin) SetUpAt(dir string, mounterArgs volume.MounterArgs) error    { return nil }
-func (o *imagePlugin) SupportsMountOption() bool                                   { return false }
-func (o *imagePlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) { return false, nil }
-func (o *imagePlugin) TearDown() error                                             { return nil }
-func (o *imagePlugin) TearDownAt(string) error                                     { return nil }
+func (o *imagePlugin) GetPath() string                                                 { return "" }
+func (o *imagePlugin) RequiresFSResize() bool                                          { return false }
+func (o *imagePlugin) RequiresRemount(logger klog.Logger, spec *volume.Spec) bool      { return false }
+func (o *imagePlugin) SetUp(ctx context.Context, mounterArgs volume.MounterArgs) error { return nil }
+func (o *imagePlugin) SetUpAt(ctx context.Context, dir string, mounterArgs volume.MounterArgs) error {
+	return nil
+}
+func (o *imagePlugin) SupportsMountOption() bool { return false }
+func (o *imagePlugin) SupportsSELinuxContextMount(logger klog.Logger, spec *volume.Spec) (bool, error) {
+	return false, nil
+}
+func (o *imagePlugin) TearDown() error         { return nil }
+func (o *imagePlugin) TearDownAt(string) error { return nil }
 
 func getVolumeSource(spec *volume.Spec) *v1.ImageVolumeSource {
 	if spec == nil || spec.Volume == nil {

--- a/pkg/volume/iscsi/attacher.go
+++ b/pkg/volume/iscsi/attacher.go
@@ -54,7 +54,7 @@ func (plugin *iscsiPlugin) NewAttacher() (volume.Attacher, error) {
 	}, nil
 }
 
-func (plugin *iscsiPlugin) VerifyExhaustedResource(spec *volume.Spec) bool {
+func (plugin *iscsiPlugin) VerifyExhaustedResource(_ klog.Logger, _ *volume.Spec) bool {
 	return false
 }
 
@@ -71,7 +71,7 @@ func (attacher *iscsiAttacher) Attach(spec *volume.Spec, nodeName types.NodeName
 	return "", nil
 }
 
-func (attacher *iscsiAttacher) VolumesAreAttached(specs []*volume.Spec, nodeName types.NodeName) (map[*volume.Spec]bool, error) {
+func (attacher *iscsiAttacher) VolumesAreAttached(logger klog.Logger, specs []*volume.Spec, nodeName types.NodeName) (map[*volume.Spec]bool, error) {
 	volumesAttachedCheck := make(map[*volume.Spec]bool)
 	for _, spec := range specs {
 		volumesAttachedCheck[spec] = true
@@ -103,7 +103,7 @@ func (attacher *iscsiAttacher) GetDeviceMountPath(
 	return attacher.manager.MakeGlobalPDName(*mounter.iscsiDisk), nil
 }
 
-func (attacher *iscsiAttacher) MountDevice(spec *volume.Spec, devicePath string, deviceMountPath string, mountArgs volume.DeviceMounterArgs) error {
+func (attacher *iscsiAttacher) MountDevice(logger klog.Logger, spec *volume.Spec, devicePath string, deviceMountPath string, mountArgs volume.DeviceMounterArgs) error {
 	mounter := attacher.host.GetMounter()
 	notMnt, err := mounter.IsLikelyNotMountPoint(deviceMountPath)
 	if err != nil {
@@ -183,7 +183,7 @@ func (detacher *iscsiDetacher) UnmountDevice(deviceMountPath string) error {
 	return nil
 }
 
-func (plugin *iscsiPlugin) CanAttach(spec *volume.Spec) (bool, error) {
+func (plugin *iscsiPlugin) CanAttach(logger klog.Logger, spec *volume.Spec) (bool, error) {
 	return true, nil
 }
 

--- a/pkg/volume/iscsi/iscsi.go
+++ b/pkg/volume/iscsi/iscsi.go
@@ -82,7 +82,7 @@ func (plugin *iscsiPlugin) CanSupport(spec *volume.Spec) bool {
 	return (spec.Volume != nil && spec.Volume.ISCSI != nil) || (spec.PersistentVolume != nil && spec.PersistentVolume.Spec.ISCSI != nil)
 }
 
-func (plugin *iscsiPlugin) RequiresRemount(spec *volume.Spec) bool {
+func (plugin *iscsiPlugin) RequiresRemount(logger klog.Logger, spec *volume.Spec) bool {
 	return false
 }
 
@@ -90,7 +90,7 @@ func (plugin *iscsiPlugin) SupportsMountOption() bool {
 	return true
 }
 
-func (plugin *iscsiPlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
+func (plugin *iscsiPlugin) SupportsSELinuxContextMount(logger klog.Logger, spec *volume.Spec) (bool, error) {
 	return true, nil
 }
 
@@ -371,11 +371,11 @@ func (b *iscsiDiskMounter) GetAttributes() volume.Attributes {
 	}
 }
 
-func (b *iscsiDiskMounter) SetUp(mounterArgs volume.MounterArgs) error {
-	return b.SetUpAt(b.GetPath(), mounterArgs)
+func (b *iscsiDiskMounter) SetUp(ctx context.Context, mounterArgs volume.MounterArgs) error {
+	return b.SetUpAt(ctx, b.GetPath(), mounterArgs)
 }
 
-func (b *iscsiDiskMounter) SetUpAt(dir string, mounterArgs volume.MounterArgs) error {
+func (b *iscsiDiskMounter) SetUpAt(ctx context.Context, dir string, mounterArgs volume.MounterArgs) error {
 	// diskSetUp checks mountpoints and prevent repeated calls
 	err := diskSetUp(b.manager, *b, dir, b.mounter, mounterArgs)
 	if err != nil {

--- a/pkg/volume/iscsi/iscsi_test.go
+++ b/pkg/volume/iscsi/iscsi_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/mount-utils"
 	testingexec "k8s.io/utils/exec/testing"
 
@@ -151,6 +152,8 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 	}
 	defer os.RemoveAll(tmpDir)
 
+	tCtx := ktesting.Init(t)
+
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, volumetest.NewFakeVolumeHost(t, tmpDir, nil, nil))
 
@@ -176,7 +179,7 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 		t.Errorf("Unexpected path, expected %q, got: %q", expectedPath, path)
 	}
 
-	if err := mounter.SetUp(volume.MounterArgs{}); err != nil {
+	if err := mounter.SetUp(tCtx, volume.MounterArgs{}); err != nil {
 		t.Errorf("Expected success, got: %v", err)
 	}
 	if _, err := os.Stat(path); err != nil {

--- a/pkg/volume/local/local.go
+++ b/pkg/volume/local/local.go
@@ -17,6 +17,7 @@ limitations under the License.
 package local
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -85,7 +86,7 @@ func (plugin *localVolumePlugin) CanSupport(spec *volume.Spec) bool {
 	return (spec.PersistentVolume != nil && spec.PersistentVolume.Spec.Local != nil)
 }
 
-func (plugin *localVolumePlugin) RequiresRemount(spec *volume.Spec) bool {
+func (plugin *localVolumePlugin) RequiresRemount(logger klog.Logger, spec *volume.Spec) bool {
 	return false
 }
 
@@ -93,7 +94,7 @@ func (plugin *localVolumePlugin) SupportsMountOption() bool {
 	return true
 }
 
-func (plugin *localVolumePlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
+func (plugin *localVolumePlugin) SupportsSELinuxContextMount(logger klog.Logger, spec *volume.Spec) (bool, error) {
 	return false, nil
 }
 
@@ -362,7 +363,7 @@ func (dm *deviceMounter) mountLocalBlockDevice(spec *volume.Spec, devicePath str
 	return nil
 }
 
-func (dm *deviceMounter) MountDevice(spec *volume.Spec, devicePath string, deviceMountPath string, _ volume.DeviceMounterArgs) error {
+func (dm *deviceMounter) MountDevice(logger klog.Logger, spec *volume.Spec, devicePath string, deviceMountPath string, _ volume.DeviceMounterArgs) error {
 	if spec.PersistentVolume.Spec.Local == nil || len(spec.PersistentVolume.Spec.Local.Path) == 0 {
 		return fmt.Errorf("local volume source is nil or local path is not set")
 	}
@@ -521,12 +522,12 @@ func (m *localVolumeMounter) GetAttributes() volume.Attributes {
 }
 
 // SetUp bind mounts the directory to the volume path
-func (m *localVolumeMounter) SetUp(mounterArgs volume.MounterArgs) error {
-	return m.SetUpAt(m.GetPath(), mounterArgs)
+func (m *localVolumeMounter) SetUp(ctx context.Context, mounterArgs volume.MounterArgs) error {
+	return m.SetUpAt(ctx, m.GetPath(), mounterArgs)
 }
 
 // SetUpAt bind mounts the directory to the volume path and sets up volume ownership
-func (m *localVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterArgs) error {
+func (m *localVolumeMounter) SetUpAt(ctx context.Context, dir string, mounterArgs volume.MounterArgs) error {
 	m.plugin.volumeLocks.LockKey(m.globalPath)
 	defer m.plugin.volumeLocks.UnlockKey(m.globalPath)
 
@@ -665,12 +666,12 @@ var _ volume.BlockVolumeMapper = &localVolumeMapper{}
 var _ volume.CustomBlockVolumeMapper = &localVolumeMapper{}
 
 // SetUpDevice prepares the volume to the node by the plugin specific way.
-func (m *localVolumeMapper) SetUpDevice() (string, error) {
+func (m *localVolumeMapper) SetUpDevice(logger klog.Logger) (string, error) {
 	return "", nil
 }
 
 // MapPodDevice provides physical device path for the local PV.
-func (m *localVolumeMapper) MapPodDevice() (string, error) {
+func (m *localVolumeMapper) MapPodDevice(logger klog.Logger) (string, error) {
 	globalPath := util.MakeAbsolutePath(runtime.GOOS, m.globalPath)
 	klog.V(4).Infof("MapPodDevice returning path %s", globalPath)
 	return globalPath, nil

--- a/pkg/volume/local/local_linux_test.go
+++ b/pkg/volume/local/local_linux_test.go
@@ -26,9 +26,11 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 func TestFSGroupMount(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	tmpDir, plug := getPlugin(t)
 	defer os.RemoveAll(tmpDir)
 	info, err := os.Stat(tmpDir)
@@ -49,11 +51,11 @@ func TestFSGroupMount(t *testing.T) {
 	pod2.Spec.SecurityContext = &v1.PodSecurityContext{
 		FSGroup: &fsGroup2,
 	}
-	err = testFSGroupMount(plug, pod1, tmpDir, fsGroup1)
+	err = testFSGroupMount(tCtx, plug, pod1, tmpDir, fsGroup1)
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
 	}
-	err = testFSGroupMount(plug, pod2, tmpDir, fsGroup2)
+	err = testFSGroupMount(tCtx, plug, pod2, tmpDir, fsGroup2)
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
 	}

--- a/pkg/volume/local/local_test.go
+++ b/pkg/volume/local/local_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package local
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -33,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 	"k8s.io/kubernetes/pkg/volume/util/hostutil"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/mount-utils"
 	testingexec "k8s.io/utils/exec/testing"
 )
@@ -237,6 +239,7 @@ func TestGetVolumeName(t *testing.T) {
 }
 
 func TestInvalidLocalPath(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	tmpDir, plug := getPlugin(t)
 	defer os.RemoveAll(tmpDir)
 
@@ -246,7 +249,7 @@ func TestInvalidLocalPath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = mounter.SetUp(volume.MounterArgs{})
+	err = mounter.SetUp(tCtx, volume.MounterArgs{})
 	expectedMsg := "invalid path: /no/backsteps/allowed/.. must not contain '..'"
 	if err.Error() != expectedMsg {
 		t.Fatalf("expected error `%s` but got `%s`", expectedMsg, err)
@@ -257,6 +260,8 @@ func TestBlockDeviceGlobalPathAndMountDevice(t *testing.T) {
 	// Block device global mount path testing
 	tmpBlockDir, plug := getDeviceMountablePluginWithBlockPath(t, true)
 	defer os.RemoveAll(tmpBlockDir)
+
+	logger, _ := ktesting.NewTestContext(t)
 
 	dm, err := plug.newDeviceMounterInternal(plug.host.(volume.KubeletVolumeHost), plug.host.GetMounter(), &testingexec.FakeExec{DisableScripts: true})
 	if err != nil {
@@ -276,7 +281,7 @@ func TestBlockDeviceGlobalPathAndMountDevice(t *testing.T) {
 
 	fmt.Println("expected global path is:", expectedGlobalPath)
 
-	err = dm.MountDevice(pvSpec, tmpBlockDir, expectedGlobalPath, volume.DeviceMounterArgs{})
+	err = dm.MountDevice(logger, pvSpec, tmpBlockDir, expectedGlobalPath, volume.DeviceMounterArgs{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -304,6 +309,8 @@ func TestFSGlobalPathAndMountDevice(t *testing.T) {
 	tmpFSDir, plug := getDeviceMountablePluginWithBlockPath(t, false)
 	defer os.RemoveAll(tmpFSDir)
 
+	logger, _ := ktesting.NewTestContext(t)
+
 	dm, err := plug.newDeviceMounterInternal(plug.host.(volume.KubeletVolumeHost), plug.host.GetMounter(), &testingexec.FakeExec{DisableScripts: true})
 	if err != nil {
 		t.Errorf("Failed to make a new device mounter: %v", err)
@@ -321,7 +328,7 @@ func TestFSGlobalPathAndMountDevice(t *testing.T) {
 	}
 
 	// Actually, we will do nothing if the local path is FS type
-	err = dm.MountDevice(pvSpec, tmpFSDir, expectedGlobalPath, volume.DeviceMounterArgs{})
+	err = dm.MountDevice(logger, pvSpec, tmpFSDir, expectedGlobalPath, volume.DeviceMounterArgs{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -357,6 +364,7 @@ func TestNodeExpand(t *testing.T) {
 }
 
 func TestMountUnmount(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	tmpDir, plug := getPlugin(t)
 	defer os.RemoveAll(tmpDir)
 
@@ -375,7 +383,7 @@ func TestMountUnmount(t *testing.T) {
 		t.Errorf("Got unexpected path: %s", path)
 	}
 
-	if err := mounter.SetUp(volume.MounterArgs{}); err != nil {
+	if err := mounter.SetUp(tCtx, volume.MounterArgs{}); err != nil {
 		t.Errorf("Expected success, got: %v", err)
 	}
 
@@ -410,6 +418,7 @@ func TestMountUnmount(t *testing.T) {
 
 // TestMapUnmap tests block map and unmap interfaces.
 func TestMapUnmap(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	tmpDir, plug := getBlockPlugin(t)
 	defer os.RemoveAll(tmpDir)
 
@@ -442,11 +451,11 @@ func TestMapUnmap(t *testing.T) {
 	var devPath string
 
 	if customMapper, ok := mapper.(volume.CustomBlockVolumeMapper); ok {
-		_, err = customMapper.SetUpDevice()
+		_, err = customMapper.SetUpDevice(logger)
 		if err != nil {
 			t.Errorf("Failed to SetUpDevice, err: %v", err)
 		}
-		devPath, err = customMapper.MapPodDevice()
+		devPath, err = customMapper.MapPodDevice(logger)
 		if err != nil {
 			t.Errorf("Failed to MapPodDevice, err: %v", err)
 		}
@@ -479,7 +488,7 @@ func TestMapUnmap(t *testing.T) {
 	}
 }
 
-func testFSGroupMount(plug volume.VolumePlugin, pod *v1.Pod, tmpDir string, fsGroup int64) error {
+func testFSGroupMount(tCtx context.Context, plug volume.VolumePlugin, pod *v1.Pod, tmpDir string, fsGroup int64) error {
 	mounter, err := plug.NewMounter(getTestVolume(false, tmpDir, false, nil), pod)
 	if err != nil {
 		return err
@@ -496,7 +505,7 @@ func testFSGroupMount(plug volume.VolumePlugin, pod *v1.Pod, tmpDir string, fsGr
 
 	var mounterArgs volume.MounterArgs
 	mounterArgs.FsGroup = &fsGroup
-	if err := mounter.SetUp(mounterArgs); err != nil {
+	if err := mounter.SetUp(tCtx, mounterArgs); err != nil {
 		return err
 	}
 	return nil
@@ -637,6 +646,7 @@ func TestConstructBlockVolumeSpec(t *testing.T) {
 }
 
 func TestMountOptions(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	tmpDir, plug := getPlugin(t)
 	defer os.RemoveAll(tmpDir)
 
@@ -653,7 +663,7 @@ func TestMountOptions(t *testing.T) {
 	fakeMounter := mount.NewFakeMounter(nil)
 	mounter.(*localVolumeMounter).mounter = fakeMounter
 
-	if err := mounter.SetUp(volume.MounterArgs{}); err != nil {
+	if err := mounter.SetUp(tCtx, volume.MounterArgs{}); err != nil {
 		t.Errorf("Expected success, got: %v", err)
 	}
 	mountOptions := fakeMounter.MountPoints[0].Opts

--- a/pkg/volume/nfs/nfs.go
+++ b/pkg/volume/nfs/nfs.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nfs
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -93,7 +94,7 @@ func (plugin *nfsPlugin) CanSupport(spec *volume.Spec) bool {
 		(spec.Volume != nil && spec.Volume.NFS != nil)
 }
 
-func (plugin *nfsPlugin) RequiresRemount(spec *volume.Spec) bool {
+func (plugin *nfsPlugin) RequiresRemount(logger klog.Logger, spec *volume.Spec) bool {
 	return false
 }
 
@@ -101,7 +102,7 @@ func (plugin *nfsPlugin) SupportsMountOption() bool {
 	return true
 }
 
-func (plugin *nfsPlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
+func (plugin *nfsPlugin) SupportsSELinuxContextMount(logger klog.Logger, spec *volume.Spec) (bool, error) {
 	return false, nil
 }
 
@@ -219,11 +220,11 @@ func (nfsMounter *nfsMounter) GetAttributes() volume.Attributes {
 }
 
 // SetUp attaches the disk and bind mounts to the volume path.
-func (nfsMounter *nfsMounter) SetUp(mounterArgs volume.MounterArgs) error {
-	return nfsMounter.SetUpAt(nfsMounter.GetPath(), mounterArgs)
+func (nfsMounter *nfsMounter) SetUp(ctx context.Context, mounterArgs volume.MounterArgs) error {
+	return nfsMounter.SetUpAt(ctx, nfsMounter.GetPath(), mounterArgs)
 }
 
-func (nfsMounter *nfsMounter) SetUpAt(dir string, mounterArgs volume.MounterArgs) error {
+func (nfsMounter *nfsMounter) SetUpAt(ctx context.Context, dir string, mounterArgs volume.MounterArgs) error {
 	notMnt, err := mount.IsNotMountPoint(nfsMounter.mounter, dir)
 	klog.V(4).Infof("NFS mount set up: %s %v %v", dir, !notMnt, err)
 	if err != nil && !os.IsNotExist(err) {

--- a/pkg/volume/nfs/nfs_test.go
+++ b/pkg/volume/nfs/nfs_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/mount-utils"
 
 	v1 "k8s.io/api/core/v1"
@@ -103,6 +104,8 @@ func doTestPlugin(t *testing.T, spec *volume.Spec, expectedDevice string) {
 	}
 	defer os.RemoveAll(tmpDir)
 
+	tCtx := ktesting.Init(t)
+
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(volume.VolumeConfig{}), nil /* prober */, volumetest.NewFakeVolumeHost(t, tmpDir, nil, nil))
 	plug, err := plugMgr.FindPluginByName("kubernetes.io/nfs")
@@ -123,7 +126,7 @@ func doTestPlugin(t *testing.T, spec *volume.Spec, expectedDevice string) {
 	if volumePath != expectedPath {
 		t.Errorf("Unexpected path, expected %q, got: %q", expectedPath, volumePath)
 	}
-	if err := mounter.SetUp(volume.MounterArgs{}); err != nil {
+	if err := mounter.SetUp(tCtx, volume.MounterArgs{}); err != nil {
 		t.Errorf("Expected success, got: %v", err)
 	}
 	if _, err := os.Stat(volumePath); err != nil {

--- a/pkg/volume/noop_expandable_plugin.go
+++ b/pkg/volume/noop_expandable_plugin.go
@@ -20,6 +20,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 )
 
 type noopExpandableVolumePluginInstance struct {
@@ -48,7 +49,7 @@ func (n *noopExpandableVolumePluginInstance) CanSupport(spec *Spec) bool {
 	return true
 }
 
-func (n *noopExpandableVolumePluginInstance) RequiresRemount(spec *Spec) bool {
+func (n *noopExpandableVolumePluginInstance) RequiresRemount(logger klog.Logger, spec *Spec) bool {
 	return false
 }
 
@@ -72,6 +73,6 @@ func (n *noopExpandableVolumePluginInstance) RequiresFSResize() bool {
 	return true
 }
 
-func (n *noopExpandableVolumePluginInstance) SupportsSELinuxContextMount(spec *Spec) (bool, error) {
+func (n *noopExpandableVolumePluginInstance) SupportsSELinuxContextMount(logger klog.Logger, spec *Spec) (bool, error) {
 	return false, nil
 }

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -394,10 +394,10 @@ type VolumeHost interface {
 	GetNodeAllocatable() (v1.ResourceList, error)
 
 	// Returns a function that returns a secret.
-	GetSecretFunc() func(namespace, name string) (*v1.Secret, error)
+	GetSecretFunc() func(ctx context.Context, namespace, name string) (*v1.Secret, error)
 
 	// Returns a function that returns a configmap.
-	GetConfigMapFunc() func(namespace, name string) (*v1.ConfigMap, error)
+	GetConfigMapFunc() func(ctx context.Context, namespace, name string) (*v1.ConfigMap, error)
 
 	GetServiceAccountTokenFunc() func(namespace, name string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error)
 

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -153,7 +153,7 @@ type VolumePlugin interface {
 	// RequiresRemount returns true if this plugin requires mount calls to be
 	// reexecuted. Atomically updating volumes, like Downward API, depend on
 	// this to update the contents of the volume.
-	RequiresRemount(spec *Spec) bool
+	RequiresRemount(logger klog.Logger, spec *Spec) bool
 
 	// NewMounter creates a new volume.Mounter from an API specification.
 	// Ownership of the spec pointer in *not* transferred.
@@ -177,7 +177,7 @@ type VolumePlugin interface {
 
 	// SupportsSELinuxContextMount returns true if volume plugins supports
 	// mount -o context=XYZ for a given volume.
-	SupportsSELinuxContextMount(spec *Spec) (bool, error)
+	SupportsSELinuxContextMount(logger klog.Logger, spec *Spec) (bool, error)
 }
 
 // PersistentVolumePlugin is an extended interface of VolumePlugin and is used
@@ -230,8 +230,8 @@ type AttachableVolumePlugin interface {
 	NewAttacher() (Attacher, error)
 	NewDetacher() (Detacher, error)
 	// CanAttach tests if provided volume spec is attachable
-	CanAttach(spec *Spec) (bool, error)
-	VerifyExhaustedResource(spec *Spec) bool
+	CanAttach(logger klog.Logger, spec *Spec) (bool, error)
+	VerifyExhaustedResource(logger klog.Logger, spec *Spec) bool
 }
 
 // DeviceMountableVolumePlugin is an extended interface of VolumePlugin and is used
@@ -311,7 +311,7 @@ type KubeletVolumeHost interface {
 	// CSIDriverSynced returns the informer synced for the CSIDriver API Object
 	CSIDriversSynced() cache.InformerSynced
 	// WaitForCacheSync is a helper function that waits for cache sync for CSIDriverLister
-	WaitForCacheSync() error
+	WaitForCacheSync(logger klog.Logger) error
 	// Returns hostutil.HostUtils
 	GetHostUtil() hostutil.HostUtils
 
@@ -388,7 +388,7 @@ type VolumeHost interface {
 	// the provided spec.  This is used to implement volume plugins which
 	// "wrap" other plugins.  For example, the "secret" volume is
 	// implemented in terms of the "emptyDir" volume.
-	NewWrapperMounter(volName string, spec Spec, pod *v1.Pod) (Mounter, error)
+	NewWrapperMounter(logger klog.Logger, volName string, spec Spec, pod *v1.Pod) (Mounter, error)
 
 	// NewWrapperUnmounter finds an appropriate plugin with which to handle
 	// the provided spec.  See comments on NewWrapperMounter for more
@@ -399,25 +399,25 @@ type VolumeHost interface {
 	GetMounter() mount.Interface
 
 	// Returns node allocatable.
-	GetNodeAllocatable() (v1.ResourceList, error)
+	GetNodeAllocatable(ctx context.Context) (v1.ResourceList, error)
 
 	// Returns a function that returns a secret.
-	GetSecretFunc() func(namespace, name string) (*v1.Secret, error)
+	GetSecretFunc() func(ctx context.Context, namespace, name string) (*v1.Secret, error)
 
 	// Returns a function that returns a configmap.
-	GetConfigMapFunc() func(namespace, name string) (*v1.ConfigMap, error)
+	GetConfigMapFunc() func(ctx context.Context, namespace, name string) (*v1.ConfigMap, error)
 
 	GetServiceAccountTokenFunc() func(namespace, name string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error)
 
 	DeleteServiceAccountTokenFunc() func(podUID types.UID)
 
 	// Returns the labels on the node
-	GetNodeLabels() (map[string]string, error)
+	GetNodeLabels(ctx context.Context) (map[string]string, error)
 
 	// Returns the name of the node
 	GetNodeName() types.NodeName
 
-	GetAttachedVolumesFromNodeStatus() (map[v1.UniqueVolumeName]string, error)
+	GetAttachedVolumesFromNodeStatus(ctx context.Context) (map[v1.UniqueVolumeName]string, error)
 
 	// Returns the event recorder of kubelet.
 	GetEventRecorder() record.EventRecorder
@@ -807,13 +807,13 @@ func (pm *VolumePluginMgr) FindDeletablePluginByName(name string) (DeletableVolu
 // Unlike the other "FindPlugin" methods, this does not return error if no
 // plugin is found.  All volumes require a mounter and unmounter, but not
 // every volume will have an attacher/detacher.
-func (pm *VolumePluginMgr) FindAttachablePluginBySpec(spec *Spec) (AttachableVolumePlugin, error) {
+func (pm *VolumePluginMgr) FindAttachablePluginBySpec(logger klog.Logger, spec *Spec) (AttachableVolumePlugin, error) {
 	volumePlugin, err := pm.FindPluginBySpec(spec)
 	if err != nil {
 		return nil, err
 	}
 	if attachableVolumePlugin, ok := volumePlugin.(AttachableVolumePlugin); ok {
-		if canAttach, err := attachableVolumePlugin.CanAttach(spec); err != nil {
+		if canAttach, err := attachableVolumePlugin.CanAttach(logger, spec); err != nil {
 			return nil, err
 		} else if canAttach {
 			return attachableVolumePlugin, nil

--- a/pkg/volume/plugins_test.go
+++ b/pkg/volume/plugins_test.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -80,7 +81,7 @@ func (plugin *testPlugins) CanSupport(spec *Spec) bool {
 	return true
 }
 
-func (plugin *testPlugins) RequiresRemount(spec *Spec) bool {
+func (plugin *testPlugins) RequiresRemount(logger klog.Logger, spec *Spec) bool {
 	return false
 }
 
@@ -88,7 +89,7 @@ func (plugin *testPlugins) SupportsMountOption() bool {
 	return false
 }
 
-func (plugin *testPlugins) SupportsSELinuxContextMount(spec *Spec) (bool, error) {
+func (plugin *testPlugins) SupportsSELinuxContextMount(logger klog.Logger, spec *Spec) (bool, error) {
 	return false, nil
 }
 

--- a/pkg/volume/projected/projected.go
+++ b/pkg/volume/projected/projected.go
@@ -48,8 +48,8 @@ const (
 type projectedPlugin struct {
 	host                      volume.VolumeHost
 	kvHost                    volume.KubeletVolumeHost
-	getSecret                 func(namespace, name string) (*v1.Secret, error)
-	getConfigMap              func(namespace, name string) (*v1.ConfigMap, error)
+	getSecret                 func(ctx context.Context, namespace, name string) (*v1.Secret, error)
+	getConfigMap              func(ctx context.Context, namespace, name string) (*v1.ConfigMap, error)
 	getServiceAccountToken    func(namespace, name string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error)
 	deleteServiceAccountToken func(podUID types.UID)
 }
@@ -191,7 +191,8 @@ func (s *projectedVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterA
 		return err
 	}
 
-	data, err := s.collectData(mounterArgs)
+	// TODO: pass actual context to collectData once contextual migration is complete
+	data, err := s.collectData(context.TODO(), mounterArgs)
 	if err != nil {
 		klog.Errorf("Error preparing data for projected volume %v for pod %v/%v: %s", s.volName, s.pod.Namespace, s.pod.Name, err.Error())
 		return err
@@ -244,7 +245,7 @@ func (s *projectedVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterA
 	return nil
 }
 
-func (s *projectedVolumeMounter) collectData(mounterArgs volume.MounterArgs) (map[string]volumeutil.FileProjection, error) {
+func (s *projectedVolumeMounter) collectData(ctx context.Context, mounterArgs volume.MounterArgs) (map[string]volumeutil.FileProjection, error) {
 	if s.source.DefaultMode == nil {
 		return nil, fmt.Errorf("no defaultMode used, not even the default value for it")
 	}
@@ -260,7 +261,7 @@ func (s *projectedVolumeMounter) collectData(mounterArgs volume.MounterArgs) (ma
 		switch {
 		case source.Secret != nil:
 			optional := source.Secret.Optional != nil && *source.Secret.Optional
-			secretapi, err := s.plugin.getSecret(s.pod.Namespace, source.Secret.Name)
+			secretapi, err := s.plugin.getSecret(ctx, s.pod.Namespace, source.Secret.Name)
 			if err != nil {
 				if !(errors.IsNotFound(err) && optional) {
 					klog.Errorf("Couldn't get secret %v/%v: %v", s.pod.Namespace, source.Secret.Name, err)
@@ -285,7 +286,7 @@ func (s *projectedVolumeMounter) collectData(mounterArgs volume.MounterArgs) (ma
 			}
 		case source.ConfigMap != nil:
 			optional := source.ConfigMap.Optional != nil && *source.ConfigMap.Optional
-			configMap, err := s.plugin.getConfigMap(s.pod.Namespace, source.ConfigMap.Name)
+			configMap, err := s.plugin.getConfigMap(ctx, s.pod.Namespace, source.ConfigMap.Name)
 			if err != nil {
 				if !(errors.IsNotFound(err) && optional) {
 					klog.Errorf("Couldn't get configMap %v/%v: %v", s.pod.Namespace, source.ConfigMap.Name, err)
@@ -389,7 +390,7 @@ func (s *projectedVolumeMounter) collectData(mounterArgs volume.MounterArgs) (ma
 				FsUser: mounterArgs.FsUser,
 			}
 		case source.PodCertificate != nil:
-			key, certificates, err := s.plugin.kvHost.GetPodCertificateCredentialBundle(context.TODO(), s.pod.ObjectMeta.Namespace, s.pod.ObjectMeta.Name, string(s.pod.ObjectMeta.UID), s.volName, sourceIndex)
+			key, certificates, err := s.plugin.kvHost.GetPodCertificateCredentialBundle(ctx, s.pod.ObjectMeta.Namespace, s.pod.ObjectMeta.Name, string(s.pod.ObjectMeta.UID), s.volName, sourceIndex)
 			if err != nil {
 				errlist = append(errlist, err)
 				continue

--- a/pkg/volume/projected/projected.go
+++ b/pkg/volume/projected/projected.go
@@ -50,8 +50,8 @@ const (
 type projectedPlugin struct {
 	host                      volume.VolumeHost
 	kvHost                    volume.KubeletVolumeHost
-	getSecret                 func(namespace, name string) (*v1.Secret, error)
-	getConfigMap              func(namespace, name string) (*v1.ConfigMap, error)
+	getSecret                 func(ctx context.Context, namespace, name string) (*v1.Secret, error)
+	getConfigMap              func(ctx context.Context, namespace, name string) (*v1.ConfigMap, error)
 	getServiceAccountToken    func(namespace, name string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error)
 	deleteServiceAccountToken func(podUID types.UID)
 }
@@ -99,7 +99,7 @@ func (plugin *projectedPlugin) CanSupport(spec *volume.Spec) bool {
 	return spec.Volume != nil && spec.Volume.Projected != nil
 }
 
-func (plugin *projectedPlugin) RequiresRemount(spec *volume.Spec) bool {
+func (plugin *projectedPlugin) RequiresRemount(logger klog.Logger, spec *volume.Spec) bool {
 	return true
 }
 
@@ -107,7 +107,7 @@ func (plugin *projectedPlugin) SupportsMountOption() bool {
 	return false
 }
 
-func (plugin *projectedPlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
+func (plugin *projectedPlugin) SupportsSELinuxContextMount(logger klog.Logger, spec *volume.Spec) (bool, error) {
 	return false, nil
 }
 
@@ -181,26 +181,27 @@ func (sv *projectedVolume) GetAttributes() volume.Attributes {
 
 }
 
-func (s *projectedVolumeMounter) SetUp(mounterArgs volume.MounterArgs) error {
-	return s.SetUpAt(s.GetPath(), mounterArgs)
+func (s *projectedVolumeMounter) SetUp(ctx context.Context, mounterArgs volume.MounterArgs) error {
+	return s.SetUpAt(ctx, s.GetPath(), mounterArgs)
 }
 
-func (s *projectedVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterArgs) error {
+func (s *projectedVolumeMounter) SetUpAt(ctx context.Context, dir string, mounterArgs volume.MounterArgs) error {
+	logger := klog.FromContext(ctx)
 	klog.V(3).Infof("Setting up volume %v for pod %v at %v", s.volName, s.pod.UID, dir)
 
-	wrapped, err := s.plugin.host.NewWrapperMounter(s.volName, wrappedVolumeSpec(), s.pod)
+	wrapped, err := s.plugin.host.NewWrapperMounter(logger, s.volName, wrappedVolumeSpec(), s.pod)
 	if err != nil {
 		return err
 	}
 
-	data, err := s.collectData(mounterArgs)
+	data, err := s.collectData(ctx, mounterArgs)
 	if err != nil {
 		klog.Errorf("Error preparing data for projected volume %v for pod %v/%v: %s", s.volName, s.pod.Namespace, s.pod.Name, err.Error())
 		return err
 	}
 
 	setupSuccess := false
-	if err := wrapped.SetUpAt(dir, mounterArgs); err != nil {
+	if err := wrapped.SetUpAt(ctx, dir, mounterArgs); err != nil {
 		return err
 	}
 
@@ -246,7 +247,7 @@ func (s *projectedVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterA
 	return nil
 }
 
-func (s *projectedVolumeMounter) collectData(mounterArgs volume.MounterArgs) (map[string]volumeutil.FileProjection, error) {
+func (s *projectedVolumeMounter) collectData(ctx context.Context, mounterArgs volume.MounterArgs) (map[string]volumeutil.FileProjection, error) {
 	if s.source.DefaultMode == nil {
 		return nil, fmt.Errorf("no defaultMode used, not even the default value for it")
 	}
@@ -262,7 +263,7 @@ func (s *projectedVolumeMounter) collectData(mounterArgs volume.MounterArgs) (ma
 		switch {
 		case source.Secret != nil:
 			optional := source.Secret.Optional != nil && *source.Secret.Optional
-			secretapi, err := s.plugin.getSecret(s.pod.Namespace, source.Secret.Name)
+			secretapi, err := s.plugin.getSecret(ctx, s.pod.Namespace, source.Secret.Name)
 			if err != nil {
 				if !(errors.IsNotFound(err) && optional) {
 					klog.Errorf("Couldn't get secret %v/%v: %v", s.pod.Namespace, source.Secret.Name, err)
@@ -287,7 +288,7 @@ func (s *projectedVolumeMounter) collectData(mounterArgs volume.MounterArgs) (ma
 			}
 		case source.ConfigMap != nil:
 			optional := source.ConfigMap.Optional != nil && *source.ConfigMap.Optional
-			configMap, err := s.plugin.getConfigMap(s.pod.Namespace, source.ConfigMap.Name)
+			configMap, err := s.plugin.getConfigMap(ctx, s.pod.Namespace, source.ConfigMap.Name)
 			if err != nil {
 				if !(errors.IsNotFound(err) && optional) {
 					klog.Errorf("Couldn't get configMap %v/%v: %v", s.pod.Namespace, source.ConfigMap.Name, err)
@@ -311,7 +312,7 @@ func (s *projectedVolumeMounter) collectData(mounterArgs volume.MounterArgs) (ma
 				payload[k] = v
 			}
 		case source.DownwardAPI != nil:
-			downwardAPIPayload, err := downwardapi.CollectData(source.DownwardAPI.Items, s.pod, s.plugin.host, s.source.DefaultMode, s.source.DefaultUser)
+			downwardAPIPayload, err := downwardapi.CollectData(ctx, source.DownwardAPI.Items, s.pod, s.plugin.host, s.source.DefaultMode, s.source.DefaultUser)
 			if err != nil {
 				errlist = append(errlist, err)
 				continue
@@ -393,7 +394,7 @@ func (s *projectedVolumeMounter) collectData(mounterArgs volume.MounterArgs) (ma
 				FsUser: fsUser,
 			}
 		case source.PodCertificate != nil:
-			key, certificates, err := s.plugin.kvHost.GetPodCertificateCredentialBundle(context.TODO(), s.pod.ObjectMeta.Namespace, s.pod.ObjectMeta.Name, string(s.pod.ObjectMeta.UID), s.volName, sourceIndex)
+			key, certificates, err := s.plugin.kvHost.GetPodCertificateCredentialBundle(ctx, s.pod.ObjectMeta.Namespace, s.pod.ObjectMeta.Name, string(s.pod.ObjectMeta.UID), s.volName, sourceIndex)
 			if err != nil {
 				errlist = append(errlist, err)
 				continue

--- a/pkg/volume/projected/projected_test.go
+++ b/pkg/volume/projected/projected_test.go
@@ -51,10 +51,12 @@ import (
 	"k8s.io/kubernetes/pkg/volume/emptydir"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 	"k8s.io/kubernetes/pkg/volume/util"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/ptr"
 )
 
 func TestCollectDataWithSecret(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	caseMappingMode := int32(0400)
 	caseMappingUser1 := int64(1001)
 	caseMappingUser2 := int64(1002)
@@ -416,7 +418,7 @@ func TestCollectDataWithSecret(t *testing.T) {
 				pod:    pod,
 			}
 
-			actualPayload, err := myVolumeMounter.collectData(volume.MounterArgs{})
+			actualPayload, err := myVolumeMounter.collectData(tCtx, volume.MounterArgs{})
 			if err != nil && tc.success {
 				t.Errorf("%v: unexpected failure making payload: %v", tc.name, err)
 				return
@@ -436,6 +438,7 @@ func TestCollectDataWithSecret(t *testing.T) {
 }
 
 func TestCollectDataWithConfigMap(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	caseMappingMode := int32(0400)
 	caseMappingUser1 := int64(1001)
 	caseMappingUser2 := int64(1002)
@@ -804,7 +807,7 @@ func TestCollectDataWithConfigMap(t *testing.T) {
 				pod:    pod,
 			}
 
-			actualPayload, err := myVolumeMounter.collectData(volume.MounterArgs{})
+			actualPayload, err := myVolumeMounter.collectData(tCtx, volume.MounterArgs{})
 			if err != nil && tc.success {
 				t.Errorf("%v: unexpected failure making payload: %v", tc.name, err)
 				return
@@ -824,6 +827,7 @@ func TestCollectDataWithConfigMap(t *testing.T) {
 }
 
 func TestCollectDataWithDownwardAPI(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	testNamespace := "test_projected_namespace"
 	testPodUID := types.UID("test_pod_uid")
 	testPodName := "podName"
@@ -1060,7 +1064,7 @@ func TestCollectDataWithDownwardAPI(t *testing.T) {
 				pod:    tc.pod,
 			}
 
-			actualPayload, err := myVolumeMounter.collectData(volume.MounterArgs{})
+			actualPayload, err := myVolumeMounter.collectData(tCtx, volume.MounterArgs{})
 			if err != nil && tc.success {
 				t.Errorf("%v: unexpected failure making payload: %v", tc.name, err)
 				return
@@ -1081,6 +1085,7 @@ func TestCollectDataWithDownwardAPI(t *testing.T) {
 }
 
 func TestCollectDataWithServiceAccountToken(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	scheme := runtime.NewScheme()
 	utilruntime.Must(pkgauthenticationv1.RegisterDefaults(scheme))
 	utilruntime.Must(pkgcorev1.RegisterDefaults(scheme))
@@ -1308,7 +1313,7 @@ func TestCollectDataWithServiceAccountToken(t *testing.T) {
 				pod:    pod,
 			}
 
-			gotPayload, err := myVolumeMounter.collectData(volume.MounterArgs{FsUser: tc.fsUser, FsGroup: tc.fsGroup})
+			gotPayload, err := myVolumeMounter.collectData(tCtx, volume.MounterArgs{FsUser: tc.fsUser, FsGroup: tc.fsGroup})
 			if err != nil && (tc.wantErr == nil || tc.wantErr.Error() != err.Error()) {
 				t.Fatalf("collectData() = unexpected err: %v", err)
 			}
@@ -1323,6 +1328,8 @@ func TestCollectDataWithClusterTrustBundle(t *testing.T) {
 	// This test is limited by the use of a fake clientset and volume host.  We
 	// can't meaningfully test that label selectors end up doing the correct
 	// thing for example.
+
+	tCtx := ktesting.Init(t)
 
 	goodCert1 := mustMakeRoot(t, "root1")
 
@@ -1706,7 +1713,7 @@ func TestCollectDataWithClusterTrustBundle(t *testing.T) {
 				pod:    pod,
 			}
 
-			gotPayload, err := myVolumeMounter.collectData(volume.MounterArgs{FsUser: tc.fsUser, FsGroup: tc.fsGroup})
+			gotPayload, err := myVolumeMounter.collectData(tCtx, volume.MounterArgs{FsUser: tc.fsUser, FsGroup: tc.fsGroup})
 			if err != nil {
 				t.Fatalf("Unexpected failure making payload: %v", err)
 			}
@@ -1718,6 +1725,7 @@ func TestCollectDataWithClusterTrustBundle(t *testing.T) {
 }
 
 func TestCollectDataWithPodCertificate(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	testCases := []struct {
 		name string
 
@@ -2071,7 +2079,7 @@ func TestCollectDataWithPodCertificate(t *testing.T) {
 				pod:    pod,
 			}
 
-			gotPayload, err := myVolumeMounter.collectData(volume.MounterArgs{FsUser: tc.fsUser, FsGroup: tc.fsGroup})
+			gotPayload, err := myVolumeMounter.collectData(tCtx, volume.MounterArgs{FsUser: tc.fsUser, FsGroup: tc.fsGroup})
 			if err != nil {
 				t.Fatalf("Unexpected failure making payload: %v", err)
 			}
@@ -2113,6 +2121,7 @@ func TestCanSupport(t *testing.T) {
 }
 
 func TestPlugin(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	var (
 		testPodUID     = types.UID("test_pod_uid")
 		testVolumeName = "test_volume_name"
@@ -2147,7 +2156,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Got unexpected path: %s", volumePath)
 	}
 
-	err = mounter.SetUp(volume.MounterArgs{})
+	err = mounter.SetUp(tCtx, volume.MounterArgs{})
 	if err != nil {
 		t.Errorf("Failed to setup volume: %v", err)
 	}
@@ -2174,6 +2183,7 @@ func TestPlugin(t *testing.T) {
 }
 
 func TestInvalidPathProjected(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	var (
 		testPodUID     = types.UID("test_pod_uid")
 		testVolumeName = "test_volume_name"
@@ -2213,7 +2223,7 @@ func TestInvalidPathProjected(t *testing.T) {
 	}
 
 	var mounterArgs volume.MounterArgs
-	err = mounter.SetUp(mounterArgs)
+	err = mounter.SetUp(tCtx, mounterArgs)
 	if err == nil {
 		t.Errorf("Expected error while setting up secret")
 	}
@@ -2228,6 +2238,7 @@ func TestInvalidPathProjected(t *testing.T) {
 // mountpoint, which is the state the system will be in after reboot.  The dir
 // should be mounter and the secret data written to it.
 func TestPluginReboot(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	var (
 		testPodUID     = types.UID("test_pod_uid3")
 		testVolumeName = "test_volume_name"
@@ -2264,7 +2275,7 @@ func TestPluginReboot(t *testing.T) {
 		t.Errorf("Got unexpected path: %s", volumePath)
 	}
 
-	err = mounter.SetUp(volume.MounterArgs{})
+	err = mounter.SetUp(tCtx, volume.MounterArgs{})
 	if err != nil {
 		t.Errorf("Failed to setup volume: %v", err)
 	}
@@ -2281,6 +2292,7 @@ func TestPluginReboot(t *testing.T) {
 }
 
 func TestPluginOptional(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	var (
 		testPodUID     = types.UID("test_pod_uid")
 		testVolumeName = "test_volume_name"
@@ -2316,7 +2328,7 @@ func TestPluginOptional(t *testing.T) {
 		t.Errorf("Got unexpected path: %s", volumePath)
 	}
 
-	err = mounter.SetUp(volume.MounterArgs{})
+	err = mounter.SetUp(tCtx, volume.MounterArgs{})
 	if err != nil {
 		t.Errorf("Failed to setup volume: %v", err)
 	}
@@ -2372,6 +2384,7 @@ func TestPluginOptional(t *testing.T) {
 }
 
 func TestPluginOptionalKeys(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	var (
 		testPodUID     = types.UID("test_pod_uid")
 		testVolumeName = "test_volume_name"
@@ -2414,7 +2427,7 @@ func TestPluginOptionalKeys(t *testing.T) {
 		t.Errorf("Got unexpected path: %s", volumePath)
 	}
 
-	err = mounter.SetUp(volume.MounterArgs{})
+	err = mounter.SetUp(tCtx, volume.MounterArgs{})
 	if err != nil {
 		t.Errorf("Failed to setup volume: %v", err)
 	}

--- a/pkg/volume/secret/secret.go
+++ b/pkg/volume/secret/secret.go
@@ -17,6 +17,7 @@ limitations under the License.
 package secret
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -44,7 +45,7 @@ const (
 // secretPlugin implements the VolumePlugin interface.
 type secretPlugin struct {
 	host      volume.VolumeHost
-	getSecret func(namespace, name string) (*v1.Secret, error)
+	getSecret func(ctx context.Context, namespace, name string) (*v1.Secret, error)
 }
 
 var _ volume.VolumePlugin = &secretPlugin{}
@@ -156,7 +157,7 @@ type secretVolumeMounter struct {
 
 	source    v1.SecretVolumeSource
 	pod       v1.Pod
-	getSecret func(namespace, name string) (*v1.Secret, error)
+	getSecret func(ctx context.Context, namespace, name string) (*v1.Secret, error)
 }
 
 var _ volume.Mounter = &secretVolumeMounter{}
@@ -183,7 +184,7 @@ func (b *secretVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterArgs
 	}
 
 	optional := b.source.Optional != nil && *b.source.Optional
-	secret, err := b.getSecret(b.pod.Namespace, b.source.SecretName)
+	secret, err := b.getSecret(context.TODO(), b.pod.Namespace, b.source.SecretName)
 	if err != nil {
 		if !(apierrors.IsNotFound(err) && optional) {
 			klog.Errorf("Couldn't get secret %v/%v: %v", b.pod.Namespace, b.source.SecretName, err)

--- a/pkg/volume/secret/secret.go
+++ b/pkg/volume/secret/secret.go
@@ -17,6 +17,7 @@ limitations under the License.
 package secret
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -46,7 +47,7 @@ const (
 // secretPlugin implements the VolumePlugin interface.
 type secretPlugin struct {
 	host      volume.VolumeHost
-	getSecret func(namespace, name string) (*v1.Secret, error)
+	getSecret func(ctx context.Context, namespace, name string) (*v1.Secret, error)
 }
 
 var _ volume.VolumePlugin = &secretPlugin{}
@@ -84,7 +85,7 @@ func (plugin *secretPlugin) CanSupport(spec *volume.Spec) bool {
 	return spec.Volume != nil && spec.Volume.Secret != nil
 }
 
-func (plugin *secretPlugin) RequiresRemount(spec *volume.Spec) bool {
+func (plugin *secretPlugin) RequiresRemount(logger klog.Logger, spec *volume.Spec) bool {
 	return true
 }
 
@@ -92,7 +93,7 @@ func (plugin *secretPlugin) SupportsMountOption() bool {
 	return false
 }
 
-func (plugin *secretPlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
+func (plugin *secretPlugin) SupportsSELinuxContextMount(logger klog.Logger, spec *volume.Spec) (bool, error) {
 	return false, nil
 }
 
@@ -158,7 +159,7 @@ type secretVolumeMounter struct {
 
 	source    v1.SecretVolumeSource
 	pod       v1.Pod
-	getSecret func(namespace, name string) (*v1.Secret, error)
+	getSecret func(ctx context.Context, namespace, name string) (*v1.Secret, error)
 }
 
 var _ volume.Mounter = &secretVolumeMounter{}
@@ -171,21 +172,23 @@ func (sv *secretVolume) GetAttributes() volume.Attributes {
 	}
 }
 
-func (b *secretVolumeMounter) SetUp(mounterArgs volume.MounterArgs) error {
-	return b.SetUpAt(b.GetPath(), mounterArgs)
+func (b *secretVolumeMounter) SetUp(ctx context.Context, mounterArgs volume.MounterArgs) error {
+	return b.SetUpAt(ctx, b.GetPath(), mounterArgs)
 }
 
-func (b *secretVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterArgs) error {
+func (b *secretVolumeMounter) SetUpAt(ctx context.Context, dir string, mounterArgs volume.MounterArgs) error {
+	logger := klog.FromContext(ctx)
 	klog.V(3).Infof("Setting up volume %v for pod %v at %v", b.volName, b.pod.UID, dir)
 
 	// Wrap EmptyDir, let it do the setup.
-	wrapped, err := b.plugin.host.NewWrapperMounter(b.volName, wrappedVolumeSpec(), &b.pod)
+	wrapped, err := b.plugin.host.NewWrapperMounter(logger, b.volName, wrappedVolumeSpec(), &b.pod)
 	if err != nil {
 		return err
 	}
 
 	optional := b.source.Optional != nil && *b.source.Optional
-	secret, err := b.getSecret(b.pod.Namespace, b.source.SecretName)
+	// TODO: pass actual context to collectData once contextual migration is complete
+	secret, err := b.getSecret(context.TODO(), b.pod.Namespace, b.source.SecretName)
 	if err != nil {
 		if !(apierrors.IsNotFound(err) && optional) {
 			klog.Errorf("Couldn't get secret %v/%v: %v", b.pod.Namespace, b.source.SecretName, err)
@@ -212,7 +215,7 @@ func (b *secretVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterArgs
 	}
 
 	setupSuccess := false
-	if err := wrapped.SetUpAt(dir, mounterArgs); err != nil {
+	if err := wrapped.SetUpAt(ctx, dir, mounterArgs); err != nil {
 		return err
 	}
 	if err := volumeutil.MakeNestedMountpoints(b.volName, dir, b.pod); err != nil {

--- a/pkg/volume/secret/secret_test.go
+++ b/pkg/volume/secret/secret_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/kubernetes/pkg/volume/emptydir"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 	"k8s.io/kubernetes/pkg/volume/util"
+	"k8s.io/kubernetes/test/utils/ktesting"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -428,6 +429,7 @@ func TestCanSupport(t *testing.T) {
 }
 
 func TestPlugin(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	var (
 		testPodUID     = types.UID("test_pod_uid")
 		testVolumeName = "test_volume_name"
@@ -462,7 +464,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Got unexpected path: %s", volumePath)
 	}
 
-	err = mounter.SetUp(volume.MounterArgs{})
+	err = mounter.SetUp(tCtx, volume.MounterArgs{})
 	if err != nil {
 		t.Errorf("Failed to setup volume: %v", err)
 	}
@@ -498,6 +500,7 @@ func TestPlugin(t *testing.T) {
 }
 
 func TestInvalidPathSecret(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	var (
 		testPodUID     = types.UID("test_pod_uid")
 		testVolumeName = "test_volume_name"
@@ -537,7 +540,7 @@ func TestInvalidPathSecret(t *testing.T) {
 	}
 
 	var mounterArgs volume.MounterArgs
-	err = mounter.SetUp(mounterArgs)
+	err = mounter.SetUp(tCtx, mounterArgs)
 	if err == nil {
 		t.Errorf("Expected error while setting up secret")
 	}
@@ -552,6 +555,7 @@ func TestInvalidPathSecret(t *testing.T) {
 // mountpoint, which is the state the system will be in after reboot.  The dir
 // should be mounter and the secret data written to it.
 func TestPluginReboot(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	var (
 		testPodUID     = types.UID("test_pod_uid3")
 		testVolumeName = "test_volume_name"
@@ -588,7 +592,7 @@ func TestPluginReboot(t *testing.T) {
 		t.Errorf("Got unexpected path: %s", volumePath)
 	}
 
-	err = mounter.SetUp(volume.MounterArgs{})
+	err = mounter.SetUp(tCtx, volume.MounterArgs{})
 	if err != nil {
 		t.Errorf("Failed to setup volume: %v", err)
 	}
@@ -605,6 +609,7 @@ func TestPluginReboot(t *testing.T) {
 }
 
 func TestPluginOptional(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	var (
 		testPodUID     = types.UID("test_pod_uid")
 		testVolumeName = "test_volume_name"
@@ -640,7 +645,7 @@ func TestPluginOptional(t *testing.T) {
 		t.Errorf("Got unexpected path: %s", volumePath)
 	}
 
-	err = mounter.SetUp(volume.MounterArgs{})
+	err = mounter.SetUp(tCtx, volume.MounterArgs{})
 	if err != nil {
 		t.Errorf("Failed to setup volume: %v", err)
 	}
@@ -696,6 +701,7 @@ func TestPluginOptional(t *testing.T) {
 }
 
 func TestPluginOptionalKeys(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	var (
 		testPodUID     = types.UID("test_pod_uid")
 		testVolumeName = "test_volume_name"
@@ -738,7 +744,7 @@ func TestPluginOptionalKeys(t *testing.T) {
 		t.Errorf("Got unexpected path: %s", volumePath)
 	}
 
-	err = mounter.SetUp(volume.MounterArgs{})
+	err = mounter.SetUp(tCtx, volume.MounterArgs{})
 	if err != nil {
 		t.Errorf("Failed to setup volume: %v", err)
 	}

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -17,6 +17,7 @@ limitations under the License.
 package testing
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -291,7 +292,7 @@ func (plugin *FakeVolumePlugin) CanSupport(spec *volume.Spec) bool {
 	return true
 }
 
-func (plugin *FakeVolumePlugin) RequiresRemount(spec *volume.Spec) bool {
+func (plugin *FakeVolumePlugin) RequiresRemount(logger klog.Logger, spec *volume.Spec) bool {
 	return plugin.SupportsRemount
 }
 
@@ -299,7 +300,7 @@ func (plugin *FakeVolumePlugin) SupportsMountOption() bool {
 	return true
 }
 
-func (plugin *FakeVolumePlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
+func (plugin *FakeVolumePlugin) SupportsSELinuxContextMount(logger klog.Logger, spec *volume.Spec) (bool, error) {
 	return plugin.SupportsSELinux, nil
 }
 
@@ -444,11 +445,11 @@ func (plugin *FakeVolumePlugin) GetNewDetacherCallCount() int {
 	return plugin.NewDetacherCallCount
 }
 
-func (plugin *FakeVolumePlugin) CanAttach(spec *volume.Spec) (bool, error) {
+func (plugin *FakeVolumePlugin) CanAttach(logger klog.Logger, pec *volume.Spec) (bool, error) {
 	return !plugin.NonAttachable, nil
 }
 
-func (plugin *FakeVolumePlugin) VerifyExhaustedResource(spec *volume.Spec) bool {
+func (plugin *FakeVolumePlugin) VerifyExhaustedResource(_ klog.Logger, _ *volume.Spec) bool {
 	return plugin.VerifyExhaustedEnabled
 }
 
@@ -577,12 +578,12 @@ func (f *FakeBasicVolumePlugin) NewUnmounter(volName string, podUID types.UID) (
 	return f.Plugin.NewUnmounter(volName, podUID)
 }
 
-func (f *FakeBasicVolumePlugin) RequiresRemount(spec *volume.Spec) bool {
-	return f.Plugin.RequiresRemount(spec)
+func (f *FakeBasicVolumePlugin) RequiresRemount(logger klog.Logger, spec *volume.Spec) bool {
+	return f.Plugin.RequiresRemount(logger, spec)
 }
 
-func (f *FakeBasicVolumePlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
-	return f.Plugin.SupportsSELinuxContextMount(spec)
+func (f *FakeBasicVolumePlugin) SupportsSELinuxContextMount(logger klog.Logger, spec *volume.Spec) (bool, error) {
+	return f.Plugin.SupportsSELinuxContextMount(logger, spec)
 }
 
 func (f *FakeBasicVolumePlugin) SupportsMountOption() bool {
@@ -628,11 +629,11 @@ func (f *FakeAttachableVolumePlugin) NewDetacher() (volume.Detacher, error) {
 	return f.Plugin.NewDetacher()
 }
 
-func (f *FakeAttachableVolumePlugin) CanAttach(spec *volume.Spec) (bool, error) {
+func (f *FakeAttachableVolumePlugin) CanAttach(logger klog.Logger, spec *volume.Spec) (bool, error) {
 	return true, nil
 }
 
-func (f *FakeAttachableVolumePlugin) VerifyExhaustedResource(spec *volume.Spec) bool {
+func (f *FakeAttachableVolumePlugin) VerifyExhaustedResource(_ klog.Logger, _ *volume.Spec) bool {
 	return false
 }
 
@@ -658,7 +659,7 @@ func (plugin *FakeFileVolumePlugin) CanSupport(spec *volume.Spec) bool {
 	return true
 }
 
-func (plugin *FakeFileVolumePlugin) RequiresRemount(spec *volume.Spec) bool {
+func (plugin *FakeFileVolumePlugin) RequiresRemount(logger klog.Logger, spec *volume.Spec) bool {
 	return false
 }
 
@@ -666,7 +667,7 @@ func (plugin *FakeFileVolumePlugin) SupportsMountOption() bool {
 	return false
 }
 
-func (plugin *FakeFileVolumePlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
+func (plugin *FakeFileVolumePlugin) SupportsSELinuxContextMount(logger klog.Logger, spec *volume.Spec) (bool, error) {
 	return false, nil
 }
 
@@ -744,10 +745,10 @@ func (_ *FakeVolume) GetAttributes() volume.Attributes {
 	}
 }
 
-func (fv *FakeVolume) SetUp(mounterArgs volume.MounterArgs) error {
+func (fv *FakeVolume) SetUp(ctx context.Context, mounterArgs volume.MounterArgs) error {
 	fv.Lock()
 	defer fv.Unlock()
-	err := fv.setupInternal(mounterArgs)
+	err := fv.setupInternal(ctx, mounterArgs)
 	fv.SetUpCallCount++
 	if fv.SetUpHook != nil {
 		return fv.SetUpHook(fv.Plugin, mounterArgs)
@@ -755,7 +756,7 @@ func (fv *FakeVolume) SetUp(mounterArgs volume.MounterArgs) error {
 	return err
 }
 
-func (fv *FakeVolume) setupInternal(mounterArgs volume.MounterArgs) error {
+func (fv *FakeVolume) setupInternal(ctx context.Context, mounterArgs volume.MounterArgs) error {
 	if fv.VolName == TimeoutOnSetupVolumeName {
 		fv.VolumeMountState[fv.VolName] = volumeMountUncertain
 		return volumetypes.NewUncertainProgressError("time out on setup")
@@ -794,7 +795,7 @@ func (fv *FakeVolume) setupInternal(mounterArgs volume.MounterArgs) error {
 	}
 
 	fv.VolumeMountState[fv.VolName] = volumeNotMounted
-	return fv.SetUpAt(fv.getPath(), mounterArgs)
+	return fv.SetUpAt(ctx, fv.getPath(), mounterArgs)
 }
 
 func (fv *FakeVolume) GetSetUpCallCount() int {
@@ -803,7 +804,7 @@ func (fv *FakeVolume) GetSetUpCallCount() int {
 	return fv.SetUpCallCount
 }
 
-func (fv *FakeVolume) SetUpAt(dir string, mounterArgs volume.MounterArgs) error {
+func (fv *FakeVolume) SetUpAt(ctx context.Context, dir string, mounterArgs volume.MounterArgs) error {
 	return os.MkdirAll(dir, 0750)
 }
 
@@ -835,7 +836,7 @@ func (fv *FakeVolume) TearDownAt(dir string) error {
 }
 
 // Block volume support
-func (fv *FakeVolume) SetUpDevice() (string, error) {
+func (fv *FakeVolume) SetUpDevice(logger klog.Logger) (string, error) {
 	fv.Lock()
 	defer fv.Unlock()
 	if fv.VolName == TimeoutOnMountDeviceVolumeName {
@@ -959,7 +960,7 @@ func (fv *FakeVolume) GetUnmapPodDeviceCallCount() int {
 }
 
 // Block volume support
-func (fv *FakeVolume) MapPodDevice() (string, error) {
+func (fv *FakeVolume) MapPodDevice(logger klog.Logger) (string, error) {
 	fv.Lock()
 	defer fv.Unlock()
 
@@ -1116,7 +1117,7 @@ func (fv *FakeVolume) mountDeviceInternal(spec *volume.Spec, devicePath string, 
 	return nil
 }
 
-func (fv *FakeVolume) MountDevice(spec *volume.Spec, devicePath string, deviceMountPath string, _ volume.DeviceMounterArgs) error {
+func (fv *FakeVolume) MountDevice(logger klog.Logger, spec *volume.Spec, devicePath string, deviceMountPath string, _ volume.DeviceMounterArgs) error {
 	return fv.mountDeviceInternal(spec, devicePath, deviceMountPath)
 }
 
@@ -1155,7 +1156,7 @@ func (fv *FakeVolume) Detach(volumeName string, nodeName types.NodeName) error {
 	return nil
 }
 
-func (fv *FakeVolume) VolumesAreAttached(spec []*volume.Spec, nodeName types.NodeName) (map[*volume.Spec]bool, error) {
+func (fv *FakeVolume) VolumesAreAttached(_ klog.Logger, _ []*volume.Spec, _ types.NodeName) (map[*volume.Spec]bool, error) {
 	fv.Lock()
 	defer fv.Unlock()
 	return nil, nil

--- a/pkg/volume/testing/volume_host.go
+++ b/pkg/volume/testing/volume_host.go
@@ -177,15 +177,15 @@ func (f *fakeVolumeHost) GetNodeAllocatable() (v1.ResourceList, error) {
 	return v1.ResourceList{}, nil
 }
 
-func (f *fakeVolumeHost) GetSecretFunc() func(namespace, name string) (*v1.Secret, error) {
-	return func(namespace, name string) (*v1.Secret, error) {
-		return f.kubeClient.CoreV1().Secrets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+func (f *fakeVolumeHost) GetSecretFunc() func(ctx context.Context, namespace, name string) (*v1.Secret, error) {
+	return func(ctx context.Context, namespace, name string) (*v1.Secret, error) {
+		return f.kubeClient.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
 	}
 }
 
-func (f *fakeVolumeHost) GetConfigMapFunc() func(namespace, name string) (*v1.ConfigMap, error) {
-	return func(namespace, name string) (*v1.ConfigMap, error) {
-		return f.kubeClient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+func (f *fakeVolumeHost) GetConfigMapFunc() func(ctx context.Context, namespace, name string) (*v1.ConfigMap, error) {
+	return func(ctx context.Context, namespace, name string) (*v1.ConfigMap, error) {
+		return f.kubeClient.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
 	}
 }
 

--- a/pkg/volume/testing/volume_host.go
+++ b/pkg/volume/testing/volume_host.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	csilibplugins "k8s.io/csi-translation-lib/plugins"
+	"k8s.io/klog/v2"
 	. "k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/util/hostutil"
 	"k8s.io/kubernetes/pkg/volume/util/subpath"
@@ -143,11 +144,11 @@ func (f *fakeVolumeHost) GetPluginMgr() *VolumePluginMgr {
 	return f.pluginMgr
 }
 
-func (f *fakeVolumeHost) GetAttachedVolumesFromNodeStatus() (map[v1.UniqueVolumeName]string, error) {
+func (f *fakeVolumeHost) GetAttachedVolumesFromNodeStatus(ctx context.Context) (map[v1.UniqueVolumeName]string, error) {
 	return map[v1.UniqueVolumeName]string{}, nil
 }
 
-func (f *fakeVolumeHost) NewWrapperMounter(volName string, spec Spec, pod *v1.Pod) (Mounter, error) {
+func (f *fakeVolumeHost) NewWrapperMounter(logger klog.Logger, volName string, spec Spec, pod *v1.Pod) (Mounter, error) {
 	// The name of wrapper volume is set to "wrapped_{wrapped_volume_name}"
 	wrapperVolumeName := "wrapped_" + volName
 	if spec.Volume != nil {
@@ -173,19 +174,19 @@ func (f *fakeVolumeHost) NewWrapperUnmounter(volName string, spec Spec, podUID t
 	return plug.NewUnmounter(spec.Name(), podUID)
 }
 
-func (f *fakeVolumeHost) GetNodeAllocatable() (v1.ResourceList, error) {
+func (f *fakeVolumeHost) GetNodeAllocatable(ctx context.Context) (v1.ResourceList, error) {
 	return v1.ResourceList{}, nil
 }
 
-func (f *fakeVolumeHost) GetSecretFunc() func(namespace, name string) (*v1.Secret, error) {
-	return func(namespace, name string) (*v1.Secret, error) {
-		return f.kubeClient.CoreV1().Secrets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+func (f *fakeVolumeHost) GetSecretFunc() func(ctx context.Context, namespace, name string) (*v1.Secret, error) {
+	return func(ctx context.Context, namespace, name string) (*v1.Secret, error) {
+		return f.kubeClient.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
 	}
 }
 
-func (f *fakeVolumeHost) GetConfigMapFunc() func(namespace, name string) (*v1.ConfigMap, error) {
-	return func(namespace, name string) (*v1.ConfigMap, error) {
-		return f.kubeClient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+func (f *fakeVolumeHost) GetConfigMapFunc() func(ctx context.Context, namespace, name string) (*v1.ConfigMap, error) {
+	return func(ctx context.Context, namespace, name string) (*v1.ConfigMap, error) {
+		return f.kubeClient.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
 	}
 }
 
@@ -199,7 +200,7 @@ func (f *fakeVolumeHost) DeleteServiceAccountTokenFunc() func(types.UID) {
 	return func(types.UID) {}
 }
 
-func (f *fakeVolumeHost) GetNodeLabels() (map[string]string, error) {
+func (f *fakeVolumeHost) GetNodeLabels(ctx context.Context) (map[string]string, error) {
 	if f.nodeLabels == nil {
 		f.nodeLabels = map[string]string{"test-label": "test-value"}
 	}
@@ -373,7 +374,7 @@ func (f *fakeKubeletVolumeHost) GetInformerFactory() informers.SharedInformerFac
 	return f.informerFactory
 }
 
-func (f *fakeKubeletVolumeHost) GetAttachedVolumesFromNodeStatus() (map[v1.UniqueVolumeName]string, error) {
+func (f *fakeKubeletVolumeHost) GetAttachedVolumesFromNodeStatus(_ context.Context) (map[v1.UniqueVolumeName]string, error) {
 	result := map[v1.UniqueVolumeName]string{}
 	if f.node != nil {
 		for _, av := range f.node.Status.VolumesAttached {
@@ -393,7 +394,7 @@ func (f *fakeKubeletVolumeHost) CSIDriversSynced() cache.InformerSynced {
 	return nil
 }
 
-func (f *fakeKubeletVolumeHost) WaitForCacheSync() error {
+func (f *fakeKubeletVolumeHost) WaitForCacheSync(_ klog.Logger) error {
 	return nil
 }
 

--- a/pkg/volume/util/operationexecutor/fakegenerator.go
+++ b/pkg/volume/util/operationexecutor/fakegenerator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package operationexecutor
 
 import (
+	"context"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -47,7 +48,7 @@ func NewFakeOGCounter(opFunc func() volumetypes.OperationContext) OperationGener
 	}
 }
 
-func (f *fakeOGCounter) GenerateMountVolumeFunc(waitForAttachTimeout time.Duration, volumeToMount VolumeToMount, actualStateOfWorldMounterUpdater ActualStateOfWorldMounterUpdater, isRemount bool) volumetypes.GeneratedOperations {
+func (f *fakeOGCounter) GenerateMountVolumeFunc(ctx context.Context, waitForAttachTimeout time.Duration, volumeToMount VolumeToMount, actualStateOfWorldMounterUpdater ActualStateOfWorldMounterUpdater, isRemount bool) volumetypes.GeneratedOperations {
 	return f.recordFuncCall("GenerateMountVolumeFunc")
 }
 
@@ -63,7 +64,7 @@ func (f *fakeOGCounter) GenerateDetachVolumeFunc(logger klog.Logger, volumeToDet
 	return f.recordFuncCall("GenerateDetachVolumeFunc"), nil
 }
 
-func (f *fakeOGCounter) GenerateVolumesAreAttachedFunc(attachedVolumes []AttachedVolume, nodeName types.NodeName, actualStateOfWorld ActualStateOfWorldAttacherUpdater) (volumetypes.GeneratedOperations, error) {
+func (f *fakeOGCounter) GenerateVolumesAreAttachedFunc(logger klog.Logger, attachedVolumes []AttachedVolume, nodeName types.NodeName, actualStateOfWorld ActualStateOfWorldAttacherUpdater) (volumetypes.GeneratedOperations, error) {
 	return f.recordFuncCall("GenerateVolumesAreAttachedFunc"), nil
 }
 
@@ -71,11 +72,11 @@ func (f *fakeOGCounter) GenerateUnmountDeviceFunc(deviceToDetach AttachedVolume,
 	return f.recordFuncCall("GenerateUnmountDeviceFunc"), nil
 }
 
-func (f *fakeOGCounter) GenerateVerifyControllerAttachedVolumeFunc(logger klog.Logger, volumeToMount VolumeToMount, nodeName types.NodeName, actualStateOfWorld ActualStateOfWorldAttacherUpdater) (volumetypes.GeneratedOperations, error) {
+func (f *fakeOGCounter) GenerateVerifyControllerAttachedVolumeFunc(ctx context.Context, volumeToMount VolumeToMount, nodeName types.NodeName, actualStateOfWorld ActualStateOfWorldAttacherUpdater) (volumetypes.GeneratedOperations, error) {
 	return f.recordFuncCall("GenerateVerifyControllerAttachedVolumeFunc"), nil
 }
 
-func (f *fakeOGCounter) GenerateMapVolumeFunc(waitForAttachTimeout time.Duration, volumeToMount VolumeToMount, actualStateOfWorldMounterUpdater ActualStateOfWorldMounterUpdater) (volumetypes.GeneratedOperations, error) {
+func (f *fakeOGCounter) GenerateMapVolumeFunc(ctx context.Context, waitForAttachTimeout time.Duration, volumeToMount VolumeToMount, actualStateOfWorldMounterUpdater ActualStateOfWorldMounterUpdater) (volumetypes.GeneratedOperations, error) {
 	return f.recordFuncCall("GenerateMapVolumeFunc"), nil
 }
 

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -21,6 +21,7 @@ limitations under the License.
 package operationexecutor
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -70,11 +71,11 @@ type OperationExecutor interface {
 	// Note that this operation could be operated concurrently with other attach/detach operations.
 	// In theory (but very unlikely in practise), race condition among these operations might mark volume as detached
 	// even if it is attached. But reconciler can correct this in a short period of time.
-	VerifyVolumesAreAttachedPerNode(AttachedVolumes []AttachedVolume, nodeName types.NodeName, actualStateOfWorld ActualStateOfWorldAttacherUpdater) error
+	VerifyVolumesAreAttachedPerNode(logger klog.Logger, AttachedVolumes []AttachedVolume, nodeName types.NodeName, actualStateOfWorld ActualStateOfWorldAttacherUpdater) error
 
 	// VerifyVolumesAreAttached verifies volumes being used in entire cluster and if they are still attached to the node
 	// If any volume is not attached right now, it will update actual state of world to reflect that.
-	VerifyVolumesAreAttached(volumesToVerify map[types.NodeName][]AttachedVolume, actualStateOfWorld ActualStateOfWorldAttacherUpdater)
+	VerifyVolumesAreAttached(logger klog.Logger, volumesToVerify map[types.NodeName][]AttachedVolume, actualStateOfWorld ActualStateOfWorldAttacherUpdater)
 
 	// DetachVolume detaches the volume from the node specified in
 	// volumeToDetach, and updates the actual state of the world to reflect
@@ -105,7 +106,7 @@ type OperationExecutor interface {
 	// * Map volume to global map path using symbolic link.
 	// * Map the volume to the pod device map path using symbolic link.
 	// * Update actual state of world to reflect volume is mounted/mapped to the pod path.
-	MountVolume(waitForAttachTimeout time.Duration, volumeToMount VolumeToMount, actualStateOfWorld ActualStateOfWorldMounterUpdater, isRemount bool) error
+	MountVolume(ctx context.Context, waitForAttachTimeout time.Duration, volumeToMount VolumeToMount, actualStateOfWorld ActualStateOfWorldMounterUpdater, isRemount bool) error
 
 	// If a volume has 'Filesystem' volumeMode, UnmountVolume unmounts the
 	// volume from the pod specified in volumeToUnmount and updates the actual
@@ -137,7 +138,7 @@ type OperationExecutor interface {
 	// If the volume is not found or there is an error (fetching the node
 	// object, for example) then an error is returned which triggers exponential
 	// back off on retries.
-	VerifyControllerAttachedVolume(logger klog.Logger, volumeToMount VolumeToMount, nodeName types.NodeName, actualStateOfWorld ActualStateOfWorldAttacherUpdater) error
+	VerifyControllerAttachedVolume(ctx context.Context, volumeToMount VolumeToMount, nodeName types.NodeName, actualStateOfWorld ActualStateOfWorldAttacherUpdater) error
 
 	// IsOperationPending returns true if an operation for the given volumeName
 	// and one of podName or nodeName is pending, otherwise it returns false
@@ -806,11 +807,12 @@ func (oe *operationExecutor) DetachVolume(
 }
 
 func (oe *operationExecutor) VerifyVolumesAreAttached(
+	logger klog.Logger,
 	attachedVolumes map[types.NodeName][]AttachedVolume,
 	actualStateOfWorld ActualStateOfWorldAttacherUpdater) {
 
 	for node, nodeAttachedVolumes := range attachedVolumes {
-		nodeError := oe.VerifyVolumesAreAttachedPerNode(nodeAttachedVolumes, node, actualStateOfWorld)
+		nodeError := oe.VerifyVolumesAreAttachedPerNode(logger, nodeAttachedVolumes, node, actualStateOfWorld)
 		if nodeError != nil {
 			klog.Errorf("VerifyVolumesAreAttached failed for volumes %v, node %q with error %v", nodeAttachedVolumes, node, nodeError)
 		}
@@ -818,11 +820,12 @@ func (oe *operationExecutor) VerifyVolumesAreAttached(
 }
 
 func (oe *operationExecutor) VerifyVolumesAreAttachedPerNode(
+	logger klog.Logger,
 	attachedVolumes []AttachedVolume,
 	nodeName types.NodeName,
 	actualStateOfWorld ActualStateOfWorldAttacherUpdater) error {
 	generatedOperations, err :=
-		oe.operationGenerator.GenerateVolumesAreAttachedFunc(attachedVolumes, nodeName, actualStateOfWorld)
+		oe.operationGenerator.GenerateVolumesAreAttachedFunc(logger, attachedVolumes, nodeName, actualStateOfWorld)
 	if err != nil {
 		return err
 	}
@@ -832,6 +835,7 @@ func (oe *operationExecutor) VerifyVolumesAreAttachedPerNode(
 }
 
 func (oe *operationExecutor) MountVolume(
+	ctx context.Context,
 	waitForAttachTimeout time.Duration,
 	volumeToMount VolumeToMount,
 	actualStateOfWorld ActualStateOfWorldMounterUpdater,
@@ -845,13 +849,13 @@ func (oe *operationExecutor) MountVolume(
 		// Filesystem volume case
 		// Mount/remount a volume when a volume is attached
 		generatedOperations = oe.operationGenerator.GenerateMountVolumeFunc(
-			waitForAttachTimeout, volumeToMount, actualStateOfWorld, isRemount)
+			ctx, waitForAttachTimeout, volumeToMount, actualStateOfWorld, isRemount)
 
 	} else {
 		// Block volume case
 		// Creates a map to device if a volume is attached
 		generatedOperations, err = oe.operationGenerator.GenerateMapVolumeFunc(
-			waitForAttachTimeout, volumeToMount, actualStateOfWorld)
+			ctx, waitForAttachTimeout, volumeToMount, actualStateOfWorld)
 	}
 	if err != nil {
 		return err
@@ -943,12 +947,12 @@ func (oe *operationExecutor) ExpandInUseVolume(volumeToMount VolumeToMount, actu
 }
 
 func (oe *operationExecutor) VerifyControllerAttachedVolume(
-	logger klog.Logger,
+	ctx context.Context,
 	volumeToMount VolumeToMount,
 	nodeName types.NodeName,
 	actualStateOfWorld ActualStateOfWorldAttacherUpdater) error {
 	generatedOperations, err :=
-		oe.operationGenerator.GenerateVerifyControllerAttachedVolumeFunc(logger, volumeToMount, nodeName, actualStateOfWorld)
+		oe.operationGenerator.GenerateVerifyControllerAttachedVolumeFunc(ctx, volumeToMount, nodeName, actualStateOfWorld)
 	if err != nil {
 		return err
 	}

--- a/pkg/volume/util/operationexecutor/operation_executor_test.go
+++ b/pkg/volume/util/operationexecutor/operation_executor_test.go
@@ -17,19 +17,20 @@ limitations under the License.
 package operationexecutor
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"testing"
 	"time"
 
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/test/utils/ktesting"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/util/hostutil"
 	volumetypes "k8s.io/kubernetes/pkg/volume/util/types"
@@ -53,6 +54,7 @@ const (
 var _ OperationGenerator = &fakeOperationGenerator{}
 
 func TestOperationExecutor_MountVolume_ConcurrentMountForNonAttachableAndNonDevicemountablePlugins(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	// Arrange
 	ch, quit, oe := setup()
 	volumesToMount := make([]VolumeToMount, numVolumesToMount)
@@ -70,7 +72,7 @@ func TestOperationExecutor_MountVolume_ConcurrentMountForNonAttachableAndNonDevi
 			PluginIsDeviceMountable: false, // this field determines whether the plugin is devicemountable
 			ReportedInUse:           true,
 		}
-		oe.MountVolume(0 /* waitForAttachTimeOut */, volumesToMount[i], nil /* actualStateOfWorldMounterUpdater */, false /* isRemount */)
+		_ = oe.MountVolume(tCtx, 0 /* waitForAttachTimeOut */, volumesToMount[i], nil /* actualStateOfWorldMounterUpdater */, false /* isRemount */)
 	}
 
 	// Assert
@@ -80,6 +82,7 @@ func TestOperationExecutor_MountVolume_ConcurrentMountForNonAttachableAndNonDevi
 }
 
 func TestOperationExecutor_MountVolume_ConcurrentMountForAttachablePlugins(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	t.Parallel()
 
 	// Arrange
@@ -97,7 +100,7 @@ func TestOperationExecutor_MountVolume_ConcurrentMountForAttachablePlugins(t *te
 			PluginIsAttachable: true, // this field determines whether the plugin is attachable
 			ReportedInUse:      true,
 		}
-		oe.MountVolume(0 /* waitForAttachTimeout */, volumesToMount[i], nil /* actualStateOfWorldMounterUpdater */, false /* isRemount */)
+		_ = oe.MountVolume(tCtx, 0 /* waitForAttachTimeout */, volumesToMount[i], nil /* actualStateOfWorldMounterUpdater */, false /* isRemount */)
 	}
 
 	// Assert
@@ -107,6 +110,7 @@ func TestOperationExecutor_MountVolume_ConcurrentMountForAttachablePlugins(t *te
 }
 
 func TestOperationExecutor_MountVolume_ConcurrentMountForDeviceMountablePlugins(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	t.Parallel()
 
 	// Arrange
@@ -124,7 +128,7 @@ func TestOperationExecutor_MountVolume_ConcurrentMountForDeviceMountablePlugins(
 			PluginIsDeviceMountable: true, // this field determines whether the plugin is devicemountable
 			ReportedInUse:           true,
 		}
-		oe.MountVolume(0 /* waitForAttachTimeout */, volumesToMount[i], nil /* actualStateOfWorldMounterUpdater */, false /* isRemount */)
+		_ = oe.MountVolume(tCtx, 0 /* waitForAttachTimeout */, volumesToMount[i], nil /* actualStateOfWorldMounterUpdater */, false /* isRemount */)
 	}
 
 	// Assert
@@ -404,12 +408,13 @@ func TestOperationExecutor_DetachMultiNodeVolumeConcurrentlyFromDifferentNodes(t
 }
 
 func TestOperationExecutor_VerifyVolumesAreAttachedConcurrentlyOnSameNode(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	// Arrange
 	ch, quit, oe := setup()
 
 	// Act
 	for i := 0; i < numVolumesToVerifyAttached; i++ {
-		oe.VerifyVolumesAreAttachedPerNode(nil /* attachedVolumes */, "node-name", nil /* actualStateOfWorldAttacherUpdater */)
+		_ = oe.VerifyVolumesAreAttachedPerNode(logger, nil /* attachedVolumes */, "node-name", nil /* actualStateOfWorldAttacherUpdater */)
 	}
 
 	// Assert
@@ -419,13 +424,14 @@ func TestOperationExecutor_VerifyVolumesAreAttachedConcurrentlyOnSameNode(t *tes
 }
 
 func TestOperationExecutor_VerifyVolumesAreAttachedConcurrentlyOnDifferentNodes(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	// Arrange
 	ch, quit, oe := setup()
 
 	// Act
 	for i := 0; i < numVolumesToVerifyAttached; i++ {
-		oe.VerifyVolumesAreAttachedPerNode(
-			nil, /* attachedVolumes */
+		_ = oe.VerifyVolumesAreAttachedPerNode(
+			logger, nil, /* attachedVolumes */
 			types.NodeName(fmt.Sprintf("node-name-%d", i)),
 			nil /* actualStateOfWorldAttacherUpdater */)
 	}
@@ -449,8 +455,8 @@ func TestOperationExecutor_VerifyControllerAttachedVolumeConcurrently(t *testing
 		volumesToMount[i] = VolumeToMount{
 			VolumeName: v1.UniqueVolumeName(pdName),
 		}
-		logger, _ := ktesting.NewTestContext(t)
-		oe.VerifyControllerAttachedVolume(logger, volumesToMount[i], types.NodeName("node-name"), nil /* actualStateOfWorldMounterUpdater */)
+		tCtx := ktesting.Init(t)
+		_ = oe.VerifyControllerAttachedVolume(tCtx, volumesToMount[i], types.NodeName("node-name"), nil /* actualStateOfWorldMounterUpdater */)
 	}
 
 	// Assert
@@ -460,6 +466,7 @@ func TestOperationExecutor_VerifyControllerAttachedVolumeConcurrently(t *testing
 }
 
 func TestOperationExecutor_MountVolume_ConcurrentMountForNonAttachablePlugins_VolumeMode_Block(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	// Arrange
 	ch, quit, oe := setup()
 	volumesToMount := make([]VolumeToMount, numVolumesToMap)
@@ -479,7 +486,7 @@ func TestOperationExecutor_MountVolume_ConcurrentMountForNonAttachablePlugins_Vo
 			ReportedInUse:      true,
 			VolumeSpec:         tmpSpec,
 		}
-		oe.MountVolume(0 /* waitForAttachTimeOut */, volumesToMount[i], nil /* actualStateOfWorldMounterUpdater */, false)
+		_ = oe.MountVolume(tCtx, 0 /* waitForAttachTimeOut */, volumesToMount[i], nil /* actualStateOfWorldMounterUpdater */, false)
 	}
 
 	// Assert
@@ -489,6 +496,7 @@ func TestOperationExecutor_MountVolume_ConcurrentMountForNonAttachablePlugins_Vo
 }
 
 func TestOperationExecutor_MountVolume_ConcurrentMountForAttachablePlugins_VolumeMode_Block(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	t.Parallel()
 
 	// Arrange
@@ -510,7 +518,7 @@ func TestOperationExecutor_MountVolume_ConcurrentMountForAttachablePlugins_Volum
 			ReportedInUse:      true,
 			VolumeSpec:         tmpSpec,
 		}
-		oe.MountVolume(0 /* waitForAttachTimeout */, volumesToMount[i], nil /* actualStateOfWorldMounterUpdater */, false)
+		_ = oe.MountVolume(tCtx, 0 /* waitForAttachTimeout */, volumesToMount[i], nil /* actualStateOfWorldMounterUpdater */, false)
 	}
 
 	// Assert
@@ -548,7 +556,7 @@ func TestOperationExecutor_UnmountVolume_ConcurrentUnmountForAllPlugins_VolumeMo
 				VolumeSpec: tmpSpec,
 			}
 		}
-		oe.UnmountVolume(volumesToUnmount[i], nil /* actualStateOfWorldMounterUpdater */, "" /* podsDir */)
+		_ = oe.UnmountVolume(volumesToUnmount[i], nil /* actualStateOfWorldMounterUpdater */, "" /* podsDir */)
 	}
 
 	// Assert
@@ -574,7 +582,7 @@ func TestOperationExecutor_UnmountDeviceConcurrently_VolumeMode_Block(t *testing
 			NodeName:   "node-name",
 			VolumeSpec: tmpSpec,
 		}
-		oe.UnmountDevice(attachedVolumes[i], nil /* actualStateOfWorldMounterUpdater */, nil /* mount.Interface */)
+		_ = oe.UnmountDevice(attachedVolumes[i], nil /* actualStateOfWorldMounterUpdater */, nil /* mount.Interface */)
 	}
 
 	// Assert
@@ -595,7 +603,7 @@ func newFakeOperationGenerator(ch chan interface{}, quit chan interface{}) Opera
 	}
 }
 
-func (fopg *fakeOperationGenerator) GenerateMountVolumeFunc(waitForAttachTimeout time.Duration, volumeToMount VolumeToMount, actualStateOfWorldMounterUpdater ActualStateOfWorldMounterUpdater, isRemount bool) volumetypes.GeneratedOperations {
+func (fopg *fakeOperationGenerator) GenerateMountVolumeFunc(ctx context.Context, waitForAttachTimeout time.Duration, volumeToMount VolumeToMount, actualStateOfWorldMounterUpdater ActualStateOfWorldMounterUpdater, isRemount bool) volumetypes.GeneratedOperations {
 	opFunc := func() volumetypes.OperationContext {
 		startOperationAndBlock(fopg.ch, fopg.quit)
 		return volumetypes.NewOperationContext(nil, nil, false)
@@ -631,7 +639,7 @@ func (fopg *fakeOperationGenerator) GenerateDetachVolumeFunc(logger klog.Logger,
 		OperationFunc: opFunc,
 	}, nil
 }
-func (fopg *fakeOperationGenerator) GenerateVolumesAreAttachedFunc(attachedVolumes []AttachedVolume, nodeName types.NodeName, actualStateOfWorld ActualStateOfWorldAttacherUpdater) (volumetypes.GeneratedOperations, error) {
+func (fopg *fakeOperationGenerator) GenerateVolumesAreAttachedFunc(logger klog.Logger, attachedVolumes []AttachedVolume, nodeName types.NodeName, actualStateOfWorld ActualStateOfWorldAttacherUpdater) (volumetypes.GeneratedOperations, error) {
 	opFunc := func() volumetypes.OperationContext {
 		startOperationAndBlock(fopg.ch, fopg.quit)
 		return volumetypes.NewOperationContext(nil, nil, false)
@@ -649,7 +657,7 @@ func (fopg *fakeOperationGenerator) GenerateUnmountDeviceFunc(deviceToDetach Att
 		OperationFunc: opFunc,
 	}, nil
 }
-func (fopg *fakeOperationGenerator) GenerateVerifyControllerAttachedVolumeFunc(logger klog.Logger, volumeToMount VolumeToMount, nodeName types.NodeName, actualStateOfWorld ActualStateOfWorldAttacherUpdater) (volumetypes.GeneratedOperations, error) {
+func (fopg *fakeOperationGenerator) GenerateVerifyControllerAttachedVolumeFunc(ctx context.Context, volumeToMount VolumeToMount, nodeName types.NodeName, actualStateOfWorld ActualStateOfWorldAttacherUpdater) (volumetypes.GeneratedOperations, error) {
 	opFunc := func() volumetypes.OperationContext {
 		startOperationAndBlock(fopg.ch, fopg.quit)
 		return volumetypes.NewOperationContext(nil, nil, false)
@@ -689,7 +697,7 @@ func (fopg *fakeOperationGenerator) GenerateExpandInUseVolumeFunc(volumeToMount 
 	}, nil
 }
 
-func (fopg *fakeOperationGenerator) GenerateMapVolumeFunc(waitForAttachTimeout time.Duration, volumeToMount VolumeToMount, actualStateOfWorldMounterUpdater ActualStateOfWorldMounterUpdater) (volumetypes.GeneratedOperations, error) {
+func (fopg *fakeOperationGenerator) GenerateMapVolumeFunc(ctx context.Context, waitForAttachTimeout time.Duration, volumeToMount VolumeToMount, actualStateOfWorldMounterUpdater ActualStateOfWorldMounterUpdater) (volumetypes.GeneratedOperations, error) {
 	opFunc := func() volumetypes.OperationContext {
 		startOperationAndBlock(fopg.ch, fopg.quit)
 		return volumetypes.NewOperationContext(nil, nil, false)

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -101,7 +101,7 @@ func NewOperationGenerator(kubeClient clientset.Interface,
 // OperationGenerator interface that extracts out the functions from operation_executor to make it dependency injectable
 type OperationGenerator interface {
 	// Generates the MountVolume function needed to perform the mount of a volume plugin
-	GenerateMountVolumeFunc(waitForAttachTimeout time.Duration, volumeToMount VolumeToMount, actualStateOfWorldMounterUpdater ActualStateOfWorldMounterUpdater, isRemount bool) volumetypes.GeneratedOperations
+	GenerateMountVolumeFunc(ctx context.Context, waitForAttachTimeout time.Duration, volumeToMount VolumeToMount, actualStateOfWorldMounterUpdater ActualStateOfWorldMounterUpdater, isRemount bool) volumetypes.GeneratedOperations
 
 	// Generates the UnmountVolume function needed to perform the unmount of a volume plugin
 	GenerateUnmountVolumeFunc(volumeToUnmount MountedVolume, actualStateOfWorld ActualStateOfWorldMounterUpdater, podsDir string) (volumetypes.GeneratedOperations, error)
@@ -113,16 +113,16 @@ type OperationGenerator interface {
 	GenerateDetachVolumeFunc(logger klog.Logger, volumeToDetach AttachedVolume, verifySafeToDetach bool, actualStateOfWorld ActualStateOfWorldAttacherUpdater) (volumetypes.GeneratedOperations, error)
 
 	// Generates the VolumesAreAttached function needed to verify if volume plugins are attached
-	GenerateVolumesAreAttachedFunc(attachedVolumes []AttachedVolume, nodeName types.NodeName, actualStateOfWorld ActualStateOfWorldAttacherUpdater) (volumetypes.GeneratedOperations, error)
+	GenerateVolumesAreAttachedFunc(logger klog.Logger, attachedVolumes []AttachedVolume, nodeName types.NodeName, actualStateOfWorld ActualStateOfWorldAttacherUpdater) (volumetypes.GeneratedOperations, error)
 
 	// Generates the UnMountDevice function needed to perform the unmount of a device
 	GenerateUnmountDeviceFunc(deviceToDetach AttachedVolume, actualStateOfWorld ActualStateOfWorldMounterUpdater, mounter hostutil.HostUtils) (volumetypes.GeneratedOperations, error)
 
 	// Generates the function needed to check if the attach_detach controller has attached the volume plugin
-	GenerateVerifyControllerAttachedVolumeFunc(logger klog.Logger, volumeToMount VolumeToMount, nodeName types.NodeName, actualStateOfWorld ActualStateOfWorldAttacherUpdater) (volumetypes.GeneratedOperations, error)
+	GenerateVerifyControllerAttachedVolumeFunc(ctx context.Context, volumeToMount VolumeToMount, nodeName types.NodeName, actualStateOfWorld ActualStateOfWorldAttacherUpdater) (volumetypes.GeneratedOperations, error)
 
 	// Generates the MapVolume function needed to perform the map of a volume plugin
-	GenerateMapVolumeFunc(waitForAttachTimeout time.Duration, volumeToMount VolumeToMount, actualStateOfWorldMounterUpdater ActualStateOfWorldMounterUpdater) (volumetypes.GeneratedOperations, error)
+	GenerateMapVolumeFunc(ctx context.Context, waitForAttachTimeout time.Duration, volumeToMount VolumeToMount, actualStateOfWorldMounterUpdater ActualStateOfWorldMounterUpdater) (volumetypes.GeneratedOperations, error)
 
 	// Generates the UnmapVolume function needed to perform the unmap of a volume plugin
 	GenerateUnmapVolumeFunc(volumeToUnmount MountedVolume, actualStateOfWorld ActualStateOfWorldMounterUpdater) (volumetypes.GeneratedOperations, error)
@@ -161,6 +161,7 @@ type nodeResizeOperationOpts struct {
 }
 
 func (og *operationGenerator) GenerateVolumesAreAttachedFunc(
+	logger klog.Logger,
 	attachedVolumes []AttachedVolume,
 	nodeName types.NodeName,
 	actualStateOfWorld ActualStateOfWorldAttacherUpdater) (volumetypes.GeneratedOperations, error) {
@@ -217,7 +218,7 @@ func (og *operationGenerator) GenerateVolumesAreAttachedFunc(
 				continue
 			}
 
-			attached, areAttachedErr := volumeAttacher.VolumesAreAttached(volumesSpecs, nodeName)
+			attached, areAttachedErr := volumeAttacher.VolumesAreAttached(logger, volumesSpecs, nodeName)
 			if areAttachedErr != nil {
 				klog.Errorf(
 					"VolumesAreAttached failed for checking on node %q with: %v",
@@ -254,7 +255,7 @@ func (og *operationGenerator) GenerateAttachVolumeFunc(
 
 	attachVolumeFunc := func() volumetypes.OperationContext {
 		attachableVolumePlugin, err :=
-			og.volumePluginMgr.FindAttachablePluginBySpec(volumeToAttach.VolumeSpec)
+			og.volumePluginMgr.FindAttachablePluginBySpec(logger, volumeToAttach.VolumeSpec)
 
 		migrated := getMigratedStatusBySpec(volumeToAttach.VolumeSpec)
 
@@ -323,7 +324,7 @@ func (og *operationGenerator) GenerateAttachVolumeFunc(
 
 	// Get attacher plugin
 	attachableVolumePlugin, err :=
-		og.volumePluginMgr.FindAttachablePluginBySpec(volumeToAttach.VolumeSpec)
+		og.volumePluginMgr.FindAttachablePluginBySpec(logger, volumeToAttach.VolumeSpec)
 	// It's ok to ignore the error, returning error is not expected from this function.
 	// If an error case occurred during the function generation, this error case(skipped one) will also trigger an error
 	// while the generated function is executed. And those errors will be handled during the execution of the generated
@@ -355,7 +356,7 @@ func (og *operationGenerator) GenerateDetachVolumeFunc(
 	var err error
 
 	if volumeToDetach.VolumeSpec != nil {
-		attachableVolumePlugin, err = util.FindDetachablePluginBySpec(volumeToDetach.VolumeSpec, og.volumePluginMgr)
+		attachableVolumePlugin, err = util.FindDetachablePluginBySpec(logger, volumeToDetach.VolumeSpec, og.volumePluginMgr)
 		if err != nil || attachableVolumePlugin == nil {
 			return volumetypes.GeneratedOperations{}, volumeToDetach.GenerateErrorDetailed("DetachVolume.findDetachablePluginBySpec failed", err)
 		}
@@ -431,11 +432,13 @@ func (og *operationGenerator) GenerateDetachVolumeFunc(
 }
 
 func (og *operationGenerator) GenerateMountVolumeFunc(
+	ctx context.Context,
 	waitForAttachTimeout time.Duration,
 	volumeToMount VolumeToMount,
 	actualStateOfWorld ActualStateOfWorldMounterUpdater,
 	isRemount bool) volumetypes.GeneratedOperations {
 
+	logger := klog.FromContext(ctx)
 	volumePluginName := unknownVolumePlugin
 	volumePlugin, err :=
 		og.volumePluginMgr.FindPluginBySpec(volumeToMount.VolumeSpec)
@@ -454,7 +457,7 @@ func (og *operationGenerator) GenerateMountVolumeFunc(
 			return volumetypes.NewOperationContext(eventErr, detailedErr, migrated)
 		}
 
-		affinityErr := checkNodeAffinity(og, volumeToMount)
+		affinityErr := checkNodeAffinity(ctx, og, volumeToMount)
 		if affinityErr != nil {
 			eventErr, detailedErr := volumeToMount.GenerateError("MountVolume.NodeAffinity check failed", affinityErr)
 			return volumetypes.NewOperationContext(eventErr, detailedErr, migrated)
@@ -487,7 +490,7 @@ func (og *operationGenerator) GenerateMountVolumeFunc(
 
 		// Get attacher, if possible
 		attachableVolumePlugin, _ :=
-			og.volumePluginMgr.FindAttachablePluginBySpec(volumeToMount.VolumeSpec)
+			og.volumePluginMgr.FindAttachablePluginBySpec(logger, volumeToMount.VolumeSpec)
 		var volumeAttacher volume.Attacher
 		if attachableVolumePlugin != nil {
 			volumeAttacher, _ = attachableVolumePlugin.NewAttacher()
@@ -544,6 +547,7 @@ func (og *operationGenerator) GenerateMountVolumeFunc(
 			// Mount device to global mount path
 			og.markVolumeMountAsAttempted(actualStateOfWorld, volumeToMount.PodName, volumeToMount.VolumeName)
 			err = volumeDeviceMounter.MountDevice(
+				logger,
 				volumeToMount.VolumeSpec,
 				devicePath,
 				deviceMountPath,
@@ -583,7 +587,7 @@ func (og *operationGenerator) GenerateMountVolumeFunc(
 
 		// Execute mount
 		og.markVolumeMountAsAttempted(actualStateOfWorld, volumeToMount.PodName, volumeToMount.VolumeName)
-		mountErr := volumeMounter.SetUp(volume.MounterArgs{
+		mountErr := volumeMounter.SetUp(ctx, volume.MounterArgs{
 			FsUser:              util.FsUserFrom(volumeToMount.Pod),
 			FsGroup:             fsGroup,
 			DesiredSize:         volumeToMount.DesiredSizeLimit,
@@ -933,9 +937,12 @@ func (og *operationGenerator) GenerateUnmountDeviceFunc(
 // will be released once no one uses the device.
 // If all steps are completed, the volume is marked as mounted.
 func (og *operationGenerator) GenerateMapVolumeFunc(
+	ctx context.Context,
 	waitForAttachTimeout time.Duration,
 	volumeToMount VolumeToMount,
 	actualStateOfWorld ActualStateOfWorldMounterUpdater) (volumetypes.GeneratedOperations, error) {
+
+	logger := klog.FromContext(ctx)
 
 	// Get block volume mapper plugin
 	blockVolumePlugin, err :=
@@ -948,7 +955,7 @@ func (og *operationGenerator) GenerateMapVolumeFunc(
 		return volumetypes.GeneratedOperations{}, volumeToMount.GenerateErrorDetailed("MapVolume.FindMapperPluginBySpec failed to find BlockVolumeMapper plugin. Volume plugin is nil.", nil)
 	}
 
-	affinityErr := checkNodeAffinity(og, volumeToMount)
+	affinityErr := checkNodeAffinity(ctx, og, volumeToMount)
 	if affinityErr != nil {
 		eventErr, detailedErr := volumeToMount.GenerateError("MapVolume.NodeAffinity check failed", affinityErr)
 		og.recorder.Eventf(volumeToMount.Pod, v1.EventTypeWarning, kevents.FailedMountVolume, "%s", eventErr.Error())
@@ -965,7 +972,7 @@ func (og *operationGenerator) GenerateMapVolumeFunc(
 
 	// Get attacher, if possible
 	attachableVolumePlugin, _ :=
-		og.volumePluginMgr.FindAttachablePluginBySpec(volumeToMount.VolumeSpec)
+		og.volumePluginMgr.FindAttachablePluginBySpec(logger, volumeToMount.VolumeSpec)
 	var volumeAttacher volume.Attacher
 	if attachableVolumePlugin != nil {
 		volumeAttacher, _ = attachableVolumePlugin.NewAttacher()
@@ -1015,7 +1022,7 @@ func (og *operationGenerator) GenerateMapVolumeFunc(
 		if customBlockVolumeMapper, ok := blockVolumeMapper.(volume.CustomBlockVolumeMapper); ok && actualStateOfWorld.GetDeviceMountState(volumeToMount.VolumeName) != DeviceGloballyMounted {
 			var mapErr error
 			og.markVolumeMountAsAttempted(actualStateOfWorld, volumeToMount.PodName, volumeToMount.VolumeName)
-			stagingPath, mapErr = customBlockVolumeMapper.SetUpDevice()
+			stagingPath, mapErr = customBlockVolumeMapper.SetUpDevice(logger)
 			if mapErr != nil {
 				og.markDeviceErrorState(volumeToMount, devicePath, globalMapPath, mapErr, actualStateOfWorld)
 				// On failure, return error. Caller will log and retry.
@@ -1047,7 +1054,7 @@ func (og *operationGenerator) GenerateMapVolumeFunc(
 		// Call MapPodDevice if blockVolumeMapper implements CustomBlockVolumeMapper
 		if customBlockVolumeMapper, ok := blockVolumeMapper.(volume.CustomBlockVolumeMapper); ok {
 			// Execute driver specific map
-			pluginDevicePath, mapErr := customBlockVolumeMapper.MapPodDevice()
+			pluginDevicePath, mapErr := customBlockVolumeMapper.MapPodDevice(logger)
 			if mapErr != nil {
 				// On failure, return error. Caller will log and retry.
 				og.markVolumeErrorState(volumeToMount, markVolumeOpts, mapErr, actualStateOfWorld)
@@ -1392,10 +1399,12 @@ func (og *operationGenerator) GenerateUnmapDeviceFunc(
 }
 
 func (og *operationGenerator) GenerateVerifyControllerAttachedVolumeFunc(
-	logger klog.Logger,
+	ctx context.Context,
 	volumeToMount VolumeToMount,
 	nodeName types.NodeName,
 	actualStateOfWorld ActualStateOfWorldAttacherUpdater) (volumetypes.GeneratedOperations, error) {
+	logger := klog.FromContext(ctx)
+
 	volumePlugin, err :=
 		og.volumePluginMgr.FindPluginBySpec(volumeToMount.VolumeSpec)
 	if err != nil || volumePlugin == nil {
@@ -1407,7 +1416,7 @@ func (og *operationGenerator) GenerateVerifyControllerAttachedVolumeFunc(
 	// verify status of attached volume by directly reading from API server later on.This is necessarily
 	// to ensure any race conditions because of cached state in the informer.
 	if volumeToMount.PluginIsAttachable {
-		cachedAttachedVolumes, _ := og.volumePluginMgr.Host.GetAttachedVolumesFromNodeStatus()
+		cachedAttachedVolumes, _ := og.volumePluginMgr.Host.GetAttachedVolumesFromNodeStatus(ctx)
 		if cachedAttachedVolumes != nil {
 			_, volumeFound := cachedAttachedVolumes[volumeToMount.VolumeName]
 			if !volumeFound {
@@ -2170,10 +2179,10 @@ func checkMountOptionSupport(og *operationGenerator, volumeToMount VolumeToMount
 
 // checkNodeAffinity looks at the PV node affinity, and checks if the node has the same corresponding labels
 // This ensures that we don't mount a volume that doesn't belong to this node
-func checkNodeAffinity(og *operationGenerator, volumeToMount VolumeToMount) error {
+func checkNodeAffinity(ctx context.Context, og *operationGenerator, volumeToMount VolumeToMount) error {
 	pv := volumeToMount.VolumeSpec.PersistentVolume
 	if pv != nil {
-		nodeLabels, err := og.volumePluginMgr.Host.GetNodeLabels()
+		nodeLabels, err := og.volumePluginMgr.Host.GetNodeLabels(ctx)
 		if err != nil {
 			return err
 		}

--- a/pkg/volume/util/operationexecutor/operation_generator_test.go
+++ b/pkg/volume/util/operationexecutor/operation_generator_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/test/utils/ktesting"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
@@ -515,6 +516,8 @@ func TestCheckForRecoveryFromExpansion(t *testing.T) {
 func TestGenerateMountVolumeFunc_AttemptTrackingRespectsFeatureGate(t *testing.T) {
 	featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.33"))
 
+	tCtx := ktesting.Init(t)
+
 	tests := []struct {
 		name                  string
 		featureGateEnabled    bool
@@ -550,7 +553,7 @@ func TestGenerateMountVolumeFunc_AttemptTrackingRespectsFeatureGate(t *testing.T
 				Pod:        pod,
 			}
 
-			ops := og.GenerateMountVolumeFunc(time.Second, volumeToMount, asow, false)
+			ops := og.GenerateMountVolumeFunc(tCtx, time.Second, volumeToMount, asow, false)
 			eventErr, detailedErr := ops.Run()
 			if eventErr != nil || detailedErr != nil {
 				t.Fatalf("GenerateMountVolumeFunc returned unexpected errors: event=%v detailed=%v", eventErr, detailedErr)
@@ -565,6 +568,8 @@ func TestGenerateMountVolumeFunc_AttemptTrackingRespectsFeatureGate(t *testing.T
 
 func TestGenerateMapVolumeFunc_AttemptTrackingRespectsFeatureGate(t *testing.T) {
 	featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.33"))
+
+	tCtx := ktesting.Init(t)
 
 	tests := []struct {
 		name                  string
@@ -606,7 +611,7 @@ func TestGenerateMapVolumeFunc_AttemptTrackingRespectsFeatureGate(t *testing.T) 
 				Pod:        pod,
 			}
 
-			ops, err := og.GenerateMapVolumeFunc(time.Second, volumeToMount, asow)
+			ops, err := og.GenerateMapVolumeFunc(tCtx, time.Second, volumeToMount, asow)
 			if err != nil {
 				t.Fatalf("GenerateMapVolumeFunc returned unexpected error: %v", err)
 			}

--- a/pkg/volume/util/selinux.go
+++ b/pkg/volume/util/selinux.go
@@ -26,6 +26,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/klog/v2"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/volume"
@@ -176,7 +177,9 @@ func IsSELinuxLabelTranslationError(err error) bool {
 func SupportsSELinuxContextMount(volumeSpec *volume.Spec, volumePluginMgr *volume.VolumePluginMgr) (bool, error) {
 	plugin, _ := volumePluginMgr.FindPluginBySpec(volumeSpec)
 	if plugin != nil {
-		return plugin.SupportsSELinuxContextMount(volumeSpec)
+		// Use klog.TODO() because we currently do not have a proper logger to pass in.
+		// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
+		return plugin.SupportsSELinuxContextMount(klog.TODO(), volumeSpec)
 	}
 
 	return false, nil

--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -630,7 +630,9 @@ func IsMultiAttachAllowed(volumeSpec *volume.Spec) bool {
 
 // IsAttachableVolume checks if the given volumeSpec is an attachable volume or not
 func IsAttachableVolume(volumeSpec *volume.Spec, volumePluginMgr *volume.VolumePluginMgr) bool {
-	attachableVolumePlugin, _ := volumePluginMgr.FindAttachablePluginBySpec(volumeSpec)
+	// Use klog.TODO() because we currently do not have a proper logger to pass in.
+	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
+	attachableVolumePlugin, _ := volumePluginMgr.FindAttachablePluginBySpec(klog.TODO(), volumeSpec)
 	if attachableVolumePlugin != nil {
 		volumeAttacher, err := attachableVolumePlugin.NewAttacher()
 		if err == nil && volumeAttacher != nil {
@@ -706,7 +708,7 @@ func VolumeHealthConditionSetsEqual(a, b []v1.VolumeHealthCondition) bool {
 // The difference is that it bypass the CanAttach() check for CSI plugin, i.e. it assumes all CSI plugin supports detach.
 // The intention here is that a CSI plugin volume can end up in an Uncertain state,  so that a detach
 // operation will help it to detach no matter it actually has the ability to attach/detach.
-func FindDetachablePluginBySpec(spec *volume.Spec, pm *volume.VolumePluginMgr) (volume.AttachableVolumePlugin, error) {
+func FindDetachablePluginBySpec(logger klog.Logger, spec *volume.Spec, pm *volume.VolumePluginMgr) (volume.AttachableVolumePlugin, error) {
 	volumePlugin, err := pm.FindPluginBySpec(spec)
 	if err != nil {
 		return nil, err
@@ -715,7 +717,7 @@ func FindDetachablePluginBySpec(spec *volume.Spec, pm *volume.VolumePluginMgr) (
 		if attachableVolumePlugin.GetPluginName() == "kubernetes.io/csi" {
 			return attachableVolumePlugin, nil
 		}
-		if canAttach, err := attachableVolumePlugin.CanAttach(spec); err != nil {
+		if canAttach, err := attachableVolumePlugin.CanAttach(logger, spec); err != nil {
 			return nil, err
 		} else if canAttach {
 			return attachableVolumePlugin, nil

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -17,6 +17,7 @@ limitations under the License.
 package volume
 
 import (
+	"context"
 	"sync/atomic"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
 	volumetypes "k8s.io/kubernetes/pkg/volume/util/types"
 )
 
@@ -172,7 +174,7 @@ type Mounter interface {
 	//   - TransientOperationFailure
 	//   - UncertainProgressError
 	//   - Error of any other type should be considered a final error
-	SetUp(mounterArgs MounterArgs) error
+	SetUp(ctx context.Context, mounterArgs MounterArgs) error
 
 	// SetUpAt prepares and mounts/unpacks the volume to the
 	// specified directory path, which may or may not exist yet.
@@ -180,7 +182,7 @@ type Mounter interface {
 	// 'fsGroup' so that it can be accessed by the pod. This may
 	// be called more than once, so implementations must be
 	// idempotent.
-	SetUpAt(dir string, mounterArgs MounterArgs) error
+	SetUpAt(ctx context.Context, dir string, mounterArgs MounterArgs) error
 	// GetAttributes returns the attributes of the mounter.
 	// This function is called after SetUp()/SetUpAt().
 	GetAttributes() Attributes
@@ -210,14 +212,14 @@ type CustomBlockVolumeMapper interface {
 	// will do necessary works.
 	// This may be called more than once, so implementations must be idempotent.
 	// SetUpDevice returns stagingPath if device setup was successful
-	SetUpDevice() (stagingPath string, err error)
+	SetUpDevice(logger klog.Logger) (stagingPath string, err error)
 
 	// MapPodDevice maps the block device to a path and return the path.
 	// Unique device path across kubelet node reboot is required to avoid
 	// unexpected block volume destruction.
 	// If empty string is returned, the path returned by attacher.Attach() and
 	// attacher.WaitForAttach() will be used.
-	MapPodDevice() (publishPath string, err error)
+	MapPodDevice(logger klog.Logger) (publishPath string, err error)
 
 	// GetStagingPath returns path that was used for staging the volume
 	// it is mainly used by CSI plugins
@@ -278,7 +280,7 @@ type Attacher interface {
 	// VolumesAreAttached checks whether the list of volumes still attached to the specified
 	// node. It returns a map which maps from the volume spec to the checking result.
 	// If an error is occurred during checking, the error will be returned
-	VolumesAreAttached(specs []*Spec, nodeName types.NodeName) (map[*Spec]bool, error)
+	VolumesAreAttached(logger klog.Logger, specs []*Spec, nodeName types.NodeName) (map[*Spec]bool, error)
 
 	// WaitForAttach blocks until the device is attached to this
 	// node. If it successfully attaches, the path to the device
@@ -307,7 +309,7 @@ type DeviceMounter interface {
 	//   - TransientOperationFailure
 	//   - UncertainProgressError
 	//   - Error of any other type should be considered a final error
-	MountDevice(spec *Spec, devicePath string, deviceMountPath string, deviceMounterArgs DeviceMounterArgs) error
+	MountDevice(logger klog.Logger, spec *Spec, devicePath string, deviceMountPath string, deviceMounterArgs DeviceMounterArgs) error
 }
 
 // Detacher can detach a volume from a node.

--- a/pkg/volume/volume_linux_test.go
+++ b/pkg/volume/volume_linux_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package volume
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -45,11 +46,11 @@ func (l *localFakeMounter) GetAttributes() Attributes {
 	return l.attributes
 }
 
-func (l *localFakeMounter) SetUp(mounterArgs MounterArgs) error {
+func (l *localFakeMounter) SetUp(ctx context.Context, mounterArgs MounterArgs) error {
 	return nil
 }
 
-func (l *localFakeMounter) SetUpAt(dir string, mounterArgs MounterArgs) error {
+func (l *localFakeMounter) SetUpAt(ctx context.Context, dir string, mounterArgs MounterArgs) error {
 	return nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR is the second part of replacing the appropriate context with the `context.TODO()` or `context.Background()` or `klog.TODO()` in the `./pkg/kubelet/`. 
I break it down into multiple parts to keep PRs small and readable.
The command to show the list of places needs to be replaced:
```
git grep -n 'context.TODO\|context.Background\|klog.TODO' ./pkg/kubelet/ \
    | cut -d: -f1 \
    | sed -E 's#^(./pkg/kubelet/[^/]+).*#\1#' \
    | sort \
    | uniq -c \
    | sort -nr
```

#### Which issue(s) this PR is related to:

Part of https://github.com/kubernetes/kubernetes/issues/130069

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

```release-note
NONE
```