### PR TITLE
pkg/auth, pkg/controller/certificates: replace deprecated io/ioutil with io and os

### DIFF
--- a/pkg/auth/authorizer/abac/abac_test.go
+++ b/pkg/auth/authorizer/abac/abac_test.go
@@ -18,7 +18,6 @@ package abac
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -818,14 +817,14 @@ func TestSubjectMatches(t *testing.T) {
 }
 
 func newWithContents(t *testing.T, contents string) (PolicyList, error) {
-	f, err := ioutil.TempFile("", "abac_test")
+	f, err := os.CreateTemp("", "abac_test")
 	if err != nil {
 		t.Fatalf("unexpected error creating policyfile: %v", err)
 	}
 	f.Close()
 	defer os.Remove(f.Name())
 
-	if err := ioutil.WriteFile(f.Name(), []byte(contents), 0700); err != nil {
+	if err := os.WriteFile(f.Name(), []byte(contents), 0700); err != nil {
 		t.Fatalf("unexpected error writing policyfile: %v", err)
 	}
 

--- a/pkg/controller/certificates/signer/signer_test.go
+++ b/pkg/controller/certificates/signer/signer_test.go
@@ -24,7 +24,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"math/rand"
 	"reflect"
 	"testing"
@@ -88,7 +88,7 @@ func TestSigner(t *testing.T) {
 		t.Fatalf("failed to create signer: %v", err)
 	}
 
-	csrb, err := ioutil.ReadFile("./testdata/kubelet.csr")
+	csrb, err := os.ReadFile("./testdata/kubelet.csr")
 	if err != nil {
 		t.Fatalf("failed to read CSR: %v", err)
 	}


### PR DESCRIPTION
### What type of PR is this?
/kind cleanup

### What this PR does / why we need it:
Replaces deprecated `io/ioutil` usage with modern `io` and `os` package equivalents. Since Go 1.16, `io/ioutil` is deprecated and its functions have been moved to the `io` and `os` packages. These are 1:1 mechanical replacements with zero change in behavior.

### Which issue(s) this PR fixes:

### Special notes for your reviewer:

### Does this PR introduce a user-facing change?
```release-note
NONE
```