### PR TITLE
Switch to new for defaulter pointer construction

### DIFF
--- a/pkg/apis/apps/v1/zz_generated.defaults.go
+++ b/pkg/apis/apps/v1/zz_generated.defaults.go
@@ -85,20 +85,16 @@ func SetObjectDefaults_DaemonSet(in *appsv1.DaemonSet) {
 		}
 		if a.VolumeSource.AzureDisk != nil {
 			if a.VolumeSource.AzureDisk.CachingMode == nil {
-				ptrVar1 := corev1.AzureDataDiskCachingMode(corev1.AzureDataDiskCachingReadWrite)
-				a.VolumeSource.AzureDisk.CachingMode = &ptrVar1
+				a.VolumeSource.AzureDisk.CachingMode = new(corev1.AzureDataDiskCachingMode(corev1.AzureDataDiskCachingReadWrite))
 			}
 			if a.VolumeSource.AzureDisk.FSType == nil {
-				var ptrVar1 string = "ext4"
-				a.VolumeSource.AzureDisk.FSType = &ptrVar1
+				a.VolumeSource.AzureDisk.FSType = new(string("ext4"))
 			}
 			if a.VolumeSource.AzureDisk.ReadOnly == nil {
-				var ptrVar1 bool = false
-				a.VolumeSource.AzureDisk.ReadOnly = &ptrVar1
+				a.VolumeSource.AzureDisk.ReadOnly = new(bool(false))
 			}
 			if a.VolumeSource.AzureDisk.Kind == nil {
-				ptrVar1 := corev1.AzureDataDiskKind(corev1.AzureSharedBlobDisk)
-				a.VolumeSource.AzureDisk.Kind = &ptrVar1
+				a.VolumeSource.AzureDisk.Kind = new(corev1.AzureDataDiskKind(corev1.AzureSharedBlobDisk))
 			}
 		}
 		if a.VolumeSource.Projected != nil {
@@ -151,8 +147,7 @@ func SetObjectDefaults_DaemonSet(in *appsv1.DaemonSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -166,8 +161,7 @@ func SetObjectDefaults_DaemonSet(in *appsv1.DaemonSet) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -178,8 +172,7 @@ func SetObjectDefaults_DaemonSet(in *appsv1.DaemonSet) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -190,8 +183,7 @@ func SetObjectDefaults_DaemonSet(in *appsv1.DaemonSet) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -225,8 +217,7 @@ func SetObjectDefaults_DaemonSet(in *appsv1.DaemonSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -240,8 +231,7 @@ func SetObjectDefaults_DaemonSet(in *appsv1.DaemonSet) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -252,8 +242,7 @@ func SetObjectDefaults_DaemonSet(in *appsv1.DaemonSet) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -264,8 +253,7 @@ func SetObjectDefaults_DaemonSet(in *appsv1.DaemonSet) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -299,8 +287,7 @@ func SetObjectDefaults_DaemonSet(in *appsv1.DaemonSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -314,8 +301,7 @@ func SetObjectDefaults_DaemonSet(in *appsv1.DaemonSet) {
 			}
 			if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -326,8 +312,7 @@ func SetObjectDefaults_DaemonSet(in *appsv1.DaemonSet) {
 			}
 			if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -338,8 +323,7 @@ func SetObjectDefaults_DaemonSet(in *appsv1.DaemonSet) {
 			}
 			if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -412,20 +396,16 @@ func SetObjectDefaults_Deployment(in *appsv1.Deployment) {
 		}
 		if a.VolumeSource.AzureDisk != nil {
 			if a.VolumeSource.AzureDisk.CachingMode == nil {
-				ptrVar1 := corev1.AzureDataDiskCachingMode(corev1.AzureDataDiskCachingReadWrite)
-				a.VolumeSource.AzureDisk.CachingMode = &ptrVar1
+				a.VolumeSource.AzureDisk.CachingMode = new(corev1.AzureDataDiskCachingMode(corev1.AzureDataDiskCachingReadWrite))
 			}
 			if a.VolumeSource.AzureDisk.FSType == nil {
-				var ptrVar1 string = "ext4"
-				a.VolumeSource.AzureDisk.FSType = &ptrVar1
+				a.VolumeSource.AzureDisk.FSType = new(string("ext4"))
 			}
 			if a.VolumeSource.AzureDisk.ReadOnly == nil {
-				var ptrVar1 bool = false
-				a.VolumeSource.AzureDisk.ReadOnly = &ptrVar1
+				a.VolumeSource.AzureDisk.ReadOnly = new(bool(false))
 			}
 			if a.VolumeSource.AzureDisk.Kind == nil {
-				ptrVar1 := corev1.AzureDataDiskKind(corev1.AzureSharedBlobDisk)
-				a.VolumeSource.AzureDisk.Kind = &ptrVar1
+				a.VolumeSource.AzureDisk.Kind = new(corev1.AzureDataDiskKind(corev1.AzureSharedBlobDisk))
 			}
 		}
 		if a.VolumeSource.Projected != nil {
@@ -478,8 +458,7 @@ func SetObjectDefaults_Deployment(in *appsv1.Deployment) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -493,8 +472,7 @@ func SetObjectDefaults_Deployment(in *appsv1.Deployment) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -505,8 +483,7 @@ func SetObjectDefaults_Deployment(in *appsv1.Deployment) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -517,8 +494,7 @@ func SetObjectDefaults_Deployment(in *appsv1.Deployment) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -552,8 +528,7 @@ func SetObjectDefaults_Deployment(in *appsv1.Deployment) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -567,8 +542,7 @@ func SetObjectDefaults_Deployment(in *appsv1.Deployment) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -579,8 +553,7 @@ func SetObjectDefaults_Deployment(in *appsv1.Deployment) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -591,8 +564,7 @@ func SetObjectDefaults_Deployment(in *appsv1.Deployment) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -626,8 +598,7 @@ func SetObjectDefaults_Deployment(in *appsv1.Deployment) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -641,8 +612,7 @@ func SetObjectDefaults_Deployment(in *appsv1.Deployment) {
 			}
 			if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -653,8 +623,7 @@ func SetObjectDefaults_Deployment(in *appsv1.Deployment) {
 			}
 			if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -665,8 +634,7 @@ func SetObjectDefaults_Deployment(in *appsv1.Deployment) {
 			}
 			if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -739,20 +707,16 @@ func SetObjectDefaults_ReplicaSet(in *appsv1.ReplicaSet) {
 		}
 		if a.VolumeSource.AzureDisk != nil {
 			if a.VolumeSource.AzureDisk.CachingMode == nil {
-				ptrVar1 := corev1.AzureDataDiskCachingMode(corev1.AzureDataDiskCachingReadWrite)
-				a.VolumeSource.AzureDisk.CachingMode = &ptrVar1
+				a.VolumeSource.AzureDisk.CachingMode = new(corev1.AzureDataDiskCachingMode(corev1.AzureDataDiskCachingReadWrite))
 			}
 			if a.VolumeSource.AzureDisk.FSType == nil {
-				var ptrVar1 string = "ext4"
-				a.VolumeSource.AzureDisk.FSType = &ptrVar1
+				a.VolumeSource.AzureDisk.FSType = new(string("ext4"))
 			}
 			if a.VolumeSource.AzureDisk.ReadOnly == nil {
-				var ptrVar1 bool = false
-				a.VolumeSource.AzureDisk.ReadOnly = &ptrVar1
+				a.VolumeSource.AzureDisk.ReadOnly = new(bool(false))
 			}
 			if a.VolumeSource.AzureDisk.Kind == nil {
-				ptrVar1 := corev1.AzureDataDiskKind(corev1.AzureSharedBlobDisk)
-				a.VolumeSource.AzureDisk.Kind = &ptrVar1
+				a.VolumeSource.AzureDisk.Kind = new(corev1.AzureDataDiskKind(corev1.AzureSharedBlobDisk))
 			}
 		}
 		if a.VolumeSource.Projected != nil {
@@ -805,8 +769,7 @@ func SetObjectDefaults_ReplicaSet(in *appsv1.ReplicaSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -820,8 +783,7 @@ func SetObjectDefaults_ReplicaSet(in *appsv1.ReplicaSet) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -832,8 +794,7 @@ func SetObjectDefaults_ReplicaSet(in *appsv1.ReplicaSet) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -844,8 +805,7 @@ func SetObjectDefaults_ReplicaSet(in *appsv1.ReplicaSet) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -879,8 +839,7 @@ func SetObjectDefaults_ReplicaSet(in *appsv1.ReplicaSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -894,8 +853,7 @@ func SetObjectDefaults_ReplicaSet(in *appsv1.ReplicaSet) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -906,8 +864,7 @@ func SetObjectDefaults_ReplicaSet(in *appsv1.ReplicaSet) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -918,8 +875,7 @@ func SetObjectDefaults_ReplicaSet(in *appsv1.ReplicaSet) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -953,8 +909,7 @@ func SetObjectDefaults_ReplicaSet(in *appsv1.ReplicaSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -968,8 +923,7 @@ func SetObjectDefaults_ReplicaSet(in *appsv1.ReplicaSet) {
 			}
 			if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -980,8 +934,7 @@ func SetObjectDefaults_ReplicaSet(in *appsv1.ReplicaSet) {
 			}
 			if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -992,8 +945,7 @@ func SetObjectDefaults_ReplicaSet(in *appsv1.ReplicaSet) {
 			}
 			if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -1066,20 +1018,16 @@ func SetObjectDefaults_StatefulSet(in *appsv1.StatefulSet) {
 		}
 		if a.VolumeSource.AzureDisk != nil {
 			if a.VolumeSource.AzureDisk.CachingMode == nil {
-				ptrVar1 := corev1.AzureDataDiskCachingMode(corev1.AzureDataDiskCachingReadWrite)
-				a.VolumeSource.AzureDisk.CachingMode = &ptrVar1
+				a.VolumeSource.AzureDisk.CachingMode = new(corev1.AzureDataDiskCachingMode(corev1.AzureDataDiskCachingReadWrite))
 			}
 			if a.VolumeSource.AzureDisk.FSType == nil {
-				var ptrVar1 string = "ext4"
-				a.VolumeSource.AzureDisk.FSType = &ptrVar1
+				a.VolumeSource.AzureDisk.FSType = new(string("ext4"))
 			}
 			if a.VolumeSource.AzureDisk.ReadOnly == nil {
-				var ptrVar1 bool = false
-				a.VolumeSource.AzureDisk.ReadOnly = &ptrVar1
+				a.VolumeSource.AzureDisk.ReadOnly = new(bool(false))
 			}
 			if a.VolumeSource.AzureDisk.Kind == nil {
-				ptrVar1 := corev1.AzureDataDiskKind(corev1.AzureSharedBlobDisk)
-				a.VolumeSource.AzureDisk.Kind = &ptrVar1
+				a.VolumeSource.AzureDisk.Kind = new(corev1.AzureDataDiskKind(corev1.AzureSharedBlobDisk))
 			}
 		}
 		if a.VolumeSource.Projected != nil {
@@ -1132,8 +1080,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1.StatefulSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -1147,8 +1094,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1.StatefulSet) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -1159,8 +1105,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1.StatefulSet) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -1171,8 +1116,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1.StatefulSet) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -1206,8 +1150,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1.StatefulSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -1221,8 +1164,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1.StatefulSet) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -1233,8 +1175,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1.StatefulSet) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -1245,8 +1186,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1.StatefulSet) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -1280,8 +1220,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1.StatefulSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -1295,8 +1234,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1.StatefulSet) {
 			}
 			if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -1307,8 +1245,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1.StatefulSet) {
 			}
 			if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -1319,8 +1256,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1.StatefulSet) {
 			}
 			if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}

--- a/pkg/apis/apps/v1beta1/zz_generated.defaults.go
+++ b/pkg/apis/apps/v1beta1/zz_generated.defaults.go
@@ -81,20 +81,16 @@ func SetObjectDefaults_Deployment(in *appsv1beta1.Deployment) {
 		}
 		if a.VolumeSource.AzureDisk != nil {
 			if a.VolumeSource.AzureDisk.CachingMode == nil {
-				ptrVar1 := v1.AzureDataDiskCachingMode(v1.AzureDataDiskCachingReadWrite)
-				a.VolumeSource.AzureDisk.CachingMode = &ptrVar1
+				a.VolumeSource.AzureDisk.CachingMode = new(v1.AzureDataDiskCachingMode(v1.AzureDataDiskCachingReadWrite))
 			}
 			if a.VolumeSource.AzureDisk.FSType == nil {
-				var ptrVar1 string = "ext4"
-				a.VolumeSource.AzureDisk.FSType = &ptrVar1
+				a.VolumeSource.AzureDisk.FSType = new(string("ext4"))
 			}
 			if a.VolumeSource.AzureDisk.ReadOnly == nil {
-				var ptrVar1 bool = false
-				a.VolumeSource.AzureDisk.ReadOnly = &ptrVar1
+				a.VolumeSource.AzureDisk.ReadOnly = new(bool(false))
 			}
 			if a.VolumeSource.AzureDisk.Kind == nil {
-				ptrVar1 := v1.AzureDataDiskKind(v1.AzureSharedBlobDisk)
-				a.VolumeSource.AzureDisk.Kind = &ptrVar1
+				a.VolumeSource.AzureDisk.Kind = new(v1.AzureDataDiskKind(v1.AzureSharedBlobDisk))
 			}
 		}
 		if a.VolumeSource.Projected != nil {
@@ -147,8 +143,7 @@ func SetObjectDefaults_Deployment(in *appsv1beta1.Deployment) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -162,8 +157,7 @@ func SetObjectDefaults_Deployment(in *appsv1beta1.Deployment) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -174,8 +168,7 @@ func SetObjectDefaults_Deployment(in *appsv1beta1.Deployment) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -186,8 +179,7 @@ func SetObjectDefaults_Deployment(in *appsv1beta1.Deployment) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -221,8 +213,7 @@ func SetObjectDefaults_Deployment(in *appsv1beta1.Deployment) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -236,8 +227,7 @@ func SetObjectDefaults_Deployment(in *appsv1beta1.Deployment) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -248,8 +238,7 @@ func SetObjectDefaults_Deployment(in *appsv1beta1.Deployment) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -260,8 +249,7 @@ func SetObjectDefaults_Deployment(in *appsv1beta1.Deployment) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -295,8 +283,7 @@ func SetObjectDefaults_Deployment(in *appsv1beta1.Deployment) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -310,8 +297,7 @@ func SetObjectDefaults_Deployment(in *appsv1beta1.Deployment) {
 			}
 			if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -322,8 +308,7 @@ func SetObjectDefaults_Deployment(in *appsv1beta1.Deployment) {
 			}
 			if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -334,8 +319,7 @@ func SetObjectDefaults_Deployment(in *appsv1beta1.Deployment) {
 			}
 			if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -408,20 +392,16 @@ func SetObjectDefaults_StatefulSet(in *appsv1beta1.StatefulSet) {
 		}
 		if a.VolumeSource.AzureDisk != nil {
 			if a.VolumeSource.AzureDisk.CachingMode == nil {
-				ptrVar1 := v1.AzureDataDiskCachingMode(v1.AzureDataDiskCachingReadWrite)
-				a.VolumeSource.AzureDisk.CachingMode = &ptrVar1
+				a.VolumeSource.AzureDisk.CachingMode = new(v1.AzureDataDiskCachingMode(v1.AzureDataDiskCachingReadWrite))
 			}
 			if a.VolumeSource.AzureDisk.FSType == nil {
-				var ptrVar1 string = "ext4"
-				a.VolumeSource.AzureDisk.FSType = &ptrVar1
+				a.VolumeSource.AzureDisk.FSType = new(string("ext4"))
 			}
 			if a.VolumeSource.AzureDisk.ReadOnly == nil {
-				var ptrVar1 bool = false
-				a.VolumeSource.AzureDisk.ReadOnly = &ptrVar1
+				a.VolumeSource.AzureDisk.ReadOnly = new(bool(false))
 			}
 			if a.VolumeSource.AzureDisk.Kind == nil {
-				ptrVar1 := v1.AzureDataDiskKind(v1.AzureSharedBlobDisk)
-				a.VolumeSource.AzureDisk.Kind = &ptrVar1
+				a.VolumeSource.AzureDisk.Kind = new(v1.AzureDataDiskKind(v1.AzureSharedBlobDisk))
 			}
 		}
 		if a.VolumeSource.Projected != nil {
@@ -474,8 +454,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1beta1.StatefulSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -489,8 +468,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1beta1.StatefulSet) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -501,8 +479,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1beta1.StatefulSet) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -513,8 +490,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1beta1.StatefulSet) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -548,8 +524,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1beta1.StatefulSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -563,8 +538,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1beta1.StatefulSet) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -575,8 +549,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1beta1.StatefulSet) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -587,8 +560,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1beta1.StatefulSet) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -622,8 +594,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1beta1.StatefulSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -637,8 +608,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1beta1.StatefulSet) {
 			}
 			if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -649,8 +619,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1beta1.StatefulSet) {
 			}
 			if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -661,8 +630,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1beta1.StatefulSet) {
 			}
 			if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}

--- a/pkg/apis/apps/v1beta2/zz_generated.defaults.go
+++ b/pkg/apis/apps/v1beta2/zz_generated.defaults.go
@@ -85,20 +85,16 @@ func SetObjectDefaults_DaemonSet(in *appsv1beta2.DaemonSet) {
 		}
 		if a.VolumeSource.AzureDisk != nil {
 			if a.VolumeSource.AzureDisk.CachingMode == nil {
-				ptrVar1 := v1.AzureDataDiskCachingMode(v1.AzureDataDiskCachingReadWrite)
-				a.VolumeSource.AzureDisk.CachingMode = &ptrVar1
+				a.VolumeSource.AzureDisk.CachingMode = new(v1.AzureDataDiskCachingMode(v1.AzureDataDiskCachingReadWrite))
 			}
 			if a.VolumeSource.AzureDisk.FSType == nil {
-				var ptrVar1 string = "ext4"
-				a.VolumeSource.AzureDisk.FSType = &ptrVar1
+				a.VolumeSource.AzureDisk.FSType = new(string("ext4"))
 			}
 			if a.VolumeSource.AzureDisk.ReadOnly == nil {
-				var ptrVar1 bool = false
-				a.VolumeSource.AzureDisk.ReadOnly = &ptrVar1
+				a.VolumeSource.AzureDisk.ReadOnly = new(bool(false))
 			}
 			if a.VolumeSource.AzureDisk.Kind == nil {
-				ptrVar1 := v1.AzureDataDiskKind(v1.AzureSharedBlobDisk)
-				a.VolumeSource.AzureDisk.Kind = &ptrVar1
+				a.VolumeSource.AzureDisk.Kind = new(v1.AzureDataDiskKind(v1.AzureSharedBlobDisk))
 			}
 		}
 		if a.VolumeSource.Projected != nil {
@@ -151,8 +147,7 @@ func SetObjectDefaults_DaemonSet(in *appsv1beta2.DaemonSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -166,8 +161,7 @@ func SetObjectDefaults_DaemonSet(in *appsv1beta2.DaemonSet) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -178,8 +172,7 @@ func SetObjectDefaults_DaemonSet(in *appsv1beta2.DaemonSet) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -190,8 +183,7 @@ func SetObjectDefaults_DaemonSet(in *appsv1beta2.DaemonSet) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -225,8 +217,7 @@ func SetObjectDefaults_DaemonSet(in *appsv1beta2.DaemonSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -240,8 +231,7 @@ func SetObjectDefaults_DaemonSet(in *appsv1beta2.DaemonSet) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -252,8 +242,7 @@ func SetObjectDefaults_DaemonSet(in *appsv1beta2.DaemonSet) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -264,8 +253,7 @@ func SetObjectDefaults_DaemonSet(in *appsv1beta2.DaemonSet) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -299,8 +287,7 @@ func SetObjectDefaults_DaemonSet(in *appsv1beta2.DaemonSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -314,8 +301,7 @@ func SetObjectDefaults_DaemonSet(in *appsv1beta2.DaemonSet) {
 			}
 			if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -326,8 +312,7 @@ func SetObjectDefaults_DaemonSet(in *appsv1beta2.DaemonSet) {
 			}
 			if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -338,8 +323,7 @@ func SetObjectDefaults_DaemonSet(in *appsv1beta2.DaemonSet) {
 			}
 			if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -412,20 +396,16 @@ func SetObjectDefaults_Deployment(in *appsv1beta2.Deployment) {
 		}
 		if a.VolumeSource.AzureDisk != nil {
 			if a.VolumeSource.AzureDisk.CachingMode == nil {
-				ptrVar1 := v1.AzureDataDiskCachingMode(v1.AzureDataDiskCachingReadWrite)
-				a.VolumeSource.AzureDisk.CachingMode = &ptrVar1
+				a.VolumeSource.AzureDisk.CachingMode = new(v1.AzureDataDiskCachingMode(v1.AzureDataDiskCachingReadWrite))
 			}
 			if a.VolumeSource.AzureDisk.FSType == nil {
-				var ptrVar1 string = "ext4"
-				a.VolumeSource.AzureDisk.FSType = &ptrVar1
+				a.VolumeSource.AzureDisk.FSType = new(string("ext4"))
 			}
 			if a.VolumeSource.AzureDisk.ReadOnly == nil {
-				var ptrVar1 bool = false
-				a.VolumeSource.AzureDisk.ReadOnly = &ptrVar1
+				a.VolumeSource.AzureDisk.ReadOnly = new(bool(false))
 			}
 			if a.VolumeSource.AzureDisk.Kind == nil {
-				ptrVar1 := v1.AzureDataDiskKind(v1.AzureSharedBlobDisk)
-				a.VolumeSource.AzureDisk.Kind = &ptrVar1
+				a.VolumeSource.AzureDisk.Kind = new(v1.AzureDataDiskKind(v1.AzureSharedBlobDisk))
 			}
 		}
 		if a.VolumeSource.Projected != nil {
@@ -478,8 +458,7 @@ func SetObjectDefaults_Deployment(in *appsv1beta2.Deployment) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -493,8 +472,7 @@ func SetObjectDefaults_Deployment(in *appsv1beta2.Deployment) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -505,8 +483,7 @@ func SetObjectDefaults_Deployment(in *appsv1beta2.Deployment) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -517,8 +494,7 @@ func SetObjectDefaults_Deployment(in *appsv1beta2.Deployment) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -552,8 +528,7 @@ func SetObjectDefaults_Deployment(in *appsv1beta2.Deployment) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -567,8 +542,7 @@ func SetObjectDefaults_Deployment(in *appsv1beta2.Deployment) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -579,8 +553,7 @@ func SetObjectDefaults_Deployment(in *appsv1beta2.Deployment) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -591,8 +564,7 @@ func SetObjectDefaults_Deployment(in *appsv1beta2.Deployment) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -626,8 +598,7 @@ func SetObjectDefaults_Deployment(in *appsv1beta2.Deployment) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -641,8 +612,7 @@ func SetObjectDefaults_Deployment(in *appsv1beta2.Deployment) {
 			}
 			if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -653,8 +623,7 @@ func SetObjectDefaults_Deployment(in *appsv1beta2.Deployment) {
 			}
 			if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -665,8 +634,7 @@ func SetObjectDefaults_Deployment(in *appsv1beta2.Deployment) {
 			}
 			if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -739,20 +707,16 @@ func SetObjectDefaults_ReplicaSet(in *appsv1beta2.ReplicaSet) {
 		}
 		if a.VolumeSource.AzureDisk != nil {
 			if a.VolumeSource.AzureDisk.CachingMode == nil {
-				ptrVar1 := v1.AzureDataDiskCachingMode(v1.AzureDataDiskCachingReadWrite)
-				a.VolumeSource.AzureDisk.CachingMode = &ptrVar1
+				a.VolumeSource.AzureDisk.CachingMode = new(v1.AzureDataDiskCachingMode(v1.AzureDataDiskCachingReadWrite))
 			}
 			if a.VolumeSource.AzureDisk.FSType == nil {
-				var ptrVar1 string = "ext4"
-				a.VolumeSource.AzureDisk.FSType = &ptrVar1
+				a.VolumeSource.AzureDisk.FSType = new(string("ext4"))
 			}
 			if a.VolumeSource.AzureDisk.ReadOnly == nil {
-				var ptrVar1 bool = false
-				a.VolumeSource.AzureDisk.ReadOnly = &ptrVar1
+				a.VolumeSource.AzureDisk.ReadOnly = new(bool(false))
 			}
 			if a.VolumeSource.AzureDisk.Kind == nil {
-				ptrVar1 := v1.AzureDataDiskKind(v1.AzureSharedBlobDisk)
-				a.VolumeSource.AzureDisk.Kind = &ptrVar1
+				a.VolumeSource.AzureDisk.Kind = new(v1.AzureDataDiskKind(v1.AzureSharedBlobDisk))
 			}
 		}
 		if a.VolumeSource.Projected != nil {
@@ -805,8 +769,7 @@ func SetObjectDefaults_ReplicaSet(in *appsv1beta2.ReplicaSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -820,8 +783,7 @@ func SetObjectDefaults_ReplicaSet(in *appsv1beta2.ReplicaSet) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -832,8 +794,7 @@ func SetObjectDefaults_ReplicaSet(in *appsv1beta2.ReplicaSet) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -844,8 +805,7 @@ func SetObjectDefaults_ReplicaSet(in *appsv1beta2.ReplicaSet) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -879,8 +839,7 @@ func SetObjectDefaults_ReplicaSet(in *appsv1beta2.ReplicaSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -894,8 +853,7 @@ func SetObjectDefaults_ReplicaSet(in *appsv1beta2.ReplicaSet) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -906,8 +864,7 @@ func SetObjectDefaults_ReplicaSet(in *appsv1beta2.ReplicaSet) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -918,8 +875,7 @@ func SetObjectDefaults_ReplicaSet(in *appsv1beta2.ReplicaSet) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -953,8 +909,7 @@ func SetObjectDefaults_ReplicaSet(in *appsv1beta2.ReplicaSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -968,8 +923,7 @@ func SetObjectDefaults_ReplicaSet(in *appsv1beta2.ReplicaSet) {
 			}
 			if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -980,8 +934,7 @@ func SetObjectDefaults_ReplicaSet(in *appsv1beta2.ReplicaSet) {
 			}
 			if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -992,8 +945,7 @@ func SetObjectDefaults_ReplicaSet(in *appsv1beta2.ReplicaSet) {
 			}
 			if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -1066,20 +1018,16 @@ func SetObjectDefaults_StatefulSet(in *appsv1beta2.StatefulSet) {
 		}
 		if a.VolumeSource.AzureDisk != nil {
 			if a.VolumeSource.AzureDisk.CachingMode == nil {
-				ptrVar1 := v1.AzureDataDiskCachingMode(v1.AzureDataDiskCachingReadWrite)
-				a.VolumeSource.AzureDisk.CachingMode = &ptrVar1
+				a.VolumeSource.AzureDisk.CachingMode = new(v1.AzureDataDiskCachingMode(v1.AzureDataDiskCachingReadWrite))
 			}
 			if a.VolumeSource.AzureDisk.FSType == nil {
-				var ptrVar1 string = "ext4"
-				a.VolumeSource.AzureDisk.FSType = &ptrVar1
+				a.VolumeSource.AzureDisk.FSType = new(string("ext4"))
 			}
 			if a.VolumeSource.AzureDisk.ReadOnly == nil {
-				var ptrVar1 bool = false
-				a.VolumeSource.AzureDisk.ReadOnly = &ptrVar1
+				a.VolumeSource.AzureDisk.ReadOnly = new(bool(false))
 			}
 			if a.VolumeSource.AzureDisk.Kind == nil {
-				ptrVar1 := v1.AzureDataDiskKind(v1.AzureSharedBlobDisk)
-				a.VolumeSource.AzureDisk.Kind = &ptrVar1
+				a.VolumeSource.AzureDisk.Kind = new(v1.AzureDataDiskKind(v1.AzureSharedBlobDisk))
 			}
 		}
 		if a.VolumeSource.Projected != nil {
@@ -1132,8 +1080,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1beta2.StatefulSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -1147,8 +1094,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1beta2.StatefulSet) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -1159,8 +1105,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1beta2.StatefulSet) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -1171,8 +1116,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1beta2.StatefulSet) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -1206,8 +1150,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1beta2.StatefulSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -1221,8 +1164,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1beta2.StatefulSet) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -1233,8 +1175,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1beta2.StatefulSet) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -1245,8 +1186,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1beta2.StatefulSet) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -1280,8 +1220,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1beta2.StatefulSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -1295,8 +1234,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1beta2.StatefulSet) {
 			}
 			if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -1307,8 +1245,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1beta2.StatefulSet) {
 			}
 			if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -1319,8 +1256,7 @@ func SetObjectDefaults_StatefulSet(in *appsv1beta2.StatefulSet) {
 			}
 			if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}

--- a/pkg/apis/batch/v1/zz_generated.defaults.go
+++ b/pkg/apis/batch/v1/zz_generated.defaults.go
@@ -90,20 +90,16 @@ func SetObjectDefaults_CronJob(in *batchv1.CronJob) {
 		}
 		if a.VolumeSource.AzureDisk != nil {
 			if a.VolumeSource.AzureDisk.CachingMode == nil {
-				ptrVar1 := corev1.AzureDataDiskCachingMode(corev1.AzureDataDiskCachingReadWrite)
-				a.VolumeSource.AzureDisk.CachingMode = &ptrVar1
+				a.VolumeSource.AzureDisk.CachingMode = new(corev1.AzureDataDiskCachingMode(corev1.AzureDataDiskCachingReadWrite))
 			}
 			if a.VolumeSource.AzureDisk.FSType == nil {
-				var ptrVar1 string = "ext4"
-				a.VolumeSource.AzureDisk.FSType = &ptrVar1
+				a.VolumeSource.AzureDisk.FSType = new(string("ext4"))
 			}
 			if a.VolumeSource.AzureDisk.ReadOnly == nil {
-				var ptrVar1 bool = false
-				a.VolumeSource.AzureDisk.ReadOnly = &ptrVar1
+				a.VolumeSource.AzureDisk.ReadOnly = new(bool(false))
 			}
 			if a.VolumeSource.AzureDisk.Kind == nil {
-				ptrVar1 := corev1.AzureDataDiskKind(corev1.AzureSharedBlobDisk)
-				a.VolumeSource.AzureDisk.Kind = &ptrVar1
+				a.VolumeSource.AzureDisk.Kind = new(corev1.AzureDataDiskKind(corev1.AzureSharedBlobDisk))
 			}
 		}
 		if a.VolumeSource.Projected != nil {
@@ -156,8 +152,7 @@ func SetObjectDefaults_CronJob(in *batchv1.CronJob) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -171,8 +166,7 @@ func SetObjectDefaults_CronJob(in *batchv1.CronJob) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -183,8 +177,7 @@ func SetObjectDefaults_CronJob(in *batchv1.CronJob) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -195,8 +188,7 @@ func SetObjectDefaults_CronJob(in *batchv1.CronJob) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -230,8 +222,7 @@ func SetObjectDefaults_CronJob(in *batchv1.CronJob) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -245,8 +236,7 @@ func SetObjectDefaults_CronJob(in *batchv1.CronJob) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -257,8 +247,7 @@ func SetObjectDefaults_CronJob(in *batchv1.CronJob) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -269,8 +258,7 @@ func SetObjectDefaults_CronJob(in *batchv1.CronJob) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -304,8 +292,7 @@ func SetObjectDefaults_CronJob(in *batchv1.CronJob) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -319,8 +306,7 @@ func SetObjectDefaults_CronJob(in *batchv1.CronJob) {
 			}
 			if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -331,8 +317,7 @@ func SetObjectDefaults_CronJob(in *batchv1.CronJob) {
 			}
 			if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -343,8 +328,7 @@ func SetObjectDefaults_CronJob(in *batchv1.CronJob) {
 			}
 			if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -426,20 +410,16 @@ func SetObjectDefaults_Job(in *batchv1.Job) {
 		}
 		if a.VolumeSource.AzureDisk != nil {
 			if a.VolumeSource.AzureDisk.CachingMode == nil {
-				ptrVar1 := corev1.AzureDataDiskCachingMode(corev1.AzureDataDiskCachingReadWrite)
-				a.VolumeSource.AzureDisk.CachingMode = &ptrVar1
+				a.VolumeSource.AzureDisk.CachingMode = new(corev1.AzureDataDiskCachingMode(corev1.AzureDataDiskCachingReadWrite))
 			}
 			if a.VolumeSource.AzureDisk.FSType == nil {
-				var ptrVar1 string = "ext4"
-				a.VolumeSource.AzureDisk.FSType = &ptrVar1
+				a.VolumeSource.AzureDisk.FSType = new(string("ext4"))
 			}
 			if a.VolumeSource.AzureDisk.ReadOnly == nil {
-				var ptrVar1 bool = false
-				a.VolumeSource.AzureDisk.ReadOnly = &ptrVar1
+				a.VolumeSource.AzureDisk.ReadOnly = new(bool(false))
 			}
 			if a.VolumeSource.AzureDisk.Kind == nil {
-				ptrVar1 := corev1.AzureDataDiskKind(corev1.AzureSharedBlobDisk)
-				a.VolumeSource.AzureDisk.Kind = &ptrVar1
+				a.VolumeSource.AzureDisk.Kind = new(corev1.AzureDataDiskKind(corev1.AzureSharedBlobDisk))
 			}
 		}
 		if a.VolumeSource.Projected != nil {
@@ -492,8 +472,7 @@ func SetObjectDefaults_Job(in *batchv1.Job) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -507,8 +486,7 @@ func SetObjectDefaults_Job(in *batchv1.Job) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -519,8 +497,7 @@ func SetObjectDefaults_Job(in *batchv1.Job) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -531,8 +508,7 @@ func SetObjectDefaults_Job(in *batchv1.Job) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -566,8 +542,7 @@ func SetObjectDefaults_Job(in *batchv1.Job) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -581,8 +556,7 @@ func SetObjectDefaults_Job(in *batchv1.Job) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -593,8 +567,7 @@ func SetObjectDefaults_Job(in *batchv1.Job) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -605,8 +578,7 @@ func SetObjectDefaults_Job(in *batchv1.Job) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -640,8 +612,7 @@ func SetObjectDefaults_Job(in *batchv1.Job) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -655,8 +626,7 @@ func SetObjectDefaults_Job(in *batchv1.Job) {
 			}
 			if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -667,8 +637,7 @@ func SetObjectDefaults_Job(in *batchv1.Job) {
 			}
 			if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -679,8 +648,7 @@ func SetObjectDefaults_Job(in *batchv1.Job) {
 			}
 			if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}

--- a/pkg/apis/batch/v1beta1/zz_generated.defaults.go
+++ b/pkg/apis/batch/v1beta1/zz_generated.defaults.go
@@ -89,20 +89,16 @@ func SetObjectDefaults_CronJob(in *batchv1beta1.CronJob) {
 		}
 		if a.VolumeSource.AzureDisk != nil {
 			if a.VolumeSource.AzureDisk.CachingMode == nil {
-				ptrVar1 := v1.AzureDataDiskCachingMode(v1.AzureDataDiskCachingReadWrite)
-				a.VolumeSource.AzureDisk.CachingMode = &ptrVar1
+				a.VolumeSource.AzureDisk.CachingMode = new(v1.AzureDataDiskCachingMode(v1.AzureDataDiskCachingReadWrite))
 			}
 			if a.VolumeSource.AzureDisk.FSType == nil {
-				var ptrVar1 string = "ext4"
-				a.VolumeSource.AzureDisk.FSType = &ptrVar1
+				a.VolumeSource.AzureDisk.FSType = new(string("ext4"))
 			}
 			if a.VolumeSource.AzureDisk.ReadOnly == nil {
-				var ptrVar1 bool = false
-				a.VolumeSource.AzureDisk.ReadOnly = &ptrVar1
+				a.VolumeSource.AzureDisk.ReadOnly = new(bool(false))
 			}
 			if a.VolumeSource.AzureDisk.Kind == nil {
-				ptrVar1 := v1.AzureDataDiskKind(v1.AzureSharedBlobDisk)
-				a.VolumeSource.AzureDisk.Kind = &ptrVar1
+				a.VolumeSource.AzureDisk.Kind = new(v1.AzureDataDiskKind(v1.AzureSharedBlobDisk))
 			}
 		}
 		if a.VolumeSource.Projected != nil {
@@ -155,8 +151,7 @@ func SetObjectDefaults_CronJob(in *batchv1beta1.CronJob) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -170,8 +165,7 @@ func SetObjectDefaults_CronJob(in *batchv1beta1.CronJob) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -182,8 +176,7 @@ func SetObjectDefaults_CronJob(in *batchv1beta1.CronJob) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -194,8 +187,7 @@ func SetObjectDefaults_CronJob(in *batchv1beta1.CronJob) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -229,8 +221,7 @@ func SetObjectDefaults_CronJob(in *batchv1beta1.CronJob) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -244,8 +235,7 @@ func SetObjectDefaults_CronJob(in *batchv1beta1.CronJob) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -256,8 +246,7 @@ func SetObjectDefaults_CronJob(in *batchv1beta1.CronJob) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -268,8 +257,7 @@ func SetObjectDefaults_CronJob(in *batchv1beta1.CronJob) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -303,8 +291,7 @@ func SetObjectDefaults_CronJob(in *batchv1beta1.CronJob) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -318,8 +305,7 @@ func SetObjectDefaults_CronJob(in *batchv1beta1.CronJob) {
 			}
 			if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -330,8 +316,7 @@ func SetObjectDefaults_CronJob(in *batchv1beta1.CronJob) {
 			}
 			if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -342,8 +327,7 @@ func SetObjectDefaults_CronJob(in *batchv1beta1.CronJob) {
 			}
 			if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}

--- a/pkg/apis/certificates/v1beta1/zz_generated.defaults.go
+++ b/pkg/apis/certificates/v1beta1/zz_generated.defaults.go
@@ -62,8 +62,7 @@ func SetObjectDefaults_CertificateSigningRequestList(in *certificatesv1beta1.Cer
 
 func SetObjectDefaults_PodCertificateRequest(in *certificatesv1beta1.PodCertificateRequest) {
 	if in.Spec.MaxExpirationSeconds == nil {
-		var ptrVar1 int32 = 86400
-		in.Spec.MaxExpirationSeconds = &ptrVar1
+		in.Spec.MaxExpirationSeconds = new(int32(86400))
 	}
 }
 

--- a/pkg/apis/core/v1/zz_generated.defaults.go
+++ b/pkg/apis/core/v1/zz_generated.defaults.go
@@ -154,20 +154,16 @@ func SetObjectDefaults_PersistentVolume(in *corev1.PersistentVolume) {
 	}
 	if in.Spec.PersistentVolumeSource.AzureDisk != nil {
 		if in.Spec.PersistentVolumeSource.AzureDisk.CachingMode == nil {
-			ptrVar1 := corev1.AzureDataDiskCachingMode(corev1.AzureDataDiskCachingReadWrite)
-			in.Spec.PersistentVolumeSource.AzureDisk.CachingMode = &ptrVar1
+			in.Spec.PersistentVolumeSource.AzureDisk.CachingMode = new(corev1.AzureDataDiskCachingMode(corev1.AzureDataDiskCachingReadWrite))
 		}
 		if in.Spec.PersistentVolumeSource.AzureDisk.FSType == nil {
-			var ptrVar1 string = "ext4"
-			in.Spec.PersistentVolumeSource.AzureDisk.FSType = &ptrVar1
+			in.Spec.PersistentVolumeSource.AzureDisk.FSType = new(string("ext4"))
 		}
 		if in.Spec.PersistentVolumeSource.AzureDisk.ReadOnly == nil {
-			var ptrVar1 bool = false
-			in.Spec.PersistentVolumeSource.AzureDisk.ReadOnly = &ptrVar1
+			in.Spec.PersistentVolumeSource.AzureDisk.ReadOnly = new(bool(false))
 		}
 		if in.Spec.PersistentVolumeSource.AzureDisk.Kind == nil {
-			ptrVar1 := corev1.AzureDataDiskKind(corev1.AzureSharedBlobDisk)
-			in.Spec.PersistentVolumeSource.AzureDisk.Kind = &ptrVar1
+			in.Spec.PersistentVolumeSource.AzureDisk.Kind = new(corev1.AzureDataDiskKind(corev1.AzureSharedBlobDisk))
 		}
 	}
 	if in.Spec.PersistentVolumeSource.ScaleIO != nil {
@@ -245,20 +241,16 @@ func SetObjectDefaults_Pod(in *corev1.Pod) {
 		}
 		if a.VolumeSource.AzureDisk != nil {
 			if a.VolumeSource.AzureDisk.CachingMode == nil {
-				ptrVar1 := corev1.AzureDataDiskCachingMode(corev1.AzureDataDiskCachingReadWrite)
-				a.VolumeSource.AzureDisk.CachingMode = &ptrVar1
+				a.VolumeSource.AzureDisk.CachingMode = new(corev1.AzureDataDiskCachingMode(corev1.AzureDataDiskCachingReadWrite))
 			}
 			if a.VolumeSource.AzureDisk.FSType == nil {
-				var ptrVar1 string = "ext4"
-				a.VolumeSource.AzureDisk.FSType = &ptrVar1
+				a.VolumeSource.AzureDisk.FSType = new(string("ext4"))
 			}
 			if a.VolumeSource.AzureDisk.ReadOnly == nil {
-				var ptrVar1 bool = false
-				a.VolumeSource.AzureDisk.ReadOnly = &ptrVar1
+				a.VolumeSource.AzureDisk.ReadOnly = new(bool(false))
 			}
 			if a.VolumeSource.AzureDisk.Kind == nil {
-				ptrVar1 := corev1.AzureDataDiskKind(corev1.AzureSharedBlobDisk)
-				a.VolumeSource.AzureDisk.Kind = &ptrVar1
+				a.VolumeSource.AzureDisk.Kind = new(corev1.AzureDataDiskKind(corev1.AzureSharedBlobDisk))
 			}
 		}
 		if a.VolumeSource.Projected != nil {
@@ -311,8 +303,7 @@ func SetObjectDefaults_Pod(in *corev1.Pod) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -326,8 +317,7 @@ func SetObjectDefaults_Pod(in *corev1.Pod) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -338,8 +328,7 @@ func SetObjectDefaults_Pod(in *corev1.Pod) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -350,8 +339,7 @@ func SetObjectDefaults_Pod(in *corev1.Pod) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -385,8 +373,7 @@ func SetObjectDefaults_Pod(in *corev1.Pod) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -400,8 +387,7 @@ func SetObjectDefaults_Pod(in *corev1.Pod) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -412,8 +398,7 @@ func SetObjectDefaults_Pod(in *corev1.Pod) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -424,8 +409,7 @@ func SetObjectDefaults_Pod(in *corev1.Pod) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -459,8 +443,7 @@ func SetObjectDefaults_Pod(in *corev1.Pod) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -474,8 +457,7 @@ func SetObjectDefaults_Pod(in *corev1.Pod) {
 			}
 			if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -486,8 +468,7 @@ func SetObjectDefaults_Pod(in *corev1.Pod) {
 			}
 			if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -498,8 +479,7 @@ func SetObjectDefaults_Pod(in *corev1.Pod) {
 			}
 			if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -605,20 +585,16 @@ func SetObjectDefaults_PodTemplate(in *corev1.PodTemplate) {
 		}
 		if a.VolumeSource.AzureDisk != nil {
 			if a.VolumeSource.AzureDisk.CachingMode == nil {
-				ptrVar1 := corev1.AzureDataDiskCachingMode(corev1.AzureDataDiskCachingReadWrite)
-				a.VolumeSource.AzureDisk.CachingMode = &ptrVar1
+				a.VolumeSource.AzureDisk.CachingMode = new(corev1.AzureDataDiskCachingMode(corev1.AzureDataDiskCachingReadWrite))
 			}
 			if a.VolumeSource.AzureDisk.FSType == nil {
-				var ptrVar1 string = "ext4"
-				a.VolumeSource.AzureDisk.FSType = &ptrVar1
+				a.VolumeSource.AzureDisk.FSType = new(string("ext4"))
 			}
 			if a.VolumeSource.AzureDisk.ReadOnly == nil {
-				var ptrVar1 bool = false
-				a.VolumeSource.AzureDisk.ReadOnly = &ptrVar1
+				a.VolumeSource.AzureDisk.ReadOnly = new(bool(false))
 			}
 			if a.VolumeSource.AzureDisk.Kind == nil {
-				ptrVar1 := corev1.AzureDataDiskKind(corev1.AzureSharedBlobDisk)
-				a.VolumeSource.AzureDisk.Kind = &ptrVar1
+				a.VolumeSource.AzureDisk.Kind = new(corev1.AzureDataDiskKind(corev1.AzureSharedBlobDisk))
 			}
 		}
 		if a.VolumeSource.Projected != nil {
@@ -671,8 +647,7 @@ func SetObjectDefaults_PodTemplate(in *corev1.PodTemplate) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -686,8 +661,7 @@ func SetObjectDefaults_PodTemplate(in *corev1.PodTemplate) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -698,8 +672,7 @@ func SetObjectDefaults_PodTemplate(in *corev1.PodTemplate) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -710,8 +683,7 @@ func SetObjectDefaults_PodTemplate(in *corev1.PodTemplate) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -745,8 +717,7 @@ func SetObjectDefaults_PodTemplate(in *corev1.PodTemplate) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -760,8 +731,7 @@ func SetObjectDefaults_PodTemplate(in *corev1.PodTemplate) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -772,8 +742,7 @@ func SetObjectDefaults_PodTemplate(in *corev1.PodTemplate) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -784,8 +753,7 @@ func SetObjectDefaults_PodTemplate(in *corev1.PodTemplate) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -819,8 +787,7 @@ func SetObjectDefaults_PodTemplate(in *corev1.PodTemplate) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -834,8 +801,7 @@ func SetObjectDefaults_PodTemplate(in *corev1.PodTemplate) {
 			}
 			if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -846,8 +812,7 @@ func SetObjectDefaults_PodTemplate(in *corev1.PodTemplate) {
 			}
 			if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -858,8 +823,7 @@ func SetObjectDefaults_PodTemplate(in *corev1.PodTemplate) {
 			}
 			if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -893,8 +857,7 @@ func SetObjectDefaults_PodTemplateList(in *corev1.PodTemplateList) {
 func SetObjectDefaults_ReplicationController(in *corev1.ReplicationController) {
 	SetDefaults_ReplicationController(in)
 	if in.Spec.Replicas == nil {
-		var ptrVar1 int32 = 1
-		in.Spec.Replicas = &ptrVar1
+		in.Spec.Replicas = new(int32(1))
 	}
 	if in.Spec.Template != nil {
 		SetDefaults_PodSpec(&in.Spec.Template.Spec)
@@ -937,20 +900,16 @@ func SetObjectDefaults_ReplicationController(in *corev1.ReplicationController) {
 			}
 			if a.VolumeSource.AzureDisk != nil {
 				if a.VolumeSource.AzureDisk.CachingMode == nil {
-					ptrVar1 := corev1.AzureDataDiskCachingMode(corev1.AzureDataDiskCachingReadWrite)
-					a.VolumeSource.AzureDisk.CachingMode = &ptrVar1
+					a.VolumeSource.AzureDisk.CachingMode = new(corev1.AzureDataDiskCachingMode(corev1.AzureDataDiskCachingReadWrite))
 				}
 				if a.VolumeSource.AzureDisk.FSType == nil {
-					var ptrVar1 string = "ext4"
-					a.VolumeSource.AzureDisk.FSType = &ptrVar1
+					a.VolumeSource.AzureDisk.FSType = new(string("ext4"))
 				}
 				if a.VolumeSource.AzureDisk.ReadOnly == nil {
-					var ptrVar1 bool = false
-					a.VolumeSource.AzureDisk.ReadOnly = &ptrVar1
+					a.VolumeSource.AzureDisk.ReadOnly = new(bool(false))
 				}
 				if a.VolumeSource.AzureDisk.Kind == nil {
-					ptrVar1 := corev1.AzureDataDiskKind(corev1.AzureSharedBlobDisk)
-					a.VolumeSource.AzureDisk.Kind = &ptrVar1
+					a.VolumeSource.AzureDisk.Kind = new(corev1.AzureDataDiskKind(corev1.AzureSharedBlobDisk))
 				}
 			}
 			if a.VolumeSource.Projected != nil {
@@ -1003,8 +962,7 @@ func SetObjectDefaults_ReplicationController(in *corev1.ReplicationController) {
 					}
 					if b.ValueFrom.FileKeyRef != nil {
 						if b.ValueFrom.FileKeyRef.Optional == nil {
-							var ptrVar1 bool = false
-							b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+							b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 						}
 					}
 				}
@@ -1018,8 +976,7 @@ func SetObjectDefaults_ReplicationController(in *corev1.ReplicationController) {
 				}
 				if a.LivenessProbe.ProbeHandler.GRPC != nil {
 					if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-						var ptrVar1 string = ""
-						a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+						a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 					}
 				}
 			}
@@ -1030,8 +987,7 @@ func SetObjectDefaults_ReplicationController(in *corev1.ReplicationController) {
 				}
 				if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 					if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-						var ptrVar1 string = ""
-						a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+						a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 					}
 				}
 			}
@@ -1042,8 +998,7 @@ func SetObjectDefaults_ReplicationController(in *corev1.ReplicationController) {
 				}
 				if a.StartupProbe.ProbeHandler.GRPC != nil {
 					if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-						var ptrVar1 string = ""
-						a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+						a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 					}
 				}
 			}
@@ -1077,8 +1032,7 @@ func SetObjectDefaults_ReplicationController(in *corev1.ReplicationController) {
 					}
 					if b.ValueFrom.FileKeyRef != nil {
 						if b.ValueFrom.FileKeyRef.Optional == nil {
-							var ptrVar1 bool = false
-							b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+							b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 						}
 					}
 				}
@@ -1092,8 +1046,7 @@ func SetObjectDefaults_ReplicationController(in *corev1.ReplicationController) {
 				}
 				if a.LivenessProbe.ProbeHandler.GRPC != nil {
 					if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-						var ptrVar1 string = ""
-						a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+						a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 					}
 				}
 			}
@@ -1104,8 +1057,7 @@ func SetObjectDefaults_ReplicationController(in *corev1.ReplicationController) {
 				}
 				if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 					if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-						var ptrVar1 string = ""
-						a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+						a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 					}
 				}
 			}
@@ -1116,8 +1068,7 @@ func SetObjectDefaults_ReplicationController(in *corev1.ReplicationController) {
 				}
 				if a.StartupProbe.ProbeHandler.GRPC != nil {
 					if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-						var ptrVar1 string = ""
-						a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+						a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 					}
 				}
 			}
@@ -1151,8 +1102,7 @@ func SetObjectDefaults_ReplicationController(in *corev1.ReplicationController) {
 					}
 					if b.ValueFrom.FileKeyRef != nil {
 						if b.ValueFrom.FileKeyRef.Optional == nil {
-							var ptrVar1 bool = false
-							b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+							b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 						}
 					}
 				}
@@ -1166,8 +1116,7 @@ func SetObjectDefaults_ReplicationController(in *corev1.ReplicationController) {
 				}
 				if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC != nil {
 					if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-						var ptrVar1 string = ""
-						a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+						a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 					}
 				}
 			}
@@ -1178,8 +1127,7 @@ func SetObjectDefaults_ReplicationController(in *corev1.ReplicationController) {
 				}
 				if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC != nil {
 					if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-						var ptrVar1 string = ""
-						a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+						a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 					}
 				}
 			}
@@ -1190,8 +1138,7 @@ func SetObjectDefaults_ReplicationController(in *corev1.ReplicationController) {
 				}
 				if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC != nil {
 					if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service == nil {
-						var ptrVar1 string = ""
-						a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+						a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 					}
 				}
 			}

--- a/pkg/apis/extensions/v1beta1/zz_generated.defaults.go
+++ b/pkg/apis/extensions/v1beta1/zz_generated.defaults.go
@@ -87,20 +87,16 @@ func SetObjectDefaults_DaemonSet(in *extensionsv1beta1.DaemonSet) {
 		}
 		if a.VolumeSource.AzureDisk != nil {
 			if a.VolumeSource.AzureDisk.CachingMode == nil {
-				ptrVar1 := v1.AzureDataDiskCachingMode(v1.AzureDataDiskCachingReadWrite)
-				a.VolumeSource.AzureDisk.CachingMode = &ptrVar1
+				a.VolumeSource.AzureDisk.CachingMode = new(v1.AzureDataDiskCachingMode(v1.AzureDataDiskCachingReadWrite))
 			}
 			if a.VolumeSource.AzureDisk.FSType == nil {
-				var ptrVar1 string = "ext4"
-				a.VolumeSource.AzureDisk.FSType = &ptrVar1
+				a.VolumeSource.AzureDisk.FSType = new(string("ext4"))
 			}
 			if a.VolumeSource.AzureDisk.ReadOnly == nil {
-				var ptrVar1 bool = false
-				a.VolumeSource.AzureDisk.ReadOnly = &ptrVar1
+				a.VolumeSource.AzureDisk.ReadOnly = new(bool(false))
 			}
 			if a.VolumeSource.AzureDisk.Kind == nil {
-				ptrVar1 := v1.AzureDataDiskKind(v1.AzureSharedBlobDisk)
-				a.VolumeSource.AzureDisk.Kind = &ptrVar1
+				a.VolumeSource.AzureDisk.Kind = new(v1.AzureDataDiskKind(v1.AzureSharedBlobDisk))
 			}
 		}
 		if a.VolumeSource.Projected != nil {
@@ -153,8 +149,7 @@ func SetObjectDefaults_DaemonSet(in *extensionsv1beta1.DaemonSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -168,8 +163,7 @@ func SetObjectDefaults_DaemonSet(in *extensionsv1beta1.DaemonSet) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -180,8 +174,7 @@ func SetObjectDefaults_DaemonSet(in *extensionsv1beta1.DaemonSet) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -192,8 +185,7 @@ func SetObjectDefaults_DaemonSet(in *extensionsv1beta1.DaemonSet) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -227,8 +219,7 @@ func SetObjectDefaults_DaemonSet(in *extensionsv1beta1.DaemonSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -242,8 +233,7 @@ func SetObjectDefaults_DaemonSet(in *extensionsv1beta1.DaemonSet) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -254,8 +244,7 @@ func SetObjectDefaults_DaemonSet(in *extensionsv1beta1.DaemonSet) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -266,8 +255,7 @@ func SetObjectDefaults_DaemonSet(in *extensionsv1beta1.DaemonSet) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -301,8 +289,7 @@ func SetObjectDefaults_DaemonSet(in *extensionsv1beta1.DaemonSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -316,8 +303,7 @@ func SetObjectDefaults_DaemonSet(in *extensionsv1beta1.DaemonSet) {
 			}
 			if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -328,8 +314,7 @@ func SetObjectDefaults_DaemonSet(in *extensionsv1beta1.DaemonSet) {
 			}
 			if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -340,8 +325,7 @@ func SetObjectDefaults_DaemonSet(in *extensionsv1beta1.DaemonSet) {
 			}
 			if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -414,20 +398,16 @@ func SetObjectDefaults_Deployment(in *extensionsv1beta1.Deployment) {
 		}
 		if a.VolumeSource.AzureDisk != nil {
 			if a.VolumeSource.AzureDisk.CachingMode == nil {
-				ptrVar1 := v1.AzureDataDiskCachingMode(v1.AzureDataDiskCachingReadWrite)
-				a.VolumeSource.AzureDisk.CachingMode = &ptrVar1
+				a.VolumeSource.AzureDisk.CachingMode = new(v1.AzureDataDiskCachingMode(v1.AzureDataDiskCachingReadWrite))
 			}
 			if a.VolumeSource.AzureDisk.FSType == nil {
-				var ptrVar1 string = "ext4"
-				a.VolumeSource.AzureDisk.FSType = &ptrVar1
+				a.VolumeSource.AzureDisk.FSType = new(string("ext4"))
 			}
 			if a.VolumeSource.AzureDisk.ReadOnly == nil {
-				var ptrVar1 bool = false
-				a.VolumeSource.AzureDisk.ReadOnly = &ptrVar1
+				a.VolumeSource.AzureDisk.ReadOnly = new(bool(false))
 			}
 			if a.VolumeSource.AzureDisk.Kind == nil {
-				ptrVar1 := v1.AzureDataDiskKind(v1.AzureSharedBlobDisk)
-				a.VolumeSource.AzureDisk.Kind = &ptrVar1
+				a.VolumeSource.AzureDisk.Kind = new(v1.AzureDataDiskKind(v1.AzureSharedBlobDisk))
 			}
 		}
 		if a.VolumeSource.Projected != nil {
@@ -480,8 +460,7 @@ func SetObjectDefaults_Deployment(in *extensionsv1beta1.Deployment) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -495,8 +474,7 @@ func SetObjectDefaults_Deployment(in *extensionsv1beta1.Deployment) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -507,8 +485,7 @@ func SetObjectDefaults_Deployment(in *extensionsv1beta1.Deployment) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -519,8 +496,7 @@ func SetObjectDefaults_Deployment(in *extensionsv1beta1.Deployment) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -554,8 +530,7 @@ func SetObjectDefaults_Deployment(in *extensionsv1beta1.Deployment) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -569,8 +544,7 @@ func SetObjectDefaults_Deployment(in *extensionsv1beta1.Deployment) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -581,8 +555,7 @@ func SetObjectDefaults_Deployment(in *extensionsv1beta1.Deployment) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -593,8 +566,7 @@ func SetObjectDefaults_Deployment(in *extensionsv1beta1.Deployment) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -628,8 +600,7 @@ func SetObjectDefaults_Deployment(in *extensionsv1beta1.Deployment) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -643,8 +614,7 @@ func SetObjectDefaults_Deployment(in *extensionsv1beta1.Deployment) {
 			}
 			if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -655,8 +625,7 @@ func SetObjectDefaults_Deployment(in *extensionsv1beta1.Deployment) {
 			}
 			if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -667,8 +636,7 @@ func SetObjectDefaults_Deployment(in *extensionsv1beta1.Deployment) {
 			}
 			if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -771,20 +739,16 @@ func SetObjectDefaults_ReplicaSet(in *extensionsv1beta1.ReplicaSet) {
 		}
 		if a.VolumeSource.AzureDisk != nil {
 			if a.VolumeSource.AzureDisk.CachingMode == nil {
-				ptrVar1 := v1.AzureDataDiskCachingMode(v1.AzureDataDiskCachingReadWrite)
-				a.VolumeSource.AzureDisk.CachingMode = &ptrVar1
+				a.VolumeSource.AzureDisk.CachingMode = new(v1.AzureDataDiskCachingMode(v1.AzureDataDiskCachingReadWrite))
 			}
 			if a.VolumeSource.AzureDisk.FSType == nil {
-				var ptrVar1 string = "ext4"
-				a.VolumeSource.AzureDisk.FSType = &ptrVar1
+				a.VolumeSource.AzureDisk.FSType = new(string("ext4"))
 			}
 			if a.VolumeSource.AzureDisk.ReadOnly == nil {
-				var ptrVar1 bool = false
-				a.VolumeSource.AzureDisk.ReadOnly = &ptrVar1
+				a.VolumeSource.AzureDisk.ReadOnly = new(bool(false))
 			}
 			if a.VolumeSource.AzureDisk.Kind == nil {
-				ptrVar1 := v1.AzureDataDiskKind(v1.AzureSharedBlobDisk)
-				a.VolumeSource.AzureDisk.Kind = &ptrVar1
+				a.VolumeSource.AzureDisk.Kind = new(v1.AzureDataDiskKind(v1.AzureSharedBlobDisk))
 			}
 		}
 		if a.VolumeSource.Projected != nil {
@@ -837,8 +801,7 @@ func SetObjectDefaults_ReplicaSet(in *extensionsv1beta1.ReplicaSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -852,8 +815,7 @@ func SetObjectDefaults_ReplicaSet(in *extensionsv1beta1.ReplicaSet) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -864,8 +826,7 @@ func SetObjectDefaults_ReplicaSet(in *extensionsv1beta1.ReplicaSet) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -876,8 +837,7 @@ func SetObjectDefaults_ReplicaSet(in *extensionsv1beta1.ReplicaSet) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -911,8 +871,7 @@ func SetObjectDefaults_ReplicaSet(in *extensionsv1beta1.ReplicaSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -926,8 +885,7 @@ func SetObjectDefaults_ReplicaSet(in *extensionsv1beta1.ReplicaSet) {
 			}
 			if a.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -938,8 +896,7 @@ func SetObjectDefaults_ReplicaSet(in *extensionsv1beta1.ReplicaSet) {
 			}
 			if a.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -950,8 +907,7 @@ func SetObjectDefaults_ReplicaSet(in *extensionsv1beta1.ReplicaSet) {
 			}
 			if a.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -985,8 +941,7 @@ func SetObjectDefaults_ReplicaSet(in *extensionsv1beta1.ReplicaSet) {
 				}
 				if b.ValueFrom.FileKeyRef != nil {
 					if b.ValueFrom.FileKeyRef.Optional == nil {
-						var ptrVar1 bool = false
-						b.ValueFrom.FileKeyRef.Optional = &ptrVar1
+						b.ValueFrom.FileKeyRef.Optional = new(bool(false))
 					}
 				}
 			}
@@ -1000,8 +955,7 @@ func SetObjectDefaults_ReplicaSet(in *extensionsv1beta1.ReplicaSet) {
 			}
 			if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.LivenessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -1012,8 +966,7 @@ func SetObjectDefaults_ReplicaSet(in *extensionsv1beta1.ReplicaSet) {
 			}
 			if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.ReadinessProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}
@@ -1024,8 +977,7 @@ func SetObjectDefaults_ReplicaSet(in *extensionsv1beta1.ReplicaSet) {
 			}
 			if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC != nil {
 				if a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service == nil {
-					var ptrVar1 string = ""
-					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = &ptrVar1
+					a.EphemeralContainerCommon.StartupProbe.ProbeHandler.GRPC.Service = new(string(""))
 				}
 			}
 		}

--- a/pkg/apis/resource/v1alpha3/zz_generated.defaults.go
+++ b/pkg/apis/resource/v1alpha3/zz_generated.defaults.go
@@ -57,8 +57,7 @@ func SetObjectDefaults_DeviceTaintRuleList(in *resourcev1alpha3.DeviceTaintRuleL
 func SetObjectDefaults_ResourcePoolStatusRequest(in *resourcev1alpha3.ResourcePoolStatusRequest) {
 	SetDefaults_ResourcePoolStatusRequestSpec(&in.Spec)
 	if in.Spec.Limit == nil {
-		var ptrVar1 int32 = 100
-		in.Spec.Limit = &ptrVar1
+		in.Spec.Limit = new(int32(100))
 	}
 }
 

--- a/pkg/apis/storage/v1/zz_generated.defaults.go
+++ b/pkg/apis/storage/v1/zz_generated.defaults.go
@@ -87,20 +87,16 @@ func SetObjectDefaults_VolumeAttachment(in *storagev1.VolumeAttachment) {
 		}
 		if in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk != nil {
 			if in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.CachingMode == nil {
-				ptrVar1 := corev1.AzureDataDiskCachingMode(corev1.AzureDataDiskCachingReadWrite)
-				in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.CachingMode = &ptrVar1
+				in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.CachingMode = new(corev1.AzureDataDiskCachingMode(corev1.AzureDataDiskCachingReadWrite))
 			}
 			if in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.FSType == nil {
-				var ptrVar1 string = "ext4"
-				in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.FSType = &ptrVar1
+				in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.FSType = new(string("ext4"))
 			}
 			if in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.ReadOnly == nil {
-				var ptrVar1 bool = false
-				in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.ReadOnly = &ptrVar1
+				in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.ReadOnly = new(bool(false))
 			}
 			if in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.Kind == nil {
-				ptrVar1 := corev1.AzureDataDiskKind(corev1.AzureSharedBlobDisk)
-				in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.Kind = &ptrVar1
+				in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.Kind = new(corev1.AzureDataDiskKind(corev1.AzureSharedBlobDisk))
 			}
 		}
 		if in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.ScaleIO != nil {

--- a/pkg/apis/storage/v1alpha1/zz_generated.defaults.go
+++ b/pkg/apis/storage/v1alpha1/zz_generated.defaults.go
@@ -63,20 +63,16 @@ func SetObjectDefaults_VolumeAttachment(in *storagev1alpha1.VolumeAttachment) {
 		}
 		if in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk != nil {
 			if in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.CachingMode == nil {
-				ptrVar1 := v1.AzureDataDiskCachingMode(v1.AzureDataDiskCachingReadWrite)
-				in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.CachingMode = &ptrVar1
+				in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.CachingMode = new(v1.AzureDataDiskCachingMode(v1.AzureDataDiskCachingReadWrite))
 			}
 			if in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.FSType == nil {
-				var ptrVar1 string = "ext4"
-				in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.FSType = &ptrVar1
+				in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.FSType = new(string("ext4"))
 			}
 			if in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.ReadOnly == nil {
-				var ptrVar1 bool = false
-				in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.ReadOnly = &ptrVar1
+				in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.ReadOnly = new(bool(false))
 			}
 			if in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.Kind == nil {
-				ptrVar1 := v1.AzureDataDiskKind(v1.AzureSharedBlobDisk)
-				in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.Kind = &ptrVar1
+				in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.Kind = new(v1.AzureDataDiskKind(v1.AzureSharedBlobDisk))
 			}
 		}
 		if in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.ScaleIO != nil {

--- a/pkg/apis/storage/v1beta1/zz_generated.defaults.go
+++ b/pkg/apis/storage/v1beta1/zz_generated.defaults.go
@@ -89,20 +89,16 @@ func SetObjectDefaults_VolumeAttachment(in *storagev1beta1.VolumeAttachment) {
 		}
 		if in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk != nil {
 			if in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.CachingMode == nil {
-				ptrVar1 := v1.AzureDataDiskCachingMode(v1.AzureDataDiskCachingReadWrite)
-				in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.CachingMode = &ptrVar1
+				in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.CachingMode = new(v1.AzureDataDiskCachingMode(v1.AzureDataDiskCachingReadWrite))
 			}
 			if in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.FSType == nil {
-				var ptrVar1 string = "ext4"
-				in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.FSType = &ptrVar1
+				in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.FSType = new(string("ext4"))
 			}
 			if in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.ReadOnly == nil {
-				var ptrVar1 bool = false
-				in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.ReadOnly = &ptrVar1
+				in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.ReadOnly = new(bool(false))
 			}
 			if in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.Kind == nil {
-				ptrVar1 := v1.AzureDataDiskKind(v1.AzureSharedBlobDisk)
-				in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.Kind = &ptrVar1
+				in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.AzureDisk.Kind = new(v1.AzureDataDiskKind(v1.AzureSharedBlobDisk))
 			}
 		}
 		if in.Spec.Source.InlineVolumeSpec.PersistentVolumeSource.ScaleIO != nil {

--- a/staging/src/k8s.io/code-generator/cmd/defaulter-gen/generators/defaulter.go
+++ b/staging/src/k8s.io/code-generator/cmd/defaulter-gen/generators/defaulter.go
@@ -1095,53 +1095,50 @@ func (n *callNode) writeDefaulter(c *generator.Context, varName string, index st
 			// If the destination is a pointer, the last element in
 			// defaultDepth is the element type of the bottommost pointer:
 			// the base type of our default value.
-			destElemType := pointerPath[len(pointerPath)-1]
+			baseElemType := pointerPath[len(pointerPath)-1]
 			pointerArgs := args.WithArgs(generator.Args{
-				"varDepth":     len(pointerPath),
-				"baseElemType": destElemType,
+				"baseElemType": baseElemType,
 			})
 
 			sw.Do(fmt.Sprintf("if %s == nil {\n", variablePlaceholder), pointerArgs)
-			if len(n.defaultValue.InlineConstant) > 0 {
-				// If default value is a literal then it can be assigned via var stmt
-				sw.Do("var ptrVar$.varDepth$ $.baseElemType|raw$ = $.defaultValue$\n", pointerArgs)
-			} else {
-				// If default value is not a literal then it may need to be casted
-				// to the base type of the destination pointer
-				sw.Do("ptrVar$.varDepth$ := $.baseElemType|raw$($.defaultValue$)\n", pointerArgs)
-			}
 
-			for i := len(pointerPath); i >= 1; i-- {
-				dest := fmt.Sprintf("ptrVar%d", i-1)
-				assignment := ":="
-				if i == 1 {
-					// Last assignment is into the storage destination
-					dest = variablePlaceholder
-					assignment = "="
+			// Assignment into the storage destination
+			sw.Do(fmt.Sprintf("%v = ", variablePlaceholder), pointerArgs)
+
+			closingParens := 0
+
+			// Build up all the new calls
+			for i := range pointerPath {
+				destElemType := pointerPath[i]
+				var sourceType string
+				if i < len(pointerPath)-1 {
+					sourceType = "*" + pointerPath[i+1].String()
+				} else {
+					sourceType = baseElemType.String()
 				}
 
-				sourceType := "*" + destElemType.String()
-				if i == len(pointerPath) {
-					// Initial value is not a pointer
-					sourceType = destElemType.String()
-				}
-				destElemType = pointerPath[i-1]
-
-				// Cannot include `dest` into args since its value may be
-				// `variablePlaceholder` which is a template, not a value
 				elementArgs := pointerArgs.WithArgs(generator.Args{
-					"assignment":   assignment,
-					"source":       fmt.Sprintf("ptrVar%d", i),
 					"destElemType": destElemType,
 				})
 
 				// Skip cast if type is exact match
 				if destElemType.String() == sourceType {
-					sw.Do(fmt.Sprintf("%v $.assignment$ &$.source$\n", dest), elementArgs)
+					sw.Do("new(", elementArgs)
+					closingParens++
 				} else {
-					sw.Do(fmt.Sprintf("%v $.assignment$ (*$.destElemType|raw$)(&$.source$)\n", dest), elementArgs)
+					sw.Do("new($.destElemType|raw$(", elementArgs)
+					closingParens += 2
 				}
 			}
+
+			// To avoid headaches with new(), always cast to the base type of the destination pointer
+			sw.Do("$.baseElemType|raw$($.defaultValue$)", pointerArgs)
+
+			// Close all the new calls
+			for range closingParens {
+				sw.Do(")", pointerArgs)
+			}
+			sw.Do("\n", pointerArgs)
 		} else {
 			// For primitive types, nil checks cannot be used and the zero value must be determined
 			defaultZero, err := getTypeZeroValue(n.defaultType.String())

--- a/staging/src/k8s.io/code-generator/cmd/defaulter-gen/output_tests/marker/zz_generated.defaults.go
+++ b/staging/src/k8s.io/code-generator/cmd/defaulter-gen/output_tests/marker/zz_generated.defaults.go
@@ -46,16 +46,13 @@ func SetObjectDefaults_Defaulted(in *Defaulted) {
 		in.StringDefault = "bar"
 	}
 	if in.StringPointer == nil {
-		var ptrVar1 string = "default"
-		in.StringPointer = &ptrVar1
+		in.StringPointer = new(string("default"))
 	}
 	if in.Int64 == nil {
-		var ptrVar1 int64 = 64
-		in.Int64 = &ptrVar1
+		in.Int64 = new(int64(64))
 	}
 	if in.Int32 == nil {
-		var ptrVar1 int32 = 32
-		in.Int32 = &ptrVar1
+		in.Int32 = new(int32(32))
 	}
 	if in.IntDefault == 0 {
 		in.IntDefault = 1
@@ -70,8 +67,7 @@ func SetObjectDefaults_Defaulted(in *Defaulted) {
 	}
 	for i := range in.List {
 		if in.List[i] == nil {
-			var ptrVar1 string = "apple"
-			in.List[i] = &ptrVar1
+			in.List[i] = new(string("apple"))
 		}
 	}
 	if in.Sub == nil {
@@ -123,8 +119,7 @@ func SetObjectDefaults_Defaulted(in *Defaulted) {
 	}
 	for i_Map := range in.Map {
 		if in.Map[i_Map] == nil {
-			var ptrVar1 string = "apple"
-			in.Map[i_Map] = &ptrVar1
+			in.Map[i_Map] = new(string("apple"))
 		}
 	}
 	if in.StructMap == nil {
@@ -138,8 +133,7 @@ func SetObjectDefaults_Defaulted(in *Defaulted) {
 		}
 	}
 	if in.AliasPtr == nil {
-		var ptrVar1 string = "banana"
-		in.AliasPtr = &ptrVar1
+		in.AliasPtr = new(string("banana"))
 	}
 }
 
@@ -148,16 +142,13 @@ func SetObjectDefaults_DefaultedOmitempty(in *DefaultedOmitempty) {
 		in.StringDefault = "bar"
 	}
 	if in.StringPointer == nil {
-		var ptrVar1 string = "default"
-		in.StringPointer = &ptrVar1
+		in.StringPointer = new(string("default"))
 	}
 	if in.Int64 == nil {
-		var ptrVar1 int64 = 64
-		in.Int64 = &ptrVar1
+		in.Int64 = new(int64(64))
 	}
 	if in.Int32 == nil {
-		var ptrVar1 int32 = 32
-		in.Int32 = &ptrVar1
+		in.Int32 = new(int32(32))
 	}
 	if in.IntDefault == 0 {
 		in.IntDefault = 1
@@ -172,8 +163,7 @@ func SetObjectDefaults_DefaultedOmitempty(in *DefaultedOmitempty) {
 	}
 	for i := range in.List {
 		if in.List[i] == nil {
-			var ptrVar1 string = "apple"
-			in.List[i] = &ptrVar1
+			in.List[i] = new(string("apple"))
 		}
 	}
 	if in.Sub == nil {
@@ -225,8 +215,7 @@ func SetObjectDefaults_DefaultedOmitempty(in *DefaultedOmitempty) {
 	}
 	for i_Map := range in.Map {
 		if in.Map[i_Map] == nil {
-			var ptrVar1 string = "apple"
-			in.Map[i_Map] = &ptrVar1
+			in.Map[i_Map] = new(string("apple"))
 		}
 	}
 	if in.StructMap == nil {
@@ -240,8 +229,7 @@ func SetObjectDefaults_DefaultedOmitempty(in *DefaultedOmitempty) {
 		}
 	}
 	if in.AliasPtr == nil {
-		var ptrVar1 string = "banana"
-		in.AliasPtr = &ptrVar1
+		in.AliasPtr = new(string("banana"))
 	}
 }
 
@@ -257,31 +245,25 @@ func SetObjectDefaults_DefaultedWithFunction(in *DefaultedWithFunction) {
 
 func SetObjectDefaults_DefaultedWithReference(in *DefaultedWithReference) {
 	if in.AliasConvertDefaultPointer == nil {
-		ptrVar1 := DefaultedValueItem(SomeValue)
-		in.AliasConvertDefaultPointer = &ptrVar1
+		in.AliasConvertDefaultPointer = new(DefaultedValueItem(SomeValue))
 	}
 	if in.PointerAliasDefault == nil {
-		var ptrVar1 string = "apple"
-		in.PointerAliasDefault = &ptrVar1
+		in.PointerAliasDefault = new(string("apple"))
 	}
 	if in.AliasPointerInside == nil {
-		ptrVar1 := string(SomeDefault)
-		in.AliasPointerInside = &ptrVar1
+		in.AliasPointerInside = new(string(SomeDefault))
 	}
 	if in.AliasOverride == nil {
-		ptrVar1 := string(SomeDefault)
-		in.AliasOverride = &ptrVar1
+		in.AliasOverride = new(string(SomeDefault))
 	}
 	if in.AliasPointerDefault == nil {
-		ptrVar1 := DefaultedValueItem(SomeValue)
-		in.AliasPointerDefault = &ptrVar1
+		in.AliasPointerDefault = new(DefaultedValueItem(SomeValue))
 	}
 	if in.AliasNonPointer == "" {
 		in.AliasNonPointer = ValueItem(SomeValue)
 	}
 	if in.AliasPointer == nil {
-		ptrVar1 := ValueItem(SomeValue)
-		in.AliasPointer = &ptrVar1
+		in.AliasPointer = new(ValueItem(SomeValue))
 	}
 	if in.SymbolReference == "" {
 		in.SymbolReference = string(SomeDefault)
@@ -293,33 +275,15 @@ func SetObjectDefaults_DefaultedWithReference(in *DefaultedWithReference) {
 		in.SameNamePackageSymbolReference2 = string(externalexternal.AnotherConstant)
 	}
 	if in.PointerConversion == nil {
-		ptrVar9 := string(SomeValue)
-		ptrVar8 := &ptrVar9
-		ptrVar7 := (*B1)(&ptrVar8)
-		ptrVar6 := (*B2)(&ptrVar7)
-		ptrVar5 := &ptrVar6
-		ptrVar4 := &ptrVar5
-		ptrVar3 := &ptrVar4
-		ptrVar2 := (*B3)(&ptrVar3)
-		ptrVar1 := &ptrVar2
-		in.PointerConversion = (*B4)(&ptrVar1)
+		in.PointerConversion = new(B4(new(new(B3(new(new(new(new(B2(new(B1(new(string(SomeValue))))))))))))))
 	}
 	if in.PointerConversionValue == nil {
-		ptrVar8 := string(SomeValue)
-		ptrVar7 := &ptrVar8
-		ptrVar6 := (*B1)(&ptrVar7)
-		ptrVar5 := (*B2)(&ptrVar6)
-		ptrVar4 := &ptrVar5
-		ptrVar3 := &ptrVar4
-		ptrVar2 := &ptrVar3
-		ptrVar1 := (*B3)(&ptrVar2)
-		in.PointerConversionValue = &ptrVar1
+		in.PointerConversionValue = new(new(B3(new(new(new(new(B2(new(B1(new(string(SomeValue))))))))))))
 	}
 	if in.FullyQualifiedLocalSymbol == "" {
 		in.FullyQualifiedLocalSymbol = string(SomeValue)
 	}
 	if in.ImportFromAliasCast == nil {
-		ptrVar1 := external2.String(SomeValue)
-		in.ImportFromAliasCast = &ptrVar1
+		in.ImportFromAliasCast = new(external2.String(SomeValue))
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Instead of a sequence of ptrVars, use new(). To avoid issues with constant values cast to int32/int64/etc., initial constant values are always cast to the expected type.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
