### PR TITLE
Retry services repair initial sync with backoff instead of waiting a full interval

### DIFF
--- a/pkg/registry/core/service/ipallocator/controller/repair.go
+++ b/pkg/registry/core/service/ipallocator/controller/repair.go
@@ -122,6 +122,30 @@ func (c *Repair) RunUntil(onFirstSuccess func(), stopCh chan struct{}) {
 	defer c.broadcaster.Shutdown()
 
 	var once sync.Once
+	// Retry the initial sync quickly with exponential backoff (rather than
+	// waiting a full repair interval between attempts) until it succeeds once.
+	// On servers with a large keyspace the very first attempts can race
+	// storage cache initialization and transiently fail (e.g. with 429s while
+	// the watch cache warms up), and the "start-service-ip-repair-controllers"
+	// post-start hook that waits for the first success fails the whole server
+	// after a hard-coded one minute. Once the initial sync has succeeded, the
+	// regular repair interval takes over.
+	ctx := wait.ContextForChannel(stopCh)
+	_ = wait.ExponentialBackoffWithContext(ctx, wait.Backoff{
+		Duration: time.Second,
+		Factor:   2.0,
+		Jitter:   0.1,
+		Steps:    10,
+		Cap:      c.interval,
+	}, func(_ context.Context) (bool, error) {
+		if err := c.runOnce(); err != nil {
+			runtime.HandleError(err)
+			return false, nil
+		}
+		once.Do(onFirstSuccess)
+		return true, nil
+	})
+
 	wait.Until(func() {
 		if err := c.runOnce(); err != nil {
 			runtime.HandleError(err)

--- a/pkg/registry/core/service/ipallocator/controller/repairip.go
+++ b/pkg/registry/core/service/ipallocator/controller/repairip.go
@@ -231,7 +231,25 @@ func (r *RepairIPAddress) RunUntil(onFirstSuccess func(), stopCh chan struct{}) 
 	// First sync goes through all the Services and IPAddresses in the cache,
 	// once synced, it signals the main loop and works using the handlers, since
 	// it's less expensive and more optimal.
-	if err := r.runOnce(); err != nil {
+	// Retry the initial sync with exponential backoff instead of giving up:
+	// on servers with a large keyspace the first attempts can race storage
+	// cache initialization and transiently fail, and bailing out here starves
+	// the "start-service-ip-repair-controllers" post-start hook, which fails
+	// the whole server after a hard-coded one minute.
+	err = wait.ExponentialBackoffWithContext(ctx, wait.Backoff{
+		Duration: time.Second,
+		Factor:   2.0,
+		Jitter:   0.1,
+		Steps:    10,
+		Cap:      time.Minute,
+	}, func(_ context.Context) (bool, error) {
+		if err := r.runOnce(); err != nil {
+			runtime.HandleError(err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
 		runtime.HandleError(err)
 		return
 	}

--- a/pkg/registry/core/service/portallocator/controller/repair.go
+++ b/pkg/registry/core/service/portallocator/controller/repair.go
@@ -80,6 +80,30 @@ func (c *Repair) RunUntil(onFirstSuccess func(), stopCh chan struct{}) {
 	defer c.broadcaster.Shutdown()
 
 	var once sync.Once
+	// Retry the initial sync quickly with exponential backoff (rather than
+	// waiting a full repair interval between attempts) until it succeeds once.
+	// On servers with a large keyspace the very first attempts can race
+	// storage cache initialization and transiently fail (e.g. with 429s while
+	// the watch cache warms up), and the "start-service-ip-repair-controllers"
+	// post-start hook that waits for the first success fails the whole server
+	// after a hard-coded one minute. Once the initial sync has succeeded, the
+	// regular repair interval takes over.
+	ctx := wait.ContextForChannel(stopCh)
+	_ = wait.ExponentialBackoffWithContext(ctx, wait.Backoff{
+		Duration: time.Second,
+		Factor:   2.0,
+		Jitter:   0.1,
+		Steps:    10,
+		Cap:      c.interval,
+	}, func(_ context.Context) (bool, error) {
+		if err := c.runOnce(); err != nil {
+			runtime.HandleError(err)
+			return false, nil
+		}
+		once.Do(onFirstSuccess)
+		return true, nil
+	})
+
 	wait.Until(func() {
 		if err := c.runOnce(); err != nil {
 			runtime.HandleError(err)

--- a/pkg/registry/core/service/portallocator/controller/repair_test.go
+++ b/pkg/registry/core/service/portallocator/controller/repair_test.go
@@ -17,11 +17,17 @@ limitations under the License.
 package controller
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -384,5 +390,44 @@ func expectMetrics(t *testing.T, em testMetrics) {
 	}
 	if m != em {
 		t.Fatalf("metrics error: expected %v, received %v", em, m)
+	}
+}
+
+// TestRunUntilRetriesInitialSyncQuickly verifies that RunUntil retries a
+// failing initial sync with backoff instead of waiting a full repair interval:
+// the start-service-ip-repair-controllers post-start hook waits for the first
+// success under a hard one-minute deadline, and on servers with a large
+// keyspace the first attempts can transiently fail while storage caches warm
+// up. A three-minute first retry would fail the whole server.
+func TestRunUntilRetriesInitialSyncQuickly(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
+	// Fail the first two service LISTs (as the warming-up apiserver would,
+	// e.g. with 429s), then succeed.
+	var calls atomic.Int32
+	fakeClient.PrependReactor("list", "services", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if calls.Add(1) <= 2 {
+			return true, nil, errors.New("storage is (re)initializing")
+		}
+		return false, nil, nil
+	})
+	pr, _ := net.ParsePortRange("100-200")
+	r := NewRepair(10*time.Minute, fakeClient.CoreV1(), fakeClient.EventsV1(), *pr, &mockRangeRegistry{
+		item: &api.RangeAllocation{Range: pr.String()},
+	})
+
+	firstSuccess := make(chan struct{})
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go r.RunUntil(func() { close(firstSuccess) }, stopCh)
+
+	select {
+	case <-firstSuccess:
+		// Initial sync succeeded after quick retries — well under the
+		// one-minute post-start-hook deadline despite a 10m repair interval.
+	case <-time.After(30 * time.Second):
+		t.Fatalf("initial sync did not succeed within 30s (calls=%d); first-attempt failures must be retried with backoff, not after the full repair interval", calls.Load())
+	}
+	if calls.Load() < 3 {
+		t.Fatalf("expected at least 3 list attempts, got %d", calls.Load())
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig network

**What this PR does / why we need it:**

The ClusterIP/NodePort repair loops treat the FIRST successful sync specially: the apiserver's post-start hook blocks readiness on it. But when that first runOnce fails transiently (storage not yet warm right after startup, a network blip, etc.):

- `repair.go` (ClusterIP/NodePort): RunUntil waits a full `interval` (3 minutes) before the next attempt, while the post-start hook only waits 1 minute — so one transient failure at startup guarantees the hook deadline is exceeded and the apiserver exits, even though a retry two seconds later would have succeeded.

- `repairip.go` (MultiCIDRServiceAllocator): worse — a first-sync failure returns from the goroutine permanently; the repair loop never runs again for the lifetime of the process.

This PR retries the initial sync with exponential backoff (1s, 2s, 4s, ... capped at the repair interval) until it succeeds, in both implementations, and fixes the permanent-give-up path in repairip.go.

**Which issue(s) this PR fixes:**

None filed; found while operating clusters where the first List after apiserver restart can transiently fail.

**Special notes for your reviewer:**

The regression test makes the first two Service Lists fail via a reactor and asserts the first successful sync completes within seconds instead of a full interval (it previously took 3 minutes).

**Does this PR introduce a user-facing change?**

```release-note
The ClusterIP/NodePort repair controllers now retry a failed initial sync with exponential backoff instead of waiting a full repair interval, and the MultiCIDRServiceAllocator repair loop no longer permanently stops after a failed initial sync.
```
