### PR TITLE
kubectl: suggest --dry-run= in shell completion

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -504,6 +504,13 @@ func AddDryRunFlag(cmd *cobra.Command) {
 		`Must be "none", "server", or "client". If client strategy, only print the object that would be sent, without sending it. If server strategy, submit server-side request without persisting the resource.`,
 	)
 	cmd.Flags().Lookup("dry-run").NoOptDefVal = "unchanged"
+	// Suggest "--dry-run=" (with no trailing space) so the user is guided toward
+	// the "--dry-run=client"/"--dry-run=server" form rather than the deprecated
+	// bare "--dry-run".
+	CheckErr(cmd.MarkFlagAppendEqual("dry-run"))
+	CheckErr(cmd.RegisterFlagCompletionFunc("dry-run", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+		return []string{"client", "none", "server"}, cobra.ShellCompDirectiveNoFileComp
+	}))
 }
 
 func AddFieldManagerFlagVar(cmd *cobra.Command, p *string, defaultFieldManager string) {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**

`kubectl <cmd> --dry-run<TAB>` currently completes to `--dry-run ` (with a
trailing space) and then offers file completion. But `--dry-run` carries an
_optional_ value via `NoOptDefVal`, so the space-separated form `--dry-run client`
does **not** bind the value — the only syntax that actually assigns one is
`--dry-run=client` / `--dry-run=server` (bare `--dry-run` is deprecated).

This PR marks the flag with cobra's new `MarkFlagAppendEqual`, so completion
suggests `--dry-run=` with **no** trailing space, and registers a completion
function offering `client` / `none` / `server` as values. The result is that
tabbing through `--dry-run` guides the user straight to the working
`--dry-run=<value>` form.

**Which issue(s) this PR fixes**

Fixes #140297

**Dependency / merge blocker**

⚠️ This depends on the new `Command.MarkFlagAppendEqual` API in cobra:
spf13/cobra#2433. It cannot merge until that PR lands, cobra cuts a release
with it, and kubernetes bumps its vendored `github.com/spf13/cobra` to that
version. Keeping this as a **draft** until then.

**Special notes for your reviewer**

The completion behavior can be checked manually with:

```
kubectl apply -f x.yaml --dry-run<TAB>     # -> --dry-run=
kubectl apply -f x.yaml --dry-run=<TAB>    # -> client  none  server
```

**Does this PR introduce a user-facing change?**

```release-note
kubectl shell completion now suggests `--dry-run=` (with the `=`) and offers
`client`/`none`/`server` as completion values, guiding users toward the working
`--dry-run=<value>` form.
```
