### PR TITLE
WIP: AI generated nftables change to use a single map

### DIFF
--- a/pkg/proxy/nftables/helpers_test.go
+++ b/pkg/proxy/nftables/helpers_test.go
@@ -275,6 +275,11 @@ var endpointVMapEntryRegexp = regexp.MustCompile(`\d+ : goto (\S+)`)
 var endpointDNATRegexp = regexp.MustCompile(`^dnat ip6* addr \. port to numgen random mod \d+ map \{(.*)\}$`)
 var endpointDNATEntryRegexp = regexp.MustCompile(`\d+ : (\S+) \. (\d+)`)
 
+// Shared "lb-N-endpoints" bucket chains: a concrete l4proto match (handled by
+// l4protoRegexp) followed by a DNAT that looks up the per-protocol endpoints
+// map by "destIP . destPort . slot".
+var endpointsMapDNATRegexp = regexp.MustCompile(`^dnat ip6* addr \. port to ip6* daddr \. (?:tcp|udp|sctp) dport \. numgen random mod \d+ map @(\S+)$`)
+
 var masqMarkRegexp = regexp.MustCompile(`^mark set mark or 0x[[:xdigit:]]+$`)
 var masqCheckRegexp = regexp.MustCompile(`^mark and 0x[[:xdigit:]]+ != 0 mark set mark xor 0x[[:xdigit:]]+`)
 var masqueradeRegexp = regexp.MustCompile(`^masquerade fully-random$`)
@@ -568,6 +573,24 @@ func (tracer *nftablesTracer) runChain(chname, sourceIP, protocol, destIP, destP
 
 					tracer.matches = append(tracer.matches, ruleObj.Rule)
 					tracer.outputs = append(tracer.outputs, net.JoinHostPort(endpointIP, endpointPort))
+				}
+				return true
+
+			case endpointsMapDNATRegexp.MatchString(rule):
+				// `^dnat ip6* addr \. port to ip6* daddr \. (tcp|udp|sctp) dport \. numgen random mod N map @(\S+)$`
+				// Used by the shared bucket chains: looks up
+				// "destIP . destPort . slot" in the per-protocol endpoints map
+				// (the protocol is encoded in the map name and already matched
+				// by the preceding "meta l4proto" guard) and DNATs to the
+				// result. For tracePacket's purposes, we DNAT to *all* of this
+				// service's endpoints in the map.
+				match := endpointsMapDNATRegexp.FindStringSubmatch(rule)
+				mapName := match[1]
+				for _, element := range tracer.nft.Table.Maps[mapName].Elements {
+					if element.Key[0] == destIP && element.Key[1] == destPort {
+						tracer.matches = append(tracer.matches, ruleObj.Rule)
+						tracer.outputs = append(tracer.outputs, net.JoinHostPort(element.Value[0], element.Value[1]))
+					}
 				}
 				return true
 

--- a/pkg/proxy/nftables/helpers_test.go
+++ b/pkg/proxy/nftables/helpers_test.go
@@ -276,6 +276,11 @@ var endpointDNATRegexp = regexp.MustCompile(`^dnat ip6* addr \. port to numgen r
 var endpointDNATEntryRegexp = regexp.MustCompile(`\d+ : (\S+) \. (\d+)`)
 var singleEndpointDNATRegexp = regexp.MustCompile(`^dnat ip6* addr \. port to (\S+) \. (\d+)$`)
 
+// Shared "dispatch-N" bucket chains: store a random slot in the
+// conntrack mark, then DNAT via the shared endpoints map keyed by
+// "destIP . protocol . destPort . mark".
+var endpointsMapDNATRegexp = regexp.MustCompile(`^ct mark set numgen random mod \d+ dnat ip6* addr \. port to ip6* daddr \. meta l4proto \. th dport \. ct mark map @(\S+)$`)
+
 var masqMarkRegexp = regexp.MustCompile(`^mark set mark or 0x[[:xdigit:]]+$`)
 var masqCheckRegexp = regexp.MustCompile(`^mark and 0x[[:xdigit:]]+ != 0 mark set mark xor 0x[[:xdigit:]]+`)
 var masqueradeRegexp = regexp.MustCompile(`^masquerade fully-random$`)
@@ -569,6 +574,22 @@ func (tracer *nftablesTracer) runChain(chname, sourceIP, protocol, destIP, destP
 
 					tracer.matches = append(tracer.matches, ruleObj.Rule)
 					tracer.outputs = append(tracer.outputs, net.JoinHostPort(endpointIP, endpointPort))
+				}
+				return true
+
+			case endpointsMapDNATRegexp.MatchString(rule):
+				// `^ct mark set numgen random mod \d+ dnat ip6* addr \. port to ip6* daddr \. meta l4proto \. th dport \. ct mark map @(\S+)$`
+				// Used by the shared bucket chains: looks up
+				// "destIP . protocol . destPort . slot" in the shared endpoints
+				// map and DNATs to the result. For tracePacket's purposes, we
+				// DNAT to *all* of this service's endpoints in the map.
+				match := endpointsMapDNATRegexp.FindStringSubmatch(rule)
+				mapName := match[1]
+				for _, element := range tracer.nft.Table.Maps[mapName].Elements {
+					if element.Key[0] == destIP && element.Key[1] == protocol && element.Key[2] == destPort {
+						tracer.matches = append(tracer.matches, ruleObj.Rule)
+						tracer.outputs = append(tracer.outputs, net.JoinHostPort(element.Value[0], element.Value[1]))
+					}
 				}
 				return true
 

--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -73,6 +73,14 @@ const (
 	serviceIPsMap       = "service-ips"
 	serviceNodePortsMap = "service-nodeports"
 
+	// shared load-balancing for eligible (plain ClusterIP, non-affinity,
+	// cluster-policy) services: per-protocol endpoints maps keyed by
+	// "clusterIP . port . slot", looked up from per-endpoint-count
+	// "lb-N-endpoints" bucket chains. This lets many services share a handful
+	// of chains instead of one bespoke chain each. There is one map per
+	// protocol (see endpointsMapName).
+	endpointsMapPrefix = "endpoints-"
+
 	// set of IPs that accept NodePort traffic
 	nodePortIPsSet = "nodeport-ips"
 
@@ -193,6 +201,9 @@ type Proxier struct {
 	noEndpointNodePorts *nftElementStorage
 	serviceNodePorts    *nftElementStorage
 	hairpinConnections  *nftElementStorage
+	// endpoints holds the per-protocol shared endpoints maps, keyed by the
+	// lowercase protocol name (see bucketProtocols / endpointsMapName).
+	endpoints map[string]*nftElementStorage
 }
 
 // Proxier implements proxy.Provider
@@ -263,6 +274,7 @@ func NewProxier(ctx context.Context,
 		noEndpointNodePorts: newNFTElementStorage("map", noEndpointNodePortsMap),
 		serviceNodePorts:    newNFTElementStorage("map", serviceNodePortsMap),
 		hairpinConnections:  newNFTElementStorage("set", hairpinConnectionsSet),
+		endpoints:           newEndpointsStorage(),
 	}
 
 	logger.V(2).Info("NFTables sync params", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod, "maxSyncPeriod", proxyutil.FullSyncPeriod)
@@ -626,6 +638,32 @@ func (proxier *Proxier) setupNFTables(tx *knftables.Transaction) {
 		Comment: ptr.To("NodePort traffic"),
 	})
 
+	// Per-protocol endpoints maps shared by all eligible (plain ClusterIP,
+	// non-affinity, cluster-policy) services. Each is keyed by the service tuple
+	// plus a slot index ("clusterIP . port . slot"); the value is the endpoint
+	// "ip . port". The lb-N-endpoints bucket chains generate the slot.
+	//
+	// The key/value are declared with "typeof" rather than "type" because the
+	// slot is produced by "numgen", whose datatype is a variable-sized integer
+	// that nftables refuses to put in a concatenation via a plain "type"
+	// declaration. "typeof" captures numgen's concrete fixed-width type. The
+	// "mod 2" is arbitrary; it only defines the slot field's type, not its
+	// range (any modulus yields the same type, and slots scale to large values).
+	//
+	// There is one map per protocol, each pinning a concrete "<proto> dport",
+	// rather than a single map keyed by the generic "meta l4proto . th dport".
+	// A generic key resolves fine when the map and its referencing rule are in
+	// the same transaction, but once the map is committed a bucket rule added in
+	// a later sync transaction fails with "conflicting protocols specified: tcp
+	// vs. th". Pinning the protocol bakes a definite type into the committed map.
+	for _, protocol := range bucketProtocols {
+		tx.Add(&knftables.Map{
+			Name:    endpointsMapName(protocol),
+			TypeOf:  ipX + " daddr . " + protocol + " dport . numgen random mod 2 : " + ipX + " daddr . " + protocol + " dport",
+			Comment: new("endpoints for " + protocol + " services using shared load-balancing buckets"),
+		})
+	}
+
 	if proxier.masqueradeAll {
 		tx.Add(&knftables.Rule{
 			Chain: servicesChain,
@@ -688,6 +726,9 @@ func (proxier *Proxier) setupNFTables(tx *knftables.Transaction) {
 	proxier.noEndpointNodePorts.readOrReset(tx, proxier.nftables, proxier.logger)
 	proxier.serviceNodePorts.readOrReset(tx, proxier.nftables, proxier.logger)
 	proxier.hairpinConnections.readOrReset(tx, proxier.nftables, proxier.logger)
+	for _, protocol := range bucketProtocols {
+		proxier.endpoints[protocol].readOrReset(tx, proxier.nftables, proxier.logger)
+	}
 }
 
 // Sync is called to synchronize the proxier state to nftables as soon as possible.
@@ -838,7 +879,46 @@ const (
 	servicePortEndpointChainNamePrefix      = "endpoint-"
 	servicePortEndpointAffinityNamePrefix   = "affinity-"
 	servicePortFirewallChainNamePrefix      = "firewall-"
+	// lbBucketChainNamePrefix is the prefix for the shared per-endpoint-count
+	// bucket chains, e.g. "lb-3-endpoints".
+	lbBucketChainNamePrefix = "lb-"
 )
+
+// lbBucketChainName returns the name of the shared bucket chain for services
+// with the given number of endpoints, e.g. "lb-3-endpoints".
+func lbBucketChainName(numEndpoints int) string {
+	return fmt.Sprintf("%s%d-endpoints", lbBucketChainNamePrefix, numEndpoints)
+}
+
+func isBucketChainName(chainString string) bool {
+	return strings.HasPrefix(chainString, lbBucketChainNamePrefix)
+}
+
+// bucketProtocols are the transport protocols that have a dedicated endpoints
+// map. There is a separate map per protocol because nftables bakes a concrete
+// transport protocol into a "typeof ... <proto> dport ..." map's committed key
+// type. A generic "meta l4proto . th dport" key works when the map and its
+// referencing rule are created in the same transaction, but once the map is
+// committed, a rule added in a later transaction (the normal incremental sync
+// case) fails to resolve the generic transport-header protocol context with
+// "conflicting protocols specified: tcp vs. th". Pinning the protocol avoids
+// that. The values are the lowercase v1.Protocol names.
+var bucketProtocols = []string{"tcp", "udp", "sctp"}
+
+// endpointsMapName returns the name of the shared endpoints map for the given
+// (lowercase) protocol, e.g. "endpoints-tcp".
+func endpointsMapName(protocol string) string {
+	return endpointsMapPrefix + protocol
+}
+
+// newEndpointsStorage builds the per-protocol endpoints element storage.
+func newEndpointsStorage() map[string]*nftElementStorage {
+	storage := make(map[string]*nftElementStorage, len(bucketProtocols))
+	for _, protocol := range bucketProtocols {
+		storage[protocol] = newNFTElementStorage("map", endpointsMapName(protocol))
+	}
+	return storage
+}
 
 // hashAndTruncate prefixes name with a hash of itself and then truncates to
 // chainNameBaseLengthMax. The hash ensures that (a) the name is still unique if we have
@@ -1246,6 +1326,20 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		// clusterPolicyChain contains the endpoints used with "Cluster" traffic policy
 		clusterPolicyChain := svcInfo.clusterPolicyChainName
 		usesClusterPolicyChain := len(clusterEndpoints) > 0 && svcInfo.UsesClusterEndpoints()
+
+		// Eligible services are load-balanced through a shared
+		// "lb-N-endpoints" bucket chain and the global endpoints map instead of
+		// a bespoke per-service chain. A service is eligible when its internal
+		// (ClusterIP) traffic uses the cluster policy, it has no session
+		// affinity, and it has no external access (NodePort/ExternalIP/LB).
+		// Those restrictions guarantee that the bucket's "ip daddr"-keyed lookup
+		// always resolves to the right service.
+		useBucket := usesClusterPolicyChain && !serviceUsesAffinity &&
+			!svcInfo.InternalPolicyLocal() && !svcInfo.ExternallyAccessible()
+		if useBucket {
+			// The bucket chain replaces the per-service cluster policy chain.
+			usesClusterPolicyChain = false
+		}
 		if usesClusterPolicyChain {
 			ensureChain(clusterPolicyChain, tx, activeChains, skipServiceUpdate)
 		}
@@ -1272,6 +1366,11 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 			}
 		}
 		internalTrafficChain := internalPolicyChain
+		if useBucket {
+			// Route internal traffic to the shared bucket chain for this
+			// service's endpoint count instead of a per-service chain.
+			internalTrafficChain = proxier.ensureBucketChain(tx, len(clusterEndpoints), activeChains, existingChains, doFullSync)
+		}
 
 		// Similarly, externalPolicyChain is the chain containing the endpoints
 		// for "external" (NodePort, LoadBalancer, and ExternalIP) traffic.
@@ -1343,6 +1442,11 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 					fmt.Sprintf("goto %s", internalTrafficChain),
 				},
 			})
+			if useBucket {
+				// Populate the global endpoints map with this service's
+				// endpoints; the bucket chain selects one by slot at runtime.
+				proxier.ensureBucketEndpoints(tx, svcInfo, protocol, clusterEndpoints)
+			}
 		} else {
 			// No endpoints.
 			proxier.noEndpointServices.ensureElem(tx, &knftables.Element{
@@ -1682,7 +1786,7 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 	// now, and record the time that they become stale in staleChains so they can be
 	// deleted later.
 	for chain := range existingChains {
-		if isServiceChainName(chain) {
+		if isServiceChainName(chain) || isBucketChainName(chain) {
 			if !activeChains.Has(chain) {
 				tx.Flush(&knftables.Chain{
 					Name: chain,
@@ -1710,6 +1814,9 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 	proxier.noEndpointNodePorts.cleanupLeftoverKeys(tx)
 	proxier.serviceNodePorts.cleanupLeftoverKeys(tx)
 	proxier.hairpinConnections.cleanupLeftoverKeys(tx)
+	for _, protocol := range bucketProtocols {
+		proxier.endpoints[protocol].cleanupLeftoverKeys(tx)
+	}
 
 	// Sync rules.
 	proxier.logger.V(2).Info("Reloading service nftables data",
@@ -1766,6 +1873,93 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap)
 	}
 	return
+}
+
+// ensureBucketChain ensures that the shared "lb-N-endpoints" bucket chain for
+// services with numEndpoints endpoints exists and contains its single
+// endpoints-map lookup rule, and returns its name. Multiple eligible services
+// with the same endpoint count share one bucket chain. The chain is tracked in
+// activeChains like other dynamic chains so it can be garbage-collected once no
+// service references it. When numEndpoints is new this sync, every service at
+// that count has changed (so skipCreation is false for the first caller), which
+// guarantees the rule is written whenever the chain is (re)created.
+func (proxier *Proxier) ensureBucketChain(tx *knftables.Transaction, numEndpoints int, activeChains, existingChains sets.Set[string], doFullSync bool) string {
+	chain := lbBucketChainName(numEndpoints)
+	if activeChains.Has(chain) {
+		return chain
+	}
+	activeChains.Insert(chain)
+
+	// A bucket chain's rule is fully determined by numEndpoints (encoded in the
+	// chain name), so it never needs rewriting once created. Skip recreation
+	// unless this is a full resync, the chain doesn't exist yet, or it was
+	// flushed (i.e. is stale) and needs its rule restored. Gating on chain
+	// existence rather than per-service dirtiness keeps the transaction
+	// deterministic regardless of service processing order.
+	_, isStale := proxier.staleChains[chain]
+	if !doFullSync && existingChains.Has(chain) && !isStale {
+		return chain
+	}
+
+	ipX := "ip"
+	if proxier.ipFamily == v1.IPv6Protocol {
+		ipX = "ip6"
+	}
+
+	tx.Add(&knftables.Chain{Name: chain})
+	tx.Flush(&knftables.Chain{Name: chain})
+
+	// One DNAT rule per protocol, each pinning its concrete protocol and looking
+	// up the matching per-protocol endpoints map (see bucketProtocols for why
+	// the maps are split by protocol). Only the rule matching the packet's
+	// protocol fires; the others are no-ops for that packet.
+	//
+	// slot selects which endpoint to use, generated at runtime. We always use
+	// "numgen random mod N" (even for N==1, which always yields 0): a bare
+	// integer literal has no type in a rule concatenation and nftables rejects
+	// it, whereas numgen provides the concrete integer type the map expects.
+	for _, protocol := range bucketProtocols {
+		tx.Add(&knftables.Rule{
+			Chain: chain,
+			Rule: knftables.Concat(
+				"meta l4proto", protocol,
+				"dnat", ipX, "addr . port to",
+				ipX, "daddr", ".", protocol+" dport", ".",
+				"numgen", "random", "mod", strconv.Itoa(numEndpoints),
+				"map", "@", endpointsMapName(protocol),
+			),
+		})
+	}
+	return chain
+}
+
+// ensureBucketEndpoints adds this service's endpoints to the per-protocol
+// endpoints map, keyed by "clusterIP . port . slot". The bucket chain for
+// len(endpoints) generates the slot at runtime to select one of them.
+func (proxier *Proxier) ensureBucketEndpoints(tx *knftables.Transaction, svcInfo *servicePortInfo, protocol string, endpoints []proxy.Endpoint) {
+	clusterIP := svcInfo.ClusterIP().String()
+	port := strconv.Itoa(svcInfo.Port())
+	storage := proxier.endpoints[protocol]
+	mapName := endpointsMapName(protocol)
+	for i, ep := range endpoints {
+		epInfo, ok := ep.(*endpointInfo)
+		if !ok {
+			proxier.logger.Error(nil, "Failed to cast endpointInfo", "endpointInfo", ep)
+			continue
+		}
+		storage.ensureElem(tx, &knftables.Element{
+			Map: mapName,
+			Key: []string{
+				clusterIP,
+				port,
+				strconv.Itoa(i),
+			},
+			Value: []string{
+				epInfo.IP(),
+				strconv.Itoa(epInfo.Port()),
+			},
+		})
+	}
 }
 
 func (proxier *Proxier) writeServiceToEndpointDNATs(tx *knftables.Transaction, svcInfo *servicePortInfo, svcChain string, endpoints []proxy.Endpoint) {

--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -76,6 +76,7 @@ const (
 	servicesChain       = "services"
 	serviceIPsMap       = "service-ips"
 	serviceNodePortsMap = "service-nodeports"
+	sharedEndpointsMap  = "endpoints"
 
 	// set of IPs that accept NodePort traffic
 	nodePortIPsSet = "nodeport-ips"
@@ -180,6 +181,11 @@ type Proxier struct {
 	nodeName       string
 	nodeIP         net.IP
 
+	// prepopulatedBucketChains is the number of shared "dispatch-N" bucket
+	// chains (dispatch-1 through dispatch-N) that are pre-created at setup time
+	// and exempt from garbage collection.
+	prepopulatedBucketChains int
+
 	serviceHealthServer healthcheck.ServiceHealthServer
 	healthzServer       *healthcheck.ProxyHealthServer
 
@@ -206,6 +212,7 @@ type Proxier struct {
 	noEndpointNodePorts *nftElementStorage
 	serviceNodePorts    *nftElementStorage
 	hairpinConnections  *nftElementStorage
+	endpoints           *nftElementStorage
 
 	// localhostNodePortRejects holds the (proto . port) keys of localhost NodePorts
 	// that kube-proxy rejects rather than serving.
@@ -278,6 +285,7 @@ func NewProxier(ctx context.Context,
 		nodePortAddresses:        nodePortAddresses,
 		networkInterfacer:        proxyutil.RealNetwork{},
 		staleChains:              make(map[string]time.Time),
+		prepopulatedBucketChains: defaultPrepopulatedBucketChains,
 		logger:                   logger,
 		logRateLimiter:           rate.NewLimiter(rate.Every(24*time.Hour), 1),
 		clusterIPs:               newNFTElementStorage("set", clusterIPsSet),
@@ -287,6 +295,7 @@ func NewProxier(ctx context.Context,
 		noEndpointNodePorts:      newNFTElementStorage("map", noEndpointNodePortsMap),
 		serviceNodePorts:         newNFTElementStorage("map", serviceNodePortsMap),
 		hairpinConnections:       newNFTElementStorage("set", hairpinConnectionsSet),
+		endpoints:                newNFTElementStorage("map", sharedEndpointsMap),
 		localhostNodePortRejects: newNFTElementStorage("map", localhostNodePortRejectMap),
 	}
 
@@ -732,6 +741,18 @@ func (proxier *Proxier) setupNFTables(tx *knftables.Transaction) {
 		Comment: ptr.To("NodePort traffic"),
 	})
 
+	tx.Add(&knftables.Map{
+		Name:    sharedEndpointsMap,
+		Type:    ipvX_addr + " . inet_proto . inet_service . mark : " + ipvX_addr + " . inet_service",
+		Comment: new("endpoints for services using shared buckets"),
+	})
+
+	// Pre-create the bucket chains for the most common endpoint counts so that
+	// partial syncs rarely need to create one.
+	for n := 1; n <= proxier.prepopulatedBucketChains; n++ {
+		proxier.addBucketChain(tx, n)
+	}
+
 	if proxier.masqueradeAll {
 		tx.Add(&knftables.Rule{
 			Chain: servicesChain,
@@ -794,6 +815,7 @@ func (proxier *Proxier) setupNFTables(tx *knftables.Transaction) {
 	proxier.noEndpointNodePorts.readOrReset(tx, proxier.nftables, proxier.logger)
 	proxier.serviceNodePorts.readOrReset(tx, proxier.nftables, proxier.logger)
 	proxier.hairpinConnections.readOrReset(tx, proxier.nftables, proxier.logger)
+	proxier.endpoints.readOrReset(tx, proxier.nftables, proxier.logger)
 	if proxier.localhostNodePortsEnabled {
 		proxier.localhostNodePortRejects.readOrReset(tx, proxier.nftables, proxier.logger)
 	}
@@ -947,7 +969,33 @@ const (
 	servicePortEndpointChainNamePrefix      = "endpoint-"
 	servicePortEndpointAffinityNamePrefix   = "affinity-"
 	servicePortFirewallChainNamePrefix      = "firewall-"
+	serviceDispatchChainNamePrefix          = "dispatch-"
 )
+
+// defaultPrepopulatedBucketChains is how many shared "dispatch-N" bucket chains
+// (dispatch-1 through dispatch-N) are pre-created at setup time, covering the
+// most common endpoint counts so partial syncs rarely need to create one.
+const defaultPrepopulatedBucketChains = 10
+
+// numEndpointsChainName returns the name of the shared bucket chain for services
+// with the given number of endpoints, e.g. "dispatch-3".
+func numEndpointsChainName(numEndpoints int) string {
+	return fmt.Sprintf("%s%d", serviceDispatchChainNamePrefix, numEndpoints)
+}
+
+// dispatchChainNumEndpoints returns the endpoint count N encoded in a
+// "dispatch-N" bucket chain name, or false if chainString is not one.
+func dispatchChainNumEndpoints(chainString string) (int, bool) {
+	numStr, ok := strings.CutPrefix(chainString, serviceDispatchChainNamePrefix)
+	if !ok {
+		return 0, false
+	}
+	n, err := strconv.Atoi(numStr)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
 
 // hashAndTruncate prefixes name with a hash of itself and then truncates to
 // chainNameBaseLengthMax. The hash ensures that (a) the name is still unique if we have
@@ -1361,6 +1409,20 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		// clusterPolicyChain contains the endpoints used with "Cluster" traffic policy
 		clusterPolicyChain := svcInfo.clusterPolicyChainName
 		usesClusterPolicyChain := len(clusterEndpoints) > 0 && svcInfo.UsesClusterEndpoints()
+
+		// Eligible services are routed through a shared
+		// "dispatch-N" bucket chain and the global endpoints map instead of
+		// a bespoke per-service chain. A service is eligible when its internal
+		// (ClusterIP) traffic uses the cluster policy, it has no session
+		// affinity, and it has no external access (NodePort/ExternalIP/LB).
+		// Those restrictions guarantee that the bucket's "ip daddr"-keyed lookup
+		// always resolves to the right service.
+		useBucket := usesClusterPolicyChain && !serviceUsesAffinity &&
+			!svcInfo.InternalPolicyLocal() && !svcInfo.ExternallyAccessible()
+		if useBucket {
+			// The bucket chain replaces the per-service cluster policy chain.
+			usesClusterPolicyChain = false
+		}
 		if usesClusterPolicyChain {
 			ensureChain(clusterPolicyChain, tx, activeChains, skipServiceUpdate)
 		}
@@ -1387,6 +1449,11 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 			}
 		}
 		internalTrafficChain := internalPolicyChain
+		if useBucket {
+			// Route internal traffic to the shared bucket chain for this
+			// service's endpoint count instead of a per-service chain.
+			internalTrafficChain = proxier.ensureBucketChain(tx, len(clusterEndpoints), activeChains, existingChains, doFullSync)
+		}
 
 		// Similarly, externalPolicyChain is the chain containing the endpoints
 		// for "external" (NodePort, LoadBalancer, and ExternalIP) traffic.
@@ -1458,6 +1525,11 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 					fmt.Sprintf("goto %s", internalTrafficChain),
 				},
 			})
+			if useBucket {
+				// Populate the global endpoints map with this service's
+				// endpoints; the bucket chain selects one by slot at runtime.
+				proxier.ensureBucketEndpoints(tx, svcInfo, protocol, clusterEndpoints)
+			}
 		} else {
 			// No endpoints.
 			proxier.noEndpointServices.ensureElem(tx, &knftables.Element{
@@ -1827,15 +1899,20 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 	// now, and record the time that they become stale in staleChains so they can be
 	// deleted later.
 	for chain := range existingChains {
-		if isServiceChainName(chain) {
-			if !activeChains.Has(chain) {
-				tx.Flush(&knftables.Chain{
-					Name: chain,
-				})
-				proxier.staleChains[chain] = start
-			} else {
-				delete(proxier.staleChains, chain)
-			}
+		keep := activeChains.Has(chain)
+		if n, isDispatch := dispatchChainNumEndpoints(chain); isDispatch {
+			// Pre-populated bucket chains are part of the base setup; never GC them.
+			keep = keep || n <= proxier.prepopulatedBucketChains
+		} else if !isServiceChainName(chain) {
+			continue
+		}
+		if !keep {
+			tx.Flush(&knftables.Chain{
+				Name: chain,
+			})
+			proxier.staleChains[chain] = start
+		} else {
+			delete(proxier.staleChains, chain)
 		}
 	}
 
@@ -1855,6 +1932,7 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 	proxier.noEndpointNodePorts.cleanupLeftoverKeys(tx)
 	proxier.serviceNodePorts.cleanupLeftoverKeys(tx)
 	proxier.hairpinConnections.cleanupLeftoverKeys(tx)
+	proxier.endpoints.cleanupLeftoverKeys(tx)
 	if proxier.localhostNodePortsEnabled {
 		proxier.localhostNodePortRejects.cleanupLeftoverKeys(tx)
 	}
@@ -1918,6 +1996,104 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap, serviceUpdateResult.DeletedServices)
 	}
 	return
+}
+
+// ensureBucketChain ensures that the shared "dispatch-N" bucket chain for
+// services with numEndpoints endpoints exists and contains its single
+// endpoints-map lookup rule, and returns its name. Multiple eligible services
+// with the same endpoint count share one bucket chain. Chains up to
+// proxier.prepopulatedBucketChains are written by setupNFTables and never
+// garbage-collected; the rest are tracked in activeChains like other dynamic
+// chains so they can be garbage-collected once no service references them.
+func (proxier *Proxier) ensureBucketChain(tx *knftables.Transaction, numEndpoints int, activeChains, existingChains sets.Set[string], doFullSync bool) string {
+	chain := numEndpointsChainName(numEndpoints)
+	if activeChains.Has(chain) {
+		return chain
+	}
+	activeChains.Insert(chain)
+
+	// On a full sync, setupNFTables already wrote the pre-populated chains to
+	// this transaction.
+	if doFullSync && numEndpoints <= proxier.prepopulatedBucketChains {
+		return chain
+	}
+
+	// A bucket chain's rule is fully determined by numEndpoints (encoded in the
+	// chain name), so it never needs rewriting once created. Skip recreation
+	// unless this is a full resync, the chain doesn't exist yet, or it was
+	// flushed (i.e. is stale) and needs its rule restored. Gating on chain
+	// existence rather than per-service dirtiness keeps the transaction
+	// deterministic regardless of service processing order.
+	_, isStale := proxier.staleChains[chain]
+	if !doFullSync && existingChains.Has(chain) && !isStale {
+		return chain
+	}
+
+	proxier.addBucketChain(tx, numEndpoints)
+	return chain
+}
+
+// addBucketChain writes the "dispatch-numEndpoints" bucket chain and its single
+// endpoints-map lookup rule to tx, flushing any previous contents.
+func (proxier *Proxier) addBucketChain(tx *knftables.Transaction, numEndpoints int) {
+	chain := numEndpointsChainName(numEndpoints)
+
+	ipX := "ip"
+	if proxier.ipFamily == v1.IPv6Protocol {
+		ipX = "ip6"
+	}
+
+	tx.Add(&knftables.Chain{Name: chain})
+	tx.Flush(&knftables.Chain{Name: chain})
+
+	// A single DNAT rule for all protocols; the packet's protocol is part of
+	// the endpoints map key ("meta l4proto"), so only elements for the right
+	// protocol can match, and a lookup miss means no DNAT.
+	//
+	// The slot is generated by storing "numgen random mod N" (even for N==1,
+	// which always yields 0) into the conntrack mark and using "ct mark" in
+	// the lookup key: numgen's bare-integer datatype can't be used directly in
+	// a concatenation against the map's mark-typed slot field, but routing it
+	// through the ct mark gives it the mark datatype without clobbering the
+	// packet mark (and thus the masquerade bit set in the services chain).
+	tx.Add(&knftables.Rule{
+		Chain: chain,
+		Rule: knftables.Concat(
+			"ct mark set numgen random mod", strconv.Itoa(numEndpoints),
+			"dnat", ipX, "addr . port to",
+			ipX, "daddr", ".", "meta l4proto", ".", "th dport", ".",
+			"ct mark",
+			"map", "@", sharedEndpointsMap,
+		),
+	})
+}
+
+// ensureBucketEndpoints adds this service's endpoints to the shared
+// endpoints map, keyed by "clusterIP . protocol . port . slot". The bucket
+// chain for len(endpoints) generates the slot at runtime to select one of them.
+func (proxier *Proxier) ensureBucketEndpoints(tx *knftables.Transaction, svcInfo *servicePortInfo, protocol string, endpoints []proxy.Endpoint) {
+	clusterIP := svcInfo.ClusterIP().String()
+	port := strconv.Itoa(svcInfo.Port())
+	for i, ep := range endpoints {
+		epInfo, ok := ep.(*endpointInfo)
+		if !ok {
+			proxier.logger.Error(nil, "Failed to cast endpointInfo", "endpointInfo", ep)
+			continue
+		}
+		proxier.endpoints.ensureElem(tx, &knftables.Element{
+			Map: sharedEndpointsMap,
+			Key: []string{
+				clusterIP,
+				protocol,
+				port,
+				strconv.Itoa(i),
+			},
+			Value: []string{
+				epInfo.IP(),
+				strconv.Itoa(epInfo.Port()),
+			},
+		})
+	}
 }
 
 func (proxier *Proxier) writeServiceToEndpointDNATs(tx *knftables.Transaction, svcInfo *servicePortInfo, svcChain string, endpoints []proxy.Endpoint) {

--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -1351,6 +1351,25 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 
 	var localhostNodePorts []localnodeportproxy.NodePortSpec
 
+	// Index the current shared-endpoints map elements by service, so that
+	// ensureBucketEndpoints can keep endpoints in their existing slots.
+	prevBucketSlots := make(map[string]map[int]string)
+	for key, value := range proxier.endpoints.elements {
+		parts := splitNFTSlice(key)
+		if len(parts) != 4 {
+			continue
+		}
+		slot, err := strconv.Atoi(parts[3])
+		if err != nil {
+			continue
+		}
+		svcKey := joinNFTSlice(parts[:3])
+		if prevBucketSlots[svcKey] == nil {
+			prevBucketSlots[svcKey] = make(map[int]string)
+		}
+		prevBucketSlots[svcKey][slot] = value
+	}
+
 	// Build rules for each service-port.
 	for svcName, svc := range proxier.svcPortMap {
 		svcInfo, ok := svc.(*servicePortInfo)
@@ -1528,7 +1547,7 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 			if useBucket {
 				// Populate the global endpoints map with this service's
 				// endpoints; the bucket chain selects one by slot at runtime.
-				proxier.ensureBucketEndpoints(tx, svcInfo, protocol, clusterEndpoints)
+				proxier.ensureBucketEndpoints(tx, svcInfo, protocol, clusterEndpoints, prevBucketSlots)
 			}
 		} else {
 			// No endpoints.
@@ -2071,13 +2090,69 @@ func (proxier *Proxier) addBucketChain(tx *knftables.Transaction, numEndpoints i
 // ensureBucketEndpoints adds this service's endpoints to the shared
 // endpoints map, keyed by "clusterIP . protocol . port . slot". The bucket
 // chain for len(endpoints) generates the slot at runtime to select one of them.
-func (proxier *Proxier) ensureBucketEndpoints(tx *knftables.Transaction, svcInfo *servicePortInfo, protocol string, endpoints []proxy.Endpoint) {
+// Surviving endpoints keep the slot recorded in prevBucketSlots; removed
+// endpoints' slots are backfilled from the highest slots down, so adding or
+// removing one endpoint churns at most one map element instead of reshuffling
+// every endpoint after it.
+func (proxier *Proxier) ensureBucketEndpoints(tx *knftables.Transaction, svcInfo *servicePortInfo, protocol string, endpoints []proxy.Endpoint, prevBucketSlots map[string]map[int]string) {
 	clusterIP := svcInfo.ClusterIP().String()
 	port := strconv.Itoa(svcInfo.Port())
-	for i, ep := range endpoints {
+	prevSlots := prevBucketSlots[joinNFTSlice([]string{clusterIP, protocol, port})]
+
+	values := make([]string, 0, len(endpoints))
+	for _, ep := range endpoints {
 		epInfo, ok := ep.(*endpointInfo)
 		if !ok {
 			proxier.logger.Error(nil, "Failed to cast endpointInfo", "endpointInfo", ep)
+			continue
+		}
+		values = append(values, joinNFTSlice([]string{epInfo.IP(), strconv.Itoa(epInfo.Port())}))
+	}
+	n := len(values)
+	unplaced := sets.New(values...)
+
+	// Keep surviving endpoints in their current slots.
+	assigned := make([]string, n)
+	for slot, v := range prevSlots {
+		if slot < n && unplaced.Has(v) {
+			assigned[slot] = v
+			unplaced.Delete(v)
+		}
+	}
+
+	// pending lists the endpoints that still need a slot: first survivors
+	// displaced from now-out-of-range slots (highest slot first), then new
+	// endpoints in the order they were given.
+	var pending []string
+	var outOfRange []int
+	for slot := range prevSlots {
+		if slot >= n {
+			outOfRange = append(outOfRange, slot)
+		}
+	}
+	slices.Sort(outOfRange)
+	for i := len(outOfRange) - 1; i >= 0; i-- {
+		if v := prevSlots[outOfRange[i]]; unplaced.Has(v) {
+			pending = append(pending, v)
+			unplaced.Delete(v)
+		}
+	}
+	for _, v := range values {
+		if unplaced.Has(v) {
+			pending = append(pending, v)
+			unplaced.Delete(v)
+		}
+	}
+
+	// Backfill the holes left by removed endpoints.
+	for slot := 0; slot < n && len(pending) > 0; slot++ {
+		if assigned[slot] == "" {
+			assigned[slot], pending = pending[0], pending[1:]
+		}
+	}
+
+	for slot, v := range assigned {
+		if v == "" {
 			continue
 		}
 		proxier.endpoints.ensureElem(tx, &knftables.Element{
@@ -2086,12 +2161,9 @@ func (proxier *Proxier) ensureBucketEndpoints(tx *knftables.Transaction, svcInfo
 				clusterIP,
 				protocol,
 				port,
-				strconv.Itoa(i),
+				strconv.Itoa(slot),
 			},
-			Value: []string{
-				epInfo.IP(),
-				strconv.Itoa(epInfo.Port()),
-			},
+			Value: splitNFTSlice(v),
 		})
 	}
 }

--- a/pkg/proxy/nftables/proxier_test.go
+++ b/pkg/proxy/nftables/proxier_test.go
@@ -138,6 +138,7 @@ func NewFakeProxier(ipFamily v1.IPFamily) (*knftables.Fake, *Proxier) {
 		noEndpointNodePorts: newNFTElementStorage("map", noEndpointNodePortsMap),
 		serviceNodePorts:    newNFTElementStorage("map", serviceNodePortsMap),
 		hairpinConnections:  newNFTElementStorage("set", hairpinConnectionsSet),
+		endpoints:           newEndpointsStorage(),
 	}
 	p.setInitialized(true)
 	p.syncRunner = runner.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, 30*time.Second, time.Minute)
@@ -157,6 +158,9 @@ var baseRules = dedent.Dedent(`
 	add map ip kube-proxy no-endpoint-services { type ipv4_addr . inet_proto . inet_service : verdict ; comment "vmap to drop or reject packets to services with no endpoints" ; }
 	add map ip kube-proxy service-ips { type ipv4_addr . inet_proto . inet_service : verdict ; comment "ClusterIP, ExternalIP and LoadBalancer IP traffic" ; }
 	add map ip kube-proxy service-nodeports { type inet_proto . inet_service : verdict ; comment "NodePort traffic" ; }
+	add map ip kube-proxy endpoints-sctp { typeof ip daddr . sctp dport . numgen random mod 2 : ip daddr . sctp dport ; comment "endpoints for sctp services using shared load-balancing buckets" ; }
+	add map ip kube-proxy endpoints-tcp { typeof ip daddr . tcp dport . numgen random mod 2 : ip daddr . tcp dport ; comment "endpoints for tcp services using shared load-balancing buckets" ; }
+	add map ip kube-proxy endpoints-udp { typeof ip daddr . udp dport . numgen random mod 2 : ip daddr . udp dport ; comment "endpoints for udp services using shared load-balancing buckets" ; }
 
 	add chain ip kube-proxy cluster-ips-check
 	add chain ip kube-proxy filter-prerouting-pre-dnat { type filter hook prerouting priority -110 ; }
@@ -372,11 +376,14 @@ func TestOverallNFTablesRules(t *testing.T) {
 
 	expected := baseRules + dedent.Dedent(`
 		# svc1
-		add chain ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80
-		add rule ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 1 map { 0 : 10.180.0.1 . 80 }
+		add chain ip kube-proxy lb-1-endpoints
+		add rule ip kube-proxy lb-1-endpoints meta l4proto tcp dnat ip addr . port to ip daddr . tcp dport . numgen random mod 1 map @endpoints-tcp
+		add rule ip kube-proxy lb-1-endpoints meta l4proto udp dnat ip addr . port to ip daddr . udp dport . numgen random mod 1 map @endpoints-udp
+		add rule ip kube-proxy lb-1-endpoints meta l4proto sctp dnat ip addr . port to ip daddr . sctp dport . numgen random mod 1 map @endpoints-sctp
 
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
-		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto service-ULMVA6XW-ns1/svc1/tcp/p80 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto lb-1-endpoints }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.41 . 80 . 0 : 10.180.0.1 . 80 }
 		add element ip kube-proxy hairpin-connections { 10.180.0.1 . 10.180.0.1 . tcp . 80 }
 
 		# svc2
@@ -3977,16 +3984,17 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 	expected := baseRules + dedent.Dedent(`
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.42 }
-		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto service-ULMVA6XW-ns1/svc1/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.42 . tcp . 8080 : goto service-MHHHYRWA-ns2/svc2/tcp/p8080 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto lb-1-endpoints }
+		add element ip kube-proxy service-ips { 172.30.0.42 . tcp . 8080 : goto lb-1-endpoints }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.41 . 80 . 0 : 10.0.1.1 . 80 }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.42 . 8080 . 0 : 10.0.2.1 . 8080 }
 		add element ip kube-proxy hairpin-connections { 10.0.1.1 . 10.0.1.1 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.2.1 . 10.0.2.1 . tcp . 8080 }
 
-		add chain ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80
-		add rule ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 1 map { 0 : 10.0.1.1 . 80 }
-
-		add chain ip kube-proxy service-MHHHYRWA-ns2/svc2/tcp/p8080
-		add rule ip kube-proxy service-MHHHYRWA-ns2/svc2/tcp/p8080 meta l4proto tcp dnat ip addr . port to numgen random mod 1 map { 0 : 10.0.2.1 . 8080 }
+		add chain ip kube-proxy lb-1-endpoints
+		add rule ip kube-proxy lb-1-endpoints meta l4proto tcp dnat ip addr . port to ip daddr . tcp dport . numgen random mod 1 map @endpoints-tcp
+		add rule ip kube-proxy lb-1-endpoints meta l4proto udp dnat ip addr . port to ip daddr . udp dport . numgen random mod 1 map @endpoints-udp
+		add rule ip kube-proxy lb-1-endpoints meta l4proto sctp dnat ip addr . port to ip daddr . sctp dport . numgen random mod 1 map @endpoints-sctp
                 `)
 	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
 
@@ -4024,26 +4032,25 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.42 }
 		add element ip kube-proxy cluster-ips { 172.30.0.43 }
-		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto service-ULMVA6XW-ns1/svc1/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.42 . tcp . 8080 : goto service-MHHHYRWA-ns2/svc2/tcp/p8080 }
-		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto service-4AT6LBPK-ns3/svc3/tcp/p80 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto lb-1-endpoints }
+		add element ip kube-proxy service-ips { 172.30.0.42 . tcp . 8080 : goto lb-1-endpoints }
+		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto lb-1-endpoints }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.41 . 80 . 0 : 10.0.1.1 . 80 }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.42 . 8080 . 0 : 10.0.2.1 . 8080 }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.43 . 80 . 0 : 10.0.3.1 . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.1.1 . 10.0.1.1 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.2.1 . 10.0.2.1 . tcp . 8080 }
 		add element ip kube-proxy hairpin-connections { 10.0.3.1 . 10.0.3.1 . tcp . 80 }
 
-		add chain ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80
-		add rule ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 1 map { 0 : 10.0.1.1 . 80 }
-
-		add chain ip kube-proxy service-MHHHYRWA-ns2/svc2/tcp/p8080
-		add rule ip kube-proxy service-MHHHYRWA-ns2/svc2/tcp/p8080 meta l4proto tcp dnat ip addr . port to numgen random mod 1 map { 0 : 10.0.2.1 . 8080 }
-
-		add chain ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80
-		add rule ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 1 map { 0 : 10.0.3.1 . 80 }
+		add chain ip kube-proxy lb-1-endpoints
+		add rule ip kube-proxy lb-1-endpoints meta l4proto tcp dnat ip addr . port to ip daddr . tcp dport . numgen random mod 1 map @endpoints-tcp
+		add rule ip kube-proxy lb-1-endpoints meta l4proto udp dnat ip addr . port to ip daddr . udp dport . numgen random mod 1 map @endpoints-udp
+		add rule ip kube-proxy lb-1-endpoints meta l4proto sctp dnat ip addr . port to ip daddr . sctp dport . numgen random mod 1 map @endpoints-sctp
 		`)
 	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
 	assertNumOperations(t, nft,
 		3, // add 1 element each to cluster-ips, service-ips, and hairpin-connections
-		3, // add+flush service chain, add 1 rule
+		1, // add 1 endpoints map element (svc3 reuses the shared lb-1 bucket chain)
 	)
 
 	// Delete a service; its chains will be flushed, but not immediately deleted.
@@ -4052,23 +4059,21 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 	expected = baseRules + dedent.Dedent(`
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.43 }
-		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto service-ULMVA6XW-ns1/svc1/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto service-4AT6LBPK-ns3/svc3/tcp/p80 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto lb-1-endpoints }
+		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto lb-1-endpoints }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.41 . 80 . 0 : 10.0.1.1 . 80 }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.43 . 80 . 0 : 10.0.3.1 . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.1.1 . 10.0.1.1 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.3.1 . 10.0.3.1 . tcp . 80 }
 
-		add chain ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80
-		add rule ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 1 map { 0 : 10.0.1.1 . 80 }
-
-		add chain ip kube-proxy service-MHHHYRWA-ns2/svc2/tcp/p8080
-
-		add chain ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80
-		add rule ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 1 map { 0 : 10.0.3.1 . 80 }
+		add chain ip kube-proxy lb-1-endpoints
+		add rule ip kube-proxy lb-1-endpoints meta l4proto tcp dnat ip addr . port to ip daddr . tcp dport . numgen random mod 1 map @endpoints-tcp
+		add rule ip kube-proxy lb-1-endpoints meta l4proto udp dnat ip addr . port to ip daddr . udp dport . numgen random mod 1 map @endpoints-udp
+		add rule ip kube-proxy lb-1-endpoints meta l4proto sctp dnat ip addr . port to ip daddr . sctp dport . numgen random mod 1 map @endpoints-sctp
 		`)
 	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
 	assertNumOperations(t, nft,
-		3, // delete 1 element each from cluster-ips, service-ips, hairpin-connections
-		1, // flush service chain
+		4, // delete 1 element each from cluster-ips, service-ips, endpoints, and hairpin-connections
 	)
 
 	// Fake the passage of time and confirm that the stale chains get deleted.
@@ -4077,19 +4082,20 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 	expected = baseRules + dedent.Dedent(`
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.43 }
-		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto service-ULMVA6XW-ns1/svc1/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto service-4AT6LBPK-ns3/svc3/tcp/p80 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto lb-1-endpoints }
+		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto lb-1-endpoints }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.41 . 80 . 0 : 10.0.1.1 . 80 }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.43 . 80 . 0 : 10.0.3.1 . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.1.1 . 10.0.1.1 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.3.1 . 10.0.3.1 . tcp . 80 }
 
-		add chain ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80
-		add rule ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 1 map { 0 : 10.0.1.1 . 80 }
-
-		add chain ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80
-		add rule ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 1 map { 0 : 10.0.3.1 . 80 }
+		add chain ip kube-proxy lb-1-endpoints
+		add rule ip kube-proxy lb-1-endpoints meta l4proto tcp dnat ip addr . port to ip daddr . tcp dport . numgen random mod 1 map @endpoints-tcp
+		add rule ip kube-proxy lb-1-endpoints meta l4proto udp dnat ip addr . port to ip daddr . udp dport . numgen random mod 1 map @endpoints-udp
+		add rule ip kube-proxy lb-1-endpoints meta l4proto sctp dnat ip addr . port to ip daddr . sctp dport . numgen random mod 1 map @endpoints-sctp
 		`)
 	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
-	// delete stale chains happens in a separate transaction, nothing else changed
+	// no stale chains exist (services share bucket chains), nothing changed
 	assertNumOperations(t, nft, 0)
 
 	// Add a service, sync, then add its endpoints.
@@ -4109,16 +4115,17 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.43 }
 		add element ip kube-proxy cluster-ips { 172.30.0.44 }
-		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto service-ULMVA6XW-ns1/svc1/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto service-4AT6LBPK-ns3/svc3/tcp/p80 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto lb-1-endpoints }
+		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto lb-1-endpoints }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.41 . 80 . 0 : 10.0.1.1 . 80 }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.43 . 80 . 0 : 10.0.3.1 . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.1.1 . 10.0.1.1 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.3.1 . 10.0.3.1 . tcp . 80 }
 
-		add chain ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80
-		add rule ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 1 map { 0 : 10.0.1.1 . 80 }
-
-		add chain ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80
-		add rule ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 1 map { 0 : 10.0.3.1 . 80 }
+		add chain ip kube-proxy lb-1-endpoints
+		add rule ip kube-proxy lb-1-endpoints meta l4proto tcp dnat ip addr . port to ip daddr . tcp dport . numgen random mod 1 map @endpoints-tcp
+		add rule ip kube-proxy lb-1-endpoints meta l4proto udp dnat ip addr . port to ip daddr . udp dport . numgen random mod 1 map @endpoints-udp
+		add rule ip kube-proxy lb-1-endpoints meta l4proto sctp dnat ip addr . port to ip daddr . sctp dport . numgen random mod 1 map @endpoints-sctp
 
 		add element ip kube-proxy no-endpoint-services { 172.30.0.44 . tcp . 80 comment "ns4/svc4:p80" : goto reject-chain }
 		`)
@@ -4146,27 +4153,26 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.43 }
 		add element ip kube-proxy cluster-ips { 172.30.0.44 }
-		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto service-ULMVA6XW-ns1/svc1/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto service-4AT6LBPK-ns3/svc3/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.44 . tcp . 80 : goto service-LAUZTJTB-ns4/svc4/tcp/p80 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto lb-1-endpoints }
+		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto lb-1-endpoints }
+		add element ip kube-proxy service-ips { 172.30.0.44 . tcp . 80 : goto lb-1-endpoints }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.41 . 80 . 0 : 10.0.1.1 . 80 }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.43 . 80 . 0 : 10.0.3.1 . 80 }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.44 . 80 . 0 : 10.0.4.1 . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.1.1 . 10.0.1.1 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.3.1 . 10.0.3.1 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.4.1 . 10.0.4.1 . tcp . 80 }
 
-		add chain ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80
-		add rule ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 1 map { 0 : 10.0.1.1 . 80 }
-
-		add chain ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80
-		add rule ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 1 map { 0 : 10.0.3.1 . 80 }
-
-		add chain ip kube-proxy service-LAUZTJTB-ns4/svc4/tcp/p80
-		add rule ip kube-proxy service-LAUZTJTB-ns4/svc4/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 1 map { 0 : 10.0.4.1 . 80 }
+		add chain ip kube-proxy lb-1-endpoints
+		add rule ip kube-proxy lb-1-endpoints meta l4proto tcp dnat ip addr . port to ip daddr . tcp dport . numgen random mod 1 map @endpoints-tcp
+		add rule ip kube-proxy lb-1-endpoints meta l4proto udp dnat ip addr . port to ip daddr . udp dport . numgen random mod 1 map @endpoints-udp
+		add rule ip kube-proxy lb-1-endpoints meta l4proto sctp dnat ip addr . port to ip daddr . sctp dport . numgen random mod 1 map @endpoints-sctp
 		`)
 	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
 	assertNumOperations(t, nft,
 		2, // add 1 element to service-ips, remove 1 element from no-endpoint-services
 		1, // add 1 element to hairpin-connections
-		3, // add+flush service chain, add 1 rule
+		1, // add 1 endpoints map element (svc4 reuses the shared lb-1 bucket chain)
 	)
 
 	// Change an endpoint of an existing service.
@@ -4180,26 +4186,25 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.43 }
 		add element ip kube-proxy cluster-ips { 172.30.0.44 }
-		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto service-ULMVA6XW-ns1/svc1/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto service-4AT6LBPK-ns3/svc3/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.44 . tcp . 80 : goto service-LAUZTJTB-ns4/svc4/tcp/p80 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto lb-1-endpoints }
+		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto lb-1-endpoints }
+		add element ip kube-proxy service-ips { 172.30.0.44 . tcp . 80 : goto lb-1-endpoints }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.41 . 80 . 0 : 10.0.1.1 . 80 }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.43 . 80 . 0 : 10.0.3.2 . 80 }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.44 . 80 . 0 : 10.0.4.1 . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.1.1 . 10.0.1.1 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.3.2 . 10.0.3.2 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.4.1 . 10.0.4.1 . tcp . 80 }
 
-		add chain ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80
-		add rule ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 1 map { 0 : 10.0.1.1 . 80 }
-
-		add chain ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80
-		add rule ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 1 map { 0 : 10.0.3.2 . 80 }
-
-		add chain ip kube-proxy service-LAUZTJTB-ns4/svc4/tcp/p80
-		add rule ip kube-proxy service-LAUZTJTB-ns4/svc4/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 1 map { 0 : 10.0.4.1 . 80 }
+		add chain ip kube-proxy lb-1-endpoints
+		add rule ip kube-proxy lb-1-endpoints meta l4proto tcp dnat ip addr . port to ip daddr . tcp dport . numgen random mod 1 map @endpoints-tcp
+		add rule ip kube-proxy lb-1-endpoints meta l4proto udp dnat ip addr . port to ip daddr . udp dport . numgen random mod 1 map @endpoints-udp
+		add rule ip kube-proxy lb-1-endpoints meta l4proto sctp dnat ip addr . port to ip daddr . sctp dport . numgen random mod 1 map @endpoints-sctp
 		`)
 	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
 	assertNumOperations(t, nft,
 		2, // remove 1 old element from hairpin-connections, add 1 new one
-		3, // add+flush service chain, add 1 rule
+		2, // update svc3's endpoints map element (delete+add)
 	)
 
 	// (Ensure the old svc3 chain gets deleted in the next sync.)
@@ -4218,28 +4223,34 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.43 }
 		add element ip kube-proxy cluster-ips { 172.30.0.44 }
-		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto service-ULMVA6XW-ns1/svc1/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto service-4AT6LBPK-ns3/svc3/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.44 . tcp . 80 : goto service-LAUZTJTB-ns4/svc4/tcp/p80 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto lb-1-endpoints }
+		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto lb-2-endpoints }
+		add element ip kube-proxy service-ips { 172.30.0.44 . tcp . 80 : goto lb-1-endpoints }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.41 . 80 . 0 : 10.0.1.1 . 80 }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.43 . 80 . 0 : 10.0.3.2 . 80 }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.43 . 80 . 1 : 10.0.3.3 . 80 }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.44 . 80 . 0 : 10.0.4.1 . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.1.1 . 10.0.1.1 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.3.2 . 10.0.3.2 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.3.3 . 10.0.3.3 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.4.1 . 10.0.4.1 . tcp . 80 }
 
-		add chain ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80
-		add rule ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 1 map { 0 : 10.0.1.1 . 80 }
+		add chain ip kube-proxy lb-1-endpoints
+		add rule ip kube-proxy lb-1-endpoints meta l4proto tcp dnat ip addr . port to ip daddr . tcp dport . numgen random mod 1 map @endpoints-tcp
+		add rule ip kube-proxy lb-1-endpoints meta l4proto udp dnat ip addr . port to ip daddr . udp dport . numgen random mod 1 map @endpoints-udp
+		add rule ip kube-proxy lb-1-endpoints meta l4proto sctp dnat ip addr . port to ip daddr . sctp dport . numgen random mod 1 map @endpoints-sctp
 
-		add chain ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80
-		add rule ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 2 map { 0 : 10.0.3.2 . 80 , 1 : 10.0.3.3 . 80 }
-
-		add chain ip kube-proxy service-LAUZTJTB-ns4/svc4/tcp/p80
-		add rule ip kube-proxy service-LAUZTJTB-ns4/svc4/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 1 map { 0 : 10.0.4.1 . 80 }
+		add chain ip kube-proxy lb-2-endpoints
+		add rule ip kube-proxy lb-2-endpoints meta l4proto tcp dnat ip addr . port to ip daddr . tcp dport . numgen random mod 2 map @endpoints-tcp
+		add rule ip kube-proxy lb-2-endpoints meta l4proto udp dnat ip addr . port to ip daddr . udp dport . numgen random mod 2 map @endpoints-udp
+		add rule ip kube-proxy lb-2-endpoints meta l4proto sctp dnat ip addr . port to ip daddr . sctp dport . numgen random mod 2 map @endpoints-sctp
 		`)
 	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
-	// (The first endpoint chain is unchanged, but the code recreates it anyway.)
 	assertNumOperations(t, nft,
 		1, // add 1 element to hairpin-connections
-		3, // add+flush service chain, add 1 rule
+		1, // add svc3's second endpoints map element
+		2, // re-point svc3's service-ips element from lb-1 to lb-2 (delete+add)
+		5, // add+flush lb-2 bucket chain, add 3 rules
 	)
 
 	// Empty a service's endpoints; its chains will be flushed, but not immediately deleted.
@@ -4251,28 +4262,30 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.43 }
 		add element ip kube-proxy cluster-ips { 172.30.0.44 }
-		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto service-ULMVA6XW-ns1/svc1/tcp/p80 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto lb-1-endpoints }
 		add element ip kube-proxy no-endpoint-services { 172.30.0.43 . tcp . 80 comment "ns3/svc3:p80" : goto reject-chain }
-		add element ip kube-proxy service-ips { 172.30.0.44 . tcp . 80 : goto service-LAUZTJTB-ns4/svc4/tcp/p80 }
+		add element ip kube-proxy service-ips { 172.30.0.44 . tcp . 80 : goto lb-1-endpoints }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.41 . 80 . 0 : 10.0.1.1 . 80 }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.44 . 80 . 0 : 10.0.4.1 . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.1.1 . 10.0.1.1 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.4.1 . 10.0.4.1 . tcp . 80 }
 
-		add chain ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80
-		add rule ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 1 map { 0 : 10.0.1.1 . 80 }
+		add chain ip kube-proxy lb-1-endpoints
+		add rule ip kube-proxy lb-1-endpoints meta l4proto tcp dnat ip addr . port to ip daddr . tcp dport . numgen random mod 1 map @endpoints-tcp
+		add rule ip kube-proxy lb-1-endpoints meta l4proto udp dnat ip addr . port to ip daddr . udp dport . numgen random mod 1 map @endpoints-udp
+		add rule ip kube-proxy lb-1-endpoints meta l4proto sctp dnat ip addr . port to ip daddr . sctp dport . numgen random mod 1 map @endpoints-sctp
 
-		add chain ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80
-
-		add chain ip kube-proxy service-LAUZTJTB-ns4/svc4/tcp/p80
-		add rule ip kube-proxy service-LAUZTJTB-ns4/svc4/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 1 map { 0 : 10.0.4.1 . 80 }
+		add chain ip kube-proxy lb-2-endpoints
 		`)
 	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
 	assertNumOperations(t, nft,
 		2, // remove 1 element from service-ips, add 1 element to no-endpoint-services
 		2, // remove 2 elements from hairpin-connections
-		1, // flush service chain
+		2, // remove svc3's 2 endpoints map elements
+		1, // flush now-unused lb-2 bucket chain
 	)
 
-	expectedStaleChains := sets.NewString("service-4AT6LBPK-ns3/svc3/tcp/p80")
+	expectedStaleChains := sets.NewString("lb-2-endpoints")
 	gotStaleChains := sets.StringKeySet(fp.staleChains)
 	if !expectedStaleChains.Equal(gotStaleChains) {
 		t.Errorf("expected stale chains %v, got %v", expectedStaleChains, gotStaleChains)
@@ -4284,28 +4297,34 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.43 }
 		add element ip kube-proxy cluster-ips { 172.30.0.44 }
-		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto service-ULMVA6XW-ns1/svc1/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto service-4AT6LBPK-ns3/svc3/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.44 . tcp . 80 : goto service-LAUZTJTB-ns4/svc4/tcp/p80 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto lb-1-endpoints }
+		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto lb-2-endpoints }
+		add element ip kube-proxy service-ips { 172.30.0.44 . tcp . 80 : goto lb-1-endpoints }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.41 . 80 . 0 : 10.0.1.1 . 80 }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.43 . 80 . 0 : 10.0.3.2 . 80 }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.43 . 80 . 1 : 10.0.3.3 . 80 }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.44 . 80 . 0 : 10.0.4.1 . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.1.1 . 10.0.1.1 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.3.2 . 10.0.3.2 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.3.3 . 10.0.3.3 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.4.1 . 10.0.4.1 . tcp . 80 }
 
-		add chain ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80
-		add rule ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 1 map { 0 : 10.0.1.1 . 80 }
+		add chain ip kube-proxy lb-1-endpoints
+		add rule ip kube-proxy lb-1-endpoints meta l4proto tcp dnat ip addr . port to ip daddr . tcp dport . numgen random mod 1 map @endpoints-tcp
+		add rule ip kube-proxy lb-1-endpoints meta l4proto udp dnat ip addr . port to ip daddr . udp dport . numgen random mod 1 map @endpoints-udp
+		add rule ip kube-proxy lb-1-endpoints meta l4proto sctp dnat ip addr . port to ip daddr . sctp dport . numgen random mod 1 map @endpoints-sctp
 
-		add chain ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80
-		add rule ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 2 map { 0 : 10.0.3.2 . 80 , 1 : 10.0.3.3 . 80 }
-
-		add chain ip kube-proxy service-LAUZTJTB-ns4/svc4/tcp/p80
-		add rule ip kube-proxy service-LAUZTJTB-ns4/svc4/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 1 map { 0 : 10.0.4.1 . 80 }
+		add chain ip kube-proxy lb-2-endpoints
+		add rule ip kube-proxy lb-2-endpoints meta l4proto tcp dnat ip addr . port to ip daddr . tcp dport . numgen random mod 2 map @endpoints-tcp
+		add rule ip kube-proxy lb-2-endpoints meta l4proto udp dnat ip addr . port to ip daddr . udp dport . numgen random mod 2 map @endpoints-udp
+		add rule ip kube-proxy lb-2-endpoints meta l4proto sctp dnat ip addr . port to ip daddr . sctp dport . numgen random mod 2 map @endpoints-sctp
 		`)
 	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
 	assertNumOperations(t, nft,
 		2, // remove 1 element from no-endpoint-services, add 1 element to service-ips
 		2, // add 2 elements to hairpin-connections
-		3, // add+flush service chain, add 1 rule
+		2, // add svc3's 2 endpoints map elements
+		5, // re-create lb-2 bucket chain (add+flush, add 3 rules)
 	)
 
 	if len(fp.staleChains) != 0 {
@@ -4431,25 +4450,39 @@ func TestSyncProxyRulesStartup(t *testing.T) {
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.42 }
 		add element ip kube-proxy cluster-ips { 172.30.0.43 }
-		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto service-ULMVA6XW-ns1/svc1/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.42 . tcp . 8080 : goto service-MHHHYRWA-ns2/svc2/tcp/p8080 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto lb-2-endpoints }
+		add element ip kube-proxy service-ips { 172.30.0.42 . tcp . 8080 : goto lb-1-endpoints }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.41 . 80 . 0 : 10.0.1.1 . 80 }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.41 . 80 . 1 : 10.0.1.2 . 80 }
+		add element ip kube-proxy endpoints-tcp { 172.30.0.42 . 8080 . 0 : 10.0.2.1 . 8080 }
 		add element ip kube-proxy no-endpoint-services { 172.30.0.43 . tcp . 80 comment "ns3/svc3:p80" : goto reject-chain }
 		add element ip kube-proxy hairpin-connections { 10.0.1.1 . 10.0.1.1 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.1.2 . 10.0.1.2 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.2.1 . 10.0.2.1 . tcp . 8080 }
 
+		add chain ip kube-proxy lb-1-endpoints
+		add rule ip kube-proxy lb-1-endpoints meta l4proto tcp dnat ip addr . port to ip daddr . tcp dport . numgen random mod 1 map @endpoints-tcp
+		add rule ip kube-proxy lb-1-endpoints meta l4proto udp dnat ip addr . port to ip daddr . udp dport . numgen random mod 1 map @endpoints-udp
+		add rule ip kube-proxy lb-1-endpoints meta l4proto sctp dnat ip addr . port to ip daddr . sctp dport . numgen random mod 1 map @endpoints-sctp
+
+		add chain ip kube-proxy lb-2-endpoints
+		add rule ip kube-proxy lb-2-endpoints meta l4proto tcp dnat ip addr . port to ip daddr . tcp dport . numgen random mod 2 map @endpoints-tcp
+		add rule ip kube-proxy lb-2-endpoints meta l4proto udp dnat ip addr . port to ip daddr . udp dport . numgen random mod 2 map @endpoints-udp
+		add rule ip kube-proxy lb-2-endpoints meta l4proto sctp dnat ip addr . port to ip daddr . sctp dport . numgen random mod 2 map @endpoints-sctp
+
 		add chain ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80
-		add rule ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 2 map { 0 : 10.0.1.1 . 80 , 1 : 10.0.1.2 . 80 }
 
 		add chain ip kube-proxy service-MHHHYRWA-ns2/svc2/tcp/p8080
-		add rule ip kube-proxy service-MHHHYRWA-ns2/svc2/tcp/p8080 meta l4proto tcp dnat ip addr . port to numgen random mod 1 map { 0 : 10.0.2.1 . 8080 }
 	`)
 	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
 	assertNumOperations(t, nft,
 		setupOps, // nft setup
 		1,        // add new svc1 endpoint to hairpin-connections
 		2,        // add svc3 IP to the cluster-ips, and to the no-endpoint-services set
-		6,        // add+flush 2 service chains + 1 rule each
+		10,       // add+flush 2 bucket chains + 3 rules each
+		3,        // add 3 endpoints map elements
+		4,        // re-point 2 service-ips elements at bucket chains (delete+add each)
+		2,        // flush 2 now-stale per-service chains
 	)
 }
 

--- a/pkg/proxy/nftables/proxier_test.go
+++ b/pkg/proxy/nftables/proxier_test.go
@@ -4454,6 +4454,121 @@ func TestPrepopulatedBucketChains(t *testing.T) {
 	)
 }
 
+// Test that bucket endpoints keep their slots in the shared endpoints map when
+// other endpoints are added or removed.
+func TestBucketEndpointSlotStability(t *testing.T) {
+	nft, fp := NewFakeProxier(v1.IPv4Protocol)
+	fp.prepopulatedBucketChains = 3
+
+	makeServiceMap(fp,
+		makeTestService("ns1", "svc1", func(svc *v1.Service) {
+			svc.Spec.Type = v1.ServiceTypeClusterIP
+			svc.Spec.ClusterIP = "172.30.0.41"
+			svc.Spec.Ports = []v1.ServicePort{{
+				Name:     "p80",
+				Port:     80,
+				Protocol: v1.ProtocolTCP,
+			}}
+		}),
+	)
+	var eps1 *discovery.EndpointSlice
+	populateEndpointSlices(fp,
+		makeTestEndpointSlice("ns1", "svc1", 1, func(eps *discovery.EndpointSlice) {
+			eps1 = eps
+			eps.AddressType = discovery.AddressTypeIPv4
+			eps.Endpoints = []discovery.Endpoint{{
+				Addresses: []string{"10.0.1.1"},
+				NodeName:  ptr.To(testNodeName),
+			}, {
+				Addresses: []string{"10.0.1.3"},
+				NodeName:  ptr.To(testNodeName),
+			}}
+			eps.Ports = []discovery.EndpointPort{{
+				Name:     ptr.To("p80"),
+				Port:     ptr.To[int32](80),
+				Protocol: ptr.To(v1.ProtocolTCP),
+			}}
+		}),
+	)
+
+	fp.syncProxyRules()
+
+	dispatchChains := dedent.Dedent(`
+		add chain ip kube-proxy dispatch-1
+		add rule ip kube-proxy dispatch-1 ct mark set numgen random mod 1 dnat ip addr . port to ip daddr . meta l4proto . th dport . ct mark map @endpoints
+		add chain ip kube-proxy dispatch-2
+		add rule ip kube-proxy dispatch-2 ct mark set numgen random mod 2 dnat ip addr . port to ip daddr . meta l4proto . th dport . ct mark map @endpoints
+		add chain ip kube-proxy dispatch-3
+		add rule ip kube-proxy dispatch-3 ct mark set numgen random mod 3 dnat ip addr . port to ip daddr . meta l4proto . th dport . ct mark map @endpoints
+		`)
+
+	expected := baseRules + dedent.Dedent(`
+		add element ip kube-proxy cluster-ips { 172.30.0.41 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto dispatch-2 }
+		add element ip kube-proxy endpoints { 172.30.0.41 . tcp . 80 . 0 : 10.0.1.1 . 80 }
+		add element ip kube-proxy endpoints { 172.30.0.41 . tcp . 80 . 1 : 10.0.1.3 . 80 }
+		add element ip kube-proxy hairpin-connections { 10.0.1.1 . 10.0.1.1 . tcp . 80 }
+		add element ip kube-proxy hairpin-connections { 10.0.1.3 . 10.0.1.3 . tcp . 80 }
+		`) + dispatchChains
+	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
+
+	// Add an endpoint that sorts into the middle of the endpoint list. The
+	// existing endpoints keep their slots; the new one takes the next free slot.
+	eps1update := eps1.DeepCopy()
+	eps1update.Endpoints = []discovery.Endpoint{{
+		Addresses: []string{"10.0.1.1"},
+		NodeName:  ptr.To(testNodeName),
+	}, {
+		Addresses: []string{"10.0.1.2"},
+		NodeName:  ptr.To(testNodeName),
+	}, {
+		Addresses: []string{"10.0.1.3"},
+		NodeName:  ptr.To(testNodeName),
+	}}
+	fp.OnEndpointSliceUpdate(eps1, eps1update)
+	fp.syncProxyRules()
+
+	expected = baseRules + dedent.Dedent(`
+		add element ip kube-proxy cluster-ips { 172.30.0.41 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto dispatch-3 }
+		add element ip kube-proxy endpoints { 172.30.0.41 . tcp . 80 . 0 : 10.0.1.1 . 80 }
+		add element ip kube-proxy endpoints { 172.30.0.41 . tcp . 80 . 1 : 10.0.1.3 . 80 }
+		add element ip kube-proxy endpoints { 172.30.0.41 . tcp . 80 . 2 : 10.0.1.2 . 80 }
+		add element ip kube-proxy hairpin-connections { 10.0.1.1 . 10.0.1.1 . tcp . 80 }
+		add element ip kube-proxy hairpin-connections { 10.0.1.2 . 10.0.1.2 . tcp . 80 }
+		add element ip kube-proxy hairpin-connections { 10.0.1.3 . 10.0.1.3 . tcp . 80 }
+		`) + dispatchChains
+	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
+	assertNumOperations(t, nft,
+		2, // re-point svc1's service-ips element from dispatch-2 to dispatch-3 (delete+add)
+		1, // add 1 endpoints map element for the new endpoint
+		1, // add 1 hairpin-connections element for the new endpoint
+	)
+
+	// Remove the endpoint in slot 0. The endpoint in the highest slot backfills
+	// the hole; the other endpoint stays put.
+	eps1update2 := eps1update.DeepCopy()
+	eps1update2.Endpoints = eps1update2.Endpoints[1:]
+	fp.OnEndpointSliceUpdate(eps1update, eps1update2)
+	fp.syncProxyRules()
+
+	expected = baseRules + dedent.Dedent(`
+		add element ip kube-proxy cluster-ips { 172.30.0.41 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto dispatch-2 }
+		add element ip kube-proxy endpoints { 172.30.0.41 . tcp . 80 . 0 : 10.0.1.2 . 80 }
+		add element ip kube-proxy endpoints { 172.30.0.41 . tcp . 80 . 1 : 10.0.1.3 . 80 }
+		add element ip kube-proxy hairpin-connections { 10.0.1.2 . 10.0.1.2 . tcp . 80 }
+		add element ip kube-proxy hairpin-connections { 10.0.1.3 . 10.0.1.3 . tcp . 80 }
+		`) + dispatchChains
+	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
+	assertNumOperations(t, nft,
+		2, // re-point svc1's service-ips element from dispatch-3 to dispatch-2 (delete+add)
+		2, // backfill slot 0 with the endpoint from slot 2 (delete+add)
+		1, // remove the now-empty slot 2 endpoints map element
+		1, // remove 1 hairpin-connections element for the deleted endpoint
+	)
+}
+
 // Test calling syncProxyRules() multiple times with various changes
 func TestSyncProxyRulesRepeated(t *testing.T) {
 	nft, fp := NewFakeProxier(v1.IPv4Protocol)

--- a/pkg/proxy/nftables/proxier_test.go
+++ b/pkg/proxy/nftables/proxier_test.go
@@ -140,6 +140,7 @@ func NewFakeProxier(ipFamily v1.IPFamily) (*knftables.Fake, *Proxier) {
 		noEndpointNodePorts:      newNFTElementStorage("map", noEndpointNodePortsMap),
 		serviceNodePorts:         newNFTElementStorage("map", serviceNodePortsMap),
 		hairpinConnections:       newNFTElementStorage("set", hairpinConnectionsSet),
+		endpoints:                newNFTElementStorage("map", sharedEndpointsMap),
 		localhostNodePortRejects: newNFTElementStorage("map", localhostNodePortRejectMap),
 	}
 	p.setInitialized(true)
@@ -160,6 +161,7 @@ var baseRules = dedent.Dedent(`
 	add map ip kube-proxy no-endpoint-services { type ipv4_addr . inet_proto . inet_service : verdict ; comment "vmap to drop or reject packets to services with no endpoints" ; }
 	add map ip kube-proxy service-ips { type ipv4_addr . inet_proto . inet_service : verdict ; comment "ClusterIP, ExternalIP and LoadBalancer IP traffic" ; }
 	add map ip kube-proxy service-nodeports { type inet_proto . inet_service : verdict ; comment "NodePort traffic" ; }
+	add map ip kube-proxy endpoints { type ipv4_addr . inet_proto . inet_service . mark : ipv4_addr . inet_service ; comment "endpoints for services using shared buckets" ; }
 
 	add chain ip kube-proxy cluster-ips-check
 	add chain ip kube-proxy filter-prerouting-pre-dnat { type filter hook prerouting priority -110 ; }
@@ -215,6 +217,7 @@ var baseRulesV6 = dedent.Dedent(`
 	add map ip6 kube-proxy no-endpoint-services { type ipv6_addr . inet_proto . inet_service : verdict ; comment "vmap to drop or reject packets to services with no endpoints" ; }
 	add map ip6 kube-proxy service-ips { type ipv6_addr . inet_proto . inet_service : verdict ; comment "ClusterIP, ExternalIP and LoadBalancer IP traffic" ; }
 	add map ip6 kube-proxy service-nodeports { type inet_proto . inet_service : verdict ; comment "NodePort traffic" ; }
+	add map ip6 kube-proxy endpoints { type ipv6_addr . inet_proto . inet_service . mark : ipv6_addr . inet_service ; comment "endpoints for services using shared buckets" ; }
 
 	add chain ip6 kube-proxy cluster-ips-check
 	add chain ip6 kube-proxy filter-prerouting-pre-dnat { type filter hook prerouting priority -110 ; }
@@ -435,11 +438,12 @@ func TestOverallNFTablesRules(t *testing.T) {
 
 	expected := baseRules + dedent.Dedent(`
 		# svc1
-		add chain ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80
-		add rule ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80 meta l4proto tcp dnat to 10.180.0.1:80
+		add chain ip kube-proxy dispatch-1
+		add rule ip kube-proxy dispatch-1 ct mark set numgen random mod 1 dnat ip addr . port to ip daddr . meta l4proto . th dport . ct mark map @endpoints
 
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
-		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto service-ULMVA6XW-ns1/svc1/tcp/p80 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto dispatch-1 }
+		add element ip kube-proxy endpoints { 172.30.0.41 . tcp . 80 . 0 : 10.180.0.1 . 80 }
 		add element ip kube-proxy hairpin-connections { 10.180.0.1 . 10.180.0.1 . tcp . 80 }
 
 		# svc2
@@ -709,11 +713,12 @@ func TestOverallNFTablesRulesIPv6(t *testing.T) {
 
 	expected := baseRulesV6 + dedent.Dedent(`
 		# svc1
-		add chain ip6 kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80
-		add rule ip6 kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80 meta l4proto tcp dnat to [fd00:10:180::1]:80
+		add chain ip6 kube-proxy dispatch-1
+		add rule ip6 kube-proxy dispatch-1 ct mark set numgen random mod 1 dnat ip6 addr . port to ip6 daddr . meta l4proto . th dport . ct mark map @endpoints
 
 		add element ip6 kube-proxy cluster-ips { fd00:172:30::41 }
-		add element ip6 kube-proxy service-ips { fd00:172:30::41 . tcp . 80 : goto service-ULMVA6XW-ns1/svc1/tcp/p80 }
+		add element ip6 kube-proxy service-ips { fd00:172:30::41 . tcp . 80 : goto dispatch-1 }
+		add element ip6 kube-proxy endpoints { fd00:172:30::41 . tcp . 80 . 0 : fd00:10:180::1 . 80 }
 		add element ip6 kube-proxy hairpin-connections { fd00:10:180::1 . fd00:10:180::1 . tcp . 80 }
 
 		# svc2
@@ -853,12 +858,16 @@ func TestEndpointDNATRules(t *testing.T) {
 
 			makeServiceMap(fp,
 				makeTestService("ns1", "svc1", func(svc *v1.Service) {
-					svc.Spec.Type = v1.ServiceTypeClusterIP
+					// Use a NodePort service: externally-accessible services
+					// are not eligible for the shared bucket chains, so this
+					// exercises the per-service chain DNAT rules.
+					svc.Spec.Type = v1.ServiceTypeNodePort
 					svc.Spec.ClusterIP = tc.svcIP
 					svc.Spec.Ports = []v1.ServicePort{{
 						Name:     "p80",
 						Port:     80,
 						Protocol: v1.ProtocolTCP,
+						NodePort: 3001,
 					}}
 				}),
 			)
@@ -4359,6 +4368,92 @@ func assertNumOperations(t *testing.T, nft *knftables.Fake, ops ...int) {
 	}
 }
 
+// Test that pre-populated bucket chains are created at setup time and are not
+// garbage-collected even when no service uses them.
+func TestPrepopulatedBucketChains(t *testing.T) {
+	nft, fp := NewFakeProxier(v1.IPv4Protocol)
+	fp.prepopulatedBucketChains = 3
+
+	makeServiceMap(fp,
+		makeTestService("ns1", "svc1", func(svc *v1.Service) {
+			svc.Spec.Type = v1.ServiceTypeClusterIP
+			svc.Spec.ClusterIP = "172.30.0.41"
+			svc.Spec.Ports = []v1.ServicePort{{
+				Name:     "p80",
+				Port:     80,
+				Protocol: v1.ProtocolTCP,
+			}}
+		}),
+	)
+	var eps1 *discovery.EndpointSlice
+	populateEndpointSlices(fp,
+		makeTestEndpointSlice("ns1", "svc1", 1, func(eps *discovery.EndpointSlice) {
+			eps1 = eps
+			eps.AddressType = discovery.AddressTypeIPv4
+			eps.Endpoints = []discovery.Endpoint{{
+				Addresses: []string{"10.0.1.1"},
+				NodeName:  ptr.To(testNodeName),
+			}}
+			eps.Ports = []discovery.EndpointPort{{
+				Name:     ptr.To("p80"),
+				Port:     ptr.To[int32](80),
+				Protocol: ptr.To(v1.ProtocolTCP),
+			}}
+		}),
+	)
+
+	fp.syncProxyRules()
+
+	// All three bucket chains exist even though only dispatch-1 is used.
+	expected := baseRules + dedent.Dedent(`
+		add element ip kube-proxy cluster-ips { 172.30.0.41 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto dispatch-1 }
+		add element ip kube-proxy endpoints { 172.30.0.41 . tcp . 80 . 0 : 10.0.1.1 . 80 }
+		add element ip kube-proxy hairpin-connections { 10.0.1.1 . 10.0.1.1 . tcp . 80 }
+
+		add chain ip kube-proxy dispatch-1
+		add rule ip kube-proxy dispatch-1 ct mark set numgen random mod 1 dnat ip addr . port to ip daddr . meta l4proto . th dport . ct mark map @endpoints
+		add chain ip kube-proxy dispatch-2
+		add rule ip kube-proxy dispatch-2 ct mark set numgen random mod 2 dnat ip addr . port to ip daddr . meta l4proto . th dport . ct mark map @endpoints
+		add chain ip kube-proxy dispatch-3
+		add rule ip kube-proxy dispatch-3 ct mark set numgen random mod 3 dnat ip addr . port to ip daddr . meta l4proto . th dport . ct mark map @endpoints
+		`)
+	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
+
+	// Scale the service to 2 endpoints. The partial sync re-points the service
+	// at the pre-populated dispatch-2 chain without recreating it, and the
+	// now-unused dispatch-1 (and still-unused dispatch-3) are not flushed.
+	eps1update := eps1.DeepCopy()
+	eps1update.Endpoints = append(eps1update.Endpoints, discovery.Endpoint{
+		Addresses: []string{"10.0.1.2"},
+		NodeName:  ptr.To(testNodeName),
+	})
+	fp.OnEndpointSliceUpdate(eps1, eps1update)
+	fp.syncProxyRules()
+
+	expected = baseRules + dedent.Dedent(`
+		add element ip kube-proxy cluster-ips { 172.30.0.41 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto dispatch-2 }
+		add element ip kube-proxy endpoints { 172.30.0.41 . tcp . 80 . 0 : 10.0.1.1 . 80 }
+		add element ip kube-proxy endpoints { 172.30.0.41 . tcp . 80 . 1 : 10.0.1.2 . 80 }
+		add element ip kube-proxy hairpin-connections { 10.0.1.1 . 10.0.1.1 . tcp . 80 }
+		add element ip kube-proxy hairpin-connections { 10.0.1.2 . 10.0.1.2 . tcp . 80 }
+
+		add chain ip kube-proxy dispatch-1
+		add rule ip kube-proxy dispatch-1 ct mark set numgen random mod 1 dnat ip addr . port to ip daddr . meta l4proto . th dport . ct mark map @endpoints
+		add chain ip kube-proxy dispatch-2
+		add rule ip kube-proxy dispatch-2 ct mark set numgen random mod 2 dnat ip addr . port to ip daddr . meta l4proto . th dport . ct mark map @endpoints
+		add chain ip kube-proxy dispatch-3
+		add rule ip kube-proxy dispatch-3 ct mark set numgen random mod 3 dnat ip addr . port to ip daddr . meta l4proto . th dport . ct mark map @endpoints
+		`)
+	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
+	assertNumOperations(t, nft,
+		2, // re-point svc1's service-ips element from dispatch-1 to dispatch-2 (delete+add)
+		1, // add 1 endpoints map element for the new endpoint
+		1, // add 1 hairpin-connections element for the new endpoint
+	)
+}
+
 // Test calling syncProxyRules() multiple times with various changes
 func TestSyncProxyRulesRepeated(t *testing.T) {
 	nft, fp := NewFakeProxier(v1.IPv4Protocol)
@@ -4428,16 +4523,15 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 	expected := baseRules + dedent.Dedent(`
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.42 }
-		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto service-ULMVA6XW-ns1/svc1/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.42 . tcp . 8080 : goto service-MHHHYRWA-ns2/svc2/tcp/p8080 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto dispatch-1 }
+		add element ip kube-proxy service-ips { 172.30.0.42 . tcp . 8080 : goto dispatch-1 }
+		add element ip kube-proxy endpoints { 172.30.0.41 . tcp . 80 . 0 : 10.0.1.1 . 80 }
+		add element ip kube-proxy endpoints { 172.30.0.42 . tcp . 8080 . 0 : 10.0.2.1 . 8080 }
 		add element ip kube-proxy hairpin-connections { 10.0.1.1 . 10.0.1.1 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.2.1 . 10.0.2.1 . tcp . 8080 }
 
-		add chain ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80
-		add rule ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80 meta l4proto tcp dnat to 10.0.1.1:80
-
-		add chain ip kube-proxy service-MHHHYRWA-ns2/svc2/tcp/p8080
-		add rule ip kube-proxy service-MHHHYRWA-ns2/svc2/tcp/p8080 meta l4proto tcp dnat to 10.0.2.1:8080
+		add chain ip kube-proxy dispatch-1
+		add rule ip kube-proxy dispatch-1 ct mark set numgen random mod 1 dnat ip addr . port to ip daddr . meta l4proto . th dport . ct mark map @endpoints
                 `)
 	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
 
@@ -4475,26 +4569,23 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.42 }
 		add element ip kube-proxy cluster-ips { 172.30.0.43 }
-		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto service-ULMVA6XW-ns1/svc1/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.42 . tcp . 8080 : goto service-MHHHYRWA-ns2/svc2/tcp/p8080 }
-		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto service-4AT6LBPK-ns3/svc3/tcp/p80 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto dispatch-1 }
+		add element ip kube-proxy service-ips { 172.30.0.42 . tcp . 8080 : goto dispatch-1 }
+		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto dispatch-1 }
+		add element ip kube-proxy endpoints { 172.30.0.41 . tcp . 80 . 0 : 10.0.1.1 . 80 }
+		add element ip kube-proxy endpoints { 172.30.0.42 . tcp . 8080 . 0 : 10.0.2.1 . 8080 }
+		add element ip kube-proxy endpoints { 172.30.0.43 . tcp . 80 . 0 : 10.0.3.1 . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.1.1 . 10.0.1.1 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.2.1 . 10.0.2.1 . tcp . 8080 }
 		add element ip kube-proxy hairpin-connections { 10.0.3.1 . 10.0.3.1 . tcp . 80 }
 
-		add chain ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80
-		add rule ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80 meta l4proto tcp dnat to 10.0.1.1:80
-
-		add chain ip kube-proxy service-MHHHYRWA-ns2/svc2/tcp/p8080
-		add rule ip kube-proxy service-MHHHYRWA-ns2/svc2/tcp/p8080 meta l4proto tcp dnat to 10.0.2.1:8080
-
-		add chain ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80
-		add rule ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80 meta l4proto tcp dnat to 10.0.3.1:80
+		add chain ip kube-proxy dispatch-1
+		add rule ip kube-proxy dispatch-1 ct mark set numgen random mod 1 dnat ip addr . port to ip daddr . meta l4proto . th dport . ct mark map @endpoints
 		`)
 	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
 	assertNumOperations(t, nft,
 		3, // add 1 element each to cluster-ips, service-ips, and hairpin-connections
-		3, // add+flush service chain, add 1 rule
+		1, // add 1 endpoints map element (svc3 reuses the shared dispatch-1 bucket chain)
 	)
 
 	// Delete a service; its chains will be flushed, but not immediately deleted.
@@ -4503,23 +4594,19 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 	expected = baseRules + dedent.Dedent(`
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.43 }
-		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto service-ULMVA6XW-ns1/svc1/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto service-4AT6LBPK-ns3/svc3/tcp/p80 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto dispatch-1 }
+		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto dispatch-1 }
+		add element ip kube-proxy endpoints { 172.30.0.41 . tcp . 80 . 0 : 10.0.1.1 . 80 }
+		add element ip kube-proxy endpoints { 172.30.0.43 . tcp . 80 . 0 : 10.0.3.1 . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.1.1 . 10.0.1.1 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.3.1 . 10.0.3.1 . tcp . 80 }
 
-		add chain ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80
-		add rule ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80 meta l4proto tcp dnat to 10.0.1.1:80
-
-		add chain ip kube-proxy service-MHHHYRWA-ns2/svc2/tcp/p8080
-
-		add chain ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80
-		add rule ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80 meta l4proto tcp dnat to 10.0.3.1:80
+		add chain ip kube-proxy dispatch-1
+		add rule ip kube-proxy dispatch-1 ct mark set numgen random mod 1 dnat ip addr . port to ip daddr . meta l4proto . th dport . ct mark map @endpoints
 		`)
 	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
 	assertNumOperations(t, nft,
-		3, // delete 1 element each from cluster-ips, service-ips, hairpin-connections
-		1, // flush service chain
+		4, // delete 1 element each from cluster-ips, service-ips, endpoints, and hairpin-connections
 	)
 
 	// Fake the passage of time and confirm that the stale chains get deleted.
@@ -4528,19 +4615,18 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 	expected = baseRules + dedent.Dedent(`
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.43 }
-		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto service-ULMVA6XW-ns1/svc1/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto service-4AT6LBPK-ns3/svc3/tcp/p80 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto dispatch-1 }
+		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto dispatch-1 }
+		add element ip kube-proxy endpoints { 172.30.0.41 . tcp . 80 . 0 : 10.0.1.1 . 80 }
+		add element ip kube-proxy endpoints { 172.30.0.43 . tcp . 80 . 0 : 10.0.3.1 . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.1.1 . 10.0.1.1 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.3.1 . 10.0.3.1 . tcp . 80 }
 
-		add chain ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80
-		add rule ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80 meta l4proto tcp dnat to 10.0.1.1:80
-
-		add chain ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80
-		add rule ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80 meta l4proto tcp dnat to 10.0.3.1:80
+		add chain ip kube-proxy dispatch-1
+		add rule ip kube-proxy dispatch-1 ct mark set numgen random mod 1 dnat ip addr . port to ip daddr . meta l4proto . th dport . ct mark map @endpoints
 		`)
 	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
-	// delete stale chains happens in a separate transaction, nothing else changed
+	// no stale chains exist (services share bucket chains), nothing changed
 	assertNumOperations(t, nft, 0)
 
 	// Add a service, sync, then add its endpoints.
@@ -4560,16 +4646,15 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.43 }
 		add element ip kube-proxy cluster-ips { 172.30.0.44 }
-		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto service-ULMVA6XW-ns1/svc1/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto service-4AT6LBPK-ns3/svc3/tcp/p80 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto dispatch-1 }
+		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto dispatch-1 }
+		add element ip kube-proxy endpoints { 172.30.0.41 . tcp . 80 . 0 : 10.0.1.1 . 80 }
+		add element ip kube-proxy endpoints { 172.30.0.43 . tcp . 80 . 0 : 10.0.3.1 . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.1.1 . 10.0.1.1 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.3.1 . 10.0.3.1 . tcp . 80 }
 
-		add chain ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80
-		add rule ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80 meta l4proto tcp dnat to 10.0.1.1:80
-
-		add chain ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80
-		add rule ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80 meta l4proto tcp dnat to 10.0.3.1:80
+		add chain ip kube-proxy dispatch-1
+		add rule ip kube-proxy dispatch-1 ct mark set numgen random mod 1 dnat ip addr . port to ip daddr . meta l4proto . th dport . ct mark map @endpoints
 
 		add element ip kube-proxy no-endpoint-services { 172.30.0.44 . tcp . 80 comment "ns4/svc4:p80" : goto reject-chain }
 		`)
@@ -4597,27 +4682,24 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.43 }
 		add element ip kube-proxy cluster-ips { 172.30.0.44 }
-		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto service-ULMVA6XW-ns1/svc1/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto service-4AT6LBPK-ns3/svc3/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.44 . tcp . 80 : goto service-LAUZTJTB-ns4/svc4/tcp/p80 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto dispatch-1 }
+		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto dispatch-1 }
+		add element ip kube-proxy service-ips { 172.30.0.44 . tcp . 80 : goto dispatch-1 }
+		add element ip kube-proxy endpoints { 172.30.0.41 . tcp . 80 . 0 : 10.0.1.1 . 80 }
+		add element ip kube-proxy endpoints { 172.30.0.43 . tcp . 80 . 0 : 10.0.3.1 . 80 }
+		add element ip kube-proxy endpoints { 172.30.0.44 . tcp . 80 . 0 : 10.0.4.1 . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.1.1 . 10.0.1.1 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.3.1 . 10.0.3.1 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.4.1 . 10.0.4.1 . tcp . 80 }
 
-		add chain ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80
-		add rule ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80 meta l4proto tcp dnat to 10.0.1.1:80
-
-		add chain ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80
-		add rule ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80 meta l4proto tcp dnat to 10.0.3.1:80
-
-		add chain ip kube-proxy service-LAUZTJTB-ns4/svc4/tcp/p80
-		add rule ip kube-proxy service-LAUZTJTB-ns4/svc4/tcp/p80 meta l4proto tcp dnat to 10.0.4.1:80
+		add chain ip kube-proxy dispatch-1
+		add rule ip kube-proxy dispatch-1 ct mark set numgen random mod 1 dnat ip addr . port to ip daddr . meta l4proto . th dport . ct mark map @endpoints
 		`)
 	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
 	assertNumOperations(t, nft,
 		2, // add 1 element to service-ips, remove 1 element from no-endpoint-services
 		1, // add 1 element to hairpin-connections
-		3, // add+flush service chain, add 1 rule
+		1, // add 1 endpoints map element (svc4 reuses the shared dispatch-1 bucket chain)
 	)
 
 	// Change an endpoint of an existing service.
@@ -4631,26 +4713,23 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.43 }
 		add element ip kube-proxy cluster-ips { 172.30.0.44 }
-		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto service-ULMVA6XW-ns1/svc1/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto service-4AT6LBPK-ns3/svc3/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.44 . tcp . 80 : goto service-LAUZTJTB-ns4/svc4/tcp/p80 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto dispatch-1 }
+		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto dispatch-1 }
+		add element ip kube-proxy service-ips { 172.30.0.44 . tcp . 80 : goto dispatch-1 }
+		add element ip kube-proxy endpoints { 172.30.0.41 . tcp . 80 . 0 : 10.0.1.1 . 80 }
+		add element ip kube-proxy endpoints { 172.30.0.43 . tcp . 80 . 0 : 10.0.3.2 . 80 }
+		add element ip kube-proxy endpoints { 172.30.0.44 . tcp . 80 . 0 : 10.0.4.1 . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.1.1 . 10.0.1.1 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.3.2 . 10.0.3.2 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.4.1 . 10.0.4.1 . tcp . 80 }
 
-		add chain ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80
-		add rule ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80 meta l4proto tcp dnat to 10.0.1.1:80
-
-		add chain ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80
-		add rule ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80 meta l4proto tcp dnat to 10.0.3.2:80
-
-		add chain ip kube-proxy service-LAUZTJTB-ns4/svc4/tcp/p80
-		add rule ip kube-proxy service-LAUZTJTB-ns4/svc4/tcp/p80 meta l4proto tcp dnat to 10.0.4.1:80
+		add chain ip kube-proxy dispatch-1
+		add rule ip kube-proxy dispatch-1 ct mark set numgen random mod 1 dnat ip addr . port to ip daddr . meta l4proto . th dport . ct mark map @endpoints
 		`)
 	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
 	assertNumOperations(t, nft,
 		2, // remove 1 old element from hairpin-connections, add 1 new one
-		3, // add+flush service chain, add 1 rule
+		2, // update svc3's endpoints map element (delete+add)
 	)
 
 	// (Ensure the old svc3 chain gets deleted in the next sync.)
@@ -4669,28 +4748,30 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.43 }
 		add element ip kube-proxy cluster-ips { 172.30.0.44 }
-		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto service-ULMVA6XW-ns1/svc1/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto service-4AT6LBPK-ns3/svc3/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.44 . tcp . 80 : goto service-LAUZTJTB-ns4/svc4/tcp/p80 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto dispatch-1 }
+		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto dispatch-2 }
+		add element ip kube-proxy service-ips { 172.30.0.44 . tcp . 80 : goto dispatch-1 }
+		add element ip kube-proxy endpoints { 172.30.0.41 . tcp . 80 . 0 : 10.0.1.1 . 80 }
+		add element ip kube-proxy endpoints { 172.30.0.43 . tcp . 80 . 0 : 10.0.3.2 . 80 }
+		add element ip kube-proxy endpoints { 172.30.0.43 . tcp . 80 . 1 : 10.0.3.3 . 80 }
+		add element ip kube-proxy endpoints { 172.30.0.44 . tcp . 80 . 0 : 10.0.4.1 . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.1.1 . 10.0.1.1 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.3.2 . 10.0.3.2 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.3.3 . 10.0.3.3 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.4.1 . 10.0.4.1 . tcp . 80 }
 
-		add chain ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80
-		add rule ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80 meta l4proto tcp dnat to 10.0.1.1:80
+		add chain ip kube-proxy dispatch-1
+		add rule ip kube-proxy dispatch-1 ct mark set numgen random mod 1 dnat ip addr . port to ip daddr . meta l4proto . th dport . ct mark map @endpoints
 
-		add chain ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80
-		add rule ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 2 map { 0 : 10.0.3.2 . 80 , 1 : 10.0.3.3 . 80 }
-
-		add chain ip kube-proxy service-LAUZTJTB-ns4/svc4/tcp/p80
-		add rule ip kube-proxy service-LAUZTJTB-ns4/svc4/tcp/p80 meta l4proto tcp dnat to 10.0.4.1:80
+		add chain ip kube-proxy dispatch-2
+		add rule ip kube-proxy dispatch-2 ct mark set numgen random mod 2 dnat ip addr . port to ip daddr . meta l4proto . th dport . ct mark map @endpoints
 		`)
 	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
-	// (The first endpoint chain is unchanged, but the code recreates it anyway.)
 	assertNumOperations(t, nft,
 		1, // add 1 element to hairpin-connections
-		3, // add+flush service chain, add 1 rule
+		1, // add svc3's second endpoints map element
+		2, // re-point svc3's service-ips element from dispatch-1 to dispatch-2 (delete+add)
+		3, // add+flush dispatch-2 bucket chain, add 1 rule
 	)
 
 	// Empty a service's endpoints; its chains will be flushed, but not immediately deleted.
@@ -4702,28 +4783,28 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.43 }
 		add element ip kube-proxy cluster-ips { 172.30.0.44 }
-		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto service-ULMVA6XW-ns1/svc1/tcp/p80 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto dispatch-1 }
 		add element ip kube-proxy no-endpoint-services { 172.30.0.43 . tcp . 80 comment "ns3/svc3:p80" : goto reject-chain }
-		add element ip kube-proxy service-ips { 172.30.0.44 . tcp . 80 : goto service-LAUZTJTB-ns4/svc4/tcp/p80 }
+		add element ip kube-proxy service-ips { 172.30.0.44 . tcp . 80 : goto dispatch-1 }
+		add element ip kube-proxy endpoints { 172.30.0.41 . tcp . 80 . 0 : 10.0.1.1 . 80 }
+		add element ip kube-proxy endpoints { 172.30.0.44 . tcp . 80 . 0 : 10.0.4.1 . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.1.1 . 10.0.1.1 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.4.1 . 10.0.4.1 . tcp . 80 }
 
-		add chain ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80
-		add rule ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80 meta l4proto tcp dnat to 10.0.1.1:80
+		add chain ip kube-proxy dispatch-1
+		add rule ip kube-proxy dispatch-1 ct mark set numgen random mod 1 dnat ip addr . port to ip daddr . meta l4proto . th dport . ct mark map @endpoints
 
-		add chain ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80
-
-		add chain ip kube-proxy service-LAUZTJTB-ns4/svc4/tcp/p80
-		add rule ip kube-proxy service-LAUZTJTB-ns4/svc4/tcp/p80 meta l4proto tcp dnat to 10.0.4.1:80
+		add chain ip kube-proxy dispatch-2
 		`)
 	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
 	assertNumOperations(t, nft,
 		2, // remove 1 element from service-ips, add 1 element to no-endpoint-services
 		2, // remove 2 elements from hairpin-connections
-		1, // flush service chain
+		2, // remove svc3's 2 endpoints map elements
+		1, // flush now-unused dispatch-2 bucket chain
 	)
 
-	expectedStaleChains := sets.NewString("service-4AT6LBPK-ns3/svc3/tcp/p80")
+	expectedStaleChains := sets.NewString("dispatch-2")
 	gotStaleChains := sets.StringKeySet(fp.staleChains)
 	if !expectedStaleChains.Equal(gotStaleChains) {
 		t.Errorf("expected stale chains %v, got %v", expectedStaleChains, gotStaleChains)
@@ -4735,28 +4816,30 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.43 }
 		add element ip kube-proxy cluster-ips { 172.30.0.44 }
-		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto service-ULMVA6XW-ns1/svc1/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto service-4AT6LBPK-ns3/svc3/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.44 . tcp . 80 : goto service-LAUZTJTB-ns4/svc4/tcp/p80 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto dispatch-1 }
+		add element ip kube-proxy service-ips { 172.30.0.43 . tcp . 80 : goto dispatch-2 }
+		add element ip kube-proxy service-ips { 172.30.0.44 . tcp . 80 : goto dispatch-1 }
+		add element ip kube-proxy endpoints { 172.30.0.41 . tcp . 80 . 0 : 10.0.1.1 . 80 }
+		add element ip kube-proxy endpoints { 172.30.0.43 . tcp . 80 . 0 : 10.0.3.2 . 80 }
+		add element ip kube-proxy endpoints { 172.30.0.43 . tcp . 80 . 1 : 10.0.3.3 . 80 }
+		add element ip kube-proxy endpoints { 172.30.0.44 . tcp . 80 . 0 : 10.0.4.1 . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.1.1 . 10.0.1.1 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.3.2 . 10.0.3.2 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.3.3 . 10.0.3.3 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.4.1 . 10.0.4.1 . tcp . 80 }
 
-		add chain ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80
-		add rule ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80 meta l4proto tcp dnat to 10.0.1.1:80
+		add chain ip kube-proxy dispatch-1
+		add rule ip kube-proxy dispatch-1 ct mark set numgen random mod 1 dnat ip addr . port to ip daddr . meta l4proto . th dport . ct mark map @endpoints
 
-		add chain ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80
-		add rule ip kube-proxy service-4AT6LBPK-ns3/svc3/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 2 map { 0 : 10.0.3.2 . 80 , 1 : 10.0.3.3 . 80 }
-
-		add chain ip kube-proxy service-LAUZTJTB-ns4/svc4/tcp/p80
-		add rule ip kube-proxy service-LAUZTJTB-ns4/svc4/tcp/p80 meta l4proto tcp dnat to 10.0.4.1:80
+		add chain ip kube-proxy dispatch-2
+		add rule ip kube-proxy dispatch-2 ct mark set numgen random mod 2 dnat ip addr . port to ip daddr . meta l4proto . th dport . ct mark map @endpoints
 		`)
 	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
 	assertNumOperations(t, nft,
 		2, // remove 1 element from no-endpoint-services, add 1 element to service-ips
 		2, // add 2 elements to hairpin-connections
-		3, // add+flush service chain, add 1 rule
+		2, // add svc3's 2 endpoints map elements
+		3, // re-create dispatch-2 bucket chain (add+flush, add 1 rule)
 	)
 
 	if len(fp.staleChains) != 0 {
@@ -4882,25 +4965,35 @@ func TestSyncProxyRulesStartup(t *testing.T) {
 		add element ip kube-proxy cluster-ips { 172.30.0.41 }
 		add element ip kube-proxy cluster-ips { 172.30.0.42 }
 		add element ip kube-proxy cluster-ips { 172.30.0.43 }
-		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto service-ULMVA6XW-ns1/svc1/tcp/p80 }
-		add element ip kube-proxy service-ips { 172.30.0.42 . tcp . 8080 : goto service-MHHHYRWA-ns2/svc2/tcp/p8080 }
+		add element ip kube-proxy service-ips { 172.30.0.41 . tcp . 80 : goto dispatch-2 }
+		add element ip kube-proxy service-ips { 172.30.0.42 . tcp . 8080 : goto dispatch-1 }
+		add element ip kube-proxy endpoints { 172.30.0.41 . tcp . 80 . 0 : 10.0.1.1 . 80 }
+		add element ip kube-proxy endpoints { 172.30.0.41 . tcp . 80 . 1 : 10.0.1.2 . 80 }
+		add element ip kube-proxy endpoints { 172.30.0.42 . tcp . 8080 . 0 : 10.0.2.1 . 8080 }
 		add element ip kube-proxy no-endpoint-services { 172.30.0.43 . tcp . 80 comment "ns3/svc3:p80" : goto reject-chain }
 		add element ip kube-proxy hairpin-connections { 10.0.1.1 . 10.0.1.1 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.1.2 . 10.0.1.2 . tcp . 80 }
 		add element ip kube-proxy hairpin-connections { 10.0.2.1 . 10.0.2.1 . tcp . 8080 }
 
+		add chain ip kube-proxy dispatch-1
+		add rule ip kube-proxy dispatch-1 ct mark set numgen random mod 1 dnat ip addr . port to ip daddr . meta l4proto . th dport . ct mark map @endpoints
+
+		add chain ip kube-proxy dispatch-2
+		add rule ip kube-proxy dispatch-2 ct mark set numgen random mod 2 dnat ip addr . port to ip daddr . meta l4proto . th dport . ct mark map @endpoints
+
 		add chain ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80
-		add rule ip kube-proxy service-ULMVA6XW-ns1/svc1/tcp/p80 meta l4proto tcp dnat ip addr . port to numgen random mod 2 map { 0 : 10.0.1.1 . 80 , 1 : 10.0.1.2 . 80 }
 
 		add chain ip kube-proxy service-MHHHYRWA-ns2/svc2/tcp/p8080
-		add rule ip kube-proxy service-MHHHYRWA-ns2/svc2/tcp/p8080 meta l4proto tcp dnat to 10.0.2.1:8080
 	`)
 	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
 	assertNumOperations(t, nft,
 		setupOps, // nft setup
 		1,        // add new svc1 endpoint to hairpin-connections
 		2,        // add svc3 IP to the cluster-ips, and to the no-endpoint-services set
-		6,        // add+flush 2 service chains + 1 rule each
+		6,        // add+flush 2 bucket chains + 1 rule each
+		3,        // add 3 endpoints map elements
+		4,        // re-point 2 service-ips elements at bucket chains (delete+add each)
+		2,        // flush 2 now-stale per-service chains
 	)
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

Bug? Cleanup? I'm not sure.


#### What this PR does / why we need it:

Decrease the number of sets/maps used by kube-proxy to reduce the time it takes to program nftables.
There are more places where sets/maps are used, but, I figured to only scope this to regular ClusterIPs 

#### Which issue(s) this PR is related to:

Relates to: https://github.com/kubernetes/kubernetes/issues/139513

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

(FIXME: add a release note)

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

---

Over in https://github.com/kubernetes/kubernetes/issues/139513 the user said that they had 45k services with its own endpoint. I recreated the scenario and did some testing.

I used `perf` to measure this:
```console
root@308f9efce777:/# perf record -g --call-graph dwarf -- nft -f kube-proxy-nft-45k.commands
[ perf record: Woken up 47626 times to write data ]
Warning:
Processed 1489197 events and lost 3 chunks!

Check IO/CPU overload!

[ perf record: Captured and wrote 11907.591 MB perf.data (1435605 samples) ]
```

That allowed me to figure out what was going on when `nft` was running
Using `perf report --stdio -i perf.data-raw-commands --no-children -g none --percent-limit 5` I got this output:
```
# Total Lost Samples: 61
#
# Samples: 1M of event 'task-clock:ppp'
# Event count (approx.): 358901250000
#
# Overhead  Command  Shared Object          Symbol
# ........  .......  .....................  ...........................................................
#
    42.26%  nft      [nf_tables]            [k] nft_set_lookup_global
    16.29%  nft      [nf_tables]            [k] __nft_set_trans_bind.isra.0
    10.16%  nft      [kernel.kallsyms]      [k] _parse_integer_limit
     9.92%  nft      [kernel.kallsyms]      [k] nla_strcmp
     8.30%  nft      [kernel.kallsyms]      [k] strlen
```

It seems that `nft_set_lookup_global` is the top consumer. Inspecting it with `perf report -i perf.data-raw-commands --stdio -g callee --symbol-filter=nft_set_lookup_global`:
```
# Samples: 1M of event 'task-clock:ppp'
# Event count (approx.): 358901250000
#
# Children      Self  Command  Shared Object  Symbol
# ........  ........  .......  .............  .....................................
#
    47.24%    42.26%  nft      [nf_tables]    [k] nft_set_lookup_global
            |
            ---nft_set_lookup_global
               |
               |--23.71%--nf_tables_newsetelem
               |          nfnetlink_rcv_batch
               |          nfnetlink_rcv
               |          netlink_unicast
               |          netlink_sendmsg
               |          __sock_sendmsg
               |          ____sys_sendmsg
               |          ___sys_sendmsg
               |          __sys_sendmsg
               |          __arm64_sys_sendmsg
               |          invoke_syscall
               |          el0_svc_common.constprop.0
               |          do_el0_svc
               |          el0_svc
               |          el0t_64_sync_handler
               |          el0t_64_sync
               |          sendmsg
               |          0xfd28121b09ff
               |          0xfd28121b09ff
               |
                --23.53%--nft_lookup_init
                          nf_tables_newrule
                          nfnetlink_rcv_batch
                          nfnetlink_rcv
                          netlink_unicast
                          netlink_sendmsg
                          __sock_sendmsg
                          ____sys_sendmsg
                          ___sys_sendmsg
                          __sys_sendmsg
                          __arm64_sys_sendmsg
                          invoke_syscall
                          el0_svc_common.constprop.0
                          do_el0_svc
                          el0_svc
                          el0t_64_sync_handler
                          el0t_64_sync
                          sendmsg
                          0xfd28121b09ff
                          0xfd28121b09ff
```

Both `nf_tables_newsetelem` and `nft_lookup_init` seem to be the root cause here.

I tried a few scenarios, and the end result was that if I could reduce the number of sets/maps, it sped up the nft command significantly.

It reduced the `nft` command down to sub 1 second (compared to 5-8 minutes).

It seems that the way forward here is to reduce the number of sets/maps that kube-proxy uses.

I did also run some benchmarks to see if there was a limit to the size of maps/sets, but I couldn't find a breaking point, so I assume it will scale enough for kube-proxy's needs.