### PR TITLE
test: stabilize async preemption queue assertions

### DIFF
--- a/test/integration/scheduler/preemption/preemption_test.go
+++ b/test/integration/scheduler/preemption/preemption_test.go
@@ -519,6 +519,11 @@ func TestAsyncPreemption(t *testing.T) {
 		// completePreemption completes the preemption that is currently on-going.
 		// You should give a Pod name.
 		completePreemption string
+		// waitForAsyncPreemptionToFinish waits until the async preemption executor no longer tracks
+		// the preemptor after completePreemption. Only use this for scenarios that assert
+		// post-preemption queue state; scenarios that intentionally observe intermediate async
+		// state should not wait.
+		waitForAsyncPreemptionToFinish bool
 		// podGatedInQueue checks if the given Pod is in the scheduling queue and gated by the preemption.
 		// You should give a Pod name.
 		podGatedInQueue string
@@ -760,12 +765,18 @@ func TestAsyncPreemption(t *testing.T) {
 					podGatedInQueue: "preemptor-super-high-priority",
 				},
 				{
-					name:               "complete the preemption API calls of super-high-priority",
-					completePreemption: "preemptor-super-high-priority",
+					name:                           "complete the preemption API calls of super-high-priority",
+					completePreemption:             "preemptor-super-high-priority",
+					waitForAsyncPreemptionToFinish: true,
 				},
 				{
-					name:               "complete the preemption API calls of high-priority",
-					completePreemption: "preemptor-high-priority",
+					name:                           "complete the preemption API calls of high-priority",
+					completePreemption:             "preemptor-high-priority",
+					waitForAsyncPreemptionToFinish: true,
+				},
+				{
+					name:               "flush scheduling queue after preemption completes",
+					flushUnschedulable: true,
 				},
 				{
 					name: "schedule the super-high-priority Pod",
@@ -840,12 +851,18 @@ func TestAsyncPreemption(t *testing.T) {
 					podRunningPreemption: ptr.To(5),
 				},
 				{
-					name:               "complete the preemption API calls",
-					completePreemption: "preemptor-mid-priority",
+					name:                           "complete the preemption API calls",
+					completePreemption:             "preemptor-mid-priority",
+					waitForAsyncPreemptionToFinish: true,
 				},
 				{
-					name:               "complete the preemption API calls",
-					completePreemption: "preemptor-high-priority",
+					name:                           "complete the preemption API calls",
+					completePreemption:             "preemptor-high-priority",
+					waitForAsyncPreemptionToFinish: true,
+				},
+				{
+					name:               "flush scheduling queue after preemption completes",
+					flushUnschedulable: true,
 				},
 				{
 					// the preemptor pod should be popped from the queue before the mid-priority pod.
@@ -1514,6 +1531,24 @@ func TestAsyncPreemption(t *testing.T) {
 						close(preemptionDoneChannels[scenario.completePreemption])
 						delete(preemptionDoneChannels, scenario.completePreemption)
 						lock.Unlock()
+
+						if scenario.waitForAsyncPreemptionToFinish {
+							var preemptorPod *v1.Pod
+							for _, pod := range createdPods {
+								if pod.Name == scenario.completePreemption {
+									preemptorPod = pod
+									break
+								}
+							}
+							if preemptorPod == nil {
+								t.Fatalf("Failed to find created preemptor Pod %q", scenario.completePreemption)
+							}
+							if err := wait.PollUntilContextTimeout(testCtx.Ctx, time.Millisecond*200, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+								return !preemptionPlugin.Executor.IsPodRunningPreemption(preemptorPod.GetUID()), nil
+							}); err != nil {
+								t.Fatalf("Timed out waiting for Pod %q to finish preemption", scenario.completePreemption)
+							}
+						}
 					case scenario.podGatedInQueue != "":
 						// make sure the Pod is in the queue in the first place.
 						if !podInUnschedulablePodPool(t, testCtx.Scheduler.SchedulingQueue, scenario.podGatedInQueue) {


### PR DESCRIPTION
 #### What type of PR is this?

  /kind flake

  #### What this PR does / why we need it:

 This is a test-only change.

  The alternative I considered was a scheduler-side change: after async preemption finishes deleting victims and clears the executor bookkeeping for the preemptor, explicitly activate the preemptor's gated pods / unschedulable pods again. That would make the scheduler proactively requeue pods after preemption completion instead of relying only on victim delete/update events to move them back to `activeQ`.

  I did not include that product-code change in this PR because the observed failures look test-induced: the test unblocks fake `PreemptPod` calls and immediately asserts post-preemption queue order, but at that point async preemption cleanup and queue event handling may still be settling. In real clusters, the same eventual requeue path is still driven by normal pod delete/update events; the flaky part here is the test asserting a fully settled queue state without an explicit synchronization point.

  at https://github.com/kubernetes/kubernetes/pull/140054. That PR addresses a related async preemption gap for in-memory victims, such as pods in `WaitingPod` / `PodInPreBind`, where normal API deletion events are not sufficient because the victim may not have a regular delete event path yet. Its fix is intentionally scoped to those in-memory preemption cases. The flakes addressed here are different: the victims are ordinary scheduled pods whose deletion/update events still provide the eventual wake-up path. The race is in the integration test's timing: it releases the fake preemption API calls and immediately checks queue order before async preemption bookkeeping and queue updates have fully settled.

  So this PR keeps the fix scoped to the integration test: it waits until the async preemption executor no longer tracks the relevant preemptor, then flushes the unschedulable queue before checking post-preemption queue order.

  Reviewer input is welcome on whether we should instead prefer the scheduler-side activation path.


  Tested with:

- `make test-integration WHAT=./test/integration/scheduler/preemption KUBE_TEST_ARGS='-run TestAsyncPreemption/Lower_priority_Pod_can_select_the_same_place_where_the_higher_priority_Pod_is_preempting_if_the_node_is_big_enough -count=1 -v'`
- `make test-integration WHAT=./test/integration/scheduler/preemption KUBE_TEST_ARGS='-run TestAsyncPreemption/Higher_priority_Pod_takes_over_the_place_for_lower_priority_Pod_that_is_running_the_preemption -count=1 -v'`
- `make test-integration WHAT=./test/integration/scheduler/preemption KUBE_TEST_ARGS='-run TestAsyncPreemption -count=1 -v'`
- `git diff --check`


  #### Does this PR introduce a user-facing change?
```text
  NONE
```
  #### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```text
  NONE
```
