### PR TITLE
Harden probe stress test container state checks

### DIFF
--- a/test/e2e_node/probe_stress_test.go
+++ b/test/e2e_node/probe_stress_test.go
@@ -72,7 +72,7 @@ var _ = SIGDescribe("Probe Stress", framework.WithSerial(), func() {
 })
 
 // runProbeStressTest creates a pod with many containers, waits for them to be running,
-// and verifies that none of the containers have restarted unexpectedly.
+// and verifies that all containers keep running without restarting unexpectedly.
 func runProbeStressTest(ctx context.Context, f *framework.Framework, pod *v1.Pod) {
 	ginkgo.By(fmt.Sprintf("Creating pod %s with %d containers", pod.Name, len(pod.Spec.Containers)))
 	pod = e2epod.NewPodClient(f).Create(ctx, pod)
@@ -81,21 +81,35 @@ func runProbeStressTest(ctx context.Context, f *framework.Framework, pod *v1.Pod
 	err := e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod)
 	framework.ExpectNoError(err, "Failed to start pod")
 
-	ginkgo.By("Verifying no containers restarted")
+	ginkgo.By("Verifying all containers stay running with no restarts")
 	gomega.Consistently(ctx, func(ctx context.Context) error {
 		updatedPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
+		// The pod uses RestartPolicy Never, so a failed liveness probe kills the
+		// container without incrementing RestartCount. Also require every container
+		// status to be present and Running to catch probe-induced kills.
+		if len(updatedPod.Status.ContainerStatuses) != len(pod.Spec.Containers) {
+			return fmt.Errorf("expected %d container statuses, got %d", len(pod.Spec.Containers), len(updatedPod.Status.ContainerStatuses))
+		}
 		for _, containerStatus := range updatedPod.Status.ContainerStatuses {
 			if containerStatus.RestartCount > 0 {
 				return fmt.Errorf("container %s restarted %d times", containerStatus.Name, containerStatus.RestartCount)
+			}
+			switch {
+			case containerStatus.State.Waiting != nil:
+				return fmt.Errorf("container %s is waiting: %s", containerStatus.Name, containerStatus.State.Waiting.Reason)
+			case containerStatus.State.Terminated != nil:
+				return fmt.Errorf("container %s terminated: reason=%s, exitCode=%d", containerStatus.Name, containerStatus.State.Terminated.Reason, containerStatus.State.Terminated.ExitCode)
+			case containerStatus.State.Running == nil:
+				return fmt.Errorf("container %s is not running", containerStatus.Name)
 			}
 		}
 		return nil
 	}, probeStressWaitTime, 1*time.Second).Should(gomega.Succeed())
 
-	ginkgo.By("Test passed: no unexpected container restarts")
+	ginkgo.By("Test passed: all containers stayed running with no restarts")
 }
 
 func createPodWithHTTPProbes(numContainers int) *v1.Pod {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig node

#### What this PR does / why we need it

This hardens the probe stress e2e test by verifying that all expected container statuses are present and that each container remains running during the stress window.

The existing test checks RestartCount, but the stress pod uses RestartPolicy: Never. If a liveness probe kills a container under that restart policy, the container may terminate without incrementing RestartCount. Checking the running state makes the test catch that failure mode.

#### Which issue(s) this PR fixes

Related to #115782

#### Special notes for your reviewer

Test-only follow-up to the existing probe stress coverage.

Local validation:
- `git diff --check`
- `./hack/verify-gofmt.sh`
- `./hack/verify-boilerplate.sh`
- `go test -c ./test/e2e_node`

Note: `go test ./test/e2e_node -run '^$'` was not run to completion locally because WSL2 fails node-e2e system validation before running specs due to missing freezer cgroup support.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```