### PR TITLE
[FG: InPlacePodVerticalScalingExclusiveCPUs] Add state management to support resize in checkpoint v4

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -52,8 +52,14 @@ import (
 
 type mockState struct {
 	assignments    state.ContainerCPUAssignments
+	baselines      state.ContainerCPUBaselines
 	podAssignments state.PodCPUAssignments
 	defaultCPUSet  cpuset.CPUSet
+}
+
+func (s *mockState) GetBaselineCPUSet(podUID string, containerName string) (cpuset.CPUSet, bool) {
+	res, exists := s.baselines[podUID][containerName]
+	return res.Baseline.Clone(), exists
 }
 
 func (s *mockState) GetCPUSet(podUID string, containerName string) (cpuset.CPUSet, bool) {
@@ -82,6 +88,16 @@ func (s *mockState) SetCPUSet(podUID string, containerName string, cset cpuset.C
 		s.assignments[podUID] = make(map[string]cpuset.CPUSet)
 	}
 	s.assignments[podUID][containerName] = cset
+	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingExclusiveCPUs) {
+		if _, exists := s.baselines[podUID]; !exists {
+			s.baselines[podUID] = make(map[string]state.ContainerCPUBaseline)
+			s.baselines[podUID][containerName] = state.ContainerCPUBaseline{Baseline: cset.Clone()}
+		} else {
+			if _, exists := s.baselines[podUID][containerName]; !exists {
+				s.baselines[podUID][containerName] = state.ContainerCPUBaseline{Baseline: cset.Clone()}
+			}
+		}
+	}
 }
 
 func (s *mockState) SetPodCPUSet(podUID string, cset cpuset.CPUSet) {
@@ -103,11 +119,18 @@ func (s *mockState) Delete(podUID string, containerName string) {
 	if len(s.assignments[podUID]) == 0 {
 		delete(s.assignments, podUID)
 	}
+	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingExclusiveCPUs) {
+		delete(s.baselines[podUID], containerName)
+		if len(s.baselines[podUID]) == 0 {
+			delete(s.baselines, podUID)
+		}
+	}
 }
 
 func (s *mockState) ClearState() {
 	s.defaultCPUSet = cpuset.New()
 	s.assignments = make(state.ContainerCPUAssignments)
+	s.baselines = make(state.ContainerCPUBaselines)
 	s.podAssignments = make(state.PodCPUAssignments)
 }
 
@@ -123,12 +146,20 @@ func (s *mockState) SetPodCPUAssignments(a state.PodCPUAssignments) {
 	s.podAssignments = a.Clone()
 }
 
+func (s *mockState) SetCPUBaselines(a state.ContainerCPUBaselines) {
+	s.baselines = a.Clone()
+}
+
 func (s *mockState) GetCPUAssignments() state.ContainerCPUAssignments {
 	return s.assignments.Clone()
 }
 
 func (s *mockState) GetPodCPUAssignments() state.PodCPUAssignments {
 	return s.podAssignments.Clone()
+}
+
+func (s *mockState) GetCPUBaselines() state.ContainerCPUBaselines {
+	return s.baselines.Clone()
 }
 
 type mockPolicy struct {
@@ -352,6 +383,7 @@ func TestCPUManagerAdd(t *testing.T) {
 	}
 
 	logger, tCtx := ktesting.NewTestContext(t)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingExclusiveCPUs, false)
 
 	testPolicy, _ := NewStaticPolicy(
 		logger,
@@ -400,7 +432,8 @@ func TestCPUManagerAdd(t *testing.T) {
 
 	for _, testCase := range testCases {
 		mgr := &manager{
-			policy: testCase.policy,
+			policy:          testCase.policy,
+			reconcilePeriod: 10 * time.Second,
 			state: &mockState{
 				assignments:   state.ContainerCPUAssignments{},
 				defaultCPUSet: cpuset.New(1, 2, 3, 4),
@@ -442,6 +475,7 @@ func TestCPUManagerAddWithInitContainers(t *testing.T) {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsCPUAndMemoryAffinity, true)
 	}
 
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingExclusiveCPUs, false)
 	testCases := []struct {
 		description      string
 		topo             *topology.CPUTopology
@@ -698,6 +732,7 @@ func TestCPUManagerGenerate(t *testing.T) {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsCPUAndMemoryAffinity, true)
 	}
 
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingExclusiveCPUs, false)
 	testCases := []struct {
 		description                string
 		cpuPolicyName              string
@@ -814,6 +849,7 @@ func TestCPUManagerRemove(t *testing.T) {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsCPUAndMemoryAffinity, true)
 	}
 
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingExclusiveCPUs, false)
 	containerID := "fakeID"
 	containerMap := containermap.NewContainerMap()
 
@@ -863,6 +899,7 @@ func TestReconcileState(t *testing.T) {
 	}
 
 	logger, tCtx := ktesting.NewTestContext(t)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingExclusiveCPUs, false)
 
 	testPolicy, _ := NewStaticPolicy(
 		logger,
@@ -1393,6 +1430,7 @@ func TestCPUManagerAddWithResvList(t *testing.T) {
 	}
 
 	logger, tCtx := ktesting.NewTestContext(t)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingExclusiveCPUs, false)
 	testPolicy, _ := NewStaticPolicy(
 		logger,
 		&topology.CPUTopology{
@@ -1472,6 +1510,7 @@ func TestCPUManagerHandlePolicyOptions(t *testing.T) {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsCPUAndMemoryAffinity, true)
 	}
 
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingExclusiveCPUs, false)
 	testCases := []struct {
 		description      string
 		cpuPolicyName    string
@@ -1546,6 +1585,7 @@ func TestCPUManagerGetAllocatableCPUs(t *testing.T) {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsCPUAndMemoryAffinity, true)
 	}
 
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingExclusiveCPUs, false)
 	nonePolicy, _ := NewNonePolicy(nil)
 	staticPolicy, _ := NewStaticPolicy(
 		logger,

--- a/pkg/kubelet/cm/cpumanager/state/checkpoint.go
+++ b/pkg/kubelet/cm/cpumanager/state/checkpoint.go
@@ -38,12 +38,20 @@ var _ checkpointmanager.Checkpoint = &CPUManagerCheckpointV3{}
 var _ checkpointmanager.Checkpoint = &CPUManagerCheckpointV4{}
 var _ checkpointmanager.Checkpoint = &CPUManagerCheckpoint{}
 
+// ContainerCPUs struct is used in a checkpoint in v4 format,
+// to support In place update pod resources alongside Static CPU Manager policy
+type ContainerCPUs struct {
+	Baseline string `json:"baseline"`
+}
+
 // CPUManagerCheckpointData struct is used to store CPU/pod assignments, which is part of a checkpoint in v4 format
+// CPU assignments at admission time is required for in-place vertical scaling, and stored in Baselines.
 type CPUManagerCheckpointData struct {
-	PolicyName    string                       `json:"policyName"`
-	DefaultCPUSet string                       `json:"defaultCpuSet"`
-	Entries       map[string]map[string]string `json:"entries,omitempty"`
-	PodEntries    PodCPUAssignments            `json:"podEntries,omitempty"`
+	PolicyName    string                              `json:"policyName"`
+	DefaultCPUSet string                              `json:"defaultCpuSet"`
+	Entries       map[string]map[string]string        `json:"entries,omitempty"`
+	PodEntries    PodCPUAssignments                   `json:"podEntries,omitempty"`
+	Baselines     map[string]map[string]ContainerCPUs `json:"baselines,omitempty"`
 }
 
 // CPUManagerCheckpoint represents a structure to store CPU manager checkpoint data.
@@ -110,6 +118,7 @@ func newCPUManagerCheckpointV4() *CPUManagerCheckpointV4 {
 		CheckpointData: CPUManagerCheckpointData{
 			Entries:    make(map[string]map[string]string),
 			PodEntries: make(PodCPUAssignments),
+			Baselines:  make(map[string]map[string]ContainerCPUs),
 		},
 	}
 }

--- a/pkg/kubelet/cm/cpumanager/state/state.go
+++ b/pkg/kubelet/cm/cpumanager/state/state.go
@@ -27,6 +27,7 @@ import (
 )
 
 // ContainerCPUAssignments type used in cpu manager state
+// without in-place vertical scaling.
 type ContainerCPUAssignments map[string]map[string]cpuset.CPUSet
 
 // Clone returns a copy of ContainerCPUAssignments
@@ -109,6 +110,32 @@ func (a PodCPUAssignments) Clone() PodCPUAssignments {
 	return clone
 }
 
+// ContainerCPUAllocation tracks the current allocation state
+// ContainerCPUBaselines tracks the allocation state at admission time.
+// If in-place vertical scaling is enabled, the allocation state at admission
+// time is required to proper resource accounting; otherwise the field is
+// unused and only the current state is relevant.
+
+type ContainerCPUBaseline struct {
+	Baseline cpuset.CPUSet
+}
+
+type ContainerCPUBaselines map[string]map[string]ContainerCPUBaseline
+
+// Clone returns a deep copy of ContainerCPUBaselines
+func (as ContainerCPUBaselines) Clone() ContainerCPUBaselines {
+	ret := make(ContainerCPUBaselines, len(as))
+	for pod := range as {
+		ret[pod] = make(map[string]ContainerCPUBaseline, len(as[pod]))
+		for container, orig := range as[pod] {
+			ret[pod][container] = ContainerCPUBaseline{
+				Baseline: orig.Baseline.Clone(),
+			}
+		}
+	}
+	return ret
+}
+
 // Reader interface used to read current cpu/pod assignment state
 type Reader interface {
 	GetCPUSet(podUID string, containerName string) (cpuset.CPUSet, bool)
@@ -119,6 +146,10 @@ type Reader interface {
 	GetPodCPUSet(podUID string) (cpuset.CPUSet, bool)
 	// GetPodCPUAssignments returns all pod-level CPU assignments
 	GetPodCPUAssignments() PodCPUAssignments
+	// GetCPUBaselines returns all container-level CPU assignments recorded at admission time, prior to any resize
+	GetCPUBaselines() ContainerCPUBaselines
+	// GetBaselineCPUSet returns container-level CPU assignments recorded at admission time, prior to any resize
+	GetBaselineCPUSet(podUID string, containerName string) (cpuset.CPUSet, bool)
 }
 
 type writer interface {
@@ -133,6 +164,8 @@ type writer interface {
 	SetPodCPUAssignments(PodCPUAssignments)
 	// DeletePod deletes pod-level CPU assignments for specified pod
 	DeletePod(podUID string)
+	// SetCPUBaselines stores all container-level CPU assignments recorded at admission time, prior to any resize
+	SetCPUBaselines(ContainerCPUBaselines)
 }
 
 // State interface provides methods for tracking and setting cpu/pod assignment

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint.go
@@ -126,7 +126,9 @@ func (sc *stateCheckpoint) restoreState() error {
 
 	var tmpDefaultCPUSet cpuset.CPUSet
 	var tmpContainerCPUSet cpuset.CPUSet
+	var tmpContainerBaselineCPUSet cpuset.CPUSet
 	tmpAssignments := ContainerCPUAssignments{}
+	tmpBaselines := ContainerCPUBaselines{}
 
 	if sc.policyName != cp.CheckpointData.PolicyName {
 		return fmt.Errorf("configured policy %q differs from state checkpoint policy %q", sc.policyName, cp.CheckpointData.PolicyName)
@@ -144,8 +146,36 @@ func (sc *stateCheckpoint) restoreState() error {
 		}
 	}
 
+	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingExclusiveCPUs) {
+		if len(cp.CheckpointData.Baselines) > 0 {
+			// restore Baselines from checkpoint data
+			for pod := range cp.CheckpointData.Baselines {
+				tmpBaselines[pod] = make(map[string]ContainerCPUBaseline, len(cp.CheckpointData.Baselines[pod]))
+				for container, cpuBaselines := range cp.CheckpointData.Baselines[pod] {
+					if tmpContainerBaselineCPUSet, err = cpuset.Parse(cpuBaselines.Baseline); err != nil {
+						return fmt.Errorf("could not parse Baseline cpuset %q for container %q in pod %q: %w", cpuBaselines.Baseline, container, pod, err)
+					}
+					tmpBaselines[pod][container] = ContainerCPUBaseline{Baseline: tmpContainerBaselineCPUSet}
+				}
+			}
+		} else {
+			// It's safe to use Entries as Baselines because Baselines are unset only by kubelets
+			// without the in-place vertical resize with exclusive CPUs.
+			// In that case, no resize was possible so the two set are identical by construction.
+			for pod := range tmpAssignments {
+				tmpBaselines[pod] = make(map[string]ContainerCPUBaseline, len(tmpAssignments[pod]))
+				for container, entries := range tmpAssignments[pod] {
+					tmpBaselines[pod][container] = ContainerCPUBaseline{Baseline: entries.Clone()}
+				}
+			}
+		}
+	}
+
 	sc.cache.SetDefaultCPUSet(tmpDefaultCPUSet)
 	sc.cache.SetCPUAssignments(tmpAssignments)
+	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingExclusiveCPUs) {
+		sc.cache.SetCPUBaselines(tmpBaselines)
+	}
 	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResourceManagers) {
 		sc.cache.SetPodCPUAssignments(cp.CheckpointData.PodEntries)
 	}
@@ -244,12 +274,20 @@ func (sc *stateCheckpoint) storeState() error {
 	checkpoint := newCPUManagerCheckpoint()
 	checkpoint.CheckpointData.PolicyName = sc.policyName
 	checkpoint.CheckpointData.DefaultCPUSet = sc.cache.GetDefaultCPUSet().String()
-
 	assignments := sc.cache.GetCPUAssignments()
 	for pod := range assignments {
 		checkpoint.CheckpointData.Entries[pod] = make(map[string]string, len(assignments[pod]))
 		for container, cset := range assignments[pod] {
 			checkpoint.CheckpointData.Entries[pod][container] = cset.String()
+		}
+	}
+	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingExclusiveCPUs) {
+		baselines := sc.cache.GetCPUBaselines()
+		for pod := range baselines {
+			checkpoint.CheckpointData.Baselines[pod] = make(map[string]ContainerCPUs, len(baselines[pod]))
+			for container, cpuAllocation := range baselines[pod] {
+				checkpoint.CheckpointData.Baselines[pod][container] = ContainerCPUs{Baseline: cpuAllocation.Baseline.String()}
+			}
 		}
 	}
 
@@ -397,6 +435,33 @@ func (sc *stateCheckpoint) ClearState() {
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
 	sc.cache.ClearState()
+	err := sc.storeState()
+	if err != nil {
+		sc.logger.Error(err, "Failed to store state to checkpoint")
+	}
+}
+
+// GetBaselineCPUSet returns container-level CPU assignment recorded at admission time, prior to any resize
+func (sc *stateCheckpoint) GetBaselineCPUSet(podUID string, containerName string) (cpuset.CPUSet, bool) {
+	sc.mux.RLock()
+	defer sc.mux.RUnlock()
+
+	return sc.cache.GetBaselineCPUSet(podUID, containerName)
+}
+
+// GetCPUBaselines returns container-level CPU assignments recorded at admission time, prior to any resize, for all containers
+func (sc *stateCheckpoint) GetCPUBaselines() ContainerCPUBaselines {
+	sc.mux.RLock()
+	defer sc.mux.RUnlock()
+
+	return sc.cache.GetCPUBaselines()
+}
+
+// SetCPUBaselines stores container-level CPU assignments recorded at admission time, prior to any resize, for all containers
+func (sc *stateCheckpoint) SetCPUBaselines(a ContainerCPUBaselines) {
+	sc.mux.Lock()
+	defer sc.mux.Unlock()
+	sc.cache.SetCPUBaselines(a)
 	err := sc.storeState()
 	if err != nil {
 		sc.logger.Error(err, "Failed to store state to checkpoint")

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -744,6 +744,13 @@ func AssertStateEqual(t *testing.T, sf State, sm State) {
 	if !reflect.DeepEqual(podcpuassignmentSf, podcpuassignmentSm) {
 		t.Errorf("State CPU assignments mismatch. Have %s, want %s", podcpuassignmentSf, podcpuassignmentSm)
 	}
+
+	cpubaselinesSf := sf.GetCPUBaselines()
+	cpubaselinesSm := sm.GetCPUBaselines()
+	if !reflect.DeepEqual(cpubaselinesSf, cpubaselinesSm) {
+		t.Errorf("State CPU baseline entries mismatch. Have %s, want %s", cpubaselinesSf, cpubaselinesSm)
+	}
+
 }
 
 func TestCPUManagerCheckpoint_MarshalCheckpoint_HashCompatibility(t *testing.T) {

--- a/pkg/kubelet/cm/cpumanager/state/state_mem.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_mem.go
@@ -30,6 +30,7 @@ type stateMemory struct {
 	sync.RWMutex
 	logger         klog.Logger
 	assignments    ContainerCPUAssignments
+	baselines      ContainerCPUBaselines
 	podAssignments PodCPUAssignments
 	defaultCPUSet  cpuset.CPUSet
 }
@@ -42,21 +43,21 @@ func NewMemoryState(logger klog.Logger) State {
 	// since we store a checkpoint, we can use the relatively expensive "WithName".
 	logger = klog.LoggerWithName(logger, "CPUManager state memory")
 	logger.Info("Initialized")
-
-	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResourceManagers) {
-		return &stateMemory{
-			logger:         logger,
-			assignments:    ContainerCPUAssignments{},
-			podAssignments: PodCPUAssignments{},
-			defaultCPUSet:  cpuset.New(),
-		}
-	}
-
 	return &stateMemory{
-		logger:        logger,
-		assignments:   ContainerCPUAssignments{},
-		defaultCPUSet: cpuset.New(),
+		logger:         logger,
+		assignments:    ContainerCPUAssignments{},
+		baselines:      ContainerCPUBaselines{},
+		podAssignments: PodCPUAssignments{},
+		defaultCPUSet:  cpuset.New(),
 	}
+}
+
+func (s *stateMemory) GetBaselineCPUSet(podUID string, containerName string) (cpuset.CPUSet, bool) {
+	s.RLock()
+	defer s.RUnlock()
+
+	entry, exists := s.baselines[podUID][containerName]
+	return entry.Baseline.Clone(), exists
 }
 
 func (s *stateMemory) GetCPUSet(podUID string, containerName string) (cpuset.CPUSet, bool) {
@@ -102,16 +103,35 @@ func (s *stateMemory) GetPodCPUAssignments() PodCPUAssignments {
 	return clone
 }
 
+func (s *stateMemory) GetCPUBaselines() ContainerCPUBaselines {
+	s.RLock()
+	defer s.RUnlock()
+	return s.baselines.Clone()
+}
+
 func (s *stateMemory) SetCPUSet(podUID string, containerName string, cset cpuset.CPUSet) {
 	s.Lock()
 	defer s.Unlock()
-
 	if _, ok := s.assignments[podUID]; !ok {
 		s.assignments[podUID] = make(map[string]cpuset.CPUSet)
 	}
 
 	s.assignments[podUID][containerName] = cset
-	s.logger.Info("Updated desired CPUSet", "podUID", podUID, "containerName", containerName, "cpuSet", cset)
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingExclusiveCPUs) {
+		if _, ok := s.baselines[podUID]; !ok {
+			s.baselines[podUID] = make(map[string]ContainerCPUBaseline)
+		}
+
+		if _, ok := s.baselines[podUID][containerName]; !ok {
+			s.baselines[podUID][containerName] = ContainerCPUBaseline{Baseline: cset.Clone()}
+		}
+
+		baselineSet := s.baselines[podUID][containerName].Baseline
+		s.logger.Info("Updated desired CPUSet", "podUID", podUID, "containerName", containerName, "CPUSet", cset, "Baseline CPUSet", baselineSet)
+	} else {
+		s.logger.Info("Updated desired CPUSet", "podUID", podUID, "containerName", containerName, "CPUSet", cset)
+	}
 }
 
 func (s *stateMemory) SetDefaultCPUSet(cset cpuset.CPUSet) {
@@ -149,6 +169,14 @@ func (s *stateMemory) SetPodCPUAssignments(a PodCPUAssignments) {
 	s.logger.Info("Updated pod CPUSet assignments", "assignments", a)
 }
 
+func (s *stateMemory) SetCPUBaselines(a ContainerCPUBaselines) {
+	s.Lock()
+	defer s.Unlock()
+
+	s.baselines = a.Clone()
+	s.logger.Info("Updated CPUSet baselines", "baselines", a)
+}
+
 func (s *stateMemory) Delete(podUID string, containerName string) {
 	s.Lock()
 	defer s.Unlock()
@@ -158,6 +186,14 @@ func (s *stateMemory) Delete(podUID string, containerName string) {
 		delete(s.assignments, podUID)
 	}
 	s.logger.V(2).Info("Deleted CPUSet assignment", "podUID", podUID, "containerName", containerName)
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingExclusiveCPUs) {
+		delete(s.baselines[podUID], containerName)
+		if len(s.baselines[podUID]) == 0 {
+			delete(s.baselines, podUID)
+		}
+		s.logger.V(2).Info("Deleted CPUSet baseline entry", "podUID", podUID, "containerName", containerName)
+	}
 }
 
 // DeletePod deletes pod-level CPU assignments for specified pod. It does not
@@ -176,8 +212,7 @@ func (s *stateMemory) ClearState() {
 
 	s.defaultCPUSet = cpuset.New()
 	s.assignments = make(ContainerCPUAssignments)
-	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResourceManagers) {
-		s.podAssignments = make(PodCPUAssignments)
-	}
+	s.baselines = make(ContainerCPUBaselines)
+	s.podAssignments = make(PodCPUAssignments)
 	s.logger.V(2).Info("Cleared state")
 }

--- a/pkg/kubelet/cm/cpumanager/state/state_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_test.go
@@ -97,3 +97,16 @@ func TestString(t *testing.T) {
 		})
 	}
 }
+
+func TestCloneWithInPlacePodVerticalScalingExclusiveCPUs(t *testing.T) {
+	expect := ContainerCPUBaselines{
+		"pod": map[string]ContainerCPUBaseline{
+			"container1": {Baseline: cpuset.New(4, 5, 6)},
+			"container2": {Baseline: cpuset.New(1, 2, 3)},
+		},
+	}
+	actual := expect.Clone()
+	if &expect == &actual || !reflect.DeepEqual(expect, actual) {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind feature
Originals
#### What this PR does / why we need it:

Container-level CPU assignments recorded at admission time, prior to any resize
is required for in-place vertical scaling exclusive CPUs. 

This commits stores this in Baseline and in Baselines for all containers.

Updates in CPU Manager checkpoint v4 format to support Baseline/Baselines ( replacing name Original/Originals in KEP  ).

This commit is needed as part of the preparation commits for InPlacePodVerticalScalingExclusiveCPUs feature, it implements the CPUManager
checkpoint state changes as documented in KEP5554

#### Which issue(s) this PR is related to:
KEP https://github.com/kubernetes/enhancements/issues/5554

#### Special notes for your reviewer:
It is part of the decision to split KEP 5554 PR as per https://github.com/kubernetes/kubernetes/pull/129719#discussion_r3500702351 . This is the third PR from the split which needs to be merged to continue with the PR split. It can be merged standalone.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node
/priority important-soon
/milestone v1.37

/assign @ffromani @tallclair @natasha41575
/cc @lukaszwojciechowski @pravk03
@Chunxia202410
