### PR TITLE
optimization: Create kubectl profile outputs with owner-only file permissions

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/profiling.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/profiling.go
@@ -48,7 +48,7 @@ func initProfiling() (func() error, error) {
 	case "none":
 		return nil, nil
 	case "cpu":
-		f, err = os.Create(profileOutput)
+		f, err = os.OpenFile(profileOutput, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 		if err != nil {
 			return nil, err
 		}
@@ -65,7 +65,7 @@ func initProfiling() (func() error, error) {
 	case "mutex":
 		runtime.SetMutexProfileFraction(1)
 	case "trace":
-		f, err = os.Create(profileOutput)
+		f, err = os.OpenFile(profileOutput, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 		if err != nil {
 			return nil, err
 		}
@@ -120,7 +120,7 @@ func flushProfiling(output io.Closer) error {
 			return nil
 		}
 
-		f, err := os.Create(profileOutput)
+		f, err := os.OpenFile(profileOutput, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 		if err != nil {
 			return err
 		}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/profiling_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/profiling_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestHeapProfilingCreatesOutputWithOwnerOnlyPermissions(t *testing.T) {
+	oldProfileName, oldProfileOutput := profileName, profileOutput
+	t.Cleanup(func() {
+		profileName = oldProfileName
+		profileOutput = oldProfileOutput
+	})
+
+	oldUmask := syscall.Umask(0022)
+	t.Cleanup(func() {
+		syscall.Umask(oldUmask)
+	})
+
+	profileName = "heap"
+	profileOutput = filepath.Join(t.TempDir(), "heap.pprof")
+
+	if err := flushProfiling(nil); err != nil {
+		t.Fatalf("unexpected error flushing profile: %v", err)
+	}
+
+	fileInfo, err := os.Stat(profileOutput)
+	if err != nil {
+		t.Fatalf("unexpected error stating profile output: %v", err)
+	}
+	if fileInfo.Mode().Perm() != 0600 {
+		t.Errorf("expected file mode: %v, saw: %v", os.FileMode(0600), fileInfo.Mode().Perm())
+	}
+}


### PR DESCRIPTION


#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The old kubectl profiling code created profile output files with os.Create(profileOutput). 
In Go, os.Create opens files with mode 0666 before the process umask is applied. On common  systems with umask 0022, this produces 0644 files, meaning other local users can read them.

 This becomes a permission issue when users run kubectl with profiling enabled, for example kubectl --profile=heap --profile-output=/tmp/heap.pprof cluster-info dump --all-namespaces. 

Expected behavior is that kubectl profile outputs should be created with owner-only permissions. 

The code should  create or truncate profile files with os.OpenFile(profileOutput, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600) so only file owner can read or write them.
 
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
