### PR TITLE
Always set UpdatePodResources when a starting container is resized

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -423,6 +423,7 @@ func (m *kubeGenericRuntimeManager) updateContainerResources(ctx context.Context
 func (m *kubeGenericRuntimeManager) setActuatedContainerResources(logger klog.Logger, pod *v1.Pod, container *v1.Container) error {
 	containerResources := container.Resources
 	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodLevelResourcesVerticalScaling) {
+		containerResources = *containerResources.DeepCopy()
 		containerResources.Limits = kubeutil.GetLimits(&kubeutil.ResourceOpts{PodResources: pod.Spec.Resources, ContainerResources: &container.Resources})
 	}
 	return m.actuatedState.SetContainerResources(logger, pod.UID, container.Name, containerResources)
@@ -1309,6 +1310,11 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(ctx context.Cont
 	for i := 0; i < l/2; i++ {
 		changes.InitContainersToStart[i], changes.InitContainersToStart[l-1-i] =
 			changes.InitContainersToStart[l-1-i], changes.InitContainersToStart[i]
+	}
+
+	if !changes.UpdatePodLevelResources && !changes.UpdatePodResources {
+		// If any starting containers have resized, we need to resize the pod resources.
+		changes.UpdatePodResources = m.startingResizedContainer(logger, pod, pod.Spec.InitContainers, changes.InitContainersToStart)
 	}
 
 	return podHasInitialized

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1382,7 +1382,33 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 	}
 
 	changes.UpdatePodLevelResources = m.computePodLevelResourcesResizeAction(ctx, pod)
+	if !changes.UpdatePodLevelResources && !changes.UpdatePodResources {
+		// If any starting containers have resized, we need to resize the pod resources.
+		changes.UpdatePodResources = m.startingResizedContainer(logger, pod, pod.Spec.Containers, changes.ContainersToStart)
+	}
+
 	return changes
+}
+
+// startingResizedContainer reports whether any of the contaniersToStart have been resized.
+func (m *kubeGenericRuntimeManager) startingResizedContainer(logger klog.Logger, pod *v1.Pod, containers []v1.Container, containersToStart []int) bool {
+	for _, i := range containersToStart {
+		c := containers[i]
+		actuatedResources, ok := m.actuatedState.GetContainerResources(pod.UID, c.Name)
+		if !ok {
+			logger.V(4).Info("Actuated resources missing for container", "pod", format.Pod(pod), "container", c.Name)
+		}
+		var actuatedPodResources *v1.ResourceRequirements
+		if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodLevelResourcesVerticalScaling) {
+			actuatedPodResources, _ = m.actuatedState.GetPodLevelResources(pod.UID)
+		}
+		desired := containerResourcesFromRequirements(pod.Spec.Resources, &c.Resources)
+		actuated := containerResourcesFromRequirements(actuatedPodResources, &actuatedResources)
+		if desired != actuated {
+			return true
+		}
+	}
+	return false
 }
 
 // getContainersToReset returns container info about the containers to remove from the runtime.
@@ -1443,9 +1469,9 @@ func (m *kubeGenericRuntimeManager) computePodLevelResourcesResizeAction(ctx con
 //  3. Kill any containers that should not be running.
 //  4. Create sandbox if necessary.
 //  5. Invoke OnPodSandboxReady to notify Kubelet to update pod status.
-//  6. Create ephemeral containers.
-//  7. Create init containers.
-//  8. Resize running containers (if InPlacePodVerticalScaling==true)
+//  6. Resize pod & running containers
+//  7. Create ephemeral containers.
+//  8. Create init containers.
 //  9. Create normal containers.
 func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, podStatus *kubecontainer.PodStatus, pullSecrets []v1.Secret, backOff *flowcontrol.Backoff, restartAllContainers bool) (result kubecontainer.PodSyncResult) {
 	logger := klog.FromContext(ctx)
@@ -1664,6 +1690,13 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 		podIP = podIPs[0]
 	}
 
+	// Step 6: Resize pod & running containers (if necessary).
+	if resizable, _, _ := allocation.IsInPlacePodVerticalScalingAllowed(pod); resizable {
+		if len(podContainerChanges.ContainersToUpdate) > 0 || podContainerChanges.UpdatePodResources || podContainerChanges.UpdatePodLevelResources {
+			result.AddSyncResult(m.doPodResizeAction(ctx, pod, podStatus, podContainerChanges))
+		}
+	}
+
 	// Helper containing boilerplate common to starting all types of containers.
 	// typeName is a description used to describe this type of container in log messages,
 	// currently: "container", "init container" or "ephemeral container"
@@ -1759,7 +1792,7 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 		}
 	}
 
-	// Step 6: start ephemeral containers
+	// Step 7: start ephemeral containers
 	// These are started "prior" to init containers to allow running ephemeral containers even when there
 	// are errors starting an init container. In practice init containers will start first since ephemeral
 	// containers cannot be specified on pod creation.
@@ -1772,7 +1805,7 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 		start(ctx, "ephemeral container", metrics.EphemeralContainer, ephemeralContainerStartSpec(&pod.Spec.EphemeralContainers[idx]))
 	}
 
-	// Step 7: start init containers.
+	// Step 8: start init containers.
 	for _, idx := range podContainerChanges.InitContainersToStart {
 		start := lazyStart()
 		if start == nil {
@@ -1806,13 +1839,6 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 					m.podInitContainerTimeRecorder.RecordInitContainerFinished(pod.UID, cs.FinishedAt)
 				}
 			}
-		}
-	}
-
-	// Step 8: For containers in podContainerChanges.ContainersToUpdate[CPU,Memory] list, invoke UpdateContainerResources
-	if resizable, _, _ := allocation.IsInPlacePodVerticalScalingAllowed(pod); resizable {
-		if len(podContainerChanges.ContainersToUpdate) > 0 || podContainerChanges.UpdatePodResources || podContainerChanges.UpdatePodLevelResources {
-			result.AddSyncResult(m.doPodResizeAction(ctx, pod, podStatus, podContainerChanges))
 		}
 	}
 
@@ -2199,6 +2225,16 @@ func (m *kubeGenericRuntimeManager) ListPodSandboxMetrics(ctx context.Context) (
 }
 
 func (m *kubeGenericRuntimeManager) UpdateActuatedPodLevelResources(logger klog.Logger, actuatedPod *v1.Pod) error {
+	if _, ok := m.actuatedState.GetPodResourceInfo(actuatedPod.UID); !ok {
+		// This is a new pod. Initialize actuated resources to detect pre-start container resizes to
+		// trigger pod cgroup updates.
+		for c := range podutil.ContainerIter(&actuatedPod.Spec, podutil.InitContainers|podutil.Containers) {
+			if err := m.setActuatedContainerResources(logger, actuatedPod, c); err != nil {
+				logger.Error(err, "Failed to set container actuated resources", "pod", format.Pod(actuatedPod), "container", c.Name)
+			}
+		}
+	}
+
 	if !utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		return nil
 	}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -1502,12 +1502,8 @@ func TestComputePodActionsForRestartAllContainers(t *testing.T) {
 		features.NodeDeclaredFeatures:                 true,
 		features.RestartAllContainersOnContainerExits: true,
 	})
-	TestComputePodActions(t)
-	TestComputePodActionsWithInitContainers(t)
-
-	tCtx := ktesting.Init(t)
-	_, _, m, err := createTestRuntimeManager(tCtx)
-	require.NoError(t, err)
+	t.Run("TestComputePodActions", TestComputePodActions)
+	t.Run("TestComputePodActionsWithInitContainers", TestComputePodActionsWithInitContainers)
 
 	allContainersRestartingTrue := []v1.PodCondition{
 		{
@@ -1798,41 +1794,49 @@ func TestComputePodActionsForRestartAllContainers(t *testing.T) {
 			containersToStart: []int{0, 1, 2},
 		},
 	} {
-		pod := test.podFunc()
-		status := test.podStatusFunc()
-		tCtx := ktesting.Init(t)
-		actions := m.computePodActions(tCtx, pod, status, test.restartAllContainers)
+		t.Run(desc, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+			_, _, m, err := createTestRuntimeManager(tCtx)
+			require.NoError(t, err)
 
-		expected := &podActions{
-			CreateSandbox:     false,
-			KillPod:           false,
-			SandboxID:         status.SandboxStatuses[0].Id,
-			ContainersToKill:  map[kubecontainer.ContainerID]containerToKillInfo{},
-			ContainersToStart: []int{},
-		}
-		if test.containersToStart != nil {
-			expected.ContainersToStart = test.containersToStart
-		}
-		if test.initContainersToStart != nil {
-			expected.InitContainersToStart = test.initContainersToStart
-		}
+			pod := test.podFunc()
+			status := test.podStatusFunc()
 
-		containerSpecByName := make(map[string]*v1.Container)
-		for idx, c := range pod.Spec.Containers {
-			containerSpecByName[c.Name] = &pod.Spec.Containers[idx]
-		}
-		for idx, c := range pod.Spec.InitContainers {
-			containerSpecByName[c.Name] = &pod.Spec.InitContainers[idx]
-		}
-		for _, info := range test.containersToRemove {
-			cName := info.container.Name
-			info.container = containerSpecByName[cName]
-			expected.ContainersToReset = append(expected.ContainersToReset, info)
-		}
+			// Initialize the actuated resources.
+			require.NoError(t, m.UpdateActuatedPodLevelResources(tCtx.Logger(), pod))
 
-		verifyActions(t, expected, &actions, desc)
+			actions := m.computePodActions(tCtx, pod, status, test.restartAllContainers)
+
+			expected := &podActions{
+				CreateSandbox:     false,
+				KillPod:           false,
+				SandboxID:         status.SandboxStatuses[0].Id,
+				ContainersToKill:  map[kubecontainer.ContainerID]containerToKillInfo{},
+				ContainersToStart: []int{},
+			}
+			if test.containersToStart != nil {
+				expected.ContainersToStart = test.containersToStart
+			}
+			if test.initContainersToStart != nil {
+				expected.InitContainersToStart = test.initContainersToStart
+			}
+
+			containerSpecByName := make(map[string]*v1.Container)
+			for idx, c := range pod.Spec.Containers {
+				containerSpecByName[c.Name] = &pod.Spec.Containers[idx]
+			}
+			for idx, c := range pod.Spec.InitContainers {
+				containerSpecByName[c.Name] = &pod.Spec.InitContainers[idx]
+			}
+			for _, info := range test.containersToRemove {
+				cName := info.container.Name
+				info.container = containerSpecByName[cName]
+				expected.ContainersToReset = append(expected.ContainersToReset, info)
+			}
+
+			verifyActions(t, expected, &actions, desc)
+		})
 	}
-
 }
 
 func getKillMap(pod *v1.Pod, status *kubecontainer.PodStatus, cIndexes []int) map[kubecontainer.ContainerID]containerToKillInfo {
@@ -1887,7 +1891,7 @@ func verifyActions(t *testing.T, expected, actual *podActions, desc string) {
 }
 
 func TestComputePodActionsWithInitContainers(t *testing.T) {
-	logger, tCtx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	_, _, m, err := createTestRuntimeManager(tCtx)
 	require.NoError(t, err)
 
@@ -2112,6 +2116,7 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 				InitContainersToStart: []int{0},
 				ContainersToStart:     []int{},
 				ContainersToKill:      getKillMapWithInitContainers(basePod, baseStatus, []int{}),
+				UpdatePodResources:    true,
 			},
 		},
 		"resize of a running non-sidecar init container": {
@@ -2189,10 +2194,16 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 			if test.skipWindows && goruntime.GOOS == "windows" {
 				t.Skip("Skipping test since Windows does not support resize")
 			}
+			tCtx := ktesting.Init(t)
+
 			if test.disableIPPRInitCtrFG {
 				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingInitContainers, false)
 			}
 			pod, status := makeBasePodAndStatusWithInitContainers()
+
+			// Sync the actuated state with the base values before any resize
+			require.NoError(t, m.UpdateActuatedPodLevelResources(tCtx.Logger(), pod))
+
 			if test.actions.ContainersToUpdate != nil {
 				for res := range test.actions.ContainersToUpdate {
 					for i := range test.actions.ContainersToUpdate[res] {
@@ -2200,9 +2211,6 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 						test.actions.ContainersToUpdate[res][i].container = &pod.Spec.InitContainers[0]
 					}
 				}
-				// Sync the state manager with the base (old) values before the resize
-				resources := pod.Spec.InitContainers[0].Resources
-				require.NoError(t, m.actuatedState.SetContainerResources(logger, pod.UID, pod.Spec.InitContainers[0].Name, resources))
 			}
 
 			if test.mutatePodFn != nil {
@@ -2211,7 +2219,6 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 			if test.mutateStatusFn != nil {
 				test.mutateStatusFn(status)
 			}
-			tCtx := ktesting.Init(t)
 			actions := m.computePodActions(tCtx, pod, status, false)
 			verifyActions(t, &test.actions, &actions, desc)
 		})
@@ -3945,6 +3952,188 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 			verifyActions(t, expectedActions, &actions, desc)
 		})
 	}
+}
+
+func TestComputePodResizeActionForOOMKilledContainer(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("in-place resize is only supported on Linux")
+	}
+	logger, tCtx := ktesting.NewTestContext(t)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
+	_, _, m, err := createTestRuntimeManager(tCtx)
+	m.machineInfo.MemoryCapacity = 17179860387 // 16GB
+	require.NoError(t, err)
+
+	mem100M := resource.MustParse("100Mi")
+	mem200M := resource.MustParse("200Mi")
+	cpu100m := resource.MustParse("100m")
+
+	pod, status := makeBasePodAndStatus()
+	pod.Spec.Containers = pod.Spec.Containers[:1]
+	status.ContainerStatuses = status.ContainerStatuses[:1]
+
+	pod.Spec.Containers[0].Resources = v1.ResourceRequirements{
+		Limits:   v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem100M},
+		Requests: v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem100M},
+	}
+	pod.Spec.Containers[0].ResizePolicy = []v1.ContainerResizePolicy{
+		{ResourceName: v1.ResourceCPU, RestartPolicy: v1.NotRequired},
+		{ResourceName: v1.ResourceMemory, RestartPolicy: v1.NotRequired},
+	}
+	// record the pre-resize resource limits as what was last actuated.
+	require.NoError(t, m.UpdateActuatedPodLevelResources(logger, pod))
+
+	// Pod Resized
+	resize := pod.Spec.Containers[0].Resources.DeepCopy()
+	resize.Requests[v1.ResourceMemory] = mem200M
+	resize.Limits[v1.ResourceMemory] = mem200M
+	pod.Spec.Containers[0].Resources = *resize
+
+	// simulate OOMKilled
+	status.ContainerStatuses[0].State = kubecontainer.ContainerStateExited
+	status.ContainerStatuses[0].Hash = kubecontainer.HashContainer(&pod.Spec.Containers[0])
+
+	actions := m.computePodActions(tCtx, pod, status, false)
+
+	// the container is OOMKilled and must not be added to ContainersToUpdate (no live CRI call).
+	assert.Empty(t, actions.ContainersToUpdate, "OOMKilled container must not be in ContainersToUpdate")
+	// UpdatePodResources must be true so doPodResizeAction updates the pod-level cgroup.
+	assert.True(t, actions.UpdatePodResources, "UpdatePodResources must be true for OOMKilled container with pending resize")
+}
+
+func TestComputePodResizeActionForOOMKilledInitContainer(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("in-place resize is only supported on Linux")
+	}
+	logger, tCtx := ktesting.NewTestContext(t)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingInitContainers, true)
+	_, _, m, err := createTestRuntimeManager(tCtx)
+	m.machineInfo.MemoryCapacity = 17179860387 // 16GB
+	require.NoError(t, err)
+
+	mem100M := resource.MustParse("100Mi")
+	mem200M := resource.MustParse("200Mi")
+	cpu100m := resource.MustParse("100m")
+
+	pod, status := makeBasePodAndStatus()
+	// a single init container.
+	pod.Spec.InitContainers = []v1.Container{
+		{
+			Name:  "init1",
+			Image: "bar-image",
+			Resources: v1.ResourceRequirements{
+				Limits:   v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem100M},
+				Requests: v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem100M},
+			},
+			ResizePolicy: []v1.ContainerResizePolicy{
+				{ResourceName: v1.ResourceCPU, RestartPolicy: v1.NotRequired},
+				{ResourceName: v1.ResourceMemory, RestartPolicy: v1.NotRequired},
+			},
+		},
+	}
+	// no regular containers running so pod is not yet initialized.
+	status.ContainerStatuses = []*kubecontainer.Status{
+		{
+			ID:       kubecontainer.ContainerID{ID: "initid1"},
+			Name:     "init1",
+			State:    kubecontainer.ContainerStateExited,
+			Reason:   "OOMKilled",
+			ExitCode: 137,
+			Hash:     kubecontainer.HashContainer(&pod.Spec.InitContainers[0]),
+		},
+	}
+	pod.Spec.Containers = nil
+	pod.Status.ContainerStatuses = nil
+
+	// record pre-resize resource limits as what was last actuated.
+	require.NoError(t, m.UpdateActuatedPodLevelResources(logger, pod))
+
+	// Pod Resized
+	resize := pod.Spec.InitContainers[0].Resources.DeepCopy()
+	resize.Requests[v1.ResourceMemory] = mem200M
+	resize.Limits[v1.ResourceMemory] = mem200M
+	pod.Spec.InitContainers[0].Resources = *resize
+
+	actions := m.computePodActions(tCtx, pod, status, false)
+
+	// the init container is OOMKilled and must not be in ContainersToUpdate.
+	assert.Empty(t, actions.ContainersToUpdate, "OOMKilled init container must not be in ContainersToUpdate")
+	// UpdatePodResources must be true so doPodResizeAction updates the pod-level cgroup.
+	assert.True(t, actions.UpdatePodResources, "UpdatePodResources must be true for OOMKilled init container with pending resize")
+}
+
+func TestComputePodResizeActionForOOMKilledSidecarContainer(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("in-place resize is only supported on Linux")
+	}
+	logger, tCtx := ktesting.NewTestContext(t)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
+	_, _, m, err := createTestRuntimeManager(tCtx)
+	m.machineInfo.MemoryCapacity = 17179860387 // 16GB
+	require.NoError(t, err)
+
+	mem100M := resource.MustParse("100Mi")
+	mem200M := resource.MustParse("200Mi")
+	cpu100m := resource.MustParse("100m")
+
+	pod, status := makeBasePodAndStatus()
+	pod.Spec.Containers = nil
+	pod.Status.ContainerStatuses = nil
+	status.ContainerStatuses = nil
+
+	// one running regular container so the pod is considered initialized.
+	regularContainer := v1.Container{
+		Name:  "app",
+		Image: "busybox",
+	}
+	pod.Spec.Containers = []v1.Container{regularContainer}
+	status.ContainerStatuses = append(status.ContainerStatuses, &kubecontainer.Status{
+		ID:    kubecontainer.ContainerID{ID: "appid"},
+		Name:  "app",
+		State: kubecontainer.ContainerStateRunning,
+		Hash:  kubecontainer.HashContainer(&pod.Spec.Containers[0]),
+	})
+
+	// one sidecar that has been OOMKilled.
+	sidecar := v1.Container{
+		Name:          "sidecar",
+		Image:         "bar-image",
+		RestartPolicy: &containerRestartPolicyAlways,
+		Resources: v1.ResourceRequirements{
+			Limits:   v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem100M},
+			Requests: v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem100M},
+		},
+		ResizePolicy: []v1.ContainerResizePolicy{
+			{ResourceName: v1.ResourceCPU, RestartPolicy: v1.NotRequired},
+			{ResourceName: v1.ResourceMemory, RestartPolicy: v1.NotRequired},
+		},
+	}
+	pod.Spec.InitContainers = []v1.Container{sidecar}
+	status.ContainerStatuses = append(status.ContainerStatuses, &kubecontainer.Status{
+		ID:       kubecontainer.ContainerID{ID: "sidecarid"},
+		Name:     "sidecar",
+		State:    kubecontainer.ContainerStateExited,
+		Reason:   "OOMKilled",
+		ExitCode: 137,
+		Hash:     kubecontainer.HashContainer(&pod.Spec.InitContainers[0]),
+	})
+
+	// record pre-resize resource limits as what was last actuated.
+	require.NoError(t, m.UpdateActuatedPodLevelResources(logger, pod))
+
+	// Pod Resized
+	resize := pod.Spec.InitContainers[0].Resources.DeepCopy()
+	resize.Requests[v1.ResourceMemory] = mem200M
+	resize.Limits[v1.ResourceMemory] = mem200M
+	pod.Spec.InitContainers[0].Resources = *resize
+
+	actions := m.computePodActions(tCtx, pod, status, false)
+
+	// the sidecar is OOMKilled and must not be in ContainersToUpdate.
+	assert.Empty(t, actions.ContainersToUpdate, "OOMKilled sidecar must not be in ContainersToUpdate")
+	// UpdatePodResources must be true so doPodResizeAction updates the pod-level cgroup.
+	assert.True(t, actions.UpdatePodResources, "UpdatePodResources must be true for OOMKilled sidecar with pending resize")
 }
 
 func TestUpdatePodContainerResources(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

1. Initialize the actuated resources of all containers before they start. This is a bit of a hack, but it's used for determining the actuated pod cgroups.
2. When containers are being started, check whether their resources have changed, and set `UpdatePodResources` if so.
3. Move `doPodResizeAction` to before containers are started, to ensure the pod cgroups are correctly sized.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/138760

#### Special notes for your reviewer:

I wanted to rename `UpdateActuatedPodLevelResources` to `SetActuatedPodResources`, but left it as-is to keep the diff smaller (for backporting).

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node
/assign @natasha41575 @yuehaii 