### PR TITLE
e2e_node: fix nil pointer panic in StandaloneMode restart test

### DIFF
--- a/test/e2e_node/standalone_test.go
+++ b/test/e2e_node/standalone_test.go
@@ -395,8 +395,9 @@ var _ = SIGDescribe(feature.StandaloneMode, func() {
 				ginkgo.By("wait for the mirror pod to be updated")
 				gomega.Eventually(ctx, func(g gomega.Gomega) {
 					pod, err := getPodFromStandaloneKubelet(ctx, staticPod.Namespace, staticPod.Name)
-					g.Expect(pod.Status.StartTime.Equal(startTime)).To(gomega.BeFalseBecause("startTime should not be equal"))
 					g.Expect(err).Should(gomega.Succeed())
+					g.Expect(pod.Status.StartTime).NotTo(gomega.BeNil(), "startTime should be set once the mirror pod is recreated after kubelet restart")
+					g.Expect(pod.Status.StartTime.Equal(startTime)).To(gomega.BeFalseBecause("startTime should not be equal"))
 					g.Expect(pod.Status.InitContainerStatuses).To(gomega.HaveLen(1))
 					cstatus := pod.Status.InitContainerStatuses[0]
 					// Init container should be completed.


### PR DESCRIPTION


#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

`getPodFromStandaloneKubelet` returns `(nil, err)` whenever the kubelet's
`/pods` endpoint is transiently unreachable, which happens briefly right
after a kubelet restart.

In the `StandaloneMode` restart test, the second `Eventually` block
dereferenced `pod.Status.StartTime` *before* checking `err`. When the
`/pods` endpoint was briefly unreachable post-restart, `pod` was `nil`
and the test panicked with a nil pointer dereference instead of letting
`Eventually` retry.

This reorders the assertions to check `err` first and guards
`pod.Status.StartTime` against `nil` before comparing it, matching the
pattern already used earlier in the same test (and elsewhere in this
file).

#### Which issue(s) this PR fixes:

Related to #139469

Fixes one identified failure pattern contributing to the flakiness
reported in that issue (`ci-kubernetes-node-kubelet-serial-containerd`).
Note: that issue tracks multiple flake patterns in the job, not a single
test, so this PR addresses one specific panic and is not expected to
resolve all flakiness in that job.

Evidence of the panic:
[PANICKED] runtime error: invalid memory address or nil pointer dereference
k8s.io/kubernetes/test/e2e_node/standalone_test.go:398


Build: https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-node-kubelet-serial-containerd/2061411115304226816/artifacts/junit_cos-101.xml

#### Special notes for your reviewer:

Test-only change, no production code affected.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```