### PR TITLE
Add api-approvers as owners of golangci lint configuration

### DIFF
--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -3,42 +3,51 @@
 options:
   # make root approval non-recursive
   no_parent_owners: true
-reviewers:
-  - bentheelder
-  - cblecker
-  - dchen1107
-  - justaugustus
-  - liggitt
-  - mikedanese
-  - pohly
-  - SataQiu
-  - smarterclayton
-  - sttts
-  - thockin
-  - wojtek-t
-approvers:
-  - bentheelder
-  - cblecker
-  - dchen1107
-  - deads2k
-  - dims # for local-up-cluster related files
-  - enj # for sig-auth related stuff like cert testdata
-  - liggitt
-  - mikedanese
-  - pohly # for logging and linting
-  - pwittrock
-  - SataQiu
-  - smarterclayton
-  - soltysh # for sig-cli related stuff
-  - sttts
-  - thockin
-  - wojtek-t
-emeritus_approvers:
-  - eparis
-  - fejta
-  - ixdy
-  - jbeda
-  - lavalamp
-  - zmerlynn
-  - vishh
-  - spiffxp
+filters:
+  ".*":
+    reviewers:
+      - bentheelder
+      - cblecker
+      - dchen1107
+      - justaugustus
+      - liggitt
+      - mikedanese
+      - pohly
+      - SataQiu
+      - smarterclayton
+      - sttts
+      - thockin
+      - wojtek-t
+    approvers:
+      - bentheelder
+      - cblecker
+      - dchen1107
+      - deads2k
+      - dims # for local-up-cluster related files
+      - enj # for sig-auth related stuff like cert testdata
+      - liggitt
+      - mikedanese
+      - pohly # for logging and linting
+      - pwittrock
+      - SataQiu
+      - smarterclayton
+      - soltysh # for sig-cli related stuff
+      - sttts
+      - thockin
+      - wojtek-t
+    emeritus_approvers:
+      - eparis
+      - fejta
+      - ixdy
+      - jbeda
+      - lavalamp
+      - zmerlynn
+      - vishh
+      - spiffxp
+  # hack/kube-api-linter owners may approve the lint files
+  # since they often updated as part of kube-api-linter changes.
+  "golangci[^/]*\\.yaml(\\.in)?$":
+    reviewers:
+      - api-approvers
+    approvers:
+      - api-approvers


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This appears to be a gap where API approvers have `kube-api-linter` ownership but not ownership of the sibling files in hack for linters that almost always need to be modified in tandum.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
