### PR TITLE
Migrate metav1.Condition.lastTransitionTime to declarative validation

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
@@ -221,6 +221,7 @@ message Condition {
   // +kubebuilder:validation:Required
   // +kubebuilder:validation:Type=string
   // +kubebuilder:validation:Format=date-time
+  // +k8s:alpha(since: "1.37")=+k8s:customValidation
   optional Time lastTransitionTime = 4;
 
   // reason contains a programmatic identifier indicating the reason for the condition's last transition.

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -1653,6 +1653,7 @@ type Condition struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Format=date-time
+	// +k8s:alpha(since: "1.37")=+k8s:customValidation
 	LastTransitionTime Time `json:"lastTransitionTime" protobuf:"bytes,4,opt,name=lastTransitionTime"`
 	// reason contains a programmatic identifier indicating the reason for the condition's last transition.
 	// Producers of specific condition types may define expected values and meanings for this field,

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -17,10 +17,12 @@ limitations under the License.
 package validation
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"unicode"
 
+	"k8s.io/apimachinery/pkg/api/operation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -334,7 +336,7 @@ func ValidateCondition(condition metav1.Condition, fldPath *field.Path) field.Er
 	}
 
 	if condition.LastTransitionTime.IsZero() {
-		allErrs = append(allErrs, field.Required(fldPath.Child("lastTransitionTime"), ""))
+		allErrs = append(allErrs, field.Required(fldPath.Child("lastTransitionTime"), "").MarkCoveredByDeclarative())
 	}
 
 	if len(condition.Reason) == 0 {
@@ -394,4 +396,15 @@ func ValidateIgnoreStoreReadError(fldPath *field.Path, options *metav1.DeleteOpt
 	}
 
 	return allErrs
+}
+
+// ValidateCustom_Condition_LastTransitionTime is wired into the generated
+// declarative validation by +k8s:customValidation on Condition.LastTransitionTime.
+// It enforces that the field is set, mirroring the handwritten check in
+// ValidateCondition.
+func ValidateCustom_Condition_LastTransitionTime(ctx context.Context, op operation.Operation, fldPath *field.Path, value, oldValue *metav1.Time) field.ErrorList {
+	if value.IsZero() {
+		return field.ErrorList{field.Required(fldPath, "")}
+	}
+	return nil
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/zz_generated.validations.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/zz_generated.validations.go
@@ -24,6 +24,7 @@ package validation
 import (
 	context "context"
 
+	equality "k8s.io/apimachinery/pkg/api/equality"
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
@@ -129,7 +130,31 @@ func Validate_Condition(
 		errs = append(errs, fn(fldPath.Child("observedGeneration"), &obj.ObservedGeneration, oldVal, oldObj != nil)...)
 	}
 
-	// field v1.Condition.LastTransitionTime has no validation
+	{ // field v1.Condition.LastTransitionTime
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *v1.Time,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			// custom validation
+			if e := ValidateCustom_Condition_LastTransitionTime(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *v1.Condition) *v1.Time {
+				return &oldObj.LastTransitionTime
+			})
+		errs = append(errs, fn(fldPath.Child("lastTransitionTime"), &obj.LastTransitionTime, oldVal, oldObj != nil)...)
+	}
+
 	// field v1.Condition.Reason has no validation
 	// field v1.Condition.Message has no validation
 	return errs

--- a/test/declarative_validation/certificates/podcertificaterequest/declarative_validation_test.go
+++ b/test/declarative_validation/certificates/podcertificaterequest/declarative_validation_test.go
@@ -205,6 +205,28 @@ func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 					ExpectedErrs: nil,
 				},
 				{
+					Name: "invalid missing lastTransitionTime",
+					Conditions: []metav1.Condition{
+						meta.MkCondition(
+							meta.TweakType(string(certificates.PodCertificateRequestConditionTypeDenied)),
+							meta.TweakLastTransitionTime(metav1.Time{}),
+						),
+					},
+					ExpectedErrs: field.ErrorList{
+						field.Required(field.NewPath("status", "conditions").Index(0).Child("lastTransitionTime"), "").MarkAlpha(),
+					},
+				},
+				{
+					Name: "valid lastTransitionTime",
+					Conditions: []metav1.Condition{
+						meta.MkCondition(
+							meta.TweakType(string(certificates.PodCertificateRequestConditionTypeDenied)),
+							meta.TweakLastTransitionTime(metav1.Unix(1, 0)),
+						),
+					},
+					ExpectedErrs: nil,
+				},
+				{
 					Name: "invalid missing status",
 					Conditions: []metav1.Condition{
 						meta.MkCondition(

--- a/test/declarative_validation/meta/conditions.go
+++ b/test/declarative_validation/meta/conditions.go
@@ -108,6 +108,22 @@ func GenerateConditionTestCases(fldPath *field.Path) []ConditionTestCase {
 			},
 			ExpectedErrs: nil,
 		},
+		{
+			Name: "invalid missing lastTransitionTime",
+			Conditions: []metav1.Condition{
+				MkCondition(TweakLastTransitionTime(metav1.Time{})),
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Required(fldPath.Index(0).Child("lastTransitionTime"), "").MarkAlpha(),
+			},
+		},
+		{
+			Name: "valid lastTransitionTime",
+			Conditions: []metav1.Condition{
+				MkCondition(TweakLastTransitionTime(metav1.Unix(1, 0))),
+			},
+			ExpectedErrs: nil,
+		},
 	}
 }
 
@@ -156,5 +172,11 @@ func TweakStatus(status metav1.ConditionStatus) func(*metav1.Condition) {
 func TweakObservedGeneration(gen int64) func(*metav1.Condition) {
 	return func(c *metav1.Condition) {
 		c.ObservedGeneration = gen
+	}
+}
+
+func TweakLastTransitionTime(t metav1.Time) func(*metav1.Condition) {
+	return func(c *metav1.Condition) {
+		c.LastTransitionTime = t
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Migrates the required check for `metav1.Condition.lastTransitionTime` from handwritten validation to declarative validation.

Since no existing declarative tag expresses "must be non-zero" on a non-pointer `Time` struct, this uses `+k8s:customValidation` with a handwritten `ValidateCustom_Condition_LastTransitionTime` function wired into
the generated traversal. The handwritten check in `ValidateCondition` is retained and marked `CoveredByDeclarative` during the alpha phase.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
