### PR TITLE
kubelet: add failure threshold info to probe failure events

### DIFF
--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -79,8 +79,20 @@ func (pb *prober) recordContainerEvent(ctx context.Context, pod *v1.Pod, contain
 	pb.recorder.WithLogger(logger).Eventf(ref, eventType, reason, message, args...)
 }
 
+// probeContext holds the threshold and running history of probe results for formatting events.
+type probeContext struct {
+	ResultRun        int
+	LastResult       results.Result
+	FailureThreshold int32
+	SuccessThreshold int32
+}
+
 // probe probes the container.
 func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (results.Result, error) {
+	return pb.probeWithContext(ctx, probeType, pod, status, container, containerID, nil)
+}
+
+func (pb *prober) probeWithContext(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, probeCtx *probeContext) (results.Result, error) {
 	var probeSpec *v1.Probe
 	switch probeType {
 	case readiness:
@@ -120,7 +132,21 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 
 	case probe.Failure:
 		logger.V(1).Info("Probe failed", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result, "output", output)
-		pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe failed: %s", probeType, output)
+		if probeCtx != nil && probeCtx.FailureThreshold > 0 {
+			var failureCount int
+			if probeCtx.LastResult == results.Failure {
+				failureCount = probeCtx.ResultRun + 1
+			} else {
+				failureCount = 1
+			}
+			if failureCount < int(probeCtx.FailureThreshold) {
+				pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe failed (%d/%d, will be ignored): %s", probeType, failureCount, probeCtx.FailureThreshold, output)
+			} else {
+				pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe failed (%d/%d): %s", probeType, failureCount, probeCtx.FailureThreshold, output)
+			}
+		} else {
+			pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe failed: %s", probeType, output)
+		}
 		return results.Failure, nil
 
 	case probe.Unknown:

--- a/pkg/kubelet/prober/prober_test.go
+++ b/pkg/kubelet/prober/prober_test.go
@@ -438,3 +438,155 @@ func TestRecordContainerEventUnknownStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestProbeFailureWithThresholdContext(t *testing.T) {
+	err := v1.AddToScheme(legacyscheme.Scheme)
+	require.NoError(t, err, "failed to add v1 to scheme")
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: "test-probe-pod",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "test-probe-container",
+					LivenessProbe: &v1.Probe{
+						ProbeHandler: v1.ProbeHandler{
+							Exec: &v1.ExecAction{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	containerID := kubecontainer.ContainerID{Type: "test", ID: "foobar"}
+
+	testCases := []struct {
+		name             string
+		resultRun        int
+		lastResult       results.Result
+		failureThreshold int32
+		expectedMessage  string
+	}{
+		{
+			name:             "First failure of 3 threshold - should be ignored",
+			resultRun:        0,               // no previous run count (new sequence)
+			lastResult:       results.Success, // was succeeding before
+			failureThreshold: 3,
+			expectedMessage:  "Warning Unhealthy Liveness probe failed (1/3, will be ignored)",
+		},
+		{
+			name:             "Second failure of 3 threshold - should be ignored",
+			resultRun:        1, // 1 previous failure
+			lastResult:       results.Failure,
+			failureThreshold: 3,
+			expectedMessage:  "Warning Unhealthy Liveness probe failed (2/3, will be ignored)",
+		},
+		{
+			name:             "Third failure of 3 threshold - should NOT be ignored",
+			resultRun:        2, // 2 previous failures
+			lastResult:       results.Failure,
+			failureThreshold: 3,
+			expectedMessage:  "Warning Unhealthy Liveness probe failed (3/3)",
+		},
+		{
+			name:             "Fourth failure of 3 threshold - should NOT be ignored",
+			resultRun:        3, // 3 previous failures
+			lastResult:       results.Failure,
+			failureThreshold: 3,
+			expectedMessage:  "Warning Unhealthy Liveness probe failed (4/3)",
+		},
+		{
+			name:             "First failure of 1 threshold - should NOT be ignored",
+			resultRun:        0,
+			lastResult:       results.Success,
+			failureThreshold: 1,
+			expectedMessage:  "Warning Unhealthy Liveness probe failed (1/1)",
+		},
+		{
+			name:             "First failure after many successes - should be ignored",
+			resultRun:        10, // 10 previous successes
+			lastResult:       results.Success,
+			failureThreshold: 3,
+			expectedMessage:  "Warning Unhealthy Liveness probe failed (1/3, will be ignored)",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+			fakeRecorder := record.NewFakeRecorder(10)
+
+			pb := &prober{
+				recorder: fakeRecorder,
+				exec:     fakeExecProber{probe.Failure, nil},
+			}
+
+			probeCtx := &probeContext{
+				ResultRun:        tc.resultRun,
+				LastResult:       tc.lastResult,
+				FailureThreshold: tc.failureThreshold,
+				SuccessThreshold: 1,
+			}
+
+			result, err := pb.probeWithContext(tCtx, liveness, pod, v1.PodStatus{}, pod.Spec.Containers[0], containerID, probeCtx)
+			require.NoError(t, err)
+			assert.Equal(t, results.Failure, result)
+
+			select {
+			case event := <-fakeRecorder.Events:
+				assert.Contains(t, event, tc.expectedMessage, "unexpected event message")
+			default:
+				t.Error("expected an event to be recorded")
+			}
+		})
+	}
+}
+
+func TestProbeFailureWithoutContext(t *testing.T) {
+	err := v1.AddToScheme(legacyscheme.Scheme)
+	require.NoError(t, err, "failed to add v1 to scheme")
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: "test-probe-pod",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "test-probe-container",
+					LivenessProbe: &v1.Probe{
+						ProbeHandler: v1.ProbeHandler{
+							Exec: &v1.ExecAction{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	containerID := kubecontainer.ContainerID{Type: "test", ID: "foobar"}
+
+	tCtx := ktesting.Init(t)
+	fakeRecorder := record.NewFakeRecorder(10)
+
+	pb := &prober{
+		recorder: fakeRecorder,
+		exec:     fakeExecProber{probe.Failure, nil},
+	}
+
+	// Call probe without context (backward compatibility)
+	result, err := pb.probe(tCtx, liveness, pod, v1.PodStatus{}, pod.Spec.Containers[0], containerID)
+	require.NoError(t, err)
+	assert.Equal(t, results.Failure, result)
+
+	select {
+	case event := <-fakeRecorder.Events:
+		// Should use the original message format without threshold info
+		assert.Contains(t, event, "Warning Unhealthy Liveness probe failed", "unexpected event message")
+	default:
+		t.Error("expected an event to be recorded")
+	}
+}

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -253,6 +253,8 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 		}
 
 		w.containerID = kubecontainer.ParseContainerID(logger, c.ContainerID)
+		w.lastResult = results.Unknown
+		w.resultRun = 0
 
 		if !utilfeature.DefaultFeatureGate.Enabled(features.ChangeContainerStatusOnKubeletRestart) {
 			// On kubelet restart, we don't want to immediately set the probe result to Failure,
@@ -346,7 +348,13 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 	}
 
 	// Note, exec probe does NOT have access to pod environment variables or downward API
-	result, err := w.probeManager.prober.probe(ctx, w.probeType, w.pod, status, w.container, w.containerID)
+	probeCtx := &probeContext{
+		ResultRun:        w.resultRun,
+		LastResult:       w.lastResult,
+		FailureThreshold: w.spec.FailureThreshold,
+		SuccessThreshold: w.spec.SuccessThreshold,
+	}
+	result, err := w.probeManager.prober.probeWithContext(ctx, w.probeType, w.pod, status, w.container, w.containerID, probeCtx)
 	if err != nil {
 		// Prober error, throw away the result.
 		return true


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

When a container probe (liveness, readiness, or startup) fails, Kubernetes emits a warning event. However, this event was recorded with the same format regardless of whether the failure reached the configured `FailureThreshold` (restarting the container) or was ignored. This could cause confusion for users who see failure events and assume a container has restarted when nothing occurred.

This PR addresses the issue by enhancing the probe failure event messages with threshold context:
- Below threshold: `Liveness probe failed (1/3, will be ignored): ...`
- At/above threshold: `Liveness probe failed (3/3): ...`

This provides clear visibility into whether the control plane is actively acting on a failure or if it is ignoring it.

#### Which issue(s) this PR is related to:

Fixes #115823

#### Special notes for your reviewer:

- **Backward compatibility**: The original `probe(...)` method signature has been preserved and delegates to a new `probeWithContext(...)` method to avoid breaking external or out-of-tree plugins.
- **Unit Tests**: Added `TestProbeFailureWithThresholdContext` and `TestProbeFailureWithoutContext` to verify the new formatting and backward compatibility.
- **Robust assertions**: Tests use substring checks (`assert.Contains`) rather than exact matching to prevent fragile failures caused by trailing spaces or minor whitespace changes.

#### Does this PR introduce a user-facing change?

Yes.

```release-note
Added failure count and threshold information to probe failure events (e.g., "Liveness probe failed (1/3, will be ignored)") to clarify whether a probe failure will trigger control plane action or is currently ignored due to FailureThreshold.
```