### PR TITLE
flake: deflake CR apply during CRD finalization

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/finalization_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/finalization_test.go
@@ -204,8 +204,22 @@ func TestApplyCRDuringCRDFinalization(t *testing.T) {
 	name := "foo123"
 	noxuResourceClient := newNamespacedCustomResourceClient(ns, dynamicClient, noxuDefinition)
 
-	instance := fixtures.NewNoxuInstance(ns, name)
-	_, err = noxuResourceClient.Apply(t.Context(), name, instance, metav1.ApplyOptions{DryRun: []string{"All"}, FieldManager: "manager"})
 	wantErr := `create not allowed while custom resource definition is terminating`
-	require.ErrorContains(t, err, wantErr)
+	var applyErr error
+	instance := fixtures.NewNoxuInstance(ns, name)
+	// The CRD handler uses its informer cache to decide whether creates are blocked.
+	// The CRD GET above can observe deletion before that cache does, so wait
+	// through the same dry-run apply path that this test is validating.
+	err = wait.PollUntilContextTimeout(t.Context(), 100*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+		_, applyErr = noxuResourceClient.Apply(ctx, name, instance, metav1.ApplyOptions{DryRun: []string{"All"}, FieldManager: "manager"})
+		if applyErr == nil {
+			return false, nil
+		}
+		if !errors.IsForbidden(applyErr) {
+			return false, applyErr
+		}
+		return true, nil
+	})
+	require.NoError(t, err, "timed out waiting for CR apply to be rejected while CRD is deleting")
+	require.ErrorContains(t, applyErr, wantErr)
 }


### PR DESCRIPTION
#### What type of PR is this?

  /kind flake

  #### What this PR does / why we need it:

  This deflakes `TestApplyCRDuringCRDFinalization`.

  The test deletes a CRD, waits for the CRD to report `Terminating=True`, then sends one dry-run SSA apply and expects it to be rejected with:

  ```text
  create not allowed while custom resource definition is terminating
```

  The wait on the CRD object is not a sufficient synchronization point for the apply request path. The CRD GET can observe the updated CRD before the crdHandler informer cache
  used by the custom resource apply path observes it. In that window, the dry-run apply can still succeed and the test fails with:
  ```text
  finalization_test.go:210: An error is expected but got nil.
```

  This keeps the existing wait for the CRD Terminating condition, then waits through the same dry-run apply path that the test is validating. A nil apply error keeps polling,
  unexpected non-Forbidden errors fail the test, and the final Forbidden error is still checked for the expected message.

  Observed flakes:

  - https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-integration-master/2071378038305591296
  - https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-integration-master/2071393395250565120
  - https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-integration-master/2073155273773551616
  - https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-integration-master/2073400903649464320

  #### Which issue(s) this PR is related to:

  Related to https://github.com/kubernetes/kubernetes/pull/137604

  #### Special notes for your reviewer:

  #137604 made the handler consider a CRD terminating as soon as its deletion timestamp is set. This PR addresses the remaining test-side race where the test waits on a live CRD
  GET, while the CR apply path observes CRD state through the handler informer cache.

  Verified locally:

  make test-integration WHAT=./staging/src/k8s.io/apiextensions-apiserver/test/integration GOFLAGS='-run=TestApplyCRDuringCRDFinalization -count=10 -v'
  DONE 10 tests in 40.124s

  make test-integration WHAT=./staging/src/k8s.io/apiextensions-apiserver/test/integration KUBE_TIMEOUT='-timeout=3600s' GOFLAGS='-run=TestApplyCRDuringCRDFinalization
  -count=400 -v'
  DONE 400 tests in 1584.757s

  #### Does this PR introduce a user-facing change?
```
  NONE
```
  #### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
  NONE
```
