### PR TITLE
Fix operand mutation bug in reflective ref.Val implementations of list concatenation

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
@@ -1041,6 +1041,7 @@ func TestListAdd(t *testing.T) {
 		Nested  []Nested       `json:"nested"`
 		Empty   []int64        `json:"empty"`
 		MapList []MapListEntry `json:"mapList"`
+		SetList []SetEntry     `json:"setList"`
 	}
 
 	mapListEntrySchema := &spec.Schema{SchemaProps: spec.SchemaProps{
@@ -1068,6 +1069,12 @@ func TestListAdd(t *testing.T) {
 					}},
 					SchemaProps: spec.SchemaProps{Type: []string{"array"}, Items: &spec.SchemaOrArray{Schema: mapListEntrySchema}},
 				},
+				"setList": {
+					VendorExtensible: spec.VendorExtensible{Extensions: map[string]interface{}{
+						"x-kubernetes-list-type": "set",
+					}},
+					SchemaProps: intArraySchema.SchemaProps,
+				},
 			},
 		},
 	}
@@ -1079,6 +1086,7 @@ func TestListAdd(t *testing.T) {
 		Nested:  []Nested{{Name: "n1", Info: Struct{S: "hello"}}},
 		Empty:   []int64{},
 		MapList: []MapListEntry{{Key1: "k1v1", Key2: "k2v1", Value: 1}, {Key1: "k1v2", Key2: "k2v2", Value: 2}},
+		SetList: []SetEntry{1, 2, 3},
 	}, schema: addListsSchema}
 	y := typedValue{value: AddListsStruct{
 		Tags:    []string{"d", "e"},
@@ -1087,6 +1095,7 @@ func TestListAdd(t *testing.T) {
 		Nested:  []Nested{},
 		Empty:   []int64{},
 		MapList: []MapListEntry{{Key1: "k1v1", Key2: "k2v1", Value: 10}, {Key1: "k1v3", Key2: "k2v3", Value: 3}},
+		SetList: []SetEntry{3, 30},
 	}, schema: addListsSchema}
 	// z.mapList contains the same entries as (x.mapList + y.mapList), in a different order.
 	z := typedValue{value: AddListsStruct{
@@ -1211,6 +1220,27 @@ func TestListAdd(t *testing.T) {
 		{testCase: testCase{
 			name:       "schemaless map list concatenates atomically",
 			expression: "size(x.mapList + [{'key1': 'k1v1', 'key2': 'k2v1', 'value': 99}]) == 3",
+		}, skipTyped: true, skipUnstructured: true},
+		// Lists with x-kubernetes-list-type=set.
+		{testCase: testCase{
+			name:       "set list union with literal list",
+			expression: "(x.setList + [3, 4]) == [1, 2, 3, 4]",
+		}, skipSchemaless: true},
+		{testCase: testCase{
+			name:       "set list union with set list",
+			expression: "(x.setList + y.setList) == [1, 2, 3, 30]",
+		}, skipSchemaless: true},
+		{testCase: testCase{
+			name:       "set list equality ignores element order",
+			expression: "(x.setList + [4]) == [4, 3, 2, 1]",
+		}, skipSchemaless: true},
+		{testCase: testCase{
+			name:       "chained set list union",
+			expression: "(x.setList + [4] + [4, 5]) == [1, 2, 3, 4, 5]",
+		}, skipSchemaless: true},
+		{testCase: testCase{
+			name:       "schemaless set list concatenates atomically",
+			expression: "(x.setList + [3, 4]) == [1, 2, 3, 3, 4]",
 		}, skipTyped: true, skipUnstructured: true},
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
@@ -1035,11 +1035,12 @@ func TestReflectiveWrapperValueReturnsGoValue(t *testing.T) {
 
 func TestListAdd(t *testing.T) {
 	type AddListsStruct struct {
-		Tags   []string       `json:"tags"`
-		I32s   []int32        `json:"i32s"`
-		Items  []MapListEntry `json:"items"`
-		Nested []Nested       `json:"nested"`
-		Empty  []int64        `json:"empty"`
+		Tags    []string       `json:"tags"`
+		I32s    []int32        `json:"i32s"`
+		Items   []MapListEntry `json:"items"`
+		Nested  []Nested       `json:"nested"`
+		Empty   []int64        `json:"empty"`
+		MapList []MapListEntry `json:"mapList"`
 	}
 
 	mapListEntrySchema := &spec.Schema{SchemaProps: spec.SchemaProps{
@@ -1060,26 +1061,39 @@ func TestListAdd(t *testing.T) {
 				"items":  *spec.ArrayProperty(mapListEntrySchema),
 				"nested": *spec.ArrayProperty(nestedSchema),
 				"empty":  *intArraySchema,
+				"mapList": {
+					VendorExtensible: spec.VendorExtensible{Extensions: map[string]interface{}{
+						"x-kubernetes-list-type":     "map",
+						"x-kubernetes-list-map-keys": []any{"key1", "key2"},
+					}},
+					SchemaProps: spec.SchemaProps{Type: []string{"array"}, Items: &spec.SchemaOrArray{Schema: mapListEntrySchema}},
+				},
 			},
 		},
 	}
 
 	x := typedValue{value: AddListsStruct{
-		Tags:   []string{"a", "b", "c"},
-		I32s:   []int32{1, 2, 3},
-		Items:  []MapListEntry{{Key1: "k1v1", Key2: "k2v1", Value: 1}, {Key1: "k1v2", Key2: "k2v2", Value: 2}},
-		Nested: []Nested{{Name: "n1", Info: Struct{S: "hello"}}},
-		Empty:  []int64{},
+		Tags:    []string{"a", "b", "c"},
+		I32s:    []int32{1, 2, 3},
+		Items:   []MapListEntry{{Key1: "k1v1", Key2: "k2v1", Value: 1}, {Key1: "k1v2", Key2: "k2v2", Value: 2}},
+		Nested:  []Nested{{Name: "n1", Info: Struct{S: "hello"}}},
+		Empty:   []int64{},
+		MapList: []MapListEntry{{Key1: "k1v1", Key2: "k2v1", Value: 1}, {Key1: "k1v2", Key2: "k2v2", Value: 2}},
 	}, schema: addListsSchema}
 	y := typedValue{value: AddListsStruct{
-		Tags:   []string{"d", "e"},
-		I32s:   []int32{30},
-		Items:  []MapListEntry{{Key1: "yk1", Key2: "yk2", Value: 7}},
-		Nested: []Nested{},
-		Empty:  []int64{},
+		Tags:    []string{"d", "e"},
+		I32s:    []int32{30},
+		Items:   []MapListEntry{{Key1: "yk1", Key2: "yk2", Value: 7}},
+		Nested:  []Nested{},
+		Empty:   []int64{},
+		MapList: []MapListEntry{{Key1: "k1v1", Key2: "k2v1", Value: 10}, {Key1: "k1v3", Key2: "k2v3", Value: 3}},
+	}, schema: addListsSchema}
+	// z.mapList contains the same entries as (x.mapList + y.mapList), in a different order.
+	z := typedValue{value: AddListsStruct{
+		MapList: []MapListEntry{{Key1: "k1v3", Key2: "k2v3", Value: 3}, {Key1: "k1v1", Key2: "k2v1", Value: 10}, {Key1: "k1v2", Key2: "k2v2", Value: 2}},
 	}, schema: addListsSchema}
 
-	activation := map[string]typedValue{"x": x, "y": y}
+	activation := map[string]typedValue{"x": x, "y": y, "z": z}
 
 	tests := []struct {
 		testCase
@@ -1166,6 +1180,38 @@ func TestListAdd(t *testing.T) {
 			expression: "(x.i32s + [4])[10] == 1",
 			wantErr:    "index out of bounds: 10",
 		}},
+		// Lists with x-kubernetes-list-type=map.
+		{testCase: testCase{
+			name:       "map list merge overwrites intersecting keys in place",
+			expression: "(x.mapList + y.mapList)[0].value == 10 && size(x.mapList + y.mapList) == 3",
+		}, skipSchemaless: true},
+		{testCase: testCase{
+			name:       "map list merge appends non-intersecting keys",
+			expression: "(x.mapList + y.mapList)[2].key1 == 'k1v3'",
+		}, skipSchemaless: true},
+		{testCase: testCase{
+			name:       "map list + literal list merges by key",
+			expression: "(x.mapList + [{'key1': 'k1v1', 'key2': 'k2v1', 'value': 99}])[0].value == 99 && size(x.mapList + [{'key1': 'k1v1', 'key2': 'k2v1', 'value': 99}]) == 2",
+		}, // skipUnstructured: unstructuredMapList.Add cannot compute merge keys for CEL literal elements.
+			skipSchemaless: true, skipUnstructured: true},
+		{testCase: testCase{
+			name:       "map list + literal list appends non-intersecting keys",
+			expression: "(x.mapList + [{'key1': 'k1v9', 'key2': 'k2v9', 'value': 9}])[2].value == 9",
+		}, // skipUnstructured: unstructuredMapList.Add cannot compute merge keys for CEL literal elements.
+			skipSchemaless: true, skipUnstructured: true},
+		{testCase: testCase{
+			name:       "chained map list merge",
+			expression: "(x.mapList + y.mapList + [{'key1': 'k1v3', 'key2': 'k2v3', 'value': 33}])[2].value == 33",
+		}, // skipUnstructured: unstructuredMapList.Add cannot compute merge keys for CEL literal elements.
+			skipSchemaless: true, skipUnstructured: true},
+		{testCase: testCase{
+			name:       "map list equality ignores element order",
+			expression: "(x.mapList + y.mapList) == z.mapList",
+		}, skipSchemaless: true},
+		{testCase: testCase{
+			name:       "schemaless map list concatenates atomically",
+			expression: "size(x.mapList + [{'key1': 'k1v1', 'key2': 'k2v1', 'value': 99}]) == 3",
+		}, skipTyped: true, skipUnstructured: true},
 	}
 
 	var opts []cel.EnvOption

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
@@ -19,13 +19,15 @@ package common
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"sync"
+
+	"sigs.k8s.io/structured-merge-diff/v6/value"
+
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"reflect"
-	"sigs.k8s.io/structured-merge-diff/v6/value"
-	"sync"
 
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
@@ -462,36 +464,129 @@ func (t *typedMapList) Equal(other ref.Val) ref.Val {
 // are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with
 // non-intersecting keys are appended, retaining their partial order.
 func (t *typedMapList) Add(other ref.Val) ref.Val {
-	sliceType := t.value.Type()
-	elementType := sliceType.Elem()
 	oMapList, ok := other.(traits.Lister)
 	if !ok {
 		return types.MaybeNoSuchOverloadErr(other)
 	}
 	sz := t.value.Len()
-	elements := reflect.MakeSlice(sliceType, sz, sz)
-	keyToIdx := map[interface{}]int{}
-	for i := 0; i < sz; i++ {
-		e := t.Get(types.Int(i)).Value()
-		re := reflect.ValueOf(e)
-		k := t.toMapKey(re)
-		keyToIdx[k] = i
-		elements.Index(i).Set(re.Convert(elementType))
+	elements := make([]ref.Val, sz)
+	for i := range sz {
+		elements[i] = t.Get(types.Int(i))
 	}
-	for it := oMapList.Iterator(); it.HasNext() == types.True; {
-		e := it.Next()
-		re := reflect.ValueOf(e.Value())
-		k := t.toMapKey(re)
+	return addToMapList(elements, oMapList, t.escapedKeyProps)
+}
+
+// addToMapList merges the elements of other into the given map list elements
+// according to x-kubernetes-list-type=map semantics: elements of other with
+// intersecting keys overwrite the matching entries of elements in place, and
+// elements with non-intersecting keys are appended. elements may be mutated in
+// place and may be appended to, so callers must not retain or reuse elements
+// after the call.
+func addToMapList(elements []ref.Val, other traits.Lister, escapedKeyProps []string) ref.Val {
+	keyToIdx := make(map[interface{}]int, len(elements))
+	for i, e := range elements {
+		keyToIdx[refValMapKey(e, escapedKeyProps)] = i
+	}
+	for it := other.Iterator(); it.HasNext() == types.True; {
+		v := it.Next()
+		k := refValMapKey(v, escapedKeyProps)
 		if overwritePosition, ok := keyToIdx[k]; ok {
-			elements.Index(overwritePosition).Set(re)
+			elements[overwritePosition] = v
 		} else {
-			elements = reflect.Append(elements, re.Convert(elementType))
+			elements = append(elements, v)
 		}
 	}
-	return &typedMapList{
-		typedList:       typedList{value: elements, itemsSchema: t.itemsSchema},
-		escapedKeyProps: t.escapedKeyProps,
+	return &refValMapList{
+		Lister:          types.NewRefValList(types.DefaultTypeAdapter, elements),
+		escapedKeyProps: escapedKeyProps,
 	}
+}
+
+func refValMapKey(element ref.Val, escapedKeyProps []string) interface{} {
+	get := func(prop string) interface{} {
+		key := types.String(prop)
+		var v ref.Val
+		switch e := element.(type) {
+		case traits.Mapper:
+			var found bool
+			v, found = e.Find(key)
+			if !found {
+				return nil
+			}
+		case traits.Indexer:
+			v = e.Get(key) // returns IsUnknownOrError for not found, handled below
+		}
+		if v == nil || types.IsUnknownOrError(v) {
+			return nil
+		}
+		raw := v.Value()
+		if raw != nil && !reflect.TypeOf(raw).Comparable() {
+			return fmt.Sprintf("%v", raw)
+		}
+		return raw
+	}
+
+	if len(escapedKeyProps) == 1 {
+		return get(escapedKeyProps[0])
+	}
+	if len(escapedKeyProps) == 2 {
+		return [2]interface{}{get(escapedKeyProps[0]), get(escapedKeyProps[1])}
+	}
+	if len(escapedKeyProps) == 3 {
+		return [3]interface{}{get(escapedKeyProps[0]), get(escapedKeyProps[1]), get(escapedKeyProps[2])}
+	}
+
+	key := make([]interface{}, len(escapedKeyProps))
+	for i, kf := range escapedKeyProps {
+		key[i] = get(kf)
+	}
+	return fmt.Sprintf("%v", key)
+}
+
+type refValMapList struct {
+	traits.Lister
+	escapedKeyProps []string
+}
+
+func (l *refValMapList) Add(other ref.Val) ref.Val {
+	oMapList, ok := other.(traits.Lister)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(other)
+	}
+	sz, _ := l.Size().(types.Int)
+	elements := make([]ref.Val, int(sz))
+	for i := range types.Int(sz) {
+		elements[i] = l.Get(i)
+	}
+	return addToMapList(elements, oMapList, l.escapedKeyProps)
+}
+
+func (l *refValMapList) Equal(other ref.Val) ref.Val {
+	oMapList, ok := other.(traits.Lister)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(other)
+	}
+	sz, _ := l.Size().(types.Int)
+	if sz != oMapList.Size() {
+		return types.False
+	}
+	keyToElement := make(map[interface{}]ref.Val, int(sz))
+	for i := range types.Int(sz) {
+		e := l.Get(i)
+		keyToElement[refValMapKey(e, l.escapedKeyProps)] = e
+	}
+	for it := oMapList.Iterator(); it.HasNext() == types.True; {
+		v := it.Next()
+		e, ok := keyToElement[refValMapKey(v, l.escapedKeyProps)]
+		if !ok {
+			return types.False
+		}
+		eq := e.Equal(v)
+		if eq != types.True {
+			return eq
+		}
+	}
+	return types.True
 }
 
 type typedSetList struct {

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
@@ -631,34 +631,91 @@ func (t *typedSetList) Equal(other ref.Val) ref.Val {
 	return types.True
 }
 
-// Add for a set list `X + Y` performs a union where the array positions of all elements in `X` are preserved and
-// non-intersecting elements in `Y` are appended, retaining their partial order.
 func (t *typedSetList) Add(other ref.Val) ref.Val {
-	setType := t.value.Type()
-	elementType := setType.Elem()
 	oSetList, ok := other.(traits.Lister)
 	if !ok {
 		return types.MaybeNoSuchOverloadErr(other)
 	}
 	sz := t.value.Len()
-	elements := reflect.MakeSlice(setType, sz, sz)
-	for i := 0; i < sz; i++ {
-		e := t.Get(types.Int(i)).Value()
-		re := reflect.ValueOf(e)
-		elements.Index(i).Set(re.Convert(elementType))
+	elements := make([]ref.Val, sz)
+	for i := range sz {
+		elements[i] = t.Get(types.Int(i))
 	}
-	set := t.getSet()
-	for it := oSetList.Iterator(); it.HasNext() == types.True; {
-		e := it.Next().Value()
-		re := reflect.ValueOf(e)
-		if _, ok := set[e]; !ok {
-			set[e] = struct{}{}
-			elements = reflect.Append(elements, re.Convert(elementType))
+	return addToSetList(elements, oSetList)
+}
+
+func addToSetList(elements []ref.Val, other traits.Lister) ref.Val {
+	set := make(map[interface{}]struct{}, len(elements))
+	for _, e := range elements {
+		if k, ok := setElementKey(e); ok {
+			set[k] = struct{}{}
 		}
 	}
-	return &typedSetList{
-		typedList: typedList{value: elements, itemsSchema: t.itemsSchema},
+	for it := other.Iterator(); it.HasNext() == types.True; {
+		v := it.Next()
+		k, ok := setElementKey(v)
+		if !ok {
+			elements = append(elements, v)
+			continue
+		}
+		if _, exists := set[k]; !exists {
+			set[k] = struct{}{}
+			elements = append(elements, v)
+		}
 	}
+	return &refValSetList{Lister: types.NewRefValList(types.DefaultTypeAdapter, elements)}
+}
+
+func setElementKey(element ref.Val) (interface{}, bool) {
+	raw := element.Value()
+	if raw != nil && !reflect.TypeOf(raw).Comparable() {
+		return nil, false
+	}
+	return raw, true
+}
+
+type refValSetList struct {
+	traits.Lister
+}
+
+func (l *refValSetList) Add(other ref.Val) ref.Val {
+	oSetList, ok := other.(traits.Lister)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(other)
+	}
+	sz, _ := l.Size().(types.Int)
+	elements := make([]ref.Val, int(sz))
+	for i := range types.Int(sz) {
+		elements[i] = l.Get(i)
+	}
+	return addToSetList(elements, oSetList)
+}
+
+func (l *refValSetList) Equal(other ref.Val) ref.Val {
+	oSetList, ok := other.(traits.Lister)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(other)
+	}
+	sz, _ := l.Size().(types.Int)
+	if sz != oSetList.Size() {
+		return types.False
+	}
+	set := make(map[interface{}]struct{}, int(sz))
+	for i := range types.Int(sz) {
+		if k, ok := setElementKey(l.Get(i)); ok {
+			set[k] = struct{}{}
+		}
+	}
+	for it := oSetList.Iterator(); it.HasNext() == types.True; {
+		k, ok := setElementKey(it.Next())
+		if !ok {
+			return types.False
+		}
+		if _, exists := set[k]; !exists {
+			return types.False
+		}
+	}
+	return types.True
 }
 
 type typedMap struct {


### PR DESCRIPTION
### What type of PR is this?
/kind bug
#### What this PR does / why we need it:
Fixes several bugs in the reflective and schemaless CEL type wrappers (`TypedToVal` and `SchemalessTypedToVal`)

This has been broken down into multiple PRs:
- https://github.com/kubernetes/kubernetes/pull/140288
- https://github.com/kubernetes/kubernetes/pull/140290
- https://github.com/kubernetes/kubernetes/pull/140291
- https://github.com/kubernetes/kubernetes/pull/140292
- https://github.com/kubernetes/kubernetes/pull/140293

Impact:
- DRA types (structured parameters impacted but minimally since Value() and ConvertToNative() are not exercised)
- VAP/MAP (migrating to reflective types in 1.37)

#### Which issue(s) this PR is related to:
#### Special notes for your reviewer:
#### Does this PR introduce a user-facing change?

```release-note
NONE
```