### PR TITLE
batch: reconcile field order for jobs and cronjobs to make hub and v1 type memory identical

### DIFF
--- a/pkg/apis/batch/types.go
+++ b/pkg/apis/batch/types.go
@@ -320,6 +320,14 @@ type JobSpec struct {
 	// +optional
 	Completions *int32
 
+	// Specifies the duration in seconds relative to the startTime that the job
+	// may be continuously active before the system tries to terminate it; value
+	// must be positive integer. If a Job is suspended (at creation or through an
+	// update), this timer will effectively be stopped and reset when the Job is
+	// resumed again.
+	// +optional
+	ActiveDeadlineSeconds *int64
+
 	// Specifies the policy of handling failed pods. In particular, it allows to
 	// specify the set of actions and conditions which need to be
 	// satisfied to take the associated action.
@@ -339,14 +347,6 @@ type JobSpec struct {
 	//
 	// +optional
 	SuccessPolicy *SuccessPolicy
-
-	// Specifies the duration in seconds relative to the startTime that the job
-	// may be continuously active before the system tries to terminate it; value
-	// must be positive integer. If a Job is suspended (at creation or through an
-	// update), this timer will effectively be stopped and reset when the Job is
-	// resumed again.
-	// +optional
-	ActiveDeadlineSeconds *int64
 
 	// Specifies the number of retries before marking this job failed.
 	// Defaults to 6, unless backoffLimitPerIndex (only Indexed Job) is specified.
@@ -515,16 +515,6 @@ type JobStatus struct {
 	// +optional
 	Active int32
 
-	// The number of pods which are terminating (in phase Pending or Running
-	// and have a deletionTimestamp).
-	// +optional
-	Terminating *int32
-
-	// The number of active pods which have a Ready condition and are not
-	// terminating (without a deletionTimestamp).
-	// +optional
-	Ready *int32
-
 	// The number of pods which reached phase Succeeded.
 	// The value increases monotonically for a given spec. However, it may
 	// decrease in reaction to scale down of elastic indexed jobs.
@@ -535,6 +525,11 @@ type JobStatus struct {
 	// The value increases monotonically.
 	// +optional
 	Failed int32
+
+	// The number of pods which are terminating (in phase Pending or Running
+	// and have a deletionTimestamp).
+	// +optional
+	Terminating *int32
 
 	// completedIndexes holds the completed indexes when .spec.completionMode =
 	// "Indexed" in a text format. The indexes are represented as decimal integers
@@ -576,6 +571,11 @@ type JobStatus struct {
 	// The structure is empty for finished jobs.
 	// +optional
 	UncountedTerminatedPods *UncountedTerminatedPods
+
+	// The number of active pods which have a Ready condition and are not
+	// terminating (without a deletionTimestamp).
+	// +optional
+	Ready *int32
 }
 
 // UncountedTerminatedPods holds UIDs of Pods that have terminated but haven't

--- a/pkg/apis/batch/v1/conversion.go
+++ b/pkg/apis/batch/v1/conversion.go
@@ -18,11 +18,7 @@ package v1
 
 import (
 	"fmt"
-
-	v1 "k8s.io/api/batch/v1"
-	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/kubernetes/pkg/apis/batch"
 )
 
 func addConversionFuncs(scheme *runtime.Scheme) error {
@@ -35,15 +31,4 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 				return "", "", fmt.Errorf("field label %q not supported for Job", label)
 			}
 		})
-}
-
-// The following functions don't do anything special, but they need to be added
-// here due to the dependency of v1beta1 on v1.
-
-func Convert_batch_JobSpec_To_v1_JobSpec(in *batch.JobSpec, out *v1.JobSpec, s conversion.Scope) error {
-	return autoConvert_batch_JobSpec_To_v1_JobSpec(in, out, s)
-}
-
-func Convert_v1_JobSpec_To_batch_JobSpec(in *v1.JobSpec, out *batch.JobSpec, s conversion.Scope) error {
-	return autoConvert_v1_JobSpec_To_batch_JobSpec(in, out, s)
 }

--- a/pkg/apis/batch/v1/conversion_test.go
+++ b/pkg/apis/batch/v1/conversion_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1_test
+
+import (
+	_ "k8s.io/kubernetes/pkg/apis/batch/install"
+	"math/rand"
+	"reflect"
+	"testing"
+
+	extv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
+	metafuzzer "k8s.io/apimachinery/pkg/apis/meta/fuzzer"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	internalapi "k8s.io/kubernetes/pkg/apis/batch"
+	internalfuzzer "k8s.io/kubernetes/pkg/apis/batch/fuzzer"
+)
+
+func TestJobMemoryIdenticalConversion(t *testing.T) {
+	f := fuzzer.FuzzerFor(fuzzer.MergeFuzzerFuncs(metafuzzer.Funcs, internalfuzzer.Funcs), rand.NewSource(1), legacyscheme.Codecs).NilChance(0).NumElements(1, 1)
+	t.Run("v1 to internal", func(t *testing.T) {
+		in := &extv1.Job{}
+		f.Fill(in)
+		out := &internalapi.Job{}
+		if err := legacyscheme.Scheme.Convert(in, out, nil); err != nil {
+			t.Fatalf("conversion failed: %v", err)
+		}
+		assertMemoryIdentical(t, "Job", reflect.ValueOf(in).Elem(), reflect.ValueOf(out).Elem())
+	})
+	t.Run("internal to v1", func(t *testing.T) {
+		in := &internalapi.Job{}
+		f.Fill(in)
+		out := &extv1.Job{}
+		if err := legacyscheme.Scheme.Convert(in, out, nil); err != nil {
+			t.Fatalf("conversion failed: %v", err)
+		}
+		assertMemoryIdentical(t, "Job", reflect.ValueOf(in).Elem(), reflect.ValueOf(out).Elem())
+	})
+}
+
+func TestCronJobMemoryIdenticalConversion(t *testing.T) {
+	f := fuzzer.FuzzerFor(fuzzer.MergeFuzzerFuncs(metafuzzer.Funcs, internalfuzzer.Funcs), rand.NewSource(1), legacyscheme.Codecs).NilChance(0).NumElements(1, 1)
+	t.Run("v1 to internal", func(t *testing.T) {
+		in := &extv1.CronJob{}
+		f.Fill(in)
+		out := &internalapi.CronJob{}
+		if err := legacyscheme.Scheme.Convert(in, out, nil); err != nil {
+			t.Fatalf("conversion failed: %v", err)
+		}
+		assertMemoryIdentical(t, "CronJob", reflect.ValueOf(in).Elem(), reflect.ValueOf(out).Elem())
+	})
+	t.Run("internal to v1", func(t *testing.T) {
+		in := &internalapi.CronJob{}
+		f.Fill(in)
+		out := &extv1.CronJob{}
+		if err := legacyscheme.Scheme.Convert(in, out, nil); err != nil {
+			t.Fatalf("conversion failed: %v", err)
+		}
+		assertMemoryIdentical(t, "CronJob", reflect.ValueOf(in).Elem(), reflect.ValueOf(out).Elem())
+	})
+}
+
+func assertMemoryIdentical(t *testing.T, path string, a, b reflect.Value) {
+	t.Helper()
+	if a.Kind() != b.Kind() {
+		t.Errorf("%s: unexpected kind mismatch: %s, %s", path, a.Kind(), b.Kind())
+		return
+	}
+	switch a.Kind() {
+	case reflect.Struct: // allow for copied structs since conversion copies status/spec today
+		if a.Type().Size() != b.Type().Size() {
+			t.Errorf("%s: unexpected struct size mismatch: %d, %d", path, a.Type().Size(), b.Type().Size())
+			return
+		}
+		if a.NumField() != b.NumField() {
+			t.Errorf("%s: unexpected field count mismatch: %d, %d", path, a.NumField(), b.NumField())
+			return
+		}
+		for i := 0; i < a.NumField(); i++ {
+			aTypeField := a.Type().Field(i)
+			bTypeField := b.Type().Field(i)
+			if aTypeField.Name != bTypeField.Name {
+				t.Errorf("%s: unexpected field name mismatch: %s, %s", path, aTypeField.Name, bTypeField.Name)
+			}
+			if aTypeField.Offset != bTypeField.Offset {
+				t.Errorf("%s.%s: unexpected field offset mismatch: %d, %d", path, aTypeField.Name, aTypeField.Offset, bTypeField.Offset)
+			}
+			assertMemoryIdentical(t, path+"."+aTypeField.Name, a.Field(i), b.Field(i))
+		}
+	case reflect.Pointer, reflect.Map, reflect.Slice:
+		if a.IsNil() != b.IsNil() {
+			t.Errorf("%s: nilable pointer mismatch: %v, %v", path, !a.IsNil(), !b.IsNil())
+			return
+		}
+		if !a.IsNil() && a.UnsafePointer() != b.UnsafePointer() {
+			t.Errorf("%s: nilable type was unexpectedly copied", path)
+		}
+	case reflect.Bool, reflect.Int, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64, reflect.String:
+		// Assume scalars are copied by value
+	default:
+		t.Errorf("%s: unexpected kind: %v", path, a.Kind())
+	}
+}

--- a/pkg/apis/batch/v1/zz_generated.conversion.go
+++ b/pkg/apis/batch/v1/zz_generated.conversion.go
@@ -25,11 +25,9 @@ import (
 	unsafe "unsafe"
 
 	batchv1 "k8s.io/api/batch/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	batch "k8s.io/kubernetes/pkg/apis/batch"
-	corev1 "k8s.io/kubernetes/pkg/apis/core/v1"
 )
 
 func init() {
@@ -106,6 +104,16 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}
 	if err := s.AddGeneratedConversionFunc((*batch.JobList)(nil), (*batchv1.JobList)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_batch_JobList_To_v1_JobList(a.(*batch.JobList), b.(*batchv1.JobList), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddGeneratedConversionFunc((*batchv1.JobSpec)(nil), (*batch.JobSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1_JobSpec_To_batch_JobSpec(a.(*batchv1.JobSpec), b.(*batch.JobSpec), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddGeneratedConversionFunc((*batch.JobSpec)(nil), (*batchv1.JobSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_batch_JobSpec_To_v1_JobSpec(a.(*batch.JobSpec), b.(*batchv1.JobSpec), scope)
 	}); err != nil {
 		return err
 	}
@@ -199,16 +207,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
-	if err := s.AddConversionFunc((*batch.JobSpec)(nil), (*batchv1.JobSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_batch_JobSpec_To_v1_JobSpec(a.(*batch.JobSpec), b.(*batchv1.JobSpec), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddConversionFunc((*batchv1.JobSpec)(nil), (*batch.JobSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1_JobSpec_To_batch_JobSpec(a.(*batchv1.JobSpec), b.(*batch.JobSpec), scope)
-	}); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -246,17 +244,7 @@ func Convert_batch_CronJob_To_v1_CronJob(in *batch.CronJob, out *batchv1.CronJob
 
 func autoConvert_v1_CronJobList_To_batch_CronJobList(in *batchv1.CronJobList, out *batch.CronJobList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]batch.CronJob, len(*in))
-		for i := range *in {
-			if err := Convert_v1_CronJob_To_batch_CronJob(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
+	out.Items = *(*[]batch.CronJob)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -267,17 +255,7 @@ func Convert_v1_CronJobList_To_batch_CronJobList(in *batchv1.CronJobList, out *b
 
 func autoConvert_batch_CronJobList_To_v1_CronJobList(in *batch.CronJobList, out *batchv1.CronJobList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]batchv1.CronJob, len(*in))
-		for i := range *in {
-			if err := Convert_batch_CronJob_To_v1_CronJob(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
+	out.Items = *(*[]batchv1.CronJob)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -287,16 +265,7 @@ func Convert_batch_CronJobList_To_v1_CronJobList(in *batch.CronJobList, out *bat
 }
 
 func autoConvert_v1_CronJobSpec_To_batch_CronJobSpec(in *batchv1.CronJobSpec, out *batch.CronJobSpec, s conversion.Scope) error {
-	out.Schedule = in.Schedule
-	out.TimeZone = (*string)(unsafe.Pointer(in.TimeZone))
-	out.StartingDeadlineSeconds = (*int64)(unsafe.Pointer(in.StartingDeadlineSeconds))
-	out.ConcurrencyPolicy = batch.ConcurrencyPolicy(in.ConcurrencyPolicy)
-	out.Suspend = (*bool)(unsafe.Pointer(in.Suspend))
-	if err := Convert_v1_JobTemplateSpec_To_batch_JobTemplateSpec(&in.JobTemplate, &out.JobTemplate, s); err != nil {
-		return err
-	}
-	out.SuccessfulJobsHistoryLimit = (*int32)(unsafe.Pointer(in.SuccessfulJobsHistoryLimit))
-	out.FailedJobsHistoryLimit = (*int32)(unsafe.Pointer(in.FailedJobsHistoryLimit))
+	*out = *(*batch.CronJobSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -306,16 +275,7 @@ func Convert_v1_CronJobSpec_To_batch_CronJobSpec(in *batchv1.CronJobSpec, out *b
 }
 
 func autoConvert_batch_CronJobSpec_To_v1_CronJobSpec(in *batch.CronJobSpec, out *batchv1.CronJobSpec, s conversion.Scope) error {
-	out.Schedule = in.Schedule
-	out.TimeZone = (*string)(unsafe.Pointer(in.TimeZone))
-	out.StartingDeadlineSeconds = (*int64)(unsafe.Pointer(in.StartingDeadlineSeconds))
-	out.ConcurrencyPolicy = batchv1.ConcurrencyPolicy(in.ConcurrencyPolicy)
-	out.Suspend = (*bool)(unsafe.Pointer(in.Suspend))
-	if err := Convert_batch_JobTemplateSpec_To_v1_JobTemplateSpec(&in.JobTemplate, &out.JobTemplate, s); err != nil {
-		return err
-	}
-	out.SuccessfulJobsHistoryLimit = (*int32)(unsafe.Pointer(in.SuccessfulJobsHistoryLimit))
-	out.FailedJobsHistoryLimit = (*int32)(unsafe.Pointer(in.FailedJobsHistoryLimit))
+	*out = *(*batchv1.CronJobSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -398,17 +358,7 @@ func Convert_batch_JobCondition_To_v1_JobCondition(in *batch.JobCondition, out *
 
 func autoConvert_v1_JobList_To_batch_JobList(in *batchv1.JobList, out *batch.JobList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]batch.Job, len(*in))
-		for i := range *in {
-			if err := Convert_v1_Job_To_batch_Job(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
+	out.Items = *(*[]batch.Job)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -419,17 +369,7 @@ func Convert_v1_JobList_To_batch_JobList(in *batchv1.JobList, out *batch.JobList
 
 func autoConvert_batch_JobList_To_v1_JobList(in *batch.JobList, out *batchv1.JobList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]batchv1.Job, len(*in))
-		for i := range *in {
-			if err := Convert_batch_Job_To_v1_Job(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
+	out.Items = *(*[]batchv1.Job)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -439,61 +379,27 @@ func Convert_batch_JobList_To_v1_JobList(in *batch.JobList, out *batchv1.JobList
 }
 
 func autoConvert_v1_JobSpec_To_batch_JobSpec(in *batchv1.JobSpec, out *batch.JobSpec, s conversion.Scope) error {
-	out.Parallelism = (*int32)(unsafe.Pointer(in.Parallelism))
-	out.Completions = (*int32)(unsafe.Pointer(in.Completions))
-	out.ActiveDeadlineSeconds = (*int64)(unsafe.Pointer(in.ActiveDeadlineSeconds))
-	out.PodFailurePolicy = (*batch.PodFailurePolicy)(unsafe.Pointer(in.PodFailurePolicy))
-	out.SuccessPolicy = (*batch.SuccessPolicy)(unsafe.Pointer(in.SuccessPolicy))
-	out.BackoffLimit = (*int32)(unsafe.Pointer(in.BackoffLimit))
-	out.BackoffLimitPerIndex = (*int32)(unsafe.Pointer(in.BackoffLimitPerIndex))
-	out.MaxFailedIndexes = (*int32)(unsafe.Pointer(in.MaxFailedIndexes))
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
-	out.ManualSelector = (*bool)(unsafe.Pointer(in.ManualSelector))
-	if err := corev1.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
-		return err
-	}
-	out.TTLSecondsAfterFinished = (*int32)(unsafe.Pointer(in.TTLSecondsAfterFinished))
-	out.CompletionMode = (*batch.CompletionMode)(unsafe.Pointer(in.CompletionMode))
-	out.Suspend = (*bool)(unsafe.Pointer(in.Suspend))
-	out.PodReplacementPolicy = (*batch.PodReplacementPolicy)(unsafe.Pointer(in.PodReplacementPolicy))
-	out.ManagedBy = (*string)(unsafe.Pointer(in.ManagedBy))
+	*out = *(*batch.JobSpec)(unsafe.Pointer(in))
 	return nil
+}
+
+// Convert_v1_JobSpec_To_batch_JobSpec is an autogenerated conversion function.
+func Convert_v1_JobSpec_To_batch_JobSpec(in *batchv1.JobSpec, out *batch.JobSpec, s conversion.Scope) error {
+	return autoConvert_v1_JobSpec_To_batch_JobSpec(in, out, s)
 }
 
 func autoConvert_batch_JobSpec_To_v1_JobSpec(in *batch.JobSpec, out *batchv1.JobSpec, s conversion.Scope) error {
-	out.Parallelism = (*int32)(unsafe.Pointer(in.Parallelism))
-	out.Completions = (*int32)(unsafe.Pointer(in.Completions))
-	out.PodFailurePolicy = (*batchv1.PodFailurePolicy)(unsafe.Pointer(in.PodFailurePolicy))
-	out.SuccessPolicy = (*batchv1.SuccessPolicy)(unsafe.Pointer(in.SuccessPolicy))
-	out.ActiveDeadlineSeconds = (*int64)(unsafe.Pointer(in.ActiveDeadlineSeconds))
-	out.BackoffLimit = (*int32)(unsafe.Pointer(in.BackoffLimit))
-	out.BackoffLimitPerIndex = (*int32)(unsafe.Pointer(in.BackoffLimitPerIndex))
-	out.MaxFailedIndexes = (*int32)(unsafe.Pointer(in.MaxFailedIndexes))
-	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
-	out.ManualSelector = (*bool)(unsafe.Pointer(in.ManualSelector))
-	if err := corev1.Convert_core_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
-		return err
-	}
-	out.TTLSecondsAfterFinished = (*int32)(unsafe.Pointer(in.TTLSecondsAfterFinished))
-	out.CompletionMode = (*batchv1.CompletionMode)(unsafe.Pointer(in.CompletionMode))
-	out.Suspend = (*bool)(unsafe.Pointer(in.Suspend))
-	out.PodReplacementPolicy = (*batchv1.PodReplacementPolicy)(unsafe.Pointer(in.PodReplacementPolicy))
-	out.ManagedBy = (*string)(unsafe.Pointer(in.ManagedBy))
+	*out = *(*batchv1.JobSpec)(unsafe.Pointer(in))
 	return nil
 }
 
+// Convert_batch_JobSpec_To_v1_JobSpec is an autogenerated conversion function.
+func Convert_batch_JobSpec_To_v1_JobSpec(in *batch.JobSpec, out *batchv1.JobSpec, s conversion.Scope) error {
+	return autoConvert_batch_JobSpec_To_v1_JobSpec(in, out, s)
+}
+
 func autoConvert_v1_JobStatus_To_batch_JobStatus(in *batchv1.JobStatus, out *batch.JobStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]batch.JobCondition)(unsafe.Pointer(&in.Conditions))
-	out.StartTime = (*metav1.Time)(unsafe.Pointer(in.StartTime))
-	out.CompletionTime = (*metav1.Time)(unsafe.Pointer(in.CompletionTime))
-	out.Active = in.Active
-	out.Succeeded = in.Succeeded
-	out.Failed = in.Failed
-	out.Terminating = (*int32)(unsafe.Pointer(in.Terminating))
-	out.CompletedIndexes = in.CompletedIndexes
-	out.FailedIndexes = (*string)(unsafe.Pointer(in.FailedIndexes))
-	out.UncountedTerminatedPods = (*batch.UncountedTerminatedPods)(unsafe.Pointer(in.UncountedTerminatedPods))
-	out.Ready = (*int32)(unsafe.Pointer(in.Ready))
+	*out = *(*batch.JobStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -503,17 +409,7 @@ func Convert_v1_JobStatus_To_batch_JobStatus(in *batchv1.JobStatus, out *batch.J
 }
 
 func autoConvert_batch_JobStatus_To_v1_JobStatus(in *batch.JobStatus, out *batchv1.JobStatus, s conversion.Scope) error {
-	out.Conditions = *(*[]batchv1.JobCondition)(unsafe.Pointer(&in.Conditions))
-	out.StartTime = (*metav1.Time)(unsafe.Pointer(in.StartTime))
-	out.CompletionTime = (*metav1.Time)(unsafe.Pointer(in.CompletionTime))
-	out.Active = in.Active
-	out.Terminating = (*int32)(unsafe.Pointer(in.Terminating))
-	out.Ready = (*int32)(unsafe.Pointer(in.Ready))
-	out.Succeeded = in.Succeeded
-	out.Failed = in.Failed
-	out.CompletedIndexes = in.CompletedIndexes
-	out.FailedIndexes = (*string)(unsafe.Pointer(in.FailedIndexes))
-	out.UncountedTerminatedPods = (*batchv1.UncountedTerminatedPods)(unsafe.Pointer(in.UncountedTerminatedPods))
+	*out = *(*batchv1.JobStatus)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -523,10 +419,7 @@ func Convert_batch_JobStatus_To_v1_JobStatus(in *batch.JobStatus, out *batchv1.J
 }
 
 func autoConvert_v1_JobTemplateSpec_To_batch_JobTemplateSpec(in *batchv1.JobTemplateSpec, out *batch.JobTemplateSpec, s conversion.Scope) error {
-	out.ObjectMeta = in.ObjectMeta
-	if err := Convert_v1_JobSpec_To_batch_JobSpec(&in.Spec, &out.Spec, s); err != nil {
-		return err
-	}
+	*out = *(*batch.JobTemplateSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -536,10 +429,7 @@ func Convert_v1_JobTemplateSpec_To_batch_JobTemplateSpec(in *batchv1.JobTemplate
 }
 
 func autoConvert_batch_JobTemplateSpec_To_v1_JobTemplateSpec(in *batch.JobTemplateSpec, out *batchv1.JobTemplateSpec, s conversion.Scope) error {
-	out.ObjectMeta = in.ObjectMeta
-	if err := Convert_batch_JobSpec_To_v1_JobSpec(&in.Spec, &out.Spec, s); err != nil {
-		return err
-	}
+	*out = *(*batchv1.JobTemplateSpec)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/batch/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/batch/v1beta1/zz_generated.conversion.go
@@ -28,7 +28,6 @@ import (
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	batch "k8s.io/kubernetes/pkg/apis/batch"
-	v1 "k8s.io/kubernetes/pkg/apis/batch/v1"
 )
 
 func init() {
@@ -125,17 +124,7 @@ func Convert_batch_CronJob_To_v1beta1_CronJob(in *batch.CronJob, out *batchv1bet
 
 func autoConvert_v1beta1_CronJobList_To_batch_CronJobList(in *batchv1beta1.CronJobList, out *batch.CronJobList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]batch.CronJob, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta1_CronJob_To_batch_CronJob(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
+	out.Items = *(*[]batch.CronJob)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -146,17 +135,7 @@ func Convert_v1beta1_CronJobList_To_batch_CronJobList(in *batchv1beta1.CronJobLi
 
 func autoConvert_batch_CronJobList_To_v1beta1_CronJobList(in *batch.CronJobList, out *batchv1beta1.CronJobList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]batchv1beta1.CronJob, len(*in))
-		for i := range *in {
-			if err := Convert_batch_CronJob_To_v1beta1_CronJob(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
+	out.Items = *(*[]batchv1beta1.CronJob)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -166,16 +145,7 @@ func Convert_batch_CronJobList_To_v1beta1_CronJobList(in *batch.CronJobList, out
 }
 
 func autoConvert_v1beta1_CronJobSpec_To_batch_CronJobSpec(in *batchv1beta1.CronJobSpec, out *batch.CronJobSpec, s conversion.Scope) error {
-	out.Schedule = in.Schedule
-	out.TimeZone = (*string)(unsafe.Pointer(in.TimeZone))
-	out.StartingDeadlineSeconds = (*int64)(unsafe.Pointer(in.StartingDeadlineSeconds))
-	out.ConcurrencyPolicy = batch.ConcurrencyPolicy(in.ConcurrencyPolicy)
-	out.Suspend = (*bool)(unsafe.Pointer(in.Suspend))
-	if err := Convert_v1beta1_JobTemplateSpec_To_batch_JobTemplateSpec(&in.JobTemplate, &out.JobTemplate, s); err != nil {
-		return err
-	}
-	out.SuccessfulJobsHistoryLimit = (*int32)(unsafe.Pointer(in.SuccessfulJobsHistoryLimit))
-	out.FailedJobsHistoryLimit = (*int32)(unsafe.Pointer(in.FailedJobsHistoryLimit))
+	*out = *(*batch.CronJobSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -185,16 +155,7 @@ func Convert_v1beta1_CronJobSpec_To_batch_CronJobSpec(in *batchv1beta1.CronJobSp
 }
 
 func autoConvert_batch_CronJobSpec_To_v1beta1_CronJobSpec(in *batch.CronJobSpec, out *batchv1beta1.CronJobSpec, s conversion.Scope) error {
-	out.Schedule = in.Schedule
-	out.TimeZone = (*string)(unsafe.Pointer(in.TimeZone))
-	out.StartingDeadlineSeconds = (*int64)(unsafe.Pointer(in.StartingDeadlineSeconds))
-	out.ConcurrencyPolicy = batchv1beta1.ConcurrencyPolicy(in.ConcurrencyPolicy)
-	out.Suspend = (*bool)(unsafe.Pointer(in.Suspend))
-	if err := Convert_batch_JobTemplateSpec_To_v1beta1_JobTemplateSpec(&in.JobTemplate, &out.JobTemplate, s); err != nil {
-		return err
-	}
-	out.SuccessfulJobsHistoryLimit = (*int32)(unsafe.Pointer(in.SuccessfulJobsHistoryLimit))
-	out.FailedJobsHistoryLimit = (*int32)(unsafe.Pointer(in.FailedJobsHistoryLimit))
+	*out = *(*batchv1beta1.CronJobSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -224,10 +185,7 @@ func Convert_batch_CronJobStatus_To_v1beta1_CronJobStatus(in *batch.CronJobStatu
 }
 
 func autoConvert_v1beta1_JobTemplateSpec_To_batch_JobTemplateSpec(in *batchv1beta1.JobTemplateSpec, out *batch.JobTemplateSpec, s conversion.Scope) error {
-	out.ObjectMeta = in.ObjectMeta
-	if err := v1.Convert_v1_JobSpec_To_batch_JobSpec(&in.Spec, &out.Spec, s); err != nil {
-		return err
-	}
+	*out = *(*batch.JobTemplateSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -237,10 +195,7 @@ func Convert_v1beta1_JobTemplateSpec_To_batch_JobTemplateSpec(in *batchv1beta1.J
 }
 
 func autoConvert_batch_JobTemplateSpec_To_v1beta1_JobTemplateSpec(in *batch.JobTemplateSpec, out *batchv1beta1.JobTemplateSpec, s conversion.Scope) error {
-	out.ObjectMeta = in.ObjectMeta
-	if err := v1.Convert_batch_JobSpec_To_v1_JobSpec(&in.Spec, &out.Spec, s); err != nil {
-		return err
-	}
+	*out = *(*batchv1beta1.JobTemplateSpec)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/batch/zz_generated.deepcopy.go
+++ b/pkg/apis/batch/zz_generated.deepcopy.go
@@ -252,6 +252,11 @@ func (in *JobSpec) DeepCopyInto(out *JobSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.ActiveDeadlineSeconds != nil {
+		in, out := &in.ActiveDeadlineSeconds, &out.ActiveDeadlineSeconds
+		*out = new(int64)
+		**out = **in
+	}
 	if in.PodFailurePolicy != nil {
 		in, out := &in.PodFailurePolicy, &out.PodFailurePolicy
 		*out = new(PodFailurePolicy)
@@ -261,11 +266,6 @@ func (in *JobSpec) DeepCopyInto(out *JobSpec) {
 		in, out := &in.SuccessPolicy, &out.SuccessPolicy
 		*out = new(SuccessPolicy)
 		(*in).DeepCopyInto(*out)
-	}
-	if in.ActiveDeadlineSeconds != nil {
-		in, out := &in.ActiveDeadlineSeconds, &out.ActiveDeadlineSeconds
-		*out = new(int64)
-		**out = **in
 	}
 	if in.BackoffLimit != nil {
 		in, out := &in.BackoffLimit, &out.BackoffLimit
@@ -354,11 +354,6 @@ func (in *JobStatus) DeepCopyInto(out *JobStatus) {
 		*out = new(int32)
 		**out = **in
 	}
-	if in.Ready != nil {
-		in, out := &in.Ready, &out.Ready
-		*out = new(int32)
-		**out = **in
-	}
 	if in.FailedIndexes != nil {
 		in, out := &in.FailedIndexes, &out.FailedIndexes
 		*out = new(string)
@@ -368,6 +363,11 @@ func (in *JobStatus) DeepCopyInto(out *JobStatus) {
 		in, out := &in.UncountedTerminatedPods, &out.UncountedTerminatedPods
 		*out = new(UncountedTerminatedPods)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.Ready != nil {
+		in, out := &in.Ready, &out.Ready
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Reorders fields in batch group to make conversions between hub and v1 type memory identical to allow for fast conversion.

#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/issues/6164
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)


If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
