### PR TITLE
kubelet: count rootfs in container ephemeral eviction with dedicated image fs

### DIFF
--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -608,9 +608,7 @@ func (m *managerImpl) containerEphemeralStorageLimitEviction(logger klog.Logger,
 
 	for _, containerStat := range podStats.Containers {
 		containerUsed := diskUsage(containerStat.Logs)
-		if !*m.dedicatedImageFs {
-			containerUsed.Add(*diskUsage(containerStat.Rootfs))
-		}
+		containerUsed.Add(*diskUsage(containerStat.Rootfs))
 
 		if ephemeralStorageThreshold, ok := thresholdsMap[containerStat.Name]; ok {
 			if ephemeralStorageThreshold.Cmp(*containerUsed) < 0 {

--- a/pkg/kubelet/eviction/eviction_manager_test.go
+++ b/pkg/kubelet/eviction/eviction_manager_test.go
@@ -3172,3 +3172,44 @@ func TestContainerEphemeralStorageLimitEvictionForRestartableInitContainers(t *t
 		t.Fatalf("Expected evicted pod %q, got %v", pod.Name, evictedPods)
 	}
 }
+
+func TestContainerEphemeralStorageLimitEvictionWithDedicatedImageFs(t *testing.T) {
+	tCtx := ktesting.Init(t)
+
+	pod := newPod("container-ephemeral-storage-limit", 0, []v1.Container{
+		newContainer("writer", nil, newResourceList("", "", "500Mi")),
+		newContainer("sidecar", nil, newResourceList("", "", "500Mi")),
+	}, nil)
+
+	writer := resource.MustParse("700Mi")
+	writerUsed := uint64(writer.Value())
+	zeroUsed := uint64(0)
+	podStats := statsapi.PodStats{
+		Containers: []statsapi.ContainerStats{
+			{
+				Name:   "writer",
+				Logs:   &statsapi.FsStats{UsedBytes: &zeroUsed},
+				Rootfs: &statsapi.FsStats{UsedBytes: &writerUsed},
+			},
+			{
+				Name:   "sidecar",
+				Logs:   &statsapi.FsStats{UsedBytes: &zeroUsed},
+				Rootfs: &statsapi.FsStats{UsedBytes: &zeroUsed},
+			},
+		},
+	}
+
+	podKiller := &mockPodKiller{}
+	mgr := &managerImpl{
+		killPodFunc:      podKiller.killPodNow,
+		recorder:         &record.FakeRecorder{},
+		dedicatedImageFs: ptr.To(true),
+	}
+
+	if !mgr.containerEphemeralStorageLimitEviction(tCtx.Logger(), podStats, pod) {
+		t.Fatalf("expected pod eviction")
+	}
+	if podKiller.pod != pod {
+		t.Fatalf("expected pod %q to be evicted", pod.Name)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes container ephemeral storage eviction when dedicatedImageFs is enabled. Container rootfs usage was excluded from eviction checks, allowing disk exhaustion.

When dedicatedImageFs is enabled, container ephemeral storage limit eviction must include rootfs usage alongside logs. Skipping rootfs prevented eviction when only writable layer usage exceeded limits.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/139339

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where the kubelet did not count container rootfs usage toward ephemeral storage eviction when dedicated image filesystem is enabled.
```