### PR TITLE
Fix MemoryQoS protection lost during IPPR resize and PodLevelResources memory.high miscalculation

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -939,6 +939,7 @@ func run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Depend
 				MemoryManagerPolicy:          s.MemoryManagerPolicy,
 				MemoryManagerReservedMemory:  s.ReservedMemory,
 				MemoryReservationPolicy:      s.MemoryReservationPolicy,
+				MemoryThrottlingFactor:       s.MemoryThrottlingFactor,
 				PodPidsLimit:                 s.PodPidsLimit,
 				EnforceCPULimits:             s.CPUCFSQuota,
 				CPUCFSQuotaPeriod:            s.CPUCFSQuotaPeriod.Duration,

--- a/pkg/kubelet/cm/container_manager.go
+++ b/pkg/kubelet/cm/container_manager.go
@@ -194,6 +194,7 @@ type NodeConfig struct {
 	MemoryManagerPolicy          string
 	MemoryManagerReservedMemory  []kubeletconfig.MemoryReservation
 	MemoryReservationPolicy      kubeletconfig.MemoryReservationPolicy
+	MemoryThrottlingFactor       *float64
 	PodPidsLimit                 int64
 	EnforceCPULimits             bool
 	CPUCFSQuotaPeriod            time.Duration

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -410,6 +410,7 @@ func (cm *containerManagerImpl) NewPodContainerManager() PodContainerManager {
 			cpuCFSQuotaPeriod:       uint64(cm.CPUCFSQuotaPeriod / time.Microsecond),
 			podContainerManager:     cm,
 			memoryReservationPolicy: cm.MemoryReservationPolicy,
+			memoryThrottlingFactor:  cm.MemoryThrottlingFactor,
 		}
 	}
 	return &podContainerManagerNoop{

--- a/pkg/kubelet/cm/helpers_linux.go
+++ b/pkg/kubelet/cm/helpers_linux.go
@@ -39,6 +39,23 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/util"
 )
 
+// MemoryHighForPod computes the memory.high cgroup v2 value for a pod using the
+// KEP-2570 formula. Returns "" if memory.high should not be set (e.g., Guaranteed
+// pods where request == limit, or when no memory limit is declared).
+func MemoryHighForPod(memoryRequest, memoryLimit int64, throttlingFactor float64) string {
+	if (memoryRequest == memoryLimit && memoryRequest != 0) || memoryLimit == 0 {
+		return ""
+	}
+	pageSize := int64(os.Getpagesize())
+	memoryHigh := int64(math.Floor(
+		float64(memoryRequest)+
+			(float64(memoryLimit)-float64(memoryRequest))*throttlingFactor)/float64(pageSize)) * pageSize
+	if memoryHigh > 0 && memoryHigh > memoryRequest {
+		return strconv.FormatInt(memoryHigh, 10)
+	}
+	return ""
+}
+
 const (
 	// These limits are defined in the kernel:
 	// https://github.com/torvalds/linux/blob/0bddd227f3dc55975e2b8dfa7fc6f959b062a2c7/kernel/sched/sched.h#L427-L428

--- a/pkg/kubelet/cm/helpers_linux.go
+++ b/pkg/kubelet/cm/helpers_linux.go
@@ -39,10 +39,45 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/util"
 )
 
-// MemoryHighForPod computes the memory.high cgroup v2 value for a pod using the
-// KEP-2570 formula. Returns "" if memory.high should not be set (e.g., Guaranteed
-// pods where request == limit, or when no memory limit is declared).
-func MemoryHighForPod(memoryRequest, memoryLimit int64, throttlingFactor float64) string {
+// ApplyPodLevelMemoryHigh sets memory.high on the pod cgroup using the KEP-2570 formula.
+// Applies when PodLevelResources is enabled and the pod has memory limits declared
+// (either pod-level or all containers). Skips Guaranteed-like pods where request == limit.
+func ApplyPodLevelMemoryHigh(pod *v1.Pod, rc *ResourceConfig, throttlingFactor float64) {
+	podLevelResourcesEnabled := utilfeature.DefaultFeatureGate.Enabled(kubefeatures.PodLevelResources)
+	if !podLevelResourcesEnabled || !resourcehelper.IsPodLevelResourcesSet(pod) {
+		return
+	}
+	reqs := resourcehelper.PodRequests(pod, resourcehelper.PodResourcesOptions{})
+	limits := resourcehelper.PodLimits(pod, resourcehelper.PodResourcesOptions{})
+	memoryLimitsDeclared := true
+	for c := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
+		if c.Resources.Limits.Memory().IsZero() {
+			memoryLimitsDeclared = false
+		}
+	}
+	if !pod.Spec.Resources.Limits.Memory().IsZero() {
+		memoryLimitsDeclared = true
+	}
+	if !memoryLimitsDeclared {
+		return
+	}
+	memoryRequest := int64(0)
+	memoryLimit := int64(0)
+	if req, found := reqs[v1.ResourceMemory]; found {
+		memoryRequest = req.Value()
+	}
+	if lim, found := limits[v1.ResourceMemory]; found {
+		memoryLimit = lim.Value()
+	}
+	if val := memoryHighForPod(memoryRequest, memoryLimit, throttlingFactor); val != "" {
+		if rc.Unified == nil {
+			rc.Unified = map[string]string{}
+		}
+		rc.Unified[Cgroup2MemoryHigh] = val
+	}
+}
+
+func memoryHighForPod(memoryRequest, memoryLimit int64, throttlingFactor float64) string {
 	if (memoryRequest == memoryLimit && memoryRequest != 0) || memoryLimit == 0 {
 		return ""
 	}

--- a/pkg/kubelet/cm/helpers_linux_test.go
+++ b/pkg/kubelet/cm/helpers_linux_test.go
@@ -857,3 +857,91 @@ func TestResourceConfigForPodWithEnforceMemoryQoS(t *testing.T) {
 		}
 	}
 }
+
+func TestApplyPodLevelMemoryHigh(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.PodLevelResources, true)
+
+	t.Run("cpu-only pod-level resources does not set memory.high", func(t *testing.T) {
+		pod := &v1.Pod{
+			Spec: v1.PodSpec{
+				Resources: &v1.ResourceRequirements{
+					Limits: v1.ResourceList{
+						v1.ResourceCPU: resource.MustParse("2"),
+					},
+				},
+				Containers: []v1.Container{
+					{Resources: getResourceRequirements(getResourceList("100m", "100Mi"), getResourceList("200m", ""))},
+				},
+			},
+		}
+		rc := &ResourceConfig{}
+		ApplyPodLevelMemoryHigh(pod, rc, 0.9)
+		if rc.Unified != nil {
+			t.Errorf("expected no Unified map, got %v", rc.Unified)
+		}
+	})
+
+	// Overhead is included via PodResourcesOptions{ExcludeOverhead: false} (the default).
+	t.Run("pod overhead is included in memory.high calculation", func(t *testing.T) {
+		pod := &v1.Pod{
+			Spec: v1.PodSpec{
+				Overhead: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("64Mi"),
+				},
+				Resources: &v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceMemory: resource.MustParse("128Mi"),
+						v1.ResourceCPU:    resource.MustParse("1"),
+					},
+					Limits: v1.ResourceList{
+						v1.ResourceMemory: resource.MustParse("256Mi"),
+						v1.ResourceCPU:    resource.MustParse("1"),
+					},
+				},
+				Containers: []v1.Container{
+					{Resources: getResourceRequirements(getResourceList("1", "128Mi"), getResourceList("1", "256Mi"))},
+				},
+			},
+		}
+		rc := &ResourceConfig{}
+		ApplyPodLevelMemoryHigh(pod, rc, 0.9)
+		if rc.Unified == nil {
+			t.Fatal("expected Unified map to be set")
+		}
+		// Without overhead: request=128Mi, limit=256Mi → memory.high based on 128Mi..256Mi
+		rcNoOverhead := &ResourceConfig{}
+		podNoOverhead := pod.DeepCopy()
+		podNoOverhead.Spec.Overhead = nil
+		ApplyPodLevelMemoryHigh(podNoOverhead, rcNoOverhead, 0.9)
+		if rcNoOverhead.Unified == nil {
+			t.Fatal("expected Unified map without overhead")
+		}
+		withOverhead, _ := strconv.ParseInt(rc.Unified[Cgroup2MemoryHigh], 10, 64)
+		withoutOverhead, _ := strconv.ParseInt(rcNoOverhead.Unified[Cgroup2MemoryHigh], 10, 64)
+		if withOverhead <= withoutOverhead {
+			t.Errorf("memory.high with overhead (%d) should be greater than without overhead (%d)",
+				withOverhead, withoutOverhead)
+		}
+	})
+
+	t.Run("mixed declared/undeclared memory limits does not set memory.high", func(t *testing.T) {
+		pod := &v1.Pod{
+			Spec: v1.PodSpec{
+				Resources: &v1.ResourceRequirements{
+					Limits: v1.ResourceList{
+						v1.ResourceCPU: resource.MustParse("2"),
+					},
+				},
+				Containers: []v1.Container{
+					{Resources: getResourceRequirements(getResourceList("100m", "100Mi"), getResourceList("200m", "200Mi"))},
+					{Resources: getResourceRequirements(getResourceList("100m", "100Mi"), getResourceList("", ""))},
+				},
+			},
+		}
+		rc := &ResourceConfig{}
+		ApplyPodLevelMemoryHigh(pod, rc, 0.9)
+		if rc.Unified != nil {
+			t.Errorf("expected no Unified map for mixed limits, got %v", rc.Unified)
+		}
+	})
+}

--- a/pkg/kubelet/cm/pod_container_manager_linux.go
+++ b/pkg/kubelet/cm/pod_container_manager_linux.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	resourcehelper "k8s.io/component-helpers/resource"
 	"k8s.io/klog/v2"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
@@ -116,45 +115,8 @@ func (m *podContainerManagerImpl) EnsureExists(logger klog.Logger, pod *v1.Pod) 
 // The kernel enforces memory.high hierarchically (try_charge_memcg walks ancestors),
 // so this throttles all containers in the pod without per-container memory.high.
 func (m *podContainerManagerImpl) applyPodLevelMemoryHigh(pod *v1.Pod, rc *ResourceConfig) {
-	if m.memoryThrottlingFactor == nil {
-		return
-	}
-	podLevelResourcesEnabled := utilfeature.DefaultFeatureGate.Enabled(kubefeatures.PodLevelResources)
-	if !podLevelResourcesEnabled || !resourcehelper.IsPodLevelResourcesSet(pod) {
-		return
-	}
-	reqs := resourcehelper.PodRequests(pod, resourcehelper.PodResourcesOptions{
-		SkipPodLevelResources: !podLevelResourcesEnabled,
-	})
-	memoryLimitsDeclared := true
-	limits := resourcehelper.PodLimits(pod, resourcehelper.PodResourcesOptions{
-		SkipPodLevelResources: !podLevelResourcesEnabled,
-		ContainerFn: func(res v1.ResourceList, _ resourcehelper.ContainerType) {
-			if res.Memory().IsZero() {
-				memoryLimitsDeclared = false
-			}
-		},
-	})
-	if podLevelResourcesEnabled && resourcehelper.IsPodLevelResourcesSet(pod) &&
-		!pod.Spec.Resources.Limits.Memory().IsZero() {
-		memoryLimitsDeclared = true
-	}
-	if !memoryLimitsDeclared {
-		return
-	}
-	memoryRequest := int64(0)
-	memoryLimit := int64(0)
-	if req, found := reqs[v1.ResourceMemory]; found {
-		memoryRequest = req.Value()
-	}
-	if lim, found := limits[v1.ResourceMemory]; found {
-		memoryLimit = lim.Value()
-	}
-	if val := MemoryHighForPod(memoryRequest, memoryLimit, *m.memoryThrottlingFactor); val != "" {
-		if rc.Unified == nil {
-			rc.Unified = map[string]string{}
-		}
-		rc.Unified[Cgroup2MemoryHigh] = val
+	if m.memoryThrottlingFactor != nil {
+		ApplyPodLevelMemoryHigh(pod, rc, *m.memoryThrottlingFactor)
 	}
 }
 

--- a/pkg/kubelet/cm/pod_container_manager_linux.go
+++ b/pkg/kubelet/cm/pod_container_manager_linux.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	resourcehelper "k8s.io/component-helpers/resource"
 	"k8s.io/klog/v2"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
@@ -60,6 +61,8 @@ type podContainerManagerImpl struct {
 	podContainerManager ContainerManager
 	// memoryReservationPolicy controls memory reservation protection behavior
 	memoryReservationPolicy kubeletconfig.MemoryReservationPolicy
+	// memoryThrottlingFactor is used to compute pod-level memory.high
+	memoryThrottlingFactor *float64
 }
 
 // Make sure that podContainerManagerImpl implements the PodContainerManager interface
@@ -98,6 +101,7 @@ func (m *podContainerManagerImpl) EnsureExists(logger klog.Logger, pod *v1.Pod) 
 			containerConfig.ResourceParameters.PidsLimit = &m.podPidsLimit
 		}
 		if enforceMemoryQoS {
+			m.applyPodLevelMemoryHigh(pod, containerConfig.ResourceParameters)
 			logger.V(4).Info("MemoryQoS config for pod", "pod", klog.KObj(pod), "unified", containerConfig.ResourceParameters.Unified)
 		}
 		if err := m.cgroupManager.Create(logger, containerConfig); err != nil {
@@ -106,6 +110,52 @@ func (m *podContainerManagerImpl) EnsureExists(logger klog.Logger, pod *v1.Pod) 
 
 	}
 	return nil
+}
+
+// applyPodLevelMemoryHigh sets memory.high on the pod cgroup.
+// The kernel enforces memory.high hierarchically (try_charge_memcg walks ancestors),
+// so this throttles all containers in the pod without per-container memory.high.
+func (m *podContainerManagerImpl) applyPodLevelMemoryHigh(pod *v1.Pod, rc *ResourceConfig) {
+	if m.memoryThrottlingFactor == nil {
+		return
+	}
+	podLevelResourcesEnabled := utilfeature.DefaultFeatureGate.Enabled(kubefeatures.PodLevelResources)
+	if !podLevelResourcesEnabled || !resourcehelper.IsPodLevelResourcesSet(pod) {
+		return
+	}
+	reqs := resourcehelper.PodRequests(pod, resourcehelper.PodResourcesOptions{
+		SkipPodLevelResources: !podLevelResourcesEnabled,
+	})
+	memoryLimitsDeclared := true
+	limits := resourcehelper.PodLimits(pod, resourcehelper.PodResourcesOptions{
+		SkipPodLevelResources: !podLevelResourcesEnabled,
+		ContainerFn: func(res v1.ResourceList, _ resourcehelper.ContainerType) {
+			if res.Memory().IsZero() {
+				memoryLimitsDeclared = false
+			}
+		},
+	})
+	if podLevelResourcesEnabled && resourcehelper.IsPodLevelResourcesSet(pod) &&
+		!pod.Spec.Resources.Limits.Memory().IsZero() {
+		memoryLimitsDeclared = true
+	}
+	if !memoryLimitsDeclared {
+		return
+	}
+	memoryRequest := int64(0)
+	memoryLimit := int64(0)
+	if req, found := reqs[v1.ResourceMemory]; found {
+		memoryRequest = req.Value()
+	}
+	if lim, found := limits[v1.ResourceMemory]; found {
+		memoryLimit = lim.Value()
+	}
+	if val := MemoryHighForPod(memoryRequest, memoryLimit, *m.memoryThrottlingFactor); val != "" {
+		if rc.Unified == nil {
+			rc.Unified = map[string]string{}
+		}
+		rc.Unified[Cgroup2MemoryHigh] = val
+	}
 }
 
 // GetPodContainerName returns the CgroupName identifier, and its literal cgroupfs form on the host.

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -154,7 +154,7 @@ func (m *kubeGenericRuntimeManager) generateLinuxContainerResources(ctx context.
 	if enforceMemoryQoS {
 		unified := map[string]string{}
 		memoryRequest := container.Resources.Requests.Memory().Value()
-		memoryLimit := container.Resources.Limits.Memory().Value()
+		memoryLimitValue := container.Resources.Limits.Memory().Value()
 		if memoryRequest != 0 && m.memoryReservationPolicy == kubeletconfiginternal.TieredReservationMemoryReservationPolicy {
 			// Guaranteed pods get memory.min (hard protection).
 			// Burstable pods get memory.low (soft protection).
@@ -168,19 +168,24 @@ func (m *kubeGenericRuntimeManager) generateLinuxContainerResources(ctx context.
 			unified[cm.Cgroup2MemoryLow] = "0"
 		}
 
-		// Skip memory.high only for equal, positive memory request/limit (container guaranteed memory).
-		// For Burstable pods, memory.high uses the memory limit, for BestEffort pods (request=limit=0), node allocatable is used.
-		if memoryRequest != memoryLimit || memoryRequest == 0 {
+		// When PodLevelResources is active and the container has no memory limit,
+		// skip container-level memory.high — the pod cgroup's memory.high handles
+		// throttling hierarchically (kernel walks ancestors in try_charge_memcg).
+		skipContainerMemoryHigh := memoryLimitValue == 0 &&
+			utilfeature.DefaultFeatureGate.Enabled(kubefeatures.PodLevelResources) &&
+			resourcehelper.IsPodLevelResourcesSet(pod) &&
+			!pod.Spec.Resources.Limits.Memory().IsZero()
+		if !skipContainerMemoryHigh && (memoryRequest != memoryLimitValue || memoryRequest == 0) {
 			// The formula for memory.high for container cgroup is modified in Alpha stage of the feature in K8s v1.27.
 			// It will be set based on formula:
 			// `memory.high=floor[(requests.memory + memory throttling factor * (limits.memory or node allocatable memory - requests.memory))/pageSize] * pageSize`
 			// where default value of memory throttling factor is set to 0.9
 			// More info: https://git.k8s.io/enhancements/keps/sig-node/2570-memory-qos
 			memoryHigh := int64(0)
-			if memoryLimit != 0 {
+			if memoryLimitValue != 0 {
 				memoryHigh = int64(math.Floor(
 					float64(memoryRequest)+
-						(float64(memoryLimit)-float64(memoryRequest))*float64(m.memoryThrottlingFactor))/float64(defaultPageSize)) * defaultPageSize
+						(float64(memoryLimitValue)-float64(memoryRequest))*float64(m.memoryThrottlingFactor))/float64(defaultPageSize)) * defaultPageSize
 			} else {
 				allocatable := m.getNodeAllocatable()
 				allocatableMemory, ok := allocatable[v1.ResourceMemory]
@@ -434,6 +439,55 @@ func toKubeContainerResources(statusResources *runtimeapi.ContainerResources) *k
 // the cgroup version would solely depend on the environment running the test.
 var isCgroup2UnifiedMode = libcontainercgroups.IsCgroup2UnifiedMode
 
+// isMemoryQoSEnforced reports whether MemoryQoS is enabled on cgroup v2.
+func (m *kubeGenericRuntimeManager) isMemoryQoSEnforced() bool {
+	return utilfeature.DefaultFeatureGate.Enabled(kubefeatures.MemoryQoS) && isCgroup2UnifiedMode()
+}
+
+// applyPodLevelMemoryHigh sets pod-level memory.high; kernel enforces hierarchically.
+func (m *kubeGenericRuntimeManager) applyPodLevelMemoryHigh(pod *v1.Pod, rc *cm.ResourceConfig) {
+	if m.memoryThrottlingFactor == 0 {
+		return
+	}
+	podLevelResourcesEnabled := utilfeature.DefaultFeatureGate.Enabled(kubefeatures.PodLevelResources)
+	if !podLevelResourcesEnabled || !resourcehelper.IsPodLevelResourcesSet(pod) {
+		return
+	}
+	reqs := resourcehelper.PodRequests(pod, resourcehelper.PodResourcesOptions{
+		SkipPodLevelResources: !podLevelResourcesEnabled,
+	})
+	memoryLimitsDeclared := true
+	limits := resourcehelper.PodLimits(pod, resourcehelper.PodResourcesOptions{
+		SkipPodLevelResources: !podLevelResourcesEnabled,
+		ContainerFn: func(res v1.ResourceList, _ resourcehelper.ContainerType) {
+			if res.Memory().IsZero() {
+				memoryLimitsDeclared = false
+			}
+		},
+	})
+	if podLevelResourcesEnabled && resourcehelper.IsPodLevelResourcesSet(pod) &&
+		!pod.Spec.Resources.Limits.Memory().IsZero() {
+		memoryLimitsDeclared = true
+	}
+	if !memoryLimitsDeclared {
+		return
+	}
+	memoryRequest := int64(0)
+	memoryLimit := int64(0)
+	if req, found := reqs[v1.ResourceMemory]; found {
+		memoryRequest = req.Value()
+	}
+	if lim, found := limits[v1.ResourceMemory]; found {
+		memoryLimit = lim.Value()
+	}
+	if val := cm.MemoryHighForPod(memoryRequest, memoryLimit, m.memoryThrottlingFactor); val != "" {
+		if rc.Unified == nil {
+			rc.Unified = map[string]string{}
+		}
+		rc.Unified[cm.Cgroup2MemoryHigh] = val
+	}
+}
+
 // checkSwapControllerAvailability checks if swap controller is available.
 // It returns true if the swap controller is available, false otherwise.
 func checkSwapControllerAvailability(ctx context.Context) bool {
@@ -556,9 +610,4 @@ func toKubeContainerUser(statusUser *runtimeapi.ContainerUser) *kubecontainer.Co
 	}
 
 	return user
-}
-
-// isMemoryQoSEnforced reports whether MemoryQoS is enabled on cgroup v2.
-func (m *kubeGenericRuntimeManager) isMemoryQoSEnforced() bool {
-	return utilfeature.DefaultFeatureGate.Enabled(kubefeatures.MemoryQoS) && isCgroup2UnifiedMode()
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -446,45 +446,8 @@ func (m *kubeGenericRuntimeManager) isMemoryQoSEnforced() bool {
 
 // applyPodLevelMemoryHigh sets pod-level memory.high; kernel enforces hierarchically.
 func (m *kubeGenericRuntimeManager) applyPodLevelMemoryHigh(pod *v1.Pod, rc *cm.ResourceConfig) {
-	if m.memoryThrottlingFactor == 0 {
-		return
-	}
-	podLevelResourcesEnabled := utilfeature.DefaultFeatureGate.Enabled(kubefeatures.PodLevelResources)
-	if !podLevelResourcesEnabled || !resourcehelper.IsPodLevelResourcesSet(pod) {
-		return
-	}
-	reqs := resourcehelper.PodRequests(pod, resourcehelper.PodResourcesOptions{
-		SkipPodLevelResources: !podLevelResourcesEnabled,
-	})
-	memoryLimitsDeclared := true
-	limits := resourcehelper.PodLimits(pod, resourcehelper.PodResourcesOptions{
-		SkipPodLevelResources: !podLevelResourcesEnabled,
-		ContainerFn: func(res v1.ResourceList, _ resourcehelper.ContainerType) {
-			if res.Memory().IsZero() {
-				memoryLimitsDeclared = false
-			}
-		},
-	})
-	if podLevelResourcesEnabled && resourcehelper.IsPodLevelResourcesSet(pod) &&
-		!pod.Spec.Resources.Limits.Memory().IsZero() {
-		memoryLimitsDeclared = true
-	}
-	if !memoryLimitsDeclared {
-		return
-	}
-	memoryRequest := int64(0)
-	memoryLimit := int64(0)
-	if req, found := reqs[v1.ResourceMemory]; found {
-		memoryRequest = req.Value()
-	}
-	if lim, found := limits[v1.ResourceMemory]; found {
-		memoryLimit = lim.Value()
-	}
-	if val := cm.MemoryHighForPod(memoryRequest, memoryLimit, m.memoryThrottlingFactor); val != "" {
-		if rc.Unified == nil {
-			rc.Unified = map[string]string{}
-		}
-		rc.Unified[cm.Cgroup2MemoryHigh] = val
+	if m.memoryThrottlingFactor != 0 {
+		cm.ApplyPodLevelMemoryHigh(pod, rc, m.memoryThrottlingFactor)
 	}
 }
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -557,3 +557,8 @@ func toKubeContainerUser(statusUser *runtimeapi.ContainerUser) *kubecontainer.Co
 
 	return user
 }
+
+// isMemoryQoSEnforced reports whether MemoryQoS is enabled on cgroup v2.
+func (m *kubeGenericRuntimeManager) isMemoryQoSEnforced() bool {
+	return utilfeature.DefaultFeatureGate.Enabled(kubefeatures.MemoryQoS) && isCgroup2UnifiedMode()
+}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
@@ -2243,4 +2243,103 @@ func TestContainerMemoryHighSkippedWithPodLevelResources(t *testing.T) {
 		_, ok := lcr.Unified[cm.Cgroup2MemoryHigh]
 		assert.False(t, ok, "memory.high should NOT be set on container without own limit when PodLevelResources is active")
 	})
+
+	t.Run("cpu-only pod-level resources does not skip container memory.high", func(t *testing.T) {
+		cpuOnlyPod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{UID: "cpu-only", Name: "cpu-only-test", Namespace: "test"},
+			Spec: v1.PodSpec{
+				Resources: &v1.ResourceRequirements{
+					Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
+				},
+				Containers: []v1.Container{{
+					Name: "c1", Image: "busybox",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceMemory: containerRequest,
+							v1.ResourceCPU:    resource.MustParse("100m"),
+						},
+					},
+				}},
+			},
+		}
+		lcr := m.generateLinuxContainerResources(tCtx, cpuOnlyPod, &cpuOnlyPod.Spec.Containers[0], true)
+		_, ok := lcr.Unified[cm.Cgroup2MemoryHigh]
+		assert.True(t, ok, "memory.high should be set via node-allocatable fallback when pod has CPU-only resources")
+	})
+
+	// Pod is Guaranteed via pod-level req==limit, but container req!=limit:
+	// memory.high is gated by the container's own req vs limit, not the pod's QoS class.
+	t.Run("guaranteed pod with container req!=limit sets container memory.high", func(t *testing.T) {
+		guaranteedPod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:       "12345678",
+				Name:      "guaranteed-test",
+				Namespace: "test",
+			},
+			Spec: v1.PodSpec{
+				Resources: &v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceMemory: resource.MustParse("1Gi"),
+						v1.ResourceCPU:    resource.MustParse("1"),
+					},
+					Limits: v1.ResourceList{
+						v1.ResourceMemory: resource.MustParse("1Gi"),
+						v1.ResourceCPU:    resource.MustParse("1"),
+					},
+				},
+				Containers: []v1.Container{
+					{
+						Name:  "c1",
+						Image: "busybox",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceMemory: containerRequest,
+							},
+							Limits: v1.ResourceList{
+								v1.ResourceMemory: containerLimit,
+							},
+						},
+					},
+				},
+			},
+		}
+		lcr := m.generateLinuxContainerResources(tCtx, guaranteedPod, &guaranteedPod.Spec.Containers[0], true)
+		pageSize := int64(os.Getpagesize())
+		expectedHigh := int64(math.Floor(
+			float64(containerRequest.Value())+
+				(float64(containerLimit.Value())-float64(containerRequest.Value()))*0.9)/float64(pageSize)) * pageSize
+		actualHigh, ok := lcr.Unified[cm.Cgroup2MemoryHigh]
+		assert.True(t, ok, "memory.high should be set when container req!=limit")
+		assert.Equal(t, strconv.FormatInt(expectedHigh, 10), actualHigh)
+	})
+
+	// memory.high is skipped when container memory req==limit regardless of pod QoS class.
+	t.Run("burstable pod with container memory req==limit skips memory.high", func(t *testing.T) {
+		burstablePod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:       "12345678",
+				Name:      "burstable-test",
+				Namespace: "test",
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:  "c1",
+						Image: "busybox",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceMemory: containerRequest,
+							},
+							Limits: v1.ResourceList{
+								v1.ResourceMemory: containerRequest,
+							},
+						},
+					},
+				},
+			},
+		}
+		lcr := m.generateLinuxContainerResources(tCtx, burstablePod, &burstablePod.Spec.Containers[0], true)
+		_, ok := lcr.Unified[cm.Cgroup2MemoryHigh]
+		assert.False(t, ok, "memory.high should NOT be set when container memory req==limit, even if pod is Burstable")
+	})
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
@@ -2170,3 +2170,77 @@ func setCgroupVersionDuringTest(version CgroupVersion) {
 		return version == cgroupV2
 	}
 }
+
+func TestContainerMemoryHighSkippedWithPodLevelResources(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	_, _, m, err := createTestRuntimeManager(tCtx)
+	require.NoError(t, err)
+	setCgroupVersionDuringTest(cgroupV2)
+	m.memoryThrottlingFactor = 0.9
+	m.memoryReservationPolicy = kubeletconfiginternal.NoneMemoryReservationPolicy
+
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.MemoryQoS, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResources, true)
+
+	containerRequest := resource.MustParse("256Mi")
+	containerLimit := resource.MustParse("512Mi")
+	podLimitMemory := resource.MustParse("1Gi")
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "12345678",
+			Name:      "pod-level-test",
+			Namespace: "test",
+		},
+		Spec: v1.PodSpec{
+			Resources: &v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceMemory: podLimitMemory,
+				},
+			},
+			Containers: []v1.Container{
+				{
+					Name:  "c1-with-limit",
+					Image: "busybox",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceMemory: containerRequest,
+							v1.ResourceCPU:    resource.MustParse("100m"),
+						},
+						Limits: v1.ResourceList{
+							v1.ResourceMemory: containerLimit,
+							v1.ResourceCPU:    resource.MustParse("200m"),
+						},
+					},
+				},
+				{
+					Name:  "c2-no-limit",
+					Image: "busybox",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceMemory: containerRequest,
+							v1.ResourceCPU:    resource.MustParse("100m"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("container with own limit gets per-container memory.high", func(t *testing.T) {
+		lcr := m.generateLinuxContainerResources(tCtx, pod, &pod.Spec.Containers[0], true)
+		pageSize := int64(os.Getpagesize())
+		expectedHigh := int64(math.Floor(
+			float64(containerRequest.Value())+
+				(float64(containerLimit.Value())-float64(containerRequest.Value()))*0.9)/float64(pageSize)) * pageSize
+		actualHigh, ok := lcr.Unified[cm.Cgroup2MemoryHigh]
+		assert.True(t, ok, "memory.high should be set for container with own limit")
+		assert.Equal(t, strconv.FormatInt(expectedHigh, 10), actualHigh)
+	})
+
+	t.Run("container without limit skips memory.high (pod-level handles it)", func(t *testing.T) {
+		lcr := m.generateLinuxContainerResources(tCtx, pod, &pod.Spec.Containers[1], true)
+		_, ok := lcr.Unified[cm.Cgroup2MemoryHigh]
+		assert.False(t, ok, "memory.high should NOT be set on container without own limit when PodLevelResources is active")
+	})
+}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_unsupported.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_unsupported.go
@@ -59,3 +59,7 @@ func (m *kubeGenericRuntimeManager) GetContainerSwapBehavior(pod *v1.Pod, contai
 func initSwapControllerAvailabilityCheck(ctx context.Context) func() bool {
 	return func() bool { return false }
 }
+
+func (m *kubeGenericRuntimeManager) isMemoryQoSEnforced() bool {
+	return false
+}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_unsupported.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_unsupported.go
@@ -63,3 +63,6 @@ func initSwapControllerAvailabilityCheck(ctx context.Context) func() bool {
 func (m *kubeGenericRuntimeManager) isMemoryQoSEnforced() bool {
 	return false
 }
+
+func (m *kubeGenericRuntimeManager) applyPodLevelMemoryHigh(_ *v1.Pod, _ *cm.ResourceConfig) {
+}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_windows.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_windows.go
@@ -199,3 +199,6 @@ func initSwapControllerAvailabilityCheck(ctx context.Context) func() bool {
 func (m *kubeGenericRuntimeManager) isMemoryQoSEnforced() bool {
 	return false
 }
+
+func (m *kubeGenericRuntimeManager) applyPodLevelMemoryHigh(_ *v1.Pod, _ *cm.ResourceConfig) {
+}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_windows.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_windows.go
@@ -195,3 +195,7 @@ func (m *kubeGenericRuntimeManager) GetContainerSwapBehavior(pod *v1.Pod, contai
 func initSwapControllerAvailabilityCheck(ctx context.Context) func() bool {
 	return func() bool { return false }
 }
+
+func (m *kubeGenericRuntimeManager) isMemoryQoSEnforced() bool {
+	return false
+}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -882,7 +882,6 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 
 	resizeResult := kubecontainer.NewSyncResult(kubecontainer.ResizePodInPlace, format.Pod(pod))
 	pcm := m.containerManager.NewPodContainerManager()
-	
 	enforceCPULimits := m.cpuCFSQuota
 	if utilfeature.DefaultFeatureGate.Enabled(features.DisableCPUQuotaWithExclusiveCPUs) && m.containerManager.PodHasExclusiveCPUs(logger, pod) {
 		enforceCPULimits = false
@@ -893,6 +892,9 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 		logger.Error(nil, "Unable to get resource configuration", "pod", klog.KObj(pod))
 		resizeResult.Fail(kubecontainer.ErrResizePodInPlace, fmt.Sprintf("unable to get resource configuration processing resize for pod %q", format.Pod(pod)))
 		return resizeResult
+	}
+	if m.isMemoryQoSEnforced() {
+		m.applyPodLevelMemoryHigh(pod, podResources)
 	}
 	currentPodMemoryConfig, err := pcm.GetPodCgroupConfig(pod, v1.ResourceMemory)
 	if err != nil {

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -882,13 +882,13 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 
 	resizeResult := kubecontainer.NewSyncResult(kubecontainer.ResizePodInPlace, format.Pod(pod))
 	pcm := m.containerManager.NewPodContainerManager()
-	//TODO(vinaykul,InPlacePodVerticalScaling): Figure out best way to get enforceMemoryQoS value (parameter #4 below) in platform-agnostic way
+	
 	enforceCPULimits := m.cpuCFSQuota
 	if utilfeature.DefaultFeatureGate.Enabled(features.DisableCPUQuotaWithExclusiveCPUs) && m.containerManager.PodHasExclusiveCPUs(logger, pod) {
 		enforceCPULimits = false
 		logger.V(2).Info("Disabled CFS quota", "pod", klog.KObj(pod))
 	}
-	podResources := cm.ResourceConfigForPod(pod, enforceCPULimits, uint64((m.cpuCFSQuotaPeriod.Duration)/time.Microsecond), false, kubeletconfiginternal.NoneMemoryReservationPolicy)
+	podResources := cm.ResourceConfigForPod(pod, enforceCPULimits, uint64((m.cpuCFSQuotaPeriod.Duration)/time.Microsecond), m.isMemoryQoSEnforced(), m.memoryReservationPolicy)
 	if podResources == nil {
 		logger.Error(nil, "Unable to get resource configuration", "pod", klog.KObj(pod))
 		resizeResult.Fail(kubecontainer.ErrResizePodInPlace, fmt.Sprintf("unable to get resource configuration processing resize for pod %q", format.Pod(pod)))
@@ -987,6 +987,7 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 				return nil
 			}
 			resizedResources.Memory = podResources.Memory
+			resizedResources.Unified = podResources.Unified
 		}
 
 		// Notify the runtime first. If this fails, the runtime has rejected the resize.

--- a/test/e2e_node/memory_qos_test.go
+++ b/test/e2e_node/memory_qos_test.go
@@ -1197,4 +1197,60 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 				"container-level memory.low persists after rollback (CRI limitation)")
 		})
 	})
+
+	f.Describe("IPPR resize with memory protection", func() {
+		ginkgo.AfterEach(func(ctx context.Context) { restoreConfig(ctx) })
+
+		ginkgo.It("should update pod-level memory.low after Burstable pod resize", func(ctx context.Context) {
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.TieredReservationMemoryReservationPolicy)
+
+			initialRequest := resource.MustParse("128Mi")
+			initialLimit := resource.MustParse("256Mi")
+			pod := memqosMakePod("memqos-resize-protection", f.Namespace.Name,
+				v1.ResourceList{
+					v1.ResourceMemory: initialRequest,
+					v1.ResourceCPU:    resource.MustParse("50m"),
+				},
+				v1.ResourceList{
+					v1.ResourceMemory: initialLimit,
+					v1.ResourceCPU:    resource.MustParse("100m"),
+				},
+			)
+			pod.Spec.Containers[0].ResizePolicy = []v1.ContainerResizePolicy{
+				{ResourceName: v1.ResourceMemory, RestartPolicy: v1.NotRequired},
+				{ResourceName: v1.ResourceCPU, RestartPolicy: v1.NotRequired},
+			}
+			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+
+			podCgroupPath := memqosGetPodCgroupPath(pod, cgroupDriver)
+			gomega.Expect(podCgroupPath).NotTo(gomega.BeEmpty())
+
+			ginkgo.By("Verifying initial memory.low matches request")
+			podMemLow, err := memqosReadCgroupInt64(podCgroupPath, cgroupMemoryLow)
+			framework.ExpectNoError(err)
+			framework.Logf("Pod memory.low before resize: got=%d, expected=%d", podMemLow, initialRequest.Value())
+			gomega.Expect(podMemLow).To(gomega.Equal(initialRequest.Value()),
+				"pod memory.low should equal initial request before resize")
+
+			ginkgo.By("Resizing memory request and limit via IPPR")
+			pod, err = f.ClientSet.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+
+			newRequest := resource.MustParse("192Mi")
+			newLimit := resource.MustParse("384Mi")
+			pod.Spec.Containers[0].Resources.Requests[v1.ResourceMemory] = newRequest
+			pod.Spec.Containers[0].Resources.Limits[v1.ResourceMemory] = newLimit
+			_, err = f.ClientSet.CoreV1().Pods(pod.Namespace).UpdateResize(ctx, pod.Name, pod, metav1.UpdateOptions{})
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Verifying pod-level memory.low updated to new request")
+			gomega.Eventually(ctx, func() int64 {
+				val, _ := memqosReadCgroupInt64(podCgroupPath, cgroupMemoryLow)
+				framework.Logf("Pod memory.low after resize: got=%d, expected=%d", val, newRequest.Value())
+				return val
+			}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).Should(
+				gomega.Equal(newRequest.Value()),
+				"pod memory.low should update to new request after IPPR resize")
+		})
+	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The IPPR fix required two changes: passing the real MemoryQoS config instead of hardcoded false, and copying Unified values into the resize struct. The e2e_node test confirmed both were needed. The `PodLevelResources` fix is a one-line variable shadowing issue. Added a Windows stub for the new helper to avoid cross-platform build breakage.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

The code was AI-assisted and manually verified by me.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed MemoryQoS pod-level memory protection (memory.min, memory.low) being silently dropped during in-place pod resize, and added pod-level memory.high enforcement when PodLevelResources is enabled.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2570-memory-qos/README.md
```
