### PR TITLE
scheduler: fix empty-string topology domain in TAS conflict check

### DIFF
--- a/pkg/scheduler/framework/plugins/topologyaware/topology_placement.go
+++ b/pkg/scheduler/framework/plugins/topologyaware/topology_placement.go
@@ -101,6 +101,7 @@ func (pl *TopologyPlacement) GeneratePlacements(ctx context.Context, state fwk.P
 
 func (pl *TopologyPlacement) getScheduledPodsTopologyDomain(topologyKey string, scheduledPods []*v1.Pod) (string, error) {
 	topologyDomain := ""
+	found := false
 	for _, pod := range scheduledPods {
 		node, err := pl.handle.SnapshotSharedLister().NodeInfos().Get(pod.Spec.NodeName)
 		if err != nil {
@@ -110,10 +111,11 @@ func (pl *TopologyPlacement) getScheduledPodsTopologyDomain(topologyKey string, 
 		if !ok {
 			return "", fmt.Errorf("no topology domain found for pod %v", klog.KObj(pod))
 		}
-		if topologyDomain != "" && topologyDomain != domain {
+		if found && topologyDomain != domain {
 			return "", fmt.Errorf("more than 1 domain found for pod group: %v, %v", topologyDomain, domain)
 		}
 		topologyDomain = domain
+		found = true
 	}
 	return topologyDomain, nil
 }

--- a/pkg/scheduler/framework/plugins/topologyaware/topology_placement.go
+++ b/pkg/scheduler/framework/plugins/topologyaware/topology_placement.go
@@ -101,7 +101,7 @@ func (pl *TopologyPlacement) GeneratePlacements(ctx context.Context, state fwk.P
 
 func (pl *TopologyPlacement) getScheduledPodsTopologyDomain(topologyKey string, scheduledPods []*v1.Pod) (string, error) {
 	topologyDomain := ""
-	for _, pod := range scheduledPods {
+	for i, pod := range scheduledPods {
 		node, err := pl.handle.SnapshotSharedLister().NodeInfos().Get(pod.Spec.NodeName)
 		if err != nil {
 			return "", fmt.Errorf("getting node for pod %v: %w", klog.KObj(pod), err)
@@ -110,8 +110,8 @@ func (pl *TopologyPlacement) getScheduledPodsTopologyDomain(topologyKey string, 
 		if !ok {
 			return "", fmt.Errorf("no topology domain found for pod %v", klog.KObj(pod))
 		}
-		if topologyDomain != "" && topologyDomain != domain {
-			return "", fmt.Errorf("more than 1 domain found for pod group: %v, %v", topologyDomain, domain)
+		if i > 0 && topologyDomain != domain {
+			return "", fmt.Errorf("more than 1 domain found for pod group: %q, %q", topologyDomain, domain)
 		}
 		topologyDomain = domain
 	}

--- a/pkg/scheduler/framework/plugins/topologyaware/topology_placement_test.go
+++ b/pkg/scheduler/framework/plugins/topologyaware/topology_placement_test.go
@@ -152,6 +152,24 @@ func TestGeneratePlacements(t *testing.T) {
 			},
 			wantStatus: fwk.Error,
 		},
+		"with pods already scheduled in conflicting domains where one is the empty string, returns error": {
+			podGroupInfo: makePodGroup("topology"),
+			scheduledPodGroupPods: []scheduledPod{
+				{assignedNode: "node2"},
+				{assignedNode: "node3"},
+			},
+			placementNodes: []*v1.Node{
+				st.MakeNode().Name("node0").Label("topology", "d2").Obj(),
+				st.MakeNode().Name("node1").Label("topology", "d1").Obj(),
+			},
+			otherNodes: []*v1.Node{
+				// The empty string is a valid topology label value; a pod in this
+				// domain must not be treated as "no domain seen yet".
+				st.MakeNode().Name("node2").Label("topology", "").Obj(),
+				st.MakeNode().Name("node3").Label("topology", "d1").Obj(),
+			},
+			wantStatus: fwk.Error,
+		},
 		"with already scheduled pod on node outside of snapshot, returns error": {
 			podGroupInfo: makePodGroup("topology"),
 			scheduledPodGroupPods: []scheduledPod{
@@ -471,6 +489,59 @@ func TestGeneratePlacements(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestGetScheduledPodsTopologyDomainEmptyValue(t *testing.T) {
+	_, tCtx := ktesting.NewTestContext(t)
+
+	nodes := []*v1.Node{
+		st.MakeNode().Name("empty-domain-node").Label("topology", "").Obj(),
+		st.MakeNode().Name("non-empty-domain-node").Label("topology", "d1").Obj(),
+	}
+	snapshot := cache.NewSnapshot(nil, nodes)
+	fh, _ := runtime.NewFramework(tCtx, nil, nil, runtime.WithSnapshotSharedLister(snapshot))
+	pl, err := New(tCtx, nil, fh, feature.Features{})
+	if err != nil {
+		t.Fatalf("failed when creating plugin: %v", err)
+	}
+
+	tests := map[string]struct {
+		pods       []*v1.Pod
+		wantDomain string
+		wantErr    bool
+	}{
+		"single empty domain is valid": {
+			pods: []*v1.Pod{
+				st.MakePod().Name("pod1").UID("pod1").Node("empty-domain-node").Obj(),
+			},
+			wantDomain: "",
+		},
+		"empty domain followed by non-empty domain conflicts": {
+			pods: []*v1.Pod{
+				st.MakePod().Name("pod1").UID("pod1").Node("empty-domain-node").Obj(),
+				st.MakePod().Name("pod2").UID("pod2").Node("non-empty-domain-node").Obj(),
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotDomain, err := pl.getScheduledPodsTopologyDomain("topology", tt.pods)
+			if err != nil {
+				if !tt.wantErr {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Fatal("expected error, got nil")
+			}
+			if gotDomain != tt.wantDomain {
+				t.Errorf("domain = %q, want %q", gotDomain, tt.wantDomain)
+			}
+		})
 	}
 }
 

--- a/pkg/scheduler/framework/plugins/topologyaware/topology_placement_test.go
+++ b/pkg/scheduler/framework/plugins/topologyaware/topology_placement_test.go
@@ -152,6 +152,25 @@ func TestGeneratePlacements(t *testing.T) {
 			},
 			wantStatus: fwk.Error,
 		},
+		"with pods already scheduled in the empty string domain, returns that domain": {
+			podGroupInfo: makePodGroup("topology"),
+			scheduledPodGroupPods: []scheduledPod{
+				{assignedNode: "node2"},
+				{assignedNode: "node3"},
+			},
+			placementNodes: []*v1.Node{
+				st.MakeNode().Name("node0").Label("topology", "d1").Obj(),
+				st.MakeNode().Name("node1").Label("topology", "").Obj(),
+			},
+			otherNodes: []*v1.Node{
+				st.MakeNode().Name("node2").Label("topology", "").Obj(),
+				st.MakeNode().Name("node3").Label("topology", "").Obj(),
+			},
+			wantPlacementNodes: map[string][]string{
+				"": {"node1"},
+			},
+			wantStatus: fwk.Success,
+		},
 		"with already scheduled pod on node outside of snapshot, returns error": {
 			podGroupInfo: makePodGroup("topology"),
 			scheduledPodGroupPods: []scheduledPod{
@@ -471,6 +490,66 @@ func TestGeneratePlacements(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestGetScheduledPodsTopologyDomainEmptyValue(t *testing.T) {
+	_, tCtx := ktesting.NewTestContext(t)
+
+	nodes := []*v1.Node{
+		st.MakeNode().Name("empty-domain-node").Label("topology", "").Obj(),
+		st.MakeNode().Name("non-empty-domain-node").Label("topology", "d1").Obj(),
+	}
+	snapshot := cache.NewSnapshot(nil, nodes)
+	fh, _ := runtime.NewFramework(tCtx, nil, nil, runtime.WithSnapshotSharedLister(snapshot))
+	pl, err := New(tCtx, nil, fh, feature.Features{})
+	if err != nil {
+		t.Fatalf("failed when creating plugin: %v", err)
+	}
+
+	tests := map[string]struct {
+		pods       []*v1.Pod
+		wantDomain string
+		wantErr    bool
+	}{
+		"single empty domain is valid": {
+			pods: []*v1.Pod{
+				st.MakePod().Name("pod1").UID("pod1").Node("empty-domain-node").Obj(),
+			},
+			wantDomain: "",
+		},
+		"empty domain followed by non-empty domain conflicts": {
+			pods: []*v1.Pod{
+				st.MakePod().Name("pod1").UID("pod1").Node("empty-domain-node").Obj(),
+				st.MakePod().Name("pod2").UID("pod2").Node("non-empty-domain-node").Obj(),
+			},
+			wantErr: true,
+		},
+		"non-empty domain followed by empty domain conflicts": {
+			pods: []*v1.Pod{
+				st.MakePod().Name("pod1").UID("pod1").Node("non-empty-domain-node").Obj(),
+				st.MakePod().Name("pod2").UID("pod2").Node("empty-domain-node").Obj(),
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotDomain, err := pl.getScheduledPodsTopologyDomain("topology", tt.pods)
+			if err != nil {
+				if !tt.wantErr {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Fatal("expected error, got nil")
+			}
+			if gotDomain != tt.wantDomain {
+				t.Errorf("domain = %q, want %q", gotDomain, tt.wantDomain)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**

Fixes a corner-case bug in the Topology-Aware Workload Scheduling (TAS)
placement generator. `getScheduledPodsTopologyDomain` in
`pkg/scheduler/framework/plugins/topologyaware/topology_placement.go` iterates a
pod group's already-scheduled pods to determine their common topology domain,
and errors if they span more than one. It used an empty `topologyDomain` string
as the "no domain seen yet" marker:

```go
if topologyDomain != "" && topologyDomain != domain {
    return "", fmt.Errorf("more than 1 domain found ...")
}
topologyDomain = domain
```

Because the empty string is itself a valid topology label value, if the first
scheduled pod's node is labeled with an empty topology value (`labels[key] == ""`),
the marker stays empty and a subsequent pod in a genuinely different domain
slips past the check. The pod group's required domain is then silently resolved
to `""` instead of returning an error, so placement generation can proceed on an
inconsistent set of already-scheduled pods.

The fix compares against the previously seen domain from the second pod onwards
using the loop index, so conflicting domains are detected even when one of them
is the empty string. The error message now uses `%q` for both domains so an
empty one is visible in the logs.

**Which issue(s) this PR fixes**

None

**Special notes for your reviewer**

Adds regression coverage at two levels:
- `TestGetScheduledPodsTopologyDomainEmptyValue` covers `getScheduledPodsTopologyDomain`
  directly with a fixed pod order: a single empty domain (valid), and both
  conflict orderings (empty-then-non-empty, non-empty-then-empty); and
- a `TestGeneratePlacements` case ("with pods already scheduled in the empty
  string domain, returns that domain") where the scheduled pods sit on nodes
  labeled `topology: ""`, expecting a single placement `{"": {"node1"}}` that
  excludes the `d1` node.

Verified that without the fix the empty-then-non-empty conflict case fails (no
error is returned) and passes with it; the full
`pkg/scheduler/framework/plugins/topologyaware` suite is green.

**Does this PR introduce a user-facing change?**

```release-note
kube-scheduler: fixed a bug in the alpha TopologyAwareWorkloadScheduling placement generator, where an empty string was used both as the "no domain seen yet" marker and as a valid topology label value. A pod group whose already-scheduled pods span an empty-valued topology domain and a non-empty one is now correctly reported as spanning more than one domain; previously the conflict went undetected and the group's required domain was silently resolved to the empty string. This is a behavior change: such a pod group now fails placement generation, and its remaining pods stay pending instead of continuing to be scheduled into the non-empty domain.
```

/sig scheduling
/wg workload-aware-scheduling
