### PR TITLE
kubectl explain: change keyword in long description from parentheses to uppercase

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain.go
@@ -40,7 +40,7 @@ var (
 		This command describes the fields associated with each supported API resource.
 		Fields are identified via a simple JSONPath identifier:
 
-			<type>.<fieldName>[.<fieldName>]
+			TYPE.FIELDNAME[.FIELDNAME]
 
 		Information about each field is retrieved from the server in OpenAPI format.`))
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

https://kubernetes.io/docs/reference/kubectl/generated/kubectl_explain/

description in generated file escaped in code block is not rendered because it is inside of `<code>` block
change Its parentheses to uppercase like description of other command. (e.g, kubectl autoscale https://kubernetes.io/docs/reference/kubectl/generated/kubectl_autoscale/)

from
<img width="642" height="236" alt="image" src="https://github.com/user-attachments/assets/c03cdea8-4b08-43c2-90d0-1227e4a8ce18" />

results 
<img width="637" height="229" alt="image" src="https://github.com/user-attachments/assets/7fdc8917-7a69-4d5f-81f9-8edfbce52e1b" />


#### Which issue(s) this PR is related to:

issue link: https://github.com/kubernetes/website/issues/54776 

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```
kubectl explain: long description updated for better docs. consistent with other command.
```
