### PR TITLE
Use context-aware helpers in quota evaluator core

### DIFF
--- a/pkg/quota/v1/evaluator/core/registry.go
+++ b/pkg/quota/v1/evaluator/core/registry.go
@@ -28,6 +28,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
@@ -67,7 +68,7 @@ func NewEvaluators(f quota.ListerForResourceFunc, i informers.SharedInformerFact
 			podLister = i.Core().V1().Pods().Lister()
 			logger := klog.FromContext(context.Background())
 			deviceClassMapping = extendedresourcecache.NewExtendedResourceCache(logger)
-			if _, err := i.Resource().V1().DeviceClasses().Informer().AddEventHandler(deviceClassMapping); err != nil {
+			if _, err := i.Resource().V1().DeviceClasses().Informer().AddEventHandlerWithOptions(deviceClassMapping, cache.HandlerOptions{Logger: &logger}); err != nil {
 				return nil, fmt.Errorf("failed to add device class informer event handler: %w", err)
 			}
 			var err error

--- a/pkg/quota/v1/evaluator/core/resource_claims_test.go
+++ b/pkg/quota/v1/evaluator/core/resource_claims_test.go
@@ -34,6 +34,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache"
 	"k8s.io/klog/v2/ktesting"
@@ -379,7 +380,7 @@ func TestResourceClaimEvaluatorUsage(t *testing.T) {
 	client := fake.NewClientset(deviceClass1, podImplicit, podExplicit, podHybrid, podNilStatus, podInit)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	deviceclassmapping := extendedresourcecache.NewExtendedResourceCache(logger)
-	if _, err := informerFactory.Resource().V1().DeviceClasses().Informer().AddEventHandler(deviceclassmapping); err != nil {
+	if _, err := informerFactory.Resource().V1().DeviceClasses().Informer().AddEventHandlerWithOptions(deviceclassmapping, cache.HandlerOptions{Logger: &logger}); err != nil {
 		t.Fatal(err)
 	}
 	var otherOwnedClaims []*resourceapi.ResourceClaim
@@ -388,14 +389,14 @@ func TestResourceClaimEvaluatorUsage(t *testing.T) {
 	}
 	evaluatorWithDeviceMapping := NewResourceClaimEvaluator(nil, deviceclassmapping, informerFactory.Core().V1().Pods().Lister(), claimGetter)
 
-	informerFactory.Start(tCtx.Done())
+	informerFactory.StartWithContext(tCtx)
 	t.Cleanup(func() {
 		// Need to cancel before waiting for the shutdown.
 		tCancel()
 		// Now we can wait for all goroutines to stop.
 		informerFactory.Shutdown()
 	})
-	informerFactory.WaitForCacheSync(tCtx.Done())
+	informerFactory.WaitForCacheSyncWithContext(tCtx)
 
 	// wait for informer sync
 	time.Sleep(1 * time.Second)
@@ -644,19 +645,19 @@ func TestResourceClaimEvaluatorMatchingResources(t *testing.T) {
 	client := fake.NewClientset(deviceClass1)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	deviceclassmapping := extendedresourcecache.NewExtendedResourceCache(logger)
-	if _, err := informerFactory.Resource().V1().DeviceClasses().Informer().AddEventHandler(deviceclassmapping); err != nil {
+	if _, err := informerFactory.Resource().V1().DeviceClasses().Informer().AddEventHandlerWithOptions(deviceclassmapping, cache.HandlerOptions{Logger: &logger}); err != nil {
 		logger.Error(err, "failed to add device class informer event handler")
 	}
 	evaluator := NewResourceClaimEvaluator(nil, deviceclassmapping, informerFactory.Core().V1().Pods().Lister(), nil)
 
-	informerFactory.Start(tCtx.Done())
+	informerFactory.StartWithContext(tCtx)
 	t.Cleanup(func() {
 		// Need to cancel before waiting for the shutdown.
 		tCancel()
 		// Now we can wait for all goroutines to stop.
 		informerFactory.Shutdown()
 	})
-	informerFactory.WaitForCacheSync(tCtx.Done())
+	informerFactory.WaitForCacheSyncWithContext(tCtx)
 
 	// wait for informer sync
 	time.Sleep(1 * time.Second)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/sig apimachinery
/wg structured-logging

#### What this PR does / why we need it:

This updates the `quota/v1/evaluator/core` package to use context-aware helpers.

This PR switches the informer event handlers from `AddEventHandler` to `AddEventHandlerWithOptions` (passing the logger), and updates the test informers from `Start`/`WaitForCacheSync` to `StartWithContext`/`WaitForCacheSyncWithContext`.

This keeps the package aligned with the contextual logging migration tracked in #126379.

#### Which issue(s) this PR is related to:

Related to https://github.com/kubernetes/kubernetes/issues/126379

#### Special notes for your reviewer:

Small contextual logging follow-up in the quota evaluator core package.

Local validation:
- `git diff --check`
- `./hack/verify-gofmt.sh`
- `./hack/verify-boilerplate.sh`
- `go test ./pkg/quota/v1/evaluator/core/...`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE