### PR TITLE
test/client-go: fix data race in TestRequestMaxRetries

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -2530,26 +2530,6 @@ func TestThrottledLogger(t *testing.T) {
 }
 
 func TestRequestMaxRetries(t *testing.T) {
-	successAtNthCalls := 1
-	actualCalls := 0
-	retryOneTimeHandler := func(w http.ResponseWriter, req *http.Request) {
-		defer func() { actualCalls++ }()
-		if actualCalls >= successAtNthCalls {
-			w.WriteHeader(http.StatusOK)
-			return
-		}
-		w.Header().Set("Retry-After", "1")
-		w.WriteHeader(http.StatusTooManyRequests)
-		actualCalls++
-	}
-	testServer := httptest.NewServer(http.HandlerFunc(retryOneTimeHandler))
-	defer testServer.Close()
-
-	u, err := url.Parse(testServer.URL)
-	if err != nil {
-		t.Error(err)
-	}
-
 	testCases := []struct {
 		name        string
 		maxRetries  int
@@ -2574,8 +2554,26 @@ func TestRequestMaxRetries(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			defer func() { actualCalls = 0 }()
-			_, err := NewRequestWithClient(u, "", defaultContentConfig(), testServer.Client()).
+			const successAtNthCall = 1
+			var actualCalls atomic.Int64
+
+			testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if actualCalls.Load() >= successAtNthCall {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				w.Header().Set("Retry-After", "1")
+				w.WriteHeader(http.StatusTooManyRequests)
+				actualCalls.Add(1)
+			}))
+			defer testServer.Close()
+
+			u, err := url.Parse(testServer.URL)
+			if err != nil {
+				t.Error(err)
+			}
+
+			_, err = NewRequestWithClient(u, "", defaultContentConfig(), testServer.Client()).
 				Verb("get").
 				MaxRetries(testCase.maxRetries).
 				AbsPath("/foo").


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
A data race was found in `TestRequestMaxRetries` in `staging/src/k8s.io/client-go/rest/request_test.go`. The test server's HTTP handler (`retryOneTimeHandler`) and the subtest cleanup loop read, write, and reset the shared `actualCalls` integer variable concurrently across multiple goroutines spawned by the HTTP server.

This PR adds a `sync.Mutex` to synchronize all reads, writes, and resets of the `actualCalls` variable in the test. It also simplifies the count logic in `retryOneTimeHandler` to increment exactly once per request.

#### Which issue(s) this PR is related to:
Fixes #140345

#### Special notes for your reviewer:
- Fully synchronized `actualCalls` counter under `sync.Mutex`.
- Re-ran `go test -race` on the package, passing cleanly with no data races detected.

#### Does this PR introduce a user-facing change?
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
None.
