### PR TITLE
Safely harden probe stress container checks

### DIFF
--- a/test/e2e_node/probe_stress_test.go
+++ b/test/e2e_node/probe_stress_test.go
@@ -71,8 +71,8 @@ var _ = SIGDescribe("Probe Stress", framework.WithSerial(), func() {
 	})
 })
 
-// runProbeStressTest creates a pod with many containers, waits for them to be running,
-// and verifies that none of the containers have restarted unexpectedly.
+// runProbeStressTest creates a pod with many containers, waits for them all to be
+// running, and verifies that none of the containers restart or terminate unexpectedly.
 func runProbeStressTest(ctx context.Context, f *framework.Framework, pod *v1.Pod) {
 	ginkgo.By(fmt.Sprintf("Creating pod %s with %d containers", pod.Name, len(pod.Spec.Containers)))
 	pod = e2epod.NewPodClient(f).Create(ctx, pod)
@@ -81,7 +81,24 @@ func runProbeStressTest(ctx context.Context, f *framework.Framework, pod *v1.Pod
 	err := e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod)
 	framework.ExpectNoError(err, "Failed to start pod")
 
-	ginkgo.By("Verifying no containers restarted")
+	ginkgo.By("Waiting for every container status to report Running")
+	gomega.Eventually(ctx, func(ctx context.Context) error {
+		updatedPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if len(updatedPod.Status.ContainerStatuses) != len(pod.Spec.Containers) {
+			return fmt.Errorf("expected %d container statuses, got %d", len(pod.Spec.Containers), len(updatedPod.Status.ContainerStatuses))
+		}
+		for _, containerStatus := range updatedPod.Status.ContainerStatuses {
+			if containerStatus.State.Running == nil {
+				return fmt.Errorf("container %s is not yet running", containerStatus.Name)
+			}
+		}
+		return nil
+	}, framework.PodStartTimeout, 1*time.Second).Should(gomega.Succeed())
+
+	ginkgo.By("Verifying no containers restart or terminate")
 	gomega.Consistently(ctx, func(ctx context.Context) error {
 		updatedPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{})
 		if err != nil {
@@ -91,11 +108,18 @@ func runProbeStressTest(ctx context.Context, f *framework.Framework, pod *v1.Pod
 			if containerStatus.RestartCount > 0 {
 				return fmt.Errorf("container %s restarted %d times", containerStatus.Name, containerStatus.RestartCount)
 			}
+			// The pod uses RestartPolicy Never, so a failed liveness probe kills
+			// the container without incrementing RestartCount; a Terminated state
+			// is the signal for a probe-induced kill. Waiting states and missing
+			// statuses are tolerated here as transient.
+			if containerStatus.State.Terminated != nil {
+				return fmt.Errorf("container %s terminated: reason=%s, exitCode=%d", containerStatus.Name, containerStatus.State.Terminated.Reason, containerStatus.State.Terminated.ExitCode)
+			}
 		}
 		return nil
 	}, probeStressWaitTime, 1*time.Second).Should(gomega.Succeed())
 
-	ginkgo.By("Test passed: no unexpected container restarts")
+	ginkgo.By("Test passed: no unexpected container restarts or terminations")
 }
 
 func createPodWithHTTPProbes(numContainers int) *v1.Pod {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig node

#### What this PR does / why we need it

This safely hardens the probe stress e2e test by detecting containers that terminate during the stress window.

The stress pod uses `RestartPolicy: Never`, so a liveness-probe-induced kill can terminate a container without incrementing `RestartCount`. The original test only checked `RestartCount`, which could miss that failure mode.

This is a safer follow-up to the reverted #140260. Unlike the reverted change, this PR only requires every container status to be present and Running before the stress window starts. During the 2-minute stress window, it fails only on durable failure signals:

- `RestartCount > 0`
- `State.Terminated != nil`

It does not fail during the stress window on transient Waiting states or temporarily missing statuses.

#### Which issue(s) this PR is related to

Related to #115782
Follow-up to #140260 and #140330

#### Special notes for your reviewer

This is the safer version discussed after #140260 was reverted. It preserves the original restart check and adds termination detection for `RestartPolicy: Never`, while avoiding the overly strict Consistently assertion that likely broke `node-kubelet-serial-containerd`.

Local validation:
- `git diff --check`
- `./hack/verify-gofmt.sh`
- `./hack/verify-boilerplate.sh`
- `go test -c ./test/e2e_node`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
