### PR TITLE
etcd3: fix RangeStream fallback for etcd older than 3.7

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
@@ -301,6 +301,7 @@ func (wc *watchChan) sync() error {
 		if grpcstatus.Code(err) != grpccodes.Unimplemented {
 			return err
 		}
+		etcdfeature.DefaultFeatureSupportChecker.MarkUnsupported(storage.RangeStream)
 		klog.V(4).Infof("etcd server does not support RangeStream for %v; falling back to paginated list", wc.watcher.groupResource)
 	}
 	return wc.syncPaginated()
@@ -374,12 +375,13 @@ func (wc *watchChan) syncStreamRecursive() error {
 	startTime := time.Now()
 	streamResp, err := wc.watcher.client.KV.GetStream(wc.ctx, wc.key, opts...)
 	if err != nil {
-		if grpcstatus.Code(err) == grpccodes.Unimplemented {
-			etcdfeature.DefaultFeatureSupportChecker.MarkUnsupported(storage.RangeStream)
-		}
 		return err
 	}
 	defer func() {
+		// Only record the listStream metric if streaming was actually exercised.
+		if grpcstatus.Code(err) == grpccodes.Unimplemented {
+			return
+		}
 		metrics.RecordEtcdRequest("listStream", wc.watcher.groupResource, err, startTime)
 	}()
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -25,7 +25,9 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"google.golang.org/grpc"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 
@@ -396,7 +398,7 @@ func TestWatchChanSyncStreamFallsBackToPaginated(t *testing.T) {
 	}
 
 	kvWrapper := newEtcdClientKVWrapper(store.client.KV)
-	kvWrapper.streamUnimplemented = true
+	kvWrapper.streamKV = unimplementedRangeStreamKV()
 	store.client.KV = kvWrapper
 
 	w := store.watcher.createWatchChan(origCtx, "/pods/", 0, true, false, storage.Everything)
@@ -508,7 +510,7 @@ etcd_requests_total{group="",operation="listStream",resource="pods"} 1
 	t.Run("unimplemented is not recorded", func(t *testing.T) {
 		ctx, store, _ := testSetup(t)
 		kv := newEtcdClientKVWrapper(store.client.KV)
-		kv.streamUnimplemented = true
+		kv.streamKV = unimplementedRangeStreamKV()
 		store.client.KV = kv
 
 		legacyregistry.Reset()
@@ -533,8 +535,8 @@ type etcdClientKVWrapper struct {
 	getCallCounter int
 	// keeps track of the number of times GetStream method is called
 	getStreamCallCounter int
-	// when true, GetStream returns a gRPC Unimplemented error
-	streamUnimplemented bool
+	// when set, GetStream is served by this KV instead
+	streamKV clientv3.KV
 	// when nonzero, GetStream pins the stream to this revision
 	streamRev int64
 	// getReactors is called after the etcd KV's get function is executed.
@@ -550,13 +552,31 @@ func newEtcdClientKVWrapper(kv clientv3.KV) *etcdClientKVWrapper {
 
 func (ecw *etcdClientKVWrapper) GetStream(ctx context.Context, key string, opts ...clientv3.OpOption) (clientv3.GetStreamChan, error) {
 	ecw.getStreamCallCounter++
-	if ecw.streamUnimplemented {
-		return nil, grpcstatus.Error(grpccodes.Unimplemented, "RangeStream is unimplemented")
+	if ecw.streamKV != nil {
+		return ecw.streamKV.GetStream(ctx, key, opts...)
 	}
 	if ecw.streamRev != 0 {
 		opts = append(opts, clientv3.WithRev(ecw.streamRev))
 	}
 	return ecw.KV.GetStream(ctx, key, opts...)
+}
+
+// unimplementedRangeStreamKV returns a clientv3.KV whose RangeStream fails with
+// Unimplemented on the first Recv, like an etcd server before 3.7.
+func unimplementedRangeStreamKV() clientv3.KV {
+	return clientv3.NewKVFromKVClient(unimplementedRangeStreamKVClient{}, nil)
+}
+
+type unimplementedRangeStreamKVClient struct{ pb.KVClient }
+
+func (unimplementedRangeStreamKVClient) RangeStream(ctx context.Context, in *pb.RangeRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[pb.RangeStreamResponse], error) {
+	return unimplementedRangeStream{}, nil
+}
+
+type unimplementedRangeStream struct{ grpc.ClientStream }
+
+func (unimplementedRangeStream) Recv() (*pb.RangeStreamResponse, error) {
+	return nil, grpcstatus.Error(grpccodes.Unimplemented, "RangeStream is unimplemented")
 }
 
 func (ecw *etcdClientKVWrapper) Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Handle the RangeStream Unimplemented that etcd < 3.7 delivers on the first stream consumption rather than at the GetStream call, so the fallback marks the feature unsupported and does not record a spurious listStream metric.

Please see https://gist.github.com/Jefftree/92f7ccfb2142526ff4c0e32e3a9fecc6 for testing with etcd 3.6. I made an incorrect assumption earlier that RangeStream returns Unimplemented on connection rather than on first stream consumption. 

Also adding https://github.com/kubernetes/test-infra/pull/37406 to exercise this e2e.

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```