### PR TITLE
KEP-5491: restore the intersection on backtrack in `matchAttribute` constraint when DRAListTypeAttributes is enabled

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -5972,6 +5972,39 @@ func TestAllocator(t *testing.T,
 
 			expectResults: nil,
 		},
+		"list-attributes-match-constraint-backtrack-needs-intersection-restore": {
+			features: Features{
+				ListTypeAttributes: true,
+			},
+			claimsToAllocate: objects(claimWithRequests(
+				claim0,
+				[]resourceapi.DeviceConstraint{{MatchAttribute: &stringAttribute}},
+				request(req0, classA, 3),
+			)),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
+				device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"stringAttribute": {StringValues: []string{"value1", "value2"}},
+				}),
+				device(device2, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"stringAttribute": {StringValues: []string{"value1"}},
+				}),
+				device(device3, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"stringAttribute": {StringValues: []string{"value2"}},
+				}),
+				device(device4, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"stringAttribute": {StringValues: []string{"value2"}},
+				}),
+			)),
+			node: node(node1, region1),
+
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool1, device1, false),
+				deviceAllocationResult(req0, driverA, pool1, device3, false),
+				deviceAllocationResult(req0, driverA, pool1, device4, false),
+			)},
+		},
 		"list-attributes-match-constaint-list-of-string-values-without-common-elements": {
 			features: Features{
 				ListTypeAttributes: true,
@@ -6482,6 +6515,50 @@ func TestAllocator(t *testing.T,
 			node: node(node1, region1),
 
 			expectResults: nil,
+		},
+		"list-attributes-distinct-constraint-backtrack-needs-remove": {
+			features: Features{
+				ListTypeAttributes: true,
+				ConsumableCapacity: true,
+			},
+			claimsToAllocate: objects(
+				claim(claim0).withConstraints(
+					resourceapi.DeviceConstraint{
+						Requests:          []string{req0, req1, req2},
+						DistinctAttribute: &stringAttribute,
+					},
+				).withRequests(
+					deviceRequest(req0, classA, 1),
+					deviceRequest(req1, classA, 1),
+					deviceRequest(req2, classA, 1),
+				),
+			),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
+				device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"stringAttribute": {StringValues: []string{"value1", "value2", "value3"}},
+				}),
+				device(device2, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"stringAttribute": {StringValues: []string{"value3", "value4", "value5"}},
+				}),
+				device(device3, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"stringAttribute": {StringValues: []string{"value1", "value2"}},
+				}),
+				device(device4, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"stringAttribute": {StringValues: []string{"value3", "value4"}},
+				}),
+				device(device0, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"stringAttribute": {StringValues: []string{"value5", "value6"}},
+				}),
+			)),
+			node: node(node1, region1),
+
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool1, device3, false),
+				deviceAllocationResult(req1, driverA, pool1, device4, false),
+				deviceAllocationResult(req2, driverA, pool1, device0, false),
+			)},
 		},
 
 		"allocation-mode-all-with-multi-host-resource-pool": {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -803,43 +803,43 @@ type deviceAttributeListAsSet struct {
 	versionValue sets.Set[string]
 }
 
-// hasIntersection checks if two attribute sets have common elements.
-// Returns true if there is at least one common element.
-func (s *deviceAttributeListAsSet) hasIntersection(other *deviceAttributeListAsSet) bool {
-	if s == nil || other == nil {
-		return false
-	}
+// intersection returns the new intersection set of two attribute sets as a new set.
+// Returns nil if there is no intersection or if the types do not match.
+func (s *deviceAttributeListAsSet) intersection(other *deviceAttributeListAsSet) *deviceAttributeListAsSet {
+	result := &deviceAttributeListAsSet{}
 
 	switch {
 	case s.intValue != nil && other.intValue != nil:
-		return s.intValue.Intersection(other.intValue).Len() > 0
+		intersection := s.intValue.Intersection(other.intValue)
+		if intersection.Len() == 0 {
+			return nil
+		}
+		result.intValue = intersection
+		return result
 	case s.boolValue != nil && other.boolValue != nil:
-		return s.boolValue.Intersection(other.boolValue).Len() > 0
+		intersection := s.boolValue.Intersection(other.boolValue)
+		if intersection.Len() == 0 {
+			return nil
+		}
+		result.boolValue = intersection
+		return result
 	case s.stringValue != nil && other.stringValue != nil:
-		return s.stringValue.Intersection(other.stringValue).Len() > 0
+		intersection := s.stringValue.Intersection(other.stringValue)
+		if intersection.Len() == 0 {
+			return nil
+		}
+		result.stringValue = intersection
+		return result
 	case s.versionValue != nil && other.versionValue != nil:
-		return s.versionValue.Intersection(other.versionValue).Len() > 0
+		intersection := s.versionValue.Intersection(other.versionValue)
+		if intersection.Len() == 0 {
+			return nil
+		}
+		result.versionValue = intersection
+		return result
 	default:
 		// Type mismatch
-		return false
-	}
-}
-
-// updateToIntersection updates current set to intersection with the given set.
-func (s *deviceAttributeListAsSet) updateToIntersection(other *deviceAttributeListAsSet) {
-	if s == nil || other == nil {
-		return
-	}
-
-	switch {
-	case s.intValue != nil && other.intValue != nil:
-		s.intValue = s.intValue.Intersection(other.intValue)
-	case s.boolValue != nil && other.boolValue != nil:
-		s.boolValue = s.boolValue.Intersection(other.boolValue)
-	case s.stringValue != nil && other.stringValue != nil:
-		s.stringValue = s.stringValue.Intersection(other.stringValue)
-	case s.versionValue != nil && other.versionValue != nil:
-		s.versionValue = s.versionValue.Intersection(other.versionValue)
+		return nil
 	}
 }
 
@@ -901,8 +901,10 @@ type matchAttributeConstraint struct {
 	// For scalar values (existing behavior)
 	attribute *resourceapi.DeviceAttribute
 
-	// For list values (when DRAListTypeAttributes feature gate is enabled)
-	intersection *deviceAttributeListAsSet
+	// For list values (when DRAListTypeAttributes feature gate is enabled).
+	// intersectionStack[len-1] is the current intersection; each add() pushes and each remove() pops,
+	// so backtracking always restores the intersection to its pre-add state.
+	intersectionStack []*deviceAttributeListAsSet
 
 	numDevices int
 }
@@ -926,11 +928,12 @@ func (m *matchAttributeConstraint) add(requestName, subRequestName string, devic
 		// Initialize either scalar attribute or list set based on the attribute type.
 		if m.features.ListTypeAttributes {
 			// Convert attribute to set representation (both scalar and list)
-			m.intersection = attributeAsSet(attribute)
-			if m.intersection == nil {
+			first := attributeAsSet(attribute)
+			if first == nil {
 				m.logger.V(7).Info("Attribute type unknown")
 				return false
 			}
+			m.intersectionStack = append(m.intersectionStack, first)
 		} else {
 			// Scalar attribute: use existing behavior
 			m.attribute = attribute
@@ -948,12 +951,14 @@ func (m *matchAttributeConstraint) add(requestName, subRequestName string, devic
 			m.logger.V(7).Info("Unknown attribute type")
 			return false
 		}
-		if !m.intersection.hasIntersection(newSet) {
+		current := m.intersectionStack[m.numDevices-1]
+		narrowed := current.intersection(newSet)
+		if narrowed == nil {
 			m.logger.V(7).Info("Attribute values have no common elements")
 			return false
 		}
-		// Update to intersection
-		m.intersection.updateToIntersection(newSet)
+		// Push a narrowed copy so remove() can pop back to the previous intersection.
+		m.intersectionStack = append(m.intersectionStack, narrowed)
 	} else {
 		// Scalar matching: use existing behavior
 		switch {
@@ -999,6 +1004,10 @@ func (m *matchAttributeConstraint) remove(requestName, subRequestName string, de
 	}
 
 	m.numDevices--
+	if m.features.ListTypeAttributes {
+		// Pop the current intersection; the previous entry on the stack becomes current or the stack is empty.
+		m.intersectionStack = m.intersectionStack[:m.numDevices]
+	}
 	m.logger.V(7).Info("Device removed from constraint set", "device", deviceID, "numDevices", m.numDevices)
 }
 

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/constraint.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/constraint.go
@@ -110,7 +110,7 @@ func (m *distinctAttributeConstraint) matchesAttribute(attribute resourceapi.Dev
 			if existingSet == nil {
 				continue
 			}
-			if newSet.hasIntersection(existingSet) {
+			if newSet.intersection(existingSet) != nil {
 				// New device has common elements with an existing device.
 				// This violates the distinct constraint.
 				m.logger.V(7).Info("Constraint not satisfied, devices have common elements")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/wg device-management
/sig scheduling

<!--
Add one of the following kinds:
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does:

Fixes a backtracking bug in `matchAttribute` constraint when `DRAListTypeAttributes` feature gate is enabled.

`add()` narrowed the intersection in place but `remove()` never restored it, so after backtracking, the intersection remained stale and subsequent candidates were incorrectly rejected.

This PR introduces an intersection stack(Option A in #140300): `add()` pushes the current intersection before narrowing, and `remove()` pops it back. The regression test and a backtracking coverage test for the `distinctAttribute` constraint are also added.

#### Which issue(s) this PR is related to:

Fixes #140300 
KEP: https://github.com/kubernetes/enhancements/issues/5491

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #140300 
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

The allocator uses recursive DFS with LIFO undo closures, so `remove()` is always called in the reverse order of `add()`. The stack approach is correct by construction given this invariant — however, it is worth noting that the correctness of this approach depends on the LIFO ordering being maintained. If the allocator's backtracking structure is ever refactored to allow out-of-order removal, this will silently break. 

An alternative approach (storing per-device sets and recomputing the intersection on `remove()`, as `distinctAttribute` constarint does), Option B in #140300, would be more robust but was not chosen here due to the added complexity for a marginal benefit.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
KEP-5491: Fixed a bug where `DRAListTypeAttributes` feature gate enabled could fail to allocate devices even when a valid combination exists. This occurred when the allocator needed to backtrack during allocation of multiple devices with a `matchAttribute` constraint using list-type attribute values.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/issues/5491
```
