### PR TITLE
Surface undeclared declarative-validation options as errors instead of silently disabling

### DIFF
--- a/pkg/api/testing/validation.go
+++ b/pkg/api/testing/validation.go
@@ -294,9 +294,12 @@ func VerifyValidationEquivalence(t *testing.T, ctx context.Context, obj runtime.
 	verifyValidationEquivalence(t, expectedErrs, func(c context.Context) field.ErrorList {
 		return rest.ValidateCreate(c, obj, strategy)
 	}, ctx, opts, obj)
-	// Pass the strategy's declared options to the cross-version check below.
-	if dvs, ok := strategy.(rest.DeclarativeValidationStrategy); ok {
-		testConfigs = append(testConfigs, WithOptions(dvs.DeclarativeValidationConfig(ctx, obj, nil).Options))
+	// Fall back to the strategy's declared options for the cross-version check, unless
+	// the caller supplied its own.
+	if opts.Options == nil {
+		if dvs, ok := strategy.(rest.DeclarativeValidationStrategy); ok {
+			testConfigs = append(testConfigs, WithOptions(dvs.DeclarativeValidationConfig(ctx, obj, nil).Options))
+		}
 	}
 	VerifyVersionedValidationEquivalence(t, obj, nil, testConfigs...)
 }
@@ -326,9 +329,12 @@ func VerifyUpdateValidationEquivalence(t *testing.T, ctx context.Context, obj, o
 	verifyValidationEquivalence(t, expectedErrs, func(c context.Context) field.ErrorList {
 		return rest.ValidateUpdate(c, obj, old, strategy)
 	}, ctx, opts, obj)
-	// Pass the strategy's declared options to the cross-version check below.
-	if dvs, ok := strategy.(rest.DeclarativeValidationStrategy); ok {
-		testConfigs = append(testConfigs, WithOptions(dvs.DeclarativeValidationConfig(ctx, obj, old).Options))
+	// Fall back to the strategy's declared options for the cross-version check, unless
+	// the caller supplied its own.
+	if opts.Options == nil {
+		if dvs, ok := strategy.(rest.DeclarativeValidationStrategy); ok {
+			testConfigs = append(testConfigs, WithOptions(dvs.DeclarativeValidationConfig(ctx, obj, old).Options))
+		}
 	}
 	VerifyVersionedValidationEquivalence(t, obj, old, testConfigs...)
 }

--- a/pkg/api/testing/validation.go
+++ b/pkg/api/testing/validation.go
@@ -111,7 +111,7 @@ func VerifyVersionedValidationEquivalence(t *testing.T, obj, old runtime.Object,
 		opts.Fuzzer.Fill(internalObj)
 	}
 	if old == nil {
-		runtimetest.RunValidationForEachVersion(t, legacyscheme.Scheme, []string{}, internalObj, accumulate, opts.IgnoreObjectConversionErrors, opts.SubResources...)
+		runtimetest.RunValidationForEachVersion(t, legacyscheme.Scheme, opts.Options, internalObj, accumulate, opts.IgnoreObjectConversionErrors, opts.SubResources...)
 	} else {
 		// Convert old versioned object to internal format before validation.
 		// runtimetest.RunUpdateValidationForEachVersion requires unversioned (internal) objects as input.
@@ -126,7 +126,7 @@ func VerifyVersionedValidationEquivalence(t *testing.T, obj, old runtime.Object,
 		if opts.Fuzzer != nil {
 			opts.Fuzzer.Fill(internalOld)
 		}
-		runtimetest.RunUpdateValidationForEachVersion(t, legacyscheme.Scheme, []string{}, internalObj, internalOld, accumulate, opts.IgnoreObjectConversionErrors, opts.SubResources...)
+		runtimetest.RunUpdateValidationForEachVersion(t, legacyscheme.Scheme, opts.Options, internalObj, internalOld, accumulate, opts.IgnoreObjectConversionErrors, opts.SubResources...)
 	}
 
 	// Make a copy so we can modify it.
@@ -234,6 +234,15 @@ type validationOption struct {
 
 	// Fuzzer is the fuzzer to use for generating test objects.
 	Fuzzer *randfill.Filler
+
+	// Options are the validation options to apply.
+	Options map[string]bool
+}
+
+func WithOptions(options map[string]bool) ValidationTestConfig {
+	return func(o *validationOption) {
+		o.Options = options
+	}
 }
 
 func WithSubResources(subResources ...string) ValidationTestConfig {
@@ -285,6 +294,10 @@ func VerifyValidationEquivalence(t *testing.T, ctx context.Context, obj runtime.
 	verifyValidationEquivalence(t, expectedErrs, func(c context.Context) field.ErrorList {
 		return rest.ValidateCreate(c, obj, strategy)
 	}, ctx, opts, obj)
+	// Pass the strategy's declared options to the cross-version check below.
+	if dvs, ok := strategy.(rest.DeclarativeValidationStrategy); ok {
+		testConfigs = append(testConfigs, WithOptions(dvs.DeclarativeValidationConfig(ctx, obj, nil).Options))
+	}
 	VerifyVersionedValidationEquivalence(t, obj, nil, testConfigs...)
 }
 
@@ -313,6 +326,10 @@ func VerifyUpdateValidationEquivalence(t *testing.T, ctx context.Context, obj, o
 	verifyValidationEquivalence(t, expectedErrs, func(c context.Context) field.ErrorList {
 		return rest.ValidateUpdate(c, obj, old, strategy)
 	}, ctx, opts, obj)
+	// Pass the strategy's declared options to the cross-version check below.
+	if dvs, ok := strategy.(rest.DeclarativeValidationStrategy); ok {
+		testConfigs = append(testConfigs, WithOptions(dvs.DeclarativeValidationConfig(ctx, obj, old).Options))
+	}
 	VerifyVersionedValidationEquivalence(t, obj, old, testConfigs...)
 }
 

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/strategy.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/strategy.go
@@ -87,8 +87,7 @@ func (autoscalerStrategy) Validate(ctx context.Context, obj runtime.Object) fiel
 // DeclarativeValidationConfig implements rest.DeclarativeValidationConfigurer to supply declarative
 // validation options.
 func (autoscalerStrategy) DeclarativeValidationConfig(ctx context.Context, obj, oldObj runtime.Object) rest.DeclarativeValidationConfig {
-	var options []string
-	// Pass HPAScaleToZero when the gate is enabled, OR (on update) when the
+	// HPAScaleToZero is enabled when its gate is enabled, or (on update) when the
 	// existing object already has MinReplicas == 0.
 	enableScaleToZero := utilfeature.DefaultFeatureGate.Enabled(features.HPAScaleToZero)
 	if !enableScaleToZero && oldObj != nil {
@@ -98,10 +97,9 @@ func (autoscalerStrategy) DeclarativeValidationConfig(ctx context.Context, obj, 
 			}
 		}
 	}
-	if enableScaleToZero {
-		options = append(options, "HPAScaleToZero")
-	}
-	return rest.DeclarativeValidationConfig{Options: options}
+	return rest.DeclarativeValidationConfig{Options: map[string]bool{
+		string(features.HPAScaleToZero): enableScaleToZero,
+	}}
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.

--- a/pkg/registry/scheduling/podgroup/strategy.go
+++ b/pkg/registry/scheduling/podgroup/strategy.go
@@ -75,18 +75,14 @@ func (*podGroupStrategy) Validate(ctx context.Context, obj runtime.Object) field
 	return validation.ValidatePodGroup(podGroup)
 }
 
+// DeclarativeValidationConfig declares the options referenced by this type's tags,
+// mapped to whether each is enabled.
 func (*podGroupStrategy) DeclarativeValidationConfig(ctx context.Context, obj, oldObj runtime.Object) rest.DeclarativeValidationConfig {
-	opts := []string{}
-	if utilfeature.DefaultFeatureGate.Enabled(features.TopologyAwareWorkloadScheduling) {
-		opts = append(opts, string(features.TopologyAwareWorkloadScheduling))
-	}
-	if utilfeature.DefaultFeatureGate.Enabled(features.DRAWorkloadResourceClaims) {
-		opts = append(opts, string(features.DRAWorkloadResourceClaims))
-	}
-	if utilfeature.DefaultFeatureGate.Enabled(features.PodGroupPreemptionPolicy) {
-		opts = append(opts, string(features.PodGroupPreemptionPolicy))
-	}
-	return rest.DeclarativeValidationConfig{Options: opts}
+	return rest.DeclarativeValidationConfig{Options: map[string]bool{
+		string(features.TopologyAwareWorkloadScheduling): utilfeature.DefaultFeatureGate.Enabled(features.TopologyAwareWorkloadScheduling),
+		string(features.DRAWorkloadResourceClaims):       utilfeature.DefaultFeatureGate.Enabled(features.DRAWorkloadResourceClaims),
+		string(features.PodGroupPreemptionPolicy):        utilfeature.DefaultFeatureGate.Enabled(features.PodGroupPreemptionPolicy),
+	}}
 }
 
 func (*podGroupStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {

--- a/pkg/registry/scheduling/workload/strategy.go
+++ b/pkg/registry/scheduling/workload/strategy.go
@@ -52,20 +52,14 @@ func (workloadStrategy) Validate(ctx context.Context, obj runtime.Object) field.
 	return validation.ValidateWorkload(workloadScheduling)
 }
 
-// DeclarativeValidationConfig implements rest.DeclarativeValidationConfigurer to supply declarative
-// validation options to the generic BeforeCreate/BeforeUpdate code path.
+// DeclarativeValidationConfig declares the options referenced by this type's tags,
+// mapped to whether each is enabled.
 func (workloadStrategy) DeclarativeValidationConfig(ctx context.Context, obj, oldObj runtime.Object) rest.DeclarativeValidationConfig {
-	opts := []string{}
-	if utilfeature.DefaultFeatureGate.Enabled(features.TopologyAwareWorkloadScheduling) {
-		opts = append(opts, string(features.TopologyAwareWorkloadScheduling))
-	}
-	if utilfeature.DefaultFeatureGate.Enabled(features.DRAWorkloadResourceClaims) {
-		opts = append(opts, string(features.DRAWorkloadResourceClaims))
-	}
-	if utilfeature.DefaultFeatureGate.Enabled(features.PodGroupPreemptionPolicy) {
-		opts = append(opts, string(features.PodGroupPreemptionPolicy))
-	}
-	return rest.DeclarativeValidationConfig{Options: opts}
+	return rest.DeclarativeValidationConfig{Options: map[string]bool{
+		string(features.TopologyAwareWorkloadScheduling): utilfeature.DefaultFeatureGate.Enabled(features.TopologyAwareWorkloadScheduling),
+		string(features.DRAWorkloadResourceClaims):       utilfeature.DefaultFeatureGate.Enabled(features.DRAWorkloadResourceClaims),
+		string(features.PodGroupPreemptionPolicy):        utilfeature.DefaultFeatureGate.Enabled(features.PodGroupPreemptionPolicy),
+	}}
 }
 
 func (workloadStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {

--- a/staging/src/k8s.io/apimachinery/pkg/api/operation/operation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/operation/operation.go
@@ -17,7 +17,6 @@ limitations under the License.
 package operation
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -35,24 +34,21 @@ type Operation struct {
 	// name to whether it is enabled. Option names typically match feature gates. Set by
 	// the resource strategy and read-only during validation.
 	//
-	// Every option referenced by a validation tag must be declared here. Referencing an
-	// undeclared option is a programming error (see HasOption).
+	// Every option a validation tag references must be defined here by the strategy; an
+	// option that is not defined is a programming error (see HasOption).
 	Options map[string]bool
 
 	// Request provides information about the request being validated.
 	Request Request
 }
 
-// HasOption returns whether the named option is enabled. Every option referenced by a
-// validation tag must be declared by the strategy; referencing an undeclared option
-// returns an error rather than silently treating it as disabled, so declarative
-// validation can surface the mistake as an internal error.
-func (o Operation) HasOption(option string) (bool, error) {
-	enabled, declared := o.Options[option]
-	if !declared {
-		return false, fmt.Errorf("undeclared validation option %q", option)
-	}
-	return enabled, nil
+// HasOption returns whether the named option is enabled and whether it was defined by
+// the strategy. Every option a validation tag references must be defined; callers treat
+// an undefined option as an internal error (see validate.IfOption) rather than silently
+// as disabled.
+func (o Operation) HasOption(option string) (enabled, defined bool) {
+	enabled, defined = o.Options[option]
+	return
 }
 
 // Request provides information about the request being validated.

--- a/staging/src/k8s.io/apimachinery/pkg/api/operation/operation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/operation/operation.go
@@ -31,8 +31,10 @@ type Operation struct {
 	Type Type
 
 	// Options are the validation options in effect for this operation, mapping option
-	// name to whether it is enabled. Option names typically match feature gates. Set by
-	// the resource strategy and read-only during validation.
+	// name to whether it is enabled. Option names typically match feature gates, but an
+	// option may be enabled even when its feature gate is off — e.g. when the feature is
+	// already in use by the object being updated. Set by the resource strategy and
+	// read-only during validation.
 	//
 	// Every option a validation tag references must be defined here by the strategy; an
 	// option that is not defined is a programming error (see HasOption).

--- a/staging/src/k8s.io/apimachinery/pkg/api/operation/operation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/operation/operation.go
@@ -17,7 +17,7 @@ limitations under the License.
 package operation
 
 import (
-	"slices"
+	"fmt"
 	"strings"
 )
 
@@ -31,28 +31,28 @@ type Operation struct {
 	// those into a single "Update" category.
 	Type Type
 
-	// Options declare the options enabled for validation.
+	// Options are the validation options in effect for this operation, mapping option
+	// name to whether it is enabled. Option names typically match feature gates. Set by
+	// the resource strategy and read-only during validation.
 	//
-	// Options should be set according to a resource validation strategy before validation
-	// is performed, and must be treated as read-only during validation.
-	//
-	// Options are identified by string names. Option string names may match the name of a feature
-	// gate, in which case the presence of the name in the set indicates that the feature is
-	// considered enabled for the resource being validated.  Note that a resource may have a
-	// feature enabled even when the feature gate is disabled. This can happen when feature is
-	// already in-use by a resource, often because the feature gate was enabled when the
-	// resource first began using the feature.
-	//
-	// Unset options are disabled/false.
-	Options []string
+	// Every option referenced by a validation tag must be declared here. Referencing an
+	// undeclared option is a programming error (see HasOption).
+	Options map[string]bool
 
 	// Request provides information about the request being validated.
 	Request Request
 }
 
-// HasOption returns true if the given string is in the Options slice.
-func (o Operation) HasOption(option string) bool {
-	return slices.Contains(o.Options, option)
+// HasOption returns whether the named option is enabled. Every option referenced by a
+// validation tag must be declared by the strategy; referencing an undeclared option
+// returns an error rather than silently treating it as disabled, so declarative
+// validation can surface the mistake as an internal error.
+func (o Operation) HasOption(option string) (bool, error) {
+	enabled, declared := o.Options[option]
+	if !declared {
+		return false, fmt.Errorf("undeclared validation option %q", option)
+	}
+	return enabled, nil
 }
 
 // Request provides information about the request being validated.

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/enum.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/enum.go
@@ -32,24 +32,36 @@ func Enum[T ~string](_ context.Context, op operation.Operation, fldPath *field.P
 	if value == nil {
 		return nil
 	}
-	if !validValues.Has(*value) || isExcluded(op, exclusions, *value) {
-		return field.ErrorList{field.NotSupported[T](fldPath, *value, supportedValues(op, validValues, exclusions))}
+	excluded, err := isExcluded(op, exclusions, *value)
+	if err != nil {
+		return field.ErrorList{field.InternalError(fldPath, err)}
+	}
+	if !validValues.Has(*value) || excluded {
+		supported, err := supportedValues(op, validValues, exclusions)
+		if err != nil {
+			return field.ErrorList{field.InternalError(fldPath, err)}
+		}
+		return field.ErrorList{field.NotSupported[T](fldPath, *value, supported)}
 	}
 	return nil
 }
 
 // supportedValues returns a sorted list of supported values.
 // Excluded enum values are not included in the list.
-func supportedValues[T ~string](op operation.Operation, values sets.Set[T], exclusions []EnumExclusion[T]) []T {
+func supportedValues[T ~string](op operation.Operation, values sets.Set[T], exclusions []EnumExclusion[T]) ([]T, error) {
 	res := make([]T, 0, len(values))
 	for key := range values {
-		if isExcluded(op, exclusions, key) {
+		excluded, err := isExcluded(op, exclusions, key)
+		if err != nil {
+			return nil, err
+		}
+		if excluded {
 			continue
 		}
 		res = append(res, key)
 	}
 	slices.Sort(res)
-	return res
+	return res, nil
 }
 
 // EnumExclusion represents a single enum exclusion rule.
@@ -64,11 +76,18 @@ type EnumExclusion[T ~string] struct {
 	Option string
 }
 
-func isExcluded[T ~string](op operation.Operation, exclusions []EnumExclusion[T], value T) bool {
+func isExcluded[T ~string](op operation.Operation, exclusions []EnumExclusion[T], value T) (bool, error) {
 	for _, rule := range exclusions {
-		if rule.Value == value && rule.ExcludeWhen == op.HasOption(rule.Option) {
-			return true
+		if rule.Value != value {
+			continue
+		}
+		has, err := op.HasOption(rule.Option)
+		if err != nil {
+			return false, err
+		}
+		if rule.ExcludeWhen == has {
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/enum.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/enum.go
@@ -79,14 +79,11 @@ type EnumExclusion[T ~string] struct {
 
 func isExcluded[T ~string](op operation.Operation, exclusions []EnumExclusion[T], value T) (bool, error) {
 	for _, rule := range exclusions {
-		if rule.Value != value {
-			continue
-		}
 		on, defined := op.HasOption(rule.Option)
 		if !defined {
 			return false, fmt.Errorf("undefined validation option %q", rule.Option)
 		}
-		if rule.ExcludeWhen == on {
+		if rule.Value == value && rule.ExcludeWhen == on {
 			return true, nil
 		}
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/enum.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/enum.go
@@ -18,6 +18,7 @@ package validate
 
 import (
 	"context"
+	"fmt"
 	"slices"
 
 	"k8s.io/apimachinery/pkg/api/operation"
@@ -81,11 +82,11 @@ func isExcluded[T ~string](op operation.Operation, exclusions []EnumExclusion[T]
 		if rule.Value != value {
 			continue
 		}
-		has, err := op.HasOption(rule.Option)
-		if err != nil {
-			return false, err
+		on, defined := op.HasOption(rule.Option)
+		if !defined {
+			return false, fmt.Errorf("undefined validation option %q", rule.Option)
 		}
-		if rule.ExcludeWhen == has {
+		if rule.ExcludeWhen == on {
 			return true, nil
 		}
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/enum_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/enum_test.go
@@ -139,63 +139,73 @@ func TestEnumExclude(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name      string
-		value     TestEnum
-		opts      []string
-		expectErr string
+		name           string
+		value          TestEnum
+		opts           map[string]bool
+		expectInternal bool
+		expectErr      string
 	}{
 		{
 			name:  "no options, A is valid",
 			value: ValueA,
+			opts:  map[string]bool{FeatureA: false, FeatureB: false},
 		},
 		{
 			name:      "no options, B is invalid",
 			value:     ValueB,
+			opts:      map[string]bool{FeatureA: false, FeatureB: false},
 			expectErr: `fld: Unsupported value: "B": supported values: "A", "C"`,
 		},
 		{
 			name:      "no options, D is invalid",
 			value:     ValueD,
+			opts:      map[string]bool{FeatureA: false, FeatureB: false},
 			expectErr: `fld: Unsupported value: "D": supported values: "A", "C"`,
 		},
 		{
 			name:      "FeatureA enabled, A is invalid",
 			value:     ValueA,
-			opts:      []string{FeatureA},
+			opts:      map[string]bool{FeatureA: true, FeatureB: false},
 			expectErr: `fld: Unsupported value: "A": supported values: "C"`,
 		},
 		{
 			name:      "FeatureA enabled, B is invalid",
 			value:     ValueB,
-			opts:      []string{FeatureA},
+			opts:      map[string]bool{FeatureA: true, FeatureB: false},
 			expectErr: `fld: Unsupported value: "B": supported values: "C"`,
 		},
 		{
 			name:  "FeatureB enabled, A is valid",
 			value: ValueA,
-			opts:  []string{FeatureB},
+			opts:  map[string]bool{FeatureA: false, FeatureB: true},
 		},
 		{
 			name:  "FeatureB enabled, B is valid",
 			value: ValueB,
-			opts:  []string{FeatureB},
+			opts:  map[string]bool{FeatureA: false, FeatureB: true},
 		},
 		{
 			name:      "FeatureA and FeatureB enabled, A is invalid",
 			value:     ValueA,
-			opts:      []string{FeatureA, FeatureB},
+			opts:      map[string]bool{FeatureA: true, FeatureB: true},
 			expectErr: `fld: Unsupported value: "A": supported values: "B", "C"`,
 		},
 		{
 			name:  "FeatureA and FeatureB enabled, B is valid",
 			value: ValueB,
-			opts:  []string{FeatureA, FeatureB},
+			opts:  map[string]bool{FeatureA: true, FeatureB: true},
 		},
 		{
 			name:      "FeatureA and FeatureB enabled, D is invalid",
 			value:     ValueD,
-			opts:      []string{FeatureA, FeatureB},
+			opts:      map[string]bool{FeatureA: true, FeatureB: true},
 			expectErr: `fld: Unsupported value: "D": supported values: "B", "C"`,
+		},
+		{
+			name:           "undeclared option is an internal error",
+			value:          ValueB,
+			opts:           map[string]bool{FeatureA: false},
+			expectInternal: true,
 		},
 	}
 
@@ -203,6 +213,13 @@ func TestEnumExclude(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			op := operation.Operation{Type: operation.Create, Options: tc.opts}
 			errs := Enum(context.Background(), op, field.NewPath("fld"), &tc.value, nil, testEnumValues, testEnumExclusions)
+
+			if tc.expectInternal {
+				if len(errs) != 1 || errs[0].Type != field.ErrorTypeInternal {
+					t.Fatalf("expected a single internal error, but got: %v", errs)
+				}
+				return
+			}
 
 			if tc.expectErr == "" {
 				if len(errs) > 0 {

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/options.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/options.go
@@ -28,7 +28,11 @@ import (
 func IfOption[T any](ctx context.Context, op operation.Operation, fldPath *field.Path, value, oldValue T,
 	optionName string, enabled bool, validator func(context.Context, operation.Operation, *field.Path, T, T) field.ErrorList,
 ) field.ErrorList {
-	if op.HasOption(optionName) == enabled {
+	has, err := op.HasOption(optionName)
+	if err != nil {
+		return field.ErrorList{field.InternalError(fldPath, err)}
+	}
+	if has == enabled {
 		return validator(ctx, op, fldPath, value, oldValue)
 	}
 	return nil

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/options.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/options.go
@@ -18,6 +18,7 @@ package validate
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -28,11 +29,11 @@ import (
 func IfOption[T any](ctx context.Context, op operation.Operation, fldPath *field.Path, value, oldValue T,
 	optionName string, enabled bool, validator func(context.Context, operation.Operation, *field.Path, T, T) field.ErrorList,
 ) field.ErrorList {
-	has, err := op.HasOption(optionName)
-	if err != nil {
-		return field.ErrorList{field.InternalError(fldPath, err)}
+	on, defined := op.HasOption(optionName)
+	if !defined {
+		return field.ErrorList{field.InternalError(fldPath, fmt.Errorf("undefined validation option %q", optionName))}
 	}
-	if has == enabled {
+	if on == enabled {
 		return validator(ctx, op, fldPath, value, oldValue)
 	}
 	return nil

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
@@ -370,7 +370,7 @@ func (s *Scheme) AddValidationFunc(srcType Object, fn func(ctx context.Context, 
 // Validate validates the provided Object according to the generated declarative validation code.
 // WARNING: This does not validate all objects!  The handwritten validation code in validation.go
 // is not run when this is called.  Only the generated zz_generated.validations.go validation code is run.
-func (s *Scheme) Validate(ctx context.Context, options []string, object Object, subresources ...string) field.ErrorList {
+func (s *Scheme) Validate(ctx context.Context, options map[string]bool, object Object, subresources ...string) field.ErrorList {
 	if fn, ok := s.validationFuncs[reflect.TypeOf(object)]; ok {
 		return fn(ctx, operation.Operation{Type: operation.Create, Request: operation.Request{Subresources: subresources}, Options: options}, object, nil)
 	}
@@ -380,7 +380,7 @@ func (s *Scheme) Validate(ctx context.Context, options []string, object Object, 
 // ValidateUpdate validates the provided object and oldObject according to the generated declarative validation code.
 // WARNING: This does not validate all objects!  The handwritten validation code in validation.go
 // is not run when this is called.  Only the generated zz_generated.validations.go validation code is run.
-func (s *Scheme) ValidateUpdate(ctx context.Context, options []string, object, oldObject Object, subresources ...string) field.ErrorList {
+func (s *Scheme) ValidateUpdate(ctx context.Context, options map[string]bool, object, oldObject Object, subresources ...string) field.ErrorList {
 	if fn, ok := s.validationFuncs[reflect.TypeOf(object)]; ok {
 		return fn(ctx, operation.Operation{Type: operation.Update, Request: operation.Request{Subresources: subresources}, Options: options}, object, oldObject)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme_test.go
@@ -1033,6 +1033,7 @@ func TestRegisterValidate(t *testing.T) {
 		{
 			name:     "single error",
 			object:   &TestType1{},
+			options:  map[string]bool{"option1": false},
 			expected: field.ErrorList{invalidValue},
 		},
 		{
@@ -1056,6 +1057,7 @@ func TestRegisterValidate(t *testing.T) {
 			name:        "subresource error",
 			object:      &TestType1{},
 			subresource: []string{"status"},
+			options:     map[string]bool{"option1": false},
 			expected:    field.ErrorList{invalidStatusErr},
 		},
 	}
@@ -1065,7 +1067,7 @@ func TestRegisterValidate(t *testing.T) {
 
 	// register multiple types for testing to ensure registration is working as expected
 	s.AddValidationFunc(&TestType1{}, func(ctx context.Context, op operation.Operation, object, oldObject interface{}) field.ErrorList {
-		if enabled, _ := op.HasOption("option1"); enabled {
+		if enabled, exists := op.HasOption("option1"); enabled || !exists {
 			return field.ErrorList{invalidIfOptionErr}
 		}
 		if slices.Equal(op.Request.Subresources, []string{"status"}) {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme_test.go
@@ -1027,7 +1027,7 @@ func TestRegisterValidate(t *testing.T) {
 		object      runtime.Object
 		oldObject   runtime.Object
 		subresource []string
-		options     []string
+		options     map[string]bool
 		expected    field.ErrorList
 	}{
 		{
@@ -1049,7 +1049,7 @@ func TestRegisterValidate(t *testing.T) {
 		{
 			name:     "options error",
 			object:   &TestType1{},
-			options:  []string{"option1"},
+			options:  map[string]bool{"option1": true},
 			expected: field.ErrorList{invalidIfOptionErr},
 		},
 		{
@@ -1065,7 +1065,7 @@ func TestRegisterValidate(t *testing.T) {
 
 	// register multiple types for testing to ensure registration is working as expected
 	s.AddValidationFunc(&TestType1{}, func(ctx context.Context, op operation.Operation, object, oldObject interface{}) field.ErrorList {
-		if op.HasOption("option1") {
+		if enabled, _ := op.HasOption("option1"); enabled {
 			return field.ErrorList{invalidIfOptionErr}
 		}
 		if slices.Equal(op.Request.Subresources, []string{"status"}) {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/testing/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/testing/validation.go
@@ -37,16 +37,16 @@ type VersionValidationRunner func(t *testing.T, gv string, versionValidationErro
 //	      errs = append(errs, versionValidationErrors...) // generated declarative validation
 //		  // Validate that the errors are what was expected for this test case.
 //		})
-func RunValidationForEachVersion(t *testing.T, scheme *runtime.Scheme, options []string, unversioned runtime.Object, fn VersionValidationRunner, ignoreConversionErrors bool, subresources ...string) {
+func RunValidationForEachVersion(t *testing.T, scheme *runtime.Scheme, options map[string]bool, unversioned runtime.Object, fn VersionValidationRunner, ignoreConversionErrors bool, subresources ...string) {
 	runValidation(t, scheme, options, unversioned, fn, ignoreConversionErrors, subresources...)
 }
 
 // RunUpdateValidationForEachVersion is like RunValidationForEachVersion but for update validation.
-func RunUpdateValidationForEachVersion(t *testing.T, scheme *runtime.Scheme, options []string, unversioned, unversionedOld runtime.Object, fn VersionValidationRunner, ignoreConversionErrors bool, subresources ...string) {
+func RunUpdateValidationForEachVersion(t *testing.T, scheme *runtime.Scheme, options map[string]bool, unversioned, unversionedOld runtime.Object, fn VersionValidationRunner, ignoreConversionErrors bool, subresources ...string) {
 	runUpdateValidation(t, scheme, options, unversioned, unversionedOld, fn, ignoreConversionErrors, subresources...)
 }
 
-func runValidation(t *testing.T, scheme *runtime.Scheme, options []string, unversioned runtime.Object, fn VersionValidationRunner, ignoreConversionErrors bool, subresources ...string) {
+func runValidation(t *testing.T, scheme *runtime.Scheme, options map[string]bool, unversioned runtime.Object, fn VersionValidationRunner, ignoreConversionErrors bool, subresources ...string) {
 	unversionedGVKs, _, err := scheme.ObjectKinds(unversioned)
 	if err != nil {
 		t.Fatal(err)
@@ -78,7 +78,7 @@ func runValidation(t *testing.T, scheme *runtime.Scheme, options []string, unver
 	}
 }
 
-func runUpdateValidation(t *testing.T, scheme *runtime.Scheme, options []string, unversionedNew, unversionedOld runtime.Object, fn VersionValidationRunner, ignoreConversionErrors bool, subresources ...string) {
+func runUpdateValidation(t *testing.T, scheme *runtime.Scheme, options map[string]bool, unversionedNew, unversionedOld runtime.Object, fn VersionValidationRunner, ignoreConversionErrors bool, subresources ...string) {
 	unversionedGVKs, _, err := scheme.ObjectKinds(unversionedNew)
 	if err != nil {
 		t.Fatal(err)

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
@@ -83,10 +83,10 @@ func (d DeclarativeValidation) DeclarativeValidationConfig(ctx context.Context, 
 // DeclarativeValidationConfigurer and return this struct.
 type DeclarativeValidationConfig struct {
 	// Options contains the validation options that declarative validation tags expect,
-	// mapping option name to whether it is enabled. Every option referenced by the
-	// resource's validation tags must be declared here; a referenced option that is not
-	// declared is reported as an internal error rather than treated as disabled. Option
-	// names often correspond to feature gates.
+	// mapping option name to whether it is enabled. Every option a resource's validation
+	// tags reference must be defined here; an option that is not defined is reported as an
+	// internal error rather than treated as disabled. Option names often correspond to
+	// feature gates.
 	Options map[string]bool
 
 	// NormalizationRules are applied to field paths when comparing

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
@@ -82,9 +82,12 @@ func (d DeclarativeValidation) DeclarativeValidationConfig(ctx context.Context, 
 // Strategies that need to customize declarative validation behavior implement
 // DeclarativeValidationConfigurer and return this struct.
 type DeclarativeValidationConfig struct {
-	// Options contains validation options that declarative validation tags
-	// expect. These often correspond to feature gates.
-	Options []string
+	// Options contains the validation options that declarative validation tags expect,
+	// mapping option name to whether it is enabled. Every option referenced by the
+	// resource's validation tags must be declared here; a referenced option that is not
+	// declared is reported as an internal error rather than treated as disabled. Option
+	// names often correspond to feature gates.
+	Options map[string]bool
 
 	// NormalizationRules are applied to field paths when comparing
 	// handwritten and declarative validation errors.

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go
@@ -77,7 +77,7 @@ func TestValidateDeclaratively(t *testing.T) {
 		object      runtime.Object
 		oldObject   runtime.Object
 		subresource string
-		options     []string
+		options     map[string]bool
 		expected    field.ErrorList
 	}{
 		{
@@ -114,7 +114,7 @@ func TestValidateDeclaratively(t *testing.T) {
 		},
 		{
 			name:     "update with option",
-			options:  []string{"option1"},
+			options:  map[string]bool{"option1": true},
 			object:   valid,
 			expected: field.ErrorList{invalidIfOptionErr},
 		},
@@ -131,7 +131,7 @@ func TestValidateDeclaratively(t *testing.T) {
 
 	scheme.AddValidationFunc(&v1.Pod{}, func(ctx context.Context, op operation.Operation, object, oldObject any) field.ErrorList {
 		results := field.ErrorList{}
-		if op.HasOption("option1") {
+		if enabled, _ := op.HasOption("option1"); enabled {
 			results = append(results, invalidIfOptionErr)
 		}
 		if slices.Equal(op.Request.Subresources, []string{"status"}) {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/customvalidation/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/customvalidation/doc_test.go
@@ -66,10 +66,10 @@ func TestIfEnabled(t *testing.T) {
 	matcher := field.ErrorMatcher{}.ByType().ByField()
 
 	// Option disabled: the gated custom validation does not run.
-	st.Value(&OptionStruct{}).ExpectValid()
+	st.Value(&OptionStruct{}).Opts(map[string]bool{"FeatureX": false}).ExpectValid()
 
 	// Option enabled: the custom validation runs.
-	st.Value(&OptionStruct{}).Opts([]string{"FeatureX"}).ExpectMatches(matcher, field.ErrorList{
+	st.Value(&OptionStruct{}).Opts(map[string]bool{"FeatureX": true}).ExpectMatches(matcher, field.ErrorList{
 		field.Invalid(field.NewPath("stringField"), nil, ""),
 	})
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/enum/options/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/enum/options/doc_test.go
@@ -25,9 +25,18 @@ import (
 func Test(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
+	// opts declares all options this type references, enabling the named ones.
+	opts := func(enabled ...string) map[string]bool {
+		m := map[string]bool{"FeatureA": false, "FeatureB": false, "FeatureC": false, "FeatureD": false}
+		for _, e := range enabled {
+			m[e] = true
+		}
+		return m
+	}
+
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "",
-	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	}).Opts(opts()).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.NotSupported(field.NewPath("conditionalEnumField"), ConditionalEnum(""), []ConditionalEnum{ConditionalA, ConditionalC, ConditionalD}),
 	})
 
@@ -35,163 +44,163 @@ func Test(t *testing.T) {
 	// Valid values: A, C, D
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "B",
-	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	}).Opts(opts()).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.NotSupported(field.NewPath("conditionalEnumField"), ConditionalEnum("B"), []ConditionalEnum{ConditionalA, ConditionalC, ConditionalD}),
 	})
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "E",
-	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	}).Opts(opts()).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.NotSupported(field.NewPath("conditionalEnumField"), ConditionalEnum("E"), []ConditionalEnum{ConditionalA, ConditionalC, ConditionalD}),
 	})
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "F",
-	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	}).Opts(opts()).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.NotSupported(field.NewPath("conditionalEnumField"), ConditionalEnum("F"), []ConditionalEnum{ConditionalA, ConditionalC, ConditionalD}),
 	})
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "A",
-	}).ExpectValid()
+	}).Opts(opts()).ExpectValid()
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "C",
-	}).ExpectValid()
+	}).Opts(opts()).ExpectValid()
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "D",
-	}).ExpectValid()
+	}).Opts(opts()).ExpectValid()
 
 	// Scenario 2: FeatureA enabled
 	// Valid values: C
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "A",
-	}).Opts([]string{"FeatureA"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	}).Opts(opts("FeatureA")).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.NotSupported(field.NewPath("conditionalEnumField"), ConditionalEnum("A"), []ConditionalEnum{ConditionalC}),
 	})
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "B",
-	}).Opts([]string{"FeatureA"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	}).Opts(opts("FeatureA")).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.NotSupported(field.NewPath("conditionalEnumField"), ConditionalEnum("B"), []ConditionalEnum{ConditionalC}),
 	})
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "D",
-	}).Opts([]string{"FeatureA"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	}).Opts(opts("FeatureA")).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.NotSupported(field.NewPath("conditionalEnumField"), ConditionalEnum("D"), []ConditionalEnum{ConditionalC}),
 	})
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "E",
-	}).Opts([]string{"FeatureA"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	}).Opts(opts("FeatureA")).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.NotSupported(field.NewPath("conditionalEnumField"), ConditionalEnum("E"), []ConditionalEnum{ConditionalC}),
 	})
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "F",
-	}).Opts([]string{"FeatureA"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	}).Opts(opts("FeatureA")).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.NotSupported(field.NewPath("conditionalEnumField"), ConditionalEnum("F"), []ConditionalEnum{ConditionalC}),
 	})
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "C",
-	}).Opts([]string{"FeatureA"}).ExpectValid()
+	}).Opts(opts("FeatureA")).ExpectValid()
 
 	// Scenario 3: FeatureB enabled
 	// Valid values: A, B, C
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "D",
-	}).Opts([]string{"FeatureB"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	}).Opts(opts("FeatureB")).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.NotSupported(field.NewPath("conditionalEnumField"), ConditionalEnum("D"), []ConditionalEnum{ConditionalA, ConditionalB, ConditionalC}),
 	})
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "E",
-	}).Opts([]string{"FeatureB"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	}).Opts(opts("FeatureB")).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.NotSupported(field.NewPath("conditionalEnumField"), ConditionalEnum("E"), []ConditionalEnum{ConditionalA, ConditionalB, ConditionalC}),
 	})
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "F",
-	}).Opts([]string{"FeatureB"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	}).Opts(opts("FeatureB")).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.NotSupported(field.NewPath("conditionalEnumField"), ConditionalEnum("F"), []ConditionalEnum{ConditionalA, ConditionalB, ConditionalC}),
 	})
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "A",
-	}).Opts([]string{"FeatureB"}).ExpectValid()
+	}).Opts(opts("FeatureB")).ExpectValid()
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "B",
-	}).Opts([]string{"FeatureB"}).ExpectValid()
+	}).Opts(opts("FeatureB")).ExpectValid()
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "C",
-	}).Opts([]string{"FeatureB"}).ExpectValid()
+	}).Opts(opts("FeatureB")).ExpectValid()
 
 	// Scenario 4: FeatureA and FeatureB enabled
 	// Valid values: B, C
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "A",
-	}).Opts([]string{"FeatureA", "FeatureB"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	}).Opts(opts("FeatureA", "FeatureB")).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.NotSupported(field.NewPath("conditionalEnumField"), ConditionalEnum("A"), []ConditionalEnum{ConditionalB, ConditionalC}),
 	})
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "D",
-	}).Opts([]string{"FeatureA", "FeatureB"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	}).Opts(opts("FeatureA", "FeatureB")).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.NotSupported(field.NewPath("conditionalEnumField"), ConditionalEnum("D"), []ConditionalEnum{ConditionalB, ConditionalC}),
 	})
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "E",
-	}).Opts([]string{"FeatureA", "FeatureB"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	}).Opts(opts("FeatureA", "FeatureB")).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.NotSupported(field.NewPath("conditionalEnumField"), ConditionalEnum("E"), []ConditionalEnum{ConditionalB, ConditionalC}),
 	})
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "F",
-	}).Opts([]string{"FeatureA", "FeatureB"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	}).Opts(opts("FeatureA", "FeatureB")).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.NotSupported(field.NewPath("conditionalEnumField"), ConditionalEnum("F"), []ConditionalEnum{ConditionalB, ConditionalC}),
 	})
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "B",
-	}).Opts([]string{"FeatureA", "FeatureB"}).ExpectValid()
+	}).Opts(opts("FeatureA", "FeatureB")).ExpectValid()
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "C",
-	}).Opts([]string{"FeatureA", "FeatureB"}).ExpectValid()
+	}).Opts(opts("FeatureA", "FeatureB")).ExpectValid()
 
 	// Scenario 5: FeatureC and FeatureD enabled
 	// Valid values: A, C, D, E
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "B",
-	}).Opts([]string{"FeatureC", "FeatureD"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	}).Opts(opts("FeatureC", "FeatureD")).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.NotSupported(field.NewPath("conditionalEnumField"), ConditionalEnum("B"), []ConditionalEnum{ConditionalA, ConditionalC, ConditionalD, ConditionalE}),
 	})
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "F",
-	}).Opts([]string{"FeatureC", "FeatureD"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	}).Opts(opts("FeatureC", "FeatureD")).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.NotSupported(field.NewPath("conditionalEnumField"), ConditionalEnum("F"), []ConditionalEnum{ConditionalA, ConditionalC, ConditionalD, ConditionalE}),
 	})
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "A",
-	}).Opts([]string{"FeatureC", "FeatureD"}).ExpectValid()
+	}).Opts(opts("FeatureC", "FeatureD")).ExpectValid()
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "C",
-	}).Opts([]string{"FeatureC", "FeatureD"}).ExpectValid()
+	}).Opts(opts("FeatureC", "FeatureD")).ExpectValid()
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "D",
-	}).Opts([]string{"FeatureC", "FeatureD"}).ExpectValid()
+	}).Opts(opts("FeatureC", "FeatureD")).ExpectValid()
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "E",
-	}).Opts([]string{"FeatureC", "FeatureD"}).ExpectValid()
+	}).Opts(opts("FeatureC", "FeatureD")).ExpectValid()
 
 	// Scenario 6: FeatureB and FeatureC enabled
 	// Valid values: A, B, C, F
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "D",
-	}).Opts([]string{"FeatureB", "FeatureC"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	}).Opts(opts("FeatureB", "FeatureC")).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.NotSupported(field.NewPath("conditionalEnumField"), ConditionalEnum("D"), []ConditionalEnum{ConditionalA, ConditionalB, ConditionalC, ConditionalF}),
 	})
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "E",
-	}).Opts([]string{"FeatureB", "FeatureC"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	}).Opts(opts("FeatureB", "FeatureC")).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.NotSupported(field.NewPath("conditionalEnumField"), ConditionalEnum("E"), []ConditionalEnum{ConditionalA, ConditionalB, ConditionalC, ConditionalF}),
 	})
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "A",
-	}).Opts([]string{"FeatureB", "FeatureC"}).ExpectValid()
+	}).Opts(opts("FeatureB", "FeatureC")).ExpectValid()
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "B",
-	}).Opts([]string{"FeatureB", "FeatureC"}).ExpectValid()
+	}).Opts(opts("FeatureB", "FeatureC")).ExpectValid()
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "C",
-	}).Opts([]string{"FeatureB", "FeatureC"}).ExpectValid()
+	}).Opts(opts("FeatureB", "FeatureC")).ExpectValid()
 	st.Value(&ConditionalStruct{
 		ConditionalEnumField: "F",
-	}).Opts([]string{"FeatureB", "FeatureC"}).ExpectValid()
+	}).Opts(opts("FeatureB", "FeatureC")).ExpectValid()
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/structs/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/structs/doc_test.go
@@ -76,14 +76,14 @@ func TestConditionalStruct(t *testing.T) {
 		ConditionalFieldBeta: 15,
 		RecursiveAlpha:       25,
 		RecursiveBeta:        25,
-	}).Opts([]string{"MyFeature"}).ExpectValid()
+	}).Opts(map[string]bool{"MyFeature": true}).ExpectValid()
 
 	st.Value(&ConditionalStruct{
 		ConditionalField:     5,
 		ConditionalFieldBeta: 5,
 		RecursiveAlpha:       10,
 		RecursiveBeta:        10,
-	}).Opts([]string{"MyFeature"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin().ByValidationStabilityLevel(), field.ErrorList{
+	}).Opts(map[string]bool{"MyFeature": true}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin().ByValidationStabilityLevel(), field.ErrorList{
 		field.Invalid(field.NewPath("conditionalField"), 5, "").WithOrigin("minimum").MarkAlpha(),
 		field.Invalid(field.NewPath("conditionalFieldBeta"), 5, "").WithOrigin("minimum").MarkBeta(),
 		field.Invalid(field.NewPath("recursiveAlpha"), 10, "").WithOrigin("minimum").MarkAlpha(),

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/options/discriminators/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/options/discriminators/doc_test.go
@@ -27,7 +27,7 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		// All zero values
-	}).ExpectValid()
+	}).Opts(map[string]bool{"FeatureZ": false}).ExpectValid()
 
 	st.Value(&Struct{
 		DiscriminatorField: Discriminator{
@@ -38,7 +38,7 @@ func Test(t *testing.T) {
 			Discriminator: "A",
 			FieldB:        ptr.To("invalid"), // invalid because discriminator is A
 		},
-	}).ExpectMatches(
+	}).Opts(map[string]bool{"FeatureZ": false}).ExpectMatches(
 		field.ErrorMatcher{}.ByType().ByField().ByOrigin(),
 		field.ErrorList{field.Forbidden(field.NewPath("discriminatorFieldDisabled", "fieldB"), "").WithOrigin("")},
 	)
@@ -52,7 +52,7 @@ func Test(t *testing.T) {
 			Discriminator: "A",
 			FieldB:        ptr.To("invalid"), // invalid because discriminator is A
 		},
-	}).Opts([]string{"FeatureZ"}).ExpectMatches(
+	}).Opts(map[string]bool{"FeatureZ": true}).ExpectMatches(
 		field.ErrorMatcher{}.ByType().ByField().ByOrigin(),
 		field.ErrorList{field.Forbidden(field.NewPath("discriminatorField", "fieldB"), "").WithOrigin("")},
 	)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/options/lists/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/options/lists/doc_test.go
@@ -33,7 +33,7 @@ func Test(t *testing.T) {
 			{Name: "b", Value: "1"},
 			{Name: "b", Value: "2"},
 		},
-	}).ExpectMatches(
+	}).Opts(map[string]bool{"FeatureX": false}).ExpectMatches(
 		field.ErrorMatcher{}.ByType().ByField().ByOrigin(),
 		field.ErrorList{field.Duplicate(field.NewPath("listMapDisabled").Index(1), ListItem{Name: "b", Value: "2"}).WithOrigin("")},
 	)
@@ -47,7 +47,7 @@ func Test(t *testing.T) {
 			{Name: "b", Value: "1"},
 			{Name: "b", Value: "2"},
 		},
-	}).Opts([]string{"FeatureX"}).ExpectMatches(
+	}).Opts(map[string]bool{"FeatureX": true}).ExpectMatches(
 		field.ErrorMatcher{}.ByType().ByField().ByOrigin(),
 		field.ErrorList{field.Duplicate(field.NewPath("listMap").Index(1), ListItem{Name: "a", Value: "2"}).WithOrigin("")},
 	)
@@ -59,7 +59,7 @@ func Test(t *testing.T) {
 		ListEachValDisabled: []ListItem{
 			{Name: "d", Value: "4"},
 		},
-	}).ExpectValidateFalseByPath(map[string][]string{
+	}).Opts(map[string]bool{"FeatureX": false}).ExpectValidateFalseByPath(map[string][]string{
 		"listEachValDisabled[0]": {"field Struct.ListEachValDisabled/val"},
 	})
 
@@ -70,7 +70,7 @@ func Test(t *testing.T) {
 		ListEachValDisabled: []ListItem{
 			{Name: "d", Value: "4"},
 		},
-	}).Opts([]string{"FeatureX"}).ExpectValidateFalseByPath(map[string][]string{
+	}).Opts(map[string]bool{"FeatureX": true}).ExpectValidateFalseByPath(map[string][]string{
 		"listEachVal[0]": {"field Struct.ListEachVal/val"},
 	})
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/options/maps/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/options/maps/doc_test.go
@@ -42,7 +42,7 @@ func Test(t *testing.T) {
 		MapFieldEachValDisabled: map[string]string{
 			"b": "2",
 		},
-	}).ExpectValidateFalseByPath(map[string][]string{
+	}).Opts(map[string]bool{"FeatureX": false}).ExpectValidateFalseByPath(map[string][]string{
 		"mapFieldDisabled":           {"field Struct.MapFieldDisabled"},
 		"mapFieldEachKeyDisabled":    {"field Struct.MapFieldEachKeyDisabled/key"},
 		"mapFieldEachValDisabled[b]": {"field Struct.MapFieldEachValDisabled/val"},
@@ -67,7 +67,7 @@ func Test(t *testing.T) {
 		MapFieldEachValDisabled: map[string]string{
 			"b": "2",
 		},
-	}).Opts([]string{"FeatureX"}).ExpectValidateFalseByPath(map[string][]string{
+	}).Opts(map[string]bool{"FeatureX": true}).ExpectValidateFalseByPath(map[string][]string{
 		"mapField":           {"field Struct.MapField"},
 		"mapFieldEachKey":    {"field Struct.MapFieldEachKey/key"},
 		"mapFieldEachVal[a]": {"field Struct.MapFieldEachVal/val"},

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/options/simple/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/options/simple/doc_test.go
@@ -17,7 +17,10 @@ limitations under the License.
 package simple
 
 import (
+	"errors"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 func Test(t *testing.T) {
@@ -25,7 +28,7 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		// All zero values
-	}).ExpectValidateFalseByPath(map[string][]string{
+	}).Opts(map[string]bool{"FeatureX": false, "FeatureY": false}).ExpectValidateFalseByPath(map[string][]string{
 		// All ifDisabled validations should trigger
 		"xDisabledField": {"field Struct.XDisabledField"},
 		"yDisabledField": {"field Struct.YDisabledField"},
@@ -34,7 +37,7 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		// All zero values
-	}).Opts([]string{"FeatureX", "FeatureY"}).ExpectValidateFalseByPath(map[string][]string{
+	}).Opts(map[string]bool{"FeatureX": true, "FeatureY": true}).ExpectValidateFalseByPath(map[string][]string{
 		// All ifEnabled validations should trigger
 		"xEnabledField":     {"field Struct.XEnabledField"},
 		"yEnabledField":     {"field Struct.YEnabledField"},
@@ -44,7 +47,7 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		// All zero values
-	}).Opts([]string{"FeatureX"}).ExpectValidateFalseByPath(map[string][]string{
+	}).Opts(map[string]bool{"FeatureX": true, "FeatureY": false}).ExpectValidateFalseByPath(map[string][]string{
 		// All ifEnabled validations should trigger
 		"xEnabledField":  {"field Struct.XEnabledField"},
 		"yDisabledField": {"field Struct.YDisabledField"},
@@ -56,9 +59,23 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		// All zero values
-	}).Opts([]string{"FeatureY"}).ExpectValidateFalseByPath(map[string][]string{
+	}).Opts(map[string]bool{"FeatureX": false, "FeatureY": true}).ExpectValidateFalseByPath(map[string][]string{
 		// All ifEnabled validations should trigger
 		"xDisabledField": {"field Struct.XDisabledField"},
 		"yEnabledField":  {"field Struct.YEnabledField"},
+	})
+
+	// No options declared: every referenced option is undeclared.
+	internal := func(p string) *field.Error {
+		return field.InternalError(field.NewPath(p), errors.New(""))
+	}
+	st.Value(&Struct{}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+		internal("xEnabledField"),
+		internal("xDisabledField"),
+		internal("yEnabledField"),
+		internal("yDisabledField"),
+		internal("xyMixedField"), // ifEnabled(FeatureX)
+		internal("xyMixedField"), // ifDisabled(FeatureY)
+		internal("nilableAliasField"),
 	})
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/options/subfields/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/options/subfields/doc_test.go
@@ -25,13 +25,13 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		// All zero values
-	}).ExpectValidateFalseByPath(map[string][]string{
+	}).Opts(map[string]bool{"FeatureX": false}).ExpectValidateFalseByPath(map[string][]string{
 		"metadataDisabled.xDisabledField": {"field Struct.ObjectMetaDisabled.XDisabledField"},
 	})
 
 	st.Value(&Struct{
 		// All zero values
-	}).Opts([]string{"FeatureX"}).ExpectValidateFalseByPath(map[string][]string{
+	}).Opts(map[string]bool{"FeatureX": true}).ExpectValidateFalseByPath(map[string][]string{
 		"metadata.xEnabledField": {"field Struct.ObjectMeta.XEnabledField"},
 	})
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/options/unions/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/options/unions/doc_test.go
@@ -26,7 +26,7 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		// All zero values
-	}).ExpectValid()
+	}).Opts(map[string]bool{"FeatureX": false}).ExpectValid()
 
 	st.Value(&Struct{
 		UnionField: Union{
@@ -42,7 +42,7 @@ func Test(t *testing.T) {
 			{Name: "succeeded"},
 			{Name: "failed"},
 		},
-	}).Opts([]string{"FeatureX"}).ExpectMatches(
+	}).Opts(map[string]bool{"FeatureX": true}).ExpectMatches(
 		field.ErrorMatcher{}.ByType().ByField().ByOrigin(),
 		field.ErrorList{
 			field.Invalid(field.NewPath("unionField", "xDisabledField"), "", "").WithOrigin("union"),
@@ -66,7 +66,7 @@ func Test(t *testing.T) {
 			{Name: "succeeded"},
 			{Name: "failed"},
 		},
-	}).ExpectValid()
+	}).Opts(map[string]bool{"FeatureX": false}).ExpectValid()
 
 	st.Value(&Struct{
 		UnionFieldDisabled: UnionDisabled{
@@ -82,7 +82,7 @@ func Test(t *testing.T) {
 			{Name: "succeeded"},
 			{Name: "failed"},
 		},
-	}).ExpectMatches(
+	}).Opts(map[string]bool{"FeatureX": false}).ExpectMatches(
 		field.ErrorMatcher{}.ByType().ByField().ByOrigin(),
 		field.ErrorList{
 			field.Invalid(field.NewPath("unionFieldDisabled", "xDisabledField"), "", "").WithOrigin("union"),
@@ -106,5 +106,5 @@ func Test(t *testing.T) {
 			{Name: "succeeded"},
 			{Name: "failed"},
 		},
-	}).Opts([]string{"FeatureX"}).ExpectValid()
+	}).Opts(map[string]bool{"FeatureX": true}).ExpectValid()
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/options/update/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/options/update/doc_test.go
@@ -39,9 +39,9 @@ func Test(t *testing.T) {
 		UpdateNoModifyDisabled: "hhh",
 	}
 
-	st.Value(&structA).OldValue(&structA).ExpectValid()
+	st.Value(&structA).OldValue(&structA).Opts(map[string]bool{"FeatureX": false}).ExpectValid()
 
-	st.Value(&structB).OldValue(&structA).ExpectMatches(
+	st.Value(&structB).OldValue(&structA).Opts(map[string]bool{"FeatureX": false}).ExpectMatches(
 		field.ErrorMatcher{}.ByType().ByField().ByOrigin().ByDetailSubstring(),
 		field.ErrorList{
 			field.Invalid(field.NewPath("immutableDisabled"), nil, "").WithOrigin("immutable"),
@@ -49,7 +49,7 @@ func Test(t *testing.T) {
 		},
 	)
 
-	st.Value(&structB).OldValue(&structA).Opts([]string{"FeatureX"}).ExpectMatches(
+	st.Value(&structB).OldValue(&structA).Opts(map[string]bool{"FeatureX": true}).ExpectMatches(
 		field.ErrorMatcher{}.ByType().ByField().ByOrigin().ByDetailSubstring(),
 		field.ErrorList{
 			field.Invalid(field.NewPath("immutableEnabled"), nil, "").WithOrigin("immutable"),

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/testscheme/testscheme.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/testscheme/testscheme.go
@@ -64,7 +64,7 @@ func (s *Scheme) AddValidationFunc(srcType any, fn func(ctx context.Context, op 
 }
 
 // Validate validates an object using the registered validation function.
-func (s *Scheme) Validate(ctx context.Context, options []string, object any, subresources ...string) field.ErrorList {
+func (s *Scheme) Validate(ctx context.Context, options map[string]bool, object any, subresources ...string) field.ErrorList {
 	if len(s.registrationErrors) > 0 {
 		return s.registrationErrors // short circuit with registration errors if any are present
 	}
@@ -75,7 +75,7 @@ func (s *Scheme) Validate(ctx context.Context, options []string, object any, sub
 }
 
 // ValidateUpdate validates an update to an object using the registered validation function.
-func (s *Scheme) ValidateUpdate(ctx context.Context, options []string, object, oldObject any, subresources ...string) field.ErrorList {
+func (s *Scheme) ValidateUpdate(ctx context.Context, options map[string]bool, object, oldObject any, subresources ...string) field.ErrorList {
 	if len(s.registrationErrors) > 0 {
 		return s.registrationErrors // short circuit with registration errors if any are present
 	}
@@ -248,7 +248,7 @@ type ValidationTester struct {
 	value        any
 	oldValue     any
 	isUpdate     bool
-	options      []string
+	options      map[string]bool
 	subresources []string
 }
 
@@ -272,7 +272,7 @@ func (v *ValidationTester) OldValueFuzzed(oldValue any) *ValidationTester {
 }
 
 // Opts sets the ValidationOpts to use.
-func (v *ValidationTester) Opts(options []string) *ValidationTester {
+func (v *ValidationTester) Opts(options map[string]bool) *ValidationTester {
 	v.options = options
 	return v
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
@@ -1518,6 +1518,7 @@ func (g *genValidations) emitCallsToValidators(c *generator.Context, validations
 			targs := generator.Args{
 				"funcName": c.Universe.Type(g.resolveFunc(v.Function)),
 				"field":    mkSymbolArgs(c, fieldPkgSymbols),
+				"fmt":      mkSymbolArgs(c, fmtPkgSymbols),
 			}
 
 			emitCall := func() {
@@ -1553,12 +1554,13 @@ func (g *genValidations) emitCallsToValidators(c *generator.Context, validations
 			if !v.Conditions.Empty() {
 				emitBaseFunction := emitCall
 				emitCall = func() {
-					// emitOptionLookup emits "<var>, err := op.HasOption(<option>)" and
-					// surfaces an undeclared option as an internal error.
+					// emitOptionLookup emits "<var>, defined := op.HasOption(<option>)" and
+					// surfaces an undefined option as an internal error.
 					emitOptionLookup := func(varName, option string) {
-						sw.Do("  "+varName+", err := op.HasOption($.$)\n", strconv.Quote(option))
-						sw.Do("  if err != nil {\n", nil)
-						sw.Do("    return $.field.ErrorList|raw${$.field.InternalError|raw$(fldPath, err)}\n", targs)
+						la := generator.Args{"field": targs["field"], "fmt": targs["fmt"], "opt": strconv.Quote(option)}
+						sw.Do("  "+varName+", defined := op.HasOption($.opt$)\n", la)
+						sw.Do("  if !defined {\n", nil)
+						sw.Do("    return $.field.ErrorList|raw${$.field.InternalError|raw$(fldPath, $.fmt.Errorf|raw$(\"undefined validation option %q\", $.opt$))}\n", la)
 						sw.Do("  }\n", nil)
 					}
 					sw.Do("func() $.field.ErrorList|raw$ {\n", targs)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
@@ -1553,26 +1553,39 @@ func (g *genValidations) emitCallsToValidators(c *generator.Context, validations
 			if !v.Conditions.Empty() {
 				emitBaseFunction := emitCall
 				emitCall = func() {
+					// emitOptionLookup emits "<var>, err := op.HasOption(<option>)" and
+					// surfaces an undeclared option as an internal error.
+					emitOptionLookup := func(varName, option string) {
+						sw.Do("  "+varName+", err := op.HasOption($.$)\n", strconv.Quote(option))
+						sw.Do("  if err != nil {\n", nil)
+						sw.Do("    return $.field.ErrorList|raw${$.field.InternalError|raw$(fldPath, err)}\n", targs)
+						sw.Do("  }\n", nil)
+					}
 					sw.Do("func() $.field.ErrorList|raw$ {\n", targs)
+					if len(v.Conditions.OptionEnabled) > 0 {
+						emitOptionLookup("optionEnabled", v.Conditions.OptionEnabled)
+					}
+					if len(v.Conditions.OptionDisabled) > 0 {
+						emitOptionLookup("optionDisabled", v.Conditions.OptionDisabled)
+					}
 					sw.Do("  if ", nil)
 					firstCondition := true
 					if len(v.Conditions.OptionEnabled) > 0 {
-						sw.Do("op.HasOption($.$)", strconv.Quote(v.Conditions.OptionEnabled))
+						sw.Do("optionEnabled", nil)
 						firstCondition = false
 					}
 					if len(v.Conditions.OptionDisabled) > 0 {
 						if !firstCondition {
 							sw.Do(" && ", nil)
 						}
-						sw.Do("!op.HasOption($.$)", strconv.Quote(v.Conditions.OptionDisabled))
+						sw.Do("!optionDisabled", nil)
 					}
 					sw.Do(" {\n", nil)
 					sw.Do("    return ", nil)
 					emitBaseFunction()
 					sw.Do("\n", nil)
-					sw.Do("  } else {\n", nil)
-					sw.Do("    return nil // skip validation\n", nil)
 					sw.Do("  }\n", nil)
+					sw.Do("  return nil // skip validation\n", nil)
 					sw.Do("}()", nil)
 				}
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
`+k8s:ifEnabled` / `+k8s:ifDisabled` and enum option-exclusions decided behavior by checking whether an option name was present in the strategy-provided `Options` slice. Because it was a `[]string`, an option a strategy **failed to declare** was indistinguishable from one declared-and-disabled — so a missing option was silently treated as `false`, and the tag quietly did the opposite of what the author intended, with no codegen error and no runtime signal.

This makes options explicitly declared:
- `operation.Options` is now a `map[string]bool`, and `Operation.HasOption` returns `(bool, error)`, erroring when an option was never declared.
- `validate.IfOption` and `validate.Enum` surface that error as a `field.InternalError`, so a forgotten option fails loudly (and is caught by tests) instead of silently mis-validating.
- Resource strategies (HPA, workload, PodGroup) declare their options as maps.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #139197

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
