### PR TITLE
client-go testing: handle pod evictions in fake client

### DIFF
--- a/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated_test.go
+++ b/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated_test.go
@@ -25,6 +25,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1ac "k8s.io/client-go/applyconfigurations/core/v1"
 )
@@ -61,6 +62,69 @@ func TestNewSimpleClientset(t *testing.T) {
 	pods, err := client.CoreV1().Pods("default").List(context.Background(), meta_v1.ListOptions{})
 	require.NoError(t, err)
 	cmp.Equal(expectedPods, pods.Items)
+}
+
+func TestEvictionDeletesPod(t *testing.T) {
+	testCases := []struct {
+		name  string
+		evict func(*Clientset, context.Context, string, string) error
+	}{
+		{
+			name: "core policy v1",
+			evict: func(client *Clientset, ctx context.Context, namespace, name string) error {
+				return client.CoreV1().Pods(namespace).EvictV1(ctx, &policy.Eviction{
+					ObjectMeta: meta_v1.ObjectMeta{Name: name},
+				})
+			},
+		},
+		{
+			name: "core policy v1beta1",
+			evict: func(client *Clientset, ctx context.Context, namespace, name string) error {
+				return client.CoreV1().Pods(namespace).EvictV1beta1(ctx, &policyv1beta1.Eviction{
+					ObjectMeta: meta_v1.ObjectMeta{Name: name},
+				})
+			},
+		},
+		{
+			name: "policy v1",
+			evict: func(client *Clientset, ctx context.Context, namespace, name string) error {
+				return client.PolicyV1().Evictions(namespace).Evict(ctx, &policy.Eviction{
+					ObjectMeta: meta_v1.ObjectMeta{Name: name},
+				})
+			},
+		},
+		{
+			name: "policy v1beta1",
+			evict: func(client *Clientset, ctx context.Context, namespace, name string) error {
+				return client.PolicyV1beta1().Evictions(namespace).Evict(ctx, &policyv1beta1.Eviction{
+					ObjectMeta: meta_v1.ObjectMeta{Name: name},
+				})
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			client := NewSimpleClientset()
+			namespace := "default"
+			name := "eviction-bug"
+
+			_, err := client.CoreV1().Pods(namespace).Create(ctx, &v1.Pod{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+			}, meta_v1.CreateOptions{})
+			require.NoError(t, err)
+
+			require.NoError(t, tc.evict(client, ctx, namespace, name))
+
+			pods, err := client.CoreV1().Pods(namespace).List(ctx, meta_v1.ListOptions{})
+			require.NoError(t, err)
+			require.Empty(t, pods.Items)
+		})
+	}
 }
 
 func TestManagedFieldClientset(t *testing.T) {

--- a/staging/src/k8s.io/client-go/testing/fixture.go
+++ b/staging/src/k8s.io/client-go/testing/fixture.go
@@ -28,6 +28,8 @@ import (
 
 	jsonpatch "gopkg.in/evanphx/json-patch.v4"
 
+	policyv1 "k8s.io/api/policy/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/meta/testrestmapper"
@@ -158,6 +160,11 @@ func (o objectTrackerReact) Create(action CreateActionImpl) (runtime.Object, err
 		if err != nil {
 			return nil, err
 		}
+	} else if deleteOptions, ok := deleteOptionsForEviction(action); ok {
+		if err := o.tracker.Delete(gvr, ns, objMeta.GetName(), deleteOptions); err != nil {
+			return nil, err
+		}
+		return action.GetObject(), nil
 	} else {
 		oldObj, getOldObjErr := o.tracker.Get(gvr, ns, objMeta.GetName(), metav1.GetOptions{})
 		if getOldObjErr != nil {
@@ -183,6 +190,30 @@ func (o objectTrackerReact) Create(action CreateActionImpl) (runtime.Object, err
 	}
 	obj, err := o.tracker.Get(gvr, ns, objMeta.GetName(), metav1.GetOptions{})
 	return obj, err
+}
+
+func deleteOptionsForEviction(action CreateActionImpl) (metav1.DeleteOptions, bool) {
+	if action.GetSubresource() != "eviction" {
+		return metav1.DeleteOptions{}, false
+	}
+	if action.GetResource() != (schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}) {
+		return metav1.DeleteOptions{}, false
+	}
+
+	switch eviction := action.GetObject().(type) {
+	case *policyv1.Eviction:
+		if eviction.DeleteOptions == nil {
+			return metav1.DeleteOptions{}, true
+		}
+		return *eviction.DeleteOptions, true
+	case *policyv1beta1.Eviction:
+		if eviction.DeleteOptions == nil {
+			return metav1.DeleteOptions{}, true
+		}
+		return *eviction.DeleteOptions, true
+	default:
+		return metav1.DeleteOptions{}, false
+	}
 }
 
 func (o objectTrackerReact) Update(action UpdateActionImpl) (runtime.Object, error) {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Updates the fake client object tracker so create actions for the pod eviction subresource delete the tracked Pod. This makes fake client eviction behavior match callers expectations when listing pods after eviction.

Adds coverage for the CoreV1 pod eviction helpers and the PolicyV1/PolicyV1beta1 eviction clients.

#### Which issue(s) this PR is related to:
Fixes #112168

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
None

Tested:
```
GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false go test ./staging/src/k8s.io/client-go/kubernetes/fake ./staging/src/k8s.io/client-go/testing -count=1
GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false make test WHAT='./staging/src/k8s.io/client-go/kubernetes/fake ./staging/src/k8s.io/client-go/testing'
```