### PR TITLE
Fix/init container node restart

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -1070,10 +1070,18 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(ctx context.Cont
 	// never ran and will re-execute improperly except for the restartable init containers.
 	podHasInitialized := false
 	for _, container := range pod.Spec.Containers {
-		status := podStatus.FindContainerStatusByName(container.Name)
+		var status *kubecontainer.Status
+		for _, s := range podStatus.ActiveContainerStatuses {
+			if s.Name == container.Name {
+				status = s
+				break
+			}
+		}
+
 		if status == nil {
 			continue
 		}
+
 		switch status.State {
 		case kubecontainer.ContainerStateCreated,
 			kubecontainer.ContainerStateRunning:
@@ -1089,6 +1097,7 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(ctx context.Cont
 		default:
 			// Ignore other states
 		}
+
 		if podHasInitialized {
 			break
 		}

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -6094,6 +6094,50 @@ func TestAllocator(t *testing.T,
 				deviceAllocationResult(req0, driverA, pool1, device2, false),
 			)},
 		},
+		"list-attributes-match-constaint-list-of-int-values-requires-backtracking": {
+			// Regression test for the allocator failing to find a valid
+			// allocation because matchAttributeConstraint.remove() did not
+			// restore the intersection on backtrack, leaving it stale from
+			// a device that was already removed from consideration.
+			//
+			// device1: numa=[1,2], device2: numa=[1], device3: numa=[2], device4: numa=[2]
+			// Requesting 3 devices, the only valid combination is
+			// {device1, device3, device4}, which requires the allocator to
+			// backtrack past device2 (added and then removed) and have the
+			// intersection correctly restored to [1,2] before re-evaluating
+			// device3 and device4.
+			features: Features{
+				ListTypeAttributes: true,
+			},
+			claimsToAllocate: objects(claimWithRequests(
+				claim0,
+				[]resourceapi.DeviceConstraint{{MatchAttribute: &intAttribute}},
+				request(req0, classA, 3)),
+			),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
+				device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"numa": {IntValues: []int64{1, 2}},
+				}),
+				device(device2, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"numa": {IntValues: []int64{1}},
+				}),
+				device(device3, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"numa": {IntValues: []int64{2}},
+				}),
+				device(device4, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"numa": {IntValues: []int64{2}},
+				}),
+			)),
+			node: node(node1, region1),
+
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool1, device1, false),
+				deviceAllocationResult(req0, driverA, pool1, device3, false),
+				deviceAllocationResult(req0, driverA, pool1, device4, false),
+			)},
+		},
 		"list-attributes-match-constaint-list-of-bool-values-with-common-elements": {
 			features: Features{
 				ListTypeAttributes: true,

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -903,8 +903,11 @@ type matchAttributeConstraint struct {
 
 	// For list values (when DRAListTypeAttributes feature gate is enabled)
 	intersection *deviceAttributeListAsSet
-
-	numDevices int
+	// intersectionHistory records intersection's value before each add()
+	// narrowed it. remove() pops this stack to restore intersection on
+	// backtrack. Only used when features.ListTypeAttributes is enabled.
+	intersectionHistory []*deviceAttributeListAsSet
+	numDevices          int
 }
 
 func (m *matchAttributeConstraint) add(requestName, subRequestName string, device *draapi.Device, deviceID DeviceID) bool {
@@ -926,11 +929,13 @@ func (m *matchAttributeConstraint) add(requestName, subRequestName string, devic
 		// Initialize either scalar attribute or list set based on the attribute type.
 		if m.features.ListTypeAttributes {
 			// Convert attribute to set representation (both scalar and list)
-			m.intersection = attributeAsSet(attribute)
-			if m.intersection == nil {
+			newIntersection := attributeAsSet(attribute)
+			if newIntersection == nil {
 				m.logger.V(7).Info("Attribute type unknown")
 				return false
 			}
+			m.intersectionHistory = append(m.intersectionHistory, nil)
+			m.intersection = newIntersection
 		} else {
 			// Scalar attribute: use existing behavior
 			m.attribute = attribute
@@ -952,6 +957,8 @@ func (m *matchAttributeConstraint) add(requestName, subRequestName string, devic
 			m.logger.V(7).Info("Attribute values have no common elements")
 			return false
 		}
+		previousIntersection := *m.intersection
+		m.intersectionHistory = append(m.intersectionHistory, &previousIntersection)
 		// Update to intersection
 		m.intersection.updateToIntersection(newSet)
 	} else {
@@ -999,6 +1006,11 @@ func (m *matchAttributeConstraint) remove(requestName, subRequestName string, de
 	}
 
 	m.numDevices--
+	if m.features.ListTypeAttributes && len(m.intersectionHistory) > 0 {
+		last := len(m.intersectionHistory) - 1
+		m.intersection = m.intersectionHistory[last]
+		m.intersectionHistory = m.intersectionHistory[:last]
+	}
 	m.logger.V(7).Info("Device removed from constraint set", "device", deviceID, "numDevices", m.numDevices)
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When determining whether a pod has already completed initialization, `computeInitContainerActions()` currently checks container statuses using `podStatus.FindContainerStatusByName()`, which searches all recorded container statuses, including stale statuses from previous pod sandboxes.

After a node restart, a main container that was created but never started in a previous sandbox may still appear in `ContainerStateCreated`. This causes kubelet to incorrectly conclude that pod initialization has already completed, resulting in only the first init container being executed while the remaining init containers are skipped.

This PR changes the initialization check to use `podStatus.ActiveContainerStatuses`, ensuring that only container statuses belonging to the currently active sandbox are considered.

#### Which issue(s) this PR is related to:

Fixes: https://github.com/kubernetes/kubernetes/issues/140309

#### Special notes for your reviewer:

The change is limited to the initialization detection logic in `computeInitContainerActions()`. No other init container behavior is modified.

#### Does this PR introduce a user-facing change?

```release-note
Fixed an issue where, after a node restart, stale main container statuses from a previous pod sandbox could cause kubelet to incorrectly skip remaining init containers, resulting in only the first init container being executed.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
