### PR TITLE
kubelet: handle static pod restarts before apiserver connection is up

### DIFF
--- a/pkg/kubelet/allocation/allocation_manager.go
+++ b/pkg/kubelet/allocation/allocation_manager.go
@@ -91,7 +91,7 @@ type Manager interface {
 	RemovePod(logger klog.Logger, uid types.UID)
 
 	// RemoveOrphanedPods removes the stored state for any pods not included in the set of remaining pods.
-	RemoveOrphanedPods(remainingPods sets.Set[types.UID])
+	RemoveOrphanedPods(remainingPods sets.Set[types.UID], sourceForPodReady config.SourceForPodReadyFn)
 
 	// Run starts the allocation manager. This is currently only used to handle periodic retry of
 	// pending resizes.
@@ -532,8 +532,8 @@ func (m *manager) RemovePod(logger klog.Logger, uid types.UID) {
 	}
 }
 
-func (m *manager) RemoveOrphanedPods(remainingPods sets.Set[types.UID]) {
-	m.allocated.RemoveOrphanedPods(remainingPods)
+func (m *manager) RemoveOrphanedPods(remainingPods sets.Set[types.UID], sourceForPodReady config.SourceForPodReadyFn) {
+	m.allocated.RemoveOrphanedPods(remainingPods, sourceForPodReady)
 }
 
 func (m *manager) handlePodResourcesResize(ctx context.Context, pod *v1.Pod) (bool, error) {

--- a/pkg/kubelet/allocation/allocation_manager.go
+++ b/pkg/kubelet/allocation/allocation_manager.go
@@ -92,7 +92,7 @@ type Manager interface {
 	RemovePod(logger klog.Logger, uid types.UID)
 
 	// RemoveOrphanedPods removes the stored state for any pods not included in the set of remaining pods.
-	RemoveOrphanedPods(remainingPods sets.Set[types.UID])
+	RemoveOrphanedPods(remainingPods sets.Set[types.UID], sourceForPodReady config.SourceForPodReadyFn)
 
 	// Run starts the allocation manager. This is currently only used to handle periodic retry of
 	// pending resizes.
@@ -595,8 +595,8 @@ func (m *manager) RemovePod(logger klog.Logger, uid types.UID) {
 	}
 }
 
-func (m *manager) RemoveOrphanedPods(remainingPods sets.Set[types.UID]) {
-	m.allocated.RemoveOrphanedPods(remainingPods)
+func (m *manager) RemoveOrphanedPods(remainingPods sets.Set[types.UID], sourceForPodReady config.SourceForPodReadyFn) {
+	m.allocated.RemoveOrphanedPods(remainingPods, sourceForPodReady)
 }
 
 func (m *manager) handlePodResourcesResize(ctx context.Context, pod *v1.Pod) (bool, error) {

--- a/pkg/kubelet/allocation/allocation_manager_test.go
+++ b/pkg/kubelet/allocation/allocation_manager_test.go
@@ -2459,7 +2459,7 @@ func makeAllocationManager(t *testing.T, runtime *containertest.FakeRuntime, all
 			}
 			return nil, false
 		},
-		config.NewSourcesReady(func(_ sets.Set[string]) bool { return true }),
+		config.NewSourcesReady(func(_ sets.Set[string]) bool { return true }, func(_ types.UID) bool { return true }),
 		record.NewFakeRecorder(20),
 	)
 

--- a/pkg/kubelet/allocation/allocation_manager_test.go
+++ b/pkg/kubelet/allocation/allocation_manager_test.go
@@ -3460,7 +3460,7 @@ func makeAllocationManager(t *testing.T, runtime *containertest.FakeRuntime, all
 			}
 			return nil, false
 		},
-		config.NewSourcesReady(func(_ sets.Set[string]) bool { return true }),
+		config.NewSourcesReady(func(_ sets.Set[string]) bool { return true }, func(_ types.UID) bool { return true }),
 		record.NewFakeRecorder(20),
 	)
 

--- a/pkg/kubelet/allocation/state/state.go
+++ b/pkg/kubelet/allocation/state/state.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/kubelet/config"
 )
 
 // PodResourceInfo stores resource requirements for containers within a pod.
@@ -63,7 +64,7 @@ type writer interface {
 	SetPodLevelResources(logger klog.Logger, podUID types.UID, alloc *v1.ResourceRequirements) error
 	RemovePod(logger klog.Logger, podUID types.UID) error
 	// RemoveOrphanedPods removes the stored state for any pods not included in the set of remaining pods.
-	RemoveOrphanedPods(remainingPods sets.Set[types.UID])
+	RemoveOrphanedPods(remainingPods sets.Set[types.UID], sourceForPodReady config.SourceForPodReadyFn)
 }
 
 // State interface provides methods for tracking and setting pod resources

--- a/pkg/kubelet/allocation/state/state.go
+++ b/pkg/kubelet/allocation/state/state.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/kubelet/config"
 )
 
 // PodResourceInfo stores resource requirements for containers within a pod.
@@ -83,7 +84,7 @@ type writer interface {
 	SetEmptyDirVolumeLimit(podUID types.UID, volumeName string, limit *resource.Quantity) error
 	RemovePod(logger klog.Logger, podUID types.UID) error
 	// RemoveOrphanedPods removes the stored state for any pods not included in the set of remaining pods.
-	RemoveOrphanedPods(remainingPods sets.Set[types.UID])
+	RemoveOrphanedPods(remainingPods sets.Set[types.UID], sourceForPodReady config.SourceForPodReadyFn)
 }
 
 // State interface provides methods for tracking and setting pod resources

--- a/pkg/kubelet/allocation/state/state_checkpoint.go
+++ b/pkg/kubelet/allocation/state/state_checkpoint.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/checksum"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors"
+	"k8s.io/kubernetes/pkg/kubelet/config"
 )
 
 var _ State = &stateCheckpoint{}
@@ -176,8 +177,8 @@ func (sc *stateCheckpoint) RemovePod(logger klog.Logger, podUID types.UID) error
 	return sc.cache.RemovePod(logger, podUID)
 }
 
-func (sc *stateCheckpoint) RemoveOrphanedPods(remainingPods sets.Set[types.UID]) {
-	sc.cache.RemoveOrphanedPods(remainingPods)
+func (sc *stateCheckpoint) RemoveOrphanedPods(remainingPods sets.Set[types.UID], sourceForPodReady config.SourceForPodReadyFn) {
+	sc.cache.RemoveOrphanedPods(remainingPods, sourceForPodReady)
 	// Don't bother updating the stored state. If Kubelet is restarted before the cache is written,
 	// the orphaned pods will be removed the next time this method is called.
 }
@@ -221,4 +222,5 @@ func (sc *noopStateCheckpoint) RemovePod(_ klog.Logger, _ types.UID) error {
 	return nil
 }
 
-func (sc *noopStateCheckpoint) RemoveOrphanedPods(_ sets.Set[types.UID]) {}
+func (sc *noopStateCheckpoint) RemoveOrphanedPods(_ sets.Set[types.UID], _ config.SourceForPodReadyFn) {
+}

--- a/pkg/kubelet/allocation/state/state_checkpoint.go
+++ b/pkg/kubelet/allocation/state/state_checkpoint.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/checksum"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors"
+	"k8s.io/kubernetes/pkg/kubelet/config"
 )
 
 var _ State = &stateCheckpoint{}
@@ -196,8 +197,8 @@ func (sc *stateCheckpoint) RemovePod(logger klog.Logger, podUID types.UID) error
 	return sc.cache.RemovePod(logger, podUID)
 }
 
-func (sc *stateCheckpoint) RemoveOrphanedPods(remainingPods sets.Set[types.UID]) {
-	sc.cache.RemoveOrphanedPods(remainingPods)
+func (sc *stateCheckpoint) RemoveOrphanedPods(remainingPods sets.Set[types.UID], sourceForPodReady config.SourceForPodReadyFn) {
+	sc.cache.RemoveOrphanedPods(remainingPods, sourceForPodReady)
 	// Don't bother updating the stored state. If Kubelet is restarted before the cache is written,
 	// the orphaned pods will be removed the next time this method is called.
 }
@@ -249,4 +250,5 @@ func (sc *noopStateCheckpoint) RemovePod(_ klog.Logger, _ types.UID) error {
 	return nil
 }
 
-func (sc *noopStateCheckpoint) RemoveOrphanedPods(_ sets.Set[types.UID]) {}
+func (sc *noopStateCheckpoint) RemoveOrphanedPods(_ sets.Set[types.UID], _ config.SourceForPodReadyFn) {
+}

--- a/pkg/kubelet/allocation/state/state_mem.go
+++ b/pkg/kubelet/allocation/state/state_mem.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/kubelet/config"
 )
 
 type stateMemory struct {
@@ -142,11 +143,15 @@ func (s *stateMemory) RemovePod(logger klog.Logger, podUID types.UID) error {
 	return nil
 }
 
-func (s *stateMemory) RemoveOrphanedPods(remainingPods sets.Set[types.UID]) {
+func (s *stateMemory) RemoveOrphanedPods(remainingPods sets.Set[types.UID], sourceForPodReady config.SourceForPodReadyFn) {
 	s.Lock()
 	defer s.Unlock()
 
 	for podUID := range s.podResources {
+		// Wait for relevant source to be ready before doing cleanup
+		if !sourceForPodReady(podUID) {
+			continue
+		}
 		if _, ok := remainingPods[types.UID(podUID)]; !ok {
 			delete(s.podResources, podUID)
 		}

--- a/pkg/kubelet/allocation/state/state_mem.go
+++ b/pkg/kubelet/allocation/state/state_mem.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/kubelet/config"
 )
 
 type stateMemory struct {
@@ -185,11 +186,15 @@ func (s *stateMemory) RemovePod(logger klog.Logger, podUID types.UID) error {
 	return nil
 }
 
-func (s *stateMemory) RemoveOrphanedPods(remainingPods sets.Set[types.UID]) {
+func (s *stateMemory) RemoveOrphanedPods(remainingPods sets.Set[types.UID], sourceForPodReady config.SourceForPodReadyFn) {
 	s.Lock()
 	defer s.Unlock()
 
 	for podUID := range s.podResources {
+		// Wait for relevant source to be ready before doing cleanup
+		if !sourceForPodReady(podUID) {
+			continue
+		}
 		if _, ok := remainingPods[types.UID(podUID)]; !ok {
 			delete(s.podResources, podUID)
 		}

--- a/pkg/kubelet/apis/pods/server_unit_test.go
+++ b/pkg/kubelet/apis/pods/server_unit_test.go
@@ -658,6 +658,10 @@ func (f *FakeSourcesReady) AllReady() bool {
 	return f.ready
 }
 
+func (f *FakeSourcesReady) SourceForPodReady(types.UID) bool {
+	return f.ready
+}
+
 func (f *FakeSourcesReady) AddSource(source string) {}
 
 func assertErrorWithCode(t *testing.T, err error, expectedCode codes.Code, expectedMsg string) {

--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -26,6 +26,7 @@ import (
 	"github.com/go-logr/logr"
 	cadvisorapi "github.com/google/cadvisor/lib/model"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	resourcehelper "k8s.io/component-helpers/resource"
@@ -165,8 +166,9 @@ var _ Manager = &manager{}
 
 type sourcesReadyStub struct{}
 
-func (s *sourcesReadyStub) AddSource(source string) {}
-func (s *sourcesReadyStub) AllReady() bool          { return true }
+func (s *sourcesReadyStub) AddSource(source string)          {}
+func (s *sourcesReadyStub) AllReady() bool                   { return true }
+func (s *sourcesReadyStub) SourceForPodReady(types.UID) bool { return true }
 
 // NewManager creates new cpu manager based on provided policy
 func NewManager(logger logr.Logger, cpuPolicyName string, cpuPolicyOptions map[string]string, reconcilePeriod time.Duration, machineInfo *cadvisorapi.MachineInfo, specificCPUs cpuset.CPUSet, nodeAllocatableReservation v1.ResourceList, stateFileDirectory string, affinity topologymanager.Store) (Manager, error) {

--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -25,6 +25,7 @@ import (
 
 	cadvisorapi "github.com/google/cadvisor/lib/model"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	resourcehelper "k8s.io/component-helpers/resource"
@@ -169,8 +170,9 @@ var _ Manager = &manager{}
 
 type sourcesReadyStub struct{}
 
-func (s *sourcesReadyStub) AddSource(_ string) {}
-func (s *sourcesReadyStub) AllReady() bool     { return true }
+func (s *sourcesReadyStub) AddSource(_ string)               {}
+func (s *sourcesReadyStub) AllReady() bool                   { return true }
+func (s *sourcesReadyStub) SourceForPodReady(types.UID) bool { return true }
 
 // NewManager creates new cpu manager based on provided policy
 func NewManager(logger klog.Logger, cpuPolicyName string, cpuPolicyOptions map[string]string, reconcilePeriod time.Duration, machineInfo *cadvisorapi.MachineInfo, specificCPUs cpuset.CPUSet, nodeAllocatableReservation v1.ResourceList, stateFileDirectory string, affinity topologymanager.Store) (Manager, error) {

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -32,6 +32,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
 	errorsutil "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/server/healthz"
@@ -127,8 +128,9 @@ type sourcesReadyStub struct{}
 // PodReusableDevices is a map by pod name of devices to reuse.
 type PodReusableDevices map[string]map[string]sets.Set[string]
 
-func (s *sourcesReadyStub) AddSource(source string) {}
-func (s *sourcesReadyStub) AllReady() bool          { return true }
+func (s *sourcesReadyStub) AddSource(source string)          {}
+func (s *sourcesReadyStub) AllReady() bool                   { return true }
+func (s *sourcesReadyStub) SourceForPodReady(types.UID) bool { return true }
 
 // NewManagerImpl creates a new manager.
 func NewManagerImpl(logger klog.Logger, topology []cadvisorapi.Node, topologyAffinityStore topologymanager.Store) (*ManagerImpl, error) {

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -32,6 +32,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
 	errorsutil "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/server/healthz"
@@ -127,8 +128,9 @@ type sourcesReadyStub struct{}
 // PodReusableDevices is a map by pod name of devices to reuse.
 type PodReusableDevices map[string]map[string]sets.Set[string]
 
-func (s *sourcesReadyStub) AddSource(_ string) {}
-func (s *sourcesReadyStub) AllReady() bool     { return true }
+func (s *sourcesReadyStub) AddSource(_ string)               {}
+func (s *sourcesReadyStub) AllReady() bool                   { return true }
+func (s *sourcesReadyStub) SourceForPodReady(types.UID) bool { return true }
 
 // NewManagerImpl creates a new manager.
 func NewManagerImpl(logger klog.Logger, topology []cadvisorapi.Node, topologyAffinityStore topologymanager.Store) (*ManagerImpl, error) {

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -336,7 +336,7 @@ func setupPluginManager(t *testing.T, pluginSocketName string, m Manager) plugin
 
 func runPluginManager(ctx context.Context, pluginManager pluginmanager.PluginManager) {
 	// FIXME: Replace sets.Set[string] with sets.Set[string]
-	sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
+	sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true }, func(_ types.UID) bool { return true })
 	go pluginManager.Run(ctx, sourcesReady, wait.NeverStop)
 }
 

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -348,7 +348,7 @@ func setupPluginManager(t *testing.T, pluginSocketName string, m Manager) plugin
 
 func runPluginManager(ctx context.Context, pluginManager pluginmanager.PluginManager) {
 	// FIXME: Replace sets.Set[string] with sets.Set[string]
-	sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
+	sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true }, func(_ types.UID) bool { return true })
 	go pluginManager.Run(ctx, sourcesReady, wait.NeverStop)
 }
 

--- a/pkg/kubelet/cm/memorymanager/memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager.go
@@ -26,6 +26,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
@@ -51,8 +52,9 @@ type runtimeService interface {
 
 type sourcesReadyStub struct{}
 
-func (s *sourcesReadyStub) AddSource(source string) {}
-func (s *sourcesReadyStub) AllReady() bool          { return true }
+func (s *sourcesReadyStub) AddSource(source string)          {}
+func (s *sourcesReadyStub) AllReady() bool                   { return true }
+func (s *sourcesReadyStub) SourceForPodReady(types.UID) bool { return true }
 
 // Manager interface provides methods for Kubelet to manage pod memory.
 type Manager interface {

--- a/pkg/kubelet/cm/memorymanager/memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager.go
@@ -26,6 +26,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/util/feature"
 	resourcehelper "k8s.io/component-helpers/resource"
@@ -56,8 +57,9 @@ type runtimeService interface {
 
 type sourcesReadyStub struct{}
 
-func (s *sourcesReadyStub) AddSource(_ string) {}
-func (s *sourcesReadyStub) AllReady() bool     { return true }
+func (s *sourcesReadyStub) AddSource(_ string)               {}
+func (s *sourcesReadyStub) AllReady() bool                   { return true }
+func (s *sourcesReadyStub) SourceForPodReady(types.UID) bool { return true }
 
 // Manager interface provides methods for Kubelet to manage pod memory.
 type Manager interface {

--- a/pkg/kubelet/config/config.go
+++ b/pkg/kubelet/config/config.go
@@ -286,10 +286,8 @@ func (s *podStorage) merge(ctx context.Context, source string, update sourceUpda
 		if _, found := pods[uid]; !found {
 			// this is a delete
 			removePods = append(removePods, existing)
-			// Remove from podSources map to prevent memory leak (if map still exists)
-			if s.podSources != nil {
-				delete(s.podSources, uid)
-			}
+			// Don't remove from podSources here - we need it for SourceForPodReady during deletion.
+			// The map will be cleared when all sources are ready (podSources set to nil).
 		}
 	}
 

--- a/pkg/kubelet/config/config.go
+++ b/pkg/kubelet/config/config.go
@@ -50,6 +50,7 @@ type PodConfig struct {
 	// contains the list of all configured sources
 	sourcesLock sync.Mutex
 	sources     sets.Set[string]
+	allReady    bool
 }
 
 type sourceUpdate struct {
@@ -95,7 +96,44 @@ func (c *PodConfig) SeenAllSources(logger klog.Logger, seenSources sets.Set[stri
 	c.sourcesLock.Lock()
 	defer c.sourcesLock.Unlock()
 	logger.V(5).Info("Looking for sources, have seen", "sources", sets.List(c.sources), "seenSources", seenSources)
-	return seenSources.HasAll(sets.List(c.sources)...) && c.pods.seenSources(sets.List(c.sources)...)
+	if !c.allReady {
+		c.allReady = seenSources.HasAll(sets.List(c.sources)...) && c.pods.seenSources(sets.List(c.sources)...)
+		if c.allReady {
+			c.pods.podLock.Lock()
+			c.pods.podSources = nil
+			c.pods.podLock.Unlock()
+		}
+	}
+	return c.allReady
+}
+
+// SourceForPodReady returns whether the source for a given pod has been seen.
+// This allows the pod manager to DeleteOrphanedPods before all sources are reporting, which allows
+// static pods to be updated before the kubelet connects to the apiserver.
+func (c *PodConfig) SourceForPodReady(uid types.UID) bool {
+	if c.pods == nil {
+		return false
+	}
+
+	c.pods.podLock.RLock()
+	// Defensive programming. Ideally callers would call SeenAllSources() first,
+	// but this is trivial to add.
+	if c.pods.podSources == nil {
+		return true
+	}
+	source, found := c.pods.podSources[uid]
+	c.pods.podLock.RUnlock()
+
+	if !found {
+		// Pod not found in any source, be conservative
+		return false
+	}
+
+	c.pods.sourcesSeenLock.RLock()
+	defer c.pods.sourcesSeenLock.RUnlock()
+
+	// Check if the source is ready
+	return c.pods.sourcesSeen.Has(source)
 }
 
 // Updates returns a channel of updates to the configuration, properly denormalized.
@@ -111,6 +149,8 @@ type podStorage struct {
 	podLock sync.RWMutex
 	// map of source name to pod uid to pod reference
 	pods map[string]map[types.UID]*v1.Pod
+	// map of pod UID to source - persists even after pod is removed from pods map
+	podSources map[types.UID]string
 
 	// ensures that updates are delivered in strict order
 	// on the updates channel
@@ -133,6 +173,7 @@ type podStorage struct {
 func newPodStorage(updates chan<- kubetypes.PodUpdate, recorder record.EventRecorderLogger, startupSLIObserver podStartupSLIObserver) *podStorage {
 	return &podStorage{
 		pods:               make(map[string]map[types.UID]*v1.Pod),
+		podSources:         make(map[types.UID]string),
 		updates:            updates,
 		sourcesSeen:        sets.Set[string]{},
 		recorder:           recorder,
@@ -211,6 +252,10 @@ func (s *podStorage) merge(ctx context.Context, source string, update sourceUpda
 			}
 			if existing, found := oldPods[ref.UID]; found {
 				pods[ref.UID] = existing
+				// Only track pod sources while not all sources are ready
+				if s.podSources != nil {
+					s.podSources[ref.UID] = source
+				}
 				needUpdate, needReconcile, needGracefulDelete := checkAndUpdatePod(existing, ref)
 				if needUpdate {
 					updatePods = append(updatePods, existing)
@@ -223,6 +268,10 @@ func (s *podStorage) merge(ctx context.Context, source string, update sourceUpda
 			}
 			recordFirstSeenTime(logger, ref)
 			pods[ref.UID] = ref
+			// Only track pod sources while not all sources are ready
+			if s.podSources != nil {
+				s.podSources[ref.UID] = source
+			}
 			addPods = append(addPods, ref)
 		}
 	}
@@ -237,6 +286,10 @@ func (s *podStorage) merge(ctx context.Context, source string, update sourceUpda
 		if _, found := pods[uid]; !found {
 			// this is a delete
 			removePods = append(removePods, existing)
+			// Remove from podSources map to prevent memory leak (if map still exists)
+			if s.podSources != nil {
+				delete(s.podSources, uid)
+			}
 		}
 	}
 

--- a/pkg/kubelet/config/config_test.go
+++ b/pkg/kubelet/config/config_test.go
@@ -421,3 +421,152 @@ func TestPodConfigRace(t *testing.T) {
 
 	wg.Wait()
 }
+
+func TestSourceForPodReadyBeforeAllSourcesReady(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	eventBroadcaster := record.NewBroadcaster(record.WithContext(tCtx))
+	config := NewPodConfig(eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "kubelet"}), &mockPodStartupSLIObserver{})
+
+	fileSource := config.Channel(tCtx, kubetypes.FileSource)
+	_ = config.Channel(tCtx, kubetypes.ApiserverSource)
+
+	filePod := CreateValidPod("test-pod", "default")
+	fileSource <- createSourceUpdate(filePod)
+	time.Sleep(50 * time.Millisecond)
+
+	if !config.SourceForPodReady(filePod.UID) {
+		t.Error("Expected file pod source to be ready")
+	}
+	if config.SourceForPodReady("nonexistent-pod") {
+		t.Error("Expected nonexistent pod source to not be ready")
+	}
+
+	config.pods.podLock.RLock()
+	mapNil := config.pods.podSources == nil
+	config.pods.podLock.RUnlock()
+	if mapNil {
+		t.Error("Expected podSources map to exist before all sources ready")
+	}
+}
+
+func TestSourceForPodReadyAfterAllSourcesReady(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	eventBroadcaster := record.NewBroadcaster(record.WithContext(tCtx))
+	config := NewPodConfig(eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "kubelet"}), &mockPodStartupSLIObserver{})
+
+	fileSource := config.Channel(tCtx, kubetypes.FileSource)
+	apiSource := config.Channel(tCtx, kubetypes.ApiserverSource)
+
+	filePod := CreateValidPod("file-pod", "default")
+	apiPod := CreateValidPod("api-pod", "default")
+
+	fileSource <- createSourceUpdate(filePod)
+	apiSource <- createSourceUpdate(apiPod)
+	time.Sleep(50 * time.Millisecond)
+
+	// Make a safe copy of sourcesSeen to avoid data race
+	config.pods.sourcesSeenLock.RLock()
+	sourcesSeen := config.pods.sourcesSeen.Clone()
+	config.pods.sourcesSeenLock.RUnlock()
+
+	if !config.SeenAllSources(tCtx.Logger(), sourcesSeen) {
+		t.Error("Expected all sources ready")
+	}
+
+	if !config.SourceForPodReady(filePod.UID) {
+		t.Error("Expected file pod to be ready after all sources ready")
+	}
+	if !config.SourceForPodReady(apiPod.UID) {
+		t.Error("Expected api pod to be ready after all sources ready")
+	}
+	if !config.SourceForPodReady("any-random-uid") {
+		t.Error("Expected any UID to be ready after all sources ready")
+	}
+
+	config.pods.podLock.RLock()
+	mapNil := config.pods.podSources == nil
+	config.pods.podLock.RUnlock()
+	if !mapNil {
+		t.Error("Expected podSources map to be cleared after all sources ready")
+	}
+}
+
+func TestSourceForPodReadyPodDeletion(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	eventBroadcaster := record.NewBroadcaster(record.WithContext(tCtx))
+	config := NewPodConfig(eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "kubelet"}), &mockPodStartupSLIObserver{})
+
+	fileSource := config.Channel(tCtx, kubetypes.FileSource)
+
+	pod := CreateValidPod("test-pod", "default")
+	fileSource <- createSourceUpdate(pod)
+	time.Sleep(50 * time.Millisecond)
+
+	if !config.SourceForPodReady(pod.UID) {
+		t.Fatal("Expected pod source to be ready after adding")
+	}
+
+	fileSource <- createSourceUpdate()
+	time.Sleep(50 * time.Millisecond)
+
+	config.pods.podLock.RLock()
+	_, exists := config.pods.podSources[pod.UID]
+	config.pods.podLock.RUnlock()
+	if exists {
+		t.Error("Expected UID to be removed from podSources after deletion")
+	}
+
+	if config.SourceForPodReady(pod.UID) {
+		t.Error("Expected deleted pod to return false")
+	}
+}
+
+func TestSourceForPodReadyNoMapGrowthAfterAllReady(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	eventBroadcaster := record.NewBroadcaster(record.WithContext(tCtx))
+	config := NewPodConfig(eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "kubelet"}), &mockPodStartupSLIObserver{})
+
+	fileSource := config.Channel(tCtx, kubetypes.FileSource)
+	apiSource := config.Channel(tCtx, kubetypes.ApiserverSource)
+
+	pod1 := CreateValidPod("file-1", "default")
+	pod2 := CreateValidPod("api-1", "default")
+	fileSource <- createSourceUpdate(pod1)
+	apiSource <- createSourceUpdate(pod2)
+	time.Sleep(50 * time.Millisecond)
+
+	// Make a safe copy of sourcesSeen to avoid data race
+	config.pods.sourcesSeenLock.RLock()
+	sourcesSeen := config.pods.sourcesSeen.Clone()
+	config.pods.sourcesSeenLock.RUnlock()
+
+	config.SeenAllSources(tCtx.Logger(), sourcesSeen)
+
+	pod3 := CreateValidPod("file-2", "default")
+	fileSource <- createSourceUpdate(pod1, pod3)
+	time.Sleep(50 * time.Millisecond)
+
+	config.pods.podLock.RLock()
+	mapNil := config.pods.podSources == nil
+	config.pods.podLock.RUnlock()
+	if !mapNil {
+		t.Error("Expected podSources map to stay nil after all sources ready")
+	}
+}
+
+func TestSourceForPodReadySourceNotReady(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	eventBroadcaster := record.NewBroadcaster(record.WithContext(tCtx))
+	config := NewPodConfig(eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "kubelet"}), &mockPodStartupSLIObserver{})
+
+	config.Channel(tCtx, kubetypes.ApiserverSource)
+
+	pod := CreateValidPod("test-pod", "default")
+	config.pods.podLock.Lock()
+	config.pods.podSources[pod.UID] = kubetypes.ApiserverSource
+	config.pods.podLock.Unlock()
+
+	if config.SourceForPodReady(pod.UID) {
+		t.Error("Expected pod source to not be ready when source not seen")
+	}
+}

--- a/pkg/kubelet/config/config_test.go
+++ b/pkg/kubelet/config/config_test.go
@@ -510,14 +510,19 @@ func TestSourceForPodReadyPodDeletion(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	config.pods.podLock.RLock()
-	_, exists := config.pods.podSources[pod.UID]
+	source, exists := config.pods.podSources[pod.UID]
 	config.pods.podLock.RUnlock()
-	if exists {
-		t.Error("Expected UID to be removed from podSources after deletion")
+	if !exists {
+		t.Error("Expected UID to remain in podSources after deletion (until all sources ready)")
+	}
+	if source != kubetypes.FileSource {
+		t.Errorf("Expected pod source to be %q, got %q", kubetypes.FileSource, source)
 	}
 
-	if config.SourceForPodReady(pod.UID) {
-		t.Error("Expected deleted pod to return false")
+	// SourceForPodReady should still return true because the file source is ready,
+	// even though the pod was deleted. This allows deletion to proceed.
+	if !config.SourceForPodReady(pod.UID) {
+		t.Error("Expected deleted pod's source to still be ready for deletion")
 	}
 }
 

--- a/pkg/kubelet/config/sources.go
+++ b/pkg/kubelet/config/sources.go
@@ -20,11 +20,15 @@ package config
 import (
 	"sync"
 
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // SourcesReadyFn is function that returns true if the specified sources have been seen.
 type SourcesReadyFn func(sourcesSeen sets.Set[string]) bool
+
+// SourceForPodReadyFn is a function that returns true if the source for the specified pod UID is ready.
+type SourceForPodReadyFn func(uid types.UID) bool
 
 // SourcesReady tracks the set of configured sources seen by the kubelet.
 type SourcesReady interface {
@@ -32,13 +36,17 @@ type SourcesReady interface {
 	AddSource(source string)
 	// AllReady returns true if the currently configured sources have all been seen.
 	AllReady() bool
+
+	// SourceForPodReady returns true if the source for the specified pod UID is ready
+	SourceForPodReady(uid types.UID) bool
 }
 
 // NewSourcesReady returns a SourcesReady with the specified function.
-func NewSourcesReady(sourcesReadyFn SourcesReadyFn) SourcesReady {
+func NewSourcesReady(sourcesReadyFn SourcesReadyFn, sourceForPodReadyFn SourceForPodReadyFn) SourcesReady {
 	return &sourcesImpl{
-		sourcesSeen:    sets.New[string](),
-		sourcesReadyFn: sourcesReadyFn,
+		sourcesSeen:         sets.New[string](),
+		sourcesReadyFn:      sourcesReadyFn,
+		sourceForPodReadyFn: sourceForPodReadyFn,
 	}
 }
 
@@ -50,6 +58,8 @@ type sourcesImpl struct {
 	sourcesSeen sets.Set[string]
 	// sourcesReady is a function that evaluates if the sources are ready.
 	sourcesReadyFn SourcesReadyFn
+	// sourceForPodReadyFn is a function that evaluates if the sources for a specific pod is ready
+	sourceForPodReadyFn SourceForPodReadyFn
 }
 
 // Add adds the specified source to the set of sources managed.
@@ -64,4 +74,14 @@ func (s *sourcesImpl) AllReady() bool {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	return s.sourcesReadyFn(s.sourcesSeen)
+}
+
+// SourceForPodReady returns true if the source for the specified pod UID is ready
+func (s *sourcesImpl) SourceForPodReady(uid types.UID) bool {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	if s.sourcesReadyFn(s.sourcesSeen) {
+		return true
+	}
+	return s.sourceForPodReadyFn(uid)
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -289,7 +289,7 @@ type SyncHandler interface {
 	HandlePodRemoves(ctx context.Context, pods []*v1.Pod)
 	HandlePodReconcile(ctx context.Context, pods []*v1.Pod)
 	HandlePodSyncs(ctx context.Context, pods []*v1.Pod)
-	HandlePodCleanups(ctx context.Context) error
+	HandlePodCleanups(ctx context.Context, sourceForPodReady config.SourceForPodReadyFn) error
 }
 
 // Option is a functional option type for Kubelet
@@ -619,7 +619,7 @@ func NewMainKubelet(ctx context.Context,
 		rootDirectory:                filepath.Clean(rootDirectory),
 		podLogsDirectory:             podLogsDirectory,
 		resyncInterval:               kubeCfg.SyncFrequency.Duration,
-		sourcesReady:                 config.NewSourcesReady(kubeDeps.PodConfig.SourcesReadyFn(logger)),
+		sourcesReady:                 config.NewSourcesReady(kubeDeps.PodConfig.SourcesReadyFn(logger), kubeDeps.PodConfig.SourceForPodReady),
 		registerNode:                 registerNode,
 		registerWithTaints:           registerWithTaints,
 		dnsConfigurer:                dns.NewConfigurer(kubeDeps.Recorder, nodeRef, nodeIPs, clusterDNS, kubeCfg.ClusterDomain, kubeCfg.ResolverConfig),
@@ -2601,16 +2601,17 @@ func (kl *Kubelet) getPodsToSync() []*v1.Pod {
 // 1.  stopping the associated pod worker asynchronously
 // 2.  signaling to kill the pod by sending on the podKillingCh channel
 //
-// deletePod returns an error if not all sources are ready or the pod is not
+// deletePod returns an error if the source of this pod is not ready or the pod is not
 // found in the runtime cache.
 func (kl *Kubelet) deletePod(ctx context.Context, pod *v1.Pod) error {
 	if pod == nil {
 		return fmt.Errorf("deletePod does not allow nil pod")
 	}
-	if !kl.sourcesReady.AllReady() {
-		// If the sources aren't ready, skip deletion, as we may accidentally delete pods
-		// for sources that haven't reported yet.
-		return fmt.Errorf("skipping delete because sources aren't ready yet")
+	// Check if the relevant source is ready.
+	if !kl.sourcesReady.SourceForPodReady(pod.UID) {
+		// If the source isn't ready, skip deletion, as we may accidentally delete pods
+		// for a source that hasn't reported yet.
+		return fmt.Errorf("skipping delete because source isn't ready yet")
 	}
 	klog.FromContext(ctx).V(3).Info("Pod has been deleted and must be killed", "pod", klog.KObj(pod), "podUID", pod.UID)
 	kl.podWorkers.UpdatePod(ctx, UpdatePodOptions{
@@ -2831,22 +2832,16 @@ func (kl *Kubelet) syncLoopIteration(ctx context.Context, configCh <-chan kubety
 			handler.HandlePodSyncs(ctx, pods)
 		}
 	case <-housekeepingCh:
-		if !kl.sourcesReady.AllReady() {
-			// If the sources aren't ready or volume manager has not yet synced the states,
-			// skip housekeeping, as we may accidentally delete pods from unready sources.
-			logger.V(4).Info("SyncLoop (housekeeping, skipped): sources aren't ready yet")
-		} else {
-			start := time.Now()
-			logger.V(4).Info("SyncLoop (housekeeping)")
-			if err := handler.HandlePodCleanups(ctx); err != nil {
-				logger.Error(err, "Failed cleaning pods")
-			}
-			duration := time.Since(start)
-			if duration > housekeepingWarningDuration {
-				logger.Error(fmt.Errorf("housekeeping took too long"), "Housekeeping took longer than expected", "expected", housekeepingWarningDuration, "actual", duration.Round(time.Millisecond))
-			}
-			logger.V(4).Info("SyncLoop (housekeeping) end", "duration", duration.Round(time.Millisecond))
+		start := time.Now()
+		logger.V(4).Info("SyncLoop (housekeeping)")
+		if err := handler.HandlePodCleanups(ctx, kl.sourcesReady.SourceForPodReady); err != nil {
+			logger.Error(err, "Failed cleaning pods")
 		}
+		duration := time.Since(start)
+		if duration > housekeepingWarningDuration {
+			logger.Error(fmt.Errorf("housekeeping took too long"), "Housekeeping took longer than expected", "expected", housekeepingWarningDuration, "actual", duration.Round(time.Millisecond))
+		}
+		logger.V(4).Info("SyncLoop (housekeeping) end", "duration", duration.Round(time.Millisecond))
 	}
 	return true
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -288,7 +288,7 @@ type SyncHandler interface {
 	HandlePodRemoves(ctx context.Context, pods []*v1.Pod)
 	HandlePodReconcile(ctx context.Context, pods []*v1.Pod)
 	HandlePodSyncs(ctx context.Context, pods []*v1.Pod)
-	HandlePodCleanups(ctx context.Context) error
+	HandlePodCleanups(ctx context.Context, sourceForPodReady config.SourceForPodReadyFn) error
 }
 
 // Option is a functional option type for Kubelet
@@ -639,7 +639,7 @@ func NewMainKubelet(ctx context.Context,
 		rootDirectory:                filepath.Clean(rootDirectory),
 		podLogsDirectory:             podLogsDirectory,
 		resyncInterval:               kubeCfg.SyncFrequency.Duration,
-		sourcesReady:                 config.NewSourcesReady(kubeDeps.PodConfig.SourcesReadyFn(logger)),
+		sourcesReady:                 config.NewSourcesReady(kubeDeps.PodConfig.SourcesReadyFn(logger), kubeDeps.PodConfig.SourceForPodReady),
 		registerNode:                 registerNode,
 		registerWithTaints:           registerWithTaints,
 		dnsConfigurer:                dns.NewConfigurer(kubeDeps.Recorder, nodeRef, nodeIPs, clusterDNS, kubeCfg.ClusterDomain, kubeCfg.ResolverConfig),
@@ -2618,16 +2618,17 @@ func (kl *Kubelet) getPodsToSync() []*v1.Pod {
 // 1.  stopping the associated pod worker asynchronously
 // 2.  signaling to kill the pod by sending on the podKillingCh channel
 //
-// deletePod returns an error if not all sources are ready or the pod is not
+// deletePod returns an error if the source of this pod is not ready or the pod is not
 // found in the runtime cache.
 func (kl *Kubelet) deletePod(ctx context.Context, pod *v1.Pod) error {
 	if pod == nil {
 		return fmt.Errorf("deletePod does not allow nil pod")
 	}
-	if !kl.sourcesReady.AllReady() {
-		// If the sources aren't ready, skip deletion, as we may accidentally delete pods
-		// for sources that haven't reported yet.
-		return fmt.Errorf("skipping delete because sources aren't ready yet")
+	// Check if the relevant source is ready.
+	if !kl.sourcesReady.SourceForPodReady(pod.UID) {
+		// If the source isn't ready, skip deletion, as we may accidentally delete pods
+		// for a source that hasn't reported yet.
+		return fmt.Errorf("skipping delete because source isn't ready yet")
 	}
 	klog.FromContext(ctx).V(3).Info("Pod has been deleted and must be killed", "pod", klog.KObj(pod), "podUID", pod.UID)
 	kl.podWorkers.UpdatePod(ctx, UpdatePodOptions{
@@ -2848,22 +2849,16 @@ func (kl *Kubelet) syncLoopIteration(ctx context.Context, configCh <-chan kubety
 			handler.HandlePodSyncs(ctx, pods)
 		}
 	case <-housekeepingCh:
-		if !kl.sourcesReady.AllReady() {
-			// If the sources aren't ready or volume manager has not yet synced the states,
-			// skip housekeeping, as we may accidentally delete pods from unready sources.
-			logger.V(4).Info("SyncLoop (housekeeping, skipped): sources aren't ready yet")
-		} else {
-			start := time.Now()
-			logger.V(4).Info("SyncLoop (housekeeping)")
-			if err := handler.HandlePodCleanups(ctx); err != nil {
-				logger.Error(err, "Failed cleaning pods")
-			}
-			duration := time.Since(start)
-			if duration > housekeepingWarningDuration {
-				logger.Error(fmt.Errorf("housekeeping took too long"), "Housekeeping took longer than expected", "expected", housekeepingWarningDuration, "actual", duration.Round(time.Millisecond))
-			}
-			logger.V(4).Info("SyncLoop (housekeeping) end", "duration", duration.Round(time.Millisecond))
+		start := time.Now()
+		logger.V(4).Info("SyncLoop (housekeeping)")
+		if err := handler.HandlePodCleanups(ctx, kl.sourcesReady.SourceForPodReady); err != nil {
+			logger.Error(err, "Failed cleaning pods")
 		}
+		duration := time.Since(start)
+		if duration > housekeepingWarningDuration {
+			logger.Error(fmt.Errorf("housekeeping took too long"), "Housekeeping took longer than expected", "expected", housekeepingWarningDuration, "actual", duration.Round(time.Millisecond))
+		}
+		logger.V(4).Info("SyncLoop (housekeeping) end", "duration", duration.Round(time.Millisecond))
 	}
 	return true
 }

--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -493,7 +493,7 @@ func (kl *Kubelet) GetAllocatedPodByName(namespace, name string) (*v1.Pod, error
 	if !found {
 		return nil, nil
 	}
-	activePods := kl.filterOutInactivePods([]*v1.Pod{pod})
+	activePods := kl.filterOutInactivePods([]*v1.Pod{pod}, kl.sourcesReady.SourceForPodReady)
 	if len(activePods) == 0 {
 		return nil, nil
 	}

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -58,6 +58,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/fieldpath"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
+	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/envvars"
 	"k8s.io/kubernetes/pkg/kubelet/images"
@@ -208,7 +209,7 @@ func (kl *Kubelet) listPodsFromDisk() ([]types.UID, error) {
 // https://github.com/kubernetes/kubernetes/issues/104824
 func (kl *Kubelet) GetActivePods() []*v1.Pod {
 	allPods := kl.podManager.GetPods()
-	activePods := kl.filterOutInactivePods(allPods)
+	activePods := kl.filterOutInactivePods(allPods, kl.sourcesReady.SourceForPodReady)
 	return activePods
 }
 
@@ -1138,9 +1139,13 @@ func (kl *Kubelet) PodIsFinished(pod *v1.Pod) bool {
 // or are known to be fully terminated. This method should only be used
 // when the set of pods being filtered is upstream of the pod worker, i.e.
 // the pods the pod manager is aware of.
-func (kl *Kubelet) filterOutInactivePods(pods []*v1.Pod) []*v1.Pod {
+func (kl *Kubelet) filterOutInactivePods(pods []*v1.Pod, sourceForPodReady config.SourceForPodReadyFn) []*v1.Pod {
 	filteredPods := make([]*v1.Pod, 0, len(pods))
 	for _, p := range pods {
+		// Don't consider a pod active until we see its source
+		if !sourceForPodReady(p.UID) {
+			continue
+		}
 		if kl.isPodInactive(p) {
 			continue
 		}
@@ -1190,7 +1195,7 @@ func (kl *Kubelet) isAdmittedPodTerminal(pod *v1.Pod) bool {
 
 // removeOrphanedPodStatuses removes obsolete entries in podStatus where
 // the pod is no longer considered bound to this node.
-func (kl *Kubelet) removeOrphanedPodStatuses(logger klog.Logger, pods []*v1.Pod, mirrorPods []*v1.Pod) {
+func (kl *Kubelet) removeOrphanedPodStatuses(logger klog.Logger, pods []*v1.Pod, mirrorPods []*v1.Pod, sourceForPodReady config.SourceForPodReadyFn) {
 	podUIDs := make(map[types.UID]bool)
 	for _, pod := range pods {
 		podUIDs[pod.UID] = true
@@ -1198,7 +1203,7 @@ func (kl *Kubelet) removeOrphanedPodStatuses(logger klog.Logger, pods []*v1.Pod,
 	for _, pod := range mirrorPods {
 		podUIDs[pod.UID] = true
 	}
-	kl.statusManager.RemoveOrphanedStatuses(logger, podUIDs)
+	kl.statusManager.RemoveOrphanedStatuses(logger, podUIDs, sourceForPodReady)
 }
 
 // HandlePodCleanups performs a series of cleanup work, including terminating
@@ -1214,7 +1219,7 @@ func (kl *Kubelet) removeOrphanedPodStatuses(logger klog.Logger, pods []*v1.Pod,
 // of this call is the minimum latency for static pods to be restarted if they
 // are updated with a fixed UID (most should use a dynamic UID), and no config
 // updates are delivered to the pod workers while this method is running.
-func (kl *Kubelet) HandlePodCleanups(ctx context.Context) error {
+func (kl *Kubelet) HandlePodCleanups(ctx context.Context, sourceForPodReady config.SourceForPodReadyFn) error {
 	logger := klog.FromContext(ctx)
 	// The kubelet lacks checkpointing, so we need to introspect the set of pods
 	// in the cgroup tree prior to inspecting the set of pods in our pod manager.
@@ -1297,16 +1302,16 @@ func (kl *Kubelet) HandlePodCleanups(ctx context.Context) error {
 
 	// Stop probing pods that are not running
 	logger.V(3).Info("Clean up probes for terminated pods")
-	kl.probeManager.CleanupPods(possiblyRunningPods)
+	kl.probeManager.CleanupPods(possiblyRunningPods, sourceForPodReady)
 
 	// Remove orphaned pod statuses not in the total list of known config pods
 	logger.V(3).Info("Clean up orphaned pod statuses")
-	kl.removeOrphanedPodStatuses(logger, allPods, mirrorPods)
-	kl.allocationManager.RemoveOrphanedPods(allPodsByUID)
+	kl.removeOrphanedPodStatuses(logger, allPods, mirrorPods, sourceForPodReady)
+	kl.allocationManager.RemoveOrphanedPods(allPodsByUID, sourceForPodReady)
 
 	// Remove orphaned pod user namespace allocations (if any).
 	logger.V(3).Info("Clean up orphaned pod user namespace allocations")
-	if err = kl.usernsManager.CleanupOrphanedPodUsernsAllocations(ctx, allPods, runningRuntimePods); err != nil {
+	if err = kl.usernsManager.CleanupOrphanedPodUsernsAllocations(ctx, allPods, runningRuntimePods, sourceForPodReady); err != nil {
 		logger.Error(err, "Failed cleaning up orphaned pod user namespaces allocations")
 	}
 
@@ -1318,7 +1323,7 @@ func (kl *Kubelet) HandlePodCleanups(ctx context.Context) error {
 	// in the future (volumes, mount dirs, logs, and containers could all be
 	// better separated)
 	logger.V(3).Info("Clean up orphaned pod directories")
-	err = kl.cleanupOrphanedPodDirs(logger, allPods, runningRuntimePods)
+	err = kl.cleanupOrphanedPodDirs(logger, allPods, runningRuntimePods, sourceForPodReady)
 	if err != nil {
 		// We want all cleanup tasks to be run even if one of them failed. So
 		// we just log an error here and continue other cleanup tasks.
@@ -1342,7 +1347,7 @@ func (kl *Kubelet) HandlePodCleanups(ctx context.Context) error {
 
 	// After pruning pod workers for terminated pods get the list of active pods for
 	// metrics and to determine restarts.
-	activePods := kl.filterOutInactivePods(allPods)
+	activePods := kl.filterOutInactivePods(allPods, sourceForPodReady)
 	allRegularPods, allStaticPods := splitPodsByStatic(allPods)
 	activeRegularPods, activeStaticPods := splitPodsByStatic(activePods)
 	metrics.DesiredPodCount.WithLabelValues("").Set(float64(len(allRegularPods)))
@@ -1399,7 +1404,7 @@ func (kl *Kubelet) HandlePodCleanups(ctx context.Context) error {
 	// Adding the pods with SyncPodKill to pod workers allows to proceed with
 	// force-deletion of such pods, yet preventing re-entry of the routine in the
 	// next invocation of HandlePodCleanups.
-	for _, pod := range kl.filterTerminalPodsToDelete(allPods, runningRuntimePods, workingPods) {
+	for _, pod := range kl.filterTerminalPodsToDelete(allPods, runningRuntimePods, workingPods, sourceForPodReady) {
 		logger.V(3).Info("Handling termination and deletion of the pod to pod workers", "pod", klog.KObj(pod), "podUID", pod.UID)
 		kl.podWorkers.UpdatePod(ctx, UpdatePodOptions{
 			UpdateType: kubetypes.SyncPodKill,
@@ -1489,9 +1494,12 @@ func (kl *Kubelet) HandlePodCleanups(ctx context.Context) error {
 // such pods is already handled by pod workers.
 // Finally, we skip runtime pods as their termination is handled separately in
 // the HandlePodCleanups routine.
-func (kl *Kubelet) filterTerminalPodsToDelete(allPods []*v1.Pod, runningRuntimePods []*kubecontainer.Pod, workingPods map[types.UID]PodWorkerSync) map[types.UID]*v1.Pod {
+func (kl *Kubelet) filterTerminalPodsToDelete(allPods []*v1.Pod, runningRuntimePods []*kubecontainer.Pod, workingPods map[types.UID]PodWorkerSync, sourceForPodReady config.SourceForPodReadyFn) map[types.UID]*v1.Pod {
 	terminalPodsToDelete := make(map[types.UID]*v1.Pod)
 	for _, pod := range allPods {
+		if !sourceForPodReady(pod.UID) {
+			continue
+		}
 		if pod.DeletionTimestamp == nil {
 			// skip pods which don't have a deletion timestamp
 			continue

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -58,6 +58,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/fieldpath"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
+	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/envvars"
 	"k8s.io/kubernetes/pkg/kubelet/images"
@@ -225,7 +226,7 @@ func (kl *Kubelet) listPodsFromDisk() ([]types.UID, error) {
 // https://github.com/kubernetes/kubernetes/issues/104824
 func (kl *Kubelet) GetActivePods() []*v1.Pod {
 	allPods := kl.podManager.GetPods()
-	activePods := kl.filterOutInactivePods(allPods)
+	activePods := kl.filterOutInactivePods(allPods, kl.sourcesReady.SourceForPodReady)
 	return activePods
 }
 
@@ -1161,9 +1162,13 @@ func (kl *Kubelet) PodIsFinished(pod *v1.Pod) bool {
 // or are known to be fully terminated. This method should only be used
 // when the set of pods being filtered is upstream of the pod worker, i.e.
 // the pods the pod manager is aware of.
-func (kl *Kubelet) filterOutInactivePods(pods []*v1.Pod) []*v1.Pod {
+func (kl *Kubelet) filterOutInactivePods(pods []*v1.Pod, sourceForPodReady config.SourceForPodReadyFn) []*v1.Pod {
 	filteredPods := make([]*v1.Pod, 0, len(pods))
 	for _, p := range pods {
+		// Don't consider a pod active until we see its source
+		if !sourceForPodReady(p.UID) {
+			continue
+		}
 		if kl.isPodInactive(p) {
 			continue
 		}
@@ -1213,7 +1218,7 @@ func (kl *Kubelet) isAdmittedPodTerminal(pod *v1.Pod) bool {
 
 // removeOrphanedPodStatuses removes obsolete entries in podStatus where
 // the pod is no longer considered bound to this node.
-func (kl *Kubelet) removeOrphanedPodStatuses(logger klog.Logger, pods []*v1.Pod, mirrorPods []*v1.Pod) {
+func (kl *Kubelet) removeOrphanedPodStatuses(logger klog.Logger, pods []*v1.Pod, mirrorPods []*v1.Pod, sourceForPodReady config.SourceForPodReadyFn) {
 	podUIDs := make(map[types.UID]bool)
 	for _, pod := range pods {
 		podUIDs[pod.UID] = true
@@ -1221,7 +1226,7 @@ func (kl *Kubelet) removeOrphanedPodStatuses(logger klog.Logger, pods []*v1.Pod,
 	for _, pod := range mirrorPods {
 		podUIDs[pod.UID] = true
 	}
-	kl.statusManager.RemoveOrphanedStatuses(logger, podUIDs)
+	kl.statusManager.RemoveOrphanedStatuses(logger, podUIDs, sourceForPodReady)
 }
 
 // HandlePodCleanups performs a series of cleanup work, including terminating
@@ -1237,7 +1242,7 @@ func (kl *Kubelet) removeOrphanedPodStatuses(logger klog.Logger, pods []*v1.Pod,
 // of this call is the minimum latency for static pods to be restarted if they
 // are updated with a fixed UID (most should use a dynamic UID), and no config
 // updates are delivered to the pod workers while this method is running.
-func (kl *Kubelet) HandlePodCleanups(ctx context.Context) error {
+func (kl *Kubelet) HandlePodCleanups(ctx context.Context, sourceForPodReady config.SourceForPodReadyFn) error {
 	logger := klog.FromContext(ctx)
 	// The kubelet lacks checkpointing, so we need to introspect the set of pods
 	// in the cgroup tree prior to inspecting the set of pods in our pod manager.
@@ -1320,16 +1325,16 @@ func (kl *Kubelet) HandlePodCleanups(ctx context.Context) error {
 
 	// Stop probing pods that are not running
 	logger.V(3).Info("Clean up probes for terminated pods")
-	kl.probeManager.CleanupPods(possiblyRunningPods)
+	kl.probeManager.CleanupPods(possiblyRunningPods, sourceForPodReady)
 
 	// Remove orphaned pod statuses not in the total list of known config pods
 	logger.V(3).Info("Clean up orphaned pod statuses")
-	kl.removeOrphanedPodStatuses(logger, allPods, mirrorPods)
-	kl.allocationManager.RemoveOrphanedPods(allPodsByUID)
+	kl.removeOrphanedPodStatuses(logger, allPods, mirrorPods, sourceForPodReady)
+	kl.allocationManager.RemoveOrphanedPods(allPodsByUID, sourceForPodReady)
 
 	// Remove orphaned pod user namespace allocations (if any).
 	logger.V(3).Info("Clean up orphaned pod user namespace allocations")
-	if err = kl.usernsManager.CleanupOrphanedPodUsernsAllocations(ctx, allPods, runningRuntimePods); err != nil {
+	if err = kl.usernsManager.CleanupOrphanedPodUsernsAllocations(ctx, allPods, runningRuntimePods, sourceForPodReady); err != nil {
 		logger.Error(err, "Failed cleaning up orphaned pod user namespaces allocations")
 	}
 
@@ -1341,7 +1346,7 @@ func (kl *Kubelet) HandlePodCleanups(ctx context.Context) error {
 	// in the future (volumes, mount dirs, logs, and containers could all be
 	// better separated)
 	logger.V(3).Info("Clean up orphaned pod directories")
-	err = kl.cleanupOrphanedPodDirs(logger, allPods, runningRuntimePods)
+	err = kl.cleanupOrphanedPodDirs(logger, allPods, runningRuntimePods, sourceForPodReady)
 	if err != nil {
 		// We want all cleanup tasks to be run even if one of them failed. So
 		// we just log an error here and continue other cleanup tasks.
@@ -1365,7 +1370,7 @@ func (kl *Kubelet) HandlePodCleanups(ctx context.Context) error {
 
 	// After pruning pod workers for terminated pods get the list of active pods for
 	// metrics and to determine restarts.
-	activePods := kl.filterOutInactivePods(allPods)
+	activePods := kl.filterOutInactivePods(allPods, sourceForPodReady)
 	allRegularPods, allStaticPods := splitPodsByStatic(allPods)
 	activeRegularPods, activeStaticPods := splitPodsByStatic(activePods)
 	metrics.DesiredPodCount.WithLabelValues("").Set(float64(len(allRegularPods)))
@@ -1422,7 +1427,7 @@ func (kl *Kubelet) HandlePodCleanups(ctx context.Context) error {
 	// Adding the pods with SyncPodKill to pod workers allows to proceed with
 	// force-deletion of such pods, yet preventing re-entry of the routine in the
 	// next invocation of HandlePodCleanups.
-	for _, pod := range kl.filterTerminalPodsToDelete(allPods, runningRuntimePods, workingPods) {
+	for _, pod := range kl.filterTerminalPodsToDelete(allPods, runningRuntimePods, workingPods, sourceForPodReady) {
 		logger.V(3).Info("Handling termination and deletion of the pod to pod workers", "pod", klog.KObj(pod), "podUID", pod.UID)
 		kl.podWorkers.UpdatePod(ctx, UpdatePodOptions{
 			UpdateType: kubetypes.SyncPodKill,
@@ -1512,9 +1517,12 @@ func (kl *Kubelet) HandlePodCleanups(ctx context.Context) error {
 // such pods is already handled by pod workers.
 // Finally, we skip runtime pods as their termination is handled separately in
 // the HandlePodCleanups routine.
-func (kl *Kubelet) filterTerminalPodsToDelete(allPods []*v1.Pod, runningRuntimePods []*kubecontainer.Pod, workingPods map[types.UID]PodWorkerSync) map[types.UID]*v1.Pod {
+func (kl *Kubelet) filterTerminalPodsToDelete(allPods []*v1.Pod, runningRuntimePods []*kubecontainer.Pod, workingPods map[types.UID]PodWorkerSync, sourceForPodReady config.SourceForPodReadyFn) map[types.UID]*v1.Pod {
 	terminalPodsToDelete := make(map[types.UID]*v1.Pod)
 	for _, pod := range allPods {
+		if !sourceForPodReady(pod.UID) {
+			continue
+		}
 		if pod.DeletionTimestamp == nil {
 			// skip pods which don't have a deletion timestamp
 			continue

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -8349,7 +8349,7 @@ func TestKubelet_HandlePodCleanups(t *testing.T) {
 				kl.rejectPod(tCtx, pod, reject.reason, reject.message)
 			}
 
-			if err := kl.HandlePodCleanups(tCtx); (err != nil) != tt.wantErr {
+			if err := kl.HandlePodCleanups(tCtx, func(_ types.UID) bool { return true }); (err != nil) != tt.wantErr {
 				t.Errorf("Kubelet.HandlePodCleanups() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			drainAllWorkers(podWorkers)
@@ -8364,7 +8364,7 @@ func TestKubelet_HandlePodCleanups(t *testing.T) {
 			// check after the terminating error clears
 			if tt.wantWorkerAfterRetry != nil {
 				podWorkers.podSyncer = originalPodSyncer
-				if err := kl.HandlePodCleanups(tCtx); (err != nil) != tt.wantErr {
+				if err := kl.HandlePodCleanups(tCtx, func(_ types.UID) bool { return true }); (err != nil) != tt.wantErr {
 					t.Errorf("Kubelet.HandlePodCleanups() second error = %v, wantErr %v", err, tt.wantErr)
 				}
 				drainAllWorkers(podWorkers)

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -8528,7 +8528,7 @@ func TestKubelet_HandlePodCleanups(t *testing.T) {
 				kl.rejectPod(tCtx, pod, reject.reason, reject.message)
 			}
 
-			if err := kl.HandlePodCleanups(tCtx); (err != nil) != tt.wantErr {
+			if err := kl.HandlePodCleanups(tCtx, func(_ types.UID) bool { return true }); (err != nil) != tt.wantErr {
 				t.Errorf("Kubelet.HandlePodCleanups() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			drainAllWorkers(podWorkers)
@@ -8543,7 +8543,7 @@ func TestKubelet_HandlePodCleanups(t *testing.T) {
 			// check after the terminating error clears
 			if tt.wantWorkerAfterRetry != nil {
 				podWorkers.podSyncer = originalPodSyncer
-				if err := kl.HandlePodCleanups(tCtx); (err != nil) != tt.wantErr {
+				if err := kl.HandlePodCleanups(tCtx, func(_ types.UID) bool { return true }); (err != nil) != tt.wantErr {
 					t.Errorf("Kubelet.HandlePodCleanups() second error = %v, wantErr %v", err, tt.wantErr)
 				}
 				drainAllWorkers(podWorkers)

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -252,7 +252,7 @@ func newTestKubeletWithImageList(
 	kubelet.runtimeState.setNetworkState(nil)
 	kubelet.rootDirectory = t.TempDir()
 	kubelet.podLogsDirectory = t.TempDir()
-	kubelet.sourcesReady = config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
+	kubelet.sourcesReady = config.NewSourcesReady(func(_ sets.Set[string]) bool { return true }, func(_ types.UID) bool { return true })
 	kubelet.serviceLister = testServiceLister{}
 	kubelet.serviceHasSynced = func() bool { return true }
 	kubelet.nodeHasSynced = func() bool { return true }
@@ -345,7 +345,7 @@ func newTestKubeletWithImageList(
 		func(ctx context.Context, pod *v1.Pod) { kubelet.HandlePodSyncs(ctx, []*v1.Pod{pod}) },
 		kubelet.GetActivePods,
 		kubelet.podManager.GetPodByUID,
-		config.NewSourcesReady(func(_ sets.Set[string]) bool { return enableResizing }),
+		config.NewSourcesReady(func(_ sets.Set[string]) bool { return enableResizing }, func(_ types.UID) bool { return true }),
 		kubelet.recorder,
 	)
 	volumeStatsAggPeriod := time.Second * 10
@@ -625,7 +625,7 @@ func TestHandlePodCleanupsPerQOS(t *testing.T) {
 	// within a goroutine so a two second delay should be enough time to
 	// mark the pod as killed (within this test case).
 
-	require.NoError(t, kubelet.HandlePodCleanups(tCtx))
+	require.NoError(t, kubelet.HandlePodCleanups(tCtx, func(_ types.UID) bool { return true }))
 
 	// assert that unwanted pods were killed
 	if actual, expected := kubelet.podWorkers.(*fakePodWorkers).triggeredDeletion, []types.UID{"12345678"}; !reflect.DeepEqual(actual, expected) {
@@ -636,9 +636,9 @@ func TestHandlePodCleanupsPerQOS(t *testing.T) {
 	// simulate Runtime.KillPod
 	fakeRuntime.PodList = nil
 
-	require.NoError(t, kubelet.HandlePodCleanups(tCtx))
-	require.NoError(t, kubelet.HandlePodCleanups(tCtx))
-	require.NoError(t, kubelet.HandlePodCleanups(tCtx))
+	require.NoError(t, kubelet.HandlePodCleanups(tCtx, func(_ types.UID) bool { return true }))
+	require.NoError(t, kubelet.HandlePodCleanups(tCtx, func(_ types.UID) bool { return true }))
+	require.NoError(t, kubelet.HandlePodCleanups(tCtx, func(_ types.UID) bool { return true }))
 
 	destroyCount := 0
 	err := wait.Poll(100*time.Millisecond, 10*time.Second, func() (bool, error) {
@@ -824,7 +824,7 @@ func TestHandlePodCleanups(t *testing.T) {
 	}
 	kubelet := testKubelet.kubelet
 
-	require.NoError(t, kubelet.HandlePodCleanups(tCtx))
+	require.NoError(t, kubelet.HandlePodCleanups(tCtx, func(_ types.UID) bool { return true }))
 
 	// assert that unwanted pods were queued to kill
 	if actual, expected := kubelet.podWorkers.(*fakePodWorkers).triggeredDeletion, []types.UID{"12345678"}; !reflect.DeepEqual(actual, expected) {
@@ -960,7 +960,7 @@ func TestHandlePodRemovesWhenSourcesAreReady(t *testing.T) {
 		{Pod: fakePod},
 	}
 	kubelet := testKubelet.kubelet
-	kubelet.sourcesReady = config.NewSourcesReady(func(_ sets.Set[string]) bool { return ready })
+	kubelet.sourcesReady = config.NewSourcesReady(func(_ sets.Set[string]) bool { return ready }, func(_ types.UID) bool { return ready })
 
 	kubelet.HandlePodRemoves(tCtx, pods)
 	time.Sleep(2 * time.Second)
@@ -1368,7 +1368,7 @@ func TestPurgingObsoleteStatusMapEntries(t *testing.T) {
 	}
 	// Sync with empty pods so that the entry in status map will be removed.
 	kl.podManager.SetPods([]*v1.Pod{})
-	require.NoError(t, kl.HandlePodCleanups(tCtx))
+	require.NoError(t, kl.HandlePodCleanups(tCtx, func(_ types.UID) bool { return true }))
 	if _, found := kl.statusManager.GetPodStatus(podToTest.UID); found {
 		t.Fatalf("expected to not have status cached for pod2")
 	}
@@ -1650,7 +1650,7 @@ func TestDeleteOrphanedMirrorPods(t *testing.T) {
 	}
 
 	// Sync with an empty pod list to delete all mirror pods.
-	require.NoError(t, kl.HandlePodCleanups(tCtx))
+	require.NoError(t, kl.HandlePodCleanups(tCtx, func(_ types.UID) bool { return true }))
 	assert.Empty(t, manager.GetPods(), "Expected no mirror pods")
 	for i, pod := range orphanPods {
 		name := kubecontainer.GetPodFullName(pod)
@@ -1746,7 +1746,7 @@ func TestFilterOutInactivePods(t *testing.T) {
 
 	expected := []*v1.Pod{pods[2], pods[3], pods[4], pods[7]}
 	kubelet.podManager.SetPods(pods)
-	actual := kubelet.filterOutInactivePods(pods)
+	actual := kubelet.filterOutInactivePods(pods, func(_ types.UID) bool { return true })
 	assert.Equal(t, expected, actual)
 }
 
@@ -2000,7 +2000,7 @@ func TestDeletePodDirsForDeletedPods(t *testing.T) {
 
 	// Pod 1 has been deleted and no longer exists.
 	kl.podManager.SetPods([]*v1.Pod{pods[0]})
-	require.NoError(t, kl.HandlePodCleanups(tCtx))
+	require.NoError(t, kl.HandlePodCleanups(tCtx, func(_ types.UID) bool { return true }))
 	assert.True(t, dirExists(kl.getPodDir(pods[0].UID)), "Expected directory to exist for pod 0")
 	assert.False(t, dirExists(kl.getPodDir(pods[1].UID)), "Expected directory to be deleted for pod 1")
 }
@@ -2012,7 +2012,7 @@ func syncAndVerifyPodDir(t *testing.T, testKubelet *TestKubelet, pods []*v1.Pod,
 
 	kl.podManager.SetPods(pods)
 	kl.HandlePodSyncs(tCtx, pods)
-	require.NoError(t, kl.HandlePodCleanups(tCtx))
+	require.NoError(t, kl.HandlePodCleanups(tCtx, func(_ types.UID) bool { return true }))
 	for i, pod := range podsToCheck {
 		exist := dirExists(kl.getPodDir(pod.UID))
 		assert.Equal(t, shouldExist, exist, "directory of pod %d", i)

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -252,7 +252,7 @@ func newTestKubeletWithImageList(
 	kubelet.runtimeState.setNetworkState(nil)
 	kubelet.rootDirectory = t.TempDir()
 	kubelet.podLogsDirectory = t.TempDir()
-	kubelet.sourcesReady = config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
+	kubelet.sourcesReady = config.NewSourcesReady(func(_ sets.Set[string]) bool { return true }, func(_ types.UID) bool { return true })
 	kubelet.serviceLister = testServiceLister{}
 	kubelet.serviceHasSynced = func() bool { return true }
 	kubelet.nodeHasSynced = func() bool { return true }
@@ -345,7 +345,7 @@ func newTestKubeletWithImageList(
 		func(ctx context.Context, pod *v1.Pod) { kubelet.HandlePodSyncs(ctx, []*v1.Pod{pod}) },
 		kubelet.GetActivePods,
 		kubelet.podManager.GetPodByUID,
-		config.NewSourcesReady(func(_ sets.Set[string]) bool { return enableResizing }),
+		config.NewSourcesReady(func(_ sets.Set[string]) bool { return enableResizing }, func(_ types.UID) bool { return true }),
 		kubelet.recorder,
 	)
 	volumeStatsAggPeriod := time.Second * 10
@@ -628,7 +628,7 @@ func TestHandlePodCleanupsPerQOS(t *testing.T) {
 	// within a goroutine so a two second delay should be enough time to
 	// mark the pod as killed (within this test case).
 
-	require.NoError(t, kubelet.HandlePodCleanups(tCtx))
+	require.NoError(t, kubelet.HandlePodCleanups(tCtx, func(_ types.UID) bool { return true }))
 
 	// assert that unwanted pods were killed
 	if actual, expected := kubelet.podWorkers.(*fakePodWorkers).triggeredDeletion, []types.UID{"12345678"}; !reflect.DeepEqual(actual, expected) {
@@ -639,9 +639,9 @@ func TestHandlePodCleanupsPerQOS(t *testing.T) {
 	// simulate Runtime.KillPod
 	fakeRuntime.PodList = nil
 
-	require.NoError(t, kubelet.HandlePodCleanups(tCtx))
-	require.NoError(t, kubelet.HandlePodCleanups(tCtx))
-	require.NoError(t, kubelet.HandlePodCleanups(tCtx))
+	require.NoError(t, kubelet.HandlePodCleanups(tCtx, func(_ types.UID) bool { return true }))
+	require.NoError(t, kubelet.HandlePodCleanups(tCtx, func(_ types.UID) bool { return true }))
+	require.NoError(t, kubelet.HandlePodCleanups(tCtx, func(_ types.UID) bool { return true }))
 
 	destroyCount := 0
 	err := wait.Poll(100*time.Millisecond, 10*time.Second, func() (bool, error) {
@@ -827,7 +827,7 @@ func TestHandlePodCleanups(t *testing.T) {
 	}
 	kubelet := testKubelet.kubelet
 
-	require.NoError(t, kubelet.HandlePodCleanups(tCtx))
+	require.NoError(t, kubelet.HandlePodCleanups(tCtx, func(_ types.UID) bool { return true }))
 
 	// assert that unwanted pods were queued to kill
 	if actual, expected := kubelet.podWorkers.(*fakePodWorkers).triggeredDeletion, []types.UID{"12345678"}; !reflect.DeepEqual(actual, expected) {
@@ -963,7 +963,7 @@ func TestHandlePodRemovesWhenSourcesAreReady(t *testing.T) {
 		{Pod: fakePod},
 	}
 	kubelet := testKubelet.kubelet
-	kubelet.sourcesReady = config.NewSourcesReady(func(_ sets.Set[string]) bool { return ready })
+	kubelet.sourcesReady = config.NewSourcesReady(func(_ sets.Set[string]) bool { return ready }, func(_ types.UID) bool { return ready })
 
 	kubelet.HandlePodRemoves(tCtx, pods)
 	time.Sleep(2 * time.Second)
@@ -1371,7 +1371,7 @@ func TestPurgingObsoleteStatusMapEntries(t *testing.T) {
 	}
 	// Sync with empty pods so that the entry in status map will be removed.
 	kl.podManager.SetPods([]*v1.Pod{})
-	require.NoError(t, kl.HandlePodCleanups(tCtx))
+	require.NoError(t, kl.HandlePodCleanups(tCtx, func(_ types.UID) bool { return true }))
 	if _, found := kl.statusManager.GetPodStatus(podToTest.UID); found {
 		t.Fatalf("expected to not have status cached for pod2")
 	}
@@ -1653,7 +1653,7 @@ func TestDeleteOrphanedMirrorPods(t *testing.T) {
 	}
 
 	// Sync with an empty pod list to delete all mirror pods.
-	require.NoError(t, kl.HandlePodCleanups(tCtx))
+	require.NoError(t, kl.HandlePodCleanups(tCtx, func(_ types.UID) bool { return true }))
 	assert.Empty(t, manager.GetPods(), "Expected no mirror pods")
 	for i, pod := range orphanPods {
 		name := kubecontainer.GetPodFullName(pod)
@@ -1749,7 +1749,7 @@ func TestFilterOutInactivePods(t *testing.T) {
 
 	expected := []*v1.Pod{pods[2], pods[3], pods[4], pods[7]}
 	kubelet.podManager.SetPods(pods)
-	actual := kubelet.filterOutInactivePods(pods)
+	actual := kubelet.filterOutInactivePods(pods, func(_ types.UID) bool { return true })
 	assert.Equal(t, expected, actual)
 }
 
@@ -2012,7 +2012,7 @@ func TestDeletePodDirsForDeletedPods(t *testing.T) {
 
 	// Pod 1 has been deleted and no longer exists.
 	kl.podManager.SetPods([]*v1.Pod{pods[0]})
-	require.NoError(t, kl.HandlePodCleanups(tCtx))
+	require.NoError(t, kl.HandlePodCleanups(tCtx, func(_ types.UID) bool { return true }))
 	assert.True(t, dirExists(kl.getPodDir(pods[0].UID)), "Expected directory to exist for pod 0")
 	assert.False(t, dirExists(kl.getPodDir(pods[1].UID)), "Expected directory to be deleted for pod 1")
 }
@@ -2024,7 +2024,7 @@ func syncAndVerifyPodDir(t *testing.T, testKubelet *TestKubelet, pods []*v1.Pod,
 
 	kl.podManager.SetPods(pods)
 	kl.HandlePodSyncs(tCtx, pods)
-	require.NoError(t, kl.HandlePodCleanups(tCtx))
+	require.NoError(t, kl.HandlePodCleanups(tCtx, func(_ types.UID) bool { return true }))
 	for i, pod := range podsToCheck {
 		exist := dirExists(kl.getPodDir(pod.UID))
 		assert.Equal(t, shouldExist, exist, "directory of pod %d", i)

--- a/pkg/kubelet/kubelet_volumes.go
+++ b/pkg/kubelet/kubelet_volumes.go
@@ -27,6 +27,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/pkg/util/removeall"
@@ -166,7 +167,7 @@ func (kl *Kubelet) removeOrphanedPodVolumeDirs(logger klog.Logger, uid types.UID
 
 // cleanupOrphanedPodDirs removes the volumes of pods that should not be
 // running and that have no containers running.  Note that we roll up logs here since it runs in the main loop.
-func (kl *Kubelet) cleanupOrphanedPodDirs(logger klog.Logger, pods []*v1.Pod, runningPods []*kubecontainer.Pod) error {
+func (kl *Kubelet) cleanupOrphanedPodDirs(logger klog.Logger, pods []*v1.Pod, runningPods []*kubecontainer.Pod, sourceForPodReady config.SourceForPodReadyFn) error {
 	allPods := sets.New[string]()
 	for _, pod := range pods {
 		allPods.Insert(string(pod.UID))
@@ -185,6 +186,10 @@ func (kl *Kubelet) cleanupOrphanedPodDirs(logger klog.Logger, pods []*v1.Pod, ru
 	var totalPods, errorPods int
 
 	for _, uid := range found {
+		// Wait for relevant source to be ready before doing cleanup
+		if !sourceForPodReady(uid) {
+			continue
+		}
 		if allPods.Has(string(uid)) {
 			continue
 		}

--- a/pkg/kubelet/kubelet_volumes_linux_test.go
+++ b/pkg/kubelet/kubelet_volumes_linux_test.go
@@ -182,7 +182,7 @@ func TestCleanupOrphanedPodDirs(t *testing.T) {
 				}
 			}
 
-			err := kubelet.cleanupOrphanedPodDirs(logger, tc.pods, nil)
+			err := kubelet.cleanupOrphanedPodDirs(logger, tc.pods, nil, func(_ types.UID) bool { return true })
 			if tc.expectErr && err == nil {
 				t.Errorf("%s failed: expected error, got success", name)
 			}

--- a/pkg/kubelet/pluginmanager/plugin_manager_test.go
+++ b/pkg/kubelet/pluginmanager/plugin_manager_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
@@ -150,7 +151,7 @@ func TestPluginManager(t *testing.T) {
 	stopChan := make(chan struct{})
 	defer close(stopChan)
 	go func() {
-		sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
+		sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true }, func(_ types.UID) bool { return true })
 		pluginManager.Run(tCtx, sourcesReady, stopChan)
 	}()
 

--- a/pkg/kubelet/prober/prober_manager.go
+++ b/pkg/kubelet/prober/prober_manager.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/klog/v2"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/prober/results"
 	"k8s.io/kubernetes/pkg/kubelet/status"
@@ -86,7 +87,7 @@ type Manager interface {
 
 	// CleanupPods handles cleaning up pods which should no longer be running.
 	// It takes a map of "desired pods" which should not be cleaned up.
-	CleanupPods(desiredPods map[types.UID]sets.Empty)
+	CleanupPods(desiredPods map[types.UID]sets.Empty, sourceForPodReady config.SourceForPodReadyFn)
 
 	// UpdatePodStatus modifies the given PodStatus with the appropriate Ready state for each
 	// container based on container running status, cached probe results and worker states.
@@ -261,11 +262,15 @@ func (m *manager) RemovePod(pod *v1.Pod) {
 	}
 }
 
-func (m *manager) CleanupPods(desiredPods map[types.UID]sets.Empty) {
+func (m *manager) CleanupPods(desiredPods map[types.UID]sets.Empty, sourceForPodReady config.SourceForPodReadyFn) {
 	m.workerLock.RLock()
 	defer m.workerLock.RUnlock()
 
 	for key, worker := range m.workers {
+		// Wait for relevant source to be ready before doing cleanup
+		if !sourceForPodReady(key.podUID) {
+			continue
+		}
 		if _, ok := desiredPods[key.podUID]; !ok {
 			worker.stop()
 		}

--- a/pkg/kubelet/prober/prober_manager.go
+++ b/pkg/kubelet/prober/prober_manager.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/klog/v2"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/prober/results"
 	"k8s.io/kubernetes/pkg/kubelet/status"
@@ -86,7 +87,7 @@ type Manager interface {
 
 	// CleanupPods handles cleaning up pods which should no longer be running.
 	// It takes a map of "desired pods" which should not be cleaned up.
-	CleanupPods(desiredPods map[types.UID]sets.Empty)
+	CleanupPods(desiredPods map[types.UID]sets.Empty, sourceForPodReady config.SourceForPodReadyFn)
 
 	// UpdatePodStatus modifies the given PodStatus with the appropriate Ready state for each
 	// container based on container running status, cached probe results and worker states.
@@ -273,11 +274,15 @@ func (m *manager) RemovePod(pod *v1.Pod) {
 	}
 }
 
-func (m *manager) CleanupPods(desiredPods map[types.UID]sets.Empty) {
+func (m *manager) CleanupPods(desiredPods map[types.UID]sets.Empty, sourceForPodReady config.SourceForPodReadyFn) {
 	m.workerLock.RLock()
 	defer m.workerLock.RUnlock()
 
 	for key, worker := range m.workers {
+		// Wait for relevant source to be ready before doing cleanup
+		if !sourceForPodReady(key.podUID) {
+			continue
+		}
 		if _, ok := desiredPods[key.podUID]; !ok {
 			worker.stop()
 		}

--- a/pkg/kubelet/prober/prober_manager_test.go
+++ b/pkg/kubelet/prober/prober_manager_test.go
@@ -310,7 +310,7 @@ func TestCleanupPods(t *testing.T) {
 
 	desiredPods := map[types.UID]sets.Empty{}
 	desiredPods[podToKeep.UID] = sets.Empty{}
-	m.CleanupPods(desiredPods)
+	m.CleanupPods(desiredPods, func(_ types.UID) bool { return true })
 
 	removedProbes := []probeKey{
 		{"pod_cleanup", "prober1", readiness},
@@ -353,7 +353,7 @@ func TestCleanupRepeated(t *testing.T) {
 	}
 
 	for i := 0; i < 10; i++ {
-		m.CleanupPods(map[types.UID]sets.Empty{})
+		m.CleanupPods(map[types.UID]sets.Empty{}, func(_ types.UID) bool { return true })
 	}
 }
 
@@ -730,7 +730,7 @@ func waitForReadyStatus(t *testing.T, m *manager, ready bool) error {
 
 // cleanup running probes to avoid leaking goroutines.
 func cleanup(t *testing.T, m *manager) {
-	m.CleanupPods(nil)
+	m.CleanupPods(nil, func(_ types.UID) bool { return true })
 
 	condition := func() (bool, error) {
 		workerCount := m.workerCount()

--- a/pkg/kubelet/prober/prober_manager_test.go
+++ b/pkg/kubelet/prober/prober_manager_test.go
@@ -408,7 +408,7 @@ func testCleanupPods(tCtx ktesting.TContext) {
 
 	desiredPods := map[types.UID]sets.Empty{}
 	desiredPods[podToKeep.UID] = sets.Empty{}
-	m.CleanupPods(desiredPods)
+	m.CleanupPods(desiredPods, func(_ types.UID) bool { return true })
 
 	removedProbes := []probeKey{
 		{"pod_cleanup", "prober1", readiness},
@@ -455,7 +455,7 @@ func testCleanupRepeated(tCtx ktesting.TContext) {
 	}
 
 	for i := 0; i < 10; i++ {
-		m.CleanupPods(map[types.UID]sets.Empty{})
+		m.CleanupPods(map[types.UID]sets.Empty{}, func(_ types.UID) bool { return true })
 	}
 }
 
@@ -837,7 +837,7 @@ func waitForReadyStatus(t ktesting.TB, m *manager, ready bool) error {
 
 // cleanup running probes to avoid leaking goroutines.
 func cleanup(t ktesting.TB, m *manager) {
-	m.CleanupPods(nil)
+	m.CleanupPods(nil, func(_ types.UID) bool { return true })
 
 	condition := func() (bool, error) {
 		workerCount := m.workerCount()

--- a/pkg/kubelet/prober/testing/fake_manager.go
+++ b/pkg/kubelet/prober/testing/fake_manager.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/kubelet/config"
 )
 
 // FakeManager simulates a prober.Manager for testing.
@@ -39,7 +40,7 @@ func (FakeManager) RemovePod(_ *v1.Pod) {}
 func (FakeManager) StopLivenessAndStartup(_ *v1.Pod) {}
 
 // CleanupPods simulates cleaning up Pods.
-func (FakeManager) CleanupPods(_ map[types.UID]sets.Empty) {}
+func (FakeManager) CleanupPods(_ map[types.UID]sets.Empty, _ config.SourceForPodReadyFn) {}
 
 // Start simulates start syncing the probe status
 func (FakeManager) Start() {}

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/klog/v2"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
@@ -171,7 +172,7 @@ type Manager interface {
 
 	// RemoveOrphanedStatuses scans the status cache and removes any entries for pods not included in
 	// the provided podUIDs.
-	RemoveOrphanedStatuses(logger klog.Logger, podUIDs map[types.UID]bool)
+	RemoveOrphanedStatuses(logger klog.Logger, podUIDs map[types.UID]bool, sourceForPodReady config.SourceForPodReadyFn)
 
 	// GetPodResizeConditions returns cached PodStatus Resize conditions value
 	GetPodResizeConditions(podUID types.UID) []*v1.PodCondition
@@ -1052,10 +1053,14 @@ func (m *manager) deletePodStatus(uid types.UID) {
 }
 
 // TODO(filipg): It'd be cleaner if we can do this without signal from user.
-func (m *manager) RemoveOrphanedStatuses(logger klog.Logger, podUIDs map[types.UID]bool) {
+func (m *manager) RemoveOrphanedStatuses(logger klog.Logger, podUIDs map[types.UID]bool, sourceForPodReady config.SourceForPodReadyFn) {
 	m.podStatusesLock.Lock()
 	defer m.podStatusesLock.Unlock()
 	for key := range m.podStatuses {
+		// Wait for relevant source to be ready before cleaning
+		if !sourceForPodReady(key) {
+			continue
+		}
 		if _, ok := podUIDs[key]; !ok {
 			logger.V(5).Info("Removing pod from status map", "podUID", key)
 			delete(m.podStatuses, key)

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/klog/v2"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
@@ -177,7 +178,7 @@ type Manager interface {
 
 	// RemoveOrphanedStatuses scans the status cache and removes any entries for pods not included in
 	// the provided podUIDs.
-	RemoveOrphanedStatuses(logger klog.Logger, podUIDs map[types.UID]bool)
+	RemoveOrphanedStatuses(logger klog.Logger, podUIDs map[types.UID]bool, sourceForPodReady config.SourceForPodReadyFn)
 
 	// GetPodResizeConditions returns cached PodStatus Resize conditions value
 	GetPodResizeConditions(podUID types.UID) []*v1.PodCondition
@@ -1144,10 +1145,14 @@ func (m *manager) deletePodStatus(uid types.UID) {
 }
 
 // TODO(filipg): It'd be cleaner if we can do this without signal from user.
-func (m *manager) RemoveOrphanedStatuses(logger klog.Logger, podUIDs map[types.UID]bool) {
+func (m *manager) RemoveOrphanedStatuses(logger klog.Logger, podUIDs map[types.UID]bool, sourceForPodReady config.SourceForPodReadyFn) {
 	m.podStatusesLock.Lock()
 	defer m.podStatusesLock.Unlock()
 	for key := range m.podStatuses {
+		// Wait for relevant source to be ready before cleaning
+		if !sourceForPodReady(key) {
+			continue
+		}
 		if _, ok := podUIDs[key]; !ok {
 			logger.V(5).Info("Removing pod from status map", "podUID", key)
 			delete(m.podStatuses, key)

--- a/pkg/kubelet/status/status_manager_test.go
+++ b/pkg/kubelet/status/status_manager_test.go
@@ -3491,7 +3491,7 @@ func TestPodDeferredResizeDurationSeconds(t *testing.T) {
 			case "delete":
 				manager.deletePodStatus(tc.podUID)
 			case "orphan":
-				manager.RemoveOrphanedStatuses(klog.Background(), map[types.UID]bool{})
+				manager.RemoveOrphanedStatuses(klog.Background(), map[types.UID]bool{}, func(types.UID) bool { return true })
 			}
 
 			count, err := testutil.GetHistogramMetricCount(

--- a/pkg/kubelet/userns/userns_manager.go
+++ b/pkg/kubelet/userns/userns_manager.go
@@ -33,6 +33,7 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/kubeletconfig"
 	utilstore "k8s.io/kubernetes/pkg/kubelet/util/store"
@@ -481,7 +482,7 @@ func (m *UsernsManager) GetOrCreateUserNamespaceMappings(logger klog.Logger, pod
 // CleanupOrphanedPodUsernsAllocations reconciliates the state of user namespace
 // allocations with the pods actually running. It frees any user namespace
 // allocation for orphaned pods.
-func (m *UsernsManager) CleanupOrphanedPodUsernsAllocations(ctx context.Context, pods []*v1.Pod, runningPods []*kubecontainer.Pod) error {
+func (m *UsernsManager) CleanupOrphanedPodUsernsAllocations(ctx context.Context, pods []*v1.Pod, runningPods []*kubecontainer.Pod, sourceForPodReady config.SourceForPodReadyFn) error {
 	if !utilfeature.DefaultFeatureGate.Enabled(features.UserNamespacesSupport) {
 		return nil
 	}
@@ -510,6 +511,10 @@ func (m *UsernsManager) CleanupOrphanedPodUsernsAllocations(ctx context.Context,
 
 	// Lets remove all the pods "found" that are not known.
 	for _, podUID := range found {
+		// Wait for relevant source to be ready before doing cleanup
+		if !sourceForPodReady(podUID) {
+			continue
+		}
 		if allPods.Has(string(podUID)) {
 			continue
 		}
@@ -520,6 +525,11 @@ func (m *UsernsManager) CleanupOrphanedPodUsernsAllocations(ctx context.Context,
 
 	// Lets remove any existing allocation for a pod that is not "found".
 	for podUID := range m.usedBy {
+		// Wait for relevant source to be ready before doing cleanup
+		// Pass nil since we only have UID, not the full pod object
+		if !sourceForPodReady(podUID) {
+			continue
+		}
 		if allFound.Has(string(podUID)) {
 			continue
 		}

--- a/pkg/kubelet/userns/userns_manager_disabled_test.go
+++ b/pkg/kubelet/userns/userns_manager_disabled_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/version"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -126,6 +127,6 @@ func TestCleanupOrphanedPodUsernsAllocationsDisabled(t *testing.T) {
 	m, err := MakeUserNsManager(logger, testUserNsPodsManager, nil)
 	require.NoError(t, err)
 
-	err = m.CleanupOrphanedPodUsernsAllocations(ctx, nil, nil)
+	err = m.CleanupOrphanedPodUsernsAllocations(ctx, nil, nil, func(_ types.UID) bool { return true })
 	assert.NoError(t, err)
 }

--- a/pkg/kubelet/userns/userns_manager_switch_test.go
+++ b/pkg/kubelet/userns/userns_manager_switch_test.go
@@ -136,7 +136,7 @@ func TestCleanupOrphanedPodUsernsAllocationsSwitch(t *testing.T) {
 	// pods registered.
 	featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.35"))
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, false)
-	err = m.CleanupOrphanedPodUsernsAllocations(ctx, nil, nil)
+	err = m.CleanupOrphanedPodUsernsAllocations(ctx, nil, nil, func(_ types.UID) bool { return true })
 	require.NoError(t, err)
 
 	// The feature gate is off, no pods should be allocated.

--- a/pkg/kubelet/userns/userns_manager_test.go
+++ b/pkg/kubelet/userns/userns_manager_test.go
@@ -473,7 +473,7 @@ func TestCleanupOrphanedPodUsernsAllocations(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			err = m.CleanupOrphanedPodUsernsAllocations(ctx, tc.pods, tc.runningPods)
+			err = m.CleanupOrphanedPodUsernsAllocations(ctx, tc.pods, tc.runningPods, func(_ types.UID) bool { return true })
 			require.NoError(t, err)
 
 			for _, pod := range tc.podSetAfterCleanup {

--- a/pkg/kubelet/userns/userns_manager_windows.go
+++ b/pkg/kubelet/userns/userns_manager_windows.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 
@@ -44,7 +45,7 @@ func (m *UsernsManager) GetOrCreateUserNamespaceMappings(klog.Logger, *v1.Pod, s
 // CleanupOrphanedPodUsernsAllocations reconciliates the state of user namespace
 // allocations with the pods actually running. It frees any user namespace
 // allocation for orphaned pods.
-func (m *UsernsManager) CleanupOrphanedPodUsernsAllocations(context.Context, []*v1.Pod, []*kubecontainer.Pod) error {
+func (m *UsernsManager) CleanupOrphanedPodUsernsAllocations(context.Context, []*v1.Pod, []*kubecontainer.Pod, config.SourceForPodReadyFn) error {
 	return nil
 }
 

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -107,7 +107,7 @@ func TestGetMountedVolumesForPodAndGetVolumesInUse(t *testing.T) {
 
 			tCtx := ktesting.Init(t)
 			defer tCtx.Cancel("test has completed")
-			sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
+			sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true }, func(_ kubetypes.UID) bool { return true })
 			go manager.Run(tCtx, sourcesReady)
 
 			podManager.SetPods([]*v1.Pod{pod})
@@ -234,7 +234,7 @@ func TestWaitForAttachAndMountError(t *testing.T) {
 
 	tCtx := ktesting.Init(t)
 	defer tCtx.Cancel("test has completed")
-	sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
+	sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true }, func(_ kubetypes.UID) bool { return true })
 	go manager.Run(tCtx, sourcesReady)
 
 	podManager.SetPods([]*v1.Pod{pod})
@@ -323,7 +323,7 @@ func TestWaitForAttachAndMountVolumeAttachLimitExceededError(t *testing.T) {
 
 	tCtx := ktesting.Init(t)
 	t.Cleanup(func() { tCtx.Cancel("test has completed") })
-	sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
+	sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true }, func(_ kubetypes.UID) bool { return true })
 	go manager.Run(tCtx, sourcesReady)
 	podManager.SetPods([]*v1.Pod{pod})
 
@@ -360,7 +360,7 @@ func TestInitialPendingVolumesForPodAndGetVolumesInUse(t *testing.T) {
 	manager := newTestVolumeManager(t, tmpDir, podManager, kubeClient, node)
 
 	defer tCtx.Cancel("test has completed")
-	sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
+	sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true }, func(_ kubetypes.UID) bool { return true })
 	go manager.Run(tCtx, sourcesReady)
 
 	podManager.SetPods([]*v1.Pod{pod})
@@ -451,7 +451,7 @@ func TestGetExtraSupplementalGroupsForPod(t *testing.T) {
 
 		tCtx := ktesting.Init(t)
 		defer tCtx.Cancel("test has completed")
-		sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
+		sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true }, func(_ kubetypes.UID) bool { return true })
 		go manager.Run(tCtx, sourcesReady)
 
 		podManager.SetPods([]*v1.Pod{pod})
@@ -714,7 +714,7 @@ func TestWaitForAllPodsUnmount(t *testing.T) {
 
 			manager := newTestVolumeManager(t, tmpDir, podManager, kubeClient, node)
 
-			sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
+			sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true }, func(_ kubetypes.UID) bool { return true })
 			go manager.Run(ctx, sourcesReady)
 
 			podManager.SetPods(pods)

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -112,7 +112,7 @@ func TestGetMountedVolumesForPodAndGetVolumesInUse(t *testing.T) {
 
 			tCtx := ktesting.Init(t)
 			defer tCtx.Cancel("test has completed")
-			sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
+			sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true }, func(_ kubetypes.UID) bool { return true })
 			go manager.Run(tCtx, sourcesReady)
 
 			podManager.SetPods([]*v1.Pod{pod})
@@ -239,7 +239,7 @@ func TestWaitForAttachAndMountError(t *testing.T) {
 
 	tCtx := ktesting.Init(t)
 	defer tCtx.Cancel("test has completed")
-	sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
+	sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true }, func(_ kubetypes.UID) bool { return true })
 	go manager.Run(tCtx, sourcesReady)
 
 	podManager.SetPods([]*v1.Pod{pod})
@@ -330,7 +330,7 @@ func TestWaitForAttachAndMountVolumeAttachLimitExceededError(t *testing.T) {
 
 	tCtx := ktesting.Init(t)
 	t.Cleanup(func() { tCtx.Cancel("test has completed") })
-	sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
+	sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true }, func(_ kubetypes.UID) bool { return true })
 	go manager.Run(tCtx, sourcesReady)
 	podManager.SetPods([]*v1.Pod{pod})
 
@@ -367,7 +367,7 @@ func TestInitialPendingVolumesForPodAndGetVolumesInUse(t *testing.T) {
 	manager := newTestVolumeManager(t, tmpDir, podManager, kubeClient, node)
 
 	defer tCtx.Cancel("test has completed")
-	sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
+	sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true }, func(_ kubetypes.UID) bool { return true })
 	go manager.Run(tCtx, sourcesReady)
 
 	podManager.SetPods([]*v1.Pod{pod})
@@ -458,7 +458,7 @@ func TestGetExtraSupplementalGroupsForPod(t *testing.T) {
 
 		tCtx := ktesting.Init(t)
 		defer tCtx.Cancel("test has completed")
-		sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
+		sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true }, func(_ kubetypes.UID) bool { return true })
 		go manager.Run(tCtx, sourcesReady)
 
 		podManager.SetPods([]*v1.Pod{pod})
@@ -723,7 +723,7 @@ func TestWaitForAllPodsUnmount(t *testing.T) {
 
 			manager := newTestVolumeManager(t, tmpDir, podManager, kubeClient, node)
 
-			sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
+			sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true }, func(_ kubetypes.UID) bool { return true })
 			go manager.Run(ctx, sourcesReady)
 
 			podManager.SetPods(pods)

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -489,3 +489,21 @@ func setExtraEnvs() {
 		os.Setenv(name, value)
 	}
 }
+
+// PauseAPIServer pauses the apiserver process using SIGSTOP.
+// This simulates an apiserver outage without killing the process.
+// Use ResumeAPIServer to resume it.
+func PauseAPIServer() error {
+	if e2es == nil {
+		return fmt.Errorf("e2es is nil, services not started")
+	}
+	return e2es.PauseServices()
+}
+
+// ResumeAPIServer resumes the apiserver process using SIGCONT.
+func ResumeAPIServer() error {
+	if e2es == nil {
+		return fmt.Errorf("e2es is nil, services not started")
+	}
+	return e2es.ResumeServices()
+}

--- a/test/e2e_node/services/server_unix.go
+++ b/test/e2e_node/services/server_unix.go
@@ -1,0 +1,54 @@
+//go:build unix
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"fmt"
+	"syscall"
+
+	"k8s.io/klog/v2"
+)
+
+// pause pauses the server process using SIGSTOP.
+func (s *server) pause() error {
+	klog.Infof("Pausing server %q", s.name)
+	cmd := s.startCommand
+	if cmd == nil || cmd.Process == nil {
+		return fmt.Errorf("server %q is not running", s.name)
+	}
+	pid := cmd.Process.Pid
+	if pid <= 1 {
+		return fmt.Errorf("invalid PID %d for %q", pid, s.name)
+	}
+	return syscall.Kill(pid, syscall.SIGSTOP)
+}
+
+// resume resumes the server process using SIGCONT.
+func (s *server) resume() error {
+	klog.Infof("Resuming server %q", s.name)
+	cmd := s.startCommand
+	if cmd == nil || cmd.Process == nil {
+		return fmt.Errorf("server %q is not running", s.name)
+	}
+	pid := cmd.Process.Pid
+	if pid <= 1 {
+		return fmt.Errorf("invalid PID %d for %q", pid, s.name)
+	}
+	return syscall.Kill(pid, syscall.SIGCONT)
+}

--- a/test/e2e_node/services/server_windows.go
+++ b/test/e2e_node/services/server_windows.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import "fmt"
+
+// pause is not supported on Windows.
+func (s *server) pause() error {
+	return fmt.Errorf("pause is not supported on Windows")
+}
+
+// resume is not supported on Windows.
+func (s *server) resume() error {
+	return fmt.Errorf("resume is not supported on Windows")
+}

--- a/test/e2e_node/services/services.go
+++ b/test/e2e_node/services/services.go
@@ -62,22 +62,33 @@ func NewE2EServices(monitorParent bool) *E2EServices {
 // * kubelet: kubelet binary is outside. (We plan to move main kubelet start logic out when we have
 // standard kubelet launcher)
 func (e *E2EServices) Start(ctx context.Context, featureGates map[string]bool) error {
-	var err error
+	if err := e.StartInternalServices(ctx, featureGates); err != nil {
+		return err
+	}
+	// running the kubelet depends on whether we are running conformance test-suite
+	if framework.TestContext.NodeConformance {
+		klog.Info("nothing to do in node-e2e-services, running conformance suite")
+	} else if err := e.StartKubelet(ctx, featureGates); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (e *E2EServices) StartKubelet(ctx context.Context, featureGates map[string]bool) (err error) {
+	// Start kubelet
+	e.kubelet, err = e.startKubelet(ctx, featureGates)
+	if err != nil {
+		return fmt.Errorf("failed to start kubelet: %w", err)
+	}
+	klog.Infof("Kubelet started.")
+	return nil
+}
+
+func (e *E2EServices) StartInternalServices(ctx context.Context, featureGates map[string]bool) (err error) {
 	if e.services, err = e.startInternalServices(); err != nil {
 		return fmt.Errorf("failed to start internal services: %w", err)
 	}
 	klog.Infof("Node services started.")
-	// running the kubelet depends on whether we are running conformance test-suite
-	if framework.TestContext.NodeConformance {
-		klog.Info("nothing to do in node-e2e-services, running conformance suite")
-	} else {
-		// Start kubelet
-		e.kubelet, err = e.startKubelet(ctx, featureGates)
-		if err != nil {
-			return fmt.Errorf("failed to start kubelet: %w", err)
-		}
-		klog.Infof("Kubelet started.")
-	}
 	return nil
 }
 
@@ -89,11 +100,24 @@ func (e *E2EServices) Stop() {
 			e.collectLogFiles()
 		}
 	}()
+	e.StopServices()
+	e.StopKubelet()
+	for _, d := range e.rmDirs {
+		err := os.RemoveAll(d)
+		if err != nil {
+			klog.Errorf("Failed to delete directory %s: %v", d, err)
+		}
+	}
+}
+
+func (e *E2EServices) StopServices() {
 	if e.services != nil {
 		if err := e.services.kill(); err != nil {
 			klog.Errorf("Failed to stop services: %v", err)
 		}
 	}
+}
+func (e *E2EServices) StopKubelet() {
 	if e.kubelet != nil {
 		if err := e.kubelet.kill(); err != nil {
 			klog.Errorf("Failed to kill kubelet: %v", err)
@@ -103,12 +127,22 @@ func (e *E2EServices) Stop() {
 			klog.Errorf("Failed to stop kubelet systemd unit: %v", err)
 		}
 	}
-	for _, d := range e.rmDirs {
-		err := os.RemoveAll(d)
-		if err != nil {
-			klog.Errorf("Failed to delete directory %s: %v", d, err)
-		}
+}
+
+// PauseServices pauses the services process (apiserver + etcd) using SIGSTOP.
+func (e *E2EServices) PauseServices() error {
+	if e.services != nil {
+		return e.services.pause()
 	}
+	return fmt.Errorf("services not started")
+}
+
+// ResumeServices resumes the services process (apiserver + etcd) using SIGCONT.
+func (e *E2EServices) ResumeServices() error {
+	if e.services != nil {
+		return e.services.resume()
+	}
+	return fmt.Errorf("services not started")
 }
 
 // RunE2EServices actually start the e2e services. This function is used to

--- a/test/e2e_node/static_pod_apiserver_down_test.go
+++ b/test/e2e_node/static_pod_apiserver_down_test.go
@@ -1,0 +1,208 @@
+//go:build linux
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = SIGDescribe("StaticPod", framework.WithDisruptive(), framework.WithSerial(), func() {
+	f := framework.NewDefaultFramework("static-pod-apiserver-down")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	ginkgo.Context("when apiserver is unreachable", func() {
+		ginkgo.It("should restart static pod when spec changes", func(ctx context.Context) {
+			staticPodName := "test-static-pod"
+			staticPodUID := types.UID("static-test-uid-123")
+			mirrorPodName := fmt.Sprintf("%s-%s", staticPodName, framework.TestContext.NodeName)
+
+			kubeletCfg, err := getCurrentKubeletConfig(ctx)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("creating initial static pod with static UID while apiserver is up")
+			staticPod := &v1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      staticPodName,
+					Namespace: f.Namespace.Name,
+					UID:       staticPodUID,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "test-container",
+							Image: imageutils.GetE2EImage(imageutils.Pause),
+							Env: []v1.EnvVar{
+								{Name: "VERSION", Value: "v1"},
+							},
+						},
+					},
+				},
+			}
+
+			staticPodPath, err := createStaticPodFromPod(kubeletCfg.StaticPodPath, staticPod)
+			framework.ExpectNoError(err)
+			ginkgo.DeferCleanup(func() {
+				ginkgo.By("cleaning up static pod file")
+				_ = os.Remove(staticPodPath)
+			})
+
+			ginkgo.By("waiting for mirror pod to appear in API server")
+			var originalMirrorPod *v1.Pod
+			gomega.Eventually(ctx, func(g gomega.Gomega) {
+				pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, mirrorPodName, metav1.GetOptions{})
+				g.Expect(err).Should(gomega.Succeed())
+				g.Expect(pod.Status.Phase).Should(gomega.Equal(v1.PodRunning))
+				originalMirrorPod = pod
+			}, 2*time.Minute, 2*time.Second).Should(gomega.Succeed())
+
+			framework.Logf("Mirror pod created: %s (UID: %s, env: %s)",
+				originalMirrorPod.Name, originalMirrorPod.UID, originalMirrorPod.Spec.Containers[0].Env[0].Value)
+
+			ginkgo.By("pausing apiserver to simulate apiserver restart")
+			err = PauseAPIServer()
+			framework.ExpectNoError(err)
+			ginkgo.DeferCleanup(func() {
+				ginkgo.By("resuming apiserver")
+				_ = ResumeAPIServer()
+			})
+
+			ginkgo.By("restarting kubelet so it hasn't seen API source yet")
+			restartKubelet(ctx, true)
+
+			// Can't use waitForKubeletToStart becase the apiserver is down
+			gomega.Eventually(ctx, func() bool {
+				return e2enode.HealthCheck(kubeletHealthCheckURL)
+			}, 2*time.Minute, 5*time.Second).Should(gomega.BeTrueBecause("expected kubelet to be healthy"))
+
+			ginkgo.By("waiting for pod to start after kubelet restart")
+			originalContainerID := waitForContainer(ctx, f.Namespace.Name, mirrorPodName, "test-container", 30*time.Second,
+				func(g gomega.Gomega, foundPodID, foundContainerID string) {
+					g.Expect(foundPodID).NotTo(gomega.BeEmpty(), "pod should exist")
+					g.Expect(foundContainerID).NotTo(gomega.BeEmpty(), "should find container")
+				})
+			framework.Logf("Pod restarted after kubelet restart, container ID: %s", originalContainerID)
+
+			ginkgo.By("deleting static pod file while apiserver is paused")
+			err = os.Remove(staticPodPath)
+			framework.ExpectNoError(err)
+
+			time.Sleep(2 * time.Second)
+
+			ginkgo.By("recreating static pod with updated spec (keeping static UID)")
+			staticPod.Spec.Containers[0].Env[0].Value = "v2"
+			staticPodPath, err = createStaticPodFromPod(kubeletCfg.StaticPodPath, staticPod)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("verifying pod restarts locally via CRI while API is still paused")
+			// The fix (SourceForPodReady) should allow deletion/recreation within ~40 seconds
+			// Without the fix (AllReady check), deletion would be blocked indefinitely while API is paused
+			newContainerID := waitForContainer(ctx, f.Namespace.Name, mirrorPodName, "test-container", 45*time.Second,
+				func(g gomega.Gomega, foundPodID, foundContainerID string) {
+					g.Expect(foundPodID).NotTo(gomega.BeEmpty(), "pod should exist")
+					g.Expect(foundContainerID).NotTo(gomega.BeEmpty(), "should find container")
+					g.Expect(foundContainerID).NotTo(gomega.Equal(originalContainerID), "should find new container with different ID")
+				})
+
+			framework.Logf("Static pod restarted locally while API was paused (old container: %s, new container: %s)",
+				originalContainerID, newContainerID)
+
+			ginkgo.By("verifying API server is still paused after pod restarted")
+			// This confirms the restart happened without waiting for API to come back
+			_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).List(ctx, metav1.ListOptions{})
+			gomega.Expect(err).Should(gomega.HaveOccurred(), "API should still be unavailable")
+
+			ginkgo.By("resuming apiserver to restore connectivity")
+			err = ResumeAPIServer()
+			framework.ExpectNoError(err)
+
+			ginkgo.By("deleting static pod file")
+			err = os.Remove(staticPodPath)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("verifying pod is deleted")
+			waitForContainer(ctx, f.Namespace.Name, mirrorPodName, "test-container", 30*time.Second,
+				func(g gomega.Gomega, foundPodID, foundContainerID string) {
+					g.Expect(foundPodID).To(gomega.BeEmpty(), "pod should be deleted")
+				})
+
+			ginkgo.By("verifying mirror pod is deleted from API")
+			gomega.Eventually(ctx, func(g gomega.Gomega) {
+				_, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, mirrorPodName, metav1.GetOptions{})
+				g.Expect(apierrors.IsNotFound(err)).To(gomega.BeTrueBecause("mirror pod should be deleted"))
+			}, 30*time.Second, 2*time.Second).Should(gomega.Succeed())
+
+			framework.Logf("Static pod and mirror pod successfully deleted")
+		})
+	})
+})
+
+func waitForContainer(ctx context.Context, namespace, podName, containerName string, timeout time.Duration,
+	verifier func(g gomega.Gomega, foundPodID, foundContainerID string)) string {
+	var containerID string
+	gomega.EventuallyWithOffset(1, ctx, func(g gomega.Gomega) {
+		cricli, _, err := getCRIClient(ctx)
+		g.Expect(err).Should(gomega.Succeed())
+
+		pods, err := cricli.ListPodSandbox(ctx, &runtimeapi.PodSandboxFilter{})
+		g.Expect(err).Should(gomega.Succeed())
+
+		var targetPodID string
+		for _, pod := range pods {
+			if pod.Metadata.Name == podName && pod.Metadata.Namespace == namespace {
+				targetPodID = pod.Id
+				break
+			}
+		}
+
+		if targetPodID != "" {
+			containers, err := cricli.ListContainers(ctx, &runtimeapi.ContainerFilter{PodSandboxId: targetPodID})
+			g.Expect(err).Should(gomega.Succeed())
+
+			for _, container := range containers {
+				if container.Metadata.Name == containerName {
+					containerID = container.Id
+					break
+				}
+			}
+		}
+
+		verifier(g, targetPodID, containerID)
+	}, timeout, 2*time.Second).Should(gomega.Succeed())
+	return containerID
+}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug 
#### What this PR does / why we need it:
Currently, while we wait for the apiserver source to become available, we also wait to do anything with static pods.

This has the side effect of not being able to restart a static pod if the kubelet knows there will eventually be an apiserver available.

Within the config package, track which source pods come from (by uid, so it can be used in RemoveOrphanedPods) and allow for updates from a source if that source is available

#### Which issue(s) this PR is related to:
fixes https://github.com/kubernetes/kubernetes/issues/105543

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix a bug where the a static apiserver pod can get wedged if a restart is timed correctly against a kubelet restart
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
