### PR TITLE
Fix resource limit for cpu manager test

### DIFF
--- a/test/e2e_node/cpu_manager_test.go
+++ b/test/e2e_node/cpu_manager_test.go
@@ -1906,7 +1906,7 @@ var _ = SIGDescribe("CPU Manager", ginkgo.Ordered, ginkgo.ContinueOnFailure, fra
 		})
 
 		ginkgo.It("should preserve CPU affinity after restarting all containers", func(ctx context.Context) {
-			cpuCount := 2 // total
+			cpuCount := 4 // total
 			skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), cpuCount)
 			updateKubeletConfigIfNeeded(ctx, f, configureCPUManagerInKubelet(oldCfg, &cpuManagerKubeletArguments{
 				policyName:         string(cpumanager.PolicyStatic),
@@ -1953,11 +1953,11 @@ var _ = SIGDescribe("CPU Manager", ginkgo.Ordered, ginkgo.ContinueOnFailure, fra
 							`},
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
-									v1.ResourceCPU:    resource.MustParse("1000m"),
+									v1.ResourceCPU:    resource.MustParse("1"),
 									v1.ResourceMemory: resource.MustParse("100Mi"),
 								},
 								Requests: v1.ResourceList{
-									v1.ResourceCPU:    resource.MustParse("1000m"),
+									v1.ResourceCPU:    resource.MustParse("1"),
 									v1.ResourceMemory: resource.MustParse("100Mi"),
 								},
 							},
@@ -1976,12 +1976,12 @@ var _ = SIGDescribe("CPU Manager", ginkgo.Ordered, ginkgo.ContinueOnFailure, fra
 							Command: []string{"/bin/sh", "-c", "sleep 10000"},
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
-									v1.ResourceCPU:    resource.MustParse("10m"),
-									v1.ResourceMemory: resource.MustParse("10Mi"),
+									v1.ResourceCPU:    resource.MustParse("1"),
+									v1.ResourceMemory: resource.MustParse("100Mi"),
 								},
 								Requests: v1.ResourceList{
-									v1.ResourceCPU:    resource.MustParse("10m"),
-									v1.ResourceMemory: resource.MustParse("10Mi"),
+									v1.ResourceCPU:    resource.MustParse("1"),
+									v1.ResourceMemory: resource.MustParse("100Mi"),
 								},
 							},
 						},


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:
The newly added e2e test in CPU manager has a wrong config in resources.limits.memory causing the test to fail (10M too small). 

Updated the test to use 100M memory request/limit, and use integer CPU request/limit. 

#### Which issue(s) this PR is related to:
Fixes #140344

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
