### PR TITLE
Reduce allocations for filtered list requests served from the watch cache

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -780,45 +780,69 @@ func (c *Cacher) GetList(ctx context.Context, key string, opts storage.ListOptio
 		return err
 	}
 	span.AddEvent("Listed items from cache", attribute.Int("count", len(resp.Items)))
-	// store pointer of eligible objects,
-	// Why not directly put object in the items of listObj?
-	//   the elements in ListObject are Struct type, making slice will bring excessive memory consumption.
-	//   so we try to delay this action as much as possible
-	var selectedObjects []runtime.Object
 	var lastSelectedObjectKey string
 	var hasMoreListItems bool
 	limit := computeListLimit(opts)
-	for i, obj := range resp.Items {
-		elem, ok := obj.(*store.Element)
-		if !ok {
-			return fmt.Errorf("non *store.Element returned from storage: %v", obj)
+	matchesAll := (opts.Predicate.Label == nil || opts.Predicate.Label.Empty()) &&
+		(opts.Predicate.Field == nil || opts.Predicate.Field.Empty())
+	if matchesAll && utilfeature.DefaultFeatureGate.Enabled(features.ShardedListAndWatch) {
+		matchesAll = opts.Predicate.ShardSelector == nil || opts.Predicate.ShardSelector.Empty()
+	}
+	if matchesAll {
+		// Every item matches, so the result size is known upfront and items can be
+		// copied directly into the result list without an intermediate slice.
+		count := len(resp.Items)
+		if limit > 0 && int64(count) > limit {
+			count = int(limit)
+			hasMoreListItems = true
 		}
-		shardMatch := true
-		if utilfeature.DefaultFeatureGate.Enabled(features.ShardedListAndWatch) {
-			var err error
-			shardMatch, err = opts.Predicate.MatchesSharding(elem.Object)
-			if err != nil {
-				return fmt.Errorf("shard matching failed: %w", err)
+		listVal.Set(reflect.MakeSlice(listVal.Type(), count, count))
+		for i, obj := range resp.Items[:count] {
+			elem, ok := obj.(*store.Element)
+			if !ok {
+				return fmt.Errorf("non *store.Element returned from storage: %v", obj)
 			}
-		}
-		if shardMatch && opts.Predicate.MatchesObjectAttributes(elem.Labels, elem.Fields) {
-			selectedObjects = append(selectedObjects, elem.Object)
+			listVal.Index(i).Set(reflect.ValueOf(elem.Object).Elem())
 			lastSelectedObjectKey = elem.Key
 		}
-		if limit > 0 && int64(len(selectedObjects)) >= limit {
-			hasMoreListItems = i < len(resp.Items)-1
-			break
-		}
-	}
-	if len(selectedObjects) == 0 {
-		// Ensure that we never return a nil Items pointer in the result for consistency.
-		listVal.Set(reflect.MakeSlice(listVal.Type(), 0, 0))
 	} else {
-		// Resize the slice appropriately, since we already know that size of result set
-		listVal.Set(reflect.MakeSlice(listVal.Type(), len(selectedObjects), len(selectedObjects)))
-		span.AddEvent("Resized result")
-		for i, o := range selectedObjects {
-			listVal.Index(i).Set(reflect.ValueOf(o).Elem())
+		// store pointer of eligible objects,
+		// Why not directly put object in the items of listObj?
+		//   the elements in ListObject are Struct type, making slice will bring excessive memory consumption.
+		//   so we try to delay this action as much as possible
+		var selectedObjects []runtime.Object
+		for i, obj := range resp.Items {
+			elem, ok := obj.(*store.Element)
+			if !ok {
+				return fmt.Errorf("non *store.Element returned from storage: %v", obj)
+			}
+			shardMatch := true
+			if utilfeature.DefaultFeatureGate.Enabled(features.ShardedListAndWatch) {
+				var err error
+				shardMatch, err = opts.Predicate.MatchesSharding(elem.Object)
+				if err != nil {
+					return fmt.Errorf("shard matching failed: %w", err)
+				}
+			}
+			if shardMatch && opts.Predicate.MatchesObjectAttributes(elem.Labels, elem.Fields) {
+				selectedObjects = append(selectedObjects, elem.Object)
+				lastSelectedObjectKey = elem.Key
+			}
+			if limit > 0 && int64(len(selectedObjects)) >= limit {
+				hasMoreListItems = i < len(resp.Items)-1
+				break
+			}
+		}
+		if len(selectedObjects) == 0 {
+			// Ensure that we never return a nil Items pointer in the result for consistency.
+			listVal.Set(reflect.MakeSlice(listVal.Type(), 0, 0))
+		} else {
+			// Resize the slice appropriately, since we already know that size of result set
+			listVal.Set(reflect.MakeSlice(listVal.Type(), len(selectedObjects), len(selectedObjects)))
+			span.AddEvent("Resized result")
+			for i, o := range selectedObjects {
+				listVal.Index(i).Set(reflect.ValueOf(o).Elem())
+			}
 		}
 	}
 	span.AddEvent("Filtered items", attribute.Int("count", listVal.Len()))

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -811,13 +811,17 @@ func (c *Cacher) GetList(ctx context.Context, key string, opts storage.ListOptio
 		//   the elements in ListObject are Struct type, making slice will bring excessive memory consumption.
 		//   so we try to delay this action as much as possible
 		var selectedObjects []runtime.Object
+		if limit > 0 && limit < int64(len(resp.Items)) {
+			selectedObjects = make([]runtime.Object, 0, limit)
+		}
+		shardingEnabled := utilfeature.DefaultFeatureGate.Enabled(features.ShardedListAndWatch)
 		for i, obj := range resp.Items {
 			elem, ok := obj.(*store.Element)
 			if !ok {
 				return fmt.Errorf("non *store.Element returned from storage: %v", obj)
 			}
 			shardMatch := true
-			if utilfeature.DefaultFeatureGate.Enabled(features.ShardedListAndWatch) {
+			if shardingEnabled {
 				var err error
 				shardMatch, err = opts.Predicate.MatchesSharding(elem.Object)
 				if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -2429,6 +2429,63 @@ func BenchmarkCacher_GetList(b *testing.B) {
 	}
 }
 
+func benchmarkPods(n int, nodeName string) []example.Pod {
+	pods := make([]example.Pod, n)
+	for i := range pods {
+		pods[i].Namespace = "default"
+		pods[i].Name = fmt.Sprintf("pod-%d", i)
+		pods[i].ResourceVersion = strconv.Itoa(i)
+		pods[i].Spec.NodeName = nodeName
+		data := make([]byte, 1024*2) // 2k labels
+		rand.Read(data)
+		pods[i].Spec.NodeSelector = map[string]string{
+			"key": string(data),
+		}
+	}
+	return pods
+}
+
+func newBenchmarkDelegator(b *testing.B, pods []example.Pod) *CacheDelegator {
+	store := &cachertesting.MockStorage{
+		GetListFn: func(_ context.Context, _ string, _ storage.ListOptions, listObj runtime.Object) error {
+			podList := listObj.(*example.PodList)
+			podList.ListMeta = metav1.ListMeta{ResourceVersion: "12345"}
+			podList.Items = pods
+			return nil
+		},
+		GetRVFn: func(_ context.Context) (uint64, error) { return 12345, nil },
+	}
+	cacher, _, err := newTestCacher(store)
+	if err != nil {
+		b.Fatalf("new cacher: %v", err)
+	}
+	b.Cleanup(cacher.Stop)
+	delegator := NewCacheDelegator(cacher, store)
+	b.Cleanup(delegator.Stop)
+	return delegator
+}
+
+func BenchmarkCacher_GetList_AllPods(b *testing.B) {
+	totalObjectNum := 10_000
+	delegator := newBenchmarkDelegator(b, benchmarkPods(totalObjectNum, ""))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result := &example.PodList{}
+		err := delegator.GetList(context.TODO(), "/pods/", storage.ListOptions{
+			Predicate:       storage.Everything,
+			Recursive:       true,
+			ResourceVersion: "12345",
+		}, result)
+		if err != nil {
+			b.Fatalf("GetList cache: %v", err)
+		}
+		if len(result.Items) != totalObjectNum {
+			b.Fatalf("expect %d but got %d", totalObjectNum, len(result.Items))
+		}
+	}
+}
+
 // TestWatchListIsSynchronisedWhenNoEventsFromStoreReceived makes sure that
 // a bookmark event will be delivered even if the cacher has not received an event.
 func TestWatchListIsSynchronisedWhenNoEventsFromStoreReceived(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -2486,6 +2486,36 @@ func BenchmarkCacher_GetList_AllPods(b *testing.B) {
 	}
 }
 
+func BenchmarkCacher_GetList_NodeFilteredPods(b *testing.B) {
+	totalObjectNum := 10_000
+	delegator := newBenchmarkDelegator(b, benchmarkPods(totalObjectNum, "node-0"))
+
+	parsedField, err := fields.ParseSelector("spec.nodeName=node-0")
+	if err != nil {
+		b.Fatalf("parse selector: %v", err)
+	}
+	pred := storage.SelectionPredicate{
+		Label: labels.Everything(),
+		Field: parsedField,
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result := &example.PodList{}
+		err = delegator.GetList(context.TODO(), "/pods/", storage.ListOptions{
+			Predicate:       pred,
+			Recursive:       true,
+			ResourceVersion: "12345",
+		}, result)
+		if err != nil {
+			b.Fatalf("GetList cache: %v", err)
+		}
+		if len(result.Items) != totalObjectNum {
+			b.Fatalf("expect %d but got %d", totalObjectNum, len(result.Items))
+		}
+	}
+}
+
 // TestWatchListIsSynchronisedWhenNoEventsFromStoreReceived makes sure that
 // a bookmark event will be delivered even if the cacher has not received an event.
 func TestWatchListIsSynchronisedWhenNoEventsFromStoreReceived(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_btree.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_btree.go
@@ -260,7 +260,8 @@ func (s *btreeStore) OrderedListPrefix(prefix, continueKey string) ([]interface{
 	if continueKey == "" {
 		continueKey = prefix
 	}
-	var result []interface{}
+	// Count the matching elements first so the result is allocated exactly once.
+	result := make([]interface{}, 0, s.Count(prefix, continueKey))
 	s.tree.AscendGreaterOrEqual(&Element{Key: continueKey}, func(item *Element) bool {
 		if !strings.HasPrefix(item.Key, prefix) {
 			return false


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Builds on https://github.com/kubernetes/kubernetes/pull/140200

This reduces allocations when serving *filtered* LIST requests by preallocating when loading data from the watch cache B tree

```
goos: linux
goarch: amd64
pkg: k8s.io/apiserver/pkg/storage/cacher
cpu: 13th Gen Intel(R) Core(TM) i9-13900K
                                   │  master      │              PR                     │
                                   │    sec/op    │   sec/op     vs base                │
Cacher_GetList_NodeFilteredPods-32    1.252m ± 3%   1.041m ± 2%  -16.86% (p=0.000 n=10)
geomean                               1.202m        909.8µ       -24.34%

                                   │  master      │              PR                      │
                                   │     B/op     │     B/op      vs base                │
Cacher_GetList_NodeFilteredPods-32   6.006Mi ± 0%   5.527Mi ± 0%   -7.97% (p=0.000 n=10)
geomean                              6.006Mi        5.200Mi       -13.42%

                                   │  master      │              PR                  │
                                   │ allocs/op  │ allocs/op   vs base                │
Cacher_GetList_NodeFilteredPods-32   67.00 ± 0%   51.00 ± 0%  -23.88% (p=0.000 n=10)
geomean                              67.00        41.02       -38.77%
```

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
