### PR TITLE
kubelet: fix device health updates being routed to the wrong pod when device IDs collide across resources

### DIFF
--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -303,7 +303,7 @@ func (m *ManagerImpl) genericDeviceUpdateCallback(logger klog.Logger, resourceNa
 		if utilfeature.DefaultFeatureGate.Enabled(features.ResourceHealthStatus) {
 			// compare with old device's health and send update to the channel if needed
 			updatePodUIDFn := func(deviceID string) {
-				podUID, _ := m.podDevices.getPodAndContainerForDevice(deviceID)
+				podUID, _ := m.podDevices.getPodAndContainerForDevice(resourceName, deviceID)
 				if podUID != "" {
 					podsToUpdate.Insert(podUID)
 				}

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -2078,6 +2078,75 @@ func TestFeatureGateResourceHealthStatus(t *testing.T) {
 	}
 }
 
+// TestDeviceHealthUpdateWithDuplicateDeviceIDs verifies that a health change is
+// routed to the pod that owns the device under the reporting resource, even when
+// another pod owns a device with the same ID under a different resource.
+func TestDeviceHealthUpdateWithDuplicateDeviceIDs(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	tmpDir, err := os.MkdirTemp("", "checkpoint")
+	require.NoError(t, err, "err should be nil")
+	defer func() {
+		err = os.RemoveAll(tmpDir)
+		if err != nil {
+			t.Fatalf("Fail to remove tmpdir: %v", err)
+		}
+	}()
+	ckm, err := checkpointmanager.NewCheckpointManager(tmpDir)
+	require.NoError(t, err, "err should be nil")
+
+	// Two resources expose a device with the same ID. Device IDs are only
+	// unique within a resource.
+	resourceName1 := "domain1.com/resource1"
+	resourceName2 := "domain2.com/resource2"
+	deviceID := "testdevice"
+	existDevices := map[string]DeviceInstances{
+		resourceName1: {deviceID: &pluginapi.Device{ID: deviceID, Health: pluginapi.Healthy}},
+		resourceName2: {deviceID: &pluginapi.Device{ID: deviceID, Health: pluginapi.Healthy}},
+	}
+
+	testManager := &ManagerImpl{
+		allDevices:        ResourceDeviceInstances(existDevices),
+		endpoints:         make(map[string]endpointInfo),
+		healthyDevices:    make(map[string]sets.Set[string]),
+		unhealthyDevices:  make(map[string]sets.Set[string]),
+		allocatedDevices:  make(map[string]sets.Set[string]),
+		podDevices:        newPodDevices(),
+		checkpointManager: ckm,
+		update:            make(chan resourceupdates.Update, 10),
+	}
+
+	testManager.podDevices.insert("pod1", "con1", resourceName1,
+		checkpoint.DevicesPerNUMA{0: []string{deviceID}},
+		newContainerAllocateResponse(
+			withDevices(map[string]string{"/dev/r1dev1": "/dev/r1dev1"}),
+		),
+	)
+	testManager.podDevices.insert("pod2", "con2", resourceName2,
+		checkpoint.DevicesPerNUMA{0: []string{deviceID}},
+		newContainerAllocateResponse(
+			withDevices(map[string]string{"/dev/r2dev1": "/dev/r2dev1"}),
+		),
+	)
+
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ResourceHealthStatus, true)
+
+	// The device of resource2 becomes unhealthy: only pod2 must be notified.
+	testManager.genericDeviceUpdateCallback(logger, resourceName2, []*pluginapi.Device{
+		{ID: deviceID, Health: pluginapi.Unhealthy},
+	})
+	u := <-testManager.update
+	assert.Equal(t, resourceupdates.Update{PodUIDs: []string{"pod2"}}, u)
+	assert.Empty(t, testManager.update)
+
+	// The device of resource1 becomes unhealthy: only pod1 must be notified.
+	testManager.genericDeviceUpdateCallback(logger, resourceName1, []*pluginapi.Device{
+		{ID: deviceID, Health: pluginapi.Unhealthy},
+	})
+	u = <-testManager.update
+	assert.Equal(t, resourceupdates.Update{PodUIDs: []string{"pod1"}}, u)
+	assert.Empty(t, testManager.update)
+}
+
 // TestAdmitPodWithDRAResources verifies the behavior of admission
 // of the pods referring DRA extended resources depending on whether
 // the DRAExtendedResource feature gate is enabled or disabled.

--- a/pkg/kubelet/cm/devicemanager/pod_devices.go
+++ b/pkg/kubelet/cm/devicemanager/pod_devices.go
@@ -181,13 +181,15 @@ func (pdev *podDevices) devices() map[string]sets.Set[string] {
 	return ret
 }
 
-// Returns podUID and containerName for a device
-func (pdev *podDevices) getPodAndContainerForDevice(deviceID string) (string, string) {
+// Returns podUID and containerName for a device allocated under the given resource.
+// The lookup must be scoped by resourceName: device IDs are only unique within a
+// resource, so different plugins may expose devices with identical IDs.
+func (pdev *podDevices) getPodAndContainerForDevice(resourceName, deviceID string) (string, string) {
 	pdev.RLock()
 	defer pdev.RUnlock()
 	for podUID, containerDevices := range pdev.devs {
 		for containerName, resources := range containerDevices {
-			for _, devices := range resources {
+			if devices, ok := resources[resourceName]; ok {
 				if devices.deviceIds.Devices().Has(deviceID) {
 					return podUID, containerName
 				}

--- a/pkg/kubelet/cm/devicemanager/pod_devices_test.go
+++ b/pkg/kubelet/cm/devicemanager/pod_devices_test.go
@@ -270,10 +270,29 @@ func TestGetPodAndContainerForDevice(t *testing.T) {
 	)
 
 	// dev2 is a new device
-	podUID, _ := podDevices.getPodAndContainerForDevice("dev2")
+	podUID, _ := podDevices.getPodAndContainerForDevice(resourceName1, "dev2")
 	assert.Equal(t, "", podUID)
 
 	// dev1 is a exist device
-	podUID, _ = podDevices.getPodAndContainerForDevice("dev1")
+	podUID, _ = podDevices.getPodAndContainerForDevice(resourceName1, "dev1")
 	assert.Equal(t, "pod1", podUID)
+
+	// a device with the same ID allocated to another pod under a different
+	// resource name must not match: device IDs are only unique per resource.
+	resourceName2 := "domain2.com/resource2"
+	podDevices.insert("pod2", contID, resourceName2,
+		devices,
+		newContainerAllocateResponse(
+			withDevices(map[string]string{"/dev/r2dev1": "/dev/r2dev1"}),
+		),
+	)
+
+	podUID, _ = podDevices.getPodAndContainerForDevice(resourceName2, "dev1")
+	assert.Equal(t, "pod2", podUID)
+
+	podUID, _ = podDevices.getPodAndContainerForDevice(resourceName1, "dev1")
+	assert.Equal(t, "pod1", podUID)
+
+	podUID, _ = podDevices.getPodAndContainerForDevice("domain3.com/unknown", "dev1")
+	assert.Empty(t, podUID)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake
/sig node
/wg device-management

#### What this PR does / why we need it:

When a device plugin reports a health change, the device manager looks up which pod owns the affected device so it can trigger a status sync for that pod. The lookup in [`getPodAndContainerForDevice`](https://github.com/kubernetes/kubernetes/blob/dd3e7940568f7156dabf8b3f13295e6a6469b4c8/pkg/kubelet/cm/devicemanager/pod_devices.go#L184-L198) matched on the device ID alone, iterating over all pods and all resources. Device IDs are only unique within a single resource, so when two plugins expose devices with the same ID under different resource names, the lookup can return a pod that owns the same device ID under an unrelated resource, and Go map iteration order makes the result nondeterministic.

When that happens, [`genericDeviceUpdateCallback`](https://github.com/kubernetes/kubernetes/blob/dd3e7940568f7156dabf8b3f13295e6a6469b4c8/pkg/kubelet/cm/devicemanager/manager.go#L293-L346) sends the update notification for the wrong pod, the [syncLoop handler](https://github.com/kubernetes/kubernetes/blob/dd3e7940568f7156dabf8b3f13295e6a6469b4c8/pkg/kubelet/kubelet.go#L2817-L2832) syncs that wrong pod, and the pod that actually owns the unhealthy device does not get its `allocatedResourcesStatus` updated until the next periodic sync, up to a minute later.

This is the root cause of the flaking test tracked in #140268. Every spec in [`device_plugin_failures_pod_status_test.go`](https://github.com/kubernetes/kubernetes/blob/dd3e7940568f7156dabf8b3f13295e6a6469b4c8/test/e2e_node/device_plugin_failures_pod_status_test.go#L131) registers its device as `testdevice` under a randomized resource name. When two of those specs run close together on the same node, which happens regularly in the parallel CI jobs, the health update from one spec is delivered to the other spec's pod and the 60 second `Eventually` in the test loses the race against the periodic sync. The kubelet log of failing run `ci-kubernetes-node-e2e-containerd/2074205743732494336` shows exactly this: the device for resource `test.device/device-plugin-failures-3083` goes unhealthy while the forwarded sync event carries the pod UID of the previous spec's pod from namespace `device-plugin-failures-5477`, and the right pod only flipped to Unhealthy at the next periodic sync, 2.4 seconds after the test timeout.

The fix scopes the lookup by resource name, which the callback already has on hand.

I reproduced the flake by running the two `Device Plugin Failures Pod Status` specs concurrently against a stock kubelet on a GCE Ubuntu 24.04 VM with containerd (`ginkgo -nodes=2 -focus="Device Plugin Failures Pod Status" e2e_node.test`, mirroring how the CI jobs share one kubelet across parallel ginkgo processes). It failed on the first iteration with the exact CI signature. With the fixed kubelet the same loop ran 10 consecutive iterations with zero failures, and every health transition in the kubelet log was routed to the pod in the matching namespace. `TestGetPodAndContainerForDevice` now also covers the collision case: the same device ID allocated to two pods under different resource names resolves to the correct pod for each resource.

#### Which issue(s) this PR fixes:

Fixes #140268

#### Does this PR introduce a user-facing change?

```release-note
kubelet: fixed device health updates being applied to the wrong pod's status when device plugins for different resources expose devices with identical IDs. Affected pods now reflect device health changes immediately instead of waiting for the next periodic pod sync.
```
