### PR TITLE
CEL reflective wrappers (3): Fix list concatenation to not mutate LHS

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
@@ -1033,6 +1033,199 @@ func TestReflectiveWrapperValueReturnsGoValue(t *testing.T) {
 	}
 }
 
+func TestListAdd(t *testing.T) {
+	type AddListsStruct struct {
+		Tags   []string       `json:"tags"`
+		I32s   []int32        `json:"i32s"`
+		Items  []MapListEntry `json:"items"`
+		Nested []Nested       `json:"nested"`
+		Empty  []int64        `json:"empty"`
+	}
+
+	mapListEntrySchema := &spec.Schema{SchemaProps: spec.SchemaProps{
+		Type: []string{"object"},
+		Properties: map[string]spec.Schema{
+			"key1":  *stringSchema,
+			"key2":  *stringSchema,
+			"value": *int64Schema,
+		},
+	}}
+
+	addListsSchema := &spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Type: []string{"object"},
+			Properties: map[string]spec.Schema{
+				"tags":   *stringArraySchema,
+				"i32s":   *spec.ArrayProperty(int32Schema),
+				"items":  *spec.ArrayProperty(mapListEntrySchema),
+				"nested": *spec.ArrayProperty(nestedSchema),
+				"empty":  *intArraySchema,
+			},
+		},
+	}
+
+	x := typedValue{value: AddListsStruct{
+		Tags:   []string{"a", "b", "c"},
+		I32s:   []int32{1, 2, 3},
+		Items:  []MapListEntry{{Key1: "k1v1", Key2: "k2v1", Value: 1}, {Key1: "k1v2", Key2: "k2v2", Value: 2}},
+		Nested: []Nested{{Name: "n1", Info: Struct{S: "hello"}}},
+		Empty:  []int64{},
+	}, schema: addListsSchema}
+	y := typedValue{value: AddListsStruct{
+		Tags:   []string{"d", "e"},
+		I32s:   []int32{30},
+		Items:  []MapListEntry{{Key1: "yk1", Key2: "yk2", Value: 7}},
+		Nested: []Nested{},
+		Empty:  []int64{},
+	}, schema: addListsSchema}
+
+	activation := map[string]typedValue{"x": x, "y": y}
+
+	tests := []struct {
+		testCase
+		skipTyped bool
+		// skipSchemaless: SchemalessTypedToVal has no schema, so map/set lists behave atomically.
+		skipSchemaless   bool
+		skipUnstructured bool
+	}{
+		{testCase: testCase{
+			name:       "string list + literal list",
+			expression: "(x.tags + ['d']) == ['a', 'b', 'c', 'd']",
+		}},
+		{testCase: testCase{
+			name:       "string list + string list",
+			expression: "(x.tags + y.tags) == ['a', 'b', 'c', 'd', 'e']",
+		}},
+		{testCase: testCase{
+			name:       "int32 list + literal list",
+			expression: "(x.i32s + [4]) == [1, 2, 3, 4]",
+		}},
+		{testCase: testCase{
+			name:       "int32 list + int32 list",
+			expression: "(x.i32s + y.i32s) == [1, 2, 3, 30]",
+		}},
+		{testCase: testCase{
+			name:       "empty list + literal list",
+			expression: "(x.empty + [1]) == [1]",
+		}},
+		{testCase: testCase{
+			name:       "list + empty literal list",
+			expression: "(x.tags + []) == ['a', 'b', 'c']",
+		}},
+		{testCase: testCase{
+			name:       "chained concatenation",
+			expression: "(x.tags + ['d'] + y.tags) == ['a', 'b', 'c', 'd', 'd', 'e']",
+		}},
+		{testCase: testCase{
+			name:       "struct list + literal list, field access",
+			expression: "(x.items + [{'key1': 'lk1', 'key2': 'lk2', 'value': 100}])[2].value == 100",
+		}, // skipUnstructured: unstructuredList.Add stores raw CEL literal element values that UnstructuredToVal cannot rewrap.
+			skipUnstructured: true},
+		{testCase: testCase{
+			name:       "struct list + literal list, exists",
+			expression: "(x.items + [{'key1': 'lk1', 'key2': 'lk2', 'value': 100}]).exists(e, e.key1 == 'lk1')",
+		}, // skipUnstructured: unstructuredList.Add stores raw CEL literal element values that UnstructuredToVal cannot rewrap.
+			skipUnstructured: true},
+		{testCase: testCase{
+			name:       "literal list + struct list",
+			expression: "([{'key1': 'lk1'}] + x.items)[0].key1 == 'lk1' && ([{'key1': 'lk1'}] + x.items)[1].key1 == 'k1v1'",
+		}},
+		{testCase: testCase{
+			name:       "struct list + struct list",
+			expression: "(x.items + y.items)[2].key1 == 'yk1'",
+		}},
+		{testCase: testCase{
+			name:       "nested field access on appended literal",
+			expression: "(x.nested + [{'name': 'n2', 'info': {'s': 'deep'}}])[1].info.s == 'deep'",
+		}, // skipUnstructured: unstructuredList.Add stores raw CEL literal element values that UnstructuredToVal cannot rewrap.
+			skipUnstructured: true},
+		{testCase: testCase{
+			name:       "size of concatenated list",
+			expression: "size(x.items + [{'key1': 'lk1'}]) == 3",
+		}},
+		{testCase: testCase{
+			name:       "all over concatenated list",
+			expression: "(x.i32s + [4]).all(i, i < 100)",
+		}},
+		{testCase: testCase{
+			name:       "membership in concatenated list",
+			expression: "4 in (x.i32s + [4])",
+		}},
+		{testCase: testCase{
+			name:       "heterogeneous literal elements",
+			expression: "(x.tags + [1])[3] == 1",
+		}, // skipUnstructured: unstructuredList.Add stores raw CEL literal element values that UnstructuredToVal cannot rewrap.
+			skipUnstructured: true},
+		{testCase: testCase{
+			name:       "add non-list",
+			expression: "(x.tags + dyn(1)) == ['a']",
+			wantErr:    "no such overload",
+		}},
+		{testCase: testCase{
+			name:       "index out of bounds on concatenated list",
+			expression: "(x.i32s + [4])[10] == 1",
+			wantErr:    "index out of bounds: 10",
+		}},
+	}
+
+	var opts []cel.EnvOption
+	for k := range activation {
+		opts = append(opts, cel.Variable(k, cel.DynType))
+	}
+	opts = append(opts, cel.StdLib())
+	env, err := cel.NewEnv(opts...)
+	if err != nil {
+		t.Fatalf("Env creation error: %v", err)
+	}
+
+	for _, tt := range tests {
+		tt.testCase.activation = activation
+		t.Run(tt.name, func(t *testing.T) {
+			if !tt.skipTyped {
+				t.Run("TypedToVal", func(t *testing.T) {
+					testTypedToVal(t, env, tt.testCase)
+				})
+			}
+			if !tt.skipSchemaless {
+				t.Run("SchemalessTypedToVal", func(t *testing.T) {
+					testSchemalessTypedToVal(t, env, tt.testCase)
+				})
+			}
+			if !tt.skipUnstructured {
+				t.Run("UnstructuredToVal", func(t *testing.T) {
+					testUnstructuredToVal(t, tt.testCase, env)
+				})
+			}
+		})
+	}
+}
+
+func schemalessTypedToValActivation(vals map[string]typedValue) map[string]interface{} {
+	activation := make(map[string]interface{}, len(vals))
+	for k, tv := range vals {
+		activation[k] = common.SchemalessTypedToVal(tv.value)
+	}
+	return activation
+}
+
+func testSchemalessTypedToVal(t *testing.T, env *cel.Env, tt testCase) {
+	out, err := evalExpression(t, env, tt.expression, schemalessTypedToValActivation(tt.activation))
+	if err != nil && len(tt.wantErr) == 0 {
+		t.Fatalf("Unexpected err with schemaless typed values: %v", err)
+	}
+	if len(tt.wantErr) > 0 {
+		if err == nil {
+			t.Fatalf("Expected error '%s' during evaluation with schemaless typed values, but got none", tt.wantErr)
+		}
+		if err.Error() != tt.wantErr {
+			t.Fatalf("Expected error '%s' during evaluation with schemaless typed values, but got: %v", tt.wantErr, err)
+		}
+	}
+	if len(tt.wantErr) == 0 && out != types.True {
+		t.Errorf("Expected true with schemaless typed values but got %v", out)
+	}
+}
+
 func testTypedToVal(t *testing.T, env *cel.Env, tt testCase) {
 	typedOut, typedErr := evalExpression(t, env, tt.expression, typedToValActivation(tt.activation))
 	if typedErr != nil && len(tt.wantErr) == 0 {

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apiserver/pkg/cel/library"
 	"k8s.io/apiserver/pkg/cel/openapi"
 	"k8s.io/kube-openapi/pkg/validation/spec"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -1011,6 +1012,24 @@ func TestToValue(t *testing.T) {
 				testUnstructuredToVal(t, tt, env)
 			})
 		})
+	}
+}
+
+func TestReflectiveWrapperValueReturnsGoValue(t *testing.T) {
+	list := common.TypedToVal([]int64{1, 2, 3}, &openapi.Schema{Schema: intArraySchema})
+	if _, ok := list.Value().([]int64); !ok {
+		t.Errorf("typedList.Value() returned %T, want []int64", list.Value())
+	}
+	m := common.TypedToVal(map[string]int64{"a": 1}, &openapi.Schema{Schema: intMapSchema})
+	if _, ok := m.Value().(map[string]int64); !ok {
+		t.Errorf("typedMap.Value() returned %T, want map[string]int64", m.Value())
+	}
+	native, err := m.ConvertToNative(reflect.TypeFor[map[string]int64]())
+	if err != nil {
+		t.Fatalf("typedMap.ConvertToNative failed: %v", err)
+	}
+	if _, ok := native.(map[string]int64); !ok {
+		t.Errorf("typedMap.ConvertToNative returned %T, want map[string]int64", native)
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
@@ -273,7 +273,7 @@ func (t *typedList) Equal(other ref.Val) ref.Val {
 	if sz != oList.Size() {
 		return types.False
 	}
-	for i := types.Int(0); i < sz; i++ {
+	for i := range types.Int(sz) {
 		eq := t.Get(i).Equal(oList.Get(i))
 		if eq != types.True {
 			return eq // either false or error
@@ -310,7 +310,7 @@ func (t *typedList) Contains(val ref.Val) ref.Val {
 	}
 	var err ref.Val
 	sz := t.value.Len()
-	for i := 0; i < sz; i++ {
+	for i := range sz {
 		elem := TypedToVal(t.value.Index(i).Interface(), t.itemsSchema)
 		cmp := elem.Equal(val)
 		b, ok := cmp.(types.Bool)
@@ -342,7 +342,7 @@ func (t *typedList) Get(idx ref.Val) ref.Val {
 func (t *typedList) Iterator() traits.Iterator {
 	elements := make([]ref.Val, t.value.Len())
 	sz := t.value.Len()
-	for i := 0; i < sz; i++ {
+	for i := range sz {
 		elements[i] = TypedToVal(t.value.Index(i).Interface(), t.itemsSchema)
 	}
 	return &sliceIter{typedList: t, elements: elements}
@@ -383,7 +383,7 @@ func (t *typedMapList) getMap() map[interface{}]interface{} {
 	t.Do(func() {
 		sz := t.value.Len()
 		t.mapOfList = make(map[interface{}]interface{}, sz)
-		for i := types.Int(0); i < types.Int(sz); i++ {
+		for i := range types.Int(sz) {
 			v := t.Get(i)
 			e := reflect.ValueOf(v.Value())
 			t.mapOfList[t.toMapKey(e)] = e.Interface()
@@ -401,7 +401,7 @@ func (t *typedMapList) toMapKey(element reflect.Value) interface{} {
 	}
 	cacheEntry := value.TypeReflectEntryOf(element.Type())
 	var fieldEntries []*value.FieldCacheEntry
-	for i := 0; i < len(t.escapedKeyProps); i++ {
+	for i := range len(t.escapedKeyProps) {
 		if ce, ok := cacheEntry.Fields()[t.escapedKeyProps[i]]; !ok {
 			return types.NewErr("unexpected data format for element of array with x-kubernetes-list-type=map: %T", element)
 		} else {
@@ -504,7 +504,7 @@ func (t *typedSetList) getSet() map[interface{}]struct{} {
 	t.Do(func() {
 		sz := t.value.Len()
 		t.set = make(map[interface{}]struct{}, sz)
-		for i := types.Int(0); i < types.Int(sz); i++ {
+		for i := range types.Int(sz) {
 			e := t.Get(i).Value()
 			t.set[e] = struct{}{}
 		}

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
@@ -295,13 +295,16 @@ func (t *typedList) Add(other ref.Val) ref.Val {
 	if !ok {
 		return types.MaybeNoSuchOverloadErr(other)
 	}
-	resultValue := t.value
-	for it := oList.Iterator(); it.HasNext() == types.True; {
-		next := it.Next().Value()
-		resultValue = reflect.Append(resultValue, reflect.ValueOf(next))
+	sz := t.value.Len()
+	otherSz, _ := oList.Size().(types.Int)
+	elements := make([]ref.Val, 0, sz+int(otherSz))
+	for i := range sz {
+		elements = append(elements, t.Get(types.Int(i)))
 	}
-
-	return &typedList{value: resultValue, itemsSchema: t.itemsSchema}
+	for it := oList.Iterator(); it.HasNext() == types.True; {
+		elements = append(elements, it.Next())
+	}
+	return types.NewRefValList(types.DefaultTypeAdapter, elements)
 }
 
 func (t *typedList) Contains(val ref.Val) ref.Val {

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
@@ -287,7 +287,7 @@ func (t *typedList) Type() ref.Type {
 }
 
 func (t *typedList) Value() interface{} {
-	return t.value
+	return t.value.Interface()
 }
 
 func (t *typedList) Add(other ref.Val) ref.Val {
@@ -572,7 +572,7 @@ type typedMap struct {
 func (t *typedMap) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 	switch typeDesc.Kind() {
 	case reflect.Map:
-		return t.value, nil
+		return t.value.Interface(), nil
 	default:
 		return nil, fmt.Errorf("type conversion error from '%s' to '%s'", t.Type(), typeDesc)
 	}
@@ -617,7 +617,7 @@ func (t *typedMap) Type() ref.Type {
 }
 
 func (t *typedMap) Value() interface{} {
-	return t.value
+	return t.value.Interface()
 }
 
 func (t *typedMap) Contains(key ref.Val) ref.Val {

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/valuesschemalesstyped.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/valuesschemalesstyped.go
@@ -209,15 +209,16 @@ func (l *reflectSchemalessTypedList) Add(other ref.Val) ref.Val {
 		return types.MaybeNoSuchOverloadErr(other)
 	}
 	sz := l.value.Len()
-	elements := make([]interface{}, 0, sz)
+	otherSz, _ := otherList.Size().(types.Int)
+	elements := make([]ref.Val, 0, sz+int(otherSz))
 	for i := range sz {
-		elements = append(elements, l.value.Index(i).Interface())
+		elements = append(elements, l.Get(types.Int(i)))
 	}
 	it := otherList.Iterator()
 	for it.HasNext() == types.True {
-		elements = append(elements, it.Next().Value())
+		elements = append(elements, it.Next())
 	}
-	return &reflectSchemalessTypedList{value: reflect.ValueOf(elements)}
+	return types.NewRefValList(types.DefaultTypeAdapter, elements)
 }
 
 func (l *reflectSchemalessTypedList) Get(index ref.Val) ref.Val {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Builds on https://github.com/kubernetes/kubernetes/pull/140290

3rd PR in a series to address https://github.com/kubernetes/kubernetes/pull/140266

`Add` appended into the left operand's backing slice via `reflect.Append`. This fixes the code to build a fresh `ref.Val` list instead.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```