### PR TITLE
Ensure the internal representation of endpointslice and v1 are memory identical

### DIFF
--- a/pkg/apis/discovery/fuzzer/fuzzer.go
+++ b/pkg/apis/discovery/fuzzer/fuzzer.go
@@ -19,8 +19,8 @@ package fuzzer
 import (
 	"sigs.k8s.io/randfill"
 
+	corev1 "k8s.io/api/core/v1"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
-	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/discovery"
 )
 
@@ -40,7 +40,7 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 				}
 
 				if endpointPort.Protocol == nil {
-					protos := []api.Protocol{api.ProtocolTCP, api.ProtocolUDP, api.ProtocolSCTP}
+					protos := []corev1.Protocol{corev1.ProtocolTCP, corev1.ProtocolUDP, corev1.ProtocolSCTP}
 					obj.Ports[i].Protocol = &protos[c.Rand.Intn(len(protos))]
 				}
 			}

--- a/pkg/apis/discovery/types.go
+++ b/pkg/apis/discovery/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package discovery
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	api "k8s.io/kubernetes/pkg/apis/core"
 )
@@ -166,7 +167,7 @@ type EndpointPort struct {
 	Name *string
 	// The IP protocol for this port.
 	// Must be UDP, TCP, or SCTP.
-	Protocol *api.Protocol
+	Protocol *corev1.Protocol
 	// The port number of the endpoint.
 	// If this is not specified, ports are not restricted and must be
 	// interpreted in the context of the specific consumer.

--- a/pkg/apis/discovery/v1/conversion_test.go
+++ b/pkg/apis/discovery/v1/conversion_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1_test
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
+	metafuzzer "k8s.io/apimachinery/pkg/apis/meta/fuzzer"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	"k8s.io/kubernetes/pkg/apis/discovery"
+	discoveryfuzzer "k8s.io/kubernetes/pkg/apis/discovery/fuzzer"
+)
+
+// TestEndpointSliceMemoryIdenticalConversion ensures the internal and v1 EndpointSlice types
+// remain memory-identical. These types must be kept memory-identical
+// for performance reasons.
+func TestEndpointSliceMemoryIdenticalConversion(t *testing.T) {
+	f := fuzzer.FuzzerFor(fuzzer.MergeFuzzerFuncs(metafuzzer.Funcs, discoveryfuzzer.Funcs), rand.NewSource(1), legacyscheme.Codecs).NilChance(0).NumElements(1, 1)
+	t.Run("v1 to internal", func(t *testing.T) {
+		in := &discoveryv1.EndpointSlice{}
+		f.Fill(in)
+		out := &discovery.EndpointSlice{}
+		if err := legacyscheme.Scheme.Convert(in, out, nil); err != nil {
+			t.Fatalf("conversion failed: %v", err)
+		}
+		assertMemoryIdentical(t, "EndpointSlice", reflect.ValueOf(in).Elem(), reflect.ValueOf(out).Elem())
+	})
+	t.Run("internal to v1", func(t *testing.T) {
+		in := &discovery.EndpointSlice{}
+		f.Fill(in)
+		out := &discoveryv1.EndpointSlice{}
+		if err := legacyscheme.Scheme.Convert(in, out, nil); err != nil {
+			t.Fatalf("conversion failed: %v", err)
+		}
+		assertMemoryIdentical(t, "EndpointSlice", reflect.ValueOf(in).Elem(), reflect.ValueOf(out).Elem())
+	})
+}
+
+func assertMemoryIdentical(t *testing.T, path string, a, b reflect.Value) {
+	t.Helper()
+	if a.Kind() != b.Kind() {
+		t.Errorf("%s: unexpected kind mismatch: %s, %s", path, a.Kind(), b.Kind())
+		return
+	}
+	switch a.Kind() {
+	case reflect.Struct: // allow for copied structs since conversion copies status/spec today
+		if a.Type().Size() != b.Type().Size() {
+			t.Errorf("%s: unexpected struct size mismatch: %d, %d", path, a.Type().Size(), b.Type().Size())
+			return
+		}
+		if a.NumField() != b.NumField() {
+			t.Errorf("%s: unexpected field count mismatch: %d, %d", path, a.NumField(), b.NumField())
+			return
+		}
+		for i := 0; i < a.NumField(); i++ {
+			aTypeField := a.Type().Field(i)
+			bTypeField := b.Type().Field(i)
+			if aTypeField.Name != bTypeField.Name {
+				t.Errorf("%s: unexpected field name mismatch: %s, %s", path, aTypeField.Name, bTypeField.Name)
+			}
+			if aTypeField.Offset != bTypeField.Offset {
+				t.Errorf("%s.%s: unexpected field offset mismatch: %d, %d", path, aTypeField.Name, aTypeField.Offset, bTypeField.Offset)
+			}
+			assertMemoryIdentical(t, path+"."+aTypeField.Name, a.Field(i), b.Field(i))
+		}
+	case reflect.Pointer, reflect.Map, reflect.Slice:
+		if a.IsNil() != b.IsNil() {
+			t.Errorf("%s: nilable pointer mismatch: %v, %v", path, !a.IsNil(), !b.IsNil())
+			return
+		}
+		if !a.IsNil() && a.UnsafePointer() != b.UnsafePointer() {
+			t.Errorf("%s: nilable type was unexpectedly copied", path)
+		}
+	case reflect.Bool, reflect.Int, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64, reflect.String:
+		// Assume scalars are copied by value
+	default:
+		t.Errorf("%s: unexpected kind: %v", path, a.Kind())
+	}
+}

--- a/pkg/apis/discovery/validation/validation.go
+++ b/pkg/apis/discovery/validation/validation.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	api "k8s.io/kubernetes/pkg/apis/core"
 	apivalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/apis/discovery"
 	netutils "k8s.io/utils/net"
@@ -40,9 +39,9 @@ var (
 		discovery.AddressTypeFQDN,
 	)
 	supportedPortProtocols = sets.New(
-		api.ProtocolTCP,
-		api.ProtocolUDP,
-		api.ProtocolSCTP,
+		corev1.ProtocolTCP,
+		corev1.ProtocolUDP,
+		corev1.ProtocolSCTP,
 	)
 	maxTopologyLabels = 16
 	maxAddresses      = 100

--- a/pkg/apis/discovery/validation/validation_test.go
+++ b/pkg/apis/discovery/validation/validation_test.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/discovery"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/utils/ptr"
@@ -49,7 +48,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
@@ -64,7 +63,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv6,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"a00:100::4"},
@@ -79,7 +78,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeFQDN,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"foo.example.com", "example.com", "example.com.", "hyphens-are-good.example.com"},
@@ -94,13 +93,13 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("tcp"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}, {
 					Name:     ptr.To("udp"),
-					Protocol: ptr.To(api.ProtocolUDP),
+					Protocol: ptr.To(corev1.ProtocolUDP),
 				}, {
 					Name:     ptr.To("sctp"),
-					Protocol: ptr.To(api.ProtocolSCTP),
+					Protocol: ptr.To(corev1.ProtocolSCTP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
@@ -115,19 +114,19 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:        ptr.To("one"),
-					Protocol:    ptr.To(api.ProtocolTCP),
+					Protocol:    ptr.To(corev1.ProtocolTCP),
 					AppProtocol: ptr.To("HTTP"),
 				}, {
 					Name:        ptr.To("two"),
-					Protocol:    ptr.To(api.ProtocolTCP),
+					Protocol:    ptr.To(corev1.ProtocolTCP),
 					AppProtocol: ptr.To("https"),
 				}, {
 					Name:        ptr.To("three"),
-					Protocol:    ptr.To(api.ProtocolTCP),
+					Protocol:    ptr.To(corev1.ProtocolTCP),
 					AppProtocol: ptr.To("my-protocol"),
 				}, {
 					Name:        ptr.To("four"),
-					Protocol:    ptr.To(api.ProtocolTCP),
+					Protocol:    ptr.To(corev1.ProtocolTCP),
 					AppProtocol: ptr.To("example.com/custom-protocol"),
 				}},
 				Endpoints: []discovery.Endpoint{{
@@ -143,10 +142,10 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To(""),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}, {
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
@@ -160,7 +159,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To(strings.Repeat("a", 63)),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
@@ -200,7 +199,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(maxAddresses),
@@ -214,7 +213,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses:          generateIPAddresses(1),
@@ -229,7 +228,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
@@ -248,7 +247,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"012.034.056.078"},
@@ -265,10 +264,10 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To(""),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}, {
 					Name:     ptr.To(""),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{},
 			},
@@ -280,7 +279,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("aCapital"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{},
 			},
@@ -292,7 +291,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("almost_valid"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{},
 			},
@@ -304,7 +303,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To(strings.Repeat("a", 64)),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{},
 			},
@@ -316,7 +315,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.Protocol("foo")),
+					Protocol: ptr.To(corev1.Protocol("foo")),
 				}},
 			},
 		},
@@ -344,7 +343,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(0),
@@ -358,7 +357,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(maxAddresses + 1),
@@ -372,7 +371,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses:          generateIPAddresses(1),
@@ -387,7 +386,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses:          generateIPAddresses(1),
@@ -402,7 +401,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
@@ -420,7 +419,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
@@ -435,7 +434,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"123.456.789.012"},
@@ -450,7 +449,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"012.034.056.078"},
@@ -465,7 +464,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"123.456.789.012", "2001:4860:4860::8888"},
@@ -480,7 +479,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv6,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"123.456.789.012", "2001:4860:4860:defg"},
@@ -495,7 +494,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeFQDN,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"foo.*", "FOO.example.com", "underscores_are_bad.example.com", "*.example.com"},
@@ -510,7 +509,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:        ptr.To("http"),
-					Protocol:    ptr.To(api.ProtocolTCP),
+					Protocol:    ptr.To(corev1.ProtocolTCP),
 					AppProtocol: ptr.To("--"),
 				}},
 				Endpoints: []discovery.Endpoint{{
@@ -526,7 +525,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
@@ -543,7 +542,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
@@ -564,7 +563,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
@@ -591,7 +590,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
@@ -611,7 +610,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
@@ -632,7 +631,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
@@ -663,7 +662,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses:          generateIPAddresses(1),
@@ -678,7 +677,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"127.0.0.1"},
@@ -693,7 +692,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv6,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"fe80::9656:d028:8652:66b6"},
@@ -732,7 +731,7 @@ func TestValidateEndpointSliceCreate(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
@@ -747,7 +746,7 @@ func TestValidateEndpointSliceCreate(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
@@ -765,7 +764,7 @@ func TestValidateEndpointSliceCreate(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
@@ -781,7 +780,7 @@ func TestValidateEndpointSliceCreate(t *testing.T) {
 				AddressType: discovery.AddressType("IP"),
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
@@ -795,7 +794,7 @@ func TestValidateEndpointSliceCreate(t *testing.T) {
 				AddressType: discovery.AddressType("other"),
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To("http"),
-					Protocol: ptr.To(api.ProtocolTCP),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
@@ -905,7 +904,7 @@ func TestValidateEndpointSliceUpdate(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To(""),
-					Protocol: ptr.To(api.Protocol("invalid")),
+					Protocol: ptr.To(corev1.Protocol("invalid")),
 				}},
 			},
 			expectedErrors: 1,
@@ -947,7 +946,7 @@ func generatePorts(n int) []discovery.EndpointPort {
 	for i := 0; i < n; i++ {
 		ports = append(ports, discovery.EndpointPort{
 			Name:     ptr.To(fmt.Sprintf("http-%d", i)),
-			Protocol: ptr.To(api.ProtocolTCP),
+			Protocol: ptr.To(corev1.ProtocolTCP),
 		})
 	}
 	return ports

--- a/pkg/apis/discovery/zz_generated.deepcopy.go
+++ b/pkg/apis/discovery/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ limitations under the License.
 package discovery
 
 import (
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	core "k8s.io/kubernetes/pkg/apis/core"
 )
@@ -147,7 +148,7 @@ func (in *EndpointPort) DeepCopyInto(out *EndpointPort) {
 	}
 	if in.Protocol != nil {
 		in, out := &in.Protocol, &out.Protocol
-		*out = new(core.Protocol)
+		*out = new(v1.Protocol)
 		**out = **in
 	}
 	if in.Port != nil {

--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -6396,7 +6396,7 @@ func TestPrintEndpoint(t *testing.T) {
 }
 
 func TestPrintEndpointSlice(t *testing.T) {
-	tcpProtocol := api.ProtocolTCP
+	tcpProtocol := apiv1.ProtocolTCP
 
 	tests := []struct {
 		endpointSlice discovery.EndpointSlice


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Part of https://github.com/kubernetes/enhancements/issues/6164 to convert endpointslice to v1 type rather than internal types.

#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/issues/6164
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
