### PR TITLE
fix: correctly track validating webhook latency across parallel dispatch and sequential retries

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
@@ -227,6 +227,11 @@ func (d *validatingDispatcher) Dispatch(ctx context.Context, attr admission.Attr
 		}(relevantHooks[i], i)
 	}
 	wg.Wait()
+	if wd, ok := endpointsrequest.LatencyTrackersFrom(ctx); ok {
+		if rc, ok := wd.ValidatingWebhookTracker.(endpointsrequest.RoundCommitter); ok {
+			rc.CommitRound()
+		}
+	}
 	close(errCh)
 
 	var errs []error

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/webhook_duration.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/webhook_duration.go
@@ -104,6 +104,63 @@ func newMaxLatencyTracker(c clock.Clock) DurationTracker {
 	}
 }
 
+type RoundCommitter interface {
+	DurationTracker
+	CommitRound()
+}
+
+// sumOfMaxPerRoundTracker accumulates latency as -
+// sum over all rounds of max(concurrent Track calls within that round)
+type sumOfMaxPerRoundTracker struct {
+	clock        clock.Clock
+	mu           sync.Mutex
+	roundMax     time.Duration
+	committedSum time.Duration
+}
+
+func newSumOfMaxPerRoundTracker(c clock.Clock) RoundCommitter {
+	return &sumOfMaxPerRoundTracker{clock: c}
+}
+
+// Track records keeps the maximum within the current round.
+func (t *sumOfMaxPerRoundTracker) Track(f func()) {
+	startedAt := t.clock.Now()
+	defer func() {
+		duration := t.clock.Since(startedAt)
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		if duration > t.roundMax {
+			t.roundMax = duration
+		}
+	}()
+	f()
+}
+
+// TrackDuration records d and keeps the maximum within the current round.
+func (t *sumOfMaxPerRoundTracker) TrackDuration(d time.Duration) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if d > t.roundMax {
+		t.roundMax = d
+	}
+}
+
+// CommitRound adds its maximum to the committed sum
+// and resets the per-round accumulator.
+func (t *sumOfMaxPerRoundTracker) CommitRound() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.committedSum += t.roundMax
+	t.roundMax = 0
+}
+
+// GetLatency returns the sum of all committed rounds' maxima.
+func (t *sumOfMaxPerRoundTracker) GetLatency() time.Duration {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.committedSum
+}
+
 // LatencyTrackers stores trackers used to measure latecny incurred in
 // components within the apiserver.
 type LatencyTrackers struct {
@@ -113,7 +170,8 @@ type LatencyTrackers struct {
 	MutatingWebhookTracker DurationTracker
 
 	// ValidatingWebhookTracker tracks the latency incurred in validating webhook(s).
-	// Validate webhooks are done in parallel, so max function is used.
+	// Within a single dispatch round the webhooks run in parallel, so only the
+	// slowest one contributes to wall-clock latency (max within a round).
 	ValidatingWebhookTracker DurationTracker
 
 	// AuthenticationTracker tracks the latency incurred by Authentication of request
@@ -188,7 +246,7 @@ func WithLatencyTrackers(parent context.Context) context.Context {
 func WithLatencyTrackersAndCustomClock(parent context.Context, c clock.Clock) context.Context {
 	return WithValue(parent, latencyTrackersKey, &LatencyTrackers{
 		MutatingWebhookTracker:   newSumLatencyTracker(c),
-		ValidatingWebhookTracker: newMaxLatencyTracker(c),
+		ValidatingWebhookTracker: newSumOfMaxPerRoundTracker(c),
 		AuthenticationTracker:    newSumLatencyTracker(c),
 		AuthorizationTracker:     newMaxLatencyTracker(c),
 		APFQueueWaitTracker:      newMaxLatencyTracker(c),

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/webhook_duration_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/webhook_duration_test.go
@@ -67,12 +67,50 @@ func TestLatencyTrackersFrom(t *testing.T) {
 			t.Errorf("expected admit duration: %q, but got: %q", tc.SumDurations, wd.MutatingWebhookTracker.GetLatency())
 		}
 
-		if wd.ValidatingWebhookTracker.GetLatency() != tc.MaxDuration {
-			t.Errorf("expected validate duration: %q, but got: %q", tc.MaxDuration, wd.ValidatingWebhookTracker.GetLatency())
+		if wd.ValidatingWebhookTracker.GetLatency() != 0 {
+			t.Errorf("expected validate duration before CommitRound: %q, but got: %q", time.Duration(0), wd.ValidatingWebhookTracker.GetLatency())
 		}
 
 		if wd.APFQueueWaitTracker.GetLatency() != tc.MaxDuration {
 			t.Errorf("expected priority & fairness duration: %q, but got: %q", tc.MaxDuration, wd.APFQueueWaitTracker.GetLatency())
 		}
 	})
+}
+
+func TestSumOfMaxPerRoundTracker(t *testing.T) {
+	clk := clocktesting.FakeClock{}
+	tracker := newSumOfMaxPerRoundTracker(&clk)
+
+	// round 1
+	for _, d := range []time.Duration{100, 400, 200} {
+		tracker.Track(func() { clk.Step(d) })
+	}
+	if got := tracker.GetLatency(); got != 0 {
+		t.Errorf("round 1 before CommitRound: want 0, got %v", got)
+	}
+	tracker.(RoundCommitter).CommitRound()
+	if got := tracker.GetLatency(); got != 400 {
+		t.Errorf("after round 1 CommitRound: want 400, got %v", got)
+	}
+
+	// round 2
+	for _, d := range []time.Duration{300, 150} {
+		tracker.Track(func() { clk.Step(d) })
+	}
+	tracker.(RoundCommitter).CommitRound()
+	if got := tracker.GetLatency(); got != 700 {
+		t.Errorf("after round 2 CommitRound: want 700 (400+300), got %v", got)
+	}
+
+	// round 3
+	tracker.Track(func() { clk.Step(50) })
+	tracker.(RoundCommitter).CommitRound()
+	if got := tracker.GetLatency(); got != 750 {
+		t.Errorf("after round 3 CommitRound: want 750 (400+300+50), got %v", got)
+	}
+
+	tracker.(RoundCommitter).CommitRound()
+	if got := tracker.GetLatency(); got != 750 {
+		t.Errorf("after empty CommitRound: want 750, got %v", got)
+	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/webhook_duration_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/webhook_duration_test.go
@@ -88,7 +88,7 @@ func TestSumOfMaxPerRoundTracker(t *testing.T) {
 	if got := tracker.GetLatency(); got != 0 {
 		t.Errorf("round 1 before CommitRound: want 0, got %v", got)
 	}
-	tracker.(RoundCommitter).CommitRound()
+	tracker.CommitRound()
 	if got := tracker.GetLatency(); got != 400 {
 		t.Errorf("after round 1 CommitRound: want 400, got %v", got)
 	}
@@ -97,19 +97,19 @@ func TestSumOfMaxPerRoundTracker(t *testing.T) {
 	for _, d := range []time.Duration{300, 150} {
 		tracker.Track(func() { clk.Step(d) })
 	}
-	tracker.(RoundCommitter).CommitRound()
+	tracker.CommitRound()
 	if got := tracker.GetLatency(); got != 700 {
 		t.Errorf("after round 2 CommitRound: want 700 (400+300), got %v", got)
 	}
 
 	// round 3
 	tracker.Track(func() { clk.Step(50) })
-	tracker.(RoundCommitter).CommitRound()
+	tracker.CommitRound()
 	if got := tracker.GetLatency(); got != 750 {
 		t.Errorf("after round 3 CommitRound: want 750 (400+300+50), got %v", got)
 	}
 
-	tracker.(RoundCommitter).CommitRound()
+	tracker.CommitRound()
 	if got := tracker.GetLatency(); got != 750 {
 		t.Errorf("after empty CommitRound: want 750, got %v", got)
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
the apiserver_request_sli_duration_seconds was miscalculating the SLI latency for requests involving validating webhooks. The SLI formula subtracts webhook latency from total elapsed time. 

the original max was correct for the actual parallel-dispatch model. if switching to sum, it will make sliLatency go negative in cluster with multiple matching validating webhooks running in parallel.

this pr introduces sumOfMaxPerRoundTracker, a new tracker type that implements the correct semantics:
  - within a round: takes the max of concurrent Track() durations which equal to the actual blocking time.
  - across rounds: sums the per-round maxima via CommitRound().

#### Which issue(s) this PR is related to:
Fixes #140383

#### Special notes for your reviewer:
the original ValidatingWebhookTracker used newMaxLatencyTracker, which was correct within a single dispatch round. however, GuaranteedUpdate retries the entire admission chain on the same context when conflicts occur.
on each retry, the same validating webhooks are dispatched again, adding to the same tracker. with max aggregation, only the single longest individual call across all rounds was kept. the remaining webhook latency was silently dropped and incorrectly attributed to processing, inflating the SLI.

#### Test cases:
> go test ./staging/src/k8s.io/apiserver/pkg/endpoints/request/... -run "TestSumOfMaxPerRoundTracker|TestLatencyTrackersFrom" -v 2>&1
> === RUN   TestLatencyTrackersFrom
> === RUN   TestLatencyTrackersFrom/TestLatencyTrackersFrom
> --- PASS: TestLatencyTrackersFrom (0.00s)
>     --- PASS: TestLatencyTrackersFrom/TestLatencyTrackersFrom (0.00s)
> === RUN   TestSumOfMaxPerRoundTracker
> --- PASS: TestSumOfMaxPerRoundTracker (0.00s)
> PASS
> ok      k8s.io/apiserver/pkg/endpoints/request  (cached)

#### release-note
```release-note
fix: correctly track validating webhook latency across parallel dispatch and sequential retries
```