### PR TITLE
kubelet/cadvisor: disable container discovery when using CRI stats

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -799,6 +799,17 @@ func run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Depend
 		return err
 	}
 
+	if utilfeature.DefaultFeatureGate.Enabled(features.PodAndContainerStatsFromCRI) && !cadvisor.UsingLegacyCadvisorStats(s.ContainerRuntimeEndpoint) {
+		_, err := kubeDeps.RemoteRuntimeService.PodSandboxStats(ctx, "")
+		if err != nil {
+			s, ok := status.FromError(err)
+			if ok && s.Code() == codes.Unimplemented {
+				logger.Info("CRI implementation does not support PodSandboxStats, falling back to cadvisor stats")
+				kubeDeps.PodSandboxStatsUnimplemented = true
+			}
+		}
+	}
+
 	// Get cgroup driver setting from CRI
 	if err := getCgroupDriverFromCRI(ctx, s, kubeDeps); err != nil {
 		return err
@@ -832,7 +843,8 @@ func run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Depend
 
 	if kubeDeps.CAdvisorInterface == nil {
 		imageFsInfoProvider := cadvisor.NewImageFsInfoProvider(s.ContainerRuntimeEndpoint)
-		kubeDeps.CAdvisorInterface, err = cadvisor.New(klog.FromContext(ctx), imageFsInfoProvider, s.RootDirectory, cgroupRoots, cadvisor.UsingLegacyCadvisorStats(s.ContainerRuntimeEndpoint), s.LocalStorageCapacityIsolation)
+		disableContainerDiscovery := utilfeature.DefaultFeatureGate.Enabled(features.PodAndContainerStatsFromCRI) && !kubeDeps.PodSandboxStatsUnimplemented
+		kubeDeps.CAdvisorInterface, err = cadvisor.New(klog.FromContext(ctx), imageFsInfoProvider, s.RootDirectory, cgroupRoots, cadvisor.UsingLegacyCadvisorStats(s.ContainerRuntimeEndpoint), s.LocalStorageCapacityIsolation, disableContainerDiscovery)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/go-openapi/jsonreference v0.21.4
 	github.com/godbus/dbus/v5 v5.2.2
-	github.com/google/cadvisor/lib v0.60.4
+	github.com/google/cadvisor/lib v0.60.5
 	github.com/google/cel-go v0.27.0
 	github.com/google/gnostic-models v0.7.0
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
-github.com/google/cadvisor/lib v0.60.4 h1:R2LFuQlm+qJiB+6gY5qNugg+SDDNDU7zv6vYF1qkqiE=
-github.com/google/cadvisor/lib v0.60.4/go.mod h1:htHKT0OSYO6zaik+iLOo3Wj1mf/5l8uV5TJaqLz13oM=
+github.com/google/cadvisor/lib v0.60.5 h1:C2Ty0ccuKDQnFW4vCSa58wmjc26jL6GiwGEY00pQcIg=
+github.com/google/cadvisor/lib v0.60.5/go.mod h1:htHKT0OSYO6zaik+iLOo3Wj1mf/5l8uV5TJaqLz13oM=
 github.com/google/cel-go v0.27.0 h1:e7ih85+4qVrBuqQWTW4FKSqZYokVuc3HnhH5keboFTo=
 github.com/google/cel-go v0.27.0/go.mod h1:tTJ11FWqnhw5KKpnWpvW9CJC3Y9GK4EIS0WXnBbebzw=
 github.com/google/gnostic-models v0.7.0 h1:qwTtogB15McXDaNqTZdzPJRHvaVJlAl+HVQnLmJEJxo=

--- a/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -88,7 +88,7 @@ func init() {
 }
 
 // New creates a new cAdvisor Interface for linux systems.
-func New(logger klog.Logger, imageFsInfoProvider ImageFsInfoProvider, rootPath string, cgroupRoots []string, usingLegacyStats, localStorageCapacityIsolation bool) (Interface, error) {
+func New(logger klog.Logger, imageFsInfoProvider ImageFsInfoProvider, rootPath string, cgroupRoots []string, usingLegacyStats, localStorageCapacityIsolation, disableContainerDiscovery bool) (Interface, error) {
 	sysFs := sysfs.NewRealSysFs()
 
 	includedMetrics := cadvisormetrics.MetricSet{
@@ -116,7 +116,7 @@ func New(logger klog.Logger, imageFsInfoProvider ImageFsInfoProvider, rootPath s
 	housekeepingConfig := manager.HousekeepingConfig{
 		Interval:                  &duration,
 		AllowDynamic:              ptr.To(allowDynamicHousekeeping),
-		DisableContainerDiscovery: utilfeature.DefaultFeatureGate.Enabled(features.PodAndContainerStatsFromCRI),
+		DisableContainerDiscovery: disableContainerDiscovery,
 	}
 
 	// Create the cAdvisor container manager.

--- a/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -114,8 +114,9 @@ func New(logger klog.Logger, imageFsInfoProvider ImageFsInfoProvider, rootPath s
 
 	duration := maxHousekeepingInterval
 	housekeepingConfig := manager.HousekeepingConfig{
-		Interval:     &duration,
-		AllowDynamic: ptr.To(allowDynamicHousekeeping),
+		Interval:                  &duration,
+		AllowDynamic:              ptr.To(allowDynamicHousekeeping),
+		DisableContainerDiscovery: utilfeature.DefaultFeatureGate.Enabled(features.PodAndContainerStatsFromCRI),
 	}
 
 	// Create the cAdvisor container manager.

--- a/pkg/kubelet/cadvisor/cadvisor_unsupported.go
+++ b/pkg/kubelet/cadvisor/cadvisor_unsupported.go
@@ -32,7 +32,7 @@ type cadvisorUnsupported struct {
 var _ Interface = new(cadvisorUnsupported)
 
 // New creates a new cAdvisor Interface for unsupported systems.
-func New(_ klog.Logger, imageFsInfoProvider ImageFsInfoProvider, rootPath string, cgroupsRoots []string, usingLegacyStats, localStorageCapacityIsolation bool) (Interface, error) {
+func New(_ klog.Logger, imageFsInfoProvider ImageFsInfoProvider, rootPath string, cgroupsRoots []string, usingLegacyStats, localStorageCapacityIsolation, disableContainerDiscovery bool) (Interface, error) {
 	return &cadvisorUnsupported{}, nil
 }
 

--- a/pkg/kubelet/cadvisor/cadvisor_windows.go
+++ b/pkg/kubelet/cadvisor/cadvisor_windows.go
@@ -34,7 +34,7 @@ type cadvisorClient struct {
 var _ Interface = new(cadvisorClient)
 
 // New creates a cAdvisor and exports its API on the specified port if port > 0.
-func New(logger klog.Logger, imageFsInfoProvider ImageFsInfoProvider, rootPath string, cgroupRoots []string, usingLegacyStats, localStorageCapacityIsolation bool) (Interface, error) {
+func New(logger klog.Logger, imageFsInfoProvider ImageFsInfoProvider, rootPath string, cgroupRoots []string, usingLegacyStats, localStorageCapacityIsolation, disableContainerDiscovery bool) (Interface, error) {
 	client, err := winstats.NewPerfCounterClient(logger)
 	return &cadvisorClient{
 		rootPath:       rootPath,

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -342,6 +342,11 @@ type Dependencies struct {
 	HealthChecker             watchdog.HealthChecker
 	// remove it after cadvisor.UsingLegacyCadvisorStats dropped.
 	useLegacyCadvisorStats bool
+	// PodSandboxStatsUnimplemented is set during init when the CRI does not
+	// support PodSandboxStats. It can be removed once
+	// PodAndContainerStatsFromCRI is GA and cadvisor stats are no longer
+	// used as a fallback.
+	PodSandboxStatsUnimplemented bool
 }
 
 // newCrashLoopBackOff configures the backoff maximum to be used
@@ -863,6 +868,7 @@ func NewMainKubelet(ctx context.Context,
 			kubeDeps.RemoteImageService,
 			hostStatsProvider,
 			utilfeature.DefaultFeatureGate.Enabled(features.PodAndContainerStatsFromCRI),
+			kubeDeps.PodSandboxStatsUnimplemented,
 			cadvisorStatsProvider,
 		)
 	}

--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -29,9 +29,6 @@ import (
 	cadvisormemory "github.com/google/cadvisor/lib/cache/memory"
 	cadvisorfs "github.com/google/cadvisor/lib/fs"
 	cadvisorapi "github.com/google/cadvisor/lib/model"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -81,17 +78,16 @@ type criStatsProvider struct {
 	windowsNetworkStatsProvider interface{} //nolint:unused // U1000 We can't import hcsshim due to Build constraints in hcsshim
 	// clock is used report current time
 	clock clock.Clock
-	// fallbackStatsProvider is used to fill in missing information incase the CRI
-	// provides insufficient data.
-	// TODO: A lot of the cadvisorStatsProvider logic is duplicated in this file, and should be read
-	//       from the fallbackStatsProvider instead.
-	// Remove this once the CRI stats migration is complete.
+	// fallbackStatsProvider is a cadvisor-backed stats provider used when
+	// the CRI does not implement PodSandboxStats.
 	fallbackStatsProvider containerStatsProvider
+	// useCRIPodSandboxStats is true when PodAndContainerStatsFromCRI is
+	// enabled and the CRI implements PodSandboxStats.
+	useCRIPodSandboxStats bool
 
 	// cpuUsageCache caches the cpu usage for containers.
-	cpuUsageCache               map[string]*cpuUsageRecord
-	mutex                       sync.RWMutex
-	podAndContainerStatsFromCRI bool
+	cpuUsageCache map[string]*cpuUsageRecord
+	mutex         sync.RWMutex
 }
 
 // newCRIStatsProvider returns a containerStatsProvider implementation that
@@ -103,18 +99,19 @@ func newCRIStatsProvider(
 	imageService internalapi.ImageManagerService,
 	hostStatsProvider HostStatsProvider,
 	podAndContainerStatsFromCRI bool,
+	podSandboxStatsUnimplemented bool,
 	fallbackStatsProvider containerStatsProvider,
 ) containerStatsProvider {
 	return &criStatsProvider{
-		cadvisor:                    cadvisor,
-		resourceAnalyzer:            resourceAnalyzer,
-		runtimeService:              runtimeService,
-		imageService:                imageService,
-		hostStatsProvider:           hostStatsProvider,
-		cpuUsageCache:               make(map[string]*cpuUsageRecord),
-		podAndContainerStatsFromCRI: podAndContainerStatsFromCRI,
-		clock:                       clock.RealClock{},
-		fallbackStatsProvider:       fallbackStatsProvider,
+		cadvisor:              cadvisor,
+		resourceAnalyzer:      resourceAnalyzer,
+		runtimeService:        runtimeService,
+		imageService:          imageService,
+		hostStatsProvider:     hostStatsProvider,
+		cpuUsageCache:         make(map[string]*cpuUsageRecord),
+		useCRIPodSandboxStats: podAndContainerStatsFromCRI && !podSandboxStatsUnimplemented,
+		clock:                 clock.RealClock{},
+		fallbackStatsProvider: fallbackStatsProvider,
 	}
 }
 
@@ -152,20 +149,8 @@ func (p *criStatsProvider) listPodStats(ctx context.Context, updateCPUNanoCoreUs
 		return nil, fmt.Errorf("failed to get pod or container map: %v", err)
 	}
 
-	logger := klog.FromContext(ctx)
-	if p.podAndContainerStatsFromCRI {
-		result, err := p.listPodStatsStrictlyFromCRI(ctx, updateCPUNanoCoreUsage, containerMap, podSandboxMap, &rootFsInfo)
-		if err == nil {
-			// Call succeeded
-			return result, nil
-		}
-		s, ok := status.FromError(err)
-		// Legitimate failure, rather than the CRI implementation does not support ListPodSandboxStats.
-		if !ok || s.Code() != codes.Unimplemented {
-			return nil, err
-		}
-		// CRI implementation doesn't support ListPodSandboxStats, warn and fallback.
-		logger.V(5).Info("CRI implementation must be updated to support ListPodSandboxStats if PodAndContainerStatsFromCRI feature gate is enabled. Falling back to populating with cAdvisor; this call will fail in the future.", "err", err)
+	if p.useCRIPodSandboxStats {
+		return p.listPodStatsStrictlyFromCRI(ctx, updateCPUNanoCoreUsage, containerMap, podSandboxMap, &rootFsInfo)
 	}
 	return p.listPodStatsPartiallyFromCRI(ctx, updateCPUNanoCoreUsage, containerMap, podSandboxMap, &rootFsInfo)
 }
@@ -299,25 +284,14 @@ func (p *criStatsProvider) PodCPUAndMemoryStats(ctx context.Context, pod *v1.Pod
 		// The StartTime in the summary API is the pod creation time.
 		StartTime: metav1.NewTime(time.Unix(0, podSandbox.CreatedAt)),
 	}
-	if p.podAndContainerStatsFromCRI {
+	if p.useCRIPodSandboxStats {
 		criSandboxStats, err := p.runtimeService.PodSandboxStats(ctx, podSandbox.Id)
 		if err != nil {
-			// Call failed, why?
-			s, ok := status.FromError(err)
-			// Legitimate failure, rather than the CRI implementation does not support PodSandboxStats.
-			if !ok || s.Code() != codes.Unimplemented {
-				return nil, err
-			}
-			// CRI implementation doesn't support PodSandboxStats, warn and fallback.
-			logger.Error(err,
-				"CRI implementation must be updated to support PodSandboxStats if PodAndContainerStatsFromCRI feature gate is enabled. Falling back to populating with cAdvisor; this call will fail in the future.",
-			)
-		} else {
-			addCRIPodCPUStats(ps, criSandboxStats)
-			addCRIPodMemoryStats(ps, criSandboxStats)
+			return nil, err
 		}
+		addCRIPodCPUStats(ps, criSandboxStats)
+		addCRIPodMemoryStats(ps, criSandboxStats)
 	}
-
 	resp, err := p.runtimeService.ListContainerStats(ctx, &runtimeapi.ContainerStatsFilter{
 		PodSandboxId: podSandbox.Id,
 	})
@@ -325,32 +299,23 @@ func (p *criStatsProvider) PodCPUAndMemoryStats(ctx context.Context, pod *v1.Pod
 		return nil, fmt.Errorf("failed to list container stats from pod %s (sandbox %s): %w", format.Pod(pod), podSandbox.Id, err)
 	}
 
-	// Fallback if ListContainerStats doesn't return any results.
-	useFallback := ps.CPU == nil || ps.Memory == nil || len(resp) == 0
 	for _, stats := range resp {
 		containerStatus := podStatus.FindContainerStatusByName(stats.Attributes.Metadata.Name)
 		if containerStatus == nil {
 			logger.V(4).Info("Received stats for unknown container", "pod", klog.KObj(pod), "container", stats.Attributes.Metadata)
 			continue
 		}
-
-		// Fill available CPU and memory stats for full set of required pod stats
 		cs := p.makeContainerCPUAndMemoryStats(stats, containerStatus.CreatedAt, false)
-		useFallback = useFallback || cs.CPU == nil || cs.Memory == nil
 		ps.Containers = append(ps.Containers, *cs)
 	}
 
-	if useFallback {
+	if !p.useCRIPodSandboxStats {
 		fallbackStats, err := p.fallbackStatsProvider.PodCPUAndMemoryStats(ctx, pod, podStatus)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch stats for pod %s from fallback provider: %w", format.Pod(pod), err)
 		}
-		if ps.CPU == nil {
-			ps.CPU = fallbackStats.CPU
-		}
-		if ps.Memory == nil {
-			ps.Memory = fallbackStats.Memory
-		}
+		ps.CPU = fallbackStats.CPU
+		ps.Memory = fallbackStats.Memory
 
 		for _, fb := range fallbackStats.Containers {
 			var container *statsapi.ContainerStats
@@ -387,36 +352,24 @@ func (p *criStatsProvider) ListPodCPUAndMemoryStats(ctx context.Context) ([]stat
 	logger := klog.FromContext(ctx)
 
 	result := make([]statsapi.PodStats, 0, len(podSandboxMap))
-	if p.podAndContainerStatsFromCRI {
+	if p.useCRIPodSandboxStats {
 		criSandboxStats, err := p.runtimeService.ListPodSandboxStats(ctx, &runtimeapi.PodSandboxStatsFilter{})
-		// Call succeeded
-		if err == nil {
-			for _, criSandboxStat := range criSandboxStats {
-				podSandbox, found := podSandboxMap[criSandboxStat.Attributes.Id]
-				if !found {
-					continue
-				}
-				ps := buildPodStats(podSandbox)
-				// Add container-level CPU and memory stats from CRI
-				p.addCRIPodContainerCPUAndMemoryStats(criSandboxStat, ps, containerMap)
-				addCRIPodCPUStats(ps, criSandboxStat)
-				addCRIPodMemoryStats(ps, criSandboxStat)
-				// Aggregate pod swap from container swap stats (CRI doesn't have pod-level swap)
-				aggregatePodSwapStats(ps)
-				result = append(result, *ps)
-			}
-			return result, err
-		}
-		// Call failed, why?
-		s, ok := status.FromError(err)
-		// Legitimate failure, rather than the CRI implementation does not support ListPodSandboxStats.
-		if !ok || s.Code() != codes.Unimplemented {
+		if err != nil {
 			return nil, err
 		}
-		// CRI implementation doesn't support ListPodSandboxStats, warn and fallback.
-		logger.Error(err,
-			"CRI implementation must be updated to support ListPodSandboxStats if PodAndContainerStatsFromCRI feature gate is enabled. Falling back to populating with cAdvisor; this call will fail in the future.",
-		)
+		for _, criSandboxStat := range criSandboxStats {
+			podSandbox, found := podSandboxMap[criSandboxStat.Attributes.Id]
+			if !found {
+				continue
+			}
+			ps := buildPodStats(podSandbox)
+			p.addCRIPodContainerCPUAndMemoryStats(criSandboxStat, ps, containerMap)
+			addCRIPodCPUStats(ps, criSandboxStat)
+			addCRIPodMemoryStats(ps, criSandboxStat)
+			aggregatePodSwapStats(ps)
+			result = append(result, *ps)
+		}
+		return result, nil
 	}
 
 	resp, err := p.runtimeService.ListContainerStats(ctx, &runtimeapi.ContainerStatsFilter{})

--- a/pkg/kubelet/stats/cri_stats_provider_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_test.go
@@ -244,6 +244,7 @@ func TestCRIListPodStats(t *testing.T) {
 		fakeImageService,
 		NewFakeHostStatsProviderWithData(fakeStats, fakeOS),
 		false,
+		false,
 		fakeContainerStatsProvider{},
 	)
 
@@ -479,6 +480,7 @@ func TestListPodStatsStrictlyFromCRI(t *testing.T) {
 		fakeImageService,
 		NewFakeHostStatsProviderWithData(fakeStats, fakeOS),
 		true,
+		false,
 		fakeContainerStatsProvider{},
 	)
 
@@ -657,6 +659,7 @@ func TestCRIListPodCPUAndMemoryStats(t *testing.T) {
 		nil,
 		NewFakeHostStatsProvider(&kubecontainertest.FakeOS{}),
 		false,
+		false,
 		fakeContainerStatsProvider{},
 	)
 
@@ -812,6 +815,7 @@ func TestCRIPodCPUAndMemoryStats(t *testing.T) {
 		nil,
 		NewFakeHostStatsProvider(&kubecontainertest.FakeOS{}),
 		false,
+		false,
 		fakeContainerStatsProvider,
 	)
 
@@ -895,6 +899,7 @@ func TestCRIImagesFsStats(t *testing.T) {
 		fakeRuntimeService,
 		fakeImageService,
 		NewFakeHostStatsProvider(&kubecontainertest.FakeOS{}),
+		false,
 		false,
 		fakeContainerStatsProvider{},
 	)

--- a/pkg/kubelet/stats/provider.go
+++ b/pkg/kubelet/stats/provider.go
@@ -54,10 +54,11 @@ func NewCRIStatsProvider(
 	imageService internalapi.ImageManagerService,
 	hostStatsProvider HostStatsProvider,
 	podAndContainerStatsFromCRI bool,
+	podSandboxStatsUnimplemented bool,
 	fallbackStatsProvider containerStatsProvider,
 ) *Provider {
 	return newStatsProvider(cadvisor, podManager, newCRIStatsProvider(cadvisor, resourceAnalyzer,
-		runtimeService, imageService, hostStatsProvider, podAndContainerStatsFromCRI, fallbackStatsProvider))
+		runtimeService, imageService, hostStatsProvider, podAndContainerStatsFromCRI, podSandboxStatsUnimplemented, fallbackStatsProvider))
 }
 
 // NewCadvisorStatsProvider returns a containerStatsProvider that provides both

--- a/vendor/github.com/google/cadvisor/lib/manager/manager.go
+++ b/vendor/github.com/google/cadvisor/lib/manager/manager.go
@@ -74,6 +74,7 @@ const (
 var HousekeepingConfigFlags = HousekeepingConfig{
 	flag.Duration("max_housekeeping_interval", 60*time.Second, "Largest interval to allow between container housekeepings"),
 	flag.Bool("allow_dynamic_housekeeping", true, "Whether to allow the housekeeping interval to be dynamic"),
+	false,
 }
 
 // The Manager interface defines operations for starting a manager and getting
@@ -157,6 +158,10 @@ type Manager interface {
 type HousekeepingConfig = struct {
 	Interval     *time.Duration
 	AllowDynamic *bool
+	// When set to true, the manager will not discover or watch for new
+	// containers. Only the root container ("/") is created at startup;
+	// other cgroup paths are created on demand when first queried.
+	DisableContainerDiscovery bool
 }
 
 // New takes a memory storage and returns a new manager.
@@ -208,6 +213,7 @@ func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, HousekeepingConfi
 		startupTime:                           time.Now(),
 		maxHousekeepingInterval:               *HousekeepingConfig.Interval,
 		allowDynamicHousekeeping:              *HousekeepingConfig.AllowDynamic,
+		disableContainerDiscovery:             HousekeepingConfig.DisableContainerDiscovery,
 		includedMetrics:                       includedMetricsSet,
 		containerWatchers:                     []watcher.ContainerWatcher{},
 		eventsChannel:                         eventsChannel,
@@ -291,21 +297,22 @@ func (c *containerMap) Range(f func(name namespacedContainerName, data *containe
 }
 
 type manager struct {
-	containers               containerMap
-	memoryCache              *memory.InMemoryCache
-	fsInfo                   fs.FsInfo
-	sysFs                    sysfs.SysFs
-	machineMu                sync.RWMutex // protects machineInfo
-	machineInfo              info.MachineInfo
-	quitChannels             []chan error
-	cadvisorContainer        string
-	inHostNamespace          bool
-	startupTime              time.Time
-	maxHousekeepingInterval  time.Duration
-	allowDynamicHousekeeping bool
-	includedMetrics          container.MetricSet
-	containerWatchers        []watcher.ContainerWatcher
-	eventsChannel            chan watcher.ContainerEvent
+	containers                containerMap
+	memoryCache               *memory.InMemoryCache
+	fsInfo                    fs.FsInfo
+	sysFs                     sysfs.SysFs
+	machineMu                 sync.RWMutex // protects machineInfo
+	machineInfo               info.MachineInfo
+	quitChannels              []chan error
+	cadvisorContainer         string
+	inHostNamespace           bool
+	startupTime               time.Time
+	maxHousekeepingInterval   time.Duration
+	allowDynamicHousekeeping  bool
+	disableContainerDiscovery bool
+	includedMetrics           container.MetricSet
+	containerWatchers         []watcher.ContainerWatcher
+	eventsChannel             chan watcher.ContainerEvent
 	// List of raw container cgroup path prefix whitelist.
 	rawContainerCgroupPathPrefixWhiteList []string
 	// List of container env prefix whitelist, the matched container envs would be collected into metrics as extra labels.
@@ -324,18 +331,22 @@ type manager struct {
 
 // Start the container manager.
 func (m *manager) Start() error {
-	m.containerWatchers = container.InitializePlugins(m, m.fsInfo, m.includedMetrics)
+	if !m.disableContainerDiscovery {
+		m.containerWatchers = container.InitializePlugins(m, m.fsInfo, m.includedMetrics)
+	}
 
 	err := raw.Register(m, m.fsInfo, m.includedMetrics, m.rawContainerCgroupPathPrefixWhiteList)
 	if err != nil {
 		klog.Errorf("Registration of the raw container factory failed: %v", err)
 	}
 
-	rawWatcher, err := raw.NewRawContainerWatcher(m.includedMetrics)
-	if err != nil {
-		return err
+	if !m.disableContainerDiscovery {
+		rawWatcher, err := raw.NewRawContainerWatcher(m.includedMetrics)
+		if err != nil {
+			return err
+		}
+		m.containerWatchers = append(m.containerWatchers, rawWatcher)
 	}
-	m.containerWatchers = append(m.containerWatchers, rawWatcher)
 
 	// If there are no factories, don't start any housekeeping and serve the information we do have.
 	if !container.HasFactories() {
@@ -347,25 +358,30 @@ func (m *manager) Start() error {
 	if err != nil {
 		return err
 	}
-	klog.V(2).Infof("Starting recovery of all containers")
-	err = m.detectSubcontainers("/")
-	if err != nil {
-		return err
-	}
-	klog.V(2).Infof("Recovery completed")
 
-	// Watch for new container.
-	quitWatcher := make(chan error)
-	err = m.watchForNewContainers(quitWatcher)
-	if err != nil {
-		return err
-	}
-	m.quitChannels = append(m.quitChannels, quitWatcher)
+	if !m.disableContainerDiscovery {
+		klog.V(2).Infof("Starting recovery of all containers")
+		err = m.detectSubcontainers("/")
+		if err != nil {
+			return err
+		}
+		klog.V(2).Infof("Recovery completed")
 
-	// Look for new containers in the main housekeeping thread.
-	quitGlobalHousekeeping := make(chan error)
-	m.quitChannels = append(m.quitChannels, quitGlobalHousekeeping)
-	go m.globalHousekeeping(quitGlobalHousekeeping)
+		// Watch for new container.
+		quitWatcher := make(chan error)
+		err = m.watchForNewContainers(quitWatcher)
+		if err != nil {
+			return err
+		}
+		m.quitChannels = append(m.quitChannels, quitWatcher)
+
+		// Look for new containers in the main housekeeping thread.
+		quitGlobalHousekeeping := make(chan error)
+		m.quitChannels = append(m.quitChannels, quitGlobalHousekeeping)
+		go m.globalHousekeeping(quitGlobalHousekeeping)
+	} else {
+		klog.V(2).Infof("Container discovery disabled; only root container will be tracked")
+	}
 
 	quitUpdateMachineInfo := make(chan error)
 	m.quitChannels = append(m.quitChannels, quitUpdateMachineInfo)
@@ -543,10 +559,21 @@ func (m *manager) containerDataToContainerInfo(cont *containerData, query *info.
 
 func (m *manager) getContainer(containerName string) (*containerData, error) {
 	cont, ok := m.containers.Load(namespacedContainerName{Name: containerName})
-	if !ok {
-		return nil, fmt.Errorf("unknown container %q", containerName)
+	if ok {
+		return cont, nil
 	}
-	return cont, nil
+
+	if m.disableContainerDiscovery {
+		if err := m.createContainer(containerName, watcher.Raw); err != nil {
+			return nil, fmt.Errorf("on-demand creation of container %q failed: %v", containerName, err)
+		}
+		cont, ok = m.containers.Load(namespacedContainerName{Name: containerName})
+		if ok {
+			return cont, nil
+		}
+	}
+
+	return nil, fmt.Errorf("unknown container %q", containerName)
 }
 
 func (m *manager) getSubcontainers(containerName string) map[string]*containerData {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -258,7 +258,7 @@ github.com/golang/protobuf/ptypes/wrappers
 # github.com/google/btree v1.1.3
 ## explicit; go 1.18
 github.com/google/btree
-# github.com/google/cadvisor/lib v0.60.4
+# github.com/google/cadvisor/lib v0.60.5
 ## explicit; go 1.25.0
 github.com/google/cadvisor/lib/cache/memory
 github.com/google/cadvisor/lib/cadvisorflags


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

When the container runtime provides stats via CRI, cAdvisor only needs to track the root container for node-level resource and filesystem metrics. Set DisableContainerDiscovery on the cAdvisor manager to skip plugin initialization, cgroup watchers, and subcontainer scanning in that mode.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/126119

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

In order to preserve the performance improvements, the fallback to cadvisor mechanism has to change. Kubelet used to fallback whenever PodSandboxStats was not implemented or returning partial data.

With container discovery disabled, cadvisor no longer tracks per-container stats, so falling back to it for partial CRI data would return empty results. Additionally, cadvisor is equally likely to return partial data for freshly created containers, making that fallback unreliable in practice.

Instead, PodSandboxStats support is now probed once at startup, before cadvisor is created. If the CRI does not implement it, container discovery stays enabled and cadvisor is used for pod-level stats. If the CRI does implement it, discovery is disabled and the CRI is used exclusively. Errors are treated as real failures rather than triggering a silent fallback.

##### cadvisor optimization comparison

All measurements at 50 pods, 1 node (8 CPU, 16 GiB), 5-minute soak period,
CRI-O runtime. Prometheus scrapes kubelet and CRI-O metrics.

##### Configurations

1. **Vanilla** — `PodAndContainerStatsFromCRI` disabled. cadvisor runs full
   per-container housekeeping and serves all container metrics.

2. **CRI stats enabled** — `PodAndContainerStatsFromCRI` enabled, stock
   cadvisor (no housekeeping fix). Both cadvisor and CRI-O collect container
   stats.

3. **Optimized** — `PodAndContainerStatsFromCRI` enabled, cadvisor
   per-container housekeeping disabled. Container stats collection moves from
   cadvisor to CRI-O.

###### Combined kubelet + CRI-O CPU (cores)

| Percentile | Vanilla | CRI stats enabled | Optimized | Vanilla → Optimized |
|---|---:|---:|---:|---:|
| p50 | 0.205 | 0.257 | 0.199 | -3% |
| p90 | 0.259 | 0.356 | 0.271 | +5% |
| p99 | 0.348 | 0.418 | 0.402 | +16% |

###### Combined kubelet + CRI-O Memory (MiB)

| Percentile | Vanilla | CRI stats enabled | Optimized | Vanilla → Optimized |
|---|---:|---:|---:|---:|
| p50 | 316.9 | 490.6 | 327.5 | +3% |
| p90 | 335.4 | 523.6 | 337.9 | +1% |
| p99 | 338.1 | 534.8 | 340.9 | +1% |

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
