### PR TITLE
:bug: fix:(kube-apiserver): hanging forever on SIGTERM when its identity Lease cannot be created (e.g. hostname longer than 63 bytes)

### DIFF
--- a/staging/src/k8s.io/component-helpers/apimachinery/lease/controller.go
+++ b/staging/src/k8s.io/component-helpers/apimachinery/lease/controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	coordinationv1 "k8s.io/api/coordination/v1"
@@ -76,7 +75,10 @@ type controller struct {
 	newLeasePostProcessFunc ProcessLeaseFunc
 
 	reconcilingLock sync.Mutex
-	stopCalled      atomic.Bool
+	// stopCh is closed by Stop so that a sync stuck retrying a lease create
+	// releases reconcilingLock instead of blocking Stop forever.
+	stopCh   chan struct{}
+	stopOnce sync.Once
 }
 
 // NewController constructs and returns a controller
@@ -96,6 +98,7 @@ func NewController(clock clock.Clock, client clientset.Interface, holderIdentity
 		clock:                      clock,
 		onRepeatedHeartbeatFailure: onRepeatedHeartbeatFailure,
 		newLeasePostProcessFunc:    newLeasePostProcessFunc,
+		stopCh:                     make(chan struct{}),
 	}
 }
 
@@ -126,7 +129,9 @@ func (c *controller) Stop() {
 		return
 	}
 
-	c.stopCalled.Store(true)
+	// Unblock a sync stuck in backoffEnsureLease, which holds the lock
+	// acquired below.
+	c.stopOnce.Do(func() { close(c.stopCh) })
 	// Ensure that there will be no race condition with the sync.
 	c.reconcilingLock.Lock()
 	defer c.reconcilingLock.Unlock()
@@ -149,8 +154,10 @@ func (c *controller) Run(ctx context.Context) {
 }
 
 func (c *controller) sync(ctx context.Context) {
-	if c.stopCalled.Load() {
+	select {
+	case <-c.stopCh:
 		return
+	default:
 	}
 
 	c.reconcilingLock.Lock()
@@ -199,9 +206,11 @@ func (c *controller) backoffEnsureLease(ctx context.Context) (*coordinationv1.Le
 		}
 		sleep = minDuration(2*sleep, maxBackoff)
 		klog.FromContext(ctx).Error(err, "Failed to ensure lease exists, will retry", "interval", sleep)
-		// backoff wait with early return if the context gets canceled
+		// backoff wait with early return if the context gets canceled or Stop is called
 		select {
 		case <-ctx.Done():
+			return nil, false
+		case <-c.stopCh:
 			return nil, false
 		case <-time.After(sleep):
 		}

--- a/staging/src/k8s.io/component-helpers/apimachinery/lease/controller_test.go
+++ b/staging/src/k8s.io/component-helpers/apimachinery/lease/controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -31,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
@@ -504,6 +506,51 @@ func TestUpdateUsingLatestLease(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestStopDoesNotBlockWhenLeaseCannotBeCreated verifies that Stop returns
+// while sync is retrying a lease create that will never succeed. sync holds
+// the reconciling lock across the retries, so Stop must interrupt them.
+func TestStopDoesNotBlockWhenLeaseCannotBeCreated(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	cl := fake.NewSimpleClientset()
+	retrying := make(chan struct{})
+	var retryingOnce sync.Once
+	cl.PrependReactor("create", "leases", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		retryingOnce.Do(func() { close(retrying) })
+		return true, nil, apierrors.NewInvalid(
+			schema.GroupKind{Group: coordinationv1.GroupName, Kind: "Lease"}, "foo", nil)
+	})
+
+	c := NewController(testingclock.NewFakeClock(time.Now()), cl, "foo", 60, nil,
+		10*time.Millisecond, "foo", corev1.NamespaceNodeLease, nil)
+	go c.Run(ctx)
+
+	// Wait until sync is inside the create retry loop, holding the
+	// reconciling lock.
+	select {
+	case <-retrying:
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatal("timed out waiting for the controller to attempt lease creation")
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		c.Stop()
+	}()
+
+	select {
+	case <-stopped:
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatal("Stop() did not return while lease creation keeps failing")
+	}
+
+	// Stop must be safe to call more than once.
+	c.Stop()
 }
 
 // setNodeOwnerFunc helps construct a newLeasePostProcessFunc which sets


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression
/sig api-machinery

#### What this PR does / why we need it:

Since 1.35, kube-apiserver deadlocks on SIGTERM when its identity Lease can never
be created (for example, a hostname longer than the 63-byte label limit). The
lease controller's `sync()` holds `reconcilingLock` while retrying the create
forever, and the pre-shutdown hook calls `Stop()`, which blocks on that lock. The
context that would end the retries is only canceled after the pre-shutdown hooks
return, so shutdown never begins and only SIGKILL ends the process.

This PR adds a `stopCh` that `Stop()` closes before taking the lock, and makes the
retry wait in `backoffEnsureLease` return when it fires. `Stop()` now returns
promptly and shutdown proceeds; the lease errors still log, but no longer block
anything.

It also adds a regression test. Without the `controller.go` change, the test hangs
in the same 7-second retry loop and fails after 30 seconds; with it, it passes in
milliseconds.

Verified with real binaries: on a host with a 64-byte hostname, the official
v1.35.0 and v1.36.2 apiservers ignore SIGTERM indefinitely, while a build with
this fix exits about 2 seconds after SIGTERM. Full analysis, goroutine dump, and
reproducers are in the linked issue.

#### Which issue(s) this PR is related to:

Fixes #140242

Introduced by #134514 (v1.35.0).

#### Special notes for your reviewer:

To see the deadlock, run the new test without the `controller.go` change:

```
go test -run TestStopDoesNotBlockWhenLeaseCannotBeCreated ./staging/src/k8s.io/component-helpers/apimachinery/lease/
```

The `stopCh` is nil-guarded in `Stop()` because tests build the `controller`
struct directly. A nil channel in the select simply never fires, so zero-value
controllers keep the old behavior.

This should be cherry-picked to release-1.35 and release-1.36, which both ship the
deadlock.

#### Does this PR introduce a user-facing change?

```release-note
Fixed kube-apiserver hanging forever on SIGTERM when its identity Lease cannot be created (e.g. hostname longer than 63 bytes).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```