### PR TITLE
DRA: check for allocated claim before marking in-flight

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dra_manager.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dra_manager.go
@@ -222,6 +222,22 @@ func (c *claimTracker) SignalClaimPendingAllocation(claimUID types.UID, allocate
 		return nil
 	}
 
+	// Check that the claim really is unallocated. The Pod's CycleState may be
+	// stale and this claim may have been allocated since that was calculated.
+	//
+	// Extended resources claims cannot be shared, so skip checking the assume
+	// cache because we already know it's not allocated.
+	if !isSpecialClaimName(allocatedClaim.Name) {
+		assumedClaim, err := c.Get(allocatedClaim.Namespace, allocatedClaim.Name)
+		if err != nil {
+			return fmt.Errorf("look up assumed claim %s/%s, UID=%s: %w", allocatedClaim.Namespace, allocatedClaim.Name, claimUID, err)
+		}
+		if assumedClaim.UID == claimUID && assumedClaim.Status.Allocation != nil {
+			c.logger.V(6).Info("Claim is already allocated, not creating in-flight", "claim", klog.KObj(assumedClaim), "uid", claimUID, "version", assumedClaim.ResourceVersion)
+			return nil
+		}
+	}
+
 	c.inFlightAllocations[claimUID] = inFlightAllocation{
 		claim:   allocatedClaim,
 		sharers: 1,

--- a/pkg/scheduler/framework/plugins/dynamicresources/dra_manager_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dra_manager_test.go
@@ -23,6 +23,9 @@ import (
 	"github.com/onsi/gomega"
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+	"k8s.io/kubernetes/pkg/scheduler/util/assumecache"
 	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
@@ -31,21 +34,62 @@ const (
 	otherClaimUID = types.UID("claim-uid-2")
 )
 
+// testInformer implements [assumecache.Informer] and can be used to feed changes into an assume
+// cache during unit testing. Only a single event handler is supported, which is
+// sufficient for one assume cache.
+type testInformer struct {
+	handler cache.ResourceEventHandler
+}
+
+func (i *testInformer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	i.handler = handler
+	return nil, nil
+}
+
+func (i *testInformer) add(obj any) {
+	if i.handler == nil {
+		return
+	}
+	i.handler.OnAdd(obj, false)
+}
+
 func TestSignalClaimPendingAllocation(t *testing.T) {
 	testSignalClaimPendingAllocation(ktesting.Init(t))
 }
 func testSignalClaimPendingAllocation(tCtx ktesting.TContext) {
+	specialAllocatedClaim := allocatedClaim.DeepCopy()
+	specialAllocatedClaim.Name = specialClaimInMemName
+
 	tests := map[string]struct {
 		inFlightAllocations         map[types.UID]inFlightAllocation
+		cachedClaims                []*resourceapi.ResourceClaim
 		claimUID                    types.UID
 		allocatedClaim              *resourceapi.ResourceClaim
 		expectedInFlightAllocations map[types.UID]inFlightAllocation
 	}{
 		"empty": {
+			cachedClaims: []*resourceapi.ResourceClaim{
+				st.FromResourceClaim(pendingClaim).UID(string(claimUID)).Obj(),
+			},
 			claimUID:       claimUID,
 			allocatedClaim: allocatedClaim,
 			expectedInFlightAllocations: map[types.UID]inFlightAllocation{
 				claimUID: {claim: allocatedClaim, sharers: 1},
+			},
+		},
+		"claim-already-allocated": {
+			claimUID: claimUID,
+			cachedClaims: []*resourceapi.ResourceClaim{
+				st.FromResourceClaim(allocatedClaim).UID(string(claimUID)).Obj(),
+			},
+			allocatedClaim:              allocatedClaim,
+			expectedInFlightAllocations: map[types.UID]inFlightAllocation{},
+		},
+		"extended-resource-claim-not-in-cache": {
+			claimUID:       claimUID,
+			allocatedClaim: specialAllocatedClaim,
+			expectedInFlightAllocations: map[types.UID]inFlightAllocation{
+				claimUID: {claim: specialAllocatedClaim, sharers: 1},
 			},
 		},
 		"already-exists": {
@@ -79,6 +123,12 @@ func testSignalClaimPendingAllocation(tCtx ktesting.TContext) {
 				inFlightAllocations: make(map[types.UID]inFlightAllocation),
 			}
 			maps.Copy(c.inFlightAllocations, test.inFlightAllocations)
+
+			informer := &testInformer{}
+			c.cache = assumecache.NewAssumeCache(tCtx.Logger(), informer, "", "", nil)
+			for _, cached := range test.cachedClaims {
+				informer.add(cached)
+			}
 
 			err := c.SignalClaimPendingAllocation(test.claimUID, test.allocatedClaim)
 			tCtx.ExpectNoError(err)

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -1241,7 +1241,7 @@ func (pl *DynamicResources) Reserve(ctx context.Context, cs fwk.CycleState, pod 
 			claim.Status.Allocation = allocation
 			err := pl.draManager.ResourceClaims().SignalClaimPendingAllocation(claim.UID, claim)
 			if err != nil {
-				return statusError(logger, fmt.Errorf("internal error, couldn't signal allocation for claim %s", claim.Name))
+				return statusError(logger, fmt.Errorf("internal error, couldn't signal allocation for claim %s: %w", claim.Name, err))
 			}
 			logger.V(5).Info("Reserved resource in allocation result", "claim", klog.KObj(claim), "uid", claim.UID, "resourceVersion", claim.ResourceVersion, "allocation", klog.Format(allocation))
 			allocIndex++

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -3832,7 +3832,7 @@ type testContext struct {
 func (tc *testContext) verify(tCtx ktesting.TContext, expected result, initialObjects []metav1.Object, testPod *v1.Pod, result interface{}, status *fwk.Status) {
 	tCtx.Helper()
 	if expected.status == nil {
-		assert.Nil(tCtx, status)
+		assert.Nil(tCtx, status, status.AsError())
 	} else if actualErr := status.AsError(); actualErr != nil {
 		// Compare only the error strings.
 		assert.ErrorContains(tCtx, actualErr, expected.status.AsError().Error())
@@ -5145,8 +5145,11 @@ func testGatherAllocatedState(tCtx ktesting.TContext) {
 
 			tCtx.Helper()
 			logger := klog.FromContext(tCtx)
+			assumeCacheInformer := &testInformer{}
+			assumeCache := assumecache.NewAssumeCache(tCtx.Logger(), assumeCacheInformer, "", "", nil)
 			draManager := &DefaultDRAManager{
 				resourceClaimTracker: &claimTracker{
+					cache:               assumeCache,
 					inFlightAllocations: make(map[types.UID]inFlightAllocation),
 					allocatedDevices:    newAllocatedDevices(logger),
 				},
@@ -5156,6 +5159,7 @@ func testGatherAllocatedState(tCtx ktesting.TContext) {
 			}
 			if tc.inflightResourceClaims != nil {
 				for claimUID, obj := range tc.inflightResourceClaims {
+					assumeCacheInformer.add(obj)
 					err := draManager.resourceClaimTracker.SignalClaimPendingAllocation(claimUID, obj)
 					if err != nil {
 						if !tc.expectErr {

--- a/test/integration/scheduler_perf/dra/workloadresourceclaims/performance-config.yaml
+++ b/test/integration/scheduler_perf/dra/workloadresourceclaims/performance-config.yaml
@@ -128,20 +128,17 @@
       nodesWithoutDRA: 0
       podGroups: 10
       measurePods: 10
-
-  # These larger cases are flaky:
-  # https://github.com/kubernetes/kubernetes/issues/140263
-  # - name: 1podgroup_1000pods
-  #   labels: [integration-test, short]
-  #   params:
-  #     nodesWithDRA: 10
-  #     nodesWithoutDRA: 0
-  #     podGroups: 1
-  #     measurePods: 1000
-  # - name: 100podgroups_5000pods
-  #   labels: [performance]
-  #   params:
-  #     nodesWithDRA: 50
-  #     nodesWithoutDRA: 0
-  #     podGroups: 100
-  #     measurePods: 5000
+  - name: 1podgroup_1000pods
+    labels: [integration-test, short]
+    params:
+      nodesWithDRA: 10
+      nodesWithoutDRA: 0
+      podGroups: 1
+      measurePods: 1000
+  - name: 100podgroups_5000pods
+    labels: [performance]
+    params:
+      nodesWithDRA: 50
+      nodesWithoutDRA: 0
+      podGroups: 100
+      measurePods: 5000


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

After PodGroup Pods have passed the scheduling cycle, the binding cycle asynchronously invokes the Reserve and PreBind phases of the DynamicResources plugin. When a shared ResourceClaim is first allocated, other Pods in the group may have yet to reach the Reserve phase. If an in-flight allocation is recorded in Reserve for a claim that is already allocated, later removing that in-flight allocation results in `Restore`-ing the claim in the assume cache to an old version that may be unallocated. If the restored claim is unallocated, then the scheduler continuously falls into a loop:

- Claim in AssumeCache is unallocated
- Pending allocation is recorded
- API GET in PreBind yields the allocated claim
- "claim got allocated elsewhere" error

This change cuts off that cycle by verifying that claims are actually unallocated in the Reserve phase before recording an in-flight allocation.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
#140263

#### Special notes for your reviewer:

This addresses the root cause of #140263 while #140264 only disables the flaky tests.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug that caused Pods in a PodGroup sharing a ResourceClaim to get stuck scheduling.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
