### PR TITLE
kubectl: prevent kuberc defaults from matching unrelated commands

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc.go
+++ b/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc.go
@@ -178,7 +178,8 @@ func (p *Preferences) applyOverrides(rootCmd *cobra.Command, kuberc *config.Pref
 			fmt.Fprintf(errOut, "Warning: command %q not found to set kuberc override\n", c.Command)
 			continue
 		}
-		if overrideCmd.Name() != cmd.Name() {
+
+		if overrideCmd.CommandPath() != cmd.CommandPath() {
 			continue
 		}
 

--- a/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc_test.go
@@ -806,7 +806,6 @@ func TestApplyOverride(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			name: "alias command override",
 			nestedCmds: []fakeCmds[string]{
@@ -3200,5 +3199,66 @@ credentialPluginPolicy: ""
 				require.NoError(t, err)
 			}
 		})
+	}
+}
+
+func TestApplyOverrideDoesNotMatchSameLeafCommand(t *testing.T) {
+	rootCmd := &cobra.Command{Use: "root"}
+
+	configCmd := &cobra.Command{Use: "config"}
+	configViewCmd := &cobra.Command{Use: "view"}
+	configViewCmd.Flags().String("output", "default", "")
+	configCmd.AddCommand(configViewCmd)
+
+	kubercCmd := &cobra.Command{Use: "kuberc"}
+	kubercViewCmd := &cobra.Command{Use: "view"}
+	kubercViewCmd.Flags().String("output", "default", "")
+	kubercCmd.AddCommand(kubercViewCmd)
+
+	rootCmd.AddCommand(configCmd, kubercCmd)
+
+	opts := genericclioptions.NewConfigFlags(false)
+	prefHandler := NewPreferences()
+	prefHandler.AddFlags(rootCmd.PersistentFlags())
+
+	pref := prefHandler.(*Preferences)
+	pref.getPreferencesFunc = func(kuberc string, errOut io.Writer) (*config.Preference, error) {
+		return &config.Preference{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Preference",
+				APIVersion: "kubectl.config.k8s.io/v1alpha1",
+			},
+			Defaults: []config.CommandDefaults{
+				{
+					Command: "config view",
+					Options: []config.CommandOptionDefault{
+						{
+							Name:    "output",
+							Default: "json",
+						},
+					},
+				},
+			},
+		}, nil
+	}
+
+	errWriter := &bytes.Buffer{}
+	args := []string{"root", "kuberc", "view"}
+
+	_, err := pref.Apply(rootCmd, opts, args, errWriter)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	if errWriter.String() != "" {
+		t.Fatalf("unexpected error message %s", errWriter.String())
+	}
+
+	actualCmd, _, err := rootCmd.Find(args[1:])
+	if err != nil {
+		t.Fatalf("unable to find command: %v", err)
+	}
+
+	if got := actualCmd.Flag("output").Value.String(); got != "default" {
+		t.Fatalf("unexpected output flag value: got %q, want %q", got, "default")
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR fixes an issue in kuberc override matching where defaults could be applied to an unintended command if two commands share the same leaf name.

Currently, [applyOverrides()](https://github.com/kubernetes/kubernetes/blob/0aadbdabad5f6bd42b99ac6afd41ae3970b20534/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc.go#L167) determines whether a kuberc default matches the running command by comparing only the command's leaf name (for example, view). As a result, a default configured for `kubectl config view` can also be applied to `kubectl kuberc view`, even though they are different commands with different command paths.

This change updates the matching logic to compare the resolved command identity instead of only the leaf name, ensuring that kuberc defaults are applied only to the command they were configured for. A regression test has also been added to prevent this behavior from reoccurring.

#### Which issue(s) this PR is related to:  ##Fixes: https://github.com/kubernetes/kubectl/issues/1862
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubectl: defaults are now matched by full command path instead of the last path segment.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
