### PR TITLE
Disable SchemalessTypeRef for MutatingAdmissionPolicies

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/conversion.go
@@ -104,27 +104,14 @@ func NewVersionedAttributes(attr Attributes, gvk schema.GroupVersionKind, o Obje
 	return versionedAttr, nil
 }
 
-// celValueOptions holds options for CELValue conversion.
-type celValueOptions struct {
-	// UseSchemalessTypeRef indicates whether to use SchemalessTypedToVal (reflection-based lazy ref.Val)
-	// instead of converting to an unstructured representation with DefaultTypeAdapter.
-	UseSchemalessTypeRef bool
-}
-
-// CELValueOption defines a functional option for CELValue.
-type CELValueOption func(*celValueOptions)
-
-// UseSchemalessTypeRef returns a CELValueOption that configures CELValue to use SchemalessTypedToVal.
-func UseSchemalessTypeRef() CELValueOption {
-	return func(o *celValueOptions) {
-		o.UseSchemalessTypeRef = true
-	}
-}
-
 // LazyObject encapsulates a versioned runtime.Object and its lazily-evaluated Common Expression Language (CEL) representation.
 type LazyObject struct {
-	object               runtime.Object
-	useSchemalessTypeRef bool
+	object runtime.Object
+	// UseSchemalessTypeRef indicates whether to use SchemalessTypedToVal (reflection-based lazy ref.Val)
+	// instead of converting to an unstructured representation with DefaultTypeAdapter.
+	//
+	// Deprecated: This field is temporary and will be removed when schemaless becomes the default.
+	UseSchemalessTypeRef bool
 	celVal               ref.Val
 }
 
@@ -143,25 +130,19 @@ func (l *LazyObject) Set(obj runtime.Object) {
 	l.celVal = nil
 }
 
-func (l *LazyObject) CELValue(options ...CELValueOption) (ref.Val, error) {
-	opts := &celValueOptions{}
-	for _, o := range options {
-		o(opts)
-	}
-	if l.celVal != nil && l.useSchemalessTypeRef == opts.UseSchemalessTypeRef {
+func (l *LazyObject) CELValue() (ref.Val, error) {
+	if l.celVal != nil {
 		return l.celVal, nil
 	}
 	if l.object == nil {
 		return nil, nil
 	}
-
-	l.useSchemalessTypeRef = opts.UseSchemalessTypeRef
 	if u, ok := l.object.(*unstructured.Unstructured); ok {
 		l.celVal = types.DefaultTypeAdapter.NativeToValue(u.Object)
 		return l.celVal, nil
 	}
 	// TODO: use SchemalessTypeRef always.
-	if opts.UseSchemalessTypeRef {
+	if l.UseSchemalessTypeRef {
 		l.celVal = common.SchemalessTypedToVal(l.object)
 		return l.celVal, nil
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/conversion.go
@@ -104,6 +104,23 @@ func NewVersionedAttributes(attr Attributes, gvk schema.GroupVersionKind, o Obje
 	return versionedAttr, nil
 }
 
+// CELValueOptions holds options for CELValue conversion.
+type CELValueOptions struct {
+	// UseSchemalessTypeRef indicates whether to use SchemalessTypedToVal (reflection-based lazy ref.Val)
+	// instead of converting to an unstructured representation with DefaultTypeAdapter.
+	UseSchemalessTypeRef bool
+}
+
+// CELValueOption defines a functional option for CELValue.
+type CELValueOption func(*CELValueOptions)
+
+// UseSchemalessTypeRef returns a CELValueOption that configures CELValue to use SchemalessTypedToVal.
+func UseSchemalessTypeRef() CELValueOption {
+	return func(o *CELValueOptions) {
+		o.UseSchemalessTypeRef = true
+	}
+}
+
 // LazyObject encapsulates a versioned runtime.Object and its lazily-evaluated Common Expression Language (CEL) representation.
 type LazyObject struct {
 	object runtime.Object
@@ -125,19 +142,33 @@ func (l *LazyObject) Set(obj runtime.Object) {
 	l.celVal = nil
 }
 
-func (l *LazyObject) CELValue() (ref.Val, error) {
+func (l *LazyObject) CELValue(options ...CELValueOption) (ref.Val, error) {
 	if l.celVal != nil {
 		return l.celVal, nil
 	}
 	if l.object == nil {
 		return nil, nil
 	}
+	opts := &CELValueOptions{}
+	for _, o := range options {
+		o(opts)
+	}
+
 	if u, ok := l.object.(*unstructured.Unstructured); ok {
 		l.celVal = types.DefaultTypeAdapter.NativeToValue(u.Object)
 		return l.celVal, nil
 	}
+	// TODO: use SchemalessTypeRef always.
+	if opts.UseSchemalessTypeRef {
+		l.celVal = common.SchemalessTypedToVal(l.object)
+		return l.celVal, nil
+	}
 
-	l.celVal = common.SchemalessTypedToVal(l.object)
+	u, err := ConvertObjectToUnstructured(l.object)
+	if err != nil {
+		return nil, err
+	}
+	l.celVal = types.DefaultTypeAdapter.NativeToValue(u.Object)
 	return l.celVal, nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/conversion.go
@@ -104,27 +104,28 @@ func NewVersionedAttributes(attr Attributes, gvk schema.GroupVersionKind, o Obje
 	return versionedAttr, nil
 }
 
-// CELValueOptions holds options for CELValue conversion.
-type CELValueOptions struct {
+// celValueOptions holds options for CELValue conversion.
+type celValueOptions struct {
 	// UseSchemalessTypeRef indicates whether to use SchemalessTypedToVal (reflection-based lazy ref.Val)
 	// instead of converting to an unstructured representation with DefaultTypeAdapter.
 	UseSchemalessTypeRef bool
 }
 
 // CELValueOption defines a functional option for CELValue.
-type CELValueOption func(*CELValueOptions)
+type CELValueOption func(*celValueOptions)
 
 // UseSchemalessTypeRef returns a CELValueOption that configures CELValue to use SchemalessTypedToVal.
 func UseSchemalessTypeRef() CELValueOption {
-	return func(o *CELValueOptions) {
+	return func(o *celValueOptions) {
 		o.UseSchemalessTypeRef = true
 	}
 }
 
 // LazyObject encapsulates a versioned runtime.Object and its lazily-evaluated Common Expression Language (CEL) representation.
 type LazyObject struct {
-	object runtime.Object
-	celVal ref.Val
+	object               runtime.Object
+	useSchemalessTypeRef bool
+	celVal               ref.Val
 }
 
 // NewLazyObject returns a new LazyObject wrapping the provided runtime.Object.
@@ -143,17 +144,18 @@ func (l *LazyObject) Set(obj runtime.Object) {
 }
 
 func (l *LazyObject) CELValue(options ...CELValueOption) (ref.Val, error) {
-	if l.celVal != nil {
+	opts := &celValueOptions{}
+	for _, o := range options {
+		o(opts)
+	}
+	if l.celVal != nil && l.useSchemalessTypeRef == opts.UseSchemalessTypeRef {
 		return l.celVal, nil
 	}
 	if l.object == nil {
 		return nil, nil
 	}
-	opts := &CELValueOptions{}
-	for _, o := range options {
-		o(opts)
-	}
 
+	l.useSchemalessTypeRef = opts.UseSchemalessTypeRef
 	if u, ok := l.object.(*unstructured.Unstructured); ok {
 		l.celVal = types.DefaultTypeAdapter.NativeToValue(u.Object)
 		return l.celVal, nil

--- a/staging/src/k8s.io/apiserver/pkg/admission/conversion_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/conversion_test.go
@@ -420,6 +420,99 @@ func TestVersionedAttributesCELObjectsCaching(t *testing.T) {
 	})
 }
 
+func TestLazyObjectCELValue(t *testing.T) {
+	tests := []struct {
+		name         string
+		object       runtime.Object
+		options      []CELValueOption
+		expectNil    bool
+		expectedName string
+		expectedType string
+	}{
+		{
+			name:      "nil object",
+			object:    nil,
+			expectNil: true,
+		},
+		{
+			name: "unstructured object",
+			object: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "example.apiserver.k8s.io/v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name": "unstructured-pod",
+					},
+				},
+			},
+			expectedName: "unstructured-pod",
+			expectedType: "map[string]interface {}",
+		},
+		{
+			name: "typed object with UseSchemalessTypeRef",
+			object: &examplev1.Pod{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "example.apiserver.k8s.io/v1", Kind: "Pod"},
+				ObjectMeta: metav1.ObjectMeta{Name: "schemaless-pod"},
+			},
+			options:      []CELValueOption{UseSchemalessTypeRef()},
+			expectedName: "schemaless-pod",
+			expectedType: "v1.Pod",
+		},
+		{
+			name: "typed object without UseSchemalessTypeRef (default unstructured conversion)",
+			object: &examplev1.Pod{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "example.apiserver.k8s.io/v1", Kind: "Pod"},
+				ObjectMeta: metav1.ObjectMeta{Name: "default-pod"},
+			},
+			expectedName: "default-pod",
+			expectedType: "map[string]interface {}",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			l := NewLazyObject(tc.object)
+			val, err := l.CELValue(tc.options...)
+			require.NoError(t, err)
+			if tc.expectNil {
+				require.Nil(t, val)
+				return
+			}
+			require.NotNil(t, val)
+			require.Equal(t, tc.expectedName, getMetaName(val))
+			require.Equal(t, tc.expectedType, reflect.TypeOf(val.Value()).String())
+
+			// verify caching
+			valCached, err := l.CELValue(tc.options...)
+			require.NoError(t, err)
+			require.Equal(t, val, valCached)
+		})
+	}
+
+	t.Run("cache invalidation when Set is called", func(t *testing.T) {
+		typedObj1 := &examplev1.Pod{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "example.apiserver.k8s.io/v1", Kind: "Pod"},
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+		}
+		l := NewLazyObject(typedObj1)
+		val, err := l.CELValue()
+		require.NoError(t, err)
+		require.Equal(t, "pod-1", getMetaName(val))
+		require.NotNil(t, l.celVal)
+
+		typedObj2 := &examplev1.Pod{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "example.apiserver.k8s.io/v1", Kind: "Pod"},
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-2"},
+		}
+		l.Set(typedObj2)
+		require.Nil(t, l.celVal)
+
+		val2, err := l.CELValue()
+		require.NoError(t, err)
+		require.Equal(t, "pod-2", getMetaName(val2))
+	})
+}
+
 func getMetaName(val ref.Val) string {
 	return getStringField(val, "metadata", "name")
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/conversion_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/conversion_test.go
@@ -422,12 +422,12 @@ func TestVersionedAttributesCELObjectsCaching(t *testing.T) {
 
 func TestLazyObjectCELValue(t *testing.T) {
 	tests := []struct {
-		name         string
-		object       runtime.Object
-		options      []CELValueOption
-		expectNil    bool
-		expectedName string
-		expectedType string
+		name          string
+		object        runtime.Object
+		useSchemaless bool
+		expectNil     bool
+		expectedName  string
+		expectedType  string
 	}{
 		{
 			name:      "nil object",
@@ -454,9 +454,9 @@ func TestLazyObjectCELValue(t *testing.T) {
 				TypeMeta:   metav1.TypeMeta{APIVersion: "example.apiserver.k8s.io/v1", Kind: "Pod"},
 				ObjectMeta: metav1.ObjectMeta{Name: "schemaless-pod"},
 			},
-			options:      []CELValueOption{UseSchemalessTypeRef()},
-			expectedName: "schemaless-pod",
-			expectedType: "v1.Pod",
+			useSchemaless: true,
+			expectedName:  "schemaless-pod",
+			expectedType:  "v1.Pod",
 		},
 		{
 			name: "typed object without UseSchemalessTypeRef (default unstructured conversion)",
@@ -472,7 +472,8 @@ func TestLazyObjectCELValue(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			l := NewLazyObject(tc.object)
-			val, err := l.CELValue(tc.options...)
+			l.UseSchemalessTypeRef = tc.useSchemaless
+			val, err := l.CELValue()
 			require.NoError(t, err)
 			if tc.expectNil {
 				require.Nil(t, val)
@@ -483,7 +484,7 @@ func TestLazyObjectCELValue(t *testing.T) {
 			require.Equal(t, tc.expectedType, reflect.TypeOf(val.Value()).String())
 
 			// verify caching
-			valCached, err := l.CELValue(tc.options...)
+			valCached, err := l.CELValue()
 			require.NoError(t, err)
 			require.Equal(t, val, valCached)
 		})
@@ -512,30 +513,32 @@ func TestLazyObjectCELValue(t *testing.T) {
 		require.Equal(t, "pod-2", getMetaName(val2))
 	})
 
-	t.Run("cache invalidation when options change between calls", func(t *testing.T) {
+	t.Run("schemaless conversion with UseSchemalessTypeRef", func(t *testing.T) {
 		typedObj := &examplev1.Pod{
 			TypeMeta:   metav1.TypeMeta{APIVersion: "example.apiserver.k8s.io/v1", Kind: "Pod"},
-			ObjectMeta: metav1.ObjectMeta{Name: "pod-cache-test"},
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-schemaless-test"},
 		}
 		l := NewLazyObject(typedObj)
+		l.UseSchemalessTypeRef = true
 
-		// 1. Initial call without UseSchemalessTypeRef()
 		val1, err := l.CELValue()
 		require.NoError(t, err)
-		require.Equal(t, "pod-cache-test", getMetaName(val1))
-		require.Equal(t, "map[string]interface {}", reflect.TypeOf(val1.Value()).String())
+		require.Equal(t, "pod-schemaless-test", getMetaName(val1))
+		require.Equal(t, "v1.Pod", reflect.TypeOf(val1.Value()).String())
 
-		// 2. Call with UseSchemalessTypeRef() should recompute and return schemaless ref.Val
-		val2, err := l.CELValue(UseSchemalessTypeRef())
+		// Verify Set clears cached value and preserves UseSchemalessTypeRef
+		typedObj2 := &examplev1.Pod{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "example.apiserver.k8s.io/v1", Kind: "Pod"},
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-2-schemaless"},
+		}
+		l.Set(typedObj2)
+		require.Nil(t, l.celVal)
+		require.True(t, l.UseSchemalessTypeRef)
+
+		val2, err := l.CELValue()
 		require.NoError(t, err)
-		require.Equal(t, "pod-cache-test", getMetaName(val2))
+		require.Equal(t, "pod-2-schemaless", getMetaName(val2))
 		require.Equal(t, "v1.Pod", reflect.TypeOf(val2.Value()).String())
-
-		// 3. Calling again without UseSchemalessTypeRef() should recompute back to default map[string]interface{}
-		val3, err := l.CELValue()
-		require.NoError(t, err)
-		require.Equal(t, "pod-cache-test", getMetaName(val3))
-		require.Equal(t, "map[string]interface {}", reflect.TypeOf(val3.Value()).String())
 	})
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/conversion_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/conversion_test.go
@@ -511,6 +511,32 @@ func TestLazyObjectCELValue(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "pod-2", getMetaName(val2))
 	})
+
+	t.Run("cache invalidation when options change between calls", func(t *testing.T) {
+		typedObj := &examplev1.Pod{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "example.apiserver.k8s.io/v1", Kind: "Pod"},
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-cache-test"},
+		}
+		l := NewLazyObject(typedObj)
+
+		// 1. Initial call without UseSchemalessTypeRef()
+		val1, err := l.CELValue()
+		require.NoError(t, err)
+		require.Equal(t, "pod-cache-test", getMetaName(val1))
+		require.Equal(t, "map[string]interface {}", reflect.TypeOf(val1.Value()).String())
+
+		// 2. Call with UseSchemalessTypeRef() should recompute and return schemaless ref.Val
+		val2, err := l.CELValue(UseSchemalessTypeRef())
+		require.NoError(t, err)
+		require.Equal(t, "pod-cache-test", getMetaName(val2))
+		require.Equal(t, "v1.Pod", reflect.TypeOf(val2.Value()).String())
+
+		// 3. Calling again without UseSchemalessTypeRef() should recompute back to default map[string]interface{}
+		val3, err := l.CELValue()
+		require.NoError(t, err)
+		require.Equal(t, "pod-cache-test", getMetaName(val3))
+		require.Equal(t, "map[string]interface {}", reflect.TypeOf(val3.Value()).String())
+	})
 }
 
 func getMetaName(val ref.Val) string {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/activation.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/activation.go
@@ -32,15 +32,42 @@ import (
 	"k8s.io/apiserver/pkg/cel/library"
 )
 
+// activationOptions holds options for newActivation.
+type activationOptions struct {
+	useSchemalessTypeRef bool
+}
+
+// activationOption defines a functional option for newActivation.
+type activationOption func(*activationOptions)
+
+// useSchemalessTypeRef returns an activationOption that configures the activation to use SchemalessTypeRef on the versioned attributes.
+func useSchemalessTypeRef() activationOption {
+	return func(o *activationOptions) {
+		o.useSchemalessTypeRef = true
+	}
+}
+
 // newActivation creates an activation for CEL admission plugins from the given request, admission chain and
 // variable binding information.
-func newActivation(compositionCtx CompositionContext, versionedAttr *admission.VersionedAttributes, request *admissionv1.AdmissionRequest, inputs OptionalVariableBindings, namespace *v1.Namespace, options ...admission.CELValueOption) (*evaluationActivation, error) {
-	celOldObjVal, err := versionedAttr.VersionedOldObject.CELValue(options...)
+func newActivation(compositionCtx CompositionContext, versionedAttr *admission.VersionedAttributes, request *admissionv1.AdmissionRequest, inputs OptionalVariableBindings, namespace *v1.Namespace, options ...activationOption) (*evaluationActivation, error) {
+	opts := &activationOptions{}
+	for _, o := range options {
+		o(opts)
+	}
+	if opts.useSchemalessTypeRef && versionedAttr != nil {
+		// SA1019: admission.LazyObject.UseSchemalessTypeRef is deprecated: This field is temporary and will be removed when schemaless becomes the default.
+		//nolint:staticcheck
+		versionedAttr.VersionedObject.UseSchemalessTypeRef = true
+		//nolint:staticcheck
+		versionedAttr.VersionedOldObject.UseSchemalessTypeRef = true
+	}
+
+	celOldObjVal, err := versionedAttr.VersionedOldObject.CELValue()
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare oldObject variable for evaluation: %w", err)
 	}
 
-	celObjVal, err := versionedAttr.VersionedObject.CELValue(options...)
+	celObjVal, err := versionedAttr.VersionedObject.CELValue()
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare object variable for evaluation: %w", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/activation.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/activation.go
@@ -34,13 +34,13 @@ import (
 
 // newActivation creates an activation for CEL admission plugins from the given request, admission chain and
 // variable binding information.
-func newActivation(compositionCtx CompositionContext, versionedAttr *admission.VersionedAttributes, request *admissionv1.AdmissionRequest, inputs OptionalVariableBindings, namespace *v1.Namespace) (*evaluationActivation, error) {
-	celOldObjVal, err := versionedAttr.VersionedOldObject.CELValue()
+func newActivation(compositionCtx CompositionContext, versionedAttr *admission.VersionedAttributes, request *admissionv1.AdmissionRequest, inputs OptionalVariableBindings, namespace *v1.Namespace, options ...admission.CELValueOption) (*evaluationActivation, error) {
+	celOldObjVal, err := versionedAttr.VersionedOldObject.CELValue(options...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare oldObject variable for evaluation: %w", err)
 	}
 
-	celObjVal, err := versionedAttr.VersionedObject.CELValue()
+	celObjVal, err := versionedAttr.VersionedObject.CELValue(options...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare object variable for evaluation: %w", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/condition.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/condition.go
@@ -75,7 +75,7 @@ func (c *condition) ForInput(ctx context.Context, versionedAttr *admission.Versi
 	// if this activation supports composition, we will need the compositionCtx. It may be nil.
 	compositionCtx, _ := ctx.(CompositionContext)
 
-	activation, err := newActivation(compositionCtx, versionedAttr, request, inputs, namespace)
+	activation, err := newActivation(compositionCtx, versionedAttr, request, inputs, namespace, admission.UseSchemalessTypeRef())
 	if err != nil {
 		return nil, -1, err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/condition.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/condition.go
@@ -75,7 +75,7 @@ func (c *condition) ForInput(ctx context.Context, versionedAttr *admission.Versi
 	// if this activation supports composition, we will need the compositionCtx. It may be nil.
 	compositionCtx, _ := ctx.(CompositionContext)
 
-	activation, err := newActivation(compositionCtx, versionedAttr, request, inputs, namespace, admission.UseSchemalessTypeRef())
+	activation, err := newActivation(compositionCtx, versionedAttr, request, inputs, namespace, useSchemalessTypeRef())
 	if err != nil {
 		return nil, -1, err
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

This PR refactors how `admission.LazyObject` evaluates CEL representations to disable `SchemalessTypeRef` by default while explicitly preserving it for Validating Admission Policies (VAPs). 

This is needed because we found out issues in SchemalessTypeRef when used to mutate a typed object. This can be reproduced by tests in #140390.

We will revert this PR, once we support all functionalities needed for Map in SchemalessTypeRef. 

Specifically, this PR:
1. **Refactors `admission.LazyObject.CELValue`**: Updates the method to accept functional options via `CELValueOption`. 
2. **Changes Default CEL Evaluation**: By default, typed objects are now converted to an unstructured representation before evaluation (`DefaultTypeAdapter.NativeToValue(u.Object)`) instead of defaulting to `SchemalessTypedToVal`.
3. **Introduces `UseSchemalessTypeRef()`**: Adds an opt-in flag to evaluate CEL representations using `SchemalessTypedToVal`.
4. **Preserves VAP Behavior**: Updates Validating Admission Policy evaluation in `condition.go` to explicitly pass `admission.UseSchemalessTypeRef()` to `newActivation`. This ensures VAPs continue to use schemaless type reflection while other systems (like MAP) default to unstructured conversion.
5. **Adds comprehensive testing**: Adds tests in `conversion_test.go` to verify both the default unstructured conversion and the `UseSchemalessTypeRef` path.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This change isolates the usage of `SchemalessTypedToVal` strictly to components that explicitly opt-in (like Validating Admission Policies). 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```