### PR TITLE
Promote DeviceTaintRule CRUD e2e tests to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2987,6 +2987,12 @@
     for resource.k8s.io/v1 DeviceClass.
   release: v1.35
   file: test/e2e/dra/dra.go
+- testname: CRUD operations for devicetaintrules
+  codename: '[sig-node] [DRA] CRUD Tests resource.k8s.io/v1 DeviceTaintRule [Conformance]'
+  description: kube-apiserver must support create/update/list/patch/delete operations
+    for resource.k8s.io/v1 DeviceTaintRule.
+  release: v1.37
+  file: test/e2e/dra/dra.go
 - testname: CRUD operations for resourceclaims
   codename: '[sig-node] [DRA] CRUD Tests resource.k8s.io/v1 ResourceClaim [Conformance]'
   description: kube-apiserver must support create/update/list/patch/delete operations

--- a/test/conformance/testdata/pending_eligible_endpoints.yaml
+++ b/test/conformance/testdata/pending_eligible_endpoints.yaml
@@ -1,11 +1,1 @@
----
-# https://github.com/kubernetes/kubernetes/issues/138814
-- createResourceV1DeviceTaintRule
-- deleteResourceV1CollectionDeviceTaintRule
-- deleteResourceV1DeviceTaintRule
-- patchResourceV1DeviceTaintRule
-- patchResourceV1DeviceTaintRuleStatus
-- readResourceV1DeviceTaintRule
-- readResourceV1DeviceTaintRuleStatus
-- replaceResourceV1DeviceTaintRule
-- replaceResourceV1DeviceTaintRuleStatus
+# No pending eligible endpoints.

--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -113,9 +113,9 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 		/*
 		   Release: v1.37
 		   Testname: CRUD operations for devicetaintrules
-		   Description: kube-apiserver must support create/update/list/patch/delete operations for resource.k8s.io/v1beta2 DeviceTaintRule.
+		   Description: kube-apiserver must support create/update/list/patch/delete operations for resource.k8s.io/v1 DeviceTaintRule.
 		*/
-		f.It("resource.k8s.io/v1 DeviceTaintRule", f.WithFeatureGate(features.DRADeviceTaintRules), func(ctx context.Context) {
+		framework.ConformanceIt("resource.k8s.io/v1 DeviceTaintRule", func(ctx context.Context) {
 			lastTransitionTime := metav1.Now()
 			lastTransitionTimeEncoded, err := lastTransitionTime.MarshalJSON()
 			framework.ExpectNoError(err)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR promotes the `DeviceTaintRule` API resource's CRUD operations test to the conformance test suite. This ensures that conformant clusters cover this GA API.

- Tests only GA, non-optional resource.k8s.io/v1 API (DeviceTaintRule GA in v1.37)
- No feature gate required (DRADeviceTaintRules is GA-locked default: true in 1.37)
- No kubelet API access, no provider-specific skips, no external dependencies
- hack/update-conformance-yaml.sh was run to update conformance.yaml


Testgrid results:
https://testgrid.k8s.io/sig-node-dynamic-resource-allocation#ci-kind-dra&include-filter-by-regex=DeviceTaintRule&include-filter-by-regex=v1%20DeviceTaintRule

#### Which issue(s) this PR is related to:

Fixes #138814

#### Special notes for your reviewer:
/area conformance

@kubernetes/sig-architecture-pr-reviews @kubernetes/sig-node-pr-reviews @kubernetes/cncf-conformance-wg

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```