### PR TITLE
storagetesting: record GetStream calls in KVRecorder

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/recorder.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/recorder.go
@@ -28,7 +28,8 @@ import (
 type KVRecorder struct {
 	clientv3.KV
 
-	reads uint64
+	reads       uint64
+	streamReads uint64
 }
 
 func NewKVRecorder(kv clientv3.KV) *KVRecorder {
@@ -42,6 +43,15 @@ func (r *KVRecorder) Get(ctx context.Context, key string, opts ...clientv3.OpOpt
 
 func (r *KVRecorder) GetReadsAndReset() uint64 {
 	return atomic.SwapUint64(&r.reads, 0)
+}
+
+func (r *KVRecorder) GetStream(ctx context.Context, key string, opts ...clientv3.OpOption) (clientv3.GetStreamChan, error) {
+	atomic.AddUint64(&r.streamReads, 1)
+	return r.KV.GetStream(ctx, key, opts...)
+}
+
+func (r *KVRecorder) GetStreamReadsAndReset() uint64 {
+	return atomic.SwapUint64(&r.streamReads, 0)
 }
 
 type KubernetesRecorder struct {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds GetStream call tracking to the test KVRecorder, mirroring the existing unary Get tracking, so tests can assert whether the etcd3 watch initial-sync goes through the RangeStream RPC.

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

Used by the RangeStream GetList work in https://github.com/kubernetes/kubernetes/pull/139692.