### PR TITLE
iscsi: prevent plugin directory path traversal

### DIFF
--- a/pkg/volume/iscsi/attacher.go
+++ b/pkg/volume/iscsi/attacher.go
@@ -104,6 +104,11 @@ func (attacher *iscsiAttacher) GetDeviceMountPath(
 }
 
 func (attacher *iscsiAttacher) MountDevice(spec *volume.Spec, devicePath string, deviceMountPath string, mountArgs volume.DeviceMounterArgs) error {
+	pluginDir := attacher.host.GetPluginDir(iscsiPluginName)
+	if err := validateISCSIPluginPath(deviceMountPath, pluginDir); err != nil {
+		return err
+	}
+
 	mounter := attacher.host.GetMounter()
 	notMnt, err := mounter.IsLikelyNotMountPoint(deviceMountPath)
 	if err != nil {
@@ -169,6 +174,11 @@ func (detacher *iscsiDetacher) Detach(volumeName string, nodeName types.NodeName
 }
 
 func (detacher *iscsiDetacher) UnmountDevice(deviceMountPath string) error {
+	pluginDir := detacher.host.GetPluginDir(iscsiPluginName)
+	if err := validateISCSIPluginPath(deviceMountPath, pluginDir); err != nil {
+		return err
+	}
+
 	unMounter := volumeSpecToUnmounter(detacher.mounter, detacher.host, detacher.plugin)
 	err := detacher.manager.DetachDisk(*unMounter, deviceMountPath)
 	if err != nil {

--- a/pkg/volume/iscsi/disk_manager.go
+++ b/pkg/volume/iscsi/disk_manager.go
@@ -67,6 +67,12 @@ func diskSetUp(manager diskManager, b iscsiDiskMounter, volPath string, mounter 
 		b.iscsiDisk.Iface = b.iscsiDisk.Portals[0] + ":" + b.iscsiDisk.VolName
 	}
 	globalPDPath := manager.MakeGlobalPDName(*b.iscsiDisk)
+
+	pluginDir := b.plugin.host.GetPluginDir(iscsiPluginName)
+	if err := validateISCSIPluginPath(globalPDPath, pluginDir); err != nil {
+		return err
+	}
+
 	mountOptions := util.JoinMountOptions(b.mountOptions, options)
 	err = mounter.MountSensitiveWithoutSystemd(globalPDPath, volPath, "", mountOptions, nil)
 	if err != nil {

--- a/pkg/volume/iscsi/iscsi_test.go
+++ b/pkg/volume/iscsi/iscsi_test.go
@@ -144,6 +144,82 @@ func (fake *fakeDiskManager) DetachBlockISCSIDisk(c iscsiDiskUnmapper, mntPath s
 	return nil
 }
 
+// pathTraversalDiskManager constructs global paths using the production
+// helpers so traversal behavior can be exercised in tests.
+type pathTraversalDiskManager struct {
+	host volume.VolumeHost
+}
+
+func (m *pathTraversalDiskManager) MakeGlobalPDName(disk iscsiDisk) string {
+	return makePDNameInternal(m.host, disk.Portals[0], disk.Iqn, disk.Lun, disk.Iface)
+}
+
+func (m *pathTraversalDiskManager) MakeGlobalVDPDName(disk iscsiDisk) string {
+	return makeVDPDNameInternal(m.host, disk.Portals[0], disk.Iqn, disk.Lun, disk.Iface)
+}
+
+func (*pathTraversalDiskManager) AttachDisk(b iscsiDiskMounter) (string, error) {
+	return "", nil
+}
+
+func (*pathTraversalDiskManager) DetachDisk(c iscsiDiskUnmounter, mntPath string) error {
+	return nil
+}
+
+func (*pathTraversalDiskManager) DetachBlockISCSIDisk(c iscsiDiskUnmapper, mntPath string) error {
+	return nil
+}
+
+func TestPersistISCSIRejectsEscapedPluginPath(t *testing.T) {
+	root := t.TempDir()
+
+	host := volumetest.NewFakeVolumeHost(t, root, nil, nil)
+	plugin := &iscsiPlugin{host: host}
+
+	manager := &pathTraversalDiskManager{host: host}
+
+	mounter := iscsiDiskMounter{
+		iscsiDisk: &iscsiDisk{
+			Portals: []string{"10.0.0.1:3260"},
+			Iqn:     "iqn.2026-06.example.com:../../../../../escape",
+			Lun:     "0",
+			Iface:   "default",
+			plugin:  plugin,
+			manager: manager,
+		},
+		volumeMode: v1.PersistentVolumeFilesystem,
+		mounter: &mount.SafeFormatAndMount{
+			Interface: mount.NewFakeMounter(nil),
+		},
+	}
+
+	err := (&ISCSIUtil{}).persistISCSI(mounter)
+	if err == nil {
+		t.Fatal("expected escaped plugin path to be rejected")
+	}
+	if !strings.Contains(err.Error(), "escapes plugin directory") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	pluginDir := host.GetPluginDir(iscsiPluginName)
+
+	escapedPath := makePDNameInternal(
+		host,
+		"10.0.0.1:3260",
+		"iqn.2026-06.example.com:../../../../../escape",
+		"0",
+		"default",
+	)
+
+	if mount.PathWithinBase(escapedPath, pluginDir) {
+		t.Fatalf("expected test path %q to escape plugin dir %q", escapedPath, pluginDir)
+	}
+
+	if _, err := os.Stat(escapedPath); !os.IsNotExist(err) {
+		t.Fatalf("expected escaped path not to be created, got err=%v", err)
+	}
+}
+
 func doTestPlugin(t *testing.T, spec *volume.Spec) {
 	tmpDir, err := utiltesting.MkTmpdir("iscsi_test")
 	if err != nil {

--- a/pkg/volume/iscsi/iscsi_test.go
+++ b/pkg/volume/iscsi/iscsi_test.go
@@ -95,9 +95,9 @@ type fakeDiskManager struct {
 	tmpDir string
 }
 
-func NewFakeDiskManager() *fakeDiskManager {
+func NewFakeDiskManager(pluginDir string) *fakeDiskManager {
 	return &fakeDiskManager{
-		tmpDir: utiltesting.MkTmpdirOrDie("iscsi_test"),
+		tmpDir: filepath.Join(pluginDir, "fake-global-pd"),
 	}
 }
 
@@ -144,6 +144,217 @@ func (fake *fakeDiskManager) DetachBlockISCSIDisk(c iscsiDiskUnmapper, mntPath s
 	return nil
 }
 
+// pathTraversalDiskManager constructs global paths using the production
+// helpers so traversal behavior can be exercised in tests.
+type pathTraversalDiskManager struct {
+	host volume.VolumeHost
+}
+
+func (m *pathTraversalDiskManager) MakeGlobalPDName(disk iscsiDisk) string {
+	return makePDNameInternal(m.host, disk.Portals[0], disk.Iqn, disk.Lun, disk.Iface)
+}
+
+func (m *pathTraversalDiskManager) MakeGlobalVDPDName(disk iscsiDisk) string {
+	return makeVDPDNameInternal(m.host, disk.Portals[0], disk.Iqn, disk.Lun, disk.Iface)
+}
+
+func (*pathTraversalDiskManager) AttachDisk(b iscsiDiskMounter) (string, error) {
+	return "", nil
+}
+
+func (*pathTraversalDiskManager) DetachDisk(c iscsiDiskUnmounter, mntPath string) error {
+	return nil
+}
+
+func (*pathTraversalDiskManager) DetachBlockISCSIDisk(c iscsiDiskUnmapper, mntPath string) error {
+	return nil
+}
+
+func TestPersistISCSIRejectsEscapedPluginPath(t *testing.T) {
+	root := t.TempDir()
+
+	host := volumetest.NewFakeVolumeHost(t, root, nil, nil)
+	plugin := &iscsiPlugin{host: host}
+
+	manager := &pathTraversalDiskManager{host: host}
+
+	mounter := iscsiDiskMounter{
+		iscsiDisk: &iscsiDisk{
+			Portals: []string{"10.0.0.1:3260"},
+			Iqn:     "iqn.2026-06.example.com:../../../../../escape",
+			Lun:     "0",
+			Iface:   "default",
+			plugin:  plugin,
+			manager: manager,
+		},
+		volumeMode: v1.PersistentVolumeFilesystem,
+		mounter: &mount.SafeFormatAndMount{
+			Interface: mount.NewFakeMounter(nil),
+		},
+	}
+
+	err := (&ISCSIUtil{}).persistISCSI(mounter)
+	if err == nil {
+		t.Fatal("expected escaped plugin path to be rejected")
+	}
+	if !strings.Contains(err.Error(), "escapes plugin directory") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	pluginDir := host.GetPluginDir(iscsiPluginName)
+
+	escapedPath := makePDNameInternal(
+		host,
+		"10.0.0.1:3260",
+		"iqn.2026-06.example.com:../../../../../escape",
+		"0",
+		"default",
+	)
+
+	if mount.PathWithinBase(escapedPath, pluginDir) {
+		t.Fatalf("expected test path %q to escape plugin dir %q", escapedPath, pluginDir)
+	}
+
+	if _, err := os.Stat(escapedPath); !os.IsNotExist(err) {
+		t.Fatalf("expected escaped path not to be created, got err=%v", err)
+	}
+}
+
+func TestMountDeviceRejectsEscapedPluginPath(t *testing.T) {
+	root := t.TempDir()
+	host := volumetest.NewFakeVolumeHost(t, root, nil, nil)
+
+	pluginDir := host.GetPluginDir(iscsiPluginName)
+
+	escapedPath := makePDNameInternal(
+		host,
+		"10.0.0.1:3260",
+		"iqn.2026-06.example.com:../../../../../escape",
+		"0",
+		"default",
+	)
+
+	if mount.PathWithinBase(escapedPath, pluginDir) {
+		t.Fatalf("expected test path %q to escape plugin dir %q", escapedPath, pluginDir)
+	}
+
+	attacher := &iscsiAttacher{
+		host: host,
+	}
+
+	err := attacher.MountDevice(
+		nil,
+		"/dev/fake",
+		escapedPath,
+		volume.DeviceMounterArgs{},
+	)
+	if err == nil {
+		t.Fatal("expected escaped plugin path to be rejected")
+	}
+
+	if !strings.Contains(err.Error(), "escapes plugin directory") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := os.Stat(escapedPath); !os.IsNotExist(err) {
+		t.Fatalf("expected escaped path not to be created, got err=%v", err)
+	}
+}
+
+func TestUnmountDeviceRejectsEscapedPluginPath(t *testing.T) {
+	root := t.TempDir()
+	host := volumetest.NewFakeVolumeHost(t, root, nil, nil)
+
+	pluginDir := host.GetPluginDir(iscsiPluginName)
+
+	escapedPath := makePDNameInternal(
+		host,
+		"10.0.0.1:3260",
+		"iqn.2026-06.example.com:../../../../../escape",
+		"0",
+		"default",
+	)
+
+	if mount.PathWithinBase(escapedPath, pluginDir) {
+		t.Fatalf("expected test path %q to escape plugin dir %q", escapedPath, pluginDir)
+	}
+
+	if err := os.MkdirAll(escapedPath, 0750); err != nil {
+		t.Fatalf("failed to create escaped test path: %v", err)
+	}
+
+	sentinel := filepath.Join(escapedPath, "sentinel")
+	if err := os.WriteFile(sentinel, []byte("keep"), 0600); err != nil {
+		t.Fatalf("failed to create sentinel: %v", err)
+	}
+
+	detacher := &iscsiDetacher{
+		host: host,
+	}
+
+	err := detacher.UnmountDevice(escapedPath)
+	if err == nil {
+		t.Fatal("expected escaped plugin path to be rejected")
+	}
+
+	if !strings.Contains(err.Error(), "escapes plugin directory") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("escaped path was modified or removed: %v", err)
+	}
+}
+
+func TestDiskSetUpRejectsEscapedPluginPath(t *testing.T) {
+	root := t.TempDir()
+
+	host := volumetest.NewFakeVolumeHost(t, root, nil, nil)
+	plugin := &iscsiPlugin{host: host}
+	manager := &pathTraversalDiskManager{host: host}
+
+	fakeMounter := mount.NewFakeMounter(nil)
+
+	mounter := iscsiDiskMounter{
+		iscsiDisk: &iscsiDisk{
+			Portals: []string{"10.0.0.1:3260"},
+			Iqn:     "iqn.2026-06.example.com:../../../../../escape",
+			Lun:     "0",
+			Iface:   "default",
+			plugin:  plugin,
+			manager: manager,
+		},
+		mounter: &mount.SafeFormatAndMount{
+			Interface: fakeMounter,
+		},
+	}
+
+	globalPDPath := manager.MakeGlobalPDName(*mounter.iscsiDisk)
+	pluginDir := host.GetPluginDir(iscsiPluginName)
+
+	if mount.PathWithinBase(globalPDPath, pluginDir) {
+		t.Fatalf("expected test path %q to escape plugin dir %q", globalPDPath, pluginDir)
+	}
+
+	volPath := filepath.Join(root, "pods", "poduid", "volumes", "kubernetes.io~iscsi", "vol1")
+
+	err := diskSetUp(
+		manager,
+		mounter,
+		volPath,
+		fakeMounter,
+		volume.MounterArgs{},
+	)
+
+	if err == nil {
+		t.Fatal("expected escaped plugin path to be rejected")
+	}
+
+	if !strings.Contains(err.Error(), "escapes plugin directory") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func doTestPlugin(t *testing.T, spec *volume.Spec) {
 	tmpDir, err := utiltesting.MkTmpdir("iscsi_test")
 	if err != nil {
@@ -158,7 +369,10 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
-	fakeManager := NewFakeDiskManager()
+
+	pluginDir := plug.(*iscsiPlugin).host.GetPluginDir(iscsiPluginName)
+
+	fakeManager := NewFakeDiskManager(pluginDir)
 	defer fakeManager.Cleanup()
 	fakeMounter := mount.NewFakeMounter(nil)
 	fakeExec := &testingexec.FakeExec{}
@@ -187,7 +401,7 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 		}
 	}
 
-	fakeManager2 := NewFakeDiskManager()
+	fakeManager2 := NewFakeDiskManager(pluginDir)
 	defer fakeManager2.Cleanup()
 	unmounter, err := plug.(*iscsiPlugin).newUnmounterInternal("vol1", types.UID("poduid"), fakeManager2, fakeMounter, fakeExec)
 	if err != nil {

--- a/pkg/volume/iscsi/iscsi_util.go
+++ b/pkg/volume/iscsi/iscsi_util.go
@@ -492,6 +492,21 @@ func (util *ISCSIUtil) persistISCSI(b iscsiDiskMounter) error {
 		globalPDPath = b.manager.MakeGlobalPDName(*b.iscsiDisk)
 	}
 
+	var pluginDir string
+	if b.volumeMode == v1.PersistentVolumeBlock {
+		pluginDir = b.iscsiDisk.plugin.host.GetVolumeDevicePluginDir(iscsiPluginName)
+	} else {
+		pluginDir = b.iscsiDisk.plugin.host.GetPluginDir(iscsiPluginName)
+	}
+
+	if !mount.PathWithinBase(globalPDPath, pluginDir) {
+		return fmt.Errorf(
+			"iscsi: resolved path %q escapes plugin directory %q",
+			globalPDPath,
+			pluginDir,
+		)
+	}
+
 	if err := os.MkdirAll(globalPDPath, 0750); err != nil {
 		klog.Errorf("iscsi: failed to mkdir %s: %v", globalPDPath, err)
 		return err

--- a/pkg/volume/iscsi/iscsi_util.go
+++ b/pkg/volume/iscsi/iscsi_util.go
@@ -481,6 +481,17 @@ func (util *ISCSIUtil) AttachDisk(b iscsiDiskMounter) (string, error) {
 	return devicePath, nil
 }
 
+func validateISCSIPluginPath(path, pluginDir string) error {
+	if !mount.PathWithinBase(path, pluginDir) {
+		return fmt.Errorf(
+			"iscsi: resolved path %q escapes plugin directory %q",
+			path,
+			pluginDir,
+		)
+	}
+	return nil
+}
+
 // persistISCSI saves iSCSI volume configuration for DetachDisk into global
 // mount / map directory.
 func (util *ISCSIUtil) persistISCSI(b iscsiDiskMounter) error {
@@ -490,6 +501,17 @@ func (util *ISCSIUtil) persistISCSI(b iscsiDiskMounter) error {
 		globalPDPath = b.manager.MakeGlobalVDPDName(*b.iscsiDisk)
 	} else {
 		globalPDPath = b.manager.MakeGlobalPDName(*b.iscsiDisk)
+	}
+
+	var pluginDir string
+	if b.volumeMode == v1.PersistentVolumeBlock {
+		pluginDir = b.iscsiDisk.plugin.host.GetVolumeDevicePluginDir(iscsiPluginName)
+	} else {
+		pluginDir = b.iscsiDisk.plugin.host.GetPluginDir(iscsiPluginName)
+	}
+
+	if err := validateISCSIPluginPath(globalPDPath, pluginDir); err != nil {
+		return err
 	}
 
 	if err := os.MkdirAll(globalPDPath, 0750); err != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it
This PR prevents path traversal when persisting iSCSI metadata under the kubelet plugin directory.

Previously, `persistISCSI()` trusted the path returned by `MakeGlobalPDName()` / `MakeGlobalVDPDName()` and called `os.MkdirAll()` directly. Since the global path is derived from API-supplied iSCSI identifiers (such as the IQN), a crafted IQN containing `../` segments could cause the resolved path to escape the expected kubelet iSCSI plugin directory.

This change validates that the resolved global path remains within the expected plugin directory before creating any directories or writing `iscsi.json`. If the resolved path escapes the plugin directory, `persistISCSI()` now returns an error instead of performing filesystem operations.
A regression test has also been added to verify that:
- a traversal-style IQN resolves outside the plugin directory,
- `persistISCSI()` rejects the escaped path,
- no directories or files are created outside the plugin directory.

#### Which issue(s) this PR fixes

Fixes #140129

#### Special notes for your reviewer
This change only adds a defensive validation before filesystem operations and does not change the normal path generation or behavior for valid iSCSI volumes.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```