### PR TITLE
Remove trailing whitespace from section headings in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ That said, if you have questions, reach out to us
 [Scalable Microservices with Kubernetes]: https://www.udacity.com/course/scalable-microservices-with-kubernetes--ud615
 [troubleshooting guide]: https://kubernetes.io/docs/tasks/debug/
 
-## Community Meetings 
+## Community Meetings
 
 The [Calendar](https://www.kubernetes.dev/resources/calendar/) has the list of all the meetings in the Kubernetes community in a single location.
 
@@ -87,7 +87,7 @@ The [Calendar](https://www.kubernetes.dev/resources/calendar/) has the list of a
 
 The [User Case Studies](https://kubernetes.io/case-studies/) website has real-world use cases of organizations across industries that are deploying/migrating to Kubernetes.
 
-## Governance 
+## Governance
 
 Kubernetes project is governed by a framework of principles, values, policies and processes to help our community and constituents towards our shared goals.
 
@@ -95,6 +95,6 @@ The [Kubernetes Community](https://github.com/kubernetes/community/blob/master/g
 
 The [Kubernetes Steering community repo](https://github.com/kubernetes/steering) is used by the Kubernetes Steering Committee, which oversees governance of the Kubernetes project.
 
-## Roadmap 
+## Roadmap
 
 The [Kubernetes Enhancements repo](https://github.com/kubernetes/enhancements) provides information about Kubernetes releases, as well as feature tracking and backlogs.


### PR DESCRIPTION
Remove trailing whitespace from the 'Community Meetings', 'Governance', and 'Roadmap' section headings in README.md.