### PR TITLE
e2e: skip RestartAllContainers tests on Windows

### DIFF
--- a/test/e2e/common/node/container_restart_policy.go
+++ b/test/e2e/common/node/container_restart_policy.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
 
@@ -176,6 +177,14 @@ var _ = SIGDescribe("Pod Extended (container restart policy)", framework.WithNod
 var _ = SIGDescribe("Pod Extended (RestartAllContainers)", framework.WithSlow(), framework.WithNodeConformance(), framework.WithFeatureGate(features.ContainerRestartRules), framework.WithFeatureGate(features.RestartAllContainersOnContainerExits), func() {
 	f := framework.NewDefaultFramework("pods")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
+
+	// RestartAllContainers is not supported on Windows: under Hyper-V isolation
+	// the pod sandbox is the Utility VM, which is destroyed when its containers
+	// are removed, so the in-place reset never completes and the pod latches to
+	// Failed before any container restarts.
+	ginkgo.BeforeEach(func() {
+		e2eskipper.SkipIfNodeOSDistroIs("windows")
+	})
 
 	ginkgo.Describe("RestartAllContainers", func() {
 		var (


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test
/sig node
/sig windows
/area kubectl

#### What this PR does / why we need it:

The `RestartAllContainers` e2e specs under `Pod Extended (RestartAllContainers)` time out on Hyper-V-isolated Windows nodes. As noted by @SergeyKanzhelev in the issue, the feature is not supposed to work on Windows: under Hyper-V isolation the pod sandbox is the Utility VM, which is destroyed when its containers are removed, so the in-place `ContainersToReset` restart never completes and the pod latches to `Failed`.

This skips those specs on Windows nodes via `e2eskipper.SkipIfNodeOSDistroIs("windows")`, matching how the sibling `security_context.go` tests in this package already gate Windows-unsupported behavior. Linux and Windows process-isolation coverage is unchanged.

#### Which issue(s) this PR fixes:

Fixes #140187

#### Special notes for your reviewer:

Scoped to the `Pod Extended (RestartAllContainers)` block only (the specs called out in the issue); the `Container Restart Rules` block is left as-is.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```