### PR TITLE
Use context-aware wait in kubelet config mux

### DIFF
--- a/pkg/kubelet/config/mux.go
+++ b/pkg/kubelet/config/mux.go
@@ -70,7 +70,7 @@ func (m *mux) ChannelWithContext(ctx context.Context, source string) chan source
 	newChannel := make(chan sourceUpdate)
 	m.sources[source] = newChannel
 
-	go wait.Until(func() { m.listen(ctx, source, newChannel) }, 0, ctx.Done())
+	go wait.UntilWithContext(ctx, func(ctx context.Context) { m.listen(ctx, source, newChannel) }, 0)
 	return newChannel
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig node
/wg structured-logging

#### What this PR does / why we need it

This updates the kubelet config mux to use `wait.UntilWithContext` instead of `wait.Until` with `ctx.Done()`.

The surrounding code already has a `context.Context`, and the listener already uses that context for contextual logging. This keeps the package aligned with the contextual logging migration tracked in #126379.

#### Which issue(s) this PR is related to

Related to #126379

#### Special notes for your reviewer

Small follow-up to the contextual logging migration in `pkg/kubelet/config`.

Local validation:
- `git diff --check`
- `./hack/verify-gofmt.sh`
- `./hack/verify-boilerplate.sh`
- `go test ./pkg/kubelet/config/...`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```