### PR TITLE
[release-1.36] Fix dbus connection leak in node shutdown manager causing thread exhaustion

### DIFF
--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
@@ -54,6 +54,7 @@ type dbusInhibiter interface {
 	ReloadLogindConf() error
 	MonitorShutdown(klog.Logger) (<-chan bool, error)
 	OverrideInhibitDelay(inhibitDelayMax time.Duration) error
+	Close() error
 }
 
 // managerImpl has functions that can be used to interact with the Node Shutdown Manager.
@@ -65,6 +66,7 @@ type managerImpl struct {
 	getPods        eviction.ActivePodsFunc
 	syncNodeStatus func(context.Context)
 
+	newDBusConn func() (dbusInhibiter, error)
 	dbusCon     dbusInhibiter
 	inhibitLock systemd.InhibitLock
 
@@ -97,6 +99,7 @@ func NewManager(conf *Config) Manager {
 		nodeRef:        conf.NodeRef,
 		getPods:        conf.GetPodsFunc,
 		syncNodeStatus: conf.SyncNodeStatusFunc,
+		newDBusConn:    systemDbus,
 		podManager:     podManager,
 		enableMetrics:  utilfeature.DefaultFeatureGate.Enabled(features.GracefulNodeShutdownBasedOnPodPriority),
 		storage: localStorage{
@@ -169,11 +172,31 @@ func (m *managerImpl) Start(ctx context.Context) error {
 }
 
 func (m *managerImpl) start(ctx context.Context) (chan struct{}, error) {
-	systemBus, err := systemDbus()
+	systemBus, err := m.newDBusConn()
 	if err != nil {
 		return nil, err
 	}
+
+	// Close any previous dbus connection before replacing it to avoid
+	// leaking goroutines and file descriptors. See #120613.
+	if m.dbusCon != nil {
+		if err := m.dbusCon.Close(); err != nil {
+			m.logger.Error(err, "Failed to close previous dbus connection, ignoring and starting a new one anyway")
+		}
+	}
 	m.dbusCon = systemBus
+
+	// If we fail after this point, close the new connection so we don't
+	// leak dbus goroutines on every retry.
+	startSucceeded := false
+	defer func() {
+		if !startSucceeded {
+			if err := m.dbusCon.Close(); err != nil {
+				m.logger.Error(err, "Failed to close dbus connection after start failure")
+			}
+			m.dbusCon = nil
+		}
+	}()
 
 	currentInhibitDelay, err := m.dbusCon.CurrentInhibitDelay()
 	if err != nil {
@@ -240,6 +263,7 @@ func (m *managerImpl) start(ctx context.Context) (chan struct{}, error) {
 		return nil, fmt.Errorf("failed to monitor shutdown: %v", err)
 	}
 
+	startSucceeded = true
 	stop := make(chan struct{})
 	go func() {
 		// Monitor for shutdown events. This follows the logind Inhibit Delay pattern described on https://www.freedesktop.org/wiki/Software/systemd/inhibit/

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux_test.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux_test.go
@@ -60,13 +60,31 @@ type fakeDbus struct {
 
 	didInhibitShutdown      bool
 	didOverrideInhibitDelay bool
+	closed                  bool
+	onCloseChan             chan struct{} // if set, receives a signal when Close() is called
+
+	currentInhibitDelayErr error
 }
 
 func (f *fakeDbus) CurrentInhibitDelay() (time.Duration, error) {
+	if f.currentInhibitDelayErr != nil {
+		return 0, f.currentInhibitDelayErr
+	}
 	if f.didOverrideInhibitDelay {
 		return f.overrideSystemInhibitDelay, nil
 	}
 	return f.currentInhibitDelay, nil
+}
+
+func (f *fakeDbus) Close() error {
+	f.closed = true
+	if f.onCloseChan != nil {
+		select {
+		case f.onCloseChan <- struct{}{}:
+		default:
+		}
+	}
+	return nil
 }
 
 func (f *fakeDbus) InhibitShutdown() (systemd.InhibitLock, error) {
@@ -699,4 +717,123 @@ func Test_processShutdownEvent_VolumeUnmountTimeout(t *testing.T) {
 	log := underlier.GetBuffer().String()
 	expectedLogMessage := "Failed while waiting for all the volumes belonging to Pods in this group to unmount"
 	assert.Contains(t, log, expectedLogMessage, "Expected log message not found")
+}
+
+// TestStartDbusConnectionClosedOnError verifies that when start() fails after
+// creating a dbus connection, the connection is properly closed to avoid
+// leaking goroutines and file descriptors. See #120613.
+func TestStartDbusConnectionClosedOnError(t *testing.T) {
+	logger, tCtx := ktesting.NewTestContext(t)
+	systemDbusTmp := systemDbus
+	defer func() {
+		systemDbus = systemDbusTmp
+	}()
+
+	connErr := fmt.Errorf("simulated CurrentInhibitDelay error")
+	var createdConnections []*fakeDbus
+
+	lock.Lock()
+	systemDbus = func() (dbusInhibiter, error) {
+		fd := &fakeDbus{
+			currentInhibitDelayErr: connErr,
+			shutdownChan:           make(chan bool),
+		}
+		createdConnections = append(createdConnections, fd)
+		return fd, nil
+	}
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.GracefulNodeShutdown, true)
+
+	fakeRecorder := &record.FakeRecorder{}
+	fakeVolumeManager := volumemanager.NewFakeVolumeManager([]v1.UniqueVolumeName{}, 0, nil, false)
+	nodeRef := &v1.ObjectReference{Kind: "Node", Name: "test", UID: types.UID("test"), Namespace: ""}
+	manager := NewManager(&Config{
+		Logger:        logger,
+		VolumeManager: fakeVolumeManager,
+		Recorder:      fakeRecorder,
+		NodeRef:       nodeRef,
+		GetPodsFunc:   func() []*v1.Pod { return nil },
+		KillPodFunc: func(pod *v1.Pod, isEvicted bool, gracePeriodOverride *int64, fn func(*v1.PodStatus)) error {
+			return nil
+		},
+		SyncNodeStatusFunc:              func(context.Context) {},
+		ShutdownGracePeriodRequested:    30 * time.Second,
+		ShutdownGracePeriodCriticalPods: 10 * time.Second,
+		StateDirectory:                  os.TempDir(),
+	})
+
+	err := manager.Start(tCtx)
+	lock.Unlock()
+
+	require.Error(t, err, "expected start to fail due to CurrentInhibitDelay error")
+	require.Len(t, createdConnections, 1, "expected exactly one connection to be created")
+	assert.True(t, createdConnections[0].closed, "expected the dbus connection to be closed after start() failure")
+}
+
+// TestRestartClosesOldConnection verifies that when the retry loop in Start()
+// reconnects, the old dbus connection is closed before a new one is created.
+// See #120613.
+func TestRestartClosesOldConnection(t *testing.T) {
+	logger, tCtx := ktesting.NewTestContext(t)
+	systemDbusTmp := systemDbus
+	defer func() {
+		systemDbus = systemDbusTmp
+	}()
+
+	// Use onCloseChan to get a reliable signal when Close() is called on
+	// the first connection. This avoids races with leaked goroutines from
+	// prior tests that share the global systemDbus.
+	firstConnClosedChan := make(chan struct{}, 1)
+	var firstConn *fakeDbus
+
+	lock.Lock()
+	systemDbus = func() (dbusInhibiter, error) {
+		ch := make(chan bool)
+		fd := &fakeDbus{
+			currentInhibitDelay:        40 * time.Second,
+			overrideSystemInhibitDelay: 40 * time.Second,
+			shutdownChan:               ch,
+		}
+		return fd, nil
+	}
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.GracefulNodeShutdown, true)
+
+	fakeRecorder := &record.FakeRecorder{}
+	fakeVolumeManager := volumemanager.NewFakeVolumeManager([]v1.UniqueVolumeName{}, 0, nil, false)
+	nodeRef := &v1.ObjectReference{Kind: "Node", Name: "test", UID: types.UID("test"), Namespace: ""}
+	manager := NewManager(&Config{
+		Logger:        logger,
+		VolumeManager: fakeVolumeManager,
+		Recorder:      fakeRecorder,
+		NodeRef:       nodeRef,
+		GetPodsFunc:   func() []*v1.Pod { return nil },
+		KillPodFunc: func(pod *v1.Pod, isEvicted bool, gracePeriodOverride *int64, fn func(*v1.PodStatus)) error {
+			return nil
+		},
+		SyncNodeStatusFunc:              func(context.Context) {},
+		ShutdownGracePeriodRequested:    30 * time.Second,
+		ShutdownGracePeriodCriticalPods: 10 * time.Second,
+		StateDirectory:                  os.TempDir(),
+	})
+
+	err := manager.Start(tCtx)
+
+	// Grab a reference to the first connection and arm its close notification.
+	m := manager.(*managerImpl)
+	firstConn = m.dbusCon.(*fakeDbus)
+	firstConn.onCloseChan = firstConnClosedChan
+	lock.Unlock()
+
+	require.NoError(t, err)
+
+	// Trigger reconnect by closing the shutdown channel (simulates dbus disconnect).
+	close(firstConn.shutdownChan)
+
+	// Wait for Close() to be called on the first connection by start().
+	select {
+	case <-firstConnClosedChan:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for first connection to be closed on reconnect")
+	}
+
+	assert.True(t, firstConn.closed, "expected the first dbus connection to be closed after reconnect")
 }

--- a/pkg/kubelet/nodeshutdown/systemd/inhibit_linux.go
+++ b/pkg/kubelet/nodeshutdown/systemd/inhibit_linux.go
@@ -39,6 +39,7 @@ type dBusConnector interface {
 	Object(dest string, path dbus.ObjectPath) dbus.BusObject
 	AddMatchSignal(options ...dbus.MatchOption) error
 	Signal(ch chan<- *dbus.Signal)
+	Close() error
 }
 
 // DBusCon has functions that can be used to interact with systemd and logind over dbus.
@@ -46,8 +47,13 @@ type DBusCon struct {
 	SystemBus dBusConnector
 }
 
+// Close closes the underlying DBus connection.
+func (bus *DBusCon) Close() error {
+	return bus.SystemBus.Close()
+}
+
 func NewDBusCon() (*DBusCon, error) {
-	conn, err := dbus.SystemBus()
+	conn, err := dbus.ConnectSystemBus()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/nodeshutdown/systemd/inhibit_linux_test.go
+++ b/pkg/kubelet/nodeshutdown/systemd/inhibit_linux_test.go
@@ -101,6 +101,10 @@ func (f *fakeSystemDBus) AddMatchSignal(options ...dbus.MatchOption) error {
 	return nil
 }
 
+func (f *fakeSystemDBus) Close() error {
+	return nil
+}
+
 func TestCurrentInhibitDelay(t *testing.T) {
 	thirtySeconds := time.Duration(30) * time.Second
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node

#### What this PR does / why we need it:

Cherry-pick of #137141 onto release-1.36.

When the node shutdown manager's `start()` fails after creating a dbus connection (e.g. `CurrentInhibitDelay()` errors), the connection was never closed. The infinite retry loop in `Start()` kept creating new connections, each spawning goroutines in godbus that were never cleaned up, eventually causing thread exhaustion and kubelet crash.

This cherry-pick:
1. Closes the dbus connection on `start()` failure (`startSucceeded` + defer)
2. Closes the previous connection before reconnect
3. Switches `NewDBusCon()` from shared `dbus.SystemBus()` to private `dbus.ConnectSystemBus()` so `Close()` is safe

#### Which issue(s) this PR fixes:

Fixes #120613

#### Special notes for reviewers:

- **Cherry-picked commit:** `58007a285bb` (PR #137141) — patch-id identical to master
- **Dependencies considered and not included:**
  - `efb039dad40` / `8dcc70aef79` (context threading / shutdown watcher cancellation): land on master *before* this fix but are independent refactors. This bug fix applies cleanly without them; release-1.36 already has `start(ctx context.Context)`. Including them would expand the backport surface without being required for the leak fix.
  - No API / feature-gate / dependency (go.mod) changes.
- **Conflicts:** none
- **Tests:**
  - `make test WHAT=./pkg/kubelet/nodeshutdown/...` — 9 darwin-compatible tests pass
  - Linux-only packages (`//go:build linux`) including new regression tests `TestStartDbusConnectionClosedOnError` and `TestRestartClosesOldConnection` compile successfully for `GOOS=linux` (cannot execute linux binaries on this macOS host; CI will run them)

```release-note
Fixed a bug where the kubelet node shutdown manager could leak dbus connections on repeated failures, eventually leading to thread exhaustion and crash.
```