### PR TITLE
scheduler: check extender filters during preemption dry run

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -338,7 +338,7 @@ func (pl *DefaultPreemption) SelectVictimsOnNode(
 	// inter-pod affinity to one or more victims, but we have decided not to
 	// support this case for performance reasons. Having affinity to lower
 	// importance (priority) pods is not a recommended configuration anyway.
-	if status := pl.fh.RunFilterPluginsWithNominatedPods(ctx, cycleState, preemptor, nodeInfo); !status.IsSuccess() {
+	if status := pl.podFitsOnNode(ctx, cycleState, preemptor, nodeInfo); !status.IsSuccess() {
 		return nil, 0, status
 	}
 
@@ -358,7 +358,7 @@ func (pl *DefaultPreemption) SelectVictimsOnNode(
 			return false, err
 		}
 
-		status := pl.fh.RunFilterPluginsWithNominatedPods(ctx, cycleState, preemptor, nodeInfo)
+		status := pl.podFitsOnNode(ctx, cycleState, preemptor, nodeInfo)
 		fits := status.IsSuccess()
 		if !fits {
 			if err := removeVictim(v); err != nil {
@@ -405,6 +405,42 @@ func (pl *DefaultPreemption) SelectVictimsOnNode(
 	}
 
 	return victimPods, numViolatingVictim, nil
+}
+
+
+func (pl *DefaultPreemption) podFitsOnNode(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
+	status := pl.fh.RunFilterPluginsWithNominatedPods(ctx, state, pod, nodeInfo)
+	if !status.IsSuccess() {
+		return status
+	}
+
+	logger := klog.FromContext(ctx)
+	nodeName := nodeInfo.Node().Name
+	for _, extender := range pl.fh.Extenders() {
+		if !extender.IsFilter() || !extender.IsInterested(pod) {
+			continue
+		}
+		filtered, failed, failedAndUnresolvable, err := extender.Filter(pod, []fwk.NodeInfo{nodeInfo})
+		if err != nil {
+			if extender.IsIgnorable() {
+				logger.V(2).Info("Skipped extender as it returned error and has ignorable flag set",
+					"extender", extender.Name(), "err", err)
+				continue
+			}
+			return fwk.AsStatus(err)
+		}
+		if len(filtered) != 0 {
+			continue
+		}
+		if msg, ok := failedAndUnresolvable[nodeName]; ok {
+			return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, msg)
+		}
+		if msg, ok := failed[nodeName]; ok {
+			return fwk.NewStatus(fwk.Unschedulable, msg)
+		}
+		return fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("node %q rejected by extender %q", nodeName, extender.Name()))
+	}
+	return status
 }
 
 // PodEligibleToPreemptOthers returns one bool and one string. The bool

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -371,7 +371,7 @@ func (pl *DefaultPreemption) SelectVictimsOnNode(
 	// inter-pod affinity to one or more victims, but we have decided not to
 	// support this case for performance reasons. Having affinity to lower
 	// importance (priority) pods is not a recommended configuration anyway.
-	if status := pl.fh.RunFilterPluginsWithNominatedPods(ctx, cycleState, preemptor, nodeInfo); !status.IsSuccess() {
+	if status := pl.podFitsOnNode(ctx, cycleState, preemptor, nodeInfo); !status.IsSuccess() {
 		return nil, 0, status
 	}
 
@@ -391,7 +391,7 @@ func (pl *DefaultPreemption) SelectVictimsOnNode(
 			return false, err
 		}
 
-		status := pl.fh.RunFilterPluginsWithNominatedPods(ctx, cycleState, preemptor, nodeInfo)
+		status := pl.podFitsOnNode(ctx, cycleState, preemptor, nodeInfo)
 		fits := status.IsSuccess()
 		if !fits {
 			if err := removeVictim(v); err != nil {
@@ -438,6 +438,42 @@ func (pl *DefaultPreemption) SelectVictimsOnNode(
 	}
 
 	return victimPods, numViolatingVictim, nil
+}
+
+
+func (pl *DefaultPreemption) podFitsOnNode(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
+	status := pl.fh.RunFilterPluginsWithNominatedPods(ctx, state, pod, nodeInfo)
+	if !status.IsSuccess() {
+		return status
+	}
+
+	logger := klog.FromContext(ctx)
+	nodeName := nodeInfo.Node().Name
+	for _, extender := range pl.fh.Extenders() {
+		if !extender.IsFilter() || !extender.IsInterested(pod) {
+			continue
+		}
+		filtered, failed, failedAndUnresolvable, err := extender.Filter(pod, []fwk.NodeInfo{nodeInfo})
+		if err != nil {
+			if extender.IsIgnorable() {
+				logger.V(2).Info("Skipped extender as it returned error and has ignorable flag set",
+					"extender", extender.Name(), "err", err)
+				continue
+			}
+			return fwk.AsStatus(err)
+		}
+		if len(filtered) != 0 {
+			continue
+		}
+		if msg, ok := failedAndUnresolvable[nodeName]; ok {
+			return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, msg)
+		}
+		if msg, ok := failed[nodeName]; ok {
+			return fwk.NewStatus(fwk.Unschedulable, msg)
+		}
+		return fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("node %q rejected by extender %q", nodeName, extender.Name()))
+	}
+	return status
 }
 
 // PodEligibleToPreemptOthers returns one bool and one string. The bool

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -678,6 +678,7 @@ func TestDryRunPreemption(t *testing.T) {
 		testPods                []*v1.Pod
 		initPods                []*v1.Pod
 		registerPlugins         []tf.RegisterPluginFunc
+		extenders               []*tf.FakeExtender
 		pdbs                    []*policy.PodDisruptionBudget
 		fakeFilterRC            fwk.Code // return code for fake filter plugin
 		disableParallelism      bool
@@ -766,6 +767,28 @@ func TestDryRunPreemption(t *testing.T) {
 			},
 			expectedNumFilterCalled: []int32{4},
 		},
+		{
+			name: "extender filter is checked during preemption dry run",
+			registerPlugins: []tf.RegisterPluginFunc{
+				tf.RegisterPluginAsExtensions(noderesources.Name, nodeResourcesFitFunc, "Filter", "PreFilter"),
+			},
+			extenders: []*tf.FakeExtender{
+				{
+					ExtenderName: "FakeExtender1",
+					Predicates:   []tf.FitPredicate{tf.FalsePredicateExtender},
+				},
+			},
+			nodeNames: []string{"node1"},
+			testPods: []*v1.Pod{
+				st.MakePod().Name("p").UID("p").Priority(highPriority).Req(largeRes).Obj(),
+			},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("p1").UID("p1").Node("node1").Priority(midPriority).Req(largeRes).Obj(),
+			},
+			expected:                [][]candidate{{}},
+			expectedNumFilterCalled: []int32{1},
+		},
+
 		{
 			name: "a pod that would fit on the nodes, but other pods running are higher priority, no preemption would happen",
 			registerPlugins: []tf.RegisterPluginFunc{
@@ -1340,6 +1363,10 @@ func TestDryRunPreemption(t *testing.T) {
 				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
 			)
 			registeredPlugins = append(registeredPlugins, tt.registerPlugins...)
+			var extenders []fwk.Extender
+			for _, extender := range tt.extenders {
+				extenders = append(extenders, extender)
+			}
 			var objs []runtime.Object
 			for _, p := range append(tt.testPods, tt.initPods...) {
 				objs = append(objs, p)
@@ -1366,6 +1393,7 @@ func TestDryRunPreemption(t *testing.T) {
 				frameworkruntime.WithSnapshotSharedLister(snapshot),
 				frameworkruntime.WithMutableSnapshotLister(snapshot),
 				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithExtenders(extenders),
 				frameworkruntime.WithParallelism(parallelism),
 				frameworkruntime.WithLogger(logger),
 			)

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -692,6 +692,7 @@ func TestDryRunPreemption(t *testing.T) {
 		testPods                          []*v1.Pod
 		initPods                          []*v1.Pod
 		registerPlugins                   []tf.RegisterPluginFunc
+		extenders                         []*tf.FakeExtender
 		pdbs                              []*policy.PodDisruptionBudget
 		fakeFilterRC                      fwk.Code // return code for fake filter plugin
 		disableParallelism                bool
@@ -780,6 +781,28 @@ func TestDryRunPreemption(t *testing.T) {
 			},
 			expectedNumFilterCalled: []int32{4},
 		},
+		{
+			name: "extender filter is checked during preemption dry run",
+			registerPlugins: []tf.RegisterPluginFunc{
+				tf.RegisterPluginAsExtensions(noderesources.Name, nodeResourcesFitFunc, "Filter", "PreFilter"),
+			},
+			extenders: []*tf.FakeExtender{
+				{
+					ExtenderName: "FakeExtender1",
+					Predicates:   []tf.FitPredicate{tf.FalsePredicateExtender},
+				},
+			},
+			nodeNames: []string{"node1"},
+			testPods: []*v1.Pod{
+				st.MakePod().Name("p").UID("p").Priority(highPriority).Req(largeRes).Obj(),
+			},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("p1").UID("p1").Node("node1").Priority(midPriority).Req(largeRes).Obj(),
+			},
+			expected:                [][]candidate{{}},
+			expectedNumFilterCalled: []int32{1},
+		},
+
 		{
 			name: "a pod that would fit on the nodes, but other pods running are higher priority, no preemption would happen",
 			registerPlugins: []tf.RegisterPluginFunc{
@@ -1444,6 +1467,10 @@ func TestDryRunPreemption(t *testing.T) {
 				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
 			)
 			registeredPlugins = append(registeredPlugins, tt.registerPlugins...)
+			var extenders []fwk.Extender
+			for _, extender := range tt.extenders {
+				extenders = append(extenders, extender)
+			}
 			var objs []runtime.Object
 			for _, p := range append(tt.testPods, tt.initPods...) {
 				objs = append(objs, p)
@@ -1470,6 +1497,7 @@ func TestDryRunPreemption(t *testing.T) {
 				frameworkruntime.WithSnapshotSharedLister(snapshot),
 				frameworkruntime.WithMutableSnapshotLister(snapshot),
 				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithExtenders(extenders),
 				frameworkruntime.WithParallelism(parallelism),
 				frameworkruntime.WithLogger(logger),
 			)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Checks scheduler extender filters during default preemption dry-run after in-tree filter plugins pass. Without this, preemption can select victims on nodes that extenders would still reject.

#### Which issue(s) this PR is related to:

Fixes #139270

#### Special notes for your reviewer:

Competing change: #139273 (includes unrelated files). This PR is scoped to default preemption only.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```