### PR TITLE
portforward: write listener parse-error message to errOut instead of out

### DIFF
--- a/staging/src/k8s.io/client-go/tools/portforward/portforward.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/portforward.go
@@ -405,7 +405,9 @@ func (pf *PortForwarder) getListener(protocol string, hostname string, port *For
 	localPortUInt, err := strconv.ParseUint(localPort, 10, 16)
 
 	if err != nil {
-		fmt.Fprintf(pf.out, "Failed to forward from %s:%d -> %d\n", hostname, localPortUInt, port.Remote)
+		if pf.errOut != nil {
+			fmt.Fprintf(pf.errOut, "Failed to forward from %s:%d -> %d\n", hostname, localPortUInt, port.Remote)
+		}
 		return nil, fmt.Errorf("error parsing local port: %s from %s (%s)", err, listenerAddress, host)
 	}
 	port.Local = uint16(localPortUInt)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig cli
/area kubectl

#### What this PR does / why we need it:

Per review feedback from @soltysh: rather than introducing logger-based gating for the per-connection message, make the existing `out`/`errOut` streams consistent so that stdout can simply be redirected to `/dev/null` to silence the informational output.

The `Failed to forward from ...` message in `getListener` is an error, but it was written to `pf.out` (stdout) — and without the nil guard every other `out`/`errOut` call site in this file has, so a caller passing `out=nil` would panic on that path. This PR routes it to `pf.errOut` instead.

With this change all informational messages (`Forwarding from ...`, `Handling connection for ...`) go to `out` and all errors go to `errOut`, so `kubectl port-forward > /dev/null` keeps the noise quiet without hiding errors.

#### Which issue(s) this PR fixes:

Fixes #140243

#### Special notes for your reviewer:

- The change is in `staging/src/k8s.io/client-go/tools/portforward` (client-go is the source of truth).
- The earlier revision of this PR gated `Handling connection for <port>` behind `V(2)`; that approach and its test were dropped in favor of this stream fix, as suggested in review.

#### Does this PR introduce a user-facing change?

```release-note
kubectl port-forward: the "Failed to forward from ..." error message is now written to stderr instead of stdout, so redirecting stdout no longer hides it. All informational port-forward messages remain on stdout.
```
