### PR TITLE
Remove post filters from pod group cycle

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -144,12 +144,6 @@ func (pl *DefaultPreemption) PostFilter(ctx context.Context, state fwk.CycleStat
 		metrics.PreemptionAttempts.Inc()
 	}()
 
-	if pod.Spec.SchedulingGroup != nil && pl.fts.EnableGenericWorkload {
-		// When GenericWorkload is enabled, the default preemption logic needs to be disabled for pod group scheduling to avoid performing preemption in pod by pod cycle
-		// of pod group scheduling. Instead the WAP will be called to perform preemption for the entire pod group.
-		return nil, fwk.NewStatus(fwk.Unschedulable, "preemption: not eligible due to workload aware preemption enabled")
-	}
-
 	result, status := pl.Evaluator.Preempt(ctx, state, pod, m)
 	msg := status.Message()
 	if len(msg) > 0 {

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -398,60 +398,6 @@ func TestPostFilter(t *testing.T) {
 			wantStatus: fwk.NewStatus(fwk.Success, "preemption: found a potential placement for pod on node node2, preempting 1 victims"),
 		},
 		{
-			name: "pod with SchedulingGroup with TAS with scheduling constraint enabled should not preempt",
-			pod:  st.MakePod().Name("p-with-podgroup").Namespace(v1.NamespaceDefault).PodGroupName("foo").Priority(highPriority).Obj(),
-			pods: []*v1.Pod{
-				st.MakePod().Name("p1").UID("p1").Namespace(v1.NamespaceDefault).Node("node1").Obj(),
-			},
-			nodes: []*v1.Node{
-				st.MakeNode().Name("node1").Capacity(onePodRes).Obj(),
-			},
-			podGroups: []*v1alpha3.PodGroup{
-				st.MakePodGroup().Name("foo").Namespace(v1.NamespaceDefault).TopologyKey("rack").Obj(),
-			},
-			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*fwk.Status{
-				"node1": fwk.NewStatus(fwk.Unschedulable),
-			}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
-			features:   feature.Features{EnableGenericWorkload: true, EnableTopologyAwareWorkloadScheduling: true},
-			wantResult: nil,
-			wantStatus: fwk.NewStatus(fwk.Unschedulable, "preemption: not eligible due to workload aware preemption enabled"),
-		},
-		{
-			name: "pod with SchedulingGroup with TAS without scheduling constraint enabled should not preempt",
-			pod:  st.MakePod().Name("p-with-podgroup").Namespace(v1.NamespaceDefault).PodGroupName("foo").Priority(highPriority).Obj(),
-			pods: []*v1.Pod{
-				st.MakePod().Name("p1").UID("p1").Namespace(v1.NamespaceDefault).Node("node1").Obj(),
-			},
-			nodes: []*v1.Node{
-				st.MakeNode().Name("node1").Capacity(onePodRes).Obj(),
-			},
-			podGroups: []*v1alpha3.PodGroup{
-				st.MakePodGroup().Name("foo").Namespace(v1.NamespaceDefault).Obj(),
-			},
-			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*fwk.Status{
-				"node1": fwk.NewStatus(fwk.Unschedulable),
-			}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
-			features:   feature.Features{EnableGenericWorkload: true, EnableTopologyAwareWorkloadScheduling: true},
-			wantResult: nil,
-			wantStatus: fwk.NewStatus(fwk.Unschedulable, "preemption: not eligible due to workload aware preemption enabled"),
-		},
-		{
-			name: "pod with SchedulingGroup should not preempt",
-			pod:  st.MakePod().Name("p-with-podgroup").PodGroupName("foo").Priority(highPriority).Obj(),
-			pods: []*v1.Pod{
-				st.MakePod().Name("p1").UID("p1").Namespace(v1.NamespaceDefault).Node("node1").Obj(),
-			},
-			nodes: []*v1.Node{
-				st.MakeNode().Name("node1").Capacity(onePodRes).Obj(),
-			},
-			filteredNodesStatuses: framework.NewNodeToStatus(map[string]*fwk.Status{
-				"node1": fwk.NewStatus(fwk.Unschedulable),
-			}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
-			features:   feature.Features{EnableGenericWorkload: true},
-			wantResult: nil,
-			wantStatus: fwk.NewStatus(fwk.Unschedulable, "preemption: not eligible due to workload aware preemption enabled"),
-		},
-		{
 			name: "pod with SchedulingGroup with GenericWorkload and TAS disabled should preempt",
 			pod:  st.MakePod().Name("p-with-podgroup").PodGroupName("foo").Priority(highPriority).Obj(),
 			pods: []*v1.Pod{

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -274,6 +274,14 @@ func (sched *Scheduler) schedulingAlgorithm(
 			return ScheduleResult{nominatingInfo: clearNominatedNode}, fwk.AsStatus(err)
 		}
 
+		// We do not want to run PostFilters for single pods in PodGroup cycle.
+		// Instead we will run PodGroupPostFilter at the end of PodGroup cycle.
+		if state.IsPodGroupSchedulingCycle() {
+			// Return nil as NominatingInfo. It can be overridden by the PodGroupPostFilter later
+			// and the final decision whether to clear NominatingInfo will be done in submitPodGroupAlgorithmResult.
+			return ScheduleResult{nominatingInfo: nil}, fwk.NewStatus(fwk.Unschedulable).WithError(err)
+		}
+
 		// SchedulePod() may have failed because the pod would not fit on any host, so we try to
 		// preempt, with the expectation that the next time the pod is tried for scheduling it
 		// will fit due to the preemption. It is also possible that a different pod will schedule

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -387,7 +387,7 @@ type podSchedulingContext struct {
 }
 
 // initPodSchedulingContext initializes the scheduling context of a single pod for pod group scheduling cycle.
-func initPodSchedulingContext(ctx context.Context, pod *v1.Pod, placementCycleState *framework.CycleState, postFilterMode podGroupPostFilterMode) *podSchedulingContext {
+func initPodSchedulingContext(ctx context.Context, pod *v1.Pod, placementCycleState *framework.CycleState) *podSchedulingContext {
 	logger := klog.FromContext(ctx)
 	// TODO(knelasevero): Remove duplicated keys from log entry calls
 	// When contextualized logging hits GA
@@ -411,14 +411,6 @@ func initPodSchedulingContext(ctx context.Context, pod *v1.Pod, placementCycleSt
 	// Set the placement cycle state so per-pod plugins can access placement-scoped data.
 	state.SetPlacementCycleState(placementCycleState)
 
-	// Skip post filters if requested.
-	switch postFilterMode {
-	case runWithoutPostFilters:
-		state.SetSkipAllPostFilterPlugins(true)
-	case runAllPostFilters:
-		// Default podCtx state will run all post filters.
-	}
-
 	return &podSchedulingContext{
 		logger:         logger,
 		state:          state,
@@ -429,7 +421,7 @@ func initPodSchedulingContext(ctx context.Context, pod *v1.Pod, placementCycleSt
 // podGroupCycle runs a pod group scheduling cycle for the given pod group.
 // Cluster state should be snapshotted before calling this method.
 func (sched *Scheduler) podGroupCycle(ctx context.Context, schedFwk framework.Framework, podGroupCycleState *framework.CycleState, rootPodGroupInfo *framework.QueuedPodGroupInfo, start time.Time) {
-	pgResults := sched.runRootSchedulingAlgorithm(ctx, schedFwk, podGroupCycleState, rootPodGroupInfo, runAllPostFilters)
+	pgResults := sched.runRootSchedulingAlgorithm(ctx, schedFwk, podGroupCycleState, rootPodGroupInfo)
 	rootStatus := pgResults[pgKey(rootPodGroupInfo.PodGroupInfo)].status
 	var completePGResults map[fwk.EntityKey]*podGroupAlgorithmResult
 	if utilfeature.DefaultFeatureGate.Enabled(features.CompositePodGroup) && rootPodGroupInfo.GetType() == fwk.CompositePodGroupKeyType {
@@ -437,7 +429,7 @@ func (sched *Scheduler) podGroupCycle(ctx context.Context, schedFwk framework.Fr
 	} else {
 		// pgResults has exactly 1 element.
 		queuedPodInfos := rootPodGroupInfo.QueuedPodInfos[pgKey(rootPodGroupInfo.PodGroupInfo)]
-		result := completePodGroupAlgorithmResult(ctx, queuedPodInfos, podGroupCycleState, runAllPostFilters, pgResults[pgKey(rootPodGroupInfo.PodGroupInfo)])
+		result := completePodGroupAlgorithmResult(ctx, queuedPodInfos, podGroupCycleState, pgResults[pgKey(rootPodGroupInfo.PodGroupInfo)])
 		completePGResults = map[fwk.EntityKey]*podGroupAlgorithmResult{pgKey(rootPodGroupInfo.PodGroupInfo): result}
 	}
 
@@ -447,7 +439,7 @@ func (sched *Scheduler) podGroupCycle(ctx context.Context, schedFwk framework.Fr
 	// we need to put the pods from pod group back into the scheduling queue.
 	if rootStatus.Code() == fwk.Unschedulable {
 		var pgSchedulingFunc fwk.PodGroupSchedulingFunc = func(ctx context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
-			results := sched.runRootSchedulingAlgorithm(ctx, schedFwk, podGroupCycleState, rootPodGroupInfo, runWithoutPostFilters)
+			results := sched.runRootSchedulingAlgorithm(ctx, schedFwk, podGroupCycleState, rootPodGroupInfo)
 			proposedAssignments := make([]fwk.ProposedAssignment, 0)
 			for _, res := range results {
 				proposedAssignments = append(proposedAssignments, makeProposedAssignments(res)...)
@@ -467,12 +459,12 @@ func (sched *Scheduler) podGroupCycle(ctx context.Context, schedFwk framework.Fr
 // It decides whether to evaluate a single group or recursively evaluate a composite group hierarchy
 // and eventually cleans up the tentative reservations that the algorithm makes during its execution.
 // The returned map aggregates scheduling results across the entire pod group hierarchy.
-func (sched *Scheduler) runRootSchedulingAlgorithm(ctx context.Context, schedFwk framework.Framework, podGroupCycleState *framework.CycleState, rootPodGroupInfo *framework.QueuedPodGroupInfo, postFilterMode podGroupPostFilterMode) map[fwk.EntityKey]*podGroupAlgorithmResult {
+func (sched *Scheduler) runRootSchedulingAlgorithm(ctx context.Context, schedFwk framework.Framework, podGroupCycleState *framework.CycleState, rootPodGroupInfo *framework.QueuedPodGroupInfo) map[fwk.EntityKey]*podGroupAlgorithmResult {
 	var revertFns revertFns
 	defer revertFns.revert()
 	if utilfeature.DefaultFeatureGate.Enabled(features.CompositePodGroup) && rootPodGroupInfo.GetType() == fwk.CompositePodGroupKeyType {
 		result := map[fwk.EntityKey]*podGroupAlgorithmResult{}
-		rootResult, childRevertFns := sched.podGroupSchedulingRecursiveAlgorithm(ctx, schedFwk, podGroupCycleState, rootPodGroupInfo, rootPodGroupInfo.PodGroupInfo, postFilterMode, result)
+		rootResult, childRevertFns := sched.podGroupSchedulingRecursiveAlgorithm(ctx, schedFwk, podGroupCycleState, rootPodGroupInfo, rootPodGroupInfo.PodGroupInfo, result)
 		revertFns = childRevertFns
 		if rootResult.status.IsSuccess() && !rootResult.anyScheduled {
 			// The framework requires at least 1 pod to be scheduled in order to return a success status.
@@ -480,7 +472,7 @@ func (sched *Scheduler) runRootSchedulingAlgorithm(ctx context.Context, schedFwk
 		}
 		return result
 	}
-	result, childRevertFns := sched.podGroupSchedulingAlgorithm(ctx, schedFwk, podGroupCycleState, rootPodGroupInfo.PodGroupInfo, rootPodGroupInfo, postFilterMode)
+	result, childRevertFns := sched.podGroupSchedulingAlgorithm(ctx, schedFwk, podGroupCycleState, rootPodGroupInfo.PodGroupInfo, rootPodGroupInfo)
 	revertFns = childRevertFns
 
 	if result.status.IsSuccess() && !result.anyScheduled {
@@ -500,23 +492,9 @@ type algorithmResult struct {
 	podCtx *podSchedulingContext
 	// schedulingDuration is a pod scheduling duration used for metrics recording.
 	schedulingDuration time.Duration
-	// requiresPreemption determines whether this pod requires a preemption to proceed or not.
-	requiresPreemption bool
 	// status is a scheduling algorithm status.
 	status *fwk.Status
 }
-
-// podGroupPostFilterMode defines how the pod group algorithm should run post filters plugins.
-type podGroupPostFilterMode int
-
-const (
-	// The pod group algorithm should try to run all post filters in pod-by-pod cycle.
-	runAllPostFilters podGroupPostFilterMode = iota
-	// The pod group algorithm should not try post filter at all. This can be used
-	// by workload aware preemption that tries to check if after removing some
-	// pods the pod group can be scheduled.
-	runWithoutPostFilters
-)
 
 func (ar *algorithmResult) GetPod() *v1.Pod {
 	return ar.podInfo.Pod
@@ -570,7 +548,7 @@ type podGroupAlgorithmResult struct {
 // treat that pod as already scheduled on that node with victims being already removed in memory.
 // The returned revertFns accumulates revert functions for all scheduled pods, allowing the caller
 // to rollback tentative reservations if the pod group scheduling cycle fails.
-func (sched *Scheduler) podGroupSchedulingDefaultAlgorithm(ctx context.Context, schedFwk framework.Framework, placementCycleState *framework.CycleState, podGroupInfo *framework.PodGroupInfo, queuedPodGroupInfo *framework.QueuedPodGroupInfo, postFilterMode podGroupPostFilterMode) (*podGroupAlgorithmResult, revertFns) {
+func (sched *Scheduler) podGroupSchedulingDefaultAlgorithm(ctx context.Context, schedFwk framework.Framework, placementCycleState *framework.CycleState, podGroupInfo *framework.PodGroupInfo, queuedPodGroupInfo *framework.QueuedPodGroupInfo) (*podGroupAlgorithmResult, revertFns) {
 	// Retrieve the queued podinfos for the given pod group from the root queuedPodGroupInfo.
 	queuedPodInfos := queuedPodGroupInfo.QueuedPodInfos[pgKey(podGroupInfo)]
 	result := &podGroupAlgorithmResult{
@@ -611,12 +589,11 @@ func (sched *Scheduler) podGroupSchedulingDefaultAlgorithm(ctx context.Context, 
 		return result, nil
 	}
 
-	requiresPreemption := false
 	anyScheduled := false
 	var revertFns revertFns
 
 	for _, podInfo := range queuedPodInfos {
-		podResult, revertFn := sched.podGroupPodSchedulingAlgorithm(ctx, schedFwk, placementCycleState, podGroupInfo, podInfo, postFilterMode)
+		podResult, revertFn := sched.podGroupPodSchedulingAlgorithm(ctx, schedFwk, placementCycleState, podGroupInfo, podInfo)
 		result.podResults = append(result.podResults, podResult)
 		if revertFn != nil {
 			revertFns.append([]func(){revertFn})
@@ -649,7 +626,6 @@ func (sched *Scheduler) podGroupSchedulingDefaultAlgorithm(ctx context.Context, 
 			break
 		}
 
-		requiresPreemption = requiresPreemption || podResult.requiresPreemption
 		anyScheduled = anyScheduled || podResult.status.IsSuccess()
 	}
 
@@ -658,14 +634,6 @@ func (sched *Scheduler) podGroupSchedulingDefaultAlgorithm(ctx context.Context, 
 	}
 
 	result.anyScheduled = anyScheduled
-
-	if result.status.IsSuccess() {
-		if requiresPreemption {
-			// If any preemption is required, the whole pod group requires it to be feasible.
-			result.status = fwk.NewStatus(fwk.Unschedulable, "pod group is waiting for preemption to complete").WithError(errPodGroupUnschedulable)
-			result.waitingOnPreemption = true
-		}
-	}
 
 	if !result.status.IsSuccess() {
 		revertFns.revert()
@@ -678,35 +646,24 @@ func (sched *Scheduler) podGroupSchedulingDefaultAlgorithm(ctx context.Context, 
 // It returns the algorithm result together with the revert function.
 // The returned revert function rolls back tentative node reservations for the pod if the overall
 // pod group fails to schedule.
-func (sched *Scheduler) podGroupPodSchedulingAlgorithm(ctx context.Context, schedFwk framework.Framework, placementCycleState *framework.CycleState, podGroupInfo *framework.PodGroupInfo, podInfo *framework.QueuedPodInfo, postFilterMode podGroupPostFilterMode) (algorithmResult, func()) {
+func (sched *Scheduler) podGroupPodSchedulingAlgorithm(ctx context.Context, schedFwk framework.Framework, placementCycleState *framework.CycleState, podGroupInfo *framework.PodGroupInfo, podInfo *framework.QueuedPodInfo) (algorithmResult, func()) {
 	pod := podInfo.Pod
-	podCtx := initPodSchedulingContext(ctx, pod, placementCycleState, postFilterMode)
+	podCtx := initPodSchedulingContext(ctx, pod, placementCycleState)
 	logger := podCtx.logger
 	ctx = klog.NewContext(ctx, logger)
 	start := time.Now()
 
 	logger.V(4).Info("Attempting to schedule a pod belonging to a pod group", "podGroup", klog.KObj(podGroupInfo), "pod", klog.KObj(pod))
 
-	requiresPreemption := false
 	scheduleResult, status := sched.schedulingAlgorithm(ctx, podCtx.state, schedFwk, podInfo, start)
 	if !status.IsSuccess() {
-		if scheduleResult.nominatingInfo != nil && scheduleResult.nominatingInfo.NominatedNodeName != "" {
-			// If the NominatedNodeName is set, the preemption is required.
-			// Continue with assuming and reserving, because the subsequent pods from this group
-			// have to see this one as already scheduled on its nominated place.
-			// Set SuggestedHost to NominatedNodeName to handle the pod similarly to one that is feasible.
-			scheduleResult.SuggestedHost = scheduleResult.nominatingInfo.NominatedNodeName
-			requiresPreemption = true
-		} else {
-			// In case of pod being just unschedulable or having an error, just return now.
-			return algorithmResult{
-				podInfo:            podInfo.PodInfo,
-				scheduleResult:     scheduleResult,
-				podCtx:             podCtx,
-				schedulingDuration: time.Since(start),
-				status:             status,
-			}, nil
-		}
+		return algorithmResult{
+			podInfo:            podInfo.PodInfo,
+			scheduleResult:     scheduleResult,
+			podCtx:             podCtx,
+			schedulingDuration: time.Since(start),
+			status:             status,
+		}, nil
 	}
 	assumedPodInfo, assumeStatus := sched.assumeAndReserve(ctx, podCtx.state, schedFwk, podInfo, scheduleResult)
 	if !assumeStatus.IsSuccess() {
@@ -732,12 +689,11 @@ func (sched *Scheduler) podGroupPodSchedulingAlgorithm(ctx context.Context, sche
 		podCtx:             podCtx,
 		schedulingDuration: time.Since(start),
 		status:             status,
-		requiresPreemption: requiresPreemption,
 	}, revertFn
 }
 
 // completePodGroupAlgorithmResult ensures that the podGroupAlgorithmResult contains the same number of podResults as there are pods in QueuedPodInfos.
-func completePodGroupAlgorithmResult(ctx context.Context, queuedPodInfos []*framework.QueuedPodInfo, podGroupState *framework.CycleState, postFilterMode podGroupPostFilterMode, podGroupResult *podGroupAlgorithmResult) *podGroupAlgorithmResult {
+func completePodGroupAlgorithmResult(ctx context.Context, queuedPodInfos []*framework.QueuedPodInfo, podGroupState *framework.CycleState, podGroupResult *podGroupAlgorithmResult) *podGroupAlgorithmResult {
 	numInResult := len(podGroupResult.podResults)
 	numInQueue := len(queuedPodInfos)
 	if numInResult == numInQueue {
@@ -751,7 +707,7 @@ func completePodGroupAlgorithmResult(ctx context.Context, queuedPodInfos []*fram
 		placementCycleState.SetPodGroupSchedulingCycle(podGroupState)
 		newResults[i] = algorithmResult{
 			podInfo: pInfo.PodInfo,
-			podCtx:  initPodSchedulingContext(ctx, pInfo.Pod, placementCycleState, postFilterMode),
+			podCtx:  initPodSchedulingContext(ctx, pInfo.Pod, placementCycleState),
 			status:  podGroupResult.status.Clone(),
 		}
 	}
@@ -767,7 +723,7 @@ func completeCompositePodGroupAlgorithmResult(ctx context.Context, rootPodGroupI
 	for pgKey, queuedPodInfos := range rootPodGroupInfo.QueuedPodInfos {
 		pgResult := pgResults[pgKey]
 		// Ensure podResults has an entry for each pod in the pod group with a status.
-		completePodGroupAlgorithmResult(ctx, queuedPodInfos, rootCycleState, runAllPostFilters, pgResult)
+		completePodGroupAlgorithmResult(ctx, queuedPodInfos, rootCycleState, pgResult)
 	}
 	return pgResults
 }
@@ -851,7 +807,7 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 			logger.Error(fmt.Errorf("some pods were not processed"), "scheduling error for pod group", "podGroup", klog.KObj(pgi))
 			podGroupResult.status = fwk.NewStatus(fwk.Error, "scheduling error for pod group, some pods were not processed")
 			podGroupResult.podResults = nil
-			completePodGroupAlgorithmResult(ctx, queuedPodInfos, podGroupState, runAllPostFilters, podGroupResult)
+			completePodGroupAlgorithmResult(ctx, queuedPodInfos, podGroupState, podGroupResult)
 		}
 		var scheduledPods, unschedulablePods int
 		for i, pInfo := range queuedPodInfos {
@@ -905,15 +861,8 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 			} else {
 				// TBD: Add a message to status if the pod used features for which finding a placement cannot be guaranteed,
 				// such as heterogeneous pod group or using inter-pod dependencies.
-				if podResult.requiresPreemption && !podGroupResult.waitingOnPreemption {
-					// Pod group is unschedulable, so the pod has to be marked as unschedulable, even if it just required preemption.
-					// Its rejection status is set to the pod group's status message, as the preemption message is no longer relevant.
-					status := fwk.NewStatus(fwk.Unschedulable, podGroupResult.status.Message()).WithError(errPodGroupUnschedulable)
-					sched.FailureHandler(ctx, schedFwk, pInfo, status, clearNominatedNode, podSchedulingStart)
-				} else {
-					// When a pod is unschedulable or preemption is required, just call the FailureHandler.
-					sched.FailureHandler(ctx, schedFwk, pInfo, podResult.status, podResult.scheduleResult.nominatingInfo, podSchedulingStart)
-				}
+				// When a pod is unschedulable or preemption is required, just call the FailureHandler.
+				sched.FailureHandler(ctx, schedFwk, pInfo, podResult.status, podResult.scheduleResult.nominatingInfo, podSchedulingStart)
 				unschedulablePods++
 			}
 		}
@@ -1002,7 +951,7 @@ func (sched *Scheduler) updatePodGroupCondition(ctx context.Context,
 // Placement is a set of nodes that will be considered when scheduling a pod group.
 // Then for each placement it tries to schedule the pod group through podGroupSchedulingDefaultAlgorithm.
 // Finally, it runs placement scorer plugins to select the best placement.
-func (sched *Scheduler) podGroupSchedulingPlacementAlgorithm(ctx context.Context, schedFwk framework.Framework, podGroupCycleState *framework.CycleState, podGroupInfo *framework.PodGroupInfo, queuedPodGroupInfo *framework.QueuedPodGroupInfo, postFilterMode podGroupPostFilterMode) *podGroupAlgorithmResult {
+func (sched *Scheduler) podGroupSchedulingPlacementAlgorithm(ctx context.Context, schedFwk framework.Framework, podGroupCycleState *framework.CycleState, podGroupInfo *framework.PodGroupInfo, queuedPodGroupInfo *framework.QueuedPodGroupInfo) *podGroupAlgorithmResult {
 	logger := klog.FromContext(ctx)
 	allNodes, err := sched.nodeInfoSnapshot.NodeInfos().List()
 	if err != nil {
@@ -1036,7 +985,7 @@ func (sched *Scheduler) podGroupSchedulingPlacementAlgorithm(ctx context.Context
 		}
 		placementCycleState := framework.NewCycleState()
 		placementCycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
-		result, revertFns := sched.podGroupSchedulingDefaultAlgorithm(ctx, schedFwk, placementCycleState, podGroupInfo, queuedPodGroupInfo, postFilterMode)
+		result, revertFns := sched.podGroupSchedulingDefaultAlgorithm(ctx, schedFwk, placementCycleState, podGroupInfo, queuedPodGroupInfo)
 		revertFns.revert()
 		sched.nodeInfoSnapshot.ForgetPlacement()
 
@@ -1052,7 +1001,7 @@ func (sched *Scheduler) podGroupSchedulingPlacementAlgorithm(ctx context.Context
 			anyResult = result
 		}
 
-		if result.status.IsSuccess() || result.waitingOnPreemption {
+		if result.status.IsSuccess() {
 			successfulResults[placement] = result
 		}
 	}
@@ -1144,13 +1093,13 @@ func makeProposedAssignments(res *podGroupAlgorithmResult) []fwk.ProposedAssignm
 
 // podGroupSchedulingAlgorithm attempts to schedule pods in the pod group according to the policy and constraints and returns the scheduling result for all evaluated pods in the pod group, not necessarily all pods in the pod group.
 // The returned revertFns accumulates revert functions for all scheduled pods, allowing the caller to rollback tentative reservations if the pod group scheduling cycle fails.
-func (sched *Scheduler) podGroupSchedulingAlgorithm(ctx context.Context, schedFwk framework.Framework, podGroupCycleState *framework.CycleState, podGroupInfo *framework.PodGroupInfo, queuedPodGroupInfo *framework.QueuedPodGroupInfo, postFilterMode podGroupPostFilterMode) (*podGroupAlgorithmResult, revertFns) {
+func (sched *Scheduler) podGroupSchedulingAlgorithm(ctx context.Context, schedFwk framework.Framework, podGroupCycleState *framework.CycleState, podGroupInfo *framework.PodGroupInfo, queuedPodGroupInfo *framework.QueuedPodGroupInfo) (*podGroupAlgorithmResult, revertFns) {
 	podGroupCycleCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	// We don't support TAS when scheduling composite pod groups just yet.
 	if utilfeature.DefaultFeatureGate.Enabled(features.TopologyAwareWorkloadScheduling) && queuedPodGroupInfo.GetType() == fwk.PodGroupKeyType {
-		result := sched.podGroupSchedulingPlacementAlgorithm(podGroupCycleCtx, schedFwk, podGroupCycleState, podGroupInfo, queuedPodGroupInfo, postFilterMode)
+		result := sched.podGroupSchedulingPlacementAlgorithm(podGroupCycleCtx, schedFwk, podGroupCycleState, podGroupInfo, queuedPodGroupInfo)
 		// Placement scheduling algorithm runs in simulation mode, evaluating candidate placements
 		// and reverting all tentative reservations before returning. Thus, no pending reservations
 		// remain to be reverted by the caller.
@@ -1161,23 +1110,23 @@ func (sched *Scheduler) podGroupSchedulingAlgorithm(ctx context.Context, schedFw
 	// extension points can use the same state plumbing as TAS.
 	placementCycleState := framework.NewCycleState()
 	placementCycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
-	return sched.podGroupSchedulingDefaultAlgorithm(podGroupCycleCtx, schedFwk, placementCycleState, podGroupInfo, queuedPodGroupInfo, postFilterMode)
+	return sched.podGroupSchedulingDefaultAlgorithm(podGroupCycleCtx, schedFwk, placementCycleState, podGroupInfo, queuedPodGroupInfo)
 }
 
 // podGroupSchedulingRecursiveAlgorithm runs a recursive pod group scheduling algorithm.
 // If the pod group info wraps a composite pod group, it will recursively invoke the algorithm on its children.
 // Otherwise, the pod group info wraps a leaf pod group for which we invoke the standard pod group scheduling algorithm.
 // The returned revertFns propagates revert functions from all child pod group evaluations up to the root level.
-func (sched *Scheduler) podGroupSchedulingRecursiveAlgorithm(ctx context.Context, schedFwk framework.Framework, podGroupCycleState *framework.CycleState, root *framework.QueuedPodGroupInfo, podGroupInfo *framework.PodGroupInfo, postFilterMode podGroupPostFilterMode, results map[fwk.EntityKey]*podGroupAlgorithmResult) (*podGroupAlgorithmResult, revertFns) {
+func (sched *Scheduler) podGroupSchedulingRecursiveAlgorithm(ctx context.Context, schedFwk framework.Framework, podGroupCycleState *framework.CycleState, root *framework.QueuedPodGroupInfo, podGroupInfo *framework.PodGroupInfo, results map[fwk.EntityKey]*podGroupAlgorithmResult) (*podGroupAlgorithmResult, revertFns) {
 	logger := klog.FromContext(ctx)
 	logger.V(5).Info("Running recursive podgroup scheduling algorithm", "rootType", podGroupInfo.Type, "root", klog.KObj(podGroupInfo))
 
 	var algorithmResult *podGroupAlgorithmResult
 	var childRevertFns revertFns
 	if podGroupInfo.Type == fwk.PodGroupKeyType {
-		algorithmResult, childRevertFns = sched.podGroupSchedulingAlgorithm(ctx, schedFwk, podGroupCycleState, podGroupInfo, root, postFilterMode)
+		algorithmResult, childRevertFns = sched.podGroupSchedulingAlgorithm(ctx, schedFwk, podGroupCycleState, podGroupInfo, root)
 	} else {
-		algorithmResult, childRevertFns = sched.compositePodGroupSchedulingAlgorithm(ctx, schedFwk, podGroupCycleState, root, podGroupInfo, postFilterMode, results)
+		algorithmResult, childRevertFns = sched.compositePodGroupSchedulingAlgorithm(ctx, schedFwk, podGroupCycleState, root, podGroupInfo, results)
 	}
 	results[pgKey(podGroupInfo)] = algorithmResult
 	return algorithmResult, childRevertFns
@@ -1187,7 +1136,7 @@ func (sched *Scheduler) podGroupSchedulingRecursiveAlgorithm(ctx context.Context
 // its children. It uses PlacementFeasible plugins to verify if the composite group constraints
 // remain satisfiable at each step of the recursion, aborting and reverting early if they cannot be met.
 // The returned revertFns propagates revert functions from all child pod group evaluations up to the root level.
-func (sched *Scheduler) compositePodGroupSchedulingAlgorithm(ctx context.Context, schedFwk framework.Framework, podGroupCycleState *framework.CycleState, root *framework.QueuedPodGroupInfo, podGroupInfo *framework.PodGroupInfo, postFilterMode podGroupPostFilterMode, results map[fwk.EntityKey]*podGroupAlgorithmResult) (result *podGroupAlgorithmResult, revertFns revertFns) {
+func (sched *Scheduler) compositePodGroupSchedulingAlgorithm(ctx context.Context, schedFwk framework.Framework, podGroupCycleState *framework.CycleState, root *framework.QueuedPodGroupInfo, podGroupInfo *framework.PodGroupInfo, results map[fwk.EntityKey]*podGroupAlgorithmResult) (result *podGroupAlgorithmResult, revertFns revertFns) {
 	logger := klog.FromContext(ctx)
 	defer func() {
 		if result.status.IsSuccess() {
@@ -1214,7 +1163,7 @@ func (sched *Scheduler) compositePodGroupSchedulingAlgorithm(ctx context.Context
 	anyScheduled := false
 	for _, childPGInfo := range podGroupInfo.GetChildren() {
 		childPodGroupState := framework.NewCycleState()
-		childResult, childRevertFns := sched.podGroupSchedulingRecursiveAlgorithm(ctx, schedFwk, childPodGroupState, root, childPGInfo, postFilterMode, results)
+		childResult, childRevertFns := sched.podGroupSchedulingRecursiveAlgorithm(ctx, schedFwk, childPodGroupState, root, childPGInfo, results)
 		if childResult.status.IsError() {
 			return &podGroupAlgorithmResult{
 				podGroupInfo: podGroupInfo,

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -753,7 +753,7 @@ func TestPodGroupCycle_FillsPodResultsOnFewerResults(t *testing.T) {
 	}
 	sched.SchedulePod = sched.schedulePod
 
-	resultsMap := sched.runRootSchedulingAlgorithm(ctx, schedFwk, framework.NewCycleState(), podGroupInfo, runAllPostFilters)
+	resultsMap := sched.runRootSchedulingAlgorithm(ctx, schedFwk, framework.NewCycleState(), podGroupInfo)
 	schedulePodResult := resultsMap[pgKey(podGroupInfo.PodGroupInfo)]
 	if len(schedulePodResult.podResults) != 2 {
 		t.Errorf("Expected 2 pod results, got %d", len(schedulePodResult.podResults))
@@ -972,15 +972,12 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                             string
-		plugin                           *fakePodGroupPlugin
-		podGroupFeasibleStatuses         []fwk.Code
-		expectedGroupStatusCode          fwk.Code
-		expectedGroupWaitingOnPreemption bool
-		expectedPodStatus                map[string]*fwk.Status
-		expectedPreemption               map[string]bool
-		postFilterMode                   podGroupPostFilterMode
-		skipForTAS                       bool
+		name                     string
+		plugin                   *fakePodGroupPlugin
+		podGroupFeasibleStatuses []fwk.Code
+		expectedGroupStatusCode  fwk.Code
+		expectedPodStatus        map[string]*fwk.Status
+		skipForTAS               bool
 	}{
 		{
 			name: "All pods feasible",
@@ -1105,51 +1102,12 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 			},
 		},
 		{
-			name: "All pods require preemption",
-			plugin: &fakePodGroupPlugin{
-				filterStatus: map[string]*fwk.Status{
-					"p1": fwk.NewStatus(fwk.Unschedulable),
-					"p2": fwk.NewStatus(fwk.Unschedulable),
-					"p3": fwk.NewStatus(fwk.Unschedulable),
-				},
-				postFilterStatus: map[string]*fwk.Status{
-					"p1": nil,
-					"p2": nil,
-					"p3": nil,
-				},
-				postFilterResult: map[string]*fwk.PostFilterResult{
-					"p1": {NominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride}},
-					"p2": {NominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride}},
-					"p3": {NominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride}},
-				},
-			},
-			expectedGroupStatusCode:          fwk.Unschedulable,
-			expectedGroupWaitingOnPreemption: true,
-			expectedPodStatus: map[string]*fwk.Status{
-				"p1": fwk.NewStatus(fwk.Unschedulable),
-				"p2": fwk.NewStatus(fwk.Unschedulable),
-				"p3": fwk.NewStatus(fwk.Unschedulable),
-			},
-			expectedPreemption: map[string]bool{
-				"p1": true,
-				"p2": true,
-				"p3": true,
-			},
-			skipForTAS: true,
-		},
-		{
-			name: "One pod requires preemption, podGroup schedulable with 2 schedulable pods",
+			name: "PodGroup schedulable with 2 schedulable pods",
 			plugin: &fakePodGroupPlugin{
 				filterStatus: map[string]*fwk.Status{
 					"p1": fwk.NewStatus(fwk.Unschedulable),
 					"p2": nil,
 					"p3": nil,
-				},
-				postFilterStatus: map[string]*fwk.Status{
-					"p1": nil,
-				},
-				postFilterResult: map[string]*fwk.PostFilterResult{
-					"p1": {NominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride}},
 				},
 			},
 			podGroupFeasibleStatuses: []fwk.Code{
@@ -1158,52 +1116,13 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 				fwk.Wait,
 				fwk.Success,
 			},
-			expectedGroupStatusCode:          fwk.Unschedulable,
-			expectedGroupWaitingOnPreemption: true,
+			expectedGroupStatusCode: fwk.Success,
 			expectedPodStatus: map[string]*fwk.Status{
 				"p1": fwk.NewStatus(fwk.Unschedulable),
 				"p2": nil,
 				"p3": nil,
 			},
-			expectedPreemption: map[string]bool{
-				"p1": true,
-				"p2": false,
-				"p3": false,
-			},
-			// preemption is not yet implemented for TAS
-			skipForTAS: true,
-		},
-		{
-			name: "One pod unschedulable, one requires preemption, one feasible",
-			plugin: &fakePodGroupPlugin{
-				filterStatus: map[string]*fwk.Status{
-					"p1": fwk.NewStatus(fwk.Unschedulable),
-					"p2": fwk.NewStatus(fwk.Unschedulable),
-					"p3": nil,
-				},
-				postFilterStatus: map[string]*fwk.Status{
-					"p1": nil,
-					"p2": fwk.NewStatus(fwk.Unschedulable),
-				},
-				postFilterResult: map[string]*fwk.PostFilterResult{
-					"p1": {NominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride}},
-					"p2": {NominatingInfo: clearNominatedNode},
-				},
-			},
-			expectedGroupStatusCode:          fwk.Unschedulable,
-			expectedGroupWaitingOnPreemption: true,
-			expectedPodStatus: map[string]*fwk.Status{
-				"p1": fwk.NewStatus(fwk.Unschedulable),
-				"p2": fwk.NewStatus(fwk.Unschedulable),
-				"p3": nil,
-			},
-			expectedPreemption: map[string]bool{
-				"p1": true,
-				"p2": false,
-				"p3": false,
-			},
-			// preemption is not yet implemented for TAS
-			skipForTAS: true,
+			skipForTAS: false,
 		},
 		{
 			name: "All pods unschedulable",
@@ -1298,49 +1217,6 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 				// The algorithm didn't evaluate any pods whatsoever because the first call to PlacementFeasible Plugin returned Error.
 			},
 		},
-		{
-			name: "Any filter returned Error while waiting on preemption",
-			plugin: &fakePodGroupPlugin{
-				filterStatus: map[string]*fwk.Status{
-					"p1": fwk.NewStatus(fwk.Unschedulable),
-					"p2": fwk.NewStatus(fwk.Error),
-					"p3": nil,
-				},
-				postFilterResult: map[string]*fwk.PostFilterResult{
-					"p1": {NominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride}},
-				},
-			},
-			expectedGroupStatusCode: fwk.Error,
-			expectedPodStatus: map[string]*fwk.Status{
-				"p1": fwk.NewStatus(fwk.Unschedulable),
-				"p2": fwk.NewStatus(fwk.Error),
-				// The algorithm stopped evaluating the pods after an error occurred, so a "p3" status is not expected.
-			},
-		},
-		{
-			name: "Any placementFeasible returned Error while waiting on preemption",
-			plugin: &fakePodGroupPlugin{
-				filterStatus: map[string]*fwk.Status{
-					"p1": fwk.NewStatus(fwk.Unschedulable),
-					"p2": nil,
-					"p3": nil,
-				},
-				postFilterResult: map[string]*fwk.PostFilterResult{
-					"p1": {NominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride}},
-				},
-			},
-			podGroupFeasibleStatuses: []fwk.Code{
-				fwk.Wait,
-				fwk.Success,
-				fwk.Error,
-			},
-			expectedGroupStatusCode: fwk.Error,
-			expectedPodStatus: map[string]*fwk.Status{
-				"p1": fwk.NewStatus(fwk.Unschedulable),
-				"p2": nil,
-				// The algorithm stopped evaluating the pods after an error occurred, so a "p3" status is not expected.
-			},
-		},
 	}
 
 	for _, tasEnabled := range []bool{true, false} {
@@ -1409,14 +1285,11 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 					t.Fatalf("Failed to update snapshot: %v", err)
 				}
 
-				resultsMap := sched.runRootSchedulingAlgorithm(ctx, schedFwk, framework.NewCycleState(), podGroupInfo, runAllPostFilters)
+				resultsMap := sched.runRootSchedulingAlgorithm(ctx, schedFwk, framework.NewCycleState(), podGroupInfo)
 				result := resultsMap[pgKey(podGroupInfo.PodGroupInfo)]
 
 				if result.status.Code() != tt.expectedGroupStatusCode {
 					t.Errorf("Expected group status code: %v, got: %v", tt.expectedGroupStatusCode, result.status.Code())
-				}
-				if result.waitingOnPreemption != tt.expectedGroupWaitingOnPreemption {
-					t.Errorf("Expected group waiting on preemption: %v, got: %v", tt.expectedGroupWaitingOnPreemption, result.waitingOnPreemption)
 				}
 				if len(tt.expectedPodStatus) != len(result.podResults) {
 					t.Errorf("Expected %d pod results, got %d", len(tt.expectedPodStatus), len(result.podResults))
@@ -1430,18 +1303,13 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 					} else {
 						t.Errorf("Got result for unexpected pod %s: %v", podName, podResult.status.Code())
 					}
-					if podResult.status.IsSuccess() || podResult.requiresPreemption {
+					if podResult.status.IsSuccess() {
 						if podResult.scheduleResult.SuggestedHost != "node1" {
 							t.Errorf("Expected pod %s suggested host: node1, got: %v", podName, podResult.scheduleResult.SuggestedHost)
 						}
 					} else {
 						if podResult.scheduleResult.SuggestedHost != "" {
 							t.Errorf("Expected pod %s empty suggested host, got: %v", podName, podResult.scheduleResult.SuggestedHost)
-						}
-					}
-					if expected, ok := tt.expectedPreemption[podName]; ok {
-						if podResult.requiresPreemption != expected {
-							t.Errorf("Expected pod %s requiresPreemption: %v, got: %v", podName, expected, podResult.requiresPreemption)
 						}
 					}
 				}
@@ -1563,99 +1431,6 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			expectPodsInActiveQueue: sets.New("p2"),
 		},
 		{
-			name: "All pods require preemption",
-			algorithmResult: podGroupAlgorithmResult{
-				status:              fwk.NewStatus(fwk.Unschedulable, "waiting for preemption to complete"),
-				waitingOnPreemption: true,
-				podResults: []algorithmResult{{
-					scheduleResult: ScheduleResult{
-						SuggestedHost:  "node1",
-						nominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride},
-					},
-					status:             fwk.NewStatus(fwk.Unschedulable),
-					requiresPreemption: true,
-				}, {
-					scheduleResult: ScheduleResult{
-						SuggestedHost:  "node1",
-						nominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride},
-					},
-					status:             fwk.NewStatus(fwk.Unschedulable),
-					requiresPreemption: true,
-				}, {
-					scheduleResult: ScheduleResult{
-						SuggestedHost:  "node1",
-						nominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride},
-					},
-					status:             fwk.NewStatus(fwk.Unschedulable),
-					requiresPreemption: true,
-				}},
-			},
-			expectPreempting: map[string]string{"p1": "node1", "p2": "node1", "p3": "node1"},
-			expectCondition: &metav1.Condition{
-				Type:    schedulingapi.PodGroupInitiallyScheduled,
-				Status:  metav1.ConditionFalse,
-				Reason:  schedulingapi.PodGroupReasonUnschedulable,
-				Message: "waiting for preemption to complete",
-			},
-		},
-		{
-			name: "One pod requires preemption, two are feasible",
-			algorithmResult: podGroupAlgorithmResult{
-				status:              fwk.NewStatus(fwk.Unschedulable, "waiting for preemption to complete"),
-				waitingOnPreemption: true,
-				podResults: []algorithmResult{{
-					scheduleResult: ScheduleResult{
-						SuggestedHost:  "node1",
-						nominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride},
-					},
-					status:             fwk.NewStatus(fwk.Unschedulable),
-					requiresPreemption: true,
-				}, {
-					scheduleResult: ScheduleResult{SuggestedHost: "node1", nominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride}},
-					status:         nil,
-				}, {
-					scheduleResult: ScheduleResult{SuggestedHost: "node1", nominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride}},
-					status:         nil,
-				}},
-			},
-			expectPreempting: map[string]string{"p1": "node1", "p2": "node1", "p3": "node1"},
-			expectCondition: &metav1.Condition{
-				Type:    schedulingapi.PodGroupInitiallyScheduled,
-				Status:  metav1.ConditionFalse,
-				Reason:  schedulingapi.PodGroupReasonUnschedulable,
-				Message: "waiting for preemption to complete",
-			},
-		},
-		{
-			name: "One pod unschedulable, one requires preemption, one feasible",
-			algorithmResult: podGroupAlgorithmResult{
-				status:              fwk.NewStatus(fwk.Unschedulable, "waiting for preemption to complete"),
-				waitingOnPreemption: true,
-				podResults: []algorithmResult{{
-					scheduleResult: ScheduleResult{
-						SuggestedHost:  "node1",
-						nominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride},
-					},
-					status:             fwk.NewStatus(fwk.Unschedulable),
-					requiresPreemption: true,
-				}, {
-					scheduleResult: ScheduleResult{SuggestedHost: "", nominatingInfo: clearNominatedNode},
-					status:         fwk.NewStatus(fwk.Unschedulable),
-				}, {
-					scheduleResult: ScheduleResult{SuggestedHost: "node1", nominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride}},
-					status:         nil,
-				}},
-			},
-			expectPreempting: map[string]string{"p1": "node1", "p3": "node1"},
-			expectFailed:     sets.New("p2"),
-			expectCondition: &metav1.Condition{
-				Type:    schedulingapi.PodGroupInitiallyScheduled,
-				Status:  metav1.ConditionFalse,
-				Reason:  schedulingapi.PodGroupReasonUnschedulable,
-				Message: "waiting for preemption to complete",
-			},
-		},
-		{
 			name: "All pods unschedulable",
 			algorithmResult: podGroupAlgorithmResult{
 				status: fwk.NewStatus(fwk.Unschedulable, "0/3 nodes are available: insufficient cpu"),
@@ -1745,33 +1520,6 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 				Status:  metav1.ConditionFalse,
 				Reason:  schedulingapi.PodGroupReasonSchedulerError,
 				Message: "plugin returned error",
-			},
-		},
-		{
-			name: "Error for one pod while waiting on preemption",
-			algorithmResult: podGroupAlgorithmResult{
-				status: fwk.NewStatus(fwk.Error, "internal failure"),
-				podResults: []algorithmResult{{
-					scheduleResult: ScheduleResult{
-						SuggestedHost:  "node1",
-						nominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride},
-					},
-					status:             fwk.NewStatus(fwk.Unschedulable),
-					requiresPreemption: true,
-				}, {
-					scheduleResult: ScheduleResult{SuggestedHost: "", nominatingInfo: clearNominatedNode},
-					status:         fwk.NewStatus(fwk.Error, "internal failure"),
-				}, {
-					scheduleResult: ScheduleResult{SuggestedHost: "", nominatingInfo: clearNominatedNode},
-					status:         fwk.NewStatus(fwk.Error, "internal failure"),
-				}},
-			},
-			expectFailed: sets.New("p1", "p2", "p3"),
-			expectCondition: &metav1.Condition{
-				Type:    schedulingapi.PodGroupInitiallyScheduled,
-				Status:  metav1.ConditionFalse,
-				Reason:  schedulingapi.PodGroupReasonSchedulerError,
-				Message: "internal failure",
 			},
 		},
 		{
@@ -2026,7 +1774,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 				pod := podGroupInfo.UnscheduledPods[i]
 				placementCycleState := framework.NewCycleState()
 				placementCycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
-				podCtx := initPodSchedulingContext(ctx, pod, placementCycleState, runAllPostFilters)
+				podCtx := initPodSchedulingContext(ctx, pod, placementCycleState)
 				tt.algorithmResult.podResults[i].podCtx = podCtx
 			}
 
@@ -2610,7 +2358,6 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 						scheduleResult: ScheduleResult{
 							EvaluatedNodes: 0,
 							FeasibleNodes:  0,
-							nominatingInfo: &fwk.NominatingInfo{NominatingMode: fwk.ModeOverride},
 						},
 						status: fwk.NewStatus(fwk.Unschedulable, "0/1 nodes are available:"),
 					},
@@ -2813,7 +2560,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 				},
 			}
 
-			resultsMap := sched.runRootSchedulingAlgorithm(ctx, schedFwk, framework.NewCycleState(), pgInfo, runAllPostFilters)
+			resultsMap := sched.runRootSchedulingAlgorithm(ctx, schedFwk, framework.NewCycleState(), pgInfo)
 			result := resultsMap[pgKey(pgInfo.PodGroupInfo)]
 
 			if result.podGroupInfo != pgInfo.PodGroupInfo {
@@ -2995,7 +2742,7 @@ func TestPodGroupSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 				},
 			}
 
-			result := sched.podGroupSchedulingPlacementAlgorithm(ctx, schedFwk, framework.NewCycleState(), pgInfo.PodGroupInfo, pgInfo, runAllPostFilters)
+			result := sched.podGroupSchedulingPlacementAlgorithm(ctx, schedFwk, framework.NewCycleState(), pgInfo.PodGroupInfo, pgInfo)
 
 			expectedHost := placements[tt.expectedPlacement][0]
 			actualHost := result.podResults[0].scheduleResult.SuggestedHost
@@ -3172,7 +2919,7 @@ func TestPlacementCycleStateLifecycle(t *testing.T) {
 		},
 	}
 
-	result := sched.podGroupSchedulingPlacementAlgorithm(ctx, schedFwk, framework.NewCycleState(), pgInfo.PodGroupInfo, pgInfo, runAllPostFilters)
+	result := sched.podGroupSchedulingPlacementAlgorithm(ctx, schedFwk, framework.NewCycleState(), pgInfo.PodGroupInfo, pgInfo)
 	if !result.status.IsSuccess() {
 		t.Fatalf("Expected success, got: %v", result.status)
 	}
@@ -3658,7 +3405,7 @@ func TestCPGHierarchicalScheduling_ScheduleOnePodGroup(t *testing.T) {
 
 	// Run podGroupSchedulingRecursiveAlgorithm
 	res := map[fwk.EntityKey]*podGroupAlgorithmResult{}
-	result, _ := sched.podGroupSchedulingRecursiveAlgorithm(ctx, schedFwk, framework.NewCycleState(), cpgRootInfo, cpgRootInfo.PodGroupInfo, runAllPostFilters, res)
+	result, _ := sched.podGroupSchedulingRecursiveAlgorithm(ctx, schedFwk, framework.NewCycleState(), cpgRootInfo, cpgRootInfo.PodGroupInfo, res)
 
 	status := result.status
 	if status.Code() != fwk.Success {

--- a/pkg/scheduler/testing/framework/framework_helpers.go
+++ b/pkg/scheduler/testing/framework/framework_helpers.go
@@ -68,6 +68,11 @@ func RegisterPostFilterPlugin(pluginName string, pluginNewFunc runtime.PluginFac
 	return RegisterPluginAsExtensions(pluginName, pluginNewFunc, "PostFilter")
 }
 
+// RegisterPodGroupPostFilterPlugin returns a function to register a PodGroupPostFilter Plugin to a given registry.
+func RegisterPodGroupPostFilterPlugin(pluginName string, pluginNewFunc runtime.PluginFactory) RegisterPluginFunc {
+	return RegisterPluginAsExtensions(pluginName, pluginNewFunc, "PodGroupPostFilter")
+}
+
 // RegisterReservePlugin returns a function to register a Reserve Plugin to a given registry.
 func RegisterReservePlugin(pluginName string, pluginNewFunc runtime.PluginFactory) RegisterPluginFunc {
 	return RegisterPluginAsExtensions(pluginName, pluginNewFunc, "Reserve")

--- a/test/integration/scheduler/podgroup/podgroup_test.go
+++ b/test/integration/scheduler/podgroup/podgroup_test.go
@@ -821,7 +821,7 @@ func (m *mockPostFilterPlugin) getCount() int {
 	return m.count
 }
 
-func TestPostFilterInvocationCount(t *testing.T) {
+func TestPostFilterNotCalled(t *testing.T) {
 	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
 		features.GenericWorkload: true,
 	})
@@ -917,18 +917,17 @@ func TestPostFilterInvocationCount(t *testing.T) {
 		}
 	}
 
-	// 5. Verify that MockPostFilter was called exactly once
-	// It should be called for each evaluated pod from pod group in pod group cycle
-	// but should not be called in WAP.
-	// Only one pod is evaluated for pod group because minCount=3 can't be satisfied with the remaining 2 pods.
-	err = wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 10*time.Second, false, func(ctx context.Context) (bool, error) {
-		if mockPlugin.getCount() == 1 {
-			return true, nil
+	// 5. Wait for high priority pod to be marked as unschedulable
+	for _, p := range highPods {
+		err = wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
+			testutils.PodUnschedulable(cs, ns, p.Name))
+		if err != nil {
+			t.Fatalf("failed to wait for pod %s to be unschedulable: %v", p.Name, err)
 		}
-		return false, nil
-	})
-	if err != nil {
-		t.Errorf("MockPostFilter was called %d times, expected exactly 3", mockPlugin.getCount())
+	}
+
+	if mockPlugin.getCount() != 0 {
+		t.Fatalf("MockPostFilter was called %d times, expected 0", mockPlugin.getCount())
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR disables all PostFilters from the pod group cycle. This is a follow up to https://github.com/kubernetes/kubernetes/pull/139674 which introduced a PodGroupPostFilter. We expect all PostFilter owners to adapt their plugins to PodGroupPostFilter if they wish to work with pod group cycle. This behavior is in line with the WAP KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/5710-workload-aware-preemption

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/enhancements/issues/5710

#### Special notes for your reviewer:

A DRA PodGroupPostFilter will be implemented in a separate PR in this release cycle.

#### Does this PR introduce a user-facing change?

```release-note
PostFilter plugins are no longer run during PodGroup cycle for pods from PodGroup. Instead the PodGroupPostFilter is run if the whole PodGroup is unschedulable.  
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/5710-workload-aware-preemption

