### PR TITLE
[FG: InPlacePodVerticalScalingExclusiveCPUs] cpu quota limit status set equal to request for pods with exclusive cpus

### DIFF
--- a/pkg/kubelet/cm/fake_container_manager.go
+++ b/pkg/kubelet/cm/fake_container_manager.go
@@ -48,6 +48,8 @@ type FakeContainerManager struct {
 	nodeConfig                          NodeConfig
 	cpuManager                          cpumanager.Manager
 	memoryManager                       memorymanager.Manager
+	// ExclusiveCPUs controls the return value of ContainerHasExclusiveCPUs and PodHasExclusiveCPUs.
+	ExclusiveCPUs bool
 }
 
 var _ ContainerManager = &FakeContainerManager{}
@@ -287,9 +289,9 @@ func (cm *FakeContainerManager) Updates() <-chan resourceupdates.Update {
 }
 
 func (cm *FakeContainerManager) PodHasExclusiveCPUs(logger klog.Logger, pod *v1.Pod) bool {
-	return false
+	return cm.ExclusiveCPUs
 }
 
 func (cm *FakeContainerManager) ContainerHasExclusiveCPUs(logger klog.Logger, pod *v1.Pod, container *v1.Container) bool {
-	return false
+	return cm.ExclusiveCPUs
 }

--- a/pkg/kubelet/cm/fake_container_manager.go
+++ b/pkg/kubelet/cm/fake_container_manager.go
@@ -48,6 +48,8 @@ type FakeContainerManager struct {
 	nodeConfig                          NodeConfig
 	cpuManager                          cpumanager.Manager
 	memoryManager                       memorymanager.Manager
+	// ExclusiveCPUs controls the return value of ContainerHasExclusiveCPUs and PodHasExclusiveCPUs.
+	ExclusiveCPUs bool
 }
 
 var _ ContainerManager = &FakeContainerManager{}
@@ -301,9 +303,9 @@ func (cm *FakeContainerManager) Updates() <-chan resourceupdates.Update {
 }
 
 func (cm *FakeContainerManager) PodHasExclusiveCPUs(_ klog.Logger, _ *v1.Pod) bool {
-	return false
+	return cm.ExclusiveCPUs
 }
 
 func (cm *FakeContainerManager) ContainerHasExclusiveCPUs(_ klog.Logger, _ *v1.Pod, _ *v1.Container) bool {
-	return false
+	return cm.ExclusiveCPUs
 }

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2467,10 +2467,8 @@ func (kl *Kubelet) convertToAPIContainerStatuses(ctx context.Context, pod *v1.Po
 					resources.Limits[v1.ResourceCPU] = cStatus.Resources.CPULimit.DeepCopy()
 				}
 			} else {
-				// To support InPlacePodVerticalScaling of container with exclusive CPUs,
-				// CPULimit and CPURequests must not be set independently, otherwise the resize operation fails.
-				// for that case, and for those containers we update CPULimit equal to CPURequests,
-				// when CPURequest changes.
+				// CPU quota is disabled for containers with exclusive CPUs.
+				// Default the CPU limit to match the request, as it must for exclusive CPU allocation.
 				if kl.containerManager.ContainerHasExclusiveCPUs(logger, pod, allocatedContainer) {
 					resources.Limits[v1.ResourceCPU] = resources.Requests[v1.ResourceCPU].DeepCopy()
 				} else {

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2441,25 +2441,8 @@ func (kl *Kubelet) convertToAPIContainerStatuses(ctx context.Context, pod *v1.Po
 		// For non-running containers this will be the reported values.
 		// For non-resizable resources, these values will also be used.
 		resources := allocatedContainer.Resources.DeepCopy()
-		if resources.Limits != nil {
-			if cStatus.Resources != nil && cStatus.Resources.CPULimit != nil {
-				// If both the allocated & actual resources are at or below the minimum effective limit, preserve the
-				// allocated value in the API to avoid confusion and simplify comparisons.
-				if cStatus.Resources.CPULimit.MilliValue() > cm.MinMilliCPULimit ||
-					resources.Limits.Cpu().MilliValue() > cm.MinMilliCPULimit {
-					resources.Limits[v1.ResourceCPU] = cStatus.Resources.CPULimit.DeepCopy()
-				}
-			} else {
-				preserveOldResourcesValue(v1.ResourceCPU, oldStatus.Resources.Limits, resources.Limits)
-			}
-			if cStatus.Resources != nil && cStatus.Resources.MemoryLimit != nil {
-				resources.Limits[v1.ResourceMemory] = cStatus.Resources.MemoryLimit.DeepCopy()
-			} else {
-				preserveOldResourcesValue(v1.ResourceMemory, oldStatus.Resources.Limits, resources.Limits)
-			}
-		}
 		if resources.Requests != nil {
-			if cStatus.Resources != nil && cStatus.Resources.CPURequest != nil {
+			if cStatus.Resources != nil && cStatus.Resources.CPURequest != nil && !cStatus.Resources.CPURequest.IsZero() {
 				// If both the allocated & actual resources are at or below MinShares, preserve the
 				// allocated value in the API to avoid confusion and simplify comparisons.
 				if cStatus.Resources.CPURequest.MilliValue() > cm.MinShares ||
@@ -2473,6 +2456,31 @@ func (kl *Kubelet) convertToAPIContainerStatuses(ctx context.Context, pod *v1.Po
 				resources.Requests[v1.ResourceMemory] = cStatus.Resources.MemoryRequest.DeepCopy()
 			} else {
 				preserveOldResourcesValue(v1.ResourceMemory, oldStatus.Resources.Requests, resources.Requests)
+			}
+		}
+		if resources.Limits != nil {
+			if cStatus.Resources != nil && cStatus.Resources.CPULimit != nil && !cStatus.Resources.CPULimit.IsZero() {
+				// If both the allocated & actual resources are at or below the minimum effective limit, preserve the
+				// allocated value in the API to avoid confusion and simplify comparisons.
+				if cStatus.Resources.CPULimit.MilliValue() > cm.MinMilliCPULimit ||
+					resources.Limits.Cpu().MilliValue() > cm.MinMilliCPULimit {
+					resources.Limits[v1.ResourceCPU] = cStatus.Resources.CPULimit.DeepCopy()
+				}
+			} else {
+				// To support InPlacePodVerticalScaling of container with exclusive CPUs,
+				// CPULimit and CPURequests must not be set independently, otherwise the resize operation fails.
+				// for that case, and for those containers we update CPULimit equal to CPURequests,
+				// when CPURequest changes.
+				if kl.containerManager.ContainerHasExclusiveCPUs(logger, pod, allocatedContainer) {
+					resources.Limits[v1.ResourceCPU] = resources.Requests[v1.ResourceCPU].DeepCopy()
+				} else {
+					preserveOldResourcesValue(v1.ResourceCPU, oldStatus.Resources.Limits, resources.Limits)
+				}
+			}
+			if cStatus.Resources != nil && cStatus.Resources.MemoryLimit != nil {
+				resources.Limits[v1.ResourceMemory] = cStatus.Resources.MemoryLimit.DeepCopy()
+			} else {
+				preserveOldResourcesValue(v1.ResourceMemory, oldStatus.Resources.Limits, resources.Limits)
 			}
 		}
 

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2465,25 +2465,8 @@ func (kl *Kubelet) convertToAPIContainerStatuses(ctx context.Context, pod *v1.Po
 		// For non-running containers this will be the reported values.
 		// For non-resizable resources, these values will also be used.
 		resources := allocatedContainer.Resources.DeepCopy()
-		if resources.Limits != nil {
-			if cStatus.Resources != nil && cStatus.Resources.CPULimit != nil {
-				// If both the allocated & actual resources are at or below the minimum effective limit, preserve the
-				// allocated value in the API to avoid confusion and simplify comparisons.
-				if cStatus.Resources.CPULimit.MilliValue() > cm.MinMilliCPULimit ||
-					resources.Limits.Cpu().MilliValue() > cm.MinMilliCPULimit {
-					resources.Limits[v1.ResourceCPU] = cStatus.Resources.CPULimit.DeepCopy()
-				}
-			} else {
-				preserveOldResourcesValue(v1.ResourceCPU, oldStatus.Resources.Limits, resources.Limits)
-			}
-			if cStatus.Resources != nil && cStatus.Resources.MemoryLimit != nil {
-				resources.Limits[v1.ResourceMemory] = cStatus.Resources.MemoryLimit.DeepCopy()
-			} else {
-				preserveOldResourcesValue(v1.ResourceMemory, oldStatus.Resources.Limits, resources.Limits)
-			}
-		}
 		if resources.Requests != nil {
-			if cStatus.Resources != nil && cStatus.Resources.CPURequest != nil {
+			if cStatus.Resources != nil && cStatus.Resources.CPURequest != nil && !cStatus.Resources.CPURequest.IsZero() {
 				// If both the allocated & actual resources are at or below MinShares, preserve the
 				// allocated value in the API to avoid confusion and simplify comparisons.
 				if cStatus.Resources.CPURequest.MilliValue() > cm.MinShares ||
@@ -2497,6 +2480,29 @@ func (kl *Kubelet) convertToAPIContainerStatuses(ctx context.Context, pod *v1.Po
 				resources.Requests[v1.ResourceMemory] = cStatus.Resources.MemoryRequest.DeepCopy()
 			} else {
 				preserveOldResourcesValue(v1.ResourceMemory, oldStatus.Resources.Requests, resources.Requests)
+			}
+		}
+		if resources.Limits != nil {
+			if cStatus.Resources != nil && cStatus.Resources.CPULimit != nil && !cStatus.Resources.CPULimit.IsZero() {
+				// If both the allocated & actual resources are at or below the minimum effective limit, preserve the
+				// allocated value in the API to avoid confusion and simplify comparisons.
+				if cStatus.Resources.CPULimit.MilliValue() > cm.MinMilliCPULimit ||
+					resources.Limits.Cpu().MilliValue() > cm.MinMilliCPULimit {
+					resources.Limits[v1.ResourceCPU] = cStatus.Resources.CPULimit.DeepCopy()
+				}
+			} else {
+				// CPU quota is disabled for containers with exclusive CPUs.
+				// Default the CPU limit to match the request, as it must for exclusive CPU allocation.
+				if kl.containerManager.ContainerHasExclusiveCPUs(logger, pod, allocatedContainer) {
+					resources.Limits[v1.ResourceCPU] = resources.Requests[v1.ResourceCPU].DeepCopy()
+				} else {
+					preserveOldResourcesValue(v1.ResourceCPU, oldStatus.Resources.Limits, resources.Limits)
+				}
+			}
+			if cStatus.Resources != nil && cStatus.Resources.MemoryLimit != nil {
+				resources.Limits[v1.ResourceMemory] = cStatus.Resources.MemoryLimit.DeepCopy()
+			} else {
+				preserveOldResourcesValue(v1.ResourceMemory, oldStatus.Resources.Limits, resources.Limits)
 			}
 		}
 

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -54,6 +54,7 @@ import (
 	"k8s.io/cri-streaming/pkg/streaming/remotecommand"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/kubelet/cm"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
@@ -6657,7 +6658,6 @@ func TestConvertToAPIContainerStatusesDataRace(t *testing.T) {
 }
 
 func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
-	logger, tCtx := ktesting.NewTestContext(t)
 	if goruntime.GOOS != "linux" {
 		t.Skip("InPlacePodVerticalScaling cgroup resource reporting is only supported on Linux")
 	}
@@ -6713,7 +6713,9 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 	}
 
 	CPU1AndMem1G := v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("1Gi")}
+	CPU1AndMem2G := v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("2Gi")}
 	CPU2AndMem2G := v1.ResourceList{v1.ResourceCPU: resource.MustParse("2"), v1.ResourceMemory: resource.MustParse("2Gi")}
+	Mem2G := v1.ResourceList{v1.ResourceMemory: resource.MustParse("2Gi")}
 	CPU1AndMem1GAndStorage2G := CPU1AndMem1G.DeepCopy()
 	CPU1AndMem1GAndStorage2G[v1.ResourceEphemeralStorage] = resource.MustParse("2Gi")
 	CPU1AndMem1GAndStorage2G[v1.ResourceStorage] = resource.MustParse("2Gi")
@@ -6743,12 +6745,13 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 
 	idx := 0
 	for tdesc, tc := range map[string]struct {
-		State              kubecontainer.State // Defaults to Running
-		Resources          v1.ResourceRequirements
-		AllocatedResources *v1.ResourceRequirements          // Defaults to Resources
-		ActualResources    *kubecontainer.ContainerResources // Defaults to Resources equivalent
-		OldStatus          v1.ContainerStatus
-		Expected           v1.ContainerStatus
+		State                kubecontainer.State // Defaults to Running
+		Resources            v1.ResourceRequirements
+		AllocatedResources   *v1.ResourceRequirements          // Defaults to Resources
+		ActualResources      *kubecontainer.ContainerResources // Defaults to Resources equivalent
+		OldStatus            v1.ContainerStatus
+		Expected             v1.ContainerStatus
+		MockHasExclusiveCPUs bool // Defines what FakeContainerManager returns
 	}{
 		"GuaranteedQoSPod with CPU and memory CRI status": {
 			Resources: v1.ResourceRequirements{Limits: CPU1AndMem1G, Requests: CPU1AndMem1G},
@@ -7095,8 +7098,97 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 				Resources:          &v1.ResourceRequirements{Limits: CPU1AndMem1GAndStorage2G, Requests: CPU1AndMem1GAndStorage2G},
 			},
 		},
+		"resizing Pod with update of resources without exclusive CPUs": {
+			Resources:          v1.ResourceRequirements{Limits: CPU2AndMem2G, Requests: CPU2AndMem2G},
+			AllocatedResources: &v1.ResourceRequirements{Limits: CPU2AndMem2G, Requests: CPU2AndMem2G},
+			OldStatus: v1.ContainerStatus{
+				Name:      testContainerName,
+				Image:     "img",
+				ImageID:   "img1234",
+				State:     v1.ContainerState{Running: &v1.ContainerStateRunning{}},
+				Resources: &v1.ResourceRequirements{Limits: CPU1AndMem1G, Requests: CPU1AndMem1G},
+			},
+			Expected: v1.ContainerStatus{
+				Name:               testContainerName,
+				ContainerID:        testContainerID.String(),
+				Image:              "img",
+				ImageID:            "img1234",
+				State:              v1.ContainerState{Running: &v1.ContainerStateRunning{StartedAt: metav1.NewTime(nowTime)}},
+				AllocatedResources: CPU2AndMem2G,
+				Resources:          &v1.ResourceRequirements{Limits: CPU2AndMem2G, Requests: CPU2AndMem2G},
+			},
+			MockHasExclusiveCPUs: false,
+		},
+		"resizing Pod with update of resources with exclusive CPUs": {
+			Resources:          v1.ResourceRequirements{Limits: CPU2AndMem2G, Requests: CPU2AndMem2G},
+			AllocatedResources: &v1.ResourceRequirements{Limits: CPU2AndMem2G, Requests: CPU2AndMem2G},
+			OldStatus: v1.ContainerStatus{
+				Name:      testContainerName,
+				Image:     "img",
+				ImageID:   "img1234",
+				State:     v1.ContainerState{Running: &v1.ContainerStateRunning{}},
+				Resources: &v1.ResourceRequirements{Limits: CPU1AndMem1G, Requests: CPU1AndMem1G},
+			},
+			Expected: v1.ContainerStatus{
+				Name:               testContainerName,
+				ContainerID:        testContainerID.String(),
+				Image:              "img",
+				ImageID:            "img1234",
+				State:              v1.ContainerState{Running: &v1.ContainerStateRunning{StartedAt: metav1.NewTime(nowTime)}},
+				AllocatedResources: CPU2AndMem2G,
+				Resources:          &v1.ResourceRequirements{Limits: CPU2AndMem2G, Requests: CPU2AndMem2G},
+			},
+			MockHasExclusiveCPUs: true,
+		},
+		"resizing Pod with update of resources having no CPU limits without exclusive CPUs": {
+			Resources:          v1.ResourceRequirements{Limits: Mem2G, Requests: CPU2AndMem2G},
+			AllocatedResources: &v1.ResourceRequirements{Limits: CPU2AndMem2G, Requests: CPU2AndMem2G},
+			OldStatus: v1.ContainerStatus{
+				Name:        testContainerName,
+				ContainerID: testContainerID.String(),
+				Image:       "img",
+				ImageID:     "img1234",
+				State:       v1.ContainerState{Running: &v1.ContainerStateRunning{}},
+				Resources:   &v1.ResourceRequirements{Limits: CPU1AndMem1G, Requests: CPU1AndMem1G},
+			},
+			Expected: v1.ContainerStatus{
+				Name:               testContainerName,
+				ContainerID:        testContainerID.String(),
+				Image:              "img",
+				ImageID:            "img1234",
+				State:              v1.ContainerState{Running: &v1.ContainerStateRunning{StartedAt: metav1.NewTime(nowTime)}},
+				AllocatedResources: CPU2AndMem2G,
+				// This is behavior expected in this test case: CPU Limit is not updated and preserves old status value (1 CPU).
+				Resources: &v1.ResourceRequirements{Limits: CPU1AndMem2G, Requests: CPU2AndMem2G},
+			},
+			MockHasExclusiveCPUs: false,
+		},
+		"resizing Pod with update of resources having no CPU limits with exclusive CPUs": {
+			Resources:          v1.ResourceRequirements{Limits: Mem2G, Requests: CPU2AndMem2G},
+			AllocatedResources: &v1.ResourceRequirements{Limits: CPU2AndMem2G, Requests: CPU2AndMem2G},
+			OldStatus: v1.ContainerStatus{
+				Name:        testContainerName,
+				ContainerID: testContainerID.String(),
+				Image:       "img",
+				ImageID:     "img1234",
+				State:       v1.ContainerState{Running: &v1.ContainerStateRunning{}},
+				Resources:   &v1.ResourceRequirements{Limits: CPU1AndMem1G, Requests: CPU1AndMem1G},
+			},
+			Expected: v1.ContainerStatus{
+				Name:               testContainerName,
+				ContainerID:        testContainerID.String(),
+				Image:              "img",
+				ImageID:            "img1234",
+				State:              v1.ContainerState{Running: &v1.ContainerStateRunning{StartedAt: metav1.NewTime(nowTime)}},
+				AllocatedResources: CPU2AndMem2G,
+				Resources:          &v1.ResourceRequirements{Limits: CPU2AndMem2G, Requests: CPU2AndMem2G},
+			},
+			MockHasExclusiveCPUs: true,
+		},
 	} {
 		t.Run(tdesc, func(t *testing.T) {
+			logger, tCtx := ktesting.NewTestContext(t)
+
 			tPod := testPod.DeepCopy()
 			tPod.Name = fmt.Sprintf("%s-%d", testPod.Name, idx)
 
@@ -7121,6 +7213,11 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 				state = tc.State
 			}
 			podStatus := testPodStatus(state, resources)
+			if fakeCM, ok := kubelet.containerManager.(*cm.FakeContainerManager); ok {
+				fakeCM.ExclusiveCPUs = tc.MockHasExclusiveCPUs
+				hasExclusiveCPUs := kubelet.containerManager.ContainerHasExclusiveCPUs(logger, tPod, &tPod.Spec.Containers[0])
+				assert.Equal(t, tc.MockHasExclusiveCPUs, hasExclusiveCPUs)
+			}
 			cStatuses := kubelet.convertToAPIContainerStatuses(tCtx, tPod, podStatus, []v1.ContainerStatus{tc.OldStatus}, tPod.Spec.Containers, nil, false, false, false)
 			actual := cStatuses[0]
 			// Explicitly test AllocatedResources and Resources separately for debuggability.

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -53,6 +53,7 @@ import (
 	"k8s.io/cri-streaming/pkg/streaming/remotecommand"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/kubelet/cm"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
@@ -6575,7 +6576,6 @@ func TestConvertToAPIContainerStatusesDataRace(t *testing.T) {
 }
 
 func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
-	logger, tCtx := ktesting.NewTestContext(t)
 	if goruntime.GOOS != "linux" {
 		t.Skip("InPlacePodVerticalScaling cgroup resource reporting is only supported on Linux")
 	}
@@ -6631,7 +6631,9 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 	}
 
 	CPU1AndMem1G := v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("1Gi")}
+	CPU1AndMem2G := v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("2Gi")}
 	CPU2AndMem2G := v1.ResourceList{v1.ResourceCPU: resource.MustParse("2"), v1.ResourceMemory: resource.MustParse("2Gi")}
+	Mem2G := v1.ResourceList{v1.ResourceMemory: resource.MustParse("2Gi")}
 	CPU1AndMem1GAndStorage2G := CPU1AndMem1G.DeepCopy()
 	CPU1AndMem1GAndStorage2G[v1.ResourceEphemeralStorage] = resource.MustParse("2Gi")
 	CPU1AndMem1GAndStorage2G[v1.ResourceStorage] = resource.MustParse("2Gi")
@@ -6661,12 +6663,13 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 
 	idx := 0
 	for tdesc, tc := range map[string]struct {
-		State              kubecontainer.State // Defaults to Running
-		Resources          v1.ResourceRequirements
-		AllocatedResources *v1.ResourceRequirements          // Defaults to Resources
-		ActualResources    *kubecontainer.ContainerResources // Defaults to Resources equivalent
-		OldStatus          v1.ContainerStatus
-		Expected           v1.ContainerStatus
+		State                kubecontainer.State // Defaults to Running
+		Resources            v1.ResourceRequirements
+		AllocatedResources   *v1.ResourceRequirements          // Defaults to Resources
+		ActualResources      *kubecontainer.ContainerResources // Defaults to Resources equivalent
+		OldStatus            v1.ContainerStatus
+		Expected             v1.ContainerStatus
+		MockHasExclusiveCPUs bool // Defines what FakeContainerManager returns
 	}{
 		"GuaranteedQoSPod with CPU and memory CRI status": {
 			Resources: v1.ResourceRequirements{Limits: CPU1AndMem1G, Requests: CPU1AndMem1G},
@@ -7013,8 +7016,97 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 				Resources:          &v1.ResourceRequirements{Limits: CPU1AndMem1GAndStorage2G, Requests: CPU1AndMem1GAndStorage2G},
 			},
 		},
+		"resizing Pod with update of resources without exclusive CPUs": {
+			Resources:          v1.ResourceRequirements{Limits: CPU2AndMem2G, Requests: CPU2AndMem2G},
+			AllocatedResources: &v1.ResourceRequirements{Limits: CPU2AndMem2G, Requests: CPU2AndMem2G},
+			OldStatus: v1.ContainerStatus{
+				Name:      testContainerName,
+				Image:     "img",
+				ImageID:   "img1234",
+				State:     v1.ContainerState{Running: &v1.ContainerStateRunning{}},
+				Resources: &v1.ResourceRequirements{Limits: CPU1AndMem1G, Requests: CPU1AndMem1G},
+			},
+			Expected: v1.ContainerStatus{
+				Name:               testContainerName,
+				ContainerID:        testContainerID.String(),
+				Image:              "img",
+				ImageID:            "img1234",
+				State:              v1.ContainerState{Running: &v1.ContainerStateRunning{StartedAt: metav1.NewTime(nowTime)}},
+				AllocatedResources: CPU2AndMem2G,
+				Resources:          &v1.ResourceRequirements{Limits: CPU2AndMem2G, Requests: CPU2AndMem2G},
+			},
+			MockHasExclusiveCPUs: false,
+		},
+		"resizing Pod with update of resources with exclusive CPUs": {
+			Resources:          v1.ResourceRequirements{Limits: CPU2AndMem2G, Requests: CPU2AndMem2G},
+			AllocatedResources: &v1.ResourceRequirements{Limits: CPU2AndMem2G, Requests: CPU2AndMem2G},
+			OldStatus: v1.ContainerStatus{
+				Name:      testContainerName,
+				Image:     "img",
+				ImageID:   "img1234",
+				State:     v1.ContainerState{Running: &v1.ContainerStateRunning{}},
+				Resources: &v1.ResourceRequirements{Limits: CPU1AndMem1G, Requests: CPU1AndMem1G},
+			},
+			Expected: v1.ContainerStatus{
+				Name:               testContainerName,
+				ContainerID:        testContainerID.String(),
+				Image:              "img",
+				ImageID:            "img1234",
+				State:              v1.ContainerState{Running: &v1.ContainerStateRunning{StartedAt: metav1.NewTime(nowTime)}},
+				AllocatedResources: CPU2AndMem2G,
+				Resources:          &v1.ResourceRequirements{Limits: CPU2AndMem2G, Requests: CPU2AndMem2G},
+			},
+			MockHasExclusiveCPUs: true,
+		},
+		"resizing Pod with update of resources having no CPU limits without exclusive CPUs": {
+			Resources:          v1.ResourceRequirements{Limits: Mem2G, Requests: CPU2AndMem2G},
+			AllocatedResources: &v1.ResourceRequirements{Limits: CPU2AndMem2G, Requests: CPU2AndMem2G},
+			OldStatus: v1.ContainerStatus{
+				Name:        testContainerName,
+				ContainerID: testContainerID.String(),
+				Image:       "img",
+				ImageID:     "img1234",
+				State:       v1.ContainerState{Running: &v1.ContainerStateRunning{}},
+				Resources:   &v1.ResourceRequirements{Limits: CPU1AndMem1G, Requests: CPU1AndMem1G},
+			},
+			Expected: v1.ContainerStatus{
+				Name:               testContainerName,
+				ContainerID:        testContainerID.String(),
+				Image:              "img",
+				ImageID:            "img1234",
+				State:              v1.ContainerState{Running: &v1.ContainerStateRunning{StartedAt: metav1.NewTime(nowTime)}},
+				AllocatedResources: CPU2AndMem2G,
+				// This is behavior expected in this test case: CPU Limit is not updated and preserves old status value (1 CPU).
+				Resources: &v1.ResourceRequirements{Limits: CPU1AndMem2G, Requests: CPU2AndMem2G},
+			},
+			MockHasExclusiveCPUs: false,
+		},
+		"resizing Pod with update of resources having no CPU limits with exclusive CPUs": {
+			Resources:          v1.ResourceRequirements{Limits: Mem2G, Requests: CPU2AndMem2G},
+			AllocatedResources: &v1.ResourceRequirements{Limits: CPU2AndMem2G, Requests: CPU2AndMem2G},
+			OldStatus: v1.ContainerStatus{
+				Name:        testContainerName,
+				ContainerID: testContainerID.String(),
+				Image:       "img",
+				ImageID:     "img1234",
+				State:       v1.ContainerState{Running: &v1.ContainerStateRunning{}},
+				Resources:   &v1.ResourceRequirements{Limits: CPU1AndMem1G, Requests: CPU1AndMem1G},
+			},
+			Expected: v1.ContainerStatus{
+				Name:               testContainerName,
+				ContainerID:        testContainerID.String(),
+				Image:              "img",
+				ImageID:            "img1234",
+				State:              v1.ContainerState{Running: &v1.ContainerStateRunning{StartedAt: metav1.NewTime(nowTime)}},
+				AllocatedResources: CPU2AndMem2G,
+				Resources:          &v1.ResourceRequirements{Limits: CPU2AndMem2G, Requests: CPU2AndMem2G},
+			},
+			MockHasExclusiveCPUs: true,
+		},
 	} {
 		t.Run(tdesc, func(t *testing.T) {
+			logger, tCtx := ktesting.NewTestContext(t)
+
 			tPod := testPod.DeepCopy()
 			tPod.Name = fmt.Sprintf("%s-%d", testPod.Name, idx)
 
@@ -7039,6 +7131,11 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 				state = tc.State
 			}
 			podStatus := testPodStatus(state, resources)
+			if fakeCM, ok := kubelet.containerManager.(*cm.FakeContainerManager); ok {
+				fakeCM.ExclusiveCPUs = tc.MockHasExclusiveCPUs
+				hasExclusiveCPUs := kubelet.containerManager.ContainerHasExclusiveCPUs(logger, tPod, &tPod.Spec.Containers[0])
+				assert.Equal(t, tc.MockHasExclusiveCPUs, hasExclusiveCPUs)
+			}
 			cStatuses := kubelet.convertToAPIContainerStatuses(tCtx, tPod, podStatus, []v1.ContainerStatus{tc.OldStatus}, tPod.Spec.Containers, nil, false, false, false)
 			actual := cStatuses[0]
 			// Explicitly test AllocatedResources and Resources separately for debuggability.

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -138,9 +138,9 @@ func (m *kubeGenericRuntimeManager) generateLinuxContainerResources(ctx context.
 
 	// If pod has exclusive cpu and the container in question has integer cpu requests
 	// the cfs quota will not be enforced
-	disableCPUQuota := utilfeature.DefaultFeatureGate.Enabled(kubefeatures.DisableCPUQuotaWithExclusiveCPUs) && m.containerManager.ContainerHasExclusiveCPUs(logger, pod, container)
-	logger.V(5).Info("Enforcing CFS quota", "pod", klog.KObj(pod), "unlimited", disableCPUQuota)
-	lcr := m.calculateLinuxResources(cpuRequest, cpuLimit, memoryLimit, disableCPUQuota)
+	hasExclusiveCPUs := m.containerManager.ContainerHasExclusiveCPUs(logger, pod, container)
+	logger.V(5).Info("Enforcing CFS quota", "pod", klog.KObj(pod), "hasExclusiveCPUs", hasExclusiveCPUs)
+	lcr := m.calculateLinuxResources(cpuRequest, cpuLimit, memoryLimit, hasExclusiveCPUs)
 
 	lcr.OomScoreAdj = int64(qos.GetContainerOOMScoreAdjust(pod, container,
 		int64(m.machineInfo.MemoryCapacity)))
@@ -289,7 +289,7 @@ func (m *kubeGenericRuntimeManager) generateUpdatePodSandboxResourcesRequest(san
 }
 
 // calculateLinuxResources will create the linuxContainerResources type based on the provided CPU and memory resource requests, limits
-func (m *kubeGenericRuntimeManager) calculateLinuxResources(cpuRequest, cpuLimit, memoryLimit *resource.Quantity, disableCPUQuota bool) *runtimeapi.LinuxContainerResources {
+func (m *kubeGenericRuntimeManager) calculateLinuxResources(cpuRequest, cpuLimit, memoryLimit *resource.Quantity, hasExclusiveCPUs bool) *runtimeapi.LinuxContainerResources {
 	resources := runtimeapi.LinuxContainerResources{}
 	var cpuShares int64
 
@@ -321,7 +321,8 @@ func (m *kubeGenericRuntimeManager) calculateLinuxResources(cpuRequest, cpuLimit
 		}
 		cpuQuota := cm.MilliCPUToQuota(cpuLimit.MilliValue(), cpuPeriod)
 		resources.CpuQuota = cpuQuota
-		if disableCPUQuota {
+		// If pod has exclusive cpu the sandbox will not have cfs quota enforced
+		if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.DisableCPUQuotaWithExclusiveCPUs) && hasExclusiveCPUs {
 			resources.CpuQuota = int64(-1)
 		}
 		resources.CpuPeriod = cpuPeriod

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -187,9 +187,9 @@ func (m *kubeGenericRuntimeManager) generateLinuxContainerResources(ctx context.
 
 	// If pod has exclusive cpu and the container in question has integer cpu requests
 	// the cfs quota will not be enforced
-	disableCPUQuota := utilfeature.DefaultFeatureGate.Enabled(kubefeatures.DisableCPUQuotaWithExclusiveCPUs) && m.containerManager.ContainerHasExclusiveCPUs(logger, pod, container)
-	logger.V(5).Info("Enforcing CFS quota", "pod", klog.KObj(pod), "unlimited", disableCPUQuota)
-	lcr := m.calculateLinuxResources(cpuRequest, cpuLimit, memoryLimit, disableCPUQuota)
+	hasExclusiveCPUs := m.containerManager.ContainerHasExclusiveCPUs(logger, pod, container)
+	logger.V(5).Info("Enforcing CFS quota", "pod", klog.KObj(pod), "unlimited", hasExclusiveCPUs)
+	lcr := m.calculateLinuxResources(cpuRequest, cpuLimit, memoryLimit, hasExclusiveCPUs)
 
 	lcr.OomScoreAdj = int64(qos.GetContainerOOMScoreAdjust(pod, container,
 		int64(m.machineInfo.MemoryCapacity)))
@@ -352,7 +352,7 @@ func (m *kubeGenericRuntimeManager) generateUpdatePodSandboxResourcesRequest(san
 }
 
 // calculateLinuxResources will create the linuxContainerResources type based on the provided CPU and memory resource requests, limits
-func (m *kubeGenericRuntimeManager) calculateLinuxResources(cpuRequest, cpuLimit, memoryLimit *resource.Quantity, disableCPUQuota bool) *runtimeapi.LinuxContainerResources {
+func (m *kubeGenericRuntimeManager) calculateLinuxResources(cpuRequest, cpuLimit, memoryLimit *resource.Quantity, hasExclusiveCPUs bool) *runtimeapi.LinuxContainerResources {
 	resources := runtimeapi.LinuxContainerResources{}
 	var cpuShares int64
 
@@ -384,7 +384,8 @@ func (m *kubeGenericRuntimeManager) calculateLinuxResources(cpuRequest, cpuLimit
 		}
 		cpuQuota := cm.MilliCPUToQuota(cpuLimit.MilliValue(), cpuPeriod)
 		resources.CpuQuota = cpuQuota
-		if disableCPUQuota {
+		// If pod has exclusive cpu the sandbox will not have cfs quota enforced
+		if hasExclusiveCPUs {
 			resources.CpuQuota = int64(-1)
 		}
 		resources.CpuPeriod = cpuPeriod

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
@@ -402,6 +402,7 @@ func TestCalculateLinuxResources(t *testing.T) {
 		expected             *runtimeapi.LinuxContainerResources
 		cgroupVersion        CgroupVersion
 		singleProcessOOMKill bool
+		hasExclusiveCPUs     bool
 	}{
 		{
 			name:   "Request128MBLimit256MB",
@@ -523,11 +524,26 @@ func TestCalculateLinuxResources(t *testing.T) {
 			},
 			cgroupVersion: cgroupV2,
 		},
+		{
+			name:   "RequestExclusiveCPU",
+			cpuReq: generateResourceQuantity("2"),
+			cpuLim: generateResourceQuantity("2"),
+			memLim: generateResourceQuantity("0"),
+			expected: &runtimeapi.LinuxContainerResources{
+				CpuPeriod:          100000,
+				CpuQuota:           -1,
+				CpuShares:          2048,
+				MemoryLimitInBytes: 0,
+				Unified:            map[string]string{"memory.oom.group": "1"},
+			},
+			cgroupVersion:    cgroupV2,
+			hasExclusiveCPUs: true,
+		},
 	}
 	for _, test := range tests {
 		setCgroupVersionDuringTest(test.cgroupVersion)
 		m.singleProcessOOMKill = ptr.To(test.singleProcessOOMKill)
-		linuxContainerResources := m.calculateLinuxResources(test.cpuReq, test.cpuLim, test.memLim, false)
+		linuxContainerResources := m.calculateLinuxResources(test.cpuReq, test.cpuLim, test.memLim, test.hasExclusiveCPUs)
 		assert.Equal(t, test.expected, linuxContainerResources)
 	}
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
@@ -403,6 +403,7 @@ func TestCalculateLinuxResources(t *testing.T) {
 		expected             *runtimeapi.LinuxContainerResources
 		cgroupVersion        CgroupVersion
 		singleProcessOOMKill bool
+		hasExclusiveCPUs     bool
 	}{
 		{
 			name:   "Request128MBLimit256MB",
@@ -524,11 +525,26 @@ func TestCalculateLinuxResources(t *testing.T) {
 			},
 			cgroupVersion: cgroupV2,
 		},
+		{
+			name:   "RequestExclusiveCPU",
+			cpuReq: generateResourceQuantity("2"),
+			cpuLim: generateResourceQuantity("2"),
+			memLim: generateResourceQuantity("0"),
+			expected: &runtimeapi.LinuxContainerResources{
+				CpuPeriod:          100000,
+				CpuQuota:           -1,
+				CpuShares:          2048,
+				MemoryLimitInBytes: 0,
+				Unified:            map[string]string{"memory.oom.group": "1"},
+			},
+			cgroupVersion:    cgroupV2,
+			hasExclusiveCPUs: true,
+		},
 	}
 	for _, test := range tests {
 		setCgroupVersionDuringTest(test.cgroupVersion)
 		m.singleProcessOOMKill = ptr.To(test.singleProcessOOMKill)
-		linuxContainerResources := m.calculateLinuxResources(test.cpuReq, test.cpuLim, test.memLim, false)
+		linuxContainerResources := m.calculateLinuxResources(test.cpuReq, test.cpuLim, test.memLim, test.hasExclusiveCPUs)
 		assert.Equal(t, test.expected, linuxContainerResources)
 	}
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux.go
@@ -59,11 +59,9 @@ func (m *kubeGenericRuntimeManager) calculateSandboxResources(ctx context.Contex
 		cpuRequest = req.Cpu()
 	}
 
-	// If pod has exclusive cpu the sandbox will not have cfs quote enforced
-	disableCPUQuota := utilfeature.DefaultFeatureGate.Enabled(features.DisableCPUQuotaWithExclusiveCPUs) && m.containerManager.PodHasExclusiveCPUs(logger, pod)
-
-	logger.V(5).Info("Enforcing CFS quota", "pod", klog.KObj(pod), "unlimited", disableCPUQuota)
-	return m.calculateLinuxResources(cpuRequest, lim.Cpu(), lim.Memory(), disableCPUQuota)
+	// If pod has exclusive cpu the sandbox will not have cfs quota enforced
+	hasExclusiveCPUs := m.containerManager.PodHasExclusiveCPUs(logger, pod)
+	return m.calculateLinuxResources(cpuRequest, lim.Cpu(), lim.Memory(), hasExclusiveCPUs)
 }
 
 func (m *kubeGenericRuntimeManager) applySandboxResources(ctx context.Context, pod *v1.Pod, config *runtimeapi.PodSandboxConfig) error {

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux.go
@@ -59,11 +59,11 @@ func (m *kubeGenericRuntimeManager) calculateSandboxResources(ctx context.Contex
 		cpuRequest = req.Cpu()
 	}
 
-	// If pod has exclusive cpu the sandbox will not have cfs quote enforced
-	disableCPUQuota := utilfeature.DefaultFeatureGate.Enabled(features.DisableCPUQuotaWithExclusiveCPUs) && m.containerManager.PodHasExclusiveCPUs(logger, pod)
+	// If pod has exclusive cpu the sandbox will not have cfs quota enforced
+	hasExclusiveCPUs := m.containerManager.PodHasExclusiveCPUs(logger, pod)
 
-	logger.V(5).Info("Enforcing CFS quota", "pod", klog.KObj(pod), "unlimited", disableCPUQuota)
-	return m.calculateLinuxResources(cpuRequest, lim.Cpu(), lim.Memory(), disableCPUQuota)
+	logger.V(5).Info("Enforcing CFS quota", "pod", klog.KObj(pod), "unlimited", hasExclusiveCPUs)
+	return m.calculateLinuxResources(cpuRequest, lim.Cpu(), lim.Memory(), hasExclusiveCPUs)
 }
 
 func (m *kubeGenericRuntimeManager) applySandboxResources(ctx context.Context, pod *v1.Pod, config *runtimeapi.PodSandboxConfig) error {

--- a/test/e2e_node/cpu_manager_test.go
+++ b/test/e2e_node/cpu_manager_test.go
@@ -1764,6 +1764,8 @@ var _ = SIGDescribe("CPU Manager", ginkgo.Ordered, ginkgo.ContinueOnFailure, fra
 
 			gomega.Expect(pod).To(HaveSandboxQuota("max"))
 			gomega.Expect(pod).To(HaveContainerQuota(ctnName, "max"))
+			gomega.Expect(pod).To(HaveContainerStatusCPULimits(ctnName, ""))
+			gomega.Expect(pod).To(HaveContainerStatusCPURequests(ctnName, ""))
 		})
 
 		ginkgo.It("should disable for guaranteed pod with exclusive single CPU assigned", func(ctx context.Context) {
@@ -1783,6 +1785,8 @@ var _ = SIGDescribe("CPU Manager", ginkgo.Ordered, ginkgo.ContinueOnFailure, fra
 
 			gomega.Expect(pod).To(HaveSandboxQuota("max"))
 			gomega.Expect(pod).To(HaveContainerQuota(ctnName, "max"))
+			gomega.Expect(pod).To(HaveContainerStatusCPULimits(ctnName, "1"))
+			gomega.Expect(pod).To(HaveContainerStatusCPURequests(ctnName, "1"))
 		})
 
 		ginkgo.It("should disable for guaranteed pod with exclusive four CPUs assigned", func(ctx context.Context) {
@@ -1802,6 +1806,8 @@ var _ = SIGDescribe("CPU Manager", ginkgo.Ordered, ginkgo.ContinueOnFailure, fra
 
 			gomega.Expect(pod).To(HaveSandboxQuota("max"))
 			gomega.Expect(pod).To(HaveContainerQuota(ctnName, "max"))
+			gomega.Expect(pod).To(HaveContainerStatusCPULimits(ctnName, "3"))
+			gomega.Expect(pod).To(HaveContainerStatusCPURequests(ctnName, "3"))
 
 			gomega.Expect(pod).To(HaveContainerCPUsCount(ctnName, 3))
 			gomega.Expect(pod).To(HaveContainerCPUsASubsetOf(ctnName, onlineCPUs))
@@ -1825,6 +1831,8 @@ var _ = SIGDescribe("CPU Manager", ginkgo.Ordered, ginkgo.ContinueOnFailure, fra
 
 			gomega.Expect(pod).To(HaveSandboxQuota("50000"))
 			gomega.Expect(pod).To(HaveContainerQuota(ctnName, "50000"))
+			gomega.Expect(pod).To(HaveContainerStatusCPULimits(ctnName, "500m"))
+			gomega.Expect(pod).To(HaveContainerStatusCPURequests(ctnName, "500m"))
 		})
 
 		ginkgo.It("should enforce for burstable pod", func(ctx context.Context) {
@@ -1843,6 +1851,8 @@ var _ = SIGDescribe("CPU Manager", ginkgo.Ordered, ginkgo.ContinueOnFailure, fra
 
 			gomega.Expect(pod).To(HaveSandboxQuota("50000"))
 			gomega.Expect(pod).To(HaveContainerQuota(ctnName, "50000"))
+			gomega.Expect(pod).To(HaveContainerStatusCPULimits(ctnName, "500m"))
+			gomega.Expect(pod).To(HaveContainerStatusCPURequests(ctnName, "100m"))
 		})
 
 		ginkgo.It("should not enforce with multiple containers without exclusive CPUs", func(ctx context.Context) {
@@ -1867,6 +1877,10 @@ var _ = SIGDescribe("CPU Manager", ginkgo.Ordered, ginkgo.ContinueOnFailure, fra
 			gomega.Expect(pod).To(HaveSandboxQuota("170000"))
 			gomega.Expect(pod).To(HaveContainerQuota("gu-container-non-int-values-1", "50000"))
 			gomega.Expect(pod).To(HaveContainerQuota("gu-container-non-int-values-2", "120000"))
+			gomega.Expect(pod).To(HaveContainerStatusCPULimits("gu-container-non-int-values-1", "500m"))
+			gomega.Expect(pod).To(HaveContainerStatusCPURequests("gu-container-non-int-values-1", "100m"))
+			gomega.Expect(pod).To(HaveContainerStatusCPULimits("gu-container-non-int-values-2", "1200m"))
+			gomega.Expect(pod).To(HaveContainerStatusCPURequests("gu-container-non-int-values-2", "300m"))
 		})
 
 		ginkgo.It("should not enforce with multiple containers only in the container with exclusive CPUs", func(ctx context.Context) {
@@ -1891,6 +1905,10 @@ var _ = SIGDescribe("CPU Manager", ginkgo.Ordered, ginkgo.ContinueOnFailure, fra
 			gomega.Expect(pod).To(HaveSandboxQuota("max"))
 			gomega.Expect(pod).To(HaveContainerQuota("gu-container-non-int-values", "50000"))
 			gomega.Expect(pod).To(HaveContainerQuota("gu-container-int-values", "max"))
+			gomega.Expect(pod).To(HaveContainerStatusCPULimits("gu-container-non-int-values", "500m"))
+			gomega.Expect(pod).To(HaveContainerStatusCPURequests("gu-container-non-int-values", "500m"))
+			gomega.Expect(pod).To(HaveContainerStatusCPULimits("gu-container-int-values", "1"))
+			gomega.Expect(pod).To(HaveContainerStatusCPURequests("gu-container-int-values", "1"))
 		})
 	})
 
@@ -3398,6 +3416,44 @@ func HaveStatusReasonMatchingRegex(expr string) types.GomegaMatcher {
 		}
 		return re.MatchString(actual.Status.Reason), nil
 	}).WithTemplate("Pod {{.Actual.Namespace}}/{{.Actual.Name}} UID {{.Actual.UID}} reason {{.Actual.Status.Reason}} does not match regexp {{.Data}}", expr)
+}
+
+func HaveContainerStatusCPULimits(ctnName, expected string) types.GomegaMatcher {
+	md := &msgData{
+		Name:         ctnName,
+		ExpectedCPUs: expected,
+	}
+	return gcustom.MakeMatcher(func(actual *v1.Pod) (bool, error) {
+		if actual != nil {
+			for _, ctnStatus := range actual.Status.ContainerStatuses {
+				if ctnStatus.Name == ctnName {
+					if ctnStatus.Resources != nil && ctnStatus.Resources.Limits != nil {
+						md.CurrentCPUs = ctnStatus.Resources.Limits.Cpu().String()
+					}
+				}
+			}
+		}
+		return md.ExpectedCPUs == md.CurrentCPUs, nil
+	}).WithTemplate("Pod {{.Actual.Namespace}}/{{.Actual.Name}} UID {{.Actual.UID}} has container resources CPU Limits status <{{.Data.CurrentCPUs}}> not matching expected value <{{.Data.ExpectedCPUs}}> for container {{.Data.Name}}", md)
+}
+
+func HaveContainerStatusCPURequests(ctnName, expected string) types.GomegaMatcher {
+	md := &msgData{
+		Name:         ctnName,
+		ExpectedCPUs: expected,
+	}
+	return gcustom.MakeMatcher(func(actual *v1.Pod) (bool, error) {
+		if actual != nil {
+			for _, ctnStatus := range actual.Status.ContainerStatuses {
+				if ctnStatus.Name == ctnName {
+					if ctnStatus.Resources != nil && ctnStatus.Resources.Limits != nil {
+						md.CurrentCPUs = ctnStatus.Resources.Requests.Cpu().String()
+					}
+				}
+			}
+		}
+		return md.ExpectedCPUs == md.CurrentCPUs, nil
+	}).WithTemplate("Pod {{.Actual.Namespace}}/{{.Actual.Name}} UID {{.Actual.UID}} has container resources CPU Requests status <{{.Data.CurrentCPUs}}> not matching expected value <{{.Data.ExpectedCPUs}}> for container {{.Data.Name}}", md)
 }
 
 type msgData struct {

--- a/test/e2e_node/cpu_manager_test.go
+++ b/test/e2e_node/cpu_manager_test.go
@@ -1764,6 +1764,8 @@ var _ = SIGDescribe("CPU Manager", ginkgo.Ordered, ginkgo.ContinueOnFailure, fra
 
 			gomega.Expect(pod).To(HaveSandboxQuota("max"))
 			gomega.Expect(pod).To(HaveContainerQuota(ctnName, "max"))
+			gomega.Expect(pod).To(HaveContainerStatusCPULimits(ctnName, ""))
+			gomega.Expect(pod).To(HaveContainerStatusCPURequests(ctnName, ""))
 		})
 
 		ginkgo.It("should disable for guaranteed pod with exclusive single CPU assigned", func(ctx context.Context) {
@@ -1783,6 +1785,8 @@ var _ = SIGDescribe("CPU Manager", ginkgo.Ordered, ginkgo.ContinueOnFailure, fra
 
 			gomega.Expect(pod).To(HaveSandboxQuota("max"))
 			gomega.Expect(pod).To(HaveContainerQuota(ctnName, "max"))
+			gomega.Expect(pod).To(HaveContainerStatusCPULimits(ctnName, "1"))
+			gomega.Expect(pod).To(HaveContainerStatusCPURequests(ctnName, "1"))
 		})
 
 		ginkgo.It("should disable for guaranteed pod with exclusive four CPUs assigned", func(ctx context.Context) {
@@ -1802,6 +1806,8 @@ var _ = SIGDescribe("CPU Manager", ginkgo.Ordered, ginkgo.ContinueOnFailure, fra
 
 			gomega.Expect(pod).To(HaveSandboxQuota("max"))
 			gomega.Expect(pod).To(HaveContainerQuota(ctnName, "max"))
+			gomega.Expect(pod).To(HaveContainerStatusCPULimits(ctnName, "3"))
+			gomega.Expect(pod).To(HaveContainerStatusCPURequests(ctnName, "3"))
 
 			gomega.Expect(pod).To(HaveContainerCPUsCount(ctnName, 3))
 			gomega.Expect(pod).To(HaveContainerCPUsASubsetOf(ctnName, onlineCPUs))
@@ -1825,6 +1831,8 @@ var _ = SIGDescribe("CPU Manager", ginkgo.Ordered, ginkgo.ContinueOnFailure, fra
 
 			gomega.Expect(pod).To(HaveSandboxQuota("50000"))
 			gomega.Expect(pod).To(HaveContainerQuota(ctnName, "50000"))
+			gomega.Expect(pod).To(HaveContainerStatusCPULimits(ctnName, "500m"))
+			gomega.Expect(pod).To(HaveContainerStatusCPURequests(ctnName, "500m"))
 		})
 
 		ginkgo.It("should enforce for burstable pod", func(ctx context.Context) {
@@ -1843,6 +1851,8 @@ var _ = SIGDescribe("CPU Manager", ginkgo.Ordered, ginkgo.ContinueOnFailure, fra
 
 			gomega.Expect(pod).To(HaveSandboxQuota("50000"))
 			gomega.Expect(pod).To(HaveContainerQuota(ctnName, "50000"))
+			gomega.Expect(pod).To(HaveContainerStatusCPULimits(ctnName, "500m"))
+			gomega.Expect(pod).To(HaveContainerStatusCPURequests(ctnName, "100m"))
 		})
 
 		ginkgo.It("should not enforce with multiple containers without exclusive CPUs", func(ctx context.Context) {
@@ -1867,6 +1877,10 @@ var _ = SIGDescribe("CPU Manager", ginkgo.Ordered, ginkgo.ContinueOnFailure, fra
 			gomega.Expect(pod).To(HaveSandboxQuota("170000"))
 			gomega.Expect(pod).To(HaveContainerQuota("gu-container-non-int-values-1", "50000"))
 			gomega.Expect(pod).To(HaveContainerQuota("gu-container-non-int-values-2", "120000"))
+			gomega.Expect(pod).To(HaveContainerStatusCPULimits("gu-container-non-int-values-1", "500m"))
+			gomega.Expect(pod).To(HaveContainerStatusCPURequests("gu-container-non-int-values-1", "100m"))
+			gomega.Expect(pod).To(HaveContainerStatusCPULimits("gu-container-non-int-values-2", "1200m"))
+			gomega.Expect(pod).To(HaveContainerStatusCPURequests("gu-container-non-int-values-2", "300m"))
 		})
 
 		ginkgo.It("should not enforce with multiple containers only in the container with exclusive CPUs", func(ctx context.Context) {
@@ -1891,6 +1905,10 @@ var _ = SIGDescribe("CPU Manager", ginkgo.Ordered, ginkgo.ContinueOnFailure, fra
 			gomega.Expect(pod).To(HaveSandboxQuota("max"))
 			gomega.Expect(pod).To(HaveContainerQuota("gu-container-non-int-values", "50000"))
 			gomega.Expect(pod).To(HaveContainerQuota("gu-container-int-values", "max"))
+			gomega.Expect(pod).To(HaveContainerStatusCPULimits("gu-container-non-int-values", "500m"))
+			gomega.Expect(pod).To(HaveContainerStatusCPURequests("gu-container-non-int-values", "500m"))
+			gomega.Expect(pod).To(HaveContainerStatusCPULimits("gu-container-int-values", "1"))
+			gomega.Expect(pod).To(HaveContainerStatusCPURequests("gu-container-int-values", "1"))
 		})
 	})
 
@@ -3398,6 +3416,44 @@ func HaveStatusReasonMatchingRegex(expr string) types.GomegaMatcher {
 		}
 		return re.MatchString(actual.Status.Reason), nil
 	}).WithTemplate("Pod {{.Actual.Namespace}}/{{.Actual.Name}} UID {{.Actual.UID}} reason {{.Actual.Status.Reason}} does not match regexp {{.Data}}", expr)
+}
+
+func HaveContainerStatusCPULimits(ctnName, expected string) types.GomegaMatcher {
+	md := &msgData{
+		Name:         ctnName,
+		ExpectedCPUs: expected,
+	}
+	return gcustom.MakeMatcher(func(actual *v1.Pod) (bool, error) {
+		if actual != nil {
+			for _, ctnStatus := range actual.Status.ContainerStatuses {
+				if ctnStatus.Name == ctnName {
+					if ctnStatus.Resources != nil && ctnStatus.Resources.Limits != nil {
+						md.CurrentCPUs = ctnStatus.Resources.Limits.Cpu().String()
+					}
+				}
+			}
+		}
+		return md.ExpectedCPUs == md.CurrentCPUs, nil
+	}).WithTemplate("Pod {{.Actual.Namespace}}/{{.Actual.Name}} UID {{.Actual.UID}} has container resources CPU Limits status <{{.Data.CurrentCPUs}}> not matching expected value <{{.Data.ExpectedCPUs}}> for container {{.Data.Name}}", md)
+}
+
+func HaveContainerStatusCPURequests(ctnName, expected string) types.GomegaMatcher {
+	md := &msgData{
+		Name:         ctnName,
+		ExpectedCPUs: expected,
+	}
+	return gcustom.MakeMatcher(func(actual *v1.Pod) (bool, error) {
+		if actual != nil {
+			for _, ctnStatus := range actual.Status.ContainerStatuses {
+				if ctnStatus.Name == ctnName {
+					if ctnStatus.Resources != nil && ctnStatus.Resources.Requests != nil {
+						md.CurrentCPUs = ctnStatus.Resources.Requests.Cpu().String()
+					}
+				}
+			}
+		}
+		return md.ExpectedCPUs == md.CurrentCPUs, nil
+	}).WithTemplate("Pod {{.Actual.Namespace}}/{{.Actual.Name}} UID {{.Actual.UID}} has container resources CPU Requests status <{{.Data.CurrentCPUs}}> not matching expected value <{{.Data.ExpectedCPUs}}> for container {{.Data.Name}}", md)
 }
 
 type msgData struct {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind feature

#### What this PR does / why we need it:

When pods with exlusive cpus are resized, this commit ensures the new allocated cpu quota limit will be set equal to request, when DisableCPUQuotaWithExclusiveCPUs is enabled ( enabled by default ). This commit is part of the preparation commits for InPlacePodVerticalScalingExclusiveCPUs feature.

Why we need this PR ? 

Please check https://github.com/kubernetes/kubernetes/pull/129719#issuecomment-4777937514 , https://github.com/kubernetes/kubernetes/pull/129719#issuecomment-4778833474 , https://github.com/kubernetes/kubernetes/pull/129719#issuecomment-4777732973 and https://github.com/kubernetes/kubernetes/pull/129719#issuecomment-4842655251

#### Which issue(s) this PR is related to:

KEP https://github.com/kubernetes/enhancements/issues/5554

#### Special notes for your reviewer:

It is part of the decision to split KEP 5554 PR as per https://github.com/kubernetes/kubernetes/pull/129719#discussion_r3500702351 . This is the secondPR from the split which needs to be merged to continue with the PR split. It can be merged standalone

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig node
/priority important-soon
/milestone v1.37

/assign @ffromani @tallclair @natasha41575 
/cc @lukaszwojciechowski @pravk03 
@Chunxia202410