### PR TITLE
Fix event broadcaster goroutine leak 

### DIFF
--- a/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
@@ -54,6 +54,8 @@ const (
 
 var defaultSleepDuration = 10 * time.Second
 
+var maxConcurrentRecording = 100
+
 // TODO: validate impact of copying and investigate hashing
 type eventKey struct {
 	eventType           string
@@ -71,6 +73,7 @@ type eventBroadcasterImpl struct {
 	eventCache    map[eventKey]*eventsv1.Event
 	sleepDuration time.Duration
 	sink          EventSink
+	sem           chan struct{}
 }
 
 // EventSinkImpl wraps EventsV1Interface to implement EventSink.
@@ -116,6 +119,7 @@ func newBroadcaster(sink EventSink, sleepDuration time.Duration, eventCache map[
 		eventCache:    eventCache,
 		sleepDuration: sleepDuration,
 		sink:          sink,
+		sem:           make(chan struct{}, maxConcurrentRecording),
 	}
 }
 
@@ -170,7 +174,19 @@ func (e *eventBroadcasterImpl) NewRecorder(scheme *runtime.Scheme, reportingCont
 func (e *eventBroadcasterImpl) recordToSink(ctx context.Context, event *eventsv1.Event, clock clock.Clock) {
 	// Make a copy before modification, because there could be multiple listeners.
 	eventCopy := event.DeepCopy()
+
+	// Acquire semaphore slot under context. If context is done, we return early.
+	select {
+	case <-ctx.Done():
+		return
+	case e.sem <- struct{}{}:
+	}
+
 	go func() {
+		defer func() {
+			<-e.sem
+		}()
+		defer utilruntime.HandleCrash()
 		evToRecord := func() *eventsv1.Event {
 			e.mu.Lock()
 			defer e.mu.Unlock()

--- a/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
@@ -54,7 +54,24 @@ const (
 
 var defaultSleepDuration = 10 * time.Second
 
-var maxConcurrentRecording = 100
+const defaultMaxConcurrentRecording = 100
+
+// BroadcasterOption allows to configure EventBroadcaster.
+type BroadcasterOption func(*eventBroadcasterImpl)
+
+// WithMaxConcurrentRecording limits the number of concurrent event write goroutines.
+func WithMaxConcurrentRecording(max int) BroadcasterOption {
+	return func(e *eventBroadcasterImpl) {
+		e.maxConcurrentRecording = max
+	}
+}
+
+// WithSleepDuration sets the sleep duration between event recording retries.
+func WithSleepDuration(sleepDuration time.Duration) BroadcasterOption {
+	return func(e *eventBroadcasterImpl) {
+		e.sleepDuration = sleepDuration
+	}
+}
 
 // TODO: validate impact of copying and investigate hashing
 type eventKey struct {
@@ -69,11 +86,12 @@ type eventKey struct {
 
 type eventBroadcasterImpl struct {
 	*watch.Broadcaster
-	mu            sync.Mutex
-	eventCache    map[eventKey]*eventsv1.Event
-	sleepDuration time.Duration
-	sink          EventSink
-	sem           chan struct{}
+	mu                     sync.Mutex
+	eventCache             map[eventKey]*eventsv1.Event
+	sleepDuration          time.Duration
+	sink                   EventSink
+	sem                    chan struct{}
+	maxConcurrentRecording int
 }
 
 // EventSinkImpl wraps EventsV1Interface to implement EventSink.
@@ -107,20 +125,33 @@ func (e *EventSinkImpl) Patch(ctx context.Context, event *eventsv1.Event, data [
 	return e.Interface.Events(event.Namespace).Patch(ctx, event.Name, types.StrategicMergePatchType, data, metav1.PatchOptions{})
 }
 
+// NewBroadcasterWithOptions Creates a new event broadcaster with options.
+func NewBroadcasterWithOptions(sink EventSink, opts ...BroadcasterOption) EventBroadcaster {
+	impl := &eventBroadcasterImpl{
+		Broadcaster:            watch.NewBroadcaster(maxQueuedEvents, watch.DropIfChannelFull),
+		eventCache:             map[eventKey]*eventsv1.Event{},
+		sleepDuration:          defaultSleepDuration,
+		sink:                   sink,
+		maxConcurrentRecording: defaultMaxConcurrentRecording,
+	}
+	for _, opt := range opts {
+		opt(impl)
+	}
+	impl.sem = make(chan struct{}, impl.maxConcurrentRecording)
+	return impl
+}
+
 // NewBroadcaster Creates a new event broadcaster.
 func NewBroadcaster(sink EventSink) EventBroadcaster {
-	return newBroadcaster(sink, defaultSleepDuration, map[eventKey]*eventsv1.Event{})
+	return NewBroadcasterWithOptions(sink)
 }
 
 // NewBroadcasterForTest Creates a new event broadcaster for test purposes.
 func newBroadcaster(sink EventSink, sleepDuration time.Duration, eventCache map[eventKey]*eventsv1.Event) EventBroadcaster {
-	return &eventBroadcasterImpl{
-		Broadcaster:   watch.NewBroadcaster(maxQueuedEvents, watch.DropIfChannelFull),
-		eventCache:    eventCache,
-		sleepDuration: sleepDuration,
-		sink:          sink,
-		sem:           make(chan struct{}, maxConcurrentRecording),
-	}
+	b := NewBroadcasterWithOptions(sink, WithSleepDuration(sleepDuration))
+	impl := b.(*eventBroadcasterImpl)
+	impl.eventCache = eventCache
+	return impl
 }
 
 func (e *eventBroadcasterImpl) Shutdown() {

--- a/staging/src/k8s.io/client-go/tools/events/event_broadcaster_test.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_broadcaster_test.go
@@ -110,11 +110,6 @@ func TestRecordEventToSink(t *testing.T) {
 }
 
 func TestEventBroadcasterConcurrencyLimit(t *testing.T) {
-	// Configure maxConcurrentRecording to 2 for testing
-	oldMax := maxConcurrentRecording
-	maxConcurrentRecording = 2
-	defer func() { maxConcurrentRecording = oldMax }()
-
 	// Create a mock EventSink that blocks on writes and tracks active concurrent calls
 	var mu sync.Mutex
 	activeCalls := 0
@@ -146,7 +141,7 @@ func TestEventBroadcasterConcurrencyLimit(t *testing.T) {
 		},
 	}
 
-	broadcaster := newBroadcaster(mockSink, defaultSleepDuration, map[eventKey]*eventsv1.Event{})
+	broadcaster := NewBroadcasterWithOptions(mockSink, WithMaxConcurrentRecording(2))
 	defer broadcaster.Shutdown()
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/staging/src/k8s.io/client-go/tools/events/event_broadcaster_test.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_broadcaster_test.go
@@ -18,13 +18,18 @@ package events
 
 import (
 	"context"
+	"fmt"
 	"reflect"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2/ktesting"
 )
 
@@ -102,4 +107,96 @@ func TestRecordEventToSink(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEventBroadcasterConcurrencyLimit(t *testing.T) {
+	// Configure maxConcurrentRecording to 2 for testing
+	oldMax := maxConcurrentRecording
+	maxConcurrentRecording = 2
+	defer func() { maxConcurrentRecording = oldMax }()
+
+	// Create a mock EventSink that blocks on writes and tracks active concurrent calls
+	var mu sync.Mutex
+	activeCalls := 0
+	maxActiveCalls := 0
+	releaseCh := make(chan struct{})
+
+	mockSink := &mockBlockingSink{
+		createFunc: func(ctx context.Context, event *eventsv1.Event) (*eventsv1.Event, error) {
+			mu.Lock()
+			activeCalls++
+			if activeCalls > maxActiveCalls {
+				maxActiveCalls = activeCalls
+			}
+			mu.Unlock()
+
+			defer func() {
+				mu.Lock()
+				activeCalls--
+				mu.Unlock()
+			}()
+
+			// Block until signaled to release
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-releaseCh:
+				return event, nil
+			}
+		},
+	}
+
+	broadcaster := newBroadcaster(mockSink, defaultSleepDuration, map[eventKey]*eventsv1.Event{})
+	defer broadcaster.Shutdown()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := broadcaster.StartRecordingToSinkWithContext(ctx); err != nil {
+		t.Fatalf("unexpected error starting recording: %v", err)
+	}
+
+	recorder := broadcaster.NewRecorder(scheme.Scheme, "test-controller")
+
+	// Emit 5 distinct events. Since maxConcurrentRecording is 2, only 2 events
+	// should be processed concurrently by the sink. The rest should block in recordToSink.
+	for i := 0; i < 5; i++ {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("pod-%d", i),
+				Namespace: "default",
+			},
+		}
+		recorder.Eventf(pod, nil, corev1.EventTypeNormal, "Reason", "Action", "Message %d", i)
+	}
+
+	// Give it a little time to spawn goroutines and execute them up to the concurrency limit
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	currentMaxActive := maxActiveCalls
+	mu.Unlock()
+
+	if currentMaxActive != 2 {
+		t.Errorf("Expected exactly 2 concurrent active calls to the sink, got %d", currentMaxActive)
+	}
+
+	// Signal the blocking sink to release
+	close(releaseCh)
+}
+
+type mockBlockingSink struct {
+	createFunc func(context.Context, *eventsv1.Event) (*eventsv1.Event, error)
+}
+
+func (m *mockBlockingSink) Create(ctx context.Context, event *eventsv1.Event) (*eventsv1.Event, error) {
+	return m.createFunc(ctx, event)
+}
+
+func (m *mockBlockingSink) Update(ctx context.Context, event *eventsv1.Event) (*eventsv1.Event, error) {
+	return event, nil
+}
+
+func (m *mockBlockingSink) Patch(ctx context.Context, event *eventsv1.Event, data []byte) (*eventsv1.Event, error) {
+	return event, nil
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
In large clusters under event stress (such as bursty scheduling failures), the `events.EventBroadcaster` in `client-go` can consume unbounded memory and spawn millions of goroutines. This is because `recordToSink` spawns a background goroutine for every single event write and retry loop without applying any backpressure or concurrency limiting when the API server is slow or throttling writes.

This PR introduces a concurrency limit of `100` concurrent event write goroutines in the `events.EventBroadcaster`. When this limit is reached, the broadcaster's watcher consumer blocks, filling up the internal watcher queue buffer (`w.result`), which naturally triggers the broadcaster's `DropIfChannelFull` behavior to drop incoming events. This matches the established backpressure behavior of the legacy `tools/record` package.

#### Which issue(s) this PR is related to:
Fixes #140393

#### Special notes for your reviewer:
- Enforced a concurrency ceiling using a private `sem` channel initialized to `maxConcurrentRecording` (defaulted to `100`).
- The semaphore acquisition is context-aware to ensure shutdown signals are respected.
- Modified the package variable `maxConcurrentRecording` to be non-const so that unit tests can adjust it.
- Added a robust unit test `TestEventBroadcasterConcurrencyLimit` verifying the concurrency limits and backpressure propagation.

#### Does this PR introduce a user-facing change?
```release-note
Fix: client-go/tools/events event broadcaster now restricts the number of concurrent event write goroutines (default 100) to prevent unbounded memory and goroutine growth under high event write latency.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
None.
