### PR TITLE
mount-utils: attribute NeedResize format-check error correctly

### DIFF
--- a/staging/src/k8s.io/mount-utils/resizefs_linux.go
+++ b/staging/src/k8s.io/mount-utils/resizefs_linux.go
@@ -118,7 +118,7 @@ func (resizefs *ResizeFs) NeedResize(devicePath string, deviceMountPath string) 
 
 	format, err := getDiskFormat(resizefs.exec, devicePath)
 	if err != nil {
-		formatErr := fmt.Errorf("ResizeFS.Resize - error checking format for device %s: %v", devicePath, err)
+		formatErr := fmt.Errorf("ResizeFS.NeedResize - error checking format for device %s: %w", devicePath, err)
 		return false, formatErr
 	}
 

--- a/staging/src/k8s.io/mount-utils/resizefs_linux_test.go
+++ b/staging/src/k8s.io/mount-utils/resizefs_linux_test.go
@@ -20,6 +20,7 @@ package mount
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"k8s.io/utils/exec"
@@ -410,5 +411,36 @@ func TestNeedResize(t *testing.T) {
 				t.Fatalf("Expect result is %v but got %v", test.expectResult, needResize)
 			}
 		})
+	}
+}
+
+// TestNeedResizeErrorMessage verifies that an error returned from NeedResize
+// while checking the disk format is attributed to NeedResize, not Resize.
+func TestNeedResizeErrorMessage(t *testing.T) {
+	fcmd := fakeexec.FakeCmd{
+		CombinedOutputScript: []fakeexec.FakeAction{
+			// getDeviceRO: device is not readonly.
+			func() ([]byte, []byte, error) { return []byte("0"), nil, nil },
+			// getDiskFormat: blkid fails.
+			func() ([]byte, []byte, error) { return nil, nil, fmt.Errorf("blkid failed") },
+		},
+	}
+	fexec := &fakeexec.FakeExec{
+		CommandScript: []fakeexec.FakeCommandAction{
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+	}
+	resizefs := ResizeFs{exec: fexec}
+
+	_, err := resizefs.NeedResize("/dev/test1", "/mnt/test1")
+	if err == nil {
+		t.Fatal("Expect error but got nil")
+	}
+	// The error must be attributed to NeedResize, not Resize. Because
+	// "ResizeFS.NeedResize" does not contain the substring "ResizeFS.Resize",
+	// asserting the exact prefix also rejects the old, incorrect label.
+	if !strings.HasPrefix(err.Error(), "ResizeFS.NeedResize - error checking format") {
+		t.Errorf("Expect error to reference NeedResize, but got: %v", err)
 	}
 }


### PR DESCRIPTION
The error returned by ResizeFs.NeedResize when it fails to determine the disk format was labeled "ResizeFS.Resize", having been copied from Resize(). This misattributes the failure to the wrong function in logs and surfaced errors. Correct the prefix to "ResizeFS.NeedResize" and add a regression test that asserts the error references NeedResize.


#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`ResizeFs.NeedResize` returned the error from its disk-format check with the
prefix "ResizeFS.Resize", which had been copy-pasted from `Resize()`. This
misattributes the failure to the wrong function in logs and in errors surfaced
to callers (e.g. CSI drivers). This corrects the prefix to
"ResizeFS.NeedResize" and adds a regression test that asserts the error
references NeedResize.

#### Which issue(s) this PR is related to:

None (trivial correctness fix).

#### Special notes for your reviewer:

GitHub Copilot was used to help prepare the commit and PR.

/sig storage

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
