### PR TITLE
fix: Prevent CEL Admission Panics on Three-Key Typed Map Lists

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
@@ -1033,6 +1033,61 @@ func TestReflectiveWrapperValueReturnsGoValue(t *testing.T) {
 	}
 }
 
+func TestReflectiveMapListWithThreeKeysEqual(t *testing.T) {
+	type ThreeKeyMapListEntry struct {
+		Key1  string `json:"key1"`
+		Key2  string `json:"key2"`
+		Key3  string `json:"key3"`
+		Value int64  `json:"value"`
+	}
+	type ThreeKeyMapListStruct struct {
+		Items []ThreeKeyMapListEntry `json:"items"`
+	}
+
+	entrySchema := &spec.Schema{SchemaProps: spec.SchemaProps{
+		Type: []string{"object"},
+		Properties: map[string]spec.Schema{
+			"key1":  *stringSchema,
+			"key2":  *stringSchema,
+			"key3":  *stringSchema,
+			"value": *int64Schema,
+		},
+	}}
+	objectSchema := &spec.Schema{SchemaProps: spec.SchemaProps{
+		Type: []string{"object"},
+		Properties: map[string]spec.Schema{
+			"items": {
+				VendorExtensible: spec.VendorExtensible{Extensions: map[string]interface{}{
+					"x-kubernetes-list-type":     "map",
+					"x-kubernetes-list-map-keys": []any{"key1", "key2", "key3"},
+				}},
+				SchemaProps: spec.SchemaProps{Type: []string{"array"}, Items: &spec.SchemaOrArray{Schema: entrySchema}},
+			},
+		},
+	}}
+
+	activation := map[string]typedValue{
+		"x": {value: ThreeKeyMapListStruct{Items: []ThreeKeyMapListEntry{
+			{Key1: "a", Key2: "b", Key3: "c", Value: 1},
+			{Key1: "d", Key2: "e", Key3: "f", Value: 2},
+		}}, schema: objectSchema},
+		"y": {value: ThreeKeyMapListStruct{Items: []ThreeKeyMapListEntry{
+			{Key1: "d", Key2: "e", Key3: "f", Value: 2},
+			{Key1: "a", Key2: "b", Key3: "c", Value: 1},
+		}}, schema: objectSchema},
+	}
+
+	env, err := cel.NewEnv(cel.Variable("x", cel.DynType), cel.Variable("y", cel.DynType), cel.StdLib())
+	if err != nil {
+		t.Fatalf("Env creation error: %v", err)
+	}
+	testTypedToVal(t, env, testCase{
+		name:       "three key map list equality",
+		expression: "x.items == y.items",
+		activation: activation,
+	})
+}
+
 func TestListAdd(t *testing.T) {
 	type AddListsStruct struct {
 		Tags   []string       `json:"tags"`

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
@@ -422,7 +422,7 @@ func (t *typedMapList) toMapKey(element reflect.Value) interface{} {
 		return [2]interface{}{fieldEntries[0].GetFrom(element).Interface(), fieldEntries[1].GetFrom(element).Interface()}
 	}
 	if len(fieldEntries) == 3 {
-		return [3]interface{}{fieldEntries[0].GetFrom(element).Interface(), fieldEntries[1].GetFrom(element).Interface(), fieldEntries[3].GetFrom(element).Interface()}
+		return [3]interface{}{fieldEntries[0].GetFrom(element).Interface(), fieldEntries[1].GetFrom(element).Interface(), fieldEntries[2].GetFrom(element).Interface()}
 	}
 
 	key := make([]interface{}, len(fieldEntries))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When typedMapList.toMapKey() handled a listType=map list with exactly three listMapKey  fields, it built a [3]interface{} key using indexes 0, 1, and 3. Since fieldEntries has length 3, valid indexes are only 0, 1, and 2, so accessing fieldEntries[3] panics.

Obviously , when len(fieldEntries) == 3 , the code is trying to read fieldEntries[3] and will lead a panic

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: Prevent CEL Admission Panics on Three-Key Typed Map Lists
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
