### PR TITLE
kubelet: only track pod certificates for admitted pods

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2878,8 +2878,6 @@ func (kl *Kubelet) HandlePodAdditions(ctx context.Context, pods []*v1.Pod) {
 		// the apiserver and no action (other than cleanup) is required.
 		kl.podManager.AddPod(pod)
 
-		kl.podCertificateManager.TrackPod(ctx, pod)
-
 		pod, mirrorPod, wasMirror := kl.podManager.GetPodAndMirrorPod(pod)
 		if wasMirror {
 			if pod == nil {
@@ -2915,6 +2913,8 @@ func (kl *Kubelet) HandlePodAdditions(ctx context.Context, pods []*v1.Pod) {
 				recordAdmissionRejection(reason)
 				continue
 			}
+
+			kl.podCertificateManager.TrackPod(ctx, pod)
 
 			if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 				// Backfill the queue of pending resizes, but only after all the pods have

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -2789,6 +2789,57 @@ func TestHandlePodAdditionsInvokesPodAdmitHandlers(t *testing.T) {
 	checkPodStatus(t, kl, podToAdmit, v1.PodPending)
 }
 
+// Test verifies that HandlePodAdditions only tracks pod certificates for pods
+// that pass admission, not for pods that are rejected.
+// See https://github.com/kubernetes/kubernetes/issues/138920
+func TestHandlePodAdditionsTracksCertificatesOnlyForAdmittedPods(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+	kl.nodeLister = testNodeLister{nodes: []*v1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: string(kl.nodeName)},
+			Status: v1.NodeStatus{
+				Allocatable: v1.ResourceList{
+					v1.ResourcePods: *resource.NewQuantity(110, resource.DecimalSI),
+				},
+			},
+		},
+	}}
+
+	recorder := &recordingPodCertificateManager{}
+	kl.podCertificateManager = recorder
+
+	pods := []*v1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:       "123456789",
+				Name:      "podA",
+				Namespace: "foo",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:       "987654321",
+				Name:      "podB",
+				Namespace: "foo",
+			},
+		},
+	}
+	podToReject := pods[0]
+	podToAdmit := pods[1]
+	podsToReject := []*v1.Pod{podToReject}
+
+	kl.allocationManager.AddPodAdmitHandlers(lifecycle.PodAdmitHandlers{&testPodAdmitHandler{podsToReject: podsToReject}})
+
+	kl.HandlePodAdditions(tCtx, pods)
+
+	if len(recorder.TrackedPods) != 1 || recorder.TrackedPods[0] != podToAdmit.UID {
+		t.Errorf("expected only admitted pod %q to be tracked, got %v", podToAdmit.UID, recorder.TrackedPods)
+	}
+}
+
 func TestPodResourceAllocationReset(t *testing.T) {
 	logger, tCtx := ktesting.NewTestContext(t)
 

--- a/pkg/kubelet/volume_host_test.go
+++ b/pkg/kubelet/volume_host_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/kubelet/podcertificate"
 	"k8s.io/kubernetes/test/utils/ktesting"
 )
@@ -32,6 +33,9 @@ type recordingPodCertificateManager struct {
 	PodUID      string
 	VolumeName  string
 	SourceIndex int
+
+	TrackedPods   []types.UID
+	ForgottenPods []types.UID
 }
 
 func (f *recordingPodCertificateManager) GetPodCertificateCredentialBundle(ctx context.Context, namespace, podName, podUID, volumeName string, sourceIndex int) ([]byte, []byte, error) {
@@ -44,9 +48,13 @@ func (f *recordingPodCertificateManager) GetPodCertificateCredentialBundle(ctx c
 	return nil, nil, nil
 }
 
-func (f *recordingPodCertificateManager) TrackPod(ctx context.Context, pod *corev1.Pod) {}
+func (f *recordingPodCertificateManager) TrackPod(ctx context.Context, pod *corev1.Pod) {
+	f.TrackedPods = append(f.TrackedPods, pod.UID)
+}
 
-func (f *recordingPodCertificateManager) ForgetPod(ctx context.Context, pod *corev1.Pod) {}
+func (f *recordingPodCertificateManager) ForgetPod(ctx context.Context, pod *corev1.Pod) {
+	f.ForgottenPods = append(f.ForgottenPods, pod.UID)
+}
 
 func (f *recordingPodCertificateManager) MetricReport() *podcertificate.MetricReport {
 	return &podcertificate.MetricReport{}


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it

`TrackPod` was previously called before the kubelet admission check in `HandlePodAdditions`, causing pod certificates to be tracked even for pods that were later rejected.

This PR moves `TrackPod` to execute only after a pod is successfully admitted, ensuring certificate tracking is performed only for admitted pods.

### Which issue(s) this PR fixes

Fixes #138920

### Special notes for your reviewer

* Moves `TrackPod` after the admission check.
* Adds `TestHandlePodAdditionsTracksCertificatesOnlyForAdmittedPods` to verify admitted pods are tracked while rejected pods are not.
* Verified the new test fails before the fix and passes after it.

### Does this PR introduce a user-facing change?

```release-note
NONE
```
