### PR TITLE
test: add CEL unstructured list concatenation immutability regression coverage

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
@@ -1592,6 +1592,53 @@ func TestListAdd(t *testing.T) {
 	}
 }
 
+func TestUnstructuredListAddDoesNotMutateLHS(t *testing.T) {
+	tests := []struct {
+		name       string
+		listSchema *spec.Schema
+		expression string
+	}{
+		{
+			name:       "atomic list",
+			listSchema: stringArraySchema,
+			expression: "(x + ['c']) != (x + ['d'])",
+		},
+		{
+			name: "set list",
+			listSchema: &spec.Schema{
+				VendorExtensible: spec.VendorExtensible{Extensions: map[string]interface{}{
+					"x-kubernetes-list-type": "set",
+				}},
+				SchemaProps: stringArraySchema.SchemaProps,
+			},
+			expression: "(x + ['c']) != (x + ['d']) && 'c' in (x + ['c']) && !(x == ['a', 'c'])",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env, err := cel.NewEnv(cel.Variable("x", cel.DynType), cel.StdLib())
+			if err != nil {
+				t.Fatalf("Env creation error: %v", err)
+			}
+
+			elements := make([]interface{}, 2, 3)
+			elements[0] = "a"
+			elements[1] = "b"
+
+			out, err := evalExpression(t, env, tt.expression, map[string]interface{}{
+				"x": common.UnstructuredToVal(elements, &openapi.Schema{Schema: tt.listSchema}),
+			})
+			if err != nil {
+				t.Fatalf("Unexpected err with unstructured values: %v", err)
+			}
+			if out != types.True {
+				t.Errorf("Expected true with unstructured values but got %v", out)
+			}
+		})
+	}
+}
+
 func schemalessTypedToValActivation(vals map[string]typedValue) map[string]interface{} {
 	activation := make(map[string]interface{}, len(vals))
 	for k, tv := range vals {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The original unstructured CEL list concatenation reused internal state from the left-hand-side list.

`unstructuredList.Add()` copied only the slice header with elements := t.elements, so appending the right-hand-side list could write into the same backing array when spare capacity existed.

`unstructuredSetList.Add()` had the same backing-array issue and also reused `t.getSet()`, then inserted new values into the original set cache.

  This breaks CEL’s expected value semantics: x + y should produce a new list without mutating x.

  In CRD validation scenarios using x-kubernetes-validations, a rule that concatenates an unstructured array field and then reads the same field again in the same expression can observe polluted internal state.

  The user-visible failure is incorrect admission behavior: a valid CustomResource can be rejected, or an invalid one can be accepted, because later CEL comparisons or membership checks  are evaluated against mutated list state.

  For example, assume a CRD contains this validation rule:

```
  x-kubernetes-validations:
  - rule: "'carol' in (self.members + self.requiredMembers) && !(self.members == ['alice', 'carol'])"
    message: "direct members must not be rewritten by effective member calculation"
```

  And the user submits this object:

```
  apiVersion: example.com/v1
  kind: Team
  metadata:
    name: demo
  spec:
    members:
    - alice
    - bob
    requiredMembers:
    - carol
```

  The problem happens in the first half of the rule:   `self.members + self.requiredMembers`

  This should only produce a temporary list:  [alice, bob, carol]

  However, unstructuredSetList.Add writes carol into the internal set cache of self.members.

  Then the second half of the rule evaluates:   ` self.members == ['alice', 'carol'] `

  At the surface, self.members is still:   [alice, bob]

  But its internal set cache has already been polluted and now contains:    [alice, bob, carol]

  As a result, the code can incorrectly evaluate:   self.members == ['alice', 'carol']    as true.

  Therefore, even though the user submitted a valid object:

```
  members:
  - alice
  - bob
  requiredMembers:
  - carol
```

  the API server can reject it with:  direct members must not be rewritten by effective member calculation
  

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
