### PR TITLE
flagz: note that endpoint reflects flag layer, not effective config

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/flagz/flagz_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/flagz/flagz_test.go
@@ -45,6 +45,7 @@ import (
 const wantTmpl = `
 %s flagz
 Warning: This endpoint is not meant to be machine parseable, has no formatting compatibility guarantees and is for debugging purposes only.
+Note: This shows command-line flag values (or defaults if unset), not the effective runtime configuration. Values set via configuration files are not reflected here; where available, /configz reports the resolved configuration.
 `
 
 func TestHandleFlagz(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/server/flagz/textserializer.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/flagz/textserializer.go
@@ -33,6 +33,7 @@ var (
 const headerFmt = `
 %s flagz
 Warning: This endpoint is not meant to be machine parseable, has no formatting compatibility guarantees and is for debugging purposes only.
+Note: This shows command-line flag values (or defaults if unset), not the effective runtime configuration. Values set via configuration files are not reflected here; where available, /configz reports the resolved configuration.
 `
 
 // flagzTextSerializer implements runtime.Serializer for text/plain output.


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation
/sig instrumentation

**What this PR does / why we need it:**

The `/flagz` text response is easily misread as the component's effective running configuration. For components configured via files (kubelet, kube-proxy), flag defaults shown by `/flagz` can contradict the resolved configuration reported by `/configz` — e.g. `/flagz` showing anonymous auth enabled while the kubelet config file disables it.

Per the discussion in #140083, the divergence between `/flagz` and `/configz` is intentional, and one agreed follow-up was to expose that expectation at the `/flagz` endpoint itself. This PR adds a note line to the `/flagz` plain-text header:

> Note: This shows command-line flag values (or defaults if unset), not the effective runtime configuration. Values set via configuration files are not reflected here; where available, /configz reports the resolved configuration.

The header is already documented as having no formatting compatibility guarantees, and existing integration tests assert only the header prefix, so this is a safe additive change. The companion docs update for the zpages page belongs in kubernetes/website.

**Which issue(s) this PR fixes:**

Related to #140083

**Special notes for your reviewer:**

Unit test expectation in `flagz_test.go` updated to match the new header line.

**Does this PR introduce a user-facing change?**

```release-note
The /flagz plain-text response now notes that it reports command-line flag values (or defaults), not the effective runtime configuration, and points to /configz where available.
```