### PR TITLE
Fix non-deterministic victim ordering in pod group preemption

### DIFF
--- a/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
@@ -514,6 +514,10 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakeNode().Name("node1").Obj(),
 			},
 			initPods: []*v1.Pod{
+				// UIDs ensure deterministic sort order: p1 (v1) > p2 (v2) > p3 (v3) > p4 (v4) by lexicographic UID comparison.
+				// This is critical for determinism even when StartTime is identical, which can happen on systems with
+				// coarse clock granularity (e.g., Windows) where multiple pods are created with the same timestamp.
+				// Reprieve tries p1, p2 first (both fit), then p3 fails → victims = {p3, p4}.
 				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
 				st.MakePod().Name("p2").UID("v2").Node("node1").Priority(lowPriority).Obj(),
 				st.MakePod().Name("p3").UID("v3").Node("node1").Priority(lowPriority).Obj(),

--- a/pkg/scheduler/framework/preemption/util.go
+++ b/pkg/scheduler/framework/preemption/util.go
@@ -64,6 +64,12 @@ func PodTerminatingByPreemption(p *v1.Pod) bool {
 //  5. Start Time (Tie-breaker for group types):
 //     If group types and sizes are equal, the group that started earlier (has the oldest pod)
 //     is more important.
+//
+//  6. UID (Final tie-breaker):
+//     If all other criteria are equal (including equal StartTimes), the unit
+//     with the lexicographically smaller first pod UID is considered more important.
+//     This ensures deterministic ordering across platforms regardless of clock
+//     resolution.
 func MoreImportantVictim(vi1, vi2 Victim) bool {
 	if vi1.Priority() != vi2.Priority() {
 		return vi1.Priority() > vi2.Priority()
@@ -80,7 +86,15 @@ func MoreImportantVictim(vi1, vi2 Victim) bool {
 		return len(vi1.Pods()) > len(vi2.Pods())
 	}
 
-	return vi1.EarliestStartTime().Before(vi2.EarliestStartTime())
+	t1 := vi1.EarliestStartTime()
+	t2 := vi2.EarliestStartTime()
+	if !t1.Equal(t2) {
+		return t1.Before(t2)
+	}
+
+	pods1 := vi1.Pods()
+	pods2 := vi2.Pods()
+	return string(pods1[0].GetPod().UID) < string(pods2[0].GetPod().UID)
 }
 
 func victimRank(vi Victim) int {

--- a/pkg/scheduler/framework/preemption/util_test.go
+++ b/pkg/scheduler/framework/preemption/util_test.go
@@ -397,7 +397,39 @@ func TestMoreImportantVictim(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "CPG vs Pod, same priority (CPG wins)",
+			name: "both Pods, same StartTime, vi1 has smaller UID",
+			vi1:  &victim{priority: 10, pods: []fwk.PodInfo{newPodInfo(st.MakePod().UID("alfa").Obj())}, earliestStartTime: now},
+			vi2:  &victim{priority: 10, pods: []fwk.PodInfo{newPodInfo(st.MakePod().UID("zulu").Obj())}, earliestStartTime: now},
+			want: true,
+		},
+		{
+			name: "both Pods, same StartTime, vi2 has smaller UID",
+			vi1:  &victim{priority: 10, pods: []fwk.PodInfo{newPodInfo(st.MakePod().UID("zulu").Obj())}, earliestStartTime: now},
+			vi2:  &victim{priority: 10, pods: []fwk.PodInfo{newPodInfo(st.MakePod().UID("alfa").Obj())}, earliestStartTime: now},
+			want: false,
+		},
+		{
+			name: "both PGs, same size, same StartTime, vi1 has smaller UID",
+			vi1: &victim{
+				priority: 10,
+				pods: []fwk.PodInfo{
+					newPodInfo(st.MakePod().UID("alfa").PodGroupName("pg").Obj()),
+					newPodInfo(st.MakePod().UID("alfa").PodGroupName("pg").Obj()),
+				},
+				earliestStartTime: now,
+			},
+			vi2: &victim{
+				priority: 10,
+				pods: []fwk.PodInfo{
+					newPodInfo(st.MakePod().UID("zulu").PodGroupName("pg").Obj()),
+					newPodInfo(st.MakePod().UID("zulu").PodGroupName("pg").Obj()),
+				},
+				earliestStartTime: now,
+			},
+			want: true,
+		},
+		{
+			name: "CPG vs Pod, same priority (CPG rank wins over Pod rank)",
 			vi1: &victim{
 				priority: 10,
 				keyType:  fwk.CompositePodGroupKeyType,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

MoreImportantVictim used time.Now() as fallback when pods lack StartTime, producing non-deterministic sort order across platforms. Add UID-based tie-breaker.

#### Which issue(s) this PR is related to:

Fixes #140423

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
```
