### PR TITLE
Drop unnecessary sig-apps e2e features

### DIFF
--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -52,7 +52,6 @@ import (
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/pkg/features"
 	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
-	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
@@ -1242,7 +1241,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 		})
 	})
 
-	f.Describe("Deploy clustered applications", feature.StatefulSet, framework.WithSlow(), func() {
+	f.Describe("Deploy clustered applications", framework.WithSlow(), func() {
 		var appTester *clusterAppTester
 
 		ginkgo.BeforeEach(func(ctx context.Context) {

--- a/test/e2e/cloud/gcp/apps/stateful_apps.go
+++ b/test/e2e/cloud/gcp/apps/stateful_apps.go
@@ -37,7 +37,7 @@ var upgradeTests = []upgrades.Test{
 	&apps.CassandraUpgradeTest{},
 }
 
-var _ = SIGDescribe("stateful Upgrade", feature.StatefulUpgrade, func() {
+var _ = SIGDescribe("stateful Upgrade", feature.Upgrade, func() {
 	f := framework.NewDefaultFramework("stateful-upgrade")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 	testFrameworks := upgrades.CreateUpgradeFrameworks(upgradeTests)

--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -416,14 +416,6 @@ var (
 	// Tests validating the behavior of kubelet when running without the API server.
 	StandaloneMode = framework.WithFeature(framework.ValidFeatures.Add("StandaloneMode"))
 
-	// Owner: sig-apps
-	// TODO: document the feature (when to use this feature for a test)
-	StatefulSet = framework.WithFeature(framework.ValidFeatures.Add("StatefulSet"))
-
-	// Owner: sig-apps
-	// TODO: document the feature (when to use this feature for a test)
-	StatefulUpgrade = framework.WithFeature(framework.ValidFeatures.Add("StatefulUpgrade"))
-
 	// Owner: sig-storage
 	// Tests marked with this feature exercise scheduling behavior that scores nodes based on CSI storage capacity.
 	StorageCapacityScoring = framework.WithFeature(framework.ValidFeatures.Add("StorageCapacityScoring"))


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig apps

#### What this PR does / why we need it:
This drops unused sig-apps e2e features, as called out in https://github.com/kubernetes/test-infra/pull/37410#issuecomment-4916703960

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
/assign @pohly 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
