### PR TITLE
CEL reflective wrappers (1): Switch to range loops to appease linters

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
@@ -273,7 +273,7 @@ func (t *typedList) Equal(other ref.Val) ref.Val {
 	if sz != oList.Size() {
 		return types.False
 	}
-	for i := types.Int(0); i < sz; i++ {
+	for i := range types.Int(sz) {
 		eq := t.Get(i).Equal(oList.Get(i))
 		if eq != types.True {
 			return eq // either false or error
@@ -310,7 +310,7 @@ func (t *typedList) Contains(val ref.Val) ref.Val {
 	}
 	var err ref.Val
 	sz := t.value.Len()
-	for i := 0; i < sz; i++ {
+	for i := range sz {
 		elem := TypedToVal(t.value.Index(i).Interface(), t.itemsSchema)
 		cmp := elem.Equal(val)
 		b, ok := cmp.(types.Bool)
@@ -342,7 +342,7 @@ func (t *typedList) Get(idx ref.Val) ref.Val {
 func (t *typedList) Iterator() traits.Iterator {
 	elements := make([]ref.Val, t.value.Len())
 	sz := t.value.Len()
-	for i := 0; i < sz; i++ {
+	for i := range sz {
 		elements[i] = TypedToVal(t.value.Index(i).Interface(), t.itemsSchema)
 	}
 	return &sliceIter{typedList: t, elements: elements}
@@ -383,7 +383,7 @@ func (t *typedMapList) getMap() map[interface{}]interface{} {
 	t.Do(func() {
 		sz := t.value.Len()
 		t.mapOfList = make(map[interface{}]interface{}, sz)
-		for i := types.Int(0); i < types.Int(sz); i++ {
+		for i := range types.Int(sz) {
 			v := t.Get(i)
 			e := reflect.ValueOf(v.Value())
 			t.mapOfList[t.toMapKey(e)] = e.Interface()
@@ -401,7 +401,7 @@ func (t *typedMapList) toMapKey(element reflect.Value) interface{} {
 	}
 	cacheEntry := value.TypeReflectEntryOf(element.Type())
 	var fieldEntries []*value.FieldCacheEntry
-	for i := 0; i < len(t.escapedKeyProps); i++ {
+	for i := range len(t.escapedKeyProps) {
 		if ce, ok := cacheEntry.Fields()[t.escapedKeyProps[i]]; !ok {
 			return types.NewErr("unexpected data format for element of array with x-kubernetes-list-type=map: %T", element)
 		} else {
@@ -504,7 +504,7 @@ func (t *typedSetList) getSet() map[interface{}]struct{} {
 	t.Do(func() {
 		sz := t.value.Len()
 		t.set = make(map[interface{}]struct{}, sz)
-		for i := types.Int(0); i < types.Int(sz); i++ {
+		for i := range types.Int(sz) {
 			e := t.Get(i).Value()
 			t.set[e] = struct{}{}
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

1st PR in a series to address https://github.com/kubernetes/kubernetes/pull/140266

This just switches to range syntax to appease the linter and simplify the rest of the PRs

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
