### PR TITLE
fix: increase local cache size and double check if not found in cache

### DIFF
--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -88,6 +88,9 @@ const (
 	// podGroupMembersIndex is used to find Pods in a given PodGroup.
 	podGroupMembersIndex = "podGroupMembers"
 
+	// claimMutationCacheSize is the size of the LRU in the claim mutation cache.
+	claimMutationCacheSize = 1000
+
 	// Field manager used to update the pod status.
 	fieldManager = "ResourceClaimController"
 
@@ -347,15 +350,21 @@ func newControllerWithFeatures(
 	if err := claimInformerCache.AddIndexers(cache.Indexers{claimPodOwnerIndex: claimPodOwnerIndexFunc}); err != nil {
 		return nil, fmt.Errorf("could not initialize ResourceClaim controller: %w", err)
 	}
-	ec.claimCache = cache.NewIntegerResourceVersionMutationCache(logger, claimInformerCache, claimInformerCache,
+	ec.claimCache = cache.NewIntegerResourceVersionMutationCacheWithOptions(logger, claimInformerCache, cache.MutationCacheOptions{
+		Indexer: claimInformerCache,
 		// Very long time to live, unlikely to be needed because
 		// the informer cache should get updated soon.
-		time.Hour,
+		TTL: time.Hour,
 		// Allow storing objects not in the underlying cache - that's the point...
 		// It's safe because in case of a race (claim is in mutation cache, claim
 		// gets deleted, controller updates status based on mutation cache) the
 		// "bad" pod status will get detected and fixed when the informer catches up.
-		true,
+		IncludeAdds: true,
+		// Tracks more recently mutated objects than the default (100)
+		// so that lookups still succeed locally while the informer cache lags
+		// behind etcd, avoiding the fallback GET against the apiserver.
+		MaxCacheSize: claimMutationCacheSize,
+	},
 	)
 
 	return ec, nil
@@ -1034,21 +1043,26 @@ func (ec *Controller) handleClaim(ctx context.Context, pod *v1.Pod, podGroup *sc
 		claimName := *claimName
 		// The ResourceClaim should exist because it is recorded in the pod.status.resourceClaimStatuses,
 		// but perhaps it was deleted accidentally. In that case we re-create it.
-		claim, err := ec.claimLister.ResourceClaims(pod.Namespace).Get(claimName)
-		if err != nil && !apierrors.IsNotFound(err) {
-			return err
-		}
-		if claim != nil {
-			var err error
+		checkClaimOwnedByPod := func(claim *resourceapi.ResourceClaim) bool {
 			if mustCheckOwner {
-				err = resourceclaim.IsForPod(pod, claim, ec.features.WorkloadResourceClaims)
+				if err := resourceclaim.IsForPod(pod, claim, ec.features.WorkloadResourceClaims); err != nil {
+					logger.Error(err, "Claim that was created for the pod is no longer owned by the pod, creating a new one",
+						"podClaim", podClaim.Name, "resourceClaim", claimName)
+					return false
+				}
 			}
-			if err == nil {
-				// Already created, nothing more to do.
-				logger.V(5).Info("Claim already created", "podClaim", podClaim.Name, "resourceClaim", claimName)
-				return nil
-			}
-			logger.Error(err, "Claim that was created for the pod is no longer owned by the pod, creating a new one", "podClaim", podClaim.Name, "resourceClaim", claimName)
+
+			return true
+		}
+
+		exists, err := ec.claimExists(ctx, pod.Namespace, claimName, checkClaimOwnedByPod)
+		if err != nil {
+			return fmt.Errorf("checking claim existence: %w", err)
+		}
+		if exists {
+			// Already created, nothing more to do.
+			logger.V(5).Info("Claim already created", "podClaim", podClaim.Name, "resourceClaim", claimName)
+			return nil
 		}
 	}
 
@@ -1287,21 +1301,26 @@ func (ec *Controller) handlePodGroupClaim(ctx context.Context, podGroup *schedul
 		claimName := *claimName
 		// The ResourceClaim should exist because it is recorded in the podgroup.status.resourceClaimStatuses,
 		// but perhaps it was deleted accidentally. In that case we re-create it.
-		claim, err := ec.claimLister.ResourceClaims(podGroup.Namespace).Get(claimName)
-		if err != nil && !apierrors.IsNotFound(err) {
-			return err
-		}
-		if claim != nil {
-			var err error
+		checkClaimOwnedByPodGroup := func(claim *resourceapi.ResourceClaim) bool {
 			if mustCheckOwner {
-				err = resourceclaim.IsForPodGroup(podGroup, claim)
+				if err := resourceclaim.IsForPodGroup(podGroup, claim); err != nil {
+					logger.Error(err, "Claim that was created for the PodGroup is no longer owned by the PodGroup, creating a new one",
+						"podGroupClaim", podGroupClaim.Name, "resourceClaim", claimName)
+					return false
+				}
 			}
-			if err == nil {
-				// Already created, nothing more to do.
-				logger.V(5).Info("Claim already created", "podGroupClaim", podGroupClaim.Name, "resourceClaim", claimName)
-				return nil
-			}
-			logger.Error(err, "Claim that was created for the PodGroup is no longer owned by the PodGroup, creating a new one", "podGroupClaim", podGroupClaim.Name, "resourceClaim", claimName)
+
+			return true
+		}
+
+		exists, err := ec.claimExists(ctx, podGroup.Namespace, claimName, checkClaimOwnedByPodGroup)
+		if err != nil {
+			return fmt.Errorf("checking claim existence: %w", err)
+		}
+		if exists {
+			// Already created, nothing more to do.
+			logger.V(5).Info("Claim already created", "podGroupClaim", podGroupClaim.Name, "resourceClaim", claimName)
+			return nil
 		}
 	}
 
@@ -1389,6 +1408,42 @@ func (ec *Controller) handlePodGroupClaim(ctx context.Context, podGroup *schedul
 	(*newPodGroupClaims)[podGroupClaim.Name] = claim.Name
 
 	return nil
+}
+
+type checkClaimOwnerFunc func(claim *resourceapi.ResourceClaim) bool
+
+// claimExists reports whether the named ResourceClaim still exists and is owned by the expected object.
+// It looks in the mutation cache first and falls back to the apiserver if the claim is not found there.
+// A false result means the claim is gone (e.g. deleted by accident) and the caller should re-create it.
+func (ec *Controller) claimExists(ctx context.Context, namespace, claimName string, checkClaimOwner checkClaimOwnerFunc) (bool, error) {
+	key := cache.NewObjectName(namespace, claimName)
+
+	// This may incorrectly return a claim from the mutation cache that
+	// was already deleted again on the apiserver. The sync logic for the
+	// mutation cache (checking after TTL for created
+	// claims, reacting to informer events) will detect that eventually.
+	claim, exists, err := ec.claimCache.GetByKey(key.String())
+	if err != nil && !apierrors.IsNotFound(err) {
+		return false, err
+	}
+
+	if !exists {
+		// Missing from the mutation cache and informer (e.g. evicted): fall back to the apiserver.
+		claim, err = ec.kubeClient.ResourceV1().ResourceClaims(namespace).Get(ctx, claimName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+
+			return false, err
+		}
+	}
+
+	if !checkClaimOwner(claim.(*resourceapi.ResourceClaim)) {
+		return false, nil
+	}
+
+	return true, nil
 }
 
 // findPodGroupResourceClaim looks for an existing ResourceClaim with the right

--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -200,6 +200,7 @@ func testSyncHandler(tCtx ktesting.TContext) {
 		claimsInCache            []*resourceapi.ResourceClaim
 		pods                     []*v1.Pod
 		podsLater                []*v1.Pod
+		claimsLater              []*resourceapi.ResourceClaim
 		podGroups                []*schedulingapi.PodGroup
 		templates                []*resourceapi.ResourceClaimTemplate
 		expectedClaims           []resourceapi.ResourceClaim
@@ -381,6 +382,88 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedMetrics: expectedMetrics{0, 0, 0, 0},
 		},
 		{
+			name: "nop-claim-in-mutation-cache-only",
+			pods: []*v1.Pod{func() *v1.Pod {
+				pod := testPodWithResource.DeepCopy()
+				pod.Status.ResourceClaimStatuses = []v1.PodResourceClaimStatus{
+					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestClaim.Name},
+				}
+				return pod
+			}()},
+			templates:      []*resourceapi.ResourceClaimTemplate{template},
+			key:            podKey(testPodWithResource),
+			claimsInCache:  []*resourceapi.ResourceClaim{templatedTestClaim},
+			expectedClaims: nil, // the claim only lives in the mutation cache, nothing exists in the apiserver
+			expectedStatuses: map[string][]v1.PodResourceClaimStatus{
+				testPodWithResource.Name: {
+					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestClaim.Name},
+				},
+			},
+			expectedMetrics: expectedMetrics{0, 0, 0, 0},
+		},
+		{
+			name:                "nop-claim-in-mutation-cache-only-for-podgroup",
+			featureCombinations: workloadResourceClaimsEnabled,
+			podGroups: []*schedulingapi.PodGroup{func() *schedulingapi.PodGroup {
+				podGroup := testPodGroupWithResource.DeepCopy()
+				podGroup.Status.ResourceClaimStatuses = []schedulingapi.PodGroupResourceClaimStatus{
+					{Name: testPodGroupWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestPodGroupClaim.Name},
+				}
+				return podGroup
+			}()},
+			templates:      []*resourceapi.ResourceClaimTemplate{template},
+			key:            podGroupKey(testPodGroupWithResource),
+			claimsInCache:  []*resourceapi.ResourceClaim{templatedTestPodGroupClaim},
+			expectedClaims: nil, // the claim only lives in the mutation cache, nothing exists in the apiserver
+			expectedPodGroupStatuses: map[string][]schedulingapi.PodGroupResourceClaimStatus{
+				testPodGroupWithResource.Name: {
+					{Name: testPodGroupWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestPodGroupClaim.Name},
+				},
+			},
+			expectedMetrics: expectedMetrics{0, 0, 0, 0},
+		},
+		{
+			name: "nop-claim-in-apiserver-only",
+			pods: []*v1.Pod{func() *v1.Pod {
+				pod := testPodWithResource.DeepCopy()
+				pod.Status.ResourceClaimStatuses = []v1.PodResourceClaimStatus{
+					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestClaim.Name},
+				}
+				return pod
+			}()},
+			templates:      []*resourceapi.ResourceClaimTemplate{template},
+			key:            podKey(testPodWithResource),
+			claimsLater:    []*resourceapi.ResourceClaim{templatedTestClaim},
+			expectedClaims: []resourceapi.ResourceClaim{*templatedTestClaim},
+			expectedStatuses: map[string][]v1.PodResourceClaimStatus{
+				testPodWithResource.Name: {
+					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestClaim.Name},
+				},
+			},
+			expectedMetrics: expectedMetrics{0, 0, 0, 0},
+		},
+		{
+			name:                "nop-claim-in-apiserver-only-for-podgroup",
+			featureCombinations: workloadResourceClaimsEnabled,
+			podGroups: []*schedulingapi.PodGroup{func() *schedulingapi.PodGroup {
+				podGroup := testPodGroupWithResource.DeepCopy()
+				podGroup.Status.ResourceClaimStatuses = []schedulingapi.PodGroupResourceClaimStatus{
+					{Name: testPodGroupWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestPodGroupClaim.Name},
+				}
+				return podGroup
+			}()},
+			templates:      []*resourceapi.ResourceClaimTemplate{template},
+			key:            podGroupKey(testPodGroupWithResource),
+			claimsLater:    []*resourceapi.ResourceClaim{templatedTestPodGroupClaim},
+			expectedClaims: []resourceapi.ResourceClaim{*templatedTestPodGroupClaim},
+			expectedPodGroupStatuses: map[string][]schedulingapi.PodGroupResourceClaimStatus{
+				testPodGroupWithResource.Name: {
+					{Name: testPodGroupWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestPodGroupClaim.Name},
+				},
+			},
+			expectedMetrics: expectedMetrics{0, 0, 0, 0},
+		},
+		{
 			name: "recreate",
 			pods: []*v1.Pod{func() *v1.Pod {
 				pod := testPodWithResource.DeepCopy()
@@ -485,6 +568,47 @@ func testSyncHandler(tCtx ktesting.TContext) {
 				},
 			},
 			expectedMetrics: expectedMetrics{0, 0, 0, 0},
+		},
+		{
+			name: "recreate-wrong-owner",
+			pods: []*v1.Pod{func() *v1.Pod {
+				pod := testPodWithResource.DeepCopy()
+				pod.Status.ResourceClaimStatuses = []v1.PodResourceClaimStatus{
+					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &conflictingClaim.Name},
+				}
+				return pod
+			}()},
+			templates:      []*resourceapi.ResourceClaimTemplate{template},
+			key:            podKey(testPodWithResource),
+			claims:         []*resourceapi.ResourceClaim{conflictingClaim},
+			expectedClaims: []resourceapi.ResourceClaim{*conflictingClaim, *templatedTestClaim},
+			expectedStatuses: map[string][]v1.PodResourceClaimStatus{
+				testPodWithResource.Name: {
+					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestClaim.Name},
+				},
+			},
+			expectedMetrics: expectedMetrics{1, 0, 0, 0},
+		},
+		{
+			name:                "recreate-wrong-owner-podgroup",
+			featureCombinations: workloadResourceClaimsEnabled,
+			podGroups: []*schedulingapi.PodGroup{func() *schedulingapi.PodGroup {
+				podGroup := testPodGroupWithResource.DeepCopy()
+				podGroup.Status.ResourceClaimStatuses = []schedulingapi.PodGroupResourceClaimStatus{
+					{Name: testPodGroupWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &conflictingPodGroupClaim.Name},
+				}
+				return podGroup
+			}()},
+			templates:      []*resourceapi.ResourceClaimTemplate{template},
+			key:            podGroupKey(testPodGroupWithResource),
+			claims:         []*resourceapi.ResourceClaim{conflictingPodGroupClaim},
+			expectedClaims: []resourceapi.ResourceClaim{*conflictingPodGroupClaim, *templatedTestPodGroupClaim},
+			expectedPodGroupStatuses: map[string][]schedulingapi.PodGroupResourceClaimStatus{
+				testPodGroupWithResource.Name: {
+					{Name: testPodGroupWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestPodGroupClaim.Name},
+				},
+			},
+			expectedMetrics: expectedMetrics{1, 0, 0, 0},
 		},
 		{
 			name: "no-such-pod",
@@ -908,7 +1032,7 @@ func testSyncHandler(tCtx ktesting.TContext) {
 				ec.claimCache.Mutation(claim)
 			}
 
-			// Simulate race: stop informers, add more pods that the controller doesn't know about.
+			// Simulate race: stop informers, add more objects that the controller doesn't know about.
 			stopInformers()
 			for _, pod := range tc.podsLater {
 				_, err := fakeKubeClient.CoreV1().Pods(pod.Namespace).Create(tCtx, pod, metav1.CreateOptions{})
@@ -916,8 +1040,23 @@ func testSyncHandler(tCtx ktesting.TContext) {
 					tCtx.Fatalf("unexpected error while creating pod: %v", err)
 				}
 			}
+			for _, claim := range tc.claimsLater {
+				_, err := fakeKubeClient.ResourceV1().ResourceClaims(claim.Namespace).Create(tCtx, claim, metav1.CreateOptions{})
+				if err != nil {
+					tCtx.Fatalf("unexpected error while creating claim: %v", err)
+				}
+			}
 
 			err = ec.syncHandler(tCtx, tc.key)
+			if err != nil {
+				if len(tc.expectedError) == 0 {
+					assert.NoError(tCtx, err)
+				} else {
+					assert.ErrorContains(tCtx, err, tc.expectedError, "the error message should have contained the expected error message")
+				}
+
+				return
+			}
 			if tc.expectedError != "" {
 				assert.ErrorContains(tCtx, err, tc.expectedError, "the error message should have contained the expected error message")
 			} else if err != nil {
@@ -1051,6 +1190,117 @@ func testControllerCreateDeleteRecreate(tCtx ktesting.TContext) {
 	tCtx.ExpectNoError(err)
 	if len(claims.Items) != 1 {
 		tCtx.Fatalf("expected 1 claim after second sync (recreate), got %d", len(claims.Items))
+	}
+}
+
+// TestClaimExists covering the three places it looks for a claim
+// (mutation cache, underlay informer store, storeapiserver), and a optional owner check.
+func TestClaimExists(t *testing.T) { testClaimExists(ktesting.Init(t)) }
+func testClaimExists(tCtx ktesting.TContext) {
+	alwaysOwned := func(*resourceapi.ResourceClaim) bool { return true }
+	neverOwned := func(*resourceapi.ResourceClaim) bool { return false }
+
+	for _, tc := range []struct {
+		name                 string
+		claimInMutationCache *resourceapi.ResourceClaim
+		claimInInformerCache *resourceapi.ResourceClaim
+		claimInAPIServer     *resourceapi.ResourceClaim
+		// reactor injected on GET to simulate a transient apiserver error.
+		getReactor   k8stesting.ReactionFunc
+		invalidOwner bool
+		wantExists   bool
+		wantErr      bool
+	}{
+		{
+			name:                 "found in mutation cache",
+			claimInMutationCache: templatedTestClaim,
+			wantExists:           true,
+		},
+		{
+			name:                 "found in underlay store",
+			claimInInformerCache: templatedTestClaim,
+			wantExists:           true,
+		},
+		{
+			name:             "found in apiserver fallback",
+			claimInAPIServer: templatedTestClaim,
+			wantExists:       true,
+		},
+		{
+			name:       "not found anywhere",
+			wantExists: false,
+		},
+		{
+			name: "apiserver returns error",
+			getReactor: func(k8stesting.Action) (bool, runtime.Object, error) {
+				return true, nil, apierrors.NewInternalError(errors.New("apiserver is down"))
+			},
+			wantExists: false,
+			wantErr:    true,
+		},
+		{
+			name:                 "owner check fails",
+			claimInMutationCache: templatedTestClaim,
+			invalidOwner:         true,
+			wantExists:           false,
+		},
+	} {
+		tCtx.Run(tc.name, func(tCtx ktesting.TContext) {
+			var objects []runtime.Object
+			if tc.claimInInformerCache != nil {
+				objects = append(objects, tc.claimInInformerCache)
+			}
+
+			fakeKubeClient := createTestClient(objects...)
+			if tc.getReactor != nil {
+				fakeKubeClient.PrependReactor("get", "resourceclaims", tc.getReactor)
+			}
+
+			informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
+			ec, err := newControllerWithFeatures(tCtx.Logger(), fakeKubeClient,
+				informerFactory.Core().V1().Pods(),
+				informerFactory.Scheduling().V1alpha3().PodGroups(),
+				informerFactory.Resource().V1().ResourceClaims(),
+				informerFactory.Resource().V1().ResourceClaimTemplates(),
+				controllerFeatures{})
+			tCtx.ExpectNoError(err, "creating controller")
+
+			// Ensure informers are up-to-date.
+			informerFactory.Start(tCtx.Done())
+			stopInformers := func() {
+				tCtx.Cancel("stopping informers")
+				informerFactory.Shutdown()
+			}
+			defer stopInformers()
+			informerFactory.WaitForCacheSync(tCtx.Done())
+
+			// Add claims that only exist in the mutation cache.
+			if claim := tc.claimInMutationCache; claim != nil {
+				ec.claimCache.Mutation(claim)
+			}
+
+			// Simulate race: stop informers, add more objects that the controller doesn't know about.
+			stopInformers()
+			if claim := tc.claimInAPIServer; claim != nil {
+				_, err := fakeKubeClient.ResourceV1().ResourceClaims(claim.Namespace).Create(tCtx, claim, metav1.CreateOptions{})
+				if err != nil {
+					tCtx.Fatalf("unexpected error while creating claim: %v", err)
+				}
+			}
+
+			checkOwner := alwaysOwned
+			if tc.invalidOwner {
+				checkOwner = neverOwned
+			}
+
+			exists, err := ec.claimExists(tCtx, testNamespace, templatedTestClaim.Name, checkOwner)
+			if tc.wantErr {
+				assert.Error(tCtx, err)
+			} else {
+				assert.NoError(tCtx, err)
+			}
+			assert.Equal(tCtx, tc.wantExists, exists)
+		})
 	}
 }
 

--- a/staging/src/k8s.io/client-go/tools/cache/mutation_cache.go
+++ b/staging/src/k8s.io/client-go/tools/cache/mutation_cache.go
@@ -58,7 +58,28 @@ type ResourceVersionComparator interface {
 	CompareResourceVersion(lhs, rhs runtime.Object) int
 }
 
-// NewIntegerResourceVersionMutationCache returns a MutationCache that understands how to
+// MutationCacheOptions configures the MutationCache returned by NewIntegerResourceVersionMutationCacheWithOptions.
+type MutationCacheOptions struct {
+	// Indexer is used by ByIndex to look up objects. May be nil, in which case ByIndex returns an error.
+	Indexer Indexer
+
+	// TTL controls how long an item remains in the mutation cache before it is removed.
+	// Zero means the default of 5 minutes.
+	TTL time.Duration
+
+	// IncludeAdds makes the cache return objects even if they don't exist
+	// in the underlying store. This is only safe if your use of the cache
+	// can handle mutation entries remaining in the cache for up to TTL
+	// when mutations and deletes occur very closely in time.
+	IncludeAdds bool
+
+	// MaxCacheSize limits how many mutated objects are tracked; the least
+	// recently used entries are evicted once the limit is reached.
+	// Zero means the default of 100.
+	MaxCacheSize int
+}
+
+// NewIntegerResourceVersionMutationCacheWithOptions returns a MutationCache that understands how to
 // deal with objects that have a resource version that:
 //
 //   - is an integer
@@ -86,16 +107,38 @@ type ResourceVersionComparator interface {
 // the informer might never see the added object when the add is followed
 // quickly by a delete. The caller has to handle stale added objects by
 // checking whether they still exist once the TTL is over.
-func NewIntegerResourceVersionMutationCache(logger klog.Logger, backingCache Store, indexer Indexer, ttl time.Duration, includeAdds bool) MutationCache {
+func NewIntegerResourceVersionMutationCacheWithOptions(logger klog.Logger, backingCache Store, options MutationCacheOptions) MutationCache {
+	var (
+		maxCacheSize = 100
+		ttl          = 5 * time.Minute
+	)
+
+	if options.MaxCacheSize != 0 {
+		maxCacheSize = options.MaxCacheSize
+	}
+	if options.TTL != 0 {
+		ttl = options.TTL
+	}
+
 	return &mutationCache{
 		backingCache:  backingCache,
-		indexer:       indexer,
-		mutationCache: utilcache.NewLRUExpireCache(100),
+		indexer:       options.Indexer,
+		mutationCache: utilcache.NewLRUExpireCache(maxCacheSize),
 		comparator:    etcdObjectVersioner{},
 		ttl:           ttl,
-		includeAdds:   includeAdds,
+		includeAdds:   options.IncludeAdds,
 		logger:        logger,
 	}
+}
+
+// NewIntegerResourceVersionMutationCache is like NewIntegerResourceVersionMutationCacheWithOptions with a fixed cache size of 100.
+func NewIntegerResourceVersionMutationCache(logger klog.Logger, backingCache Store, indexer Indexer, ttl time.Duration, includeAdds bool) MutationCache {
+	return NewIntegerResourceVersionMutationCacheWithOptions(logger, backingCache, MutationCacheOptions{
+		TTL:          ttl,
+		Indexer:      indexer,
+		IncludeAdds:  includeAdds,
+		MaxCacheSize: 100,
+	})
 }
 
 // mutationCache doesn't guarantee that it returns values added via Mutation since they can page out and


### PR DESCRIPTION
 

#### What type of PR is this?
 
/kind bug 

 

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to: 
Fixes #140217 

#### Special notes for your reviewer:
1. increase default cache size from 100 to 5000. maybe smaller? I'm not sure, looking forward to others' opinion.
2. double check from etcd before creating ResourceClaim. Both Pod and PodGroup path should be covered. 

#### Does this PR introduce a user-facing change?
 
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


