### PR TITLE
Fix burstable memory.low being ineffective due to missing ancestor coverage

### DIFF
--- a/pkg/kubelet/cm/node_container_manager_linux.go
+++ b/pkg/kubelet/cm/node_container_manager_linux.go
@@ -84,14 +84,15 @@ func (cm *containerManagerImpl) enforceNodeAllocatableCgroups(logger klog.Logger
 		ResourceParameters: cm.getCgroupConfig(nodeAllocatable, false),
 	}
 
-	// Stale memory.min from a previously enabled MemoryQoS state can persist
-	// across kubelet restarts. Reset to 0 so rollback takes effect.
+	// Stale memory.min/memory.low from a previously enabled MemoryQoS state can
+	// persist across kubelet restarts. Reset to 0 so rollback takes effect.
 	if !utilfeature.DefaultFeatureGate.Enabled(kubefeatures.MemoryQoS) && libcontainercgroups.IsCgroup2UnifiedMode() {
 		rp := cgroupConfig.ResourceParameters
 		if rp.Unified == nil {
 			rp.Unified = make(map[string]string)
 		}
 		rp.Unified[Cgroup2MemoryMin] = "0"
+		rp.Unified[Cgroup2MemoryLow] = "0"
 	}
 
 	// Using ObjectReference for events as the node maybe not cached; refer to #42701 for detail.

--- a/pkg/kubelet/cm/qos_container_manager_linux.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux.go
@@ -310,6 +310,7 @@ func (m *qosContainerManagerImpl) setMemoryQoS(logger klog.Logger, configs map[v
 
 	if m.memoryReservationPolicy != kubeletconfig.TieredReservationMemoryReservationPolicy {
 		setUnified(v1.PodQOSGuaranteed, Cgroup2MemoryMin, 0)
+		setUnified(v1.PodQOSGuaranteed, Cgroup2MemoryLow, 0)
 		setUnified(v1.PodQOSBurstable, Cgroup2MemoryLow, 0)
 		kubeletmetrics.MemoryQoSNodeMemoryMinBytes.Set(0)
 		kubeletmetrics.MemoryQoSNodeMemoryLowBytes.Set(0)
@@ -324,11 +325,11 @@ func (m *qosContainerManagerImpl) setMemoryQoS(logger klog.Logger, configs map[v
 	kubeletmetrics.MemoryQoSNodeMemoryMinBytes.Set(float64(guaranteedRequests))
 	kubeletmetrics.MemoryQoSNodeMemoryLowBytes.Set(float64(burstableRequests))
 
-	// Guaranteed QoS class: memory.min = sum of guaranteed + burstable requests
-	// (parent must cover children's protection for it to be effective)
+	// Root (kubepods.slice): ancestor coverage for both protection chains.
+	// v1.PodQOSGuaranteed is the map key for the root cgroup, not per-pod config.
 	setUnified(v1.PodQOSGuaranteed, Cgroup2MemoryMin, guaranteedRequests+burstableRequests)
+	setUnified(v1.PodQOSGuaranteed, Cgroup2MemoryLow, burstableRequests)
 
-	// Burstable QoS class: memory.low = sum of burstable pod requests
 	setUnified(v1.PodQOSBurstable, Cgroup2MemoryLow, burstableRequests)
 }
 

--- a/pkg/kubelet/cm/qos_container_manager_linux_test.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux_test.go
@@ -142,36 +142,39 @@ func TestQoSContainerCgroup(t *testing.T) {
 	guaranteedMin := resource.MustParse("128Mi")
 
 	tests := []struct {
-		name               string
-		pods               []*v1.Pod
-		initialGuaranteed  string
-		initialBurstable   string
-		expectedGuaranteed string
-		expectedBurstable  string
+		name                  string
+		pods                  []*v1.Pod
+		initialGuaranteed     string
+		initialBurstable      string
+		expectedGuaranteedMin string
+		expectedGuaranteedLow string
+		expectedBurstableLow  string
 	}{
 		{
-			name:               "writes aggregated memory min",
-			pods:               activeTestPods(),
-			initialGuaranteed:  "",
-			initialBurstable:   "",
-			expectedGuaranteed: strconv.FormatInt(burstableMin.Value()+guaranteedMin.Value(), 10),
-			expectedBurstable:  strconv.FormatInt(burstableMin.Value(), 10),
+			name:                  "writes aggregated memory protection",
+			pods:                  activeTestPods(),
+			initialGuaranteed:     "",
+			initialBurstable:      "",
+			expectedGuaranteedMin: strconv.FormatInt(burstableMin.Value()+guaranteedMin.Value(), 10),
+			expectedGuaranteedLow: strconv.FormatInt(burstableMin.Value(), 10),
+			expectedBurstableLow:  strconv.FormatInt(burstableMin.Value(), 10),
 		},
 		{
-			name: "writes zero memory min for best effort pod",
+			name: "writes zero memory protection for best effort pod",
 			pods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{UID: "99999999", Name: "besteffort-pod", Namespace: "test"},
 					Spec:       v1.PodSpec{Containers: []v1.Container{{Name: "foo", Image: "busybox"}}},
 				},
 			},
-			initialGuaranteed:  "",
-			initialBurstable:   "",
-			expectedGuaranteed: "0",
-			expectedBurstable:  "0",
+			initialGuaranteed:     "",
+			initialBurstable:      "",
+			expectedGuaranteedMin: "0",
+			expectedGuaranteedLow: "0",
+			expectedBurstableLow:  "0",
 		},
 		{
-			name: "writes zero memory min for burstable pod without memory request",
+			name: "writes zero memory protection for burstable pod without memory request",
 			pods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{UID: "88888888", Name: "burstable-pod-no-memory-request", Namespace: "test"},
@@ -188,18 +191,20 @@ func TestQoSContainerCgroup(t *testing.T) {
 					},
 				},
 			},
-			initialGuaranteed:  "",
-			initialBurstable:   "",
-			expectedGuaranteed: "0",
-			expectedBurstable:  "0",
+			initialGuaranteed:     "",
+			initialBurstable:      "",
+			expectedGuaranteedMin: "0",
+			expectedGuaranteedLow: "0",
+			expectedBurstableLow:  "0",
 		},
 		{
-			name:               "clears stale memory min when all pods removed",
-			pods:               nil,
-			initialGuaranteed:  "1234",
-			initialBurstable:   "5678",
-			expectedGuaranteed: "0",
-			expectedBurstable:  "0",
+			name:                  "clears stale memory protection when all pods removed",
+			pods:                  nil,
+			initialGuaranteed:     "1234",
+			initialBurstable:      "5678",
+			expectedGuaranteedMin: "0",
+			expectedGuaranteedLow: "0",
+			expectedBurstableLow:  "0",
 		},
 	}
 
@@ -242,8 +247,9 @@ func TestQoSContainerCgroup(t *testing.T) {
 
 			m.setMemoryQoS(logger, qosConfigs)
 
-			assert.Equal(t, tc.expectedGuaranteed, qosConfigs[v1.PodQOSGuaranteed].ResourceParameters.Unified[Cgroup2MemoryMin])
-			assert.Equal(t, tc.expectedBurstable, qosConfigs[v1.PodQOSBurstable].ResourceParameters.Unified[Cgroup2MemoryLow])
+			assert.Equal(t, tc.expectedGuaranteedMin, qosConfigs[v1.PodQOSGuaranteed].ResourceParameters.Unified[Cgroup2MemoryMin])
+			assert.Equal(t, tc.expectedGuaranteedLow, qosConfigs[v1.PodQOSGuaranteed].ResourceParameters.Unified[Cgroup2MemoryLow])
+			assert.Equal(t, tc.expectedBurstableLow, qosConfigs[v1.PodQOSBurstable].ResourceParameters.Unified[Cgroup2MemoryLow])
 		})
 	}
 }
@@ -284,6 +290,7 @@ func TestQoSContainerCgroupWithMemoryReservationPolicyNone(t *testing.T) {
 	m.setMemoryQoS(logger, qosConfigs)
 
 	assert.Equal(t, "0", qosConfigs[v1.PodQOSGuaranteed].ResourceParameters.Unified[Cgroup2MemoryMin])
+	assert.Equal(t, "0", qosConfigs[v1.PodQOSGuaranteed].ResourceParameters.Unified[Cgroup2MemoryLow])
 	assert.Equal(t, "0", qosConfigs[v1.PodQOSBurstable].ResourceParameters.Unified[Cgroup2MemoryLow])
 }
 

--- a/test/e2e_node/memory_qos_test.go
+++ b/test/e2e_node/memory_qos_test.go
@@ -408,10 +408,16 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 			gomega.Expect(kubepodsMemMin).To(gomega.BeNumerically(">", 0),
 				"kubepods cgroup must have memory.min > 0 for hierarchy protection to work")
 
-			burstableMemMin, err := memqosReadCgroupInt64(burstableCgroupPath, cgroupMemoryLow)
+			kubepodsMemLow, err := memqosReadCgroupInt64(kubepodsCgroupPath, cgroupMemoryLow)
+			framework.ExpectNoError(err, "reading kubepods memory.low")
+			framework.Logf("kubepods memory.low: %d", kubepodsMemLow)
+			gomega.Expect(kubepodsMemLow).To(gomega.BeNumerically(">", 0),
+				"kubepods cgroup must have memory.low > 0 for burstable effective_low to propagate")
+
+			burstableMemLow, err := memqosReadCgroupInt64(burstableCgroupPath, cgroupMemoryLow)
 			framework.ExpectNoError(err, "reading burstable QoS memory.low")
-			framework.Logf("burstable QoS memory.low: %d", burstableMemMin)
-			gomega.Expect(burstableMemMin).To(gomega.BeNumerically(">", 0),
+			framework.Logf("burstable QoS memory.low: %d", burstableMemLow)
+			gomega.Expect(burstableMemLow).To(gomega.BeNumerically(">", 0),
 				"burstable QoS cgroup must have memory.low > 0")
 		})
 	})


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Burstable pods' memory.low soft protection was silently ineffective because the parent kubepods.slice never had memory.low set. The kernel computes effective_low hierarchically, when the ancestor's value is 0, all children's effective protection collapses to 0 regardless of their own settings. This PR sets `memory.low = burstableRequests` on kubepods.slice so the protection chain propagates, and updates the gate-disable rollback path to clear the new value.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug where burstable pod memory.low (soft protection) was ineffective because the parent cgroup lacked ancestor coverage required by the kernel's hierarchical protection model
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2570-memory-qos
```
