### PR TITLE
storage: add GetListMetadata for consistency checker - part1

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -24,6 +24,7 @@ import (
 	"iter"
 	"path"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -730,6 +731,64 @@ func (s *store) GetCurrentResourceVersion(ctx context.Context) (uint64, error) {
 	return uint64(getResp.Revision), nil
 }
 
+func (s *store) GetListMetadata(ctx context.Context, key string, opts storage.ListOptions) (*storage.MetadataList, error) {
+	keyPrefix, err := s.prepareKey(key, opts.Recursive)
+	if err != nil {
+		return nil, err
+	}
+	resourcePrefix, err := s.prepareKey(s.resourcePrefix, true)
+	if err != nil {
+		return nil, err
+	}
+
+	withRev, continueKey, err := storage.ValidateListOptions(keyPrefix, s.versioner, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	items := []storage.NamespaceNameResourceVersion{}
+	var lastKey []byte
+	var count int64
+	var hasMore bool
+	for chunk, chunkErr := range s.pagedChunks(ctx, keyPrefix, opts, withRev, opts.Predicate.Limit, continueKey, true) {
+		if chunkErr != nil {
+			return nil, chunkErr
+		}
+		if err = s.validateMinimumResourceVersion(opts.ResourceVersion, uint64(chunk.revision)); err != nil {
+			return nil, err
+		}
+		if len(chunk.kvs) == 0 && chunk.hasMore {
+			return nil, fmt.Errorf("no results were found, but etcd indicated there were more values remaining")
+		}
+		if withRev == 0 {
+			withRev = chunk.revision
+		}
+		count = chunk.count
+		hasMore = chunk.hasMore
+		items = make([]storage.NamespaceNameResourceVersion, 0, len(chunk.kvs))
+		for _, kv := range chunk.kvs {
+			item, err := keyValueToMetadata(resourcePrefix, kv)
+			if err != nil {
+				return nil, err
+			}
+			items = append(items, item)
+			lastKey = kv.Key
+		}
+		break
+	}
+
+	continueValue, _, err := storage.PrepareContinueToken(string(lastKey), keyPrefix, withRev, count, hasMore, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &storage.MetadataList{
+		ResourceVersion: strconv.FormatInt(withRev, 10),
+		Continue:        continueValue,
+		Items:           items,
+	}, nil
+}
+
 // GetList implements storage.Interface.
 func (s *store) GetList(ctx context.Context, key string, opts storage.ListOptions, listObj runtime.Object) error {
 	keyPrefix, err := s.prepareKey(key, opts.Recursive)
@@ -778,7 +837,7 @@ func (s *store) GetList(ctx context.Context, key string, opts storage.ListOption
 
 	aggregator := s.listErrAggrFactory()
 
-	for chunk, chunkErr := range s.pagedChunks(ctx, keyPrefix, opts, withRev, limit, continueKey) {
+	for chunk, chunkErr := range s.pagedChunks(ctx, keyPrefix, opts, withRev, limit, continueKey, false) {
 		if chunkErr != nil {
 			return chunkErr
 		}
@@ -830,14 +889,21 @@ type listChunk struct {
 	hasMore  bool
 }
 
-func (s *store) pagedChunks(ctx context.Context, keyPrefix string, opts storage.ListOptions, withRev, limit int64, continueKey string) iter.Seq2[listChunk, error] {
+func (s *store) pagedChunks(ctx context.Context, keyPrefix string, opts storage.ListOptions, withRev, limit int64, continueKey string, keysOnly bool) iter.Seq2[listChunk, error] {
 	return func(yield func(listChunk, error) bool) {
 		for {
-			getResp, err := s.getList(ctx, keyPrefix, opts.Recursive, kubernetes.ListOptions{
+			listOpts := kubernetes.ListOptions{
 				Revision: withRev,
 				Limit:    limit,
 				Continue: continueKey,
-			})
+			}
+			var getResp kubernetes.ListResponse
+			var err error
+			if keysOnly {
+				getResp, err = s.getListKeysOnly(ctx, keyPrefix, opts.Recursive, listOpts)
+			} else {
+				getResp, err = s.getList(ctx, keyPrefix, opts.Recursive, listOpts)
+			}
 			if err != nil {
 				if errors.Is(err, etcdrpc.ErrFutureRev) {
 					currentRV, getRVErr := s.GetCurrentResourceVersion(ctx)
@@ -954,6 +1020,34 @@ func (s *store) appendChunk(ctx context.Context, kvs []*mvccpb.KeyValue, pred st
 		kvs[i] = nil
 	}
 	return lastKey, evaluated, false, nil
+}
+
+func (s *store) getListKeysOnly(ctx context.Context, keyPrefix string, recursive bool, options kubernetes.ListOptions) (resp kubernetes.ListResponse, err error) {
+	rangeStart := keyPrefix
+	if options.Continue != "" {
+		rangeStart = options.Continue
+	}
+	getOpts := []clientv3.OpOption{clientv3.WithKeysOnly()}
+	if options.Revision > 0 {
+		getOpts = append(getOpts, clientv3.WithRev(options.Revision))
+	}
+	if options.Limit > 0 {
+		getOpts = append(getOpts, clientv3.WithLimit(options.Limit))
+	}
+	if recursive {
+		getOpts = append(getOpts, clientv3.WithRange(clientv3.GetPrefixRangeEnd(keyPrefix)))
+	}
+
+	startTime := time.Now()
+	getResp, err := s.client.KV.Get(ctx, rangeStart, getOpts...)
+	metrics.RecordEtcdRequest("listMetadata", s.groupResource, err, startTime)
+	if err != nil {
+		return resp, err
+	}
+	resp.Kvs = getResp.Kvs
+	resp.Count = getResp.Count
+	resp.Revision = getResp.Header.Revision
+	return resp, nil
 }
 
 func (s *store) getList(ctx context.Context, keyPrefix string, recursive bool, options kubernetes.ListOptions) (resp kubernetes.ListResponse, err error) {
@@ -1186,6 +1280,34 @@ func (s *store) prepareKey(key string, recursive bool) (string, error) {
 		startIndex = 1
 	}
 	return s.pathPrefix + key[startIndex:], nil
+}
+
+func keyValueToMetadata(resourcePrefix string, kv *mvccpb.KeyValue) (storage.NamespaceNameResourceVersion, error) {
+	key := string(kv.Key)
+	relativeKey, found := strings.CutPrefix(key, resourcePrefix)
+	if !found {
+		return storage.NamespaceNameResourceVersion{}, fmt.Errorf("key %q does not have resource prefix %q", key, resourcePrefix)
+	}
+	if relativeKey == "" {
+		return storage.NamespaceNameResourceVersion{}, fmt.Errorf("key %q has empty name under resource prefix %q", key, resourcePrefix)
+	}
+
+	parts := strings.Split(relativeKey, "/")
+	switch len(parts) {
+	case 1:
+		return storage.NamespaceNameResourceVersion{
+			Name:            parts[0],
+			ResourceVersion: strconv.FormatInt(kv.ModRevision, 10),
+		}, nil
+	case 2:
+		return storage.NamespaceNameResourceVersion{
+			Namespace:       parts[0],
+			Name:            parts[1],
+			ResourceVersion: strconv.FormatInt(kv.ModRevision, 10),
+		}, nil
+	default:
+		return storage.NamespaceNameResourceVersion{}, fmt.Errorf("unexpected key format %q under resource prefix %q", key, resourcePrefix)
+	}
 }
 
 // recordDecodeError record decode error split by object type.

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -32,6 +33,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/kubernetes"
 	"go.etcd.io/etcd/server/v3/embed"
@@ -1088,6 +1090,195 @@ func computePodKey(obj *example.Pod) string {
 	return fmt.Sprintf("/pods/%s/%s", obj.Namespace, obj.Name)
 }
 
+func TestGetListMetadataUsesMinimalEtcdFields(t *testing.T) {
+	ctx, store, _ := testSetup(t)
+
+	var out example.Pod
+	for i := range 3 {
+		pod := &example.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: fmt.Sprintf("pod-%d", i)}}
+		if err := store.Create(ctx, computePodKey(pod), pod, &out, 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	originalDecoder := store.decoder
+	defer func() {
+		store.decoder = originalDecoder
+	}()
+	store.decoder = &panicDecoder{t: t}
+
+	firstPage, err := store.GetListMetadata(ctx, "/pods/", storage.ListOptions{
+		ResourceVersion:      out.ResourceVersion,
+		ResourceVersionMatch: metav1.ResourceVersionMatchExact,
+		Recursive:            true,
+		Predicate: storage.SelectionPredicate{
+			Label: labels.Everything(),
+			Field: fields.Everything(),
+			Limit: 2,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(firstPage.Items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(firstPage.Items))
+	}
+	if firstPage.Continue == "" {
+		t.Fatal("expected continue token for paginated metadata list")
+	}
+	if firstPage.ResourceVersion != out.ResourceVersion {
+		t.Fatalf("expected resourceVersion %q, got %q", out.ResourceVersion, firstPage.ResourceVersion)
+	}
+
+	secondPage, err := store.GetListMetadata(ctx, "/pods/", storage.ListOptions{
+		Recursive: true,
+		Predicate: storage.SelectionPredicate{
+			Label:    labels.Everything(),
+			Field:    fields.Everything(),
+			Limit:    2,
+			Continue: firstPage.Continue,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(secondPage.Items) != 1 {
+		t.Fatalf("expected 1 item on second page, got %d", len(secondPage.Items))
+	}
+	if secondPage.Continue != "" {
+		t.Fatalf("expected empty continue token on last page, got %q", secondPage.Continue)
+	}
+	if secondPage.ResourceVersion != out.ResourceVersion {
+		t.Fatalf("expected paginated resourceVersion %q, got %q", out.ResourceVersion, secondPage.ResourceVersion)
+	}
+
+	allItems := append(append([]storage.NamespaceNameResourceVersion{}, firstPage.Items...), secondPage.Items...)
+	for _, item := range allItems {
+		if item.Namespace != "default" {
+			t.Fatalf("expected namespace default, got %q", item.Namespace)
+		}
+		if item.Name == "" {
+			t.Fatal("expected name to be populated")
+		}
+		if _, err := strconv.ParseUint(item.ResourceVersion, 10, 64); err != nil {
+			t.Fatalf("expected numeric resourceVersion, got %q: %v", item.ResourceVersion, err)
+		}
+	}
+}
+
+func TestGetListMetadataMatchesGetList(t *testing.T) {
+	ctx, store, _ := testSetup(t)
+
+	keys := []string{
+		"/pods/default/pod-a",
+		"/pods/default/pod-b",
+		"/pods/kube-system/pod-c",
+		"/pods/cluster-scoped",
+	}
+	pods := []*example.Pod{
+		{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pod-a"}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pod-b"}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "pod-c"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "cluster-scoped"}},
+	}
+	var lastRV string
+	for i, key := range keys {
+		out := &example.Pod{}
+		if err := store.Create(ctx, key, pods[i], out, 0); err != nil {
+			t.Fatalf("create %q: %v", key, err)
+		}
+		lastRV = out.ResourceVersion
+	}
+
+	opts := storage.ListOptions{
+		ResourceVersion:      lastRV,
+		ResourceVersionMatch: metav1.ResourceVersionMatchExact,
+		Recursive:            true,
+		Predicate:            storage.Everything,
+	}
+
+	listObj := &example.PodList{}
+	if err := store.GetList(ctx, "/pods/", opts, listObj); err != nil {
+		t.Fatalf("GetList: %v", err)
+	}
+	want := make([]storage.NamespaceNameResourceVersion, 0, len(listObj.Items))
+	for _, item := range listObj.Items {
+		want = append(want, storage.NamespaceNameResourceVersion{
+			Namespace:       item.Namespace,
+			Name:            item.Name,
+			ResourceVersion: item.ResourceVersion,
+		})
+	}
+
+	metaList, err := store.GetListMetadata(ctx, "/pods/", opts)
+	if err != nil {
+		t.Fatalf("GetListMetadata: %v", err)
+	}
+
+	if len(want) != len(keys) {
+		t.Fatalf("expected %d decoded items, got %d", len(keys), len(want))
+	}
+	if diff := cmp.Diff(want, metaList.Items); diff != "" {
+		t.Errorf("metadata list differs from decoded list (-getList +getListMetadata):\n%s", diff)
+	}
+}
+
+func TestKeyValueToMetadata(t *testing.T) {
+	const resourcePrefix = "/registry/pods/"
+	cases := []struct {
+		name    string
+		key     string
+		modRev  int64
+		want    storage.NamespaceNameResourceVersion
+		wantErr bool
+	}{
+		{
+			name:   "namespaced",
+			key:    "/registry/pods/default/pod-a",
+			modRev: 7,
+			want:   storage.NamespaceNameResourceVersion{Namespace: "default", Name: "pod-a", ResourceVersion: "7"},
+		},
+		{
+			name:   "cluster scoped",
+			key:    "/registry/pods/node-0",
+			modRev: 9,
+			want:   storage.NamespaceNameResourceVersion{Name: "node-0", ResourceVersion: "9"},
+		},
+		{
+			name:    "missing prefix",
+			key:     "/registry/services/default/svc-a",
+			modRev:  1,
+			wantErr: true,
+		},
+		{
+			name:    "more than two segments",
+			key:     "/registry/pods/default/pod-a/extra",
+			modRev:  1,
+			wantErr: true,
+		},
+		{
+			name:    "empty relative key",
+			key:     "/registry/pods/",
+			modRev:  1,
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := keyValueToMetadata(resourcePrefix, &mvccpb.KeyValue{Key: []byte(tc.key), ModRevision: tc.modRev})
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("wantErr=%v, got err=%v", tc.wantErr, err)
+			}
+			if tc.wantErr {
+				return
+			}
+			if got != tc.want {
+				t.Fatalf("want %+v, got %+v", tc.want, got)
+			}
+		})
+	}
+}
+
 func TestGetCurrentResourceVersion(t *testing.T) {
 	ctx, store, _ := testSetup(t)
 
@@ -1132,6 +1323,20 @@ func TestGetCurrentResourceVersion(t *testing.T) {
 	currentPodRV, err := store.versioner.ParseResourceVersion(currentPod.ResourceVersion)
 	require.NoError(t, err)
 	require.Equal(t, currentPodRV, podRV, "didn't expect to see the pod's RV changed")
+}
+
+type panicDecoder struct {
+	t *testing.T
+}
+
+func (d *panicDecoder) Decode(_ []byte, _ runtime.Object, _ int64) error {
+	d.t.Fatal("unexpected decoder.Decode call")
+	return nil
+}
+
+func (d *panicDecoder) DecodeListItem(_ context.Context, _ []byte, _ uint64, _ func() runtime.Object) (runtime.Object, error) {
+	d.t.Fatal("unexpected decoder.DecodeListItem call")
+	return nil, nil
 }
 
 func BenchmarkStoreStats(b *testing.B) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -338,6 +338,27 @@ type ListOptions struct {
 	SendInitialEvents *bool
 }
 
+// NamespaceNameResourceVersion is the minimal object identity used by cache
+// consistency checks.
+type NamespaceNameResourceVersion struct {
+	Namespace       string
+	Name            string
+	ResourceVersion string
+}
+
+// MetadataList contains a paginated list of minimal object metadata.
+type MetadataList struct {
+	ResourceVersion string
+	Continue        string
+	Items           []NamespaceNameResourceVersion
+}
+
+// MetadataLister returns the minimal object metadata needed by internal callers
+// that only compare namespace/name/resourceVersion tuples.
+type MetadataLister interface {
+	GetListMetadata(ctx context.Context, key string, opts ListOptions) (*MetadataList, error)
+}
+
 // DeleteOptions provides the options that may be provided for storage delete operations.
 type DeleteOptions struct {
 	// ExpectTransformOrDecodeError, if enabled, will return an error if the object can be


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig api-machinery

#### What this PR does / why we need it:

The cache consistency checker compares etcd and the watch cache every ~5 minutes. On the etcd side it currently issues a full `GetList`, which transfers every object's value from etcd and decodes it into full Go objects — even though the checker only needs the `(namespace, name, resourceVersion)` triple to compute its digest.

On large resources this is expensive. On a cluster with ~4.2GB of Pods we see a periodic apiserver heap spike of up to ~10GiB every 5 minutes, driven by this full-object fetch + decode.

This PR is the first of two stages:

- **Stage 1 (this PR):** add a metadata-only path in the storage layer. A new `GetListMetadata` method issues an etcd range with `WithKeysOnly()` and derives the triple directly from the key and the KV `ModRevision`, avoiding value transfer and object decode. It reuses the existing list validation, revision pinning, and pagination (`continue` token) logic, so semantics match `GetList`.
- **Stage 2 (follow-up):** switch the consistency checker's etcd path to use `GetListMetadata` instead of `GetList`.


#### Which issue(s) this PR is related to:

Ref #138101

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```