### PR TITLE
storage: enable fast cast for VolumeAttachment and CSIDriver

### DIFF
--- a/pkg/apis/storage/types.go
+++ b/pkg/apis/storage/types.go
@@ -287,19 +287,6 @@ type CSIDriverSpec struct {
 	// +optional
 	AttachRequired *bool
 
-	// Defines if the underlying volume supports changing ownership and
-	// permission of the volume before being mounted.
-	// Refer to the specific FSGroupPolicy values for additional details.
-	//
-	// This field was immutable in Kubernetes < 1.29 and now is mutable.
-	//
-	// Defaults to ReadWriteOnceWithFSType, which will examine each volume
-	// to determine if Kubernetes should modify ownership and permissions of the volume.
-	// With the default policy the defined fsGroup will only be applied
-	// if a fstype is defined and the volume's access mode contains ReadWriteOnce.
-	// +optional
-	FSGroupPolicy *FSGroupPolicy
-
 	// If set to true, podInfoOnMount indicates this CSI volume driver
 	// requires additional pod information (like podName, podUID, etc.) during
 	// mount operations.
@@ -366,6 +353,19 @@ type CSIDriverSpec struct {
 	//
 	// +optional
 	StorageCapacity *bool
+
+	// Defines if the underlying volume supports changing ownership and
+	// permission of the volume before being mounted.
+	// Refer to the specific FSGroupPolicy values for additional details.
+	//
+	// This field was immutable in Kubernetes < 1.29 and now is mutable.
+	//
+	// Defaults to ReadWriteOnceWithFSType, which will examine each volume
+	// to determine if Kubernetes should modify ownership and permissions of the volume.
+	// With the default policy the defined fsGroup will only be applied
+	// if a fstype is defined and the volume's access mode contains ReadWriteOnce.
+	// +optional
+	FSGroupPolicy *FSGroupPolicy
 
 	// TokenRequests indicates the CSI driver needs pods' service account
 	// tokens it is mounting volume for to do necessary authentication. Kubelet

--- a/pkg/apis/storage/v1/conversion_test.go
+++ b/pkg/apis/storage/v1/conversion_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1_test
+
+import (
+	_ "k8s.io/kubernetes/pkg/apis/storage/install"
+	"math/rand"
+	"reflect"
+	"testing"
+
+	extv1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
+	metafuzzer "k8s.io/apimachinery/pkg/apis/meta/fuzzer"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	internalapi "k8s.io/kubernetes/pkg/apis/storage"
+	internalfuzzer "k8s.io/kubernetes/pkg/apis/storage/fuzzer"
+)
+
+func TestCSIDriverMemoryIdenticalConversion(t *testing.T) {
+	f := fuzzer.FuzzerFor(fuzzer.MergeFuzzerFuncs(metafuzzer.Funcs, internalfuzzer.Funcs), rand.NewSource(1), legacyscheme.Codecs).NilChance(0).NumElements(1, 1)
+	t.Run("v1 to internal", func(t *testing.T) {
+		in := &extv1.CSIDriver{}
+		f.Fill(in)
+		out := &internalapi.CSIDriver{}
+		if err := legacyscheme.Scheme.Convert(in, out, nil); err != nil {
+			t.Fatalf("conversion failed: %v", err)
+		}
+		assertMemoryIdentical(t, "CSIDriver", reflect.ValueOf(in).Elem(), reflect.ValueOf(out).Elem())
+	})
+	t.Run("internal to v1", func(t *testing.T) {
+		in := &internalapi.CSIDriver{}
+		f.Fill(in)
+		out := &extv1.CSIDriver{}
+		if err := legacyscheme.Scheme.Convert(in, out, nil); err != nil {
+			t.Fatalf("conversion failed: %v", err)
+		}
+		assertMemoryIdentical(t, "CSIDriver", reflect.ValueOf(in).Elem(), reflect.ValueOf(out).Elem())
+	})
+}
+
+func TestVolumeAttachmentMemoryIdenticalConversion(t *testing.T) {
+	f := fuzzer.FuzzerFor(fuzzer.MergeFuzzerFuncs(metafuzzer.Funcs, internalfuzzer.Funcs), rand.NewSource(1), legacyscheme.Codecs).NilChance(0).NumElements(1, 1)
+	t.Run("v1 to internal", func(t *testing.T) {
+		in := &extv1.VolumeAttachment{}
+		f.Fill(in)
+		out := &internalapi.VolumeAttachment{}
+		if err := legacyscheme.Scheme.Convert(in, out, nil); err != nil {
+			t.Fatalf("conversion failed: %v", err)
+		}
+		assertMemoryIdentical(t, "VolumeAttachment", reflect.ValueOf(in).Elem(), reflect.ValueOf(out).Elem())
+	})
+	t.Run("internal to v1", func(t *testing.T) {
+		in := &internalapi.VolumeAttachment{}
+		f.Fill(in)
+		out := &extv1.VolumeAttachment{}
+		if err := legacyscheme.Scheme.Convert(in, out, nil); err != nil {
+			t.Fatalf("conversion failed: %v", err)
+		}
+		assertMemoryIdentical(t, "VolumeAttachment", reflect.ValueOf(in).Elem(), reflect.ValueOf(out).Elem())
+	})
+}
+
+func assertMemoryIdentical(t *testing.T, path string, a, b reflect.Value) {
+	t.Helper()
+	if a.Kind() != b.Kind() {
+		t.Errorf("%s: unexpected kind mismatch: %s, %s", path, a.Kind(), b.Kind())
+		return
+	}
+	switch a.Kind() {
+	case reflect.Struct: // allow for copied structs since conversion copies status/spec today
+		if a.Type().Size() != b.Type().Size() {
+			t.Errorf("%s: unexpected struct size mismatch: %d, %d", path, a.Type().Size(), b.Type().Size())
+			return
+		}
+		if a.NumField() != b.NumField() {
+			t.Errorf("%s: unexpected field count mismatch: %d, %d", path, a.NumField(), b.NumField())
+			return
+		}
+		for i := 0; i < a.NumField(); i++ {
+			aTypeField := a.Type().Field(i)
+			bTypeField := b.Type().Field(i)
+			if aTypeField.Name != bTypeField.Name {
+				t.Errorf("%s: unexpected field name mismatch: %s, %s", path, aTypeField.Name, bTypeField.Name)
+			}
+			if aTypeField.Offset != bTypeField.Offset {
+				t.Errorf("%s.%s: unexpected field offset mismatch: %d, %d", path, aTypeField.Name, aTypeField.Offset, bTypeField.Offset)
+			}
+			assertMemoryIdentical(t, path+"."+aTypeField.Name, a.Field(i), b.Field(i))
+		}
+	case reflect.Pointer, reflect.Map, reflect.Slice:
+		if a.IsNil() != b.IsNil() {
+			t.Errorf("%s: nilable pointer mismatch: %v, %v", path, !a.IsNil(), !b.IsNil())
+			return
+		}
+		if !a.IsNil() && a.UnsafePointer() != b.UnsafePointer() {
+			t.Errorf("%s: nilable type was unexpectedly copied", path)
+		}
+	case reflect.Bool, reflect.Int, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64, reflect.String:
+		// Assume scalars are copied by value
+	default:
+		t.Errorf("%s: unexpected kind: %v", path, a.Kind())
+	}
+}

--- a/pkg/apis/storage/v1/zz_generated.conversion.go
+++ b/pkg/apis/storage/v1/zz_generated.conversion.go
@@ -282,17 +282,7 @@ func Convert_storage_CSIDriver_To_v1_CSIDriver(in *storage.CSIDriver, out *stora
 
 func autoConvert_v1_CSIDriverList_To_storage_CSIDriverList(in *storagev1.CSIDriverList, out *storage.CSIDriverList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]storage.CSIDriver, len(*in))
-		for i := range *in {
-			if err := Convert_v1_CSIDriver_To_storage_CSIDriver(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
+	out.Items = *(*[]storage.CSIDriver)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -303,17 +293,7 @@ func Convert_v1_CSIDriverList_To_storage_CSIDriverList(in *storagev1.CSIDriverLi
 
 func autoConvert_storage_CSIDriverList_To_v1_CSIDriverList(in *storage.CSIDriverList, out *storagev1.CSIDriverList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]storagev1.CSIDriver, len(*in))
-		for i := range *in {
-			if err := Convert_storage_CSIDriver_To_v1_CSIDriver(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
+	out.Items = *(*[]storagev1.CSIDriver)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -323,17 +303,7 @@ func Convert_storage_CSIDriverList_To_v1_CSIDriverList(in *storage.CSIDriverList
 }
 
 func autoConvert_v1_CSIDriverSpec_To_storage_CSIDriverSpec(in *storagev1.CSIDriverSpec, out *storage.CSIDriverSpec, s conversion.Scope) error {
-	out.AttachRequired = (*bool)(unsafe.Pointer(in.AttachRequired))
-	out.PodInfoOnMount = (*bool)(unsafe.Pointer(in.PodInfoOnMount))
-	out.VolumeLifecycleModes = *(*[]storage.VolumeLifecycleMode)(unsafe.Pointer(&in.VolumeLifecycleModes))
-	out.StorageCapacity = (*bool)(unsafe.Pointer(in.StorageCapacity))
-	out.FSGroupPolicy = (*storage.FSGroupPolicy)(unsafe.Pointer(in.FSGroupPolicy))
-	out.TokenRequests = *(*[]storage.TokenRequest)(unsafe.Pointer(&in.TokenRequests))
-	out.RequiresRepublish = (*bool)(unsafe.Pointer(in.RequiresRepublish))
-	out.SELinuxMount = (*bool)(unsafe.Pointer(in.SELinuxMount))
-	out.NodeAllocatableUpdatePeriodSeconds = (*int64)(unsafe.Pointer(in.NodeAllocatableUpdatePeriodSeconds))
-	out.ServiceAccountTokenInSecrets = (*bool)(unsafe.Pointer(in.ServiceAccountTokenInSecrets))
-	out.PreventPodSchedulingIfMissing = (*bool)(unsafe.Pointer(in.PreventPodSchedulingIfMissing))
+	*out = *(*storage.CSIDriverSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -343,17 +313,7 @@ func Convert_v1_CSIDriverSpec_To_storage_CSIDriverSpec(in *storagev1.CSIDriverSp
 }
 
 func autoConvert_storage_CSIDriverSpec_To_v1_CSIDriverSpec(in *storage.CSIDriverSpec, out *storagev1.CSIDriverSpec, s conversion.Scope) error {
-	out.AttachRequired = (*bool)(unsafe.Pointer(in.AttachRequired))
-	out.FSGroupPolicy = (*storagev1.FSGroupPolicy)(unsafe.Pointer(in.FSGroupPolicy))
-	out.PodInfoOnMount = (*bool)(unsafe.Pointer(in.PodInfoOnMount))
-	out.VolumeLifecycleModes = *(*[]storagev1.VolumeLifecycleMode)(unsafe.Pointer(&in.VolumeLifecycleModes))
-	out.StorageCapacity = (*bool)(unsafe.Pointer(in.StorageCapacity))
-	out.TokenRequests = *(*[]storagev1.TokenRequest)(unsafe.Pointer(&in.TokenRequests))
-	out.RequiresRepublish = (*bool)(unsafe.Pointer(in.RequiresRepublish))
-	out.SELinuxMount = (*bool)(unsafe.Pointer(in.SELinuxMount))
-	out.NodeAllocatableUpdatePeriodSeconds = (*int64)(unsafe.Pointer(in.NodeAllocatableUpdatePeriodSeconds))
-	out.ServiceAccountTokenInSecrets = (*bool)(unsafe.Pointer(in.ServiceAccountTokenInSecrets))
-	out.PreventPodSchedulingIfMissing = (*bool)(unsafe.Pointer(in.PreventPodSchedulingIfMissing))
+	*out = *(*storagev1.CSIDriverSpec)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/storage/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/storage/v1beta1/zz_generated.conversion.go
@@ -282,17 +282,7 @@ func Convert_storage_CSIDriver_To_v1beta1_CSIDriver(in *storage.CSIDriver, out *
 
 func autoConvert_v1beta1_CSIDriverList_To_storage_CSIDriverList(in *storagev1beta1.CSIDriverList, out *storage.CSIDriverList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]storage.CSIDriver, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta1_CSIDriver_To_storage_CSIDriver(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
+	out.Items = *(*[]storage.CSIDriver)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -303,17 +293,7 @@ func Convert_v1beta1_CSIDriverList_To_storage_CSIDriverList(in *storagev1beta1.C
 
 func autoConvert_storage_CSIDriverList_To_v1beta1_CSIDriverList(in *storage.CSIDriverList, out *storagev1beta1.CSIDriverList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]storagev1beta1.CSIDriver, len(*in))
-		for i := range *in {
-			if err := Convert_storage_CSIDriver_To_v1beta1_CSIDriver(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
+	out.Items = *(*[]storagev1beta1.CSIDriver)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -323,17 +303,7 @@ func Convert_storage_CSIDriverList_To_v1beta1_CSIDriverList(in *storage.CSIDrive
 }
 
 func autoConvert_v1beta1_CSIDriverSpec_To_storage_CSIDriverSpec(in *storagev1beta1.CSIDriverSpec, out *storage.CSIDriverSpec, s conversion.Scope) error {
-	out.AttachRequired = (*bool)(unsafe.Pointer(in.AttachRequired))
-	out.PodInfoOnMount = (*bool)(unsafe.Pointer(in.PodInfoOnMount))
-	out.VolumeLifecycleModes = *(*[]storage.VolumeLifecycleMode)(unsafe.Pointer(&in.VolumeLifecycleModes))
-	out.StorageCapacity = (*bool)(unsafe.Pointer(in.StorageCapacity))
-	out.FSGroupPolicy = (*storage.FSGroupPolicy)(unsafe.Pointer(in.FSGroupPolicy))
-	out.TokenRequests = *(*[]storage.TokenRequest)(unsafe.Pointer(&in.TokenRequests))
-	out.RequiresRepublish = (*bool)(unsafe.Pointer(in.RequiresRepublish))
-	out.SELinuxMount = (*bool)(unsafe.Pointer(in.SELinuxMount))
-	out.NodeAllocatableUpdatePeriodSeconds = (*int64)(unsafe.Pointer(in.NodeAllocatableUpdatePeriodSeconds))
-	out.ServiceAccountTokenInSecrets = (*bool)(unsafe.Pointer(in.ServiceAccountTokenInSecrets))
-	out.PreventPodSchedulingIfMissing = (*bool)(unsafe.Pointer(in.PreventPodSchedulingIfMissing))
+	*out = *(*storage.CSIDriverSpec)(unsafe.Pointer(in))
 	return nil
 }
 
@@ -343,17 +313,7 @@ func Convert_v1beta1_CSIDriverSpec_To_storage_CSIDriverSpec(in *storagev1beta1.C
 }
 
 func autoConvert_storage_CSIDriverSpec_To_v1beta1_CSIDriverSpec(in *storage.CSIDriverSpec, out *storagev1beta1.CSIDriverSpec, s conversion.Scope) error {
-	out.AttachRequired = (*bool)(unsafe.Pointer(in.AttachRequired))
-	out.FSGroupPolicy = (*storagev1beta1.FSGroupPolicy)(unsafe.Pointer(in.FSGroupPolicy))
-	out.PodInfoOnMount = (*bool)(unsafe.Pointer(in.PodInfoOnMount))
-	out.VolumeLifecycleModes = *(*[]storagev1beta1.VolumeLifecycleMode)(unsafe.Pointer(&in.VolumeLifecycleModes))
-	out.StorageCapacity = (*bool)(unsafe.Pointer(in.StorageCapacity))
-	out.TokenRequests = *(*[]storagev1beta1.TokenRequest)(unsafe.Pointer(&in.TokenRequests))
-	out.RequiresRepublish = (*bool)(unsafe.Pointer(in.RequiresRepublish))
-	out.SELinuxMount = (*bool)(unsafe.Pointer(in.SELinuxMount))
-	out.NodeAllocatableUpdatePeriodSeconds = (*int64)(unsafe.Pointer(in.NodeAllocatableUpdatePeriodSeconds))
-	out.ServiceAccountTokenInSecrets = (*bool)(unsafe.Pointer(in.ServiceAccountTokenInSecrets))
-	out.PreventPodSchedulingIfMissing = (*bool)(unsafe.Pointer(in.PreventPodSchedulingIfMissing))
+	*out = *(*storagev1beta1.CSIDriverSpec)(unsafe.Pointer(in))
 	return nil
 }
 

--- a/pkg/apis/storage/zz_generated.deepcopy.go
+++ b/pkg/apis/storage/zz_generated.deepcopy.go
@@ -95,11 +95,6 @@ func (in *CSIDriverSpec) DeepCopyInto(out *CSIDriverSpec) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.FSGroupPolicy != nil {
-		in, out := &in.FSGroupPolicy, &out.FSGroupPolicy
-		*out = new(FSGroupPolicy)
-		**out = **in
-	}
 	if in.PodInfoOnMount != nil {
 		in, out := &in.PodInfoOnMount, &out.PodInfoOnMount
 		*out = new(bool)
@@ -113,6 +108,11 @@ func (in *CSIDriverSpec) DeepCopyInto(out *CSIDriverSpec) {
 	if in.StorageCapacity != nil {
 		in, out := &in.StorageCapacity, &out.StorageCapacity
 		*out = new(bool)
+		**out = **in
+	}
+	if in.FSGroupPolicy != nil {
+		in, out := &in.FSGroupPolicy, &out.FSGroupPolicy
+		*out = new(FSGroupPolicy)
 		**out = **in
 	}
 	if in.TokenRequests != nil {


### PR DESCRIPTION
Reorder CSIDriver internal fields to align with staging structure. Introduce manual unsafe pointer conversion over VolumeAttachment top-level types to shortcut nested allocations.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Moves fields around to ensure memory stays identical between hub and v1 types for storage.

#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/issues/6164
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
