### PR TITLE
client-go: preserve context cancellation in retry OnError

### DIFF
--- a/staging/src/k8s.io/client-go/util/retry/util.go
+++ b/staging/src/k8s.io/client-go/util/retry/util.go
@@ -59,7 +59,7 @@ func OnError(backoff wait.Backoff, retriable func(error) bool, fn func() error) 
 			return false, err
 		}
 	})
-	if wait.Interrupted(err) {
+	if wait.Interrupted(err) && lastErr != nil {
 		err = lastErr
 	}
 	return err

--- a/staging/src/k8s.io/client-go/util/retry/util_test.go
+++ b/staging/src/k8s.io/client-go/util/retry/util_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package retry
 
 import (
+	"context"
+	stderrors "errors"
 	"fmt"
 	"testing"
 
@@ -67,5 +69,14 @@ func TestRetryOnConflict(t *testing.T) {
 	})
 	if err != nil || i != 2 {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRetryOnConflictPreservesContextErrorWithoutLastError(t *testing.T) {
+	err := RetryOnConflict(DefaultBackoff, func() error {
+		return context.Canceled
+	})
+	if !stderrors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
 	}
 }


### PR DESCRIPTION
OnError can replace context.Canceled with a nil lastErr when the error is non-retriable but wait.Interrupted returns true.

This preserves the original error unless a retriable error was recorded 

Fixes #140402