### PR TITLE
scheduler: fix pod group cache when a pod loses its node assignment

### DIFF
--- a/pkg/scheduler/backend/cache/cache_test.go
+++ b/pkg/scheduler/backend/cache/cache_test.go
@@ -778,6 +778,8 @@ func Test_UpdatePodGroupMember(t *testing.T) {
 		Labels(map[string]string{"foo": "bar"}).PodGroupName(podGroupName).Obj()
 	// assigned pod with a pod group name
 	assignedPod := st.MakePod().Namespace("namespace").Name("assigned-pod").UID("pod2").Node("node").PodGroupName(podGroupName).Obj()
+	// same pod as assignedPod but with its node assignment cleared
+	unassignedPod := st.MakePod().Namespace("namespace").Name("assigned-pod").UID("pod2").PodGroupName(podGroupName).Obj()
 	// pod with no pod group name
 	noPodGroupPod := st.MakePod().Namespace("namespace").Name("no-pod-group-pod").UID("pod3").Obj()
 	// updated pod with no pod group name
@@ -821,6 +823,13 @@ func Test_UpdatePodGroupMember(t *testing.T) {
 			newPod:                 assignedPod,
 			genericWorkloadEnabled: true,
 			expectInAssignedPods:   true,
+		},
+		{
+			name:                    "update an assigned pod group member, clear NodeName",
+			oldPod:                  assignedPod,
+			newPod:                  unassignedPod,
+			genericWorkloadEnabled:  true,
+			expectInUnscheduledPods: true,
 		},
 	}
 

--- a/pkg/scheduler/backend/cache/podgroupstate.go
+++ b/pkg/scheduler/backend/cache/podgroupstate.go
@@ -112,7 +112,11 @@ func (d *podGroupStateData) addPod(pod *v1.Pod) {
 }
 
 // updatePod updates the pod in this group.
-// In case of binding, it moves the pod to assignedPods.
+// It keeps the pod in the set that matches its NodeName: assignedPods when the
+// pod is bound, unscheduledPods otherwise. This handles both a pod becoming
+// assigned (NodeName set) and the reverse transition of a pod losing its node
+// assignment (NodeName cleared), so counts such as scheduledPodsCount stay
+// accurate.
 func (d *podGroupStateData) updatePod(oldPod, newPod *v1.Pod) {
 	d.generation = nextPodGroupGeneration()
 	d.allPods[newPod.UID] = newPod
@@ -120,6 +124,12 @@ func (d *podGroupStateData) updatePod(oldPod, newPod *v1.Pod) {
 		d.assignedPods.Insert(newPod.UID)
 		// Clear pod from unscheduled and assumed when it is assigned.
 		d.unscheduledPods.Delete(newPod.UID)
+		delete(d.assumedPods, newPod.UID)
+	} else if oldPod.Spec.NodeName != "" && newPod.Spec.NodeName == "" {
+		// The pod lost its node assignment; move it back to unscheduled so it is
+		// no longer counted as scheduled.
+		d.unscheduledPods.Insert(newPod.UID)
+		d.assignedPods.Delete(newPod.UID)
 		delete(d.assumedPods, newPod.UID)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**

Fixes a pod-group scheduler-cache accounting bug: `updatePod` in
`pkg/scheduler/backend/cache/podgroupstate.go` only handled the
`unscheduled -> assigned` transition (a pod's `NodeName` becoming set). It did
**not** handle the reverse transition where an assigned pod's `NodeName` is
cleared.

As a result, when an assigned pod loses its node assignment, its UID stays in
`assignedPods`, so `scheduledPodsCount()` (`len(assumedPods) + len(assignedPods)`)
keeps counting it as scheduled.

That count feeds the gang-scheduling quorum decisions in the `GangScheduling`
plugin's `Permit` (`scheduledPodsCount < MinCount`) and `PlacementFeasible`
(`scheduled := ScheduledPodsCount()`), so over-counting can make a gang be
treated as having met its `MinCount` when it has not.

The sibling `addPod` already handles both `NodeName` directions symmetrically;
`updatePod` now mirrors it, moving a pod that lost its node back to
`unscheduledPods` (and out of `assignedPods`/`assumedPods`).

**Which issue(s) this PR fixes**

None

**Special notes for your reviewer**

- The cache is already defensive about unexpected/out-of-order pod transitions
  (e.g. `addPod`'s comment about external binding of a previously-queued group
  member); this makes `updatePod` consistent with that.
- Adds a regression case `"update an assigned pod group member, clear NodeName"`
  to `Test_UpdatePodGroupMember`. Verified that without the fix the case fails
  (pod remains in `assignedPods`, absent from `unscheduledPods`) and passes with
  it; the full `pkg/scheduler/backend/cache` suite is green.

**Does this PR introduce a user-facing change?**

```release-note
Fixed a scheduler pod-group cache accounting bug where a gang-scheduled pod that lost its node assignment was still counted as scheduled, which could cause a gang to be incorrectly treated as having met its minCount. Only affects clusters with the GenericWorkload feature gate enabled.
```

/sig scheduling
/wg workload-aware-scheduling
