### PR TITLE
Add topology spreading gang preemption performance scenarios

### DIFF
--- a/test/integration/scheduler_perf/default_preemption/templates/pod-high-priority.yaml
+++ b/test/integration/scheduler_perf/default_preemption/templates/pod-high-priority.yaml
@@ -5,7 +5,7 @@ metadata:
   generateName: pod-high-priority-
 spec:
   terminationGracePeriodSeconds: 0
-  priority: 9999999
+  priority: 10000
   containers:
   - image: registry.k8s.io/pause:3.10.2
     name: pause

--- a/test/integration/scheduler_perf/workload_preemption/performance-config.yaml
+++ b/test/integration/scheduler_perf/workload_preemption/performance-config.yaml
@@ -237,3 +237,69 @@
       initPods: 1000
       preemptorPodGroups: 10
       podsPerGroup: 10
+
+# GangPreemptionTopologySpreading benchmarks the performance of gang preemption
+# when the gang pods also have topology spreading constraints.
+#
+# The scenario flow is:
+# 1. Create a set of nodes distributed across multiple zones (topology.kubernetes.io/zone).
+# 2. Fill the cluster with low-priority pods.
+# 3. Submit high-priority PodGroups (gangs) where the individual pods have topology spreading constraints.
+# 4. This forces the scheduler to preempt low-priority pods while ensuring the gang pods
+#    are spread across zones.
+- name: GangPreemptionTopologySpreading
+  featureGates:
+    GenericWorkload: true
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $initNodes
+    nodeTemplatePath: ../templates/node-default.yaml
+    labelNodePrepareStrategy:
+      labelKey: "topology.kubernetes.io/zone"
+      labelValues: ["zone-1", "zone-2", "zone-3"]
+  - opcode: createNamespaces
+    prefix: gang-preempt
+    count: 2
+  - opcode: createPods
+    countParam: $initPods
+    podTemplatePath: templates/pod-low-priority.yaml
+    namespace: gang-preempt-1
+    templateParams:
+      nodesCount: $initNodes
+      podsCount: $initPods
+  - opcode: createPodGroups
+    countParam: $preemptorPodGroups
+    namespace: gang-preempt-0
+    templatePath: templates/podgroup.yaml
+    templateParams:
+      podsPerGroup: $podsPerGroup
+      priority: 9999999
+  - opcode: createPods
+    collectMetrics: true
+    countParam: $preemptorPodGroups
+    countMultiplierParam: $podsPerGroup
+    namespace: gang-preempt-0
+    podTemplatePath: templates/gang-pod-with-topology-spreading.yaml
+    templateParams:
+      podsPerGroup: $podsPerGroup
+      cpuRequest: $gangCpuRequest
+      priority: 9999999
+  workloads:
+  - name: 3Nodes_1PreemptorGang_3Pods_Evicting_12InitPods
+    labels: [short, integration-test]
+    params:
+      initNodes: 3
+      initPods: 12
+      preemptorPodGroups: 1
+      podsPerGroup: 3
+      gangCpuRequest: 3900m
+  - name: 100Nodes_6PreemptorGangs_16Pods_Evicting_1000InitPods
+    labels: [performance]
+    params:
+      initNodes: 100
+      initPods: 1000
+      preemptorPodGroups: 6
+      podsPerGroup: 16
+      gangCpuRequest: 3970m
+
+

--- a/test/integration/scheduler_perf/workload_preemption/performance-config.yaml
+++ b/test/integration/scheduler_perf/workload_preemption/performance-config.yaml
@@ -303,3 +303,68 @@
     featureGates:
       TopologyAwareWorkloadScheduling: true
       CompositePodGroup: true
+
+# GangPreemptionTopologySpreading benchmarks the performance of gang preemption
+# when the gang pods also have topology spreading constraints.
+#
+# The scenario flow is:
+# 1. Create a set of nodes distributed across multiple zones (topology.kubernetes.io/zone).
+# 2. Fill the cluster with low-priority pods.
+# 3. Submit high-priority PodGroups (gangs) where the individual pods have topology spreading constraints.
+# 4. This forces the scheduler to preempt low-priority pods while ensuring the gang pods
+#    are spread across zones.
+- name: GangPreemptionTopologySpreading
+  featureGates:
+    GenericWorkload: true
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $initNodes
+    nodeTemplatePath: ../templates/node-default.yaml
+    labelNodePrepareStrategy:
+      labelKey: "topology.kubernetes.io/zone"
+      labelValues: ["zone-1", "zone-2", "zone-3"]
+  - opcode: createNamespaces
+    prefix: gang-preempt
+    count: 2
+  - opcode: createPods
+    countParam: $initPods
+    podTemplatePath: templates/pod-low-priority.yaml
+    namespace: gang-preempt-1
+    templateParams:
+      nodesCount: $initNodes
+      podsCount: $initPods
+  - opcode: createPodGroups
+    countParam: $preemptorPodGroups
+    namespace: gang-preempt-0
+    templatePath: templates/podgroup.yaml
+    templateParams:
+      podsPerGroup: $podsPerGroup
+      priority: 9999999
+  - opcode: createPods
+    collectMetrics: true
+    countParam: $preemptorPodGroups
+    countMultiplierParam: $podsPerGroup
+    namespace: gang-preempt-0
+    podTemplatePath: templates/gang-pod-with-topology-spreading.yaml
+    templateParams:
+      podsPerGroup: $podsPerGroup
+      cpuRequest: $gangCpuRequest
+      priority: 9999999
+  workloads:
+  - name: 3Nodes_1PreemptorGang_3Pods_Evicting_12InitPods
+    labels: [short, integration-test]
+    params:
+      initNodes: 3
+      initPods: 12
+      preemptorPodGroups: 1
+      podsPerGroup: 3
+      gangCpuRequest: 3900m
+  - name: 100Nodes_6PreemptorGangs_16Pods_Evicting_1000InitPods
+    labels: [performance]
+    params:
+      initNodes: 100
+      initPods: 1000
+      preemptorPodGroups: 6
+      podsPerGroup: 16
+      gangCpuRequest: 3970m
+

--- a/test/integration/scheduler_perf/workload_preemption/performance-config.yaml
+++ b/test/integration/scheduler_perf/workload_preemption/performance-config.yaml
@@ -125,7 +125,7 @@
     templatePath: templates/podgroup.yaml
     templateParams:
       podsPerGroup: $podsPerGroup
-      priority: 9999999
+      priority: 10000
   - opcode: createPods
     collectMetrics: true
     countParam: $highPriorityGroups
@@ -136,7 +136,7 @@
       podsPerGroup: $podsPerGroup
       cpuRequest: $highPriorityCpuRequest
       hostPortBase: 9000
-      priority: 9999999
+      priority: 10000
 
   workloads:
   - name: 2Nodes_1PreemptorGang_2Pods_Evicting_2LowPriorityGangs
@@ -339,7 +339,7 @@
     templatePath: templates/podgroup.yaml
     templateParams:
       podsPerGroup: $podsPerGroup
-      priority: 9999999
+      priority: 10000
   - opcode: createPods
     collectMetrics: true
     countParam: $preemptorPodGroups
@@ -349,7 +349,7 @@
     templateParams:
       podsPerGroup: $podsPerGroup
       cpuRequest: $gangCpuRequest
-      priority: 9999999
+      priority: 10000
   workloads:
   - name: 3Nodes_1PreemptorGang_3Pods_Evicting_12InitPods
     labels: [short, integration-test]

--- a/test/integration/scheduler_perf/workload_preemption/templates/gang-pod-with-topology-spreading.yaml
+++ b/test/integration/scheduler_perf/workload_preemption/templates/gang-pod-with-topology-spreading.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-gang-{{.Index}}
+  labels:
+    color: blue
+spec:
+  priority: {{if .priority}}{{AddInt 0 .priority}}{{else}}8888888{{end}}
+  schedulingGroup:
+    podGroupName: gang-{{DivideInt .Index .podsPerGroup}}
+  terminationGracePeriodSeconds: 0
+  topologySpreadConstraints:
+    - maxSkew: 5
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          color: blue
+  containers:
+  - image: registry.k8s.io/pause:3.10.1
+    name: pause
+    {{if .hostPortBase}}
+    ports:
+    - containerPort: 80
+      hostPort: {{AddInt .hostPortBase (DivideInt .Index .podsPerGroup)}}
+    {{end}}
+    resources:
+      limits:
+        cpu: {{.cpuRequest}}
+        memory: 100Mi
+      requests:
+        cpu: {{.cpuRequest}}
+        memory: 100Mi

--- a/test/integration/scheduler_perf/workload_preemption/templates/gang-pod-with-topology-spreading.yaml
+++ b/test/integration/scheduler_perf/workload_preemption/templates/gang-pod-with-topology-spreading.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     gang-name: gang-{{DivideInt .Index .podsPerGroup}}
 spec:
-  priority: {{if .priority}}{{AddInt 0 .priority}}{{else}}8888888{{end}}
+  priority: {{if .priority}}{{AddInt 0 .priority}}{{else}}10000{{end}}
   schedulingGroup:
     podGroupName: gang-{{DivideInt .Index .podsPerGroup}}
   terminationGracePeriodSeconds: 0

--- a/test/integration/scheduler_perf/workload_preemption/templates/gang-pod-with-topology-spreading.yaml
+++ b/test/integration/scheduler_perf/workload_preemption/templates/gang-pod-with-topology-spreading.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-gang-{{.Index}}
+  labels:
+    gang-name: gang-{{DivideInt .Index .podsPerGroup}}
+spec:
+  priority: {{if .priority}}{{AddInt 0 .priority}}{{else}}8888888{{end}}
+  schedulingGroup:
+    podGroupName: gang-{{DivideInt .Index .podsPerGroup}}
+  terminationGracePeriodSeconds: 0
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          gang-name: gang-{{DivideInt .Index .podsPerGroup}}
+  containers:
+  - image: registry.k8s.io/pause:3.10.1
+    name: pause
+    {{if .hostPortBase}}
+    ports:
+    - containerPort: 80
+      hostPort: {{AddInt .hostPortBase (DivideInt .Index .podsPerGroup)}}
+    {{end}}
+    resources:
+      limits:
+        cpu: {{.cpuRequest}}
+        memory: 100Mi
+      requests:
+        cpu: {{.cpuRequest}}
+        memory: 100Mi

--- a/test/integration/scheduler_perf/workload_preemption/templates/gang-pod.yaml
+++ b/test/integration/scheduler_perf/workload_preemption/templates/gang-pod.yaml
@@ -3,7 +3,7 @@ kind: Pod
 metadata:
   name: pod-gang-{{.Index}}
 spec:
-  priority: {{if .priority}}{{AddInt 0 .priority}}{{else}}8888888{{end}}
+  priority: {{if .priority}}{{AddInt 0 .priority}}{{else}}10000{{end}}
   schedulingGroup:
     podGroupName: gang-{{DivideInt .Index .podsPerGroup}}
   terminationGracePeriodSeconds: 0

--- a/test/integration/scheduler_perf/workload_preemption/templates/pod-anchor-high-priority.yaml
+++ b/test/integration/scheduler_perf/workload_preemption/templates/pod-anchor-high-priority.yaml
@@ -9,7 +9,7 @@ metadata:
     label3: value3
     label4: value4
 spec:
-  priority: 9999999
+  priority: 10000
   terminationGracePeriodSeconds: 0
   containers:
   - image: registry.k8s.io/pause:3.10.1

--- a/test/integration/scheduler_perf/workload_preemption/templates/pod-gang-affinity.yaml
+++ b/test/integration/scheduler_perf/workload_preemption/templates/pod-gang-affinity.yaml
@@ -3,7 +3,7 @@ kind: Pod
 metadata:
   name: pod-gang-{{.Index}}
 spec:
-  priority: {{if .priority}}{{AddInt 0 .priority}}{{else}}8888888{{end}}
+  priority: {{if .priority}}{{AddInt 0 .priority}}{{else}}10000{{end}}
   schedulingGroup:
     podGroupName: gang-{{DivideInt .Index .podsPerGroup}}
   affinity:

--- a/test/integration/scheduler_perf/workload_preemption/templates/podgroup.yaml
+++ b/test/integration/scheduler_perf/workload_preemption/templates/podgroup.yaml
@@ -3,7 +3,7 @@ kind: PodGroup
 metadata:
   name: gang-{{.Index}}
 spec:
-  priority: {{if .priority}}{{AddInt 0 .priority}}{{else}}8888888{{end}}
+  priority: {{if .priority}}{{AddInt 0 .priority}}{{else}}10000{{end}}
   schedulingPolicy:
     gang:
       minCount: {{.podsPerGroup}}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR introduces a new scheduler performance benchmark scenario, `GangPreemptionTopologySpreading`, to evaluate the performance of gang scheduling preemption when the preemptor pods also have topology spreading constraints.

The scenario executes the following flow:
1. Creates a set of nodes distributed across multiple zones (`topology.kubernetes.io/zone`).
2. Fills the cluster with low-priority pods to reach capacity.
3. Submits high-priority PodGroups (gangs) where the individual pods have topology spreading constraints.
4. Measures the scheduling latency as the scheduler is forced to preempt low-priority pods while ensuring the high-priority gang pods are spread across zones.

This benchmark helps track the latency overhead of `PodGroupPostFilter` (WorkloadAwarePreemption) and ensures that combining gang preemption with topology spread constraints remains performant. 

**Benchmark Results Comparison**
The following table compares the average `PodGroupPostFilter` latency across different test workloads (collected from a local 100-node simulated run):

| Scenario Suite | Scenario Config | Preemptors vs Victims | Avg Latency |
| :--- | :--- | :--- | :--- |
| **GangPreemptionBasic** | `100Nodes_1PreemptorGang_100Pods_Evicting_1000InitPods` | 1 Gang (100 pods) evicting 1000 independent pods | 27,450 ms |
| **GangPreemptionBasic** | `100Nodes_10PreemptorGangs_10Pods_Evicting_1000InitPods` | 10 Gangs (10 pods ea) evicting 1000 independent pods | 2,468 ms |
| **GangPreemptionPodGroups** | `100Nodes_1PreemptorGang_100Pods_Evicting_5LowPriorityGangs` | 1 Gang (100 pods) evicting 5 Gangs | 14,345 ms |
| **GangPreemptionPodGroups** | `100Nodes_10PreemptorGangs_10Pods_Evicting_50LowPriorityGangs` | 10 Gangs (10 pods ea) evicting 50 Gangs | 1,204 ms |
| **GangPreemptionAffinity** | `100Nodes_1PreemptorGang_100Pods_Evicting_1000InitPods` | 1 Gang (100 pods with Affinity) evicting 1000 pods | 45,756 ms |
| **GangPreemptionAffinity** | `100Nodes_10PreemptorGangs_10Pods_Evicting_1000InitPods` | 10 Gangs (10 pods ea with Affinity) evicting 1000 pods | 4,387 ms |
| **GangPreemptionTopologySpreading** | `100Nodes_6PreemptorGangs_16Pods_Evicting_1000InitPods` | 6 Gangs (16 pods ea with Topology Spread) evicting 1000 pods | 5,110 ms |

**Takeaways:**
1. Our newly added **Topology Spreading** scenario averages ~`5.1s` for 6 gangs of 16 pods, which scales reasonably well 
2. Attempting to schedule a single massive gang consistently takes ~10x longer than scheduling many smaller gangs
3. Evicting low-priority victims structured as PodGroups is nearly 50% faster than evicting independent pods, as evicting one pod invalidates the whole low-priority gang, immediately freeing up multiple pods' worth of CPU constraints for the preemptor.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
