### PR TITLE
gce: read proc/sys/kernel/random/boot_id instead of journalctl

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -3292,7 +3292,10 @@ function log-init {
   # Used by log-* functions.
   LOG_CLUSTER_ID=$(get-metadata-value 'instance/attributes/cluster-uid' 'get-metadata-value-error')
   LOG_INSTANCE_NAME=$(hostname)
-  LOG_BOOT_ID=$(journalctl --list-boots | grep -E '^ *0' | awk '{print $2}')
+  LOG_BOOT_ID=$(tr -d '-' < /proc/sys/kernel/random/boot_id 2>/dev/null) || LOG_BOOT_ID="unknown"
+  if [[ -z "${LOG_BOOT_ID}" ]]; then
+    LOG_BOOT_ID="unknown"
+  fi
   declare -Ag LOG_START_TIMES
   declare -ag LOG_TRAP_STACK
 

--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -841,7 +841,10 @@ function log-init {
   # Used by log-* functions.
   LOG_CLUSTER_ID=$(get-metadata-value 'instance/attributes/cluster-uid' 'get-metadata-value-error')
   LOG_INSTANCE_NAME=$(hostname)
-  LOG_BOOT_ID=$(journalctl --list-boots | grep -E '^ *0' | awk '{print $2}')
+  LOG_BOOT_ID=$(tr -d '-' < /proc/sys/kernel/random/boot_id 2>/dev/null) || LOG_BOOT_ID="unknown"
+  if [[ -z "${LOG_BOOT_ID}" ]]; then
+    LOG_BOOT_ID="unknown"
+  fi
   declare -Ag LOG_START_TIMES
   declare -ag LOG_TRAP_STACK
 


### PR DESCRIPTION
In E2E reboot tests that simulate crashes (unclean shutdowns), the systemd journal logs on the writeable partition can become corrupted or truncated.

On the subsequent boot, the GCE node configuration scripts (`configure.sh` and `configure-helper.sh`) attempt to read the boot history using `journalctl --list-boots` to initialize telemetry logging. Due to the journal corruption, `journalctl` fails with "No data available". Because the scripts run with `set -o errexit` enabled, this telemetry failure crashes the entire node setup early, preventing the node from becoming Ready.

This fix replaces the dependency on `journalctl` for boot ID detection with reading directly from `/proc/sys/kernel/random/boot_id`, which is in-memory and immune to disk/journal corruption.

The timing seems to match the new COS version cos-125-19216-395-31 (released May 2026) triggers this test flakiness because unclean reboots now cause journal corruption that `journalctl` cannot recover, failing boot ID detection.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup
/kind flake

#### What this PR does / why we need it:
This PR addresses the e2e reboot tests flakiness by removing dependency on `journalctl` to read the boot ID.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Refs #139444

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
