### PR TITLE
Fix auth reconcile binding nil panic

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/reconcile.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/reconcile.go
@@ -290,6 +290,9 @@ func (o *ReconcileOptions) RunReconcile() error {
 				result, err = reconcileOptions.Run()
 				return err
 			})
+			if err != nil {
+				return err
+			}
 			o.printResults(result.RoleBinding.GetObject(), result.MissingSubjects, result.ExtraSubjects, nil, nil, result.Operation, result.Protected)
 
 		case *rbacv1beta1.Role,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/reconcile.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/reconcile.go
@@ -271,6 +271,9 @@ func (o *ReconcileOptions) RunReconcile() error {
 				result, err = reconcileOptions.Run()
 				return err
 			})
+			if err != nil {
+				return err
+			}
 			o.printResults(result.RoleBinding.GetObject(), result.MissingSubjects, result.ExtraSubjects, nil, nil, result.Operation, result.Protected)
 
 		case *rbacv1.ClusterRoleBinding:

--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/reconcile_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/reconcile_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,22 +17,24 @@ limitations under the License.
 package auth
 
 import (
+	"errors"
+	"io"
 	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
 )
 
-// singleObjectVisitor visits exactly one in-memory object, without touching the
-// filesystem or a REST builder, so RunReconcile can be exercised directly.
+// singleObjectVisitor implements Visit(), so RunReconcile can be exercised directly.
 type singleObjectVisitor struct {
 	object runtime.Object
 }
@@ -41,68 +43,90 @@ func (v singleObjectVisitor) Visit(fn resource.VisitorFunc) error {
 	return fn(&resource.Info{Object: v.object}, nil)
 }
 
-// TestRunReconcileReturnsErrorOnForbidden is a regression test for a nil-pointer
-// panic: the *rbacv1.RoleBinding and *rbacv1.ClusterRoleBinding cases in
-// RunReconcile called result.RoleBinding.GetObject() without checking the error
-// returned by the reconcile Run(). When the reconcile Get was forbidden, result
-// was nil and the dereference panicked. RunReconcile must instead return the error.
-// See https://github.com/kubernetes/kubernetes/issues/XXXXX (argoproj/argo-cd#28607).
-func TestRunReconcileReturnsErrorOnForbidden(t *testing.T) {
-	forbidden := func(gr schema.GroupResource, name string) clienttesting.ReactionFunc {
-		return func(action clienttesting.Action) (bool, runtime.Object, error) {
-			return true, nil, apierrors.NewForbidden(gr, name, nil)
-		}
-	}
-
+func TestRunReconcile(t *testing.T) {
 	testCases := []struct {
-		name     string
-		object   runtime.Object
-		verb     string
-		resource string
-		grName   string
+		name          string
+		object        runtime.Object
+		reactVerb     string
+		reactResource string
+		wantErr       string
 	}{
 		{
-			name: "RoleBinding forbidden",
+			name: "RoleBinding reconciles successfully",
 			object: &rbacv1.RoleBinding{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-rb", Namespace: "test-ns"},
 				RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "Role", Name: "test-role"},
 			},
-			verb:     "get",
-			resource: "rolebindings",
-			grName:   "test-rb",
 		},
 		{
-			name: "ClusterRoleBinding forbidden",
+			name: "ClusterRoleBinding reconciles successfully",
 			object: &rbacv1.ClusterRoleBinding{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-crb"},
 				RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "test-clusterrole"},
 			},
-			verb:     "get",
-			resource: "clusterrolebindings",
-			grName:   "test-crb",
+		},
+		{
+			name: "RoleBinding forbidden returns error",
+			object: &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-rb", Namespace: "test-ns"},
+				RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "Role", Name: "test-role"},
+			},
+			reactVerb:     "get",
+			reactResource: "rolebindings",
+			wantErr:       "forbidden",
+		},
+		{
+			name: "ClusterRoleBinding forbidden returns error",
+			object: &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-crb"},
+				RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "test-clusterrole"},
+			},
+			reactVerb:     "get",
+			reactResource: "clusterrolebindings",
+			wantErr:       "forbidden",
+		},
+		{
+			name: "unsupported version returns error",
+			object: &rbacv1beta1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-rb", Namespace: "test-ns"},
+			},
+			wantErr: "only rbac.authorization.k8s.io/v1 is supported",
+		},
+		{
+			name:   "unknown type is skipped",
+			object: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod"}},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset()
-			client.PrependReactor(tc.verb, tc.resource,
-				forbidden(schema.GroupResource{Group: rbacv1.GroupName, Resource: tc.resource}, tc.grName))
+			if tc.reactResource != "" {
+				client.PrependReactor(tc.reactVerb, tc.reactResource,
+					func(action clienttesting.Action) (bool, runtime.Object, error) {
+						return true, nil, apierrors.NewForbidden(action.GetResource().GroupResource(), "", errors.New("forbidden"))
+					})
+			}
 
 			streams, _, _, _ := genericiooptions.NewTestIOStreams()
 			o := NewReconcileOptions(streams)
 			o.RBACClient = client.RbacV1()
 			o.NamespaceClient = client.CoreV1()
+			o.PrintObject = func(_ runtime.Object, _ io.Writer) error { return nil }
 			o.Visitor = singleObjectVisitor{object: tc.object}
 
-			// Before the fix this panics with a nil-pointer dereference.
-			// After the fix it must return the forbidden error.
 			err := o.RunReconcile()
-			if err == nil {
-				t.Fatalf("expected a forbidden error, got nil")
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+				return
 			}
-			if !apierrors.IsForbidden(err) && !strings.Contains(err.Error(), "forbidden") {
-				t.Fatalf("expected a forbidden error, got: %v", err)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got: %v", tc.wantErr, err)
 			}
 		})
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/reconcile_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/reconcile_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"strings"
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// singleObjectVisitor visits exactly one in-memory object, without touching the
+// filesystem or a REST builder, so RunReconcile can be exercised directly.
+type singleObjectVisitor struct {
+	object runtime.Object
+}
+
+func (v singleObjectVisitor) Visit(fn resource.VisitorFunc) error {
+	return fn(&resource.Info{Object: v.object}, nil)
+}
+
+// TestRunReconcileReturnsErrorOnForbidden is a regression test for a nil-pointer
+// panic: the *rbacv1.RoleBinding and *rbacv1.ClusterRoleBinding cases in
+// RunReconcile called result.RoleBinding.GetObject() without checking the error
+// returned by the reconcile Run(). When the reconcile Get was forbidden, result
+// was nil and the dereference panicked. RunReconcile must instead return the error.
+// See https://github.com/kubernetes/kubernetes/issues/XXXXX (argoproj/argo-cd#28607).
+func TestRunReconcileReturnsErrorOnForbidden(t *testing.T) {
+	forbidden := func(gr schema.GroupResource, name string) clienttesting.ReactionFunc {
+		return func(action clienttesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewForbidden(gr, name, nil)
+		}
+	}
+
+	testCases := []struct {
+		name     string
+		object   runtime.Object
+		verb     string
+		resource string
+		grName   string
+	}{
+		{
+			name: "RoleBinding forbidden",
+			object: &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-rb", Namespace: "test-ns"},
+				RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "Role", Name: "test-role"},
+			},
+			verb:     "get",
+			resource: "rolebindings",
+			grName:   "test-rb",
+		},
+		{
+			name: "ClusterRoleBinding forbidden",
+			object: &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-crb"},
+				RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "test-clusterrole"},
+			},
+			verb:     "get",
+			resource: "clusterrolebindings",
+			grName:   "test-crb",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset()
+			client.PrependReactor(tc.verb, tc.resource,
+				forbidden(schema.GroupResource{Group: rbacv1.GroupName, Resource: tc.resource}, tc.grName))
+
+			streams, _, _, _ := genericiooptions.NewTestIOStreams()
+			o := NewReconcileOptions(streams)
+			o.RBACClient = client.RbacV1()
+			o.NamespaceClient = client.CoreV1()
+			o.Visitor = singleObjectVisitor{object: tc.object}
+
+			// Before the fix this panics with a nil-pointer dereference.
+			// After the fix it must return the forbidden error.
+			err := o.RunReconcile()
+			if err == nil {
+				t.Fatalf("expected a forbidden error, got nil")
+			}
+			if !apierrors.IsForbidden(err) && !strings.Contains(err.Error(), "forbidden") {
+				t.Fatalf("expected a forbidden error, got: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

  /kind bug
  /kind regression
  /sig cli

 #### What this PR does / why we need it:

`kubectl auth reconcile` panics with a nil-pointer dereference when reconciling a `RoleBinding` or `ClusterRoleBinding` if the reconcile operation returns an error. 
Adds nil check pattern already present in the `*rbacv1.Role` and `*rbacv1.ClusterRole` cases

#### Which issue(s) this PR is related to:

Fixes #<issue number>

(https://github.com/kubernetes/kubernetes/issues/140338)

#### Special notes for your reviewer:

- The fix is intentionally minimal — it mirrors the existing `if err != nil { return err }`
  pattern already present in the `*rbacv1.Role` and `*rbacv1.ClusterRole` cases, keeping all
  four RBAC-v1 cases consistent.
- Added `reconcile_test.go` with `TestRunReconcileReturnsErrorOnForbidden`, which drives
  `RunReconcile` with a fake RBAC client that returns `forbidden` on the binding `get` and
  asserts the error is returned. Verified the test **panics at `reconcile.go:274`** without
  the fix and **passes** with it, for both `RoleBinding` and `ClusterRoleBinding`.
- This is being hit in the wild by Argo CD (its application controller calls
  `RunReconcile` as a library and crashes on impersonated syncs that lack RBAC):
  https://github.com/argoproj/argo-cd/issues/28607

Should cherry pick to 1.35 - 1.36

#### Does this PR introduce a user-facing change?

Fixed a nil-pointer panic in `kubectl auth reconcile` when reconciling a RoleBinding or ClusterRoleBinding fails (for example due to insufficient RBAC permissions); the underlying error is now returned instead of crashing.