### PR TITLE
Update CSI sidecar images in e2e test manifests

### DIFF
--- a/test/e2e/testing-manifests/storage-csi/external-snapshotter/volume-group-snapshots/csi-hostpath-plugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/external-snapshotter/volume-group-snapshots/csi-hostpath-plugin.yaml
@@ -353,7 +353,7 @@ spec:
               name: socket-dir
 
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v2.2.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v2.2.1
           args:
             - -v=5
             - -csi-address=/csi/csi.sock

--- a/test/e2e/testing-manifests/storage-csi/external-snapshotter/volume-group-snapshots/csi-hostpath-plugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/external-snapshotter/volume-group-snapshots/csi-hostpath-plugin.yaml
@@ -219,7 +219,7 @@ spec:
       serviceAccountName: csi-hostpathplugin-sa
       containers:
         - name: hostpath
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.17.1
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.18.0
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"

--- a/test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss.yaml
+++ b/test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss.yaml
@@ -102,7 +102,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v2.2.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v2.2.1
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
@@ -372,7 +372,7 @@ spec:
               name: socket-dir
 
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v2.2.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v2.2.1
           args:
             - -v=5
             - -csi-address=/csi/csi.sock
@@ -400,7 +400,7 @@ spec:
               name: socket-dir
 
         - name: csi-snapshot-metadata
-          image: registry.k8s.io/sig-storage/csi-snapshot-metadata:v1.0.0
+          image: registry.k8s.io/sig-storage/csi-snapshot-metadata:v1.1.0
           imagePullPolicy: IfNotPresent
           args:
           - --csi-address=/csi/csi.sock

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
@@ -237,7 +237,7 @@ spec:
       serviceAccountName: csi-hostpathplugin-sa
       containers:
         - name: hostpath
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.17.1
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.18.0
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-testing.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-testing.yaml
@@ -66,7 +66,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
         - name: socat
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.17.1
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.18.0
           command:
           - socat
           args:

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-resizer.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-resizer.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: csi-mock
       containers:
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v2.2.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v2.2.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver.yaml
@@ -66,7 +66,7 @@ spec:
           - mountPath: /registration
             name: registration-dir
         - name: mock
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.17.1
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.18.0
           args:
             - "--drivername=mock.storage.k8s.io"
             - "--nodeid=$(KUBE_NODE_NAME)"

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-proxy.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-proxy.yaml
@@ -66,7 +66,7 @@ spec:
           - mountPath: /registration
             name: registration-dir
         - name: mock
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.17.1
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.18.0
           args:
             - -v=5
             - -nodeid=$(KUBE_NODE_NAME)


### PR DESCRIPTION
## What this does

Updates csi-resizer and csi-snapshot-metadata sidecar container images to
their latest stable releases across the e2e test manifests:

- csi-resizer:           v2.2.0 -> v2.2.1
- csi-snapshot-metadata: v1.0.0 -> v1.1.0
- hostpathplugin v1.17.1 -> v1.18.0

All other tracked sidecar images (csi-provisioner, csi-attacher,
csi-snapshotter, csi-node-driver-registrar, livenessprobe,
csi-external-health-monitor-controller, hostpathplugin) are already at
their latest stable release and are left unchanged. No cluster/addons
changes are included since snapshot-controller is already current
(v8.6.0).

## Affected files

- `test/e2e/testing-manifests/storage-csi/external-snapshotter/volume-group-snapshots/csi-hostpath-plugin.yaml`
- `test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss.yaml`
- `test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml`
- `test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-resizer.yaml`

/kind cleanup
/sig storage
/area test
/priority important-soon

```release-note
NONE
```

```docs
NONE
```