### PR TITLE
Use new distroless-iptables v0.9.4 with nft 1.0.6.1

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -77,7 +77,7 @@ readonly REMOTE_OUTPUT_BINPATH="${REMOTE_OUTPUT_SUBPATH}/bin"
 readonly REMOTE_OUTPUT_GOPATH="${REMOTE_OUTPUT_SUBPATH}/go"
 
 # These are the default versions (image tags) for their respective base images.
-readonly __default_distroless_iptables_version=v0.9.3
+readonly __default_distroless_iptables_version=v0.9.6
 readonly __default_go_runner_version=v2.4.0-go1.26.4-bookworm.0
 readonly __default_setcap_version=bookworm-v1.0.6
 

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -173,7 +173,7 @@ dependencies:
       match: registry\.k8s\.io\/build-image\/debian-base:[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   - name: "registry.k8s.io/distroless-iptables: dependents"
-    version: v0.9.3
+    version: v0.9.6
     refPaths:
     - path: build/common.sh
       match: __default_distroless_iptables_version=

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -214,7 +214,7 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[APIServer] = Config{list.PromoterE2eRegistry, "sample-apiserver", "1.29.2"}
 	configs[AppArmorLoader] = Config{list.PromoterE2eRegistry, "apparmor-loader", "1.4"}
 	configs[BusyBox] = Config{list.PromoterE2eRegistry, "busybox", "1.37.0-2"}
-	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.9.3"}
+	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.9.6"}
 	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.7.0-0"}
 	configs[InvalidRegistryImage] = Config{list.InvalidRegistry, "alpine", "3.1"}
 	configs[IpcUtils] = Config{list.PromoterE2eRegistry, "ipc-utils", "1.4"}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Rebuild kube-proxy image with new distroless-iptables containing nft 1.0.6.1 to fix crashes on systems with nft 1.1.3.

#### Which issue(s) this PR is related to:
Fixes #136786

#### Does this PR introduce a user-facing change?
```release-note
Updated the version of the nft binary in the kube-proxy image to nftables 1.0.6.1,
to fix problems resyncing kube-proxy in nftables mode on systems containing
rules created by recent versions of nftables.
```
