### PR TITLE
Scale the Services repair loops for very large Service counts

### DIFF
--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -119,8 +119,13 @@ const (
 	//   2. which component owns this lease
 	// TODO(sttts): remove this indirection
 	IdentityLeaseComponentLabelKey = controlplaneapiserver.IdentityLeaseComponentLabelKey
-	// repairLoopInterval defines the interval used to run the Services ClusterIP and NodePort repair loops
-	repairLoopInterval = 3 * time.Minute
+	// repairLoopInterval defines the interval used to run the Services ClusterIP and NodePort repair loops.
+	// Each run lists every Service from quorum storage; at very large Service
+	// counts (10^6+) a 3-minute cadence keeps a full-keyspace scan almost
+	// permanently in flight against the storage backend, crowding out write
+	// traffic. Repairs are a safety net for leaked allocations, not a
+	// correctness-critical loop — a longer cadence is safe.
+	repairLoopInterval = 30 * time.Minute
 )
 
 var (

--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -530,6 +530,12 @@ func (p *legacyProvider) PostStartHook() (string, genericapiserver.PostStartHook
 		// For backward compatibility, we ensure that if we never are able
 		// to repair clusterIPs and/or nodeports, we not only fail the liveness
 		// and/or readiness, but also explicitly fail.
+		//
+		// The deadline scales with the number of Services the initial repair
+		// sync must read: with a very large Service count the first sync
+		// (bounded by storage cache initialization, which must decode every
+		// Service) can legitimately take several minutes, and a fixed
+		// one-minute deadline made such servers crash-loop on every start.
 		done := make(chan struct{})
 		go func() {
 			defer close(done)
@@ -541,7 +547,7 @@ func (p *legacyProvider) PostStartHook() (string, genericapiserver.PostStartHook
 		case <-context.Done():
 			return goerrors.New("unable to perform initial IP and Port allocation check (context cancelled)")
 
-		case <-time.After(time.Minute):
+		case <-time.After(15 * time.Minute):
 			return goerrors.New("unable to perform initial IP and Port allocation check (timeout)")
 		}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/sig network
/sig scalability

**What this PR does / why we need it:**

The Services repair loops have two hard-coded timings that break down at very large Service counts, where a single runOnce pass — a full quorum List of every Service — takes minutes:

1. The post-start hooks wait at most 1 minute for the first successful pass and kill the apiserver otherwise. With ~1.16M Services the first pass alone exceeds the deadline, so the apiserver crash-loops on every restart and can never come up. This PR raises the deadline to 15 minutes; the hook still fails fast when the repair errors out — this only extends how long a *running* first pass may take.

2. The repair cadence is 3 minutes. Each pass Lists every Service from quorum storage, so at millions of Services a full-keyspace scan is almost permanently in flight against the storage backend, measurably crowding out write traffic (in our measurements repair scans were half of all storage scan load on a 33M-key cluster). The repair loops are a safety net for leaked allocations, not a correctness-critical path; this PR stretches the cadence to 30 minutes.

Both values were validated on a 33M-key cluster (1.16M Services, 100k Nodes, 8.8M Pods, etcd-compatible storage backend).

**Special notes for your reviewer:**

If changing the defaults is undesirable, I am happy to rework either value into a configuration knob (e.g. wired through `Extra.RepairServicesInterval`, which already exists on the config struct) — guidance welcome on the preferred shape.

Related: #140414 fixes the transient-failure behavior of the same loops' initial sync.

**Does this PR introduce a user-facing change?**

```release-note
The Services repair loops now allow up to 15 minutes for their first pass at apiserver startup (was 1 minute) and run every 30 minutes (was 3 minutes), accommodating clusters with very large Service counts.
```
