### PR TITLE
Add grouping Pods into sorted homogeneous sub-groups

### DIFF
--- a/pkg/scheduler/backend/queue/active_queue.go
+++ b/pkg/scheduler/backend/queue/active_queue.go
@@ -75,7 +75,7 @@ type unlockedActiveQueuer interface {
 	unlockedActiveQueueReader
 	// update updates the pod in activeQ if oldEntity is already in the queue and the pod is present there.
 	// It returns new pod info if updated, nil otherwise.
-	update(newPod *v1.Pod, oldEntity framework.QueuedEntityInfo) *framework.QueuedPodInfo
+	update(newPod *v1.Pod, oldEntity framework.QueuedEntityInfo, newSignature fwk.PodSignature) *framework.QueuedPodInfo
 	// addEventsIfPodInFlight adds events to inFlightEvents if the newPod is in inFlightPods.
 	// It returns true if pushed the event to the inFlightEvents.
 	addEventsIfPodInFlight(oldPod, newPod *v1.Pod, events []fwk.ClusterEvent) bool
@@ -110,9 +110,9 @@ func newUnlockedActiveQueue(queue *heap.Heap[framework.QueuedEntityInfo], inFlig
 
 // update updates the pod in activeQ if oldEntity is already in the queue and the pod is present there.
 // It returns new pod info if updated, nil otherwise.
-func (uaq *unlockedActiveQueue) update(newPod *v1.Pod, oldEntity framework.QueuedEntityInfo) *framework.QueuedPodInfo {
+func (uaq *unlockedActiveQueue) update(newPod *v1.Pod, oldEntity framework.QueuedEntityInfo, newSignature fwk.PodSignature) *framework.QueuedPodInfo {
 	if entity, exists := uaq.queue.Get(oldEntity); exists {
-		podInfo, err := entity.Update(newPod)
+		podInfo, err := entity.Update(newPod, newSignature)
 		if err != nil {
 			return nil
 		}

--- a/pkg/scheduler/backend/queue/backoff_queue.go
+++ b/pkg/scheduler/backend/queue/backoff_queue.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/backend/heap"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
@@ -65,7 +66,7 @@ type backoffQueuer interface {
 	add(logger klog.Logger, entity framework.QueuedEntityInfo, event string, strategy *queueingStrategy)
 	// update updates the pod in backoffQueue if oldEntity is already in the queue and the pod is present there.
 	// It returns new pod info if updated, nil otherwise.
-	update(newPod *v1.Pod, oldEntity framework.QueuedEntityInfo) *framework.QueuedPodInfo
+	update(newPod *v1.Pod, oldEntity framework.QueuedEntityInfo, newSignature fwk.PodSignature) *framework.QueuedPodInfo
 	// delete deletes the entity from backoffQueue.
 	// It returns the removed entity if found, nil otherwise.
 	delete(entityLookup framework.QueuedEntityInfo) framework.QueuedEntityInfo
@@ -326,13 +327,13 @@ func (bq *backoffQueue) add(logger klog.Logger, entity framework.QueuedEntityInf
 
 // update updates the pod in backoffQueue if oldEntity is already in the queue and the pod is present there.
 // It returns new pod info if updated, nil otherwise.
-func (bq *backoffQueue) update(newPod *v1.Pod, oldEntity framework.QueuedEntityInfo) *framework.QueuedPodInfo {
+func (bq *backoffQueue) update(newPod *v1.Pod, oldEntity framework.QueuedEntityInfo, newSignature fwk.PodSignature) *framework.QueuedPodInfo {
 	bq.lock.Lock()
 	defer bq.lock.Unlock()
 
 	// If the entity is in the backoff queue, update the pod there.
 	if entity, exists := bq.entityBackoffQ.Get(oldEntity); exists {
-		podInfo, err := entity.Update(newPod)
+		podInfo, err := entity.Update(newPod, newSignature)
 		if err != nil {
 			return nil
 		}
@@ -341,7 +342,7 @@ func (bq *backoffQueue) update(newPod *v1.Pod, oldEntity framework.QueuedEntityI
 	}
 	// If the entity is in the error backoff queue, update the pod there.
 	if entity, exists := bq.entityErrorBackoffQ.Get(oldEntity); exists {
-		podInfo, err := entity.Update(newPod)
+		podInfo, err := entity.Update(newPod, newSignature)
 		if err != nil {
 			return nil
 		}

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -1373,6 +1373,7 @@ func (p *PriorityQueue) Update(ctx context.Context, oldPod, newPod *v1.Pod) {
 		entityLookup = newQueuedPodInfoForLookup(oldPod)
 	}
 
+	newSignature := p.signPod(ctx, newPod)
 	updated := false
 	// Run the following code under the activeQ lock to make sure that in the meantime entity is not popped from either activeQ or backoffQ.
 	// This way, the event will be registered or the entity will be updated consistently.
@@ -1390,17 +1391,15 @@ func (p *PriorityQueue) Update(ctx context.Context, oldPod, newPod *v1.Pod) {
 			return
 		}
 		// If the entity is already in the active queue, just update the pod there.
-		if pInfo := unlockedActiveQ.update(newPod, entityLookup); pInfo != nil {
+		if pInfo := unlockedActiveQ.update(newPod, entityLookup, newSignature); pInfo != nil {
 			p.UpdateNominatedPod(logger, oldPod, pInfo.PodInfo)
-			pInfo.PodSignature = p.signPod(ctx, newPod)
 			updated = true
 			return
 		}
 
 		// If the entity is in the backoff queue, update the pod there.
-		if pInfo := p.backoffQ.update(newPod, entityLookup); pInfo != nil {
+		if pInfo := p.backoffQ.update(newPod, entityLookup, newSignature); pInfo != nil {
 			p.UpdateNominatedPod(logger, oldPod, pInfo.PodInfo)
-			pInfo.PodSignature = p.signPod(ctx, newPod)
 			updated = true
 			return
 		}
@@ -1412,7 +1411,7 @@ func (p *PriorityQueue) Update(ctx context.Context, oldPod, newPod *v1.Pod) {
 
 	// If the pod is in the unschedulable queue, updating it may make it schedulable.
 	if entity := p.unschedulableEntities.get(entityLookup); entity != nil {
-		pInfo, err := entity.Update(newPod)
+		pInfo, err := entity.Update(newPod, newSignature)
 		if err != nil {
 			logger.Error(err, "Failed to update pod in an entity", "type", entity.Type(), "entity", klog.KObj(entity), "pod", klog.KObj(newPod))
 			// Handle this case gracefully by adding the newPod to the queue.
@@ -1420,7 +1419,6 @@ func (p *PriorityQueue) Update(ctx context.Context, oldPod, newPod *v1.Pod) {
 			return
 		}
 		p.UpdateNominatedPod(logger, oldPod, pInfo.PodInfo)
-		pInfo.PodSignature = p.signPod(ctx, newPod)
 
 		// When unscheduled Pods are updated, we check with QueueingHint
 		// whether the update may make the entities schedulable.

--- a/pkg/scheduler/backend/queue/workload_forest_test.go
+++ b/pkg/scheduler/backend/queue/workload_forest_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
@@ -784,7 +785,7 @@ func TestWorkloadForest_GetRootLookupInfoForPod(t *testing.T) {
 			if wantFound := tt.wantInfo != nil; gotFound != wantFound {
 				t.Errorf("Expected found: %v, got: %v", wantFound, gotFound)
 			}
-			if diff := cmp.Diff(tt.wantInfo, gotInfo); diff != "" {
+			if diff := cmp.Diff(tt.wantInfo, gotInfo, cmpopts.IgnoreUnexported(framework.QueuedPodGroupInfo{})); diff != "" {
 				t.Errorf("Unexpected QueuedPodGroupInfo (-want,+got)\n%s", diff)
 			}
 		})
@@ -910,7 +911,7 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 			if wantFound := tt.wantInfo != nil; gotFound != wantFound {
 				t.Errorf("Expected found: %v, got: %v", wantFound, gotFound)
 			}
-			if diff := cmp.Diff(tt.wantInfo, gotInfo); diff != "" {
+			if diff := cmp.Diff(tt.wantInfo, gotInfo, cmpopts.IgnoreUnexported(framework.QueuedPodGroupInfo{})); diff != "" {
 				t.Errorf("Unexpected QueuedPodGroupInfo (-want,+got)\n%s", diff)
 			}
 		})
@@ -978,7 +979,7 @@ func TestWorkloadForest_GetRootLookupInfoForCPG(t *testing.T) {
 			if wantFound := tt.wantInfo != nil; gotFound != wantFound {
 				t.Errorf("Expected found: %v, got: %v", wantFound, gotFound)
 			}
-			if diff := cmp.Diff(tt.wantInfo, gotInfo); diff != "" {
+			if diff := cmp.Diff(tt.wantInfo, gotInfo, cmpopts.IgnoreUnexported(framework.QueuedPodGroupInfo{})); diff != "" {
 				t.Errorf("Unexpected QueuedPodGroupInfo (-want,+got)\n%s", diff)
 			}
 		})

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -545,7 +545,7 @@ type QueuedEntityInfo interface {
 	// If fn returns false, the iteration stops.
 	ForEachPodInfo(fn func(pInfo *QueuedPodInfo) bool)
 	// Update updates the specified pod in the entity and returns the updated QueuedPodInfo.
-	Update(pod *v1.Pod) (*QueuedPodInfo, error)
+	Update(pod *v1.Pod, newSignature fwk.PodSignature) (*QueuedPodInfo, error)
 	// Gated returns true if the entity is gated by any plugin at PreEnqueue.
 	Gated() bool
 	// Size returns the number of pods in the entity.
@@ -708,10 +708,10 @@ func (pqi *QueuedPodInfo) ForEachPodInfo(fn func(pInfo *QueuedPodInfo) bool) {
 	_ = fn(pqi)
 }
 
-// Update updates the pod in QueuedPodInfo and clears the cached PodSignature,
+// Update updates the pod in QueuedPodInfo and sets the new PodSignature,
 // since the updated pod may no longer match the signature computed for the previous version.
-func (pqi *QueuedPodInfo) Update(pod *v1.Pod) (*QueuedPodInfo, error) {
-	pqi.PodSignature = nil
+func (pqi *QueuedPodInfo) Update(pod *v1.Pod, newSignature fwk.PodSignature) (*QueuedPodInfo, error) {
+	pqi.PodSignature = newSignature
 	err := pqi.PodInfo.Update(pod)
 	return pqi, err
 }
@@ -786,8 +786,34 @@ type QueuedPodGroupInfo struct {
 	// QueuedPodInfos are the pod group pods that are currently queued.
 	// This map is keyed by pod group keys in the same format as framework.PodGroupKey function.
 	// Its values are slices of corresponding leaf pod group's queued pods.
-	// The order of the pods in the slice is deterministic and based on the priority and timestamp.
+	// The order of the pods in the slice is deterministic.
+	// 1. Pods are arranged into sub-groups by their signatures.
+	// 2. Pods in every sub-group are sorted using PodGroupMemberPodsOrderingFunc() - higher priority, more attempts, earlier timestamp.
+	// 3. Sub-groups are sorted based on the first pod in each sub-group using PodGroupMemberPodsOrderingFunc() and lexicographically.
+	// Example:
+	// Pod1(p=1, a=2, t=3, sig="a")
+	// Pod2(p=5, a=2, t=3, sig="a")
+	// Pod3(p=10, a=3, t=3, sig="b")
+	// Pod4(p=10, a=2, t=3, sig="b")
+	// Pod5(p=5, a=3, t=2, sig="c")
+	// Pod6(p=5, a=3, t=3, sig="c")
+	// Sub-groups: {"a": {Pod1, Pod2}, "b": {Pod4, Pod3}, "c": {Pod5, Pod6}}
+	// Sorted sub-groups:
+	// 	"a": {Pod2, Pod1} - Pod2.p > Pod1.p
+	//  "b": {Pod3, Pod4} - Pod3.p == Pod4.p and Pod3.a > Pod4.a
+	//  "c": {Pod6, Pod5} - Pod5.p == Pod6.p and Pod5.a == Pod6.a and Pod6.t > Pod5.t
+	// Sub-groups order: "b", "a", "c"
+	// 	- "b" has higher priority than "a" and "c".
+	// 	- "a" and "c" have same priority, attempts and timestamp so they are sorted based on lexicographical order of signatures.
+	// Sorted pods: Pod3, Pod4, Pod2, Pod1, Pod6, Pod5
+
 	QueuedPodInfos map[fwk.EntityKey][]*QueuedPodInfo
+
+	// buckets stores pods grouped by their PodSignature string representation.
+	buckets map[fwk.EntityKey]map[string][]*QueuedPodInfo
+	// signatureOrder stores the deterministic ordering of pod signatures (sub-groups).
+	// Sorting is done based on the first pod in each sub-group using PodGroupMemberPodsOrderingFunc() and lexicographically.
+	signatureOrder map[fwk.EntityKey][]string
 }
 
 func (pgqi *QueuedPodGroupInfo) Type() fwk.EntityKeyType {
@@ -817,12 +843,30 @@ func (pgqi *QueuedPodGroupInfo) AddPod(pInfo *QueuedPodInfo) {
 	if pgqi.QueuedPodInfos == nil {
 		pgqi.QueuedPodInfos = make(map[fwk.EntityKey][]*QueuedPodInfo)
 	}
-
+	if pgqi.buckets == nil {
+		pgqi.buckets = make(map[fwk.EntityKey]map[string][]*QueuedPodInfo)
+	}
+	if pgqi.signatureOrder == nil {
+		pgqi.signatureOrder = make(map[fwk.EntityKey][]string)
+	}
 	key := fwk.PodGroupKey(leafPG.Namespace, leafPG.Name)
-	index, _ := slices.BinarySearchFunc(pgqi.QueuedPodInfos[key], pInfo, PodGroupMemberPodsOrderingFunc)
+	pgqi.addPodToLeafPg(key, pInfo)
+	pgqi.updateSliceOrder(key, leafPG)
+}
 
-	pgqi.QueuedPodInfos[key] = slices.Insert(pgqi.QueuedPodInfos[key], index, pInfo)
-	leafPG.UnscheduledPods = slices.Insert(leafPG.UnscheduledPods, index, pInfo.Pod)
+// addPodToLeafPg adds a pod to the queued pods for the leaf pod group identified by the key.
+func (pgqi *QueuedPodGroupInfo) addPodToLeafPg(key fwk.EntityKey, pInfo *QueuedPodInfo) {
+	if pgqi.buckets[key] == nil {
+		pgqi.buckets[key] = make(map[string][]*QueuedPodInfo)
+	}
+	sig := string(pInfo.PodSignature)
+	index := pgqi.addToBucket(pInfo, sig, key)
+	// Index equals 0 implies that a new bucket was created or the new
+	// pod is taking the first place in the bucket. In either case, the
+	// signature order may need to be updated.
+	if index == 0 {
+		pgqi.sortSignatures(key)
+	}
 }
 
 // RemovePod removes a pod from the queued pod group info, if the pod belongs to the pod group.
@@ -841,36 +885,48 @@ func (pgqi *QueuedPodGroupInfo) RemovePod(pod *v1.Pod) *QueuedPodInfo {
 	}
 
 	key := fwk.PodGroupKey(pod.Namespace, *pod.Spec.SchedulingGroup.PodGroupName)
-	list, exists := pgqi.QueuedPodInfos[key]
+	_, exists := pgqi.QueuedPodInfos[key]
 	if !exists {
 		return nil
 	}
 
-	var removed *QueuedPodInfo
-	for i, p := range list {
-		if p.Pod.Name == pod.Name && p.Pod.Namespace == pod.Namespace {
-			removed = p
-			pgqi.QueuedPodInfos[key] = slices.Delete(list, i, i+1)
-			if len(pgqi.QueuedPodInfos[key]) == 0 {
-				delete(pgqi.QueuedPodInfos, key)
-			}
-			break
-		}
-	}
-
 	// Remove from leaf UnscheduledPods
 	leafPG, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, *pod.Spec.SchedulingGroup.PodGroupName)
-	if leafPG == nil {
-		return removed
-	}
 
-	for i, p := range leafPG.UnscheduledPods {
-		if p.Name == pod.Name && p.Namespace == pod.Namespace {
-			leafPG.UnscheduledPods = slices.Delete(leafPG.UnscheduledPods, i, i+1)
+	removed := pgqi.removePodFromLeafPg(key, pod)
+	if removed != nil {
+		pgqi.updateSliceOrder(key, leafPG)
+	}
+	return removed
+}
+
+// removePodFromLeafPg removes a pod from the queued pods for the leaf pod group identified by the key.
+func (pgqi *QueuedPodGroupInfo) removePodFromLeafPg(key fwk.EntityKey, pod *v1.Pod) *QueuedPodInfo {
+	var removed *QueuedPodInfo
+	for _, pInfo := range pgqi.QueuedPodInfos[key] {
+		if pInfo.Pod.Name == pod.Name && pInfo.Pod.Namespace == pod.Namespace {
+			removed = pInfo
 			break
 		}
 	}
-
+	if removed == nil {
+		return nil
+	}
+	if len(pgqi.QueuedPodInfos[key]) == 1 {
+		delete(pgqi.QueuedPodInfos, key)
+		delete(pgqi.buckets, key)
+		delete(pgqi.signatureOrder, key)
+		return removed
+	}
+	index, err := pgqi.removeFromBucket(pod, string(removed.PodSignature), key)
+	if err != nil {
+		return nil
+	}
+	// Index equals 0 implies that a bucket became empty or the removed pod was
+	// its first pod. In either case, the signature order may need to be updated.
+	if index == 0 {
+		pgqi.sortSignatures(key)
+	}
 	return removed
 }
 
@@ -884,6 +940,85 @@ func (pgqi *QueuedPodGroupInfo) HasQueuedPodInfos() bool {
 		}
 	}
 	return false
+}
+
+// removeFromBucket removes a pod from the bucket and returns the index of the removed pod.
+func (pgqi *QueuedPodGroupInfo) removeFromBucket(pod *v1.Pod, sig string, key fwk.EntityKey) (int, error) {
+	bucket, exists := pgqi.buckets[key][sig]
+	if !exists {
+		return 0, fmt.Errorf("no bucket with signature %s found", sig)
+	}
+	if len(bucket) == 1 {
+		delete(pgqi.buckets[key], sig)
+		for i, s := range pgqi.signatureOrder[key] {
+			if s == sig {
+				pgqi.signatureOrder[key] = slices.Delete(pgqi.signatureOrder[key], i, i+1)
+				break
+			}
+		}
+		return 0, nil
+	}
+	for i, pInfo := range bucket {
+		if pInfo.Pod.Name == pod.Name && pInfo.Pod.Namespace == pod.Namespace {
+			pgqi.buckets[key][sig] = slices.Delete(bucket, i, i+1)
+			// Resorting is needed when removing elemnt from first place in bucket.
+			return i, nil
+		}
+	}
+	return 0, fmt.Errorf("pod %s/%s not found in bucket", pod.Namespace, pod.Name)
+}
+
+// addToBucket adds a pod to the bucket and returns the index of the added pod within the bucket.
+func (pgqi *QueuedPodGroupInfo) addToBucket(pInfo *QueuedPodInfo, sig string, key fwk.EntityKey) int {
+	bucket, exists := pgqi.buckets[key][sig]
+	if !exists {
+		pgqi.buckets[key][sig] = []*QueuedPodInfo{pInfo}
+		pgqi.signatureOrder[key] = append(pgqi.signatureOrder[key], sig)
+		return 0
+	}
+	index, _ := slices.BinarySearchFunc(bucket, pInfo, PodGroupMemberPodsOrderingFunc)
+	pgqi.buckets[key][sig] = slices.Insert(bucket, index, pInfo)
+	return index
+}
+
+// sortSignatures sorts the signatureOrder by the representative pod of each sub-group ensures
+// the oldest workload in the gang is evaluated first while preserving Opportunistic Batching.
+func (pgqi *QueuedPodGroupInfo) sortSignatures(key fwk.EntityKey) {
+	slices.SortStableFunc(pgqi.signatureOrder[key], func(sigA, sigB string) int {
+		repA := pgqi.buckets[key][sigA][0]
+		repB := pgqi.buckets[key][sigB][0]
+		if cmp := PodGroupMemberPodsOrderingFunc(repA, repB); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(sigA, sigB)
+	})
+}
+
+// updateSliceOrder synchronizes QueuedPodInfos and UnscheduledPods with the current state of buckets
+// and signatureOrder.
+func (pgqi *QueuedPodGroupInfo) updateSliceOrder(key fwk.EntityKey, pgInfo *PodGroupInfo) {
+	var total int
+	buckets, exists := pgqi.buckets[key]
+	if !exists {
+		return
+	}
+	for _, bucket := range buckets {
+		total += len(bucket)
+	}
+	pgqi.QueuedPodInfos[key] = make([]*QueuedPodInfo, 0, total)
+
+	if pgInfo != nil {
+		pgInfo.UnscheduledPods = make([]*v1.Pod, 0, total)
+	}
+	for _, sig := range pgqi.signatureOrder[key] {
+		pgqi.QueuedPodInfos[key] = append(pgqi.QueuedPodInfos[key], pgqi.buckets[key][sig]...)
+		if pgInfo != nil {
+			for _, pInfo := range pgqi.buckets[key][sig] {
+				pgInfo.UnscheduledPods = append(pgInfo.UnscheduledPods, pInfo.Pod)
+			}
+		}
+	}
+
 }
 
 // PodGroupMemberPodsOrderingFunc orders pod group member pods by priority (descending),
@@ -931,7 +1066,7 @@ func (pgqi *QueuedPodGroupInfo) ForEachPodInfo(fn func(pInfo *QueuedPodInfo) boo
 	}
 }
 
-func (pgqi *QueuedPodGroupInfo) Update(pod *v1.Pod) (*QueuedPodInfo, error) {
+func (pgqi *QueuedPodGroupInfo) Update(pod *v1.Pod, newSignature fwk.PodSignature) (*QueuedPodInfo, error) {
 	if pgqi.QueuedPodInfos == nil {
 		return nil, fmt.Errorf("pod %s/%s to update not found in the queued group info", pod.Namespace, pod.Name)
 	}
@@ -941,29 +1076,59 @@ func (pgqi *QueuedPodGroupInfo) Update(pod *v1.Pod) (*QueuedPodInfo, error) {
 	}
 
 	key := fwk.PodGroupKey(pod.Namespace, *pod.Spec.SchedulingGroup.PodGroupName)
-	list, exists := pgqi.QueuedPodInfos[key]
+	_, exists := pgqi.QueuedPodInfos[key]
 	if !exists {
 		return nil, fmt.Errorf("pod %s/%s to update not found in the queued group info", pod.Namespace, pod.Name)
 	}
-
-	for _, pInfo := range list {
-		if pInfo.Pod.Name != pod.Name || pInfo.Pod.Namespace != pod.Namespace {
-			continue
-		}
-		err := pInfo.PodInfo.Update(pod)
-
-		leafPG, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, *pod.Spec.SchedulingGroup.PodGroupName)
-		if leafPG != nil {
-			for i, p := range leafPG.UnscheduledPods {
-				if p.Name == pod.Name && p.Namespace == pod.Namespace {
-					leafPG.UnscheduledPods[i] = pod
-					break
-				}
-			}
-		}
-		return pInfo, err
+	leafPG, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, *pod.Spec.SchedulingGroup.PodGroupName)
+	pqi, err := pgqi.updateForLeafPg(key, pod, newSignature)
+	if err == nil {
+		pgqi.updateSliceOrder(key, leafPG)
 	}
+	return pqi, err
+}
 
+// updateForLeafPg updates the given pod in the queued pods for the leaf pod group identified by the key, and reorganizes the signature buckets
+// if the pod's signature changed.
+func (pgqi *QueuedPodGroupInfo) updateForLeafPg(key fwk.EntityKey, pod *v1.Pod, newSignature fwk.PodSignature) (*QueuedPodInfo, error) {
+	for _, pInfo := range pgqi.QueuedPodInfos[key] {
+		if pInfo.Pod.Name == pod.Name && pInfo.Pod.Namespace == pod.Namespace {
+			oldSig := string(pInfo.PodSignature)
+			newSig := string(newSignature)
+			if oldSig == newSig {
+				err := pInfo.PodInfo.Update(pod)
+				return pInfo, err
+			}
+			shouldSort := false
+			// Remove from old bucket
+			index, err := pgqi.removeFromBucket(pod, oldSig, key)
+			if err != nil {
+				return nil, err
+			}
+			// Index equals 0 implies that a bucket became empty or the removed pod was
+			// its first pod. In either case, the signature order may need to be updated.
+			if index == 0 {
+				shouldSort = true
+			}
+
+			// Update signature and pod.
+			pInfo.PodSignature = newSignature
+			err = pInfo.PodInfo.Update(pod)
+
+			// Add to new bucket.
+			index = pgqi.addToBucket(pInfo, newSig, key)
+			// Index equals 0 implies that a new bucket was created or the new
+			// pod is taking the first place in the bucket. In either case, the
+			// signature order may need to be updated.
+			if index == 0 {
+				shouldSort = true
+			}
+			if shouldSort {
+				pgqi.sortSignatures(key)
+			}
+			return pInfo, err
+		}
+	}
 	return nil, fmt.Errorf("pod %s/%s to update not found in the queued group info", pod.Namespace, pod.Name)
 }
 
@@ -1184,6 +1349,8 @@ func newQueuedPodGroupInfo(pg *schedulingv1beta1.PodGroup) *QueuedPodGroupInfo {
 			Children:  make([]*PodGroupInfo, 0),
 		},
 		QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
+		signatureOrder: make(map[fwk.EntityKey][]string),
+		buckets:        make(map[fwk.EntityKey]map[string][]*QueuedPodInfo),
 	}
 }
 

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -18,10 +18,11 @@ package framework
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
@@ -350,6 +351,333 @@ func TestQueuedPodGroupInfoOrdering(t *testing.T) {
 			}
 			if diff := cmp.Diff(expectedUnscheduled, pgqi.UnscheduledPods); diff != "" {
 				t.Errorf("Unexpected order in UnscheduledPods (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestQueuedPodGroupInfo_SubGroups(t *testing.T) {
+	timestamp := time.Now()
+	opts := []cmp.Option{
+		cmp.AllowUnexported(QueuedPodInfo{}, PodInfo{}, fwk.PodResource{}),
+	}
+
+	worker1 := &QueuedPodInfo{
+		PodInfo: &PodInfo{Pod: st.MakePod().Namespace("default").Name("worker1").UID("w1").Priority(highPriority).PodGroupName("pg1").Obj()},
+		QueueingParams: QueueingParams{
+			Attempts:  1,
+			Timestamp: timestamp.Add(10 * time.Second),
+		},
+		PodSignature: fwk.PodSignature("worker"),
+	}
+	worker2 := &QueuedPodInfo{
+		PodInfo: &PodInfo{Pod: st.MakePod().Namespace("default").Name("worker2").UID("w2").Priority(highPriority).PodGroupName("pg1").Obj()},
+		QueueingParams: QueueingParams{
+			Attempts:  1,
+			Timestamp: timestamp.Add(30 * time.Second),
+		},
+		PodSignature: fwk.PodSignature("worker"),
+	}
+	worker3 := &QueuedPodInfo{
+		PodInfo: &PodInfo{Pod: st.MakePod().Namespace("default").Name("worker3").UID("w3").Priority(highPriority).PodGroupName("pg1").Obj()},
+		QueueingParams: QueueingParams{
+			Attempts:  1,
+			Timestamp: timestamp.Add(20 * time.Second),
+		},
+		PodSignature: fwk.PodSignature("worker"),
+	}
+	driver1 := &QueuedPodInfo{
+		PodInfo: &PodInfo{Pod: st.MakePod().Namespace("default").Name("driver1").UID("d1").Priority(highPriority).PodGroupName("pg1").Obj()},
+		QueueingParams: QueueingParams{
+			Attempts:  1,
+			Timestamp: timestamp.Add(25 * time.Second),
+		},
+		PodSignature: fwk.PodSignature("driver"),
+	}
+	driver2 := &QueuedPodInfo{
+		PodInfo: &PodInfo{Pod: st.MakePod().Namespace("default").Name("driver2").UID("d2").Priority(highPriority).PodGroupName("pg1").Obj()},
+		QueueingParams: QueueingParams{
+			Attempts:  1,
+			Timestamp: timestamp.Add(40 * time.Second),
+		},
+		PodSignature: fwk.PodSignature("driver"),
+	}
+	ps1 := &QueuedPodInfo{
+		PodInfo: &PodInfo{Pod: st.MakePod().Namespace("default").Name("ps1").UID("p1").Priority(highPriority).PodGroupName("pg1").Obj()},
+		QueueingParams: QueueingParams{
+			Attempts:  1,
+			Timestamp: timestamp,
+		},
+		PodSignature: fwk.PodSignature("ps"),
+	}
+
+	tests := []struct {
+		name          string
+		podsToAdd     []*QueuedPodInfo
+		podToAdd      *QueuedPodInfo
+		podToRemove   *QueuedPodInfo
+		expectedOrder []*QueuedPodInfo
+	}{
+		{
+			name:          "SetPods groups by signature and sorts sub-groups by oldest representative pod",
+			podsToAdd:     []*QueuedPodInfo{driver1, worker2, driver2, worker1},
+			expectedOrder: []*QueuedPodInfo{worker1, worker2, driver1, driver2},
+		},
+		{
+			name:          "AddPod inserts into existing bucket and maintains sub-group order",
+			podsToAdd:     []*QueuedPodInfo{worker1, worker2, driver1, driver2},
+			podToAdd:      worker3,
+			expectedOrder: []*QueuedPodInfo{worker1, worker3, worker2, driver1, driver2},
+		},
+		{
+			name:          "AddPod with older timestamp creates new bucket and shifts sub-group order to front",
+			podsToAdd:     []*QueuedPodInfo{worker1, worker3, worker2, driver1, driver2},
+			podToAdd:      ps1,
+			expectedOrder: []*QueuedPodInfo{ps1, worker1, worker3, worker2, driver1, driver2},
+		},
+		{
+			name:          "RemovePod removing sole pod in bucket removes sub-group",
+			podsToAdd:     []*QueuedPodInfo{ps1, worker1, worker3, worker2, driver1, driver2},
+			podToRemove:   ps1,
+			expectedOrder: []*QueuedPodInfo{worker1, worker3, worker2, driver1, driver2},
+		},
+		{
+			name:          "RemovePod removing representative pod updates bucket head without breaking sub-group order",
+			podsToAdd:     []*QueuedPodInfo{worker1, worker3, worker2, driver1, driver2},
+			podToRemove:   worker1,
+			expectedOrder: []*QueuedPodInfo{worker3, worker2, driver1, driver2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pg := st.MakePodGroup().Namespace("default").Name("pg1").Obj()
+			pgqi := newQueuedPodGroupInfo(pg)
+			for _, p := range tt.podsToAdd {
+				pgqi.AddPod(p)
+			}
+			if tt.podToAdd != nil {
+				pgqi.AddPod(tt.podToAdd)
+			}
+			if tt.podToRemove != nil {
+				pgqi.RemovePod(tt.podToRemove.Pod)
+			}
+
+			key := fwk.PodGroupKey("default", "pg1")
+			var actualOrder []*QueuedPodInfo
+			if pgqi.QueuedPodInfos != nil {
+				actualOrder = pgqi.QueuedPodInfos[key]
+			}
+
+			if diff := cmp.Diff(tt.expectedOrder, actualOrder, opts...); diff != "" {
+				t.Errorf("Unexpected order in QueuedPodInfos (-want, +got):\n%s", diff)
+			}
+
+			expectedUnscheduled := make([]*v1.Pod, len(tt.expectedOrder))
+			for i, qpi := range tt.expectedOrder {
+				expectedUnscheduled[i] = qpi.Pod
+			}
+			if diff := cmp.Diff(expectedUnscheduled, pgqi.UnscheduledPods); diff != "" {
+				t.Errorf("Unexpected order in UnscheduledPods (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestQueuedPodGroupInfo_UpdateAndAddPod(t *testing.T) {
+	timestamp := time.Now()
+	opts := []cmp.Option{
+		cmp.AllowUnexported(QueuedPodInfo{}, PodInfo{}, fwk.PodResource{}),
+	}
+
+	worker1 := &QueuedPodInfo{
+		PodInfo: &PodInfo{Pod: st.MakePod().Namespace("default").Name("worker1").UID("w1").Priority(highPriority).PodGroupName("pg-update").Obj()},
+		QueueingParams: QueueingParams{
+			Attempts:  1,
+			Timestamp: timestamp.Add(10 * time.Second),
+		},
+		PodSignature: fwk.PodSignature("worker"),
+	}
+	driver1 := &QueuedPodInfo{
+		PodInfo: &PodInfo{Pod: st.MakePod().Namespace("default").Name("driver1").UID("d1").Priority(highPriority).PodGroupName("pg-update").Obj()},
+		QueueingParams: QueueingParams{
+			Attempts:  1,
+			Timestamp: timestamp.Add(20 * time.Second),
+		},
+		PodSignature: fwk.PodSignature("driver"),
+	}
+	worker2 := &QueuedPodInfo{
+		PodInfo: &PodInfo{Pod: st.MakePod().Namespace("default").Name("worker2").UID("w2").Priority(highPriority).PodGroupName("pg-update").Obj()},
+		QueueingParams: QueueingParams{
+			Attempts:  1,
+			Timestamp: timestamp.Add(30 * time.Second),
+		},
+		PodSignature: fwk.PodSignature("worker"),
+	}
+	pg := st.MakePodGroup().Namespace("default").Name("pg-update").Obj()
+	pgqi := newQueuedPodGroupInfo(pg)
+	pgqi.AddPod(worker1)
+	pgqi.AddPod(driver1)
+
+	// Now update worker1's pod object and signature (simulating a spec or label change)
+	updatedPod := worker1.Pod.DeepCopy()
+	updatedPod.Labels = map[string]string{"role": "driver"}
+	if _, err := pgqi.Update(updatedPod, fwk.PodSignature("driver")); err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	// Now add worker2 (whose signature is "worker")
+	pgqi.AddPod(worker2)
+
+	// Since worker1's signature changed to "driver", both worker1 and driver1 are in the "driver" bucket.
+	// Worker2 is in the "worker" bucket.
+	// Since worker1 (ts=10s) is older than worker2 (ts=30s), the "driver" bucket comes before the "worker" bucket!
+	expectedOrder := []*QueuedPodInfo{worker1, driver1, worker2}
+	if diff := cmp.Diff(expectedOrder, pgqi.QueuedPodInfos[fwk.PodGroupKey("default", "pg-update")], opts...); diff != "" {
+		t.Errorf("Unexpected order in QueuedPodInfos after Update and AddPod (-want, +got):\n%s", diff)
+	}
+}
+
+func TestQueuedPodGroupInfo_Update(t *testing.T) {
+	timestamp := time.Now()
+
+	tests := []struct {
+		name         string
+		initialPods  []*QueuedPodInfo
+		updatePod    *v1.Pod
+		newSignature fwk.PodSignature
+		expectError  bool
+		verifyState  func(t *testing.T, pgqi *QueuedPodGroupInfo)
+	}{
+		{
+			name: "Update non-existent pod",
+			initialPods: []*QueuedPodInfo{
+				{
+					PodInfo:      &PodInfo{Pod: st.MakePod().Namespace("default").Name("p1").UID("p1").Priority(highPriority).PodGroupName("pg-test").Obj()},
+					PodSignature: fwk.PodSignature("sig1"),
+				},
+			},
+			updatePod:    st.MakePod().Namespace("default").Name("p2").UID("p2").PodGroupName("pg-test").Obj(),
+			newSignature: fwk.PodSignature("sig1"),
+			expectError:  true,
+		},
+		{
+			name: "Update without signature change",
+			initialPods: []*QueuedPodInfo{
+				{
+					PodInfo:      &PodInfo{Pod: st.MakePod().Namespace("default").Name("p1").UID("p1").Priority(highPriority).PodGroupName("pg-test").Obj()},
+					PodSignature: fwk.PodSignature("sig1"),
+				},
+			},
+			updatePod:    st.MakePod().Namespace("default").Name("p1").UID("p1").Label("foo", "bar").PodGroupName("pg-test").Obj(),
+			newSignature: fwk.PodSignature("sig1"),
+			verifyState: func(t *testing.T, pgqi *QueuedPodGroupInfo) {
+				if len(pgqi.QueuedPodInfos) != 1 {
+					t.Fatalf("expected 1 pod, got %d", len(pgqi.QueuedPodInfos))
+				}
+				pInfo := pgqi.QueuedPodInfos[fwk.PodGroupKey("default", "pg-test")][0]
+				if pInfo.Pod.Labels["foo"] != "bar" {
+					t.Errorf("pod was not updated correctly")
+				}
+				if string(pInfo.PodSignature) != "sig1" {
+					t.Errorf("pod signature changed unexpectedly")
+				}
+				if len(pgqi.buckets) != 1 || len(pgqi.buckets[fwk.PodGroupKey("default", "pg-test")]["sig1"]) != 1 {
+					t.Errorf("buckets state is invalid")
+				}
+				if len(pgqi.signatureOrder) != 1 || pgqi.signatureOrder[fwk.PodGroupKey("default", "pg-test")][0] != "sig1" {
+					t.Errorf("signatureOrder state is invalid")
+				}
+			},
+		},
+		{
+			name: "Update with signature change - old bucket becomes empty",
+			initialPods: []*QueuedPodInfo{
+				{
+					PodInfo:      &PodInfo{Pod: st.MakePod().Namespace("default").Name("p1").UID("p1").Priority(highPriority).PodGroupName("pg-test").Obj()},
+					PodSignature: fwk.PodSignature("sig1"),
+				},
+				{
+					PodInfo:      &PodInfo{Pod: st.MakePod().Namespace("default").Name("p2").UID("p2").Priority(highPriority).PodGroupName("pg-test").Obj()},
+					PodSignature: fwk.PodSignature("sig2"),
+				},
+			},
+			updatePod:    st.MakePod().Namespace("default").Name("p1").UID("p1").Priority(highPriority).PodGroupName("pg-test").Obj(),
+			newSignature: fwk.PodSignature("sig2"),
+			verifyState: func(t *testing.T, pgqi *QueuedPodGroupInfo) {
+				// sig1 bucket should be completely removed
+				if _, ok := pgqi.buckets[fwk.PodGroupKey("default", "pg-test")]["sig1"]; ok {
+					t.Errorf("sig1 bucket should have been deleted")
+				}
+				if len(pgqi.signatureOrder[fwk.PodGroupKey("default", "pg-test")]) != 1 || pgqi.signatureOrder[fwk.PodGroupKey("default", "pg-test")][0] != "sig2" {
+					t.Errorf("sig1 should have been removed from signatureOrder, got order: %v", pgqi.signatureOrder[fwk.PodGroupKey("default", "pg-test")])
+				}
+				// sig2 bucket should contain both p1 and p2
+				if len(pgqi.buckets[fwk.PodGroupKey("default", "pg-test")]["sig2"]) != 2 {
+					t.Errorf("expected 2 pods in sig2 bucket, got %d", len(pgqi.buckets[fwk.PodGroupKey("default", "pg-test")]["sig2"]))
+				}
+			},
+		},
+		{
+			name: "Update with signature change - insert in middle of existing bucket",
+			initialPods: []*QueuedPodInfo{
+				{
+					PodInfo: &PodInfo{Pod: st.MakePod().Namespace("default").Name("p1").UID("p1").Priority(highPriority).PodGroupName("pg-test").Obj()},
+					QueueingParams: QueueingParams{
+						Timestamp: timestamp.Add(10 * time.Second),
+					},
+					PodSignature: fwk.PodSignature("sig1"),
+				},
+				{
+					PodInfo: &PodInfo{Pod: st.MakePod().Namespace("default").Name("p2-early").UID("p2-early").Priority(highPriority).PodGroupName("pg-test").Obj()},
+					QueueingParams: QueueingParams{
+						Timestamp: timestamp.Add(5 * time.Second),
+					},
+					PodSignature: fwk.PodSignature("sig2"),
+				},
+				{
+					PodInfo: &PodInfo{Pod: st.MakePod().Namespace("default").Name("p2-late").UID("p2-late").Priority(highPriority).PodGroupName("pg-test").Obj()},
+					QueueingParams: QueueingParams{
+						Timestamp: timestamp.Add(20 * time.Second),
+					},
+					PodSignature: fwk.PodSignature("sig2"),
+				},
+			},
+			updatePod:    st.MakePod().Namespace("default").Name("p1").UID("p1").Priority(highPriority).PodGroupName("pg-test").Obj(),
+			newSignature: fwk.PodSignature("sig2"),
+			verifyState: func(t *testing.T, pgqi *QueuedPodGroupInfo) {
+				// p1 (ts=10s) should be inserted in the middle of sig2 bucket: p2-early (5s), p1 (10s), p2-late (20s)
+				bucket := pgqi.buckets[fwk.PodGroupKey("default", "pg-test")]["sig2"]
+				if len(bucket) != 3 {
+					t.Fatalf("expected 3 pods in sig2 bucket, got %d", len(bucket))
+				}
+				if bucket[0].Pod.Name != "p2-early" || bucket[1].Pod.Name != "p1" || bucket[2].Pod.Name != "p2-late" {
+					t.Errorf("sig2 bucket pods are in wrong order: %s, %s, %s", bucket[0].Pod.Name, bucket[1].Pod.Name, bucket[2].Pod.Name)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pg := st.MakePodGroup().Namespace("default").Name("pg-test").Obj()
+			pgqi := newQueuedPodGroupInfo(pg)
+			for _, pInfo := range tt.initialPods {
+				pgqi.AddPod(pInfo)
+			}
+
+			_, err := pgqi.Update(tt.updatePod, tt.newSignature)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.verifyState != nil {
+				tt.verifyState(t, pgqi)
 			}
 		})
 	}
@@ -3273,7 +3601,7 @@ func TestQueuedPodInfo_UpdateInvalidatesSignature(t *testing.T) {
 		PodSignature: fwk.PodSignature("sig-1"),
 	}
 
-	_, err := queuedPodInfo.Update(pod2)
+	_, err := queuedPodInfo.Update(pod2, nil)
 	if err != nil {
 		t.Fatalf("Update failed: %v", err)
 	}
@@ -4237,7 +4565,7 @@ func TestQueuedPodGroupInfo_UpdateAndRemovePod(t *testing.T) {
 		{
 			name: "Update Pod",
 			execute: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
-				pInfo, err := qpgi.Update(pod1Updated)
+				pInfo, err := qpgi.Update(pod1Updated, nil)
 				if err != nil {
 					t.Errorf("Update failed: %v", err)
 				}
@@ -4251,7 +4579,7 @@ func TestQueuedPodGroupInfo_UpdateAndRemovePod(t *testing.T) {
 			execute: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				podNotFound := st.MakePod().Name("pod-not-found").Namespace("ns1").Obj()
 				podNotFound.Spec.SchedulingGroup = &v1.PodSchedulingGroup{PodGroupName: func() *string { s := "pg-standalone"; return &s }()}
-				_, err := qpgi.Update(podNotFound)
+				_, err := qpgi.Update(podNotFound, nil)
 				if err == nil {
 					t.Errorf("Expected error when updating non-existent pod")
 				}
@@ -4289,10 +4617,14 @@ func TestQueuedPodGroupInfo_UpdateAndRemovePod(t *testing.T) {
 					PodGroup: pgStandalone, Name: pgStandalone.Name, Namespace: pgStandalone.Namespace, Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0),
 				},
 				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
+				signatureOrder: make(map[fwk.EntityKey][]string),
+				buckets:        make(map[fwk.EntityKey]map[string][]*QueuedPodInfo),
 			}
 			pInfo1 := &QueuedPodInfo{PodInfo: &PodInfo{Pod: pod1}}
 			qpgi.QueuedPodInfos[podKeyStandalone] = []*QueuedPodInfo{pInfo1}
-
+			qpgi.buckets[podKeyStandalone] = make(map[string][]*QueuedPodInfo)
+			qpgi.buckets[podKeyStandalone][string(pInfo1.PodSignature)] = []*QueuedPodInfo{pInfo1}
+			qpgi.signatureOrder[podKeyStandalone] = []string{string(pInfo1.PodSignature)}
 			tt.execute(t, qpgi)
 		})
 	}

--- a/test/integration/scheduler/podgroup/batch/main_test.go
+++ b/test/integration/scheduler/podgroup/batch/main_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestMain(m *testing.M) {
+	framework.EtcdMain(m.Run)
+}

--- a/test/integration/scheduler/podgroup/batch/podgroup_batch_test.go
+++ b/test/integration/scheduler/podgroup/batch/podgroup_batch_test.go
@@ -1,0 +1,273 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batch
+
+import (
+	"strings"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	schedulingapi "k8s.io/api/scheduling/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	kubeschedulerconfigv1 "k8s.io/kube-scheduler/config/v1"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/scheduler"
+	config "k8s.io/kubernetes/pkg/scheduler/apis/config"
+	kubeschedulerscheme "k8s.io/kubernetes/pkg/scheduler/apis/config/scheme"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+	"k8s.io/kubernetes/test/integration/framework"
+	stepsframework "k8s.io/kubernetes/test/integration/scheduler/podgroup/stepsframework"
+	testutil "k8s.io/kubernetes/test/integration/util"
+)
+
+type batchGetter interface {
+	TotalBatchedPods() int64
+}
+
+func newDefaultComponentConfig() (*config.KubeSchedulerConfiguration, error) {
+	gvk := kubeschedulerconfigv1.SchemeGroupVersion.WithKind("KubeSchedulerConfiguration")
+	cfg := config.KubeSchedulerConfiguration{}
+	_, _, err := kubeschedulerscheme.Codecs.UniversalDecoder().Decode(nil, &gvk, &cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Clear pod topo spread defaults.
+	profile := cfg.Profiles[0]
+	for _, cfg := range profile.PluginConfig {
+		if cfg.Name == names.PodTopologySpread {
+			tps := cfg.Args.(*config.PodTopologySpreadArgs)
+			tps.DefaultConstraints = []v1.TopologySpreadConstraint{}
+			tps.DefaultingType = config.ListDefaulting
+		}
+	}
+
+	return &cfg, nil
+}
+
+func initScheduler(t *testing.T, nsPrefix string) (*testutil.TestContext, batchGetter) {
+	cfg, err := newDefaultComponentConfig()
+	if err != nil {
+		t.Fatalf("Error creating default component config: %v", err)
+	}
+	testCtx := testutil.InitTestSchedulerWithNS(t, nsPrefix,
+		scheduler.WithProfiles(cfg.Profiles...),
+		scheduler.WithPodMaxBackoffSeconds(0),
+		scheduler.WithPodInitialBackoffSeconds(0),
+	)
+	getter := testCtx.Scheduler.Profiles["default-scheduler"].(batchGetter)
+	return testCtx, getter
+}
+
+func TestPodGroupBatching(t *testing.T) {
+	// Enable GenericWorkload feature gate.
+	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+		features.CompositePodGroup:               true,
+		features.GenericWorkload:                 true,
+		features.TopologyAwareWorkloadScheduling: true,
+	})
+
+	// Start scheduler once for all subtests.
+	testCtx, getter := initScheduler(t, "pg-batch-shared")
+
+	// Pre-create shared templates.
+	workload := st.MakeWorkload().Name("workload").
+		PodGroupTemplate(st.MakePodGroupTemplate().Name("pg-tmpl").MinCount(2).Obj()).
+		Obj()
+	pg := st.MakePodGroup().Name("pg1").WorkloadRef("pg-tmpl", "workload").
+		Priority(100).MinCount(2).Obj()
+
+	// Pre-create shared templates for CompositePodGroup hierarchy.
+	// We require 2 PodGroups each with 2 Pods so multiple pods with identical signatures
+	// are evaluated in the same scheduling cycle to trigger opportunistic batching.
+	cpgWorkload := st.MakeWorkload().Name("cpg-workload").
+		Children(
+			st.MakeCompositePodGroupTemplate().Name("root-tmpl").MinGroupCount(2).Priority(100).Children(
+				st.MakePodGroupTemplate().Name("pg-tmpl").MinCount(2).Priority(100),
+			),
+		).Obj()
+	cpg := st.MakeCompositePodGroup().Name("cpg1").WorkloadRef("cpg-workload", "root-tmpl").
+		MinGroupCount(2).Priority(100).Obj()
+	cpgPG1 := st.MakePodGroup().Name("cpg-pg1").WorkloadRef("cpg-workload", "pg-tmpl").
+		ParentCompositePodGroup("cpg1").Priority(100).MinCount(2).Obj()
+	cpgPG2 := st.MakePodGroup().Name("cpg-pg2").WorkloadRef("cpg-workload", "pg-tmpl").
+		ParentCompositePodGroup("cpg1").Priority(100).MinCount(2).Obj()
+
+	tests := []struct {
+		name  string
+		steps []stepsframework.Step
+	}{
+		{
+			name: "StaticSignature",
+			steps: []stepsframework.Step{
+				{
+					Name: "Create Nodes",
+					CreateNodes: []*v1.Node{
+						st.MakeNode().Name("static-node1").Label("forpod", "1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Obj(),
+						st.MakeNode().Name("static-node2").Label("forpod", "1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Obj(),
+					},
+				},
+				{
+					Name:            "Create Workload",
+					CreateWorkloads: []*schedulingapi.Workload{workload},
+				},
+				{
+					Name:           "Create PodGroup",
+					CreatePodGroup: pg,
+				},
+				{
+					Name: "Create Pods",
+					CreatePods: []*v1.Pod{
+						st.MakePod().Name("p1").PodGroupName("pg1").Priority(100).
+							NodeSelector(map[string]string{"forpod": "1"}).Req(map[v1.ResourceName]string{v1.ResourceCPU: "3"}).Obj(),
+						st.MakePod().Name("p2").PodGroupName("pg1").Priority(100).
+							NodeSelector(map[string]string{"forpod": "1"}).Req(map[v1.ResourceName]string{v1.ResourceCPU: "3"}).Obj(),
+					},
+				},
+				{
+					Name:                 "Wait for pods to schedule",
+					WaitForPodsScheduled: []string{"p1", "p2"},
+				},
+			},
+		},
+		{
+			name: "DynamicSignatureUpdate",
+			steps: []stepsframework.Step{
+				{
+					Name: "Create Tainted Nodes",
+					CreateNodes: []*v1.Node{
+						st.MakeNode().Name("dynamic-node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).
+							Taints([]v1.Taint{{Key: "dedicated", Value: "group1", Effect: v1.TaintEffectNoSchedule}}).Obj(),
+						st.MakeNode().Name("dynamic-node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).
+							Taints([]v1.Taint{{Key: "dedicated", Value: "group1", Effect: v1.TaintEffectNoSchedule}}).Obj(),
+					},
+				},
+				{
+					Name:            "Create Workload",
+					CreateWorkloads: []*schedulingapi.Workload{workload},
+				},
+				{
+					Name:           "Create PodGroup",
+					CreatePodGroup: pg,
+				},
+				{
+					Name: "Create Pods",
+					CreatePods: []*v1.Pod{
+						st.MakePod().Name("p1").PodGroupName("pg1").Priority(100).
+							Tolerations([]v1.Toleration{{Key: "dedicated", Operator: v1.TolerationOpEqual, Value: "group1", Effect: v1.TaintEffectNoSchedule}}).
+							Req(map[v1.ResourceName]string{v1.ResourceCPU: "3"}).Obj(),
+						st.MakePod().Name("p2").PodGroupName("pg1").Priority(100).
+							Req(map[v1.ResourceName]string{v1.ResourceCPU: "3"}).Obj(),
+					},
+				},
+				{
+					Name: "Update p2 tolerations",
+					UpdatePod: &stepsframework.UpdatePod{
+						PodName: "p2",
+						ModifyFn: func(p *v1.Pod) {
+							p.Spec.Tolerations = []v1.Toleration{{Key: "dedicated", Operator: v1.TolerationOpEqual, Value: "group1", Effect: v1.TaintEffectNoSchedule}}
+						},
+					},
+				},
+				{
+					Name:                 "Wait for pods to schedule",
+					WaitForPodsScheduled: []string{"p1", "p2"},
+				},
+			},
+		},
+		{
+			name: "CompositePodGroup",
+			steps: []stepsframework.Step{
+				{
+					Name: "Create Nodes",
+					CreateNodes: []*v1.Node{
+						st.MakeNode().Name("cpg-node1").Label("forpod", "cpg").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Obj(),
+						st.MakeNode().Name("cpg-node2").Label("forpod", "cpg").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Obj(),
+						st.MakeNode().Name("cpg-node3").Label("forpod", "cpg").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Obj(),
+						st.MakeNode().Name("cpg-node4").Label("forpod", "cpg").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Obj(),
+					},
+				},
+				{
+					Name:            "Create Workload",
+					CreateWorkloads: []*schedulingapi.Workload{cpgWorkload},
+				},
+				{
+					Name:                    "Create CompositePodGroup",
+					CreateCompositePodGroup: cpg,
+				},
+				{
+					Name:           "Create PodGroup 1",
+					CreatePodGroup: cpgPG1,
+				},
+				{
+					Name:           "Create PodGroup 2",
+					CreatePodGroup: cpgPG2,
+				},
+				{
+					Name: "Create Pods",
+					CreatePods: []*v1.Pod{
+						st.MakePod().Name("cpg-p1").PodGroupName("cpg-pg1").Priority(100).
+							NodeSelector(map[string]string{"forpod": "cpg"}).Req(map[v1.ResourceName]string{v1.ResourceCPU: "3"}).Obj(),
+						st.MakePod().Name("cpg-p2").PodGroupName("cpg-pg1").Priority(100).
+							NodeSelector(map[string]string{"forpod": "cpg"}).Req(map[v1.ResourceName]string{v1.ResourceCPU: "3"}).Obj(),
+						st.MakePod().Name("cpg-p3").PodGroupName("cpg-pg2").Priority(100).
+							NodeSelector(map[string]string{"forpod": "cpg"}).Req(map[v1.ResourceName]string{v1.ResourceCPU: "3"}).Obj(),
+						st.MakePod().Name("cpg-p4").PodGroupName("cpg-pg2").Priority(100).
+							NodeSelector(map[string]string{"forpod": "cpg"}).Req(map[v1.ResourceName]string{v1.ResourceCPU: "3"}).Obj(),
+					},
+				},
+				{
+					Name:                 "Wait for pods to schedule",
+					WaitForPodsScheduled: []string{"cpg-p1", "cpg-p2", "cpg-p3", "cpg-p4"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a unique namespace for this subtest.
+			nsObj := framework.CreateNamespaceOrDie(testCtx.ClientSet, strings.ToLower("subtest-"+tc.name), t)
+			ns := nsObj.Name
+
+			// Clean up nodes created in this subtest upon completion.
+			t.Cleanup(func() {
+				err := testCtx.ClientSet.CoreV1().Nodes().DeleteCollection(testCtx.Ctx, *metav1.NewDeleteOptions(0), metav1.ListOptions{})
+				if err != nil {
+					t.Errorf("Failed to clean up nodes: %v", err)
+				}
+			})
+
+			// Record baseline batched pods metric
+			prevBatched := getter.TotalBatchedPods()
+
+			// Run all steps defined in the test case
+			if err := stepsframework.RunSteps(testCtx, t, ns, tc.steps); err != nil {
+				t.Fatalf("Steps execution failed: %v", err)
+			}
+
+			// Verify that opportunistic batching cache was utilized
+			currBatched := getter.TotalBatchedPods()
+			if currBatched <= prevBatched {
+				t.Errorf("Expected TotalBatchedPods to increase (used opportunistic batching), but remained at %d", currBatched)
+			}
+		})
+	}
+}

--- a/test/integration/scheduler/podgroup/stepsframework/stepsframework.go
+++ b/test/integration/scheduler/podgroup/stepsframework/stepsframework.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/scheduler/backend/queue"
 	testutils "k8s.io/kubernetes/test/integration/util"
@@ -451,12 +452,15 @@ func deletePods(testCtx *testutils.TestContext, ns string, podNames []string) er
 
 func updatePod(testCtx *testutils.TestContext, ns string, update *UpdatePod) error {
 	cs := testCtx.ClientSet
-	p, err := cs.CoreV1().Pods(ns).Get(testCtx.Ctx, update.PodName, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to get pod %s for update: %w", update.PodName, err)
-	}
-	update.ModifyFn(p)
-	_, err = cs.CoreV1().Pods(ns).Update(testCtx.Ctx, p, metav1.UpdateOptions{})
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		p, err := cs.CoreV1().Pods(ns).Get(testCtx.Ctx, update.PodName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		update.ModifyFn(p)
+		_, err = cs.CoreV1().Pods(ns).Update(testCtx.Ctx, p, metav1.UpdateOptions{})
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("failed to update pod %s: %w", update.PodName, err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds grouping pods in to sub-groups related to signature. It is allowing podGroups to efficiently use opportunistic batching.
This PR was written in part with the assistance of generative AI,
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #140354
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added sorting pods by signature for podGroup to allow Opportunistic Batching
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
-[KEP]: https://github.com/kubernetes/enhancements/blob/15ecef0909db27c649cdc3dc4d4e927354108dd1/keps/sig-scheduling/4671-gang-scheduling/README.md?plain=1#L1158-L1165
```

/sig scheduling
/wg workload-aware-scheduling