### PR TITLE
CEL reflective wrappers (2): Fix list/map Value() and ConvertToNative() to return the underlying Go value

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apiserver/pkg/cel/library"
 	"k8s.io/apiserver/pkg/cel/openapi"
 	"k8s.io/kube-openapi/pkg/validation/spec"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -1011,6 +1012,24 @@ func TestToValue(t *testing.T) {
 				testUnstructuredToVal(t, tt, env)
 			})
 		})
+	}
+}
+
+func TestReflectiveWrapperValueReturnsGoValue(t *testing.T) {
+	list := common.TypedToVal([]int64{1, 2, 3}, &openapi.Schema{Schema: intArraySchema})
+	if _, ok := list.Value().([]int64); !ok {
+		t.Errorf("typedList.Value() returned %T, want []int64", list.Value())
+	}
+	m := common.TypedToVal(map[string]int64{"a": 1}, &openapi.Schema{Schema: intMapSchema})
+	if _, ok := m.Value().(map[string]int64); !ok {
+		t.Errorf("typedMap.Value() returned %T, want map[string]int64", m.Value())
+	}
+	native, err := m.ConvertToNative(reflect.TypeFor[map[string]int64]())
+	if err != nil {
+		t.Fatalf("typedMap.ConvertToNative failed: %v", err)
+	}
+	if _, ok := native.(map[string]int64); !ok {
+		t.Errorf("typedMap.ConvertToNative returned %T, want map[string]int64", native)
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
@@ -273,7 +273,7 @@ func (t *typedList) Equal(other ref.Val) ref.Val {
 	if sz != oList.Size() {
 		return types.False
 	}
-	for i := types.Int(0); i < sz; i++ {
+	for i := range types.Int(sz) {
 		eq := t.Get(i).Equal(oList.Get(i))
 		if eq != types.True {
 			return eq // either false or error
@@ -310,7 +310,7 @@ func (t *typedList) Contains(val ref.Val) ref.Val {
 	}
 	var err ref.Val
 	sz := t.value.Len()
-	for i := 0; i < sz; i++ {
+	for i := range sz {
 		elem := TypedToVal(t.value.Index(i).Interface(), t.itemsSchema)
 		cmp := elem.Equal(val)
 		b, ok := cmp.(types.Bool)
@@ -342,7 +342,7 @@ func (t *typedList) Get(idx ref.Val) ref.Val {
 func (t *typedList) Iterator() traits.Iterator {
 	elements := make([]ref.Val, t.value.Len())
 	sz := t.value.Len()
-	for i := 0; i < sz; i++ {
+	for i := range sz {
 		elements[i] = TypedToVal(t.value.Index(i).Interface(), t.itemsSchema)
 	}
 	return &sliceIter{typedList: t, elements: elements}
@@ -383,7 +383,7 @@ func (t *typedMapList) getMap() map[interface{}]interface{} {
 	t.Do(func() {
 		sz := t.value.Len()
 		t.mapOfList = make(map[interface{}]interface{}, sz)
-		for i := types.Int(0); i < types.Int(sz); i++ {
+		for i := range types.Int(sz) {
 			v := t.Get(i)
 			e := reflect.ValueOf(v.Value())
 			t.mapOfList[t.toMapKey(e)] = e.Interface()
@@ -401,7 +401,7 @@ func (t *typedMapList) toMapKey(element reflect.Value) interface{} {
 	}
 	cacheEntry := value.TypeReflectEntryOf(element.Type())
 	var fieldEntries []*value.FieldCacheEntry
-	for i := 0; i < len(t.escapedKeyProps); i++ {
+	for i := range len(t.escapedKeyProps) {
 		if ce, ok := cacheEntry.Fields()[t.escapedKeyProps[i]]; !ok {
 			return types.NewErr("unexpected data format for element of array with x-kubernetes-list-type=map: %T", element)
 		} else {
@@ -504,7 +504,7 @@ func (t *typedSetList) getSet() map[interface{}]struct{} {
 	t.Do(func() {
 		sz := t.value.Len()
 		t.set = make(map[interface{}]struct{}, sz)
-		for i := types.Int(0); i < types.Int(sz); i++ {
+		for i := range types.Int(sz) {
 			e := t.Get(i).Value()
 			t.set[e] = struct{}{}
 		}

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
@@ -287,7 +287,7 @@ func (t *typedList) Type() ref.Type {
 }
 
 func (t *typedList) Value() interface{} {
-	return t.value
+	return t.value.Interface()
 }
 
 func (t *typedList) Add(other ref.Val) ref.Val {
@@ -572,7 +572,7 @@ type typedMap struct {
 func (t *typedMap) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	switch typeDesc.Kind() {
 	case reflect.Map:
-		return t.value, nil
+		return t.value.Interface(), nil
 	default:
 		return nil, fmt.Errorf("type conversion error from '%s' to '%s'", t.Type(), typeDesc)
 	}
@@ -617,7 +617,7 @@ func (t *typedMap) Type() ref.Type {
 }
 
 func (t *typedMap) Value() interface{} {
-	return t.value
+	return t.value.Interface()
 }
 
 func (t *typedMap) Contains(key ref.Val) ref.Val {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Builds on https://github.com/kubernetes/kubernetes/pull/140288

2nd PR in a series to address https://github.com/kubernetes/kubernetes/pull/140266

`typedList.Value()`, `typedMap.Value()` and `typedMap.ConvertToNative()` were handing back the reflect.Value wrapper instead of the actual slice/map; they now return `.Interface()`.

We first using this code in MAP in 1.37.  In 1.36 and earlier we only used the unstructured wrapper which is already correct.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
