### PR TITLE
Add TAS gang preemption performance scenarios

### DIFF
--- a/test/integration/scheduler_perf/workload_preemption/performance-config.yaml
+++ b/test/integration/scheduler_perf/workload_preemption/performance-config.yaml
@@ -237,3 +237,69 @@
       initPods: 1000
       preemptorPodGroups: 10
       podsPerGroup: 10
+
+# GangPreemptionTopology benchmarks the performance of gang preemption
+# in the presence of topology-aware scheduling (TAS) constraints.
+#
+# The scenario flow is:
+# 1. Create a set of nodes distributed across multiple zones (topology.kubernetes.io/zone).
+# 2. Fill the cluster with low-priority pods.
+# 3. Submit high-priority PodGroups (gangs) with topology constraints to co-locate in the same zone.
+# 4. This forces the scheduler to choose a single zone and preempt low-priority pods in that zone
+#    to fit the entire gang.
+- name: GangPreemptionTopology
+  featureGates:
+    GenericWorkload: true
+    TopologyAwareWorkloadScheduling: true
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $initNodes
+    nodeTemplatePath: ../templates/node-default.yaml
+    labelNodePrepareStrategy:
+      labelKey: "topology.kubernetes.io/zone"
+      labelValues: ["zone-1", "zone-2", "zone-3"]
+  - opcode: createNamespaces
+    prefix: gang-preempt
+    count: 2
+  - opcode: createPods
+    countParam: $initPods
+    podTemplatePath: templates/pod-low-priority.yaml
+    namespace: gang-preempt-1
+    templateParams:
+      nodesCount: $initNodes
+      podsCount: $initPods
+  - opcode: createPodGroups
+    countParam: $preemptorPodGroups
+    namespace: gang-preempt-0
+    templatePath: templates/podgroup-tas.yaml
+    templateParams:
+      podsPerGroup: $podsPerGroup
+      priority: 9999999
+  - opcode: createPods
+    collectMetrics: true
+    countParam: $preemptorPodGroups
+    countMultiplierParam: $podsPerGroup
+    namespace: gang-preempt-0
+    podTemplatePath: templates/gang-pod.yaml
+    templateParams:
+      podsPerGroup: $podsPerGroup
+      cpuRequest: $gangCpuRequest
+      priority: 9999999
+  workloads:
+  - name: 3Nodes_1PreemptorGang_3Pods_Evicting_12InitPods
+    labels: [short, integration-test]
+    params:
+      initNodes: 3
+      initPods: 12
+      preemptorPodGroups: 1
+      podsPerGroup: 3
+      gangCpuRequest: 3900m
+  - name: 100Nodes_6PreemptorGangs_16Pods_Evicting_1000InitPods
+    labels: [performance]
+    params:
+      initNodes: 100
+      initPods: 1000
+      preemptorPodGroups: 6
+      podsPerGroup: 16
+      gangCpuRequest: 3970m
+

--- a/test/integration/scheduler_perf/workload_preemption/performance-config.yaml
+++ b/test/integration/scheduler_perf/workload_preemption/performance-config.yaml
@@ -303,3 +303,70 @@
     featureGates:
       TopologyAwareWorkloadScheduling: true
       CompositePodGroup: true
+
+# GangPreemptionTopology benchmarks the performance of gang preemption
+# in the presence of topology-aware scheduling (TAS) constraints.
+#
+# The scenario flow is:
+# 1. Create a set of nodes distributed across multiple zones (topology.kubernetes.io/zone).
+# 2. Fill the cluster with low-priority pods.
+# 3. Submit high-priority PodGroups (gangs) with topology constraints to co-locate in the same zone.
+# 4. This forces the scheduler to choose a single zone and preempt low-priority pods in that zone
+#    to fit the entire gang.
+- name: GangPreemptionTopology
+  featureGates:
+    GenericWorkload: true
+    TopologyAwareWorkloadScheduling: true
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $initNodes
+    nodeTemplatePath: ../templates/node-default.yaml
+    labelNodePrepareStrategy:
+      labelKey: "topology.kubernetes.io/zone"
+      labelValues: ["zone-1", "zone-2", "zone-3"]
+  - opcode: createNamespaces
+    prefix: gang-preempt
+    count: 2
+  - opcode: createPods
+    countParam: $initPods
+    podTemplatePath: templates/pod-low-priority.yaml
+    namespace: gang-preempt-1
+    templateParams:
+      nodesCount: $initNodes
+      podsCount: $initPods
+  - opcode: createPodGroups
+    countParam: $preemptorPodGroups
+    namespace: gang-preempt-0
+    templatePath: templates/podgroup-tas.yaml
+    templateParams:
+      podsPerGroup: $podsPerGroup
+      priority: 9999999
+  - opcode: createPods
+    collectMetrics: true
+    countParam: $preemptorPodGroups
+    countMultiplierParam: $podsPerGroup
+    namespace: gang-preempt-0
+    podTemplatePath: templates/gang-pod.yaml
+    templateParams:
+      podsPerGroup: $podsPerGroup
+      cpuRequest: $gangCpuRequest
+      priority: 9999999
+  workloads:
+  - name: 9Nodes_1PreemptorGang_3Pods_Evicting_12InitPods
+    labels: [short, integration-test]
+    params:
+      initNodes: 9
+      initPods: 36
+      preemptorPodGroups: 1
+      podsPerGroup: 3
+      gangCpuRequest: 3900m
+  - name: 100Nodes_6PreemptorGangs_16Pods_Evicting_1000InitPods
+    labels: [performance]
+    params:
+      initNodes: 100
+      initPods: 1000
+      preemptorPodGroups: 6
+      podsPerGroup: 16
+      gangCpuRequest: 3970m
+
+

--- a/test/integration/scheduler_perf/workload_preemption/templates/podgroup-tas.yaml
+++ b/test/integration/scheduler_perf/workload_preemption/templates/podgroup-tas.yaml
@@ -1,0 +1,12 @@
+apiVersion: scheduling.k8s.io/v1alpha3
+kind: PodGroup
+metadata:
+  name: gang-{{.Index}}
+spec:
+  priority: {{if .priority}}{{AddInt 0 .priority}}{{else}}8888888{{end}}
+  schedulingPolicy:
+    gang:
+      minCount: {{.podsPerGroup}}
+  schedulingConstraints:
+    topology:
+    - key: topology.kubernetes.io/zone


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR introduces a new scheduler performance benchmark scenario, `GangPreemptionTopology`, to evaluate the performance of gang scheduling preemption when the preemptor pods are subject to Topology Aware Scheduling (TAS) constraints.

The scenario evaluates:
1. Clusters with nodes distributed across multiple zones (`topology.kubernetes.io/zone`).
2. High-priority PodGroups (gangs) that use topology constraints to force co-location in the same zone.
3. The scheduler's ability to choose a single zone and preempt low-priority pods within that zone to satisfy the gang's CPU requirements.

**Note: This PR is currently a DRAFT.**
At present, gang preemption (WorkloadAwarePreemption) does not fully support or interact correctly with Topology Aware Scheduling (TAS) constraints. We are opening this PR as a draft/WIP to track the scenarios and provide a testing baseline once TAS support for gang preemption is implemented upstream.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
This is a draft. The benchmark test requires the `TopologyAwareWorkloadScheduling` feature gate to be enabled and will currently fail to successfully preempt and schedule the PodGroups due to missing TAS preemption support in the scheduler.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
