### PR TITLE
CEL reflective wrappers (4): Keep map-list merge semantics on CEL concatenation results

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
@@ -17,9 +17,14 @@ limitations under the License.
 package common_test
 
 import (
+	"reflect"
+	"testing"
+	"time"
+
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -29,9 +34,6 @@ import (
 	"k8s.io/apiserver/pkg/cel/library"
 	"k8s.io/apiserver/pkg/cel/openapi"
 	"k8s.io/kube-openapi/pkg/validation/spec"
-	"reflect"
-	"testing"
-	"time"
 )
 
 // TestToValue tests that both UnstructuredToValue and TypedToValue correctly
@@ -1089,19 +1091,70 @@ func TestReflectiveMapListWithThreeKeysEqual(t *testing.T) {
 }
 
 func TestListAdd(t *testing.T) {
-	type AddListsStruct struct {
-		Tags   []string       `json:"tags"`
-		I32s   []int32        `json:"i32s"`
-		Items  []MapListEntry `json:"items"`
-		Nested []Nested       `json:"nested"`
-		Empty  []int64        `json:"empty"`
+	// IfEntry has a map key prop that is a CEL reserved word and so requires escaping.
+	type IfEntry struct {
+		If    string `json:"if"`
+		Value int64  `json:"value"`
 	}
+	// WideEntry has enough key props to exercise the serialized map key fallback.
+	type WideEntry struct {
+		Key1  string `json:"key1"`
+		Key2  string `json:"key2"`
+		Key3  string `json:"key3"`
+		Key4  string `json:"key4"`
+		Value int64  `json:"value"`
+	}
+
+	type PtrEntry struct {
+		Name  *string `json:"name"`
+		Port  *int64  `json:"port"`
+		Value int64   `json:"value"`
+	}
+	type AddListsStruct struct {
+		Tags    []string       `json:"tags"`
+		I32s    []int32        `json:"i32s"`
+		Items   []MapListEntry `json:"items"`
+		Nested  []Nested       `json:"nested"`
+		Empty   []int64        `json:"empty"`
+		MapList []MapListEntry `json:"mapList"`
+		IfList  []IfEntry      `json:"ifList"`
+		Wide    []WideEntry    `json:"wide"`
+		Tri     []WideEntry    `json:"tri"`
+		PtrList []PtrEntry     `json:"ptrList"`
+	}
+	strptr := func(s string) *string { return &s }
+	intptr := func(i int64) *int64 { return &i }
 
 	mapListEntrySchema := &spec.Schema{SchemaProps: spec.SchemaProps{
 		Type: []string{"object"},
 		Properties: map[string]spec.Schema{
 			"key1":  *stringSchema,
 			"key2":  *stringSchema,
+			"value": *int64Schema,
+		},
+	}}
+	ifEntrySchema := &spec.Schema{SchemaProps: spec.SchemaProps{
+		Type: []string{"object"},
+		Properties: map[string]spec.Schema{
+			"if":    *stringSchema,
+			"value": *int64Schema,
+		},
+	}}
+	wideEntrySchema := &spec.Schema{SchemaProps: spec.SchemaProps{
+		Type: []string{"object"},
+		Properties: map[string]spec.Schema{
+			"key1":  *stringSchema,
+			"key2":  *stringSchema,
+			"key3":  *stringSchema,
+			"key4":  *stringSchema,
+			"value": *int64Schema,
+		},
+	}}
+	ptrEntrySchema := &spec.Schema{SchemaProps: spec.SchemaProps{
+		Type: []string{"object"},
+		Properties: map[string]spec.Schema{
+			"name":  *stringSchema,
+			"port":  *int64Schema,
 			"value": *int64Schema,
 		},
 	}}
@@ -1115,26 +1168,84 @@ func TestListAdd(t *testing.T) {
 				"items":  *spec.ArrayProperty(mapListEntrySchema),
 				"nested": *spec.ArrayProperty(nestedSchema),
 				"empty":  *intArraySchema,
+				"mapList": {
+					VendorExtensible: spec.VendorExtensible{Extensions: map[string]interface{}{
+						"x-kubernetes-list-type":     "map",
+						"x-kubernetes-list-map-keys": []any{"key1", "key2"},
+					}},
+					SchemaProps: spec.SchemaProps{Type: []string{"array"}, Items: &spec.SchemaOrArray{Schema: mapListEntrySchema}},
+				},
+				"ifList": {
+					VendorExtensible: spec.VendorExtensible{Extensions: map[string]interface{}{
+						"x-kubernetes-list-type":     "map",
+						"x-kubernetes-list-map-keys": []any{"if"},
+					}},
+					SchemaProps: spec.SchemaProps{Type: []string{"array"}, Items: &spec.SchemaOrArray{Schema: ifEntrySchema}},
+				},
+				"wide": {
+					VendorExtensible: spec.VendorExtensible{Extensions: map[string]interface{}{
+						"x-kubernetes-list-type":     "map",
+						"x-kubernetes-list-map-keys": []any{"key1", "key2", "key3", "key4"},
+					}},
+					SchemaProps: spec.SchemaProps{Type: []string{"array"}, Items: &spec.SchemaOrArray{Schema: wideEntrySchema}},
+				},
+				"tri": {
+					VendorExtensible: spec.VendorExtensible{Extensions: map[string]interface{}{
+						"x-kubernetes-list-type":     "map",
+						"x-kubernetes-list-map-keys": []any{"key1", "key2", "key3"},
+					}},
+					SchemaProps: spec.SchemaProps{Type: []string{"array"}, Items: &spec.SchemaOrArray{Schema: wideEntrySchema}},
+				},
+				"ptrList": {
+					VendorExtensible: spec.VendorExtensible{Extensions: map[string]interface{}{
+						"x-kubernetes-list-type":     "map",
+						"x-kubernetes-list-map-keys": []any{"name", "port"},
+					}},
+					SchemaProps: spec.SchemaProps{Type: []string{"array"}, Items: &spec.SchemaOrArray{Schema: ptrEntrySchema}},
+				},
 			},
 		},
 	}
 
 	x := typedValue{value: AddListsStruct{
-		Tags:   []string{"a", "b", "c"},
-		I32s:   []int32{1, 2, 3},
-		Items:  []MapListEntry{{Key1: "k1v1", Key2: "k2v1", Value: 1}, {Key1: "k1v2", Key2: "k2v2", Value: 2}},
-		Nested: []Nested{{Name: "n1", Info: Struct{S: "hello"}}},
-		Empty:  []int64{},
+		Tags:    []string{"a", "b", "c"},
+		I32s:    []int32{1, 2, 3},
+		Items:   []MapListEntry{{Key1: "k1v1", Key2: "k2v1", Value: 1}, {Key1: "k1v2", Key2: "k2v2", Value: 2}},
+		Nested:  []Nested{{Name: "n1", Info: Struct{S: "hello"}}},
+		Empty:   []int64{},
+		MapList: []MapListEntry{{Key1: "k1v1", Key2: "k2v1", Value: 1}, {Key1: "k1v2", Key2: "k2v2", Value: 2}},
+		IfList:  []IfEntry{{If: "a", Value: 1}, {If: "b", Value: 2}},
+		Wide:    []WideEntry{{Key1: "a b", Key2: "c", Key3: "d", Key4: "e", Value: 1}},
+		Tri:     []WideEntry{{Key1: "ta", Key2: "tb", Key3: "tc", Value: 1}, {Key1: "td", Key2: "te", Key3: "tf", Value: 2}},
+		PtrList: []PtrEntry{{Name: strptr("a"), Port: intptr(80), Value: 1}, {Name: strptr("b"), Port: intptr(81), Value: 2}},
 	}, schema: addListsSchema}
 	y := typedValue{value: AddListsStruct{
-		Tags:   []string{"d", "e"},
-		I32s:   []int32{30},
-		Items:  []MapListEntry{{Key1: "yk1", Key2: "yk2", Value: 7}},
-		Nested: []Nested{},
-		Empty:  []int64{},
+		Tags:    []string{"d", "e"},
+		I32s:    []int32{30},
+		Items:   []MapListEntry{{Key1: "yk1", Key2: "yk2", Value: 7}},
+		Nested:  []Nested{},
+		Empty:   []int64{},
+		MapList: []MapListEntry{{Key1: "k1v1", Key2: "k2v1", Value: 10}, {Key1: "k1v3", Key2: "k2v3", Value: 3}},
+		IfList:  []IfEntry{{If: "a", Value: 10}, {If: "c", Value: 3}},
+		// y.wide[0] has the same key prop values as x.wide[0] except that the
+		// whitespace boundary between key1 and key2 is shifted. The two must be
+		// treated as distinct keys.
+		Wide:    []WideEntry{{Key1: "a", Key2: "b c", Key3: "d", Key4: "e", Value: 2}},
+		Tri:     []WideEntry{{Key1: "tg", Key2: "th", Key3: "ti", Value: 3}},
+		PtrList: []PtrEntry{{Name: strptr("b"), Port: intptr(81), Value: 20}, {Name: strptr("c"), Port: intptr(82), Value: 3}},
+	}, schema: addListsSchema}
+	// z.mapList contains the same entries as (x.mapList + y.mapList), in a different order.
+	// z.ifList and z.tri contain the same entries as x.ifList and x.tri, in a different order.
+	// z.wide contains the same entries as (x.wide + y.wide), in a different order.
+	z := typedValue{value: AddListsStruct{
+		MapList: []MapListEntry{{Key1: "k1v3", Key2: "k2v3", Value: 3}, {Key1: "k1v1", Key2: "k2v1", Value: 10}, {Key1: "k1v2", Key2: "k2v2", Value: 2}},
+		IfList:  []IfEntry{{If: "b", Value: 2}, {If: "a", Value: 1}},
+		Wide:    []WideEntry{{Key1: "a", Key2: "b c", Key3: "d", Key4: "e", Value: 2}, {Key1: "a b", Key2: "c", Key3: "d", Key4: "e", Value: 1}},
+		Tri:     []WideEntry{{Key1: "td", Key2: "te", Key3: "tf", Value: 2}, {Key1: "ta", Key2: "tb", Key3: "tc", Value: 1}},
+		PtrList: []PtrEntry{{Name: strptr("c"), Port: intptr(82), Value: 3}, {Name: strptr("a"), Port: intptr(80), Value: 1}, {Name: strptr("b"), Port: intptr(81), Value: 20}},
 	}, schema: addListsSchema}
 
-	activation := map[string]typedValue{"x": x, "y": y}
+	activation := map[string]typedValue{"x": x, "y": y, "z": z}
 
 	tests := []struct {
 		testCase
@@ -1220,6 +1331,101 @@ func TestListAdd(t *testing.T) {
 			name:       "index out of bounds on concatenated list",
 			expression: "(x.i32s + [4])[10] == 1",
 			wantErr:    "index out of bounds: 10",
+		}},
+		// Lists with x-kubernetes-list-type=map.
+		{testCase: testCase{
+			name:       "map list merge overwrites intersecting keys in place",
+			expression: "(x.mapList + y.mapList)[0].value == 10 && size(x.mapList + y.mapList) == 3",
+		}, skipSchemaless: true},
+		{testCase: testCase{
+			name:       "map list merge appends non-intersecting keys",
+			expression: "(x.mapList + y.mapList)[2].key1 == 'k1v3'",
+		}, skipSchemaless: true},
+		{testCase: testCase{
+			name:       "map list + literal list merges by key",
+			expression: "(x.mapList + [{'key1': 'k1v1', 'key2': 'k2v1', 'value': 99}])[0].value == 99 && size(x.mapList + [{'key1': 'k1v1', 'key2': 'k2v1', 'value': 99}]) == 2",
+		}, // skipUnstructured: unstructuredMapList.Add cannot compute merge keys for CEL literal elements.
+			skipSchemaless: true, skipUnstructured: true},
+		{testCase: testCase{
+			name:       "map list + literal list appends non-intersecting keys",
+			expression: "(x.mapList + [{'key1': 'k1v9', 'key2': 'k2v9', 'value': 9}])[2].value == 9",
+		}, // skipUnstructured: unstructuredMapList.Add cannot compute merge keys for CEL literal elements.
+			skipSchemaless: true, skipUnstructured: true},
+		{testCase: testCase{
+			name:       "chained map list merge",
+			expression: "(x.mapList + y.mapList + [{'key1': 'k1v3', 'key2': 'k2v3', 'value': 33}])[2].value == 33",
+		}, // skipUnstructured: unstructuredMapList.Add cannot compute merge keys for CEL literal elements.
+			skipSchemaless: true, skipUnstructured: true},
+		{testCase: testCase{
+			name:       "map list equality ignores element order",
+			expression: "(x.mapList + y.mapList) == z.mapList",
+		}, skipSchemaless: true},
+		{testCase: testCase{
+			name:       "schemaless map list concatenates atomically",
+			expression: "size(x.mapList + [{'key1': 'k1v1', 'key2': 'k2v1', 'value': 99}]) == 3",
+		}, skipTyped: true, skipUnstructured: true},
+		{testCase: testCase{
+			name:       "map list with escaped key prop merges intersecting keys",
+			expression: "(x.ifList + y.ifList)[0].value == 10 && size(x.ifList + y.ifList) == 3",
+		}, // skipUnstructured: unstructuredMapList allows raw JSON field names with escaped key props,
+			skipSchemaless: true, skipUnstructured: true},
+		{testCase: testCase{
+			name:       "map list with escaped key prop appends non-intersecting keys",
+			expression: "(x.ifList + y.ifList)[2].__if__ == 'c'",
+		}, // skipUnstructured: unstructuredMapList allows raw JSON field names with escaped key props,
+			skipSchemaless: true, skipUnstructured: true},
+		{testCase: testCase{
+			name:       "map list equality with escaped key prop ignores element order",
+			expression: "x.ifList == z.ifList",
+		}, // skipUnstructured: unstructuredMapList allows raw JSON field names with escaped key props,
+			skipSchemaless: true, skipUnstructured: true},
+		{testCase: testCase{
+			name:       "serialized map keys distinguish value boundaries on merge",
+			expression: "size(x.wide + y.wide) == 2 && (x.wide + y.wide)[0].value == 1",
+		}, skipSchemaless: true},
+		{testCase: testCase{
+			name:       "serialized map key equality ignores element order",
+			expression: "(x.wide + y.wide) == z.wide && z.wide == (x.wide + y.wide)",
+		}, skipSchemaless: true},
+		{testCase: testCase{
+			name:       "merge and equality of map lists with three key props",
+			expression: "size(x.tri + y.tri) == 3 && x.tri == z.tri",
+		}, skipSchemaless: true},
+		{testCase: testCase{
+			name:       "map list with pointer key props merges intersecting keys",
+			expression: "(x.ptrList + y.ptrList)[1].value == 20 && size(x.ptrList + y.ptrList) == 3",
+		}, skipSchemaless: true},
+		{testCase: testCase{
+			name:       "map list equality with pointer key props ignores element order",
+			expression: "(x.ptrList + y.ptrList) == z.ptrList && z.ptrList == (x.ptrList + y.ptrList)",
+		}, skipSchemaless: true},
+		{testCase: testCase{
+			name:       "map lists with same keys but different values are not equal",
+			expression: "x.mapList != y.mapList",
+		}},
+		{testCase: testCase{
+			name:       "concatenated map list differs from its left operand",
+			expression: "(x.mapList + y.mapList) != x.mapList && x.mapList != (x.mapList + y.mapList)",
+		}},
+		{testCase: testCase{
+			name:       "concatenated map lists with different appended keys are not equal",
+			expression: "(x.mapList + [{'key1': 'A', 'key2': 'B', 'value': 9}]) != (x.mapList + [{'key1': 'C', 'key2': 'D', 'value': 9}])",
+		}, // skipUnstructured: unstructuredMapList.Add does not compute merge keys for CEL literal elements.
+			skipSchemaless: true, skipUnstructured: true},
+		{testCase: testCase{
+			name:       "concatenated map lists with same keys but different values are not equal",
+			expression: "(x.mapList + [{'key1': 'A', 'key2': 'B', 'value': 1}]) != (x.mapList + [{'key1': 'A', 'key2': 'B', 'value': 2}])",
+		}, // skipUnstructured: unstructuredMapList.Add does not compute merge keys for CEL literal elements.
+			skipSchemaless: true, skipUnstructured: true},
+		{testCase: testCase{
+			name:       "map list add non-list",
+			expression: "(x.mapList + dyn(1)) == x.mapList",
+			wantErr:    "no such overload",
+		}},
+		{testCase: testCase{
+			name:       "concatenated map list add non-list",
+			expression: "(x.mapList + y.mapList + dyn(1)) == x.mapList",
+			wantErr:    "no such overload",
 		}},
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
@@ -19,13 +19,16 @@ package common
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"sync"
+
+	"sigs.k8s.io/structured-merge-diff/v6/value"
+
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"reflect"
-	"sigs.k8s.io/structured-merge-diff/v6/value"
-	"sync"
+	"k8s.io/apiserver/pkg/cel"
 
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
@@ -105,7 +108,7 @@ func TypedToVal(val interface{}, schema Schema) ref.Val {
 			switch listType {
 			case "map":
 				mapKeys := schema.XListMapKeys()
-				return &typedMapList{typedList: typedList, escapedKeyProps: escapeKeyProps(mapKeys)}
+				return &typedMapList{typedList: typedList, keyProps: mapKeys, escapedKeyProps: escapeKeyProps(mapKeys)}
 			case "set":
 				return &typedSetList{typedList: typedList}
 			case "atomic":
@@ -151,7 +154,8 @@ func TypedToVal(val interface{}, schema Schema) ref.Val {
 type typedStruct struct {
 	value reflect.Value // Kind is required to be: reflect.Struct
 
-	// propSchema finds the schema to use for a particular map key.
+	// propSchema finds the schema for a given key.
+	// The key is an unescaped JSON name, not an escaped CEL identifier.
 	propSchema func(key string) (Schema, bool)
 }
 
@@ -198,37 +202,46 @@ func (s *typedStruct) Value() interface{} {
 	return s.value.Interface()
 }
 
-func (s *typedStruct) IsSet(field ref.Val) ref.Val {
-	v, found := s.lookupField(field)
+// IsSet returns true if the field is set. escapedField must be a types.String containing the
+// escaped CEL identifier. For example, "__if__" for JSON name "if".
+func (s *typedStruct) IsSet(escapedField ref.Val) ref.Val {
+	v, found := s.lookupField(escapedField)
 	if v != nil && types.IsUnknownOrError(v) {
 		return v
 	}
 	return types.Bool(found)
 }
 
-func (s *typedStruct) Get(key ref.Val) ref.Val {
-	v, found := s.lookupField(key)
+// Get returns the value of a field. escapedKey must be a types.String containing the
+// escaped CEL identifier. For example, "__if__" for JSON name "if".
+func (s *typedStruct) Get(escapedKey ref.Val) ref.Val {
+	v, found := s.lookupField(escapedKey)
 	if !found {
-		return types.NewErr("no such key: %v", key)
+		return types.NewErr("no such key: %v", escapedKey)
 	}
 	return v
 }
 
-func (s *typedStruct) lookupField(key ref.Val) (ref.Val, bool) {
-	keyStr, ok := key.(types.String)
+// lookupField finds a field by name. escapedKey must be a types.String containing the escaped
+// CEL identifier of the field name. For example, "__if__" for JSON name "if".
+func (s *typedStruct) lookupField(escapedKey ref.Val) (ref.Val, bool) {
+	escapedKeyStr, ok := escapedKey.(types.String)
 	if !ok {
-		return types.MaybeNoSuchOverloadErr(key), true
+		return types.MaybeNoSuchOverloadErr(escapedKey), true
 	}
-	fieldName := keyStr.Value().(string)
+	unescapedFieldName, ok := cel.Unescape(escapedKeyStr.Value().(string))
+	if !ok {
+		return nil, false
+	}
 
 	cacheEntry := value.TypeReflectEntryOf(s.value.Type())
-	fieldCache, ok := cacheEntry.Fields()[fieldName]
+	fieldCache, ok := cacheEntry.Fields()[unescapedFieldName]
 	if !ok {
 		return nil, false
 	}
 
 	if e := fieldCache.GetFrom(s.value); !fieldCache.CanOmit(e) {
-		if propSchema, ok := s.propSchema(fieldName); ok {
+		if propSchema, ok := s.propSchema(unescapedFieldName); ok {
 			v := TypedToVal(e.Interface(), propSchema)
 			if v == types.NullValue {
 				return nil, false
@@ -376,6 +389,10 @@ func (it *sliceIter) Next() ref.Val {
 
 type typedMapList struct {
 	typedList
+	// keyProps are unescaped JSON property names
+	keyProps []string
+
+	// escapedKeyProps are escaped CEL identifiers
 	escapedKeyProps []string
 
 	sync.Once // for lazy load of mapOfList since it is only needed if Equals is called
@@ -404,32 +421,50 @@ func (t *typedMapList) toMapKey(element reflect.Value) interface{} {
 	}
 	cacheEntry := value.TypeReflectEntryOf(element.Type())
 	var fieldEntries []*value.FieldCacheEntry
-	for i := range len(t.escapedKeyProps) {
-		if ce, ok := cacheEntry.Fields()[t.escapedKeyProps[i]]; !ok {
+	for i := range len(t.keyProps) {
+		if ce, ok := cacheEntry.Fields()[t.keyProps[i]]; !ok { // Fields() is keyed by unescaped JSON property names.
 			return types.NewErr("unexpected data format for element of array with x-kubernetes-list-type=map: %T", element)
 		} else {
 			fieldEntries = append(fieldEntries, ce)
 		}
 	}
 
+	getKeyValue := func(fieldEntry *value.FieldCacheEntry) interface{} {
+		v := fieldEntry.GetFrom(element)
+		for v.Kind() == reflect.Pointer {
+			if v.IsNil() {
+				return nil
+			}
+			v = v.Elem()
+		}
+		raw := v.Interface()
+		if raw != nil && !reflect.TypeOf(raw).Comparable() {
+			// %#v includes type information and quotes strings, so the
+			// serialized form cannot collide with a comparable raw value.
+			return fmt.Sprintf("%#v", raw)
+		}
+		return raw
+	}
+
 	// Arrays are comparable in go and may be used as map keys, but maps and slices are not.
 	// So we can special case small numbers of key props as arrays and fall back to serialization
 	// for larger numbers of key props
 	if len(fieldEntries) == 1 {
-		return fieldEntries[0].GetFrom(element).Interface()
+		return getKeyValue(fieldEntries[0])
 	}
 	if len(fieldEntries) == 2 {
-		return [2]interface{}{fieldEntries[0].GetFrom(element).Interface(), fieldEntries[1].GetFrom(element).Interface()}
+		return [2]interface{}{getKeyValue(fieldEntries[0]), getKeyValue(fieldEntries[1])}
 	}
 	if len(fieldEntries) == 3 {
-		return [3]interface{}{fieldEntries[0].GetFrom(element).Interface(), fieldEntries[1].GetFrom(element).Interface(), fieldEntries[2].GetFrom(element).Interface()}
+		return [3]interface{}{getKeyValue(fieldEntries[0]), getKeyValue(fieldEntries[1]), getKeyValue(fieldEntries[2])}
 	}
 
 	key := make([]interface{}, len(fieldEntries))
 	for i := range fieldEntries {
-		key[i] = fieldEntries[i].GetFrom(element).Interface()
+		key[i] = getKeyValue(fieldEntries[i])
 	}
-	return fmt.Sprintf("%v", key)
+	// Serialize to a string for more than 3 keys. %#v quotes strings.
+	return fmt.Sprintf("%#v", key)
 }
 
 // Equal on a map list ignores list element order.
@@ -462,36 +497,138 @@ func (t *typedMapList) Equal(other ref.Val) ref.Val {
 // are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with
 // non-intersecting keys are appended, retaining their partial order.
 func (t *typedMapList) Add(other ref.Val) ref.Val {
-	sliceType := t.value.Type()
-	elementType := sliceType.Elem()
 	oMapList, ok := other.(traits.Lister)
 	if !ok {
 		return types.MaybeNoSuchOverloadErr(other)
 	}
 	sz := t.value.Len()
-	elements := reflect.MakeSlice(sliceType, sz, sz)
-	keyToIdx := map[interface{}]int{}
-	for i := 0; i < sz; i++ {
-		e := t.Get(types.Int(i)).Value()
-		re := reflect.ValueOf(e)
-		k := t.toMapKey(re)
-		keyToIdx[k] = i
-		elements.Index(i).Set(re.Convert(elementType))
+	elements := make([]ref.Val, sz)
+	for i := range sz {
+		elements[i] = t.Get(types.Int(i))
 	}
-	for it := oMapList.Iterator(); it.HasNext() == types.True; {
-		e := it.Next()
-		re := reflect.ValueOf(e.Value())
-		k := t.toMapKey(re)
+	return addToMapList(elements, oMapList, t.escapedKeyProps)
+}
+
+// addToMapList merges the elements of other into the given map list elements
+// according to x-kubernetes-list-type=map semantics: elements of other with
+// intersecting keys overwrite the matching entries of elements in place, and
+// elements with non-intersecting keys are appended. elements may be mutated in
+// place and may be appended to, so callers must not retain or reuse elements
+// after the call.
+//
+// escapedKeyProps must contain the escaped CEL identifiers keys.
+func addToMapList(elements []ref.Val, other traits.Lister, escapedKeyProps []string) ref.Val {
+	keyToIdx := make(map[interface{}]int, len(elements))
+	for i, e := range elements {
+		keyToIdx[refValMapKey(e, escapedKeyProps)] = i
+	}
+	for it := other.Iterator(); it.HasNext() == types.True; {
+		v := it.Next()
+		k := refValMapKey(v, escapedKeyProps)
 		if overwritePosition, ok := keyToIdx[k]; ok {
-			elements.Index(overwritePosition).Set(re)
+			elements[overwritePosition] = v
 		} else {
-			elements = reflect.Append(elements, re.Convert(elementType))
+			elements = append(elements, v)
 		}
 	}
-	return &typedMapList{
-		typedList:       typedList{value: elements, itemsSchema: t.itemsSchema},
-		escapedKeyProps: t.escapedKeyProps,
+	return &refValMapList{
+		Lister:          types.NewRefValList(types.DefaultTypeAdapter, elements),
+		escapedKeyProps: escapedKeyProps,
 	}
+}
+
+// refValMapKey returns a valid golang map key for the given element of a map list.
+// escapedKeyProps must contain the escaped CEL identifiers of the keys.
+func refValMapKey(element ref.Val, escapedKeyProps []string) interface{} {
+	get := func(escapedProp string) interface{} {
+		key := types.String(escapedProp)
+		var v ref.Val
+		var found bool
+		switch e := element.(type) {
+		case traits.Mapper:
+			v, found = e.Find(key)
+		case traits.Indexer:
+			if tester, ok := element.(traits.FieldTester); ok {
+				found = tester.IsSet(key) == types.True
+			}
+			if found {
+				v = e.Get(key)
+			}
+		}
+		if !found || v == nil || types.IsUnknownOrError(v) {
+			return nil
+		}
+		raw := v.Value()
+		if raw != nil && !reflect.TypeOf(raw).Comparable() {
+			// %#v includes type information and quotes strings, so the
+			// serialized form cannot collide with a comparable raw value.
+			return fmt.Sprintf("%#v", raw)
+		}
+		return raw
+	}
+
+	if len(escapedKeyProps) == 1 {
+		return get(escapedKeyProps[0])
+	}
+	if len(escapedKeyProps) == 2 {
+		return [2]interface{}{get(escapedKeyProps[0]), get(escapedKeyProps[1])}
+	}
+	if len(escapedKeyProps) == 3 {
+		return [3]interface{}{get(escapedKeyProps[0]), get(escapedKeyProps[1]), get(escapedKeyProps[2])}
+	}
+
+	key := make([]interface{}, len(escapedKeyProps))
+	for i, kf := range escapedKeyProps {
+		key[i] = get(kf)
+	}
+	// Serialize to a string for more than 3 keys. %#v quotes strings.
+	return fmt.Sprintf("%#v", key)
+}
+
+type refValMapList struct {
+	traits.Lister
+	escapedKeyProps []string
+}
+
+func (l *refValMapList) Add(other ref.Val) ref.Val {
+	oMapList, ok := other.(traits.Lister)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(other)
+	}
+	sz, _ := l.Size().(types.Int)
+	elements := make([]ref.Val, int(sz))
+	for i := range types.Int(sz) {
+		elements[i] = l.Get(i)
+	}
+	return addToMapList(elements, oMapList, l.escapedKeyProps)
+}
+
+func (l *refValMapList) Equal(other ref.Val) ref.Val {
+	oMapList, ok := other.(traits.Lister)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(other)
+	}
+	sz, _ := l.Size().(types.Int)
+	if sz != oMapList.Size() {
+		return types.False
+	}
+	keyToElement := make(map[interface{}]ref.Val, int(sz))
+	for i := range types.Int(sz) {
+		e := l.Get(i)
+		keyToElement[refValMapKey(e, l.escapedKeyProps)] = e
+	}
+	for it := oMapList.Iterator(); it.HasNext() == types.True; {
+		v := it.Next()
+		e, ok := keyToElement[refValMapKey(v, l.escapedKeyProps)]
+		if !ok {
+			return types.False
+		}
+		eq := e.Equal(v)
+		if eq != types.True {
+			return eq
+		}
+	}
+	return types.True
 }
 
 type typedSetList struct {
@@ -644,6 +781,8 @@ func (t *typedMap) Size() ref.Val {
 	return types.Int(t.value.Len())
 }
 
+// Find returns the value of the map entry for the given key, if present. The map keys
+// are normal strings, not CEL identifiers, and are not escaped.
 func (t *typedMap) Find(key ref.Val) (ref.Val, bool) {
 	keyStr, ok := key.(types.String)
 	if !ok {

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect_test.go
@@ -1,0 +1,294 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+// This file directly tests construction of the golang map keys used to implement
+// x-kubernetes-list-type=map semantics (merge on Add, order-insensitive Equal) in
+// valuesreflect.go. TestListAdd in values_test.go covers the same dimensions end-to-end
+// through CEL expression evaluation; the tests here assert the exact keys produced —
+// including the fmt %#v serialized string form used for more than 3 key props — so that the
+// constructed keys are directly visible in the test expectations.
+//
+// Two key constructors exist, and keys from one are never compared with keys from the other:
+//
+//   - typedMapList.toMapKey reads struct fields reflectively by unescaped JSON property name
+//     and preserves the declared Go types of the fields (e.g. an int32 key field contributes
+//     an int32). Pointer fields are dereferenced so keys compare by value, not by address.
+//
+//   - refValMapKey reads key values through CEL accessors by escaped property name. The
+//     accessors return CEL-normalized values (all ints as int64, named string types as string,
+//     pointers dereferenced), which is what makes keys agree across typed struct, unstructured
+//     map and CEL literal map representations of the same logical element.
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+)
+
+type keyTestEntry struct {
+	Name     string  `json:"name"`
+	Port     int32   `json:"port"`
+	Protocol string  `json:"protocol"`
+	Extra    string  `json:"extra"`
+	If       string  `json:"if"` // CEL reserved word, escapes to __if__
+	PtrName  *string `json:"ptrName"`
+	PtrPort  *int32  `json:"ptrPort"`
+	Raw      []byte  `json:"raw"` // not comparable in go
+}
+
+type keyTestWideEntry struct {
+	K1 string `json:"k1"`
+	K2 string `json:"k2"`
+	K3 string `json:"k3"`
+	K4 string `json:"k4"`
+}
+
+func TestTypedMapListToMapKey(t *testing.T) {
+	cases := []struct {
+		name                string
+		keyProps            []string // unescaped JSON names
+		element             interface{}
+		want                interface{}
+		wantErr             bool
+		sameKeyElement      interface{} // If set, test that this key is considered equivalent to keyProps (useful for testing pointer keys)
+		differentKeyElement interface{} // If set, test that this key is considered non-equivalent to keyProps (provides a negative test when testing pointer keys)
+	}{
+		{
+			name:     "one key prop",
+			keyProps: []string{"name"},
+			element:  keyTestEntry{Name: "a"},
+			want:     "a",
+		},
+		{
+			name:     "two key props preserve declared go types",
+			keyProps: []string{"name", "port"},
+			element:  keyTestEntry{Name: "a", Port: 8080},
+			want:     [2]interface{}{"a", int32(8080)},
+		},
+		{
+			name:     "three key props",
+			keyProps: []string{"name", "port", "protocol"},
+			element:  keyTestEntry{Name: "a", Port: 8080, Protocol: "TCP"},
+			want:     [3]interface{}{"a", int32(8080), "TCP"},
+		},
+		{
+			name:     "four key props serialize to a string",
+			keyProps: []string{"name", "port", "protocol", "extra"},
+			element:  keyTestEntry{Name: "a", Port: 8080, Protocol: "TCP", Extra: "x"},
+			want:     `[]interface {}{"a", 8080, "TCP", "x"}`,
+		},
+		{
+			name:                "serialized keys keep whitespace boundaries distinct",
+			keyProps:            []string{"k1", "k2", "k3", "k4"},
+			element:             keyTestWideEntry{K1: "a b", K2: "c", K3: "d", K4: "e"},
+			want:                `[]interface {}{"a b", "c", "d", "e"}`,
+			differentKeyElement: keyTestWideEntry{K1: "a", K2: "b c", K3: "d", K4: "e"},
+		},
+		{
+			name:     "key prop that requires escaping in CEL is unescaped here",
+			keyProps: []string{"if"},
+			element:  keyTestEntry{If: "cond"},
+			want:     "cond",
+		},
+		{
+			name:           "pointer key prop is dereferenced",
+			keyProps:       []string{"ptrName"},
+			element:        keyTestEntry{PtrName: new("a")},
+			want:           "a",
+			sameKeyElement: keyTestEntry{PtrName: new("a")},
+		},
+		{
+			name:                "two pointer key props compare by pointed-to values",
+			keyProps:            []string{"ptrName", "ptrPort"},
+			element:             keyTestEntry{PtrName: new("a"), PtrPort: new(int32(8080))},
+			want:                [2]interface{}{"a", int32(8080)},
+			sameKeyElement:      keyTestEntry{PtrName: new("a"), PtrPort: new(int32(8080))},
+			differentKeyElement: keyTestEntry{PtrName: new("a"), PtrPort: new(int32(8081))},
+		},
+		{
+			name:     "nil pointer key props contribute nil",
+			keyProps: []string{"ptrName", "ptrPort"},
+			element:  keyTestEntry{},
+			want:     [2]interface{}{nil, nil},
+		},
+		{
+			name:           "serialized keys contain pointed-to values, not addresses",
+			keyProps:       []string{"ptrName", "ptrPort", "name", "extra"},
+			element:        keyTestEntry{PtrName: new("a"), PtrPort: new(int32(8080)), Name: "n", Extra: "x"},
+			want:           `[]interface {}{"a", 8080, "n", "x"}`,
+			sameKeyElement: keyTestEntry{PtrName: new("a"), PtrPort: new(int32(8080)), Name: "n", Extra: "x"},
+		},
+		{
+			name:     "non-comparable key value is serialized",
+			keyProps: []string{"raw"},
+			element:  keyTestEntry{Raw: []byte("ab")},
+			want:     `[]byte{0x61, 0x62}`,
+		},
+		{
+			name:     "non-struct element returns an error key",
+			keyProps: []string{"name"},
+			element:  "not a struct",
+			wantErr:  true,
+		},
+		{
+			name:     "unknown key prop returns an error key",
+			keyProps: []string{"nosuch"},
+			element:  keyTestEntry{Name: "a"},
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			list := &typedMapList{
+				typedList:       typedList{value: reflect.ValueOf([]interface{}{tc.element})},
+				keyProps:        tc.keyProps,
+				escapedKeyProps: escapeKeyProps(tc.keyProps),
+			}
+			got := list.toMapKey(reflect.ValueOf(tc.element))
+			if tc.wantErr {
+				if _, isErr := got.(*types.Err); !isErr {
+					t.Errorf("toMapKey() = %#v (%T), want *types.Err", got, got)
+				}
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("toMapKey() = %#v (%T), want %#v (%T)", got, got, tc.want, tc.want)
+			}
+			if tc.sameKeyElement != nil {
+				same := list.toMapKey(reflect.ValueOf(tc.sameKeyElement))
+				if got != same {
+					t.Errorf("elements with equal key values produced distinct keys: %#v != %#v", got, same)
+				}
+			}
+			if tc.differentKeyElement != nil {
+				different := list.toMapKey(reflect.ValueOf(tc.differentKeyElement))
+				if got == different {
+					t.Errorf("elements with different key values produced the same key: %#v", got)
+				}
+			}
+		})
+	}
+}
+
+func TestRefValMapKey(t *testing.T) {
+	typedStructOf := func(v interface{}) ref.Val {
+		return &typedStruct{
+			value:      reflect.ValueOf(v),
+			propSchema: func(key string) (Schema, bool) { return nil, true },
+		}
+	}
+
+	cases := []struct {
+		name             string
+		escapedKeyProps  []string // escaped CEL identifiers
+		element          interface{}
+		want             interface{}
+		equivalentCELMap map[string]interface{} // If set, is the same logical map.
+	}{
+		{
+			name:             "one key prop",
+			escapedKeyProps:  []string{"name"},
+			element:          keyTestEntry{Name: "a"},
+			want:             "a",
+			equivalentCELMap: map[string]interface{}{"name": "a"},
+		},
+		{
+			name:             "int key props normalize to int64 across representations",
+			escapedKeyProps:  []string{"name", "port"},
+			element:          keyTestEntry{Name: "a", Port: 8080}, // int32 field
+			want:             [2]interface{}{"a", int64(8080)},
+			equivalentCELMap: map[string]interface{}{"name": "a", "port": 8080}, // go int
+		},
+		{
+			name:             "reserved word key prop is looked up by escaped name",
+			escapedKeyProps:  []string{"__if__"},
+			element:          keyTestEntry{If: "cond"},
+			want:             "cond",
+			equivalentCELMap: map[string]interface{}{"__if__": "cond"},
+		},
+		{
+			name:            "three key props",
+			escapedKeyProps: []string{"name", "port", "protocol"},
+			element:         keyTestEntry{Name: "a", Port: 8080, Protocol: "TCP"},
+			want:            [3]interface{}{"a", int64(8080), "TCP"},
+		},
+		{
+			name:             "four key props serialize to a string",
+			escapedKeyProps:  []string{"name", "port", "protocol", "extra"},
+			element:          keyTestEntry{Name: "a", Port: 8080, Protocol: "TCP", Extra: "x"},
+			want:             `[]interface {}{"a", 8080, "TCP", "x"}`,
+			equivalentCELMap: map[string]interface{}{"name": "a", "port": 8080, "protocol": "TCP", "extra": "x"},
+		},
+		{
+			name:             "serialized map key with whitespace in values",
+			escapedKeyProps:  []string{"k1", "k2", "k3", "k4"},
+			element:          keyTestWideEntry{K1: "a b", K2: "c", K3: "d", K4: "e"},
+			want:             `[]interface {}{"a b", "c", "d", "e"}`,
+			equivalentCELMap: map[string]interface{}{"k1": "a b", "k2": "c", "k3": "d", "k4": "e"},
+		},
+		{
+			name:            "serialized map key with shifted whitespace boundary is distinct",
+			escapedKeyProps: []string{"k1", "k2", "k3", "k4"},
+			element:         keyTestWideEntry{K1: "a", K2: "b c", K3: "d", K4: "e"},
+			want:            `[]interface {}{"a", "b c", "d", "e"}`,
+		},
+		{
+			name:             "pointer key props are dereferenced and normalized",
+			escapedKeyProps:  []string{"ptrName", "ptrPort"},
+			element:          keyTestEntry{PtrName: new("a"), PtrPort: new(int32(8080))},
+			want:             [2]interface{}{"a", int64(8080)},
+			equivalentCELMap: map[string]interface{}{"ptrName": "a", "ptrPort": 8080},
+		},
+		{
+			name:            "unset pointer key props contribute nil",
+			escapedKeyProps: []string{"ptrName", "ptrPort"},
+			element:         keyTestEntry{},
+			want:            [2]interface{}{nil, nil},
+		},
+		{
+			name:            "unresolvable key prop contributes nil",
+			escapedKeyProps: []string{"nosuch"},
+			element:         keyTestEntry{Name: "a"},
+			want:            nil,
+		},
+		{
+			name:            "non-comparable key value is serialized",
+			escapedKeyProps: []string{"raw"},
+			element:         keyTestEntry{Raw: []byte("ab")},
+			want:            `[]byte{0x61, 0x62}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := refValMapKey(typedStructOf(tc.element), tc.escapedKeyProps)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("refValMapKey() = %#v (%T), want %#v (%T)", got, got, tc.want, tc.want)
+			}
+			if tc.equivalentCELMap != nil {
+				celMapKey := refValMapKey(types.DefaultTypeAdapter.NativeToValue(tc.equivalentCELMap), tc.escapedKeyProps)
+				if got != celMapKey {
+					t.Errorf("typed element key %#v differs from equivalent CEL map key %#v", got, celMapKey)
+				}
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/valuesunstructured.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/valuesunstructured.go
@@ -281,7 +281,8 @@ func (t *unstructuredMapList) toMapKey(element interface{}) interface{} {
 	for i, kf := range t.escapedKeyProps {
 		key[i] = eObj[kf]
 	}
-	return fmt.Sprintf("%v", key)
+	// Serialize to a string for more than 3 keys. %#v quotes strings.
+	return fmt.Sprintf("%#v", key)
 }
 
 // Equal on a map list ignores list element order.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Builds on https://github.com/kubernetes/kubernetes/pull/140291

4th PR in a series to address https://github.com/kubernetes/kubernetes/pull/140266

This addresses merge ordering of `+x-kubernetes-list-type=map` to preserve order-insensitive merge-by-key equality that all schema-aware wrappers use.

#### Which issue(s) this PR is related to:


#### Special notes for your reviewer:

```release-note
NONE
```
