### PR TITLE
component-base/metrics: make CounterVec satisfy CounterVecMetric

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/counter.go
+++ b/staging/src/k8s.io/component-base/metrics/counter.go
@@ -139,10 +139,9 @@ type CounterVec struct {
 }
 
 var _ kubeCollector = &CounterVec{}
+var _ CounterVecMetric = &CounterVec{}
 
-// TODO: make this true: var _ CounterVecMetric = &CounterVec{}
-
-// NewCounterVec returns an object which satisfies the kubeCollector and (almost) CounterVecMetric interfaces.
+// NewCounterVec returns an object which satisfies the kubeCollector and CounterVecMetric interfaces.
 // However, the object returned will not measure anything unless the collector is first
 // registered, since the metric is lazily instantiated, and only members extracted after
 // registration will actually measure anything.

--- a/staging/src/k8s.io/component-base/metrics/wrappers.go
+++ b/staging/src/k8s.io/component-base/metrics/wrappers.go
@@ -51,10 +51,10 @@ type CounterMetric interface {
 	Add(float64)
 }
 
-// CounterVecMetric is an interface which prometheus.CounterVec satisfies.
+// CounterVecMetric is an interface which CounterVec satisfies.
 type CounterVecMetric interface {
 	WithLabelValues(...string) CounterMetric
-	With(prometheus.Labels) CounterMetric
+	With(map[string]string) CounterMetric
 }
 
 // GaugeMetric is an interface which defines a subset of the interface provided by prometheus.Gauge


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Align the interface with the implementation and with the rest of the package (all five concrete Vec With methods and the `GaugeVecMetric` interface already use map[string]string), turn the TODO into a real compile-time assertion, and fix the two comments that wrongly claimed the interface was satisfied.

The interface has no in-tree consumers, and since `CounterVec` itself did not satisfy the old signature, no existing code could have been relying on it.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

I used AI to detect this. Not sure if the CI will fail.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
