### PR TITLE
Fix DRA test flake caused by goroutine leak racing with TempDir cleanup

### DIFF
--- a/pkg/kubelet/cm/dra/manager.go
+++ b/pkg/kubelet/cm/dra/manager.go
@@ -156,6 +156,15 @@ func (m *Manager) GetWatcherHandler() cache.PluginHandler {
 	return m.draPlugins
 }
 
+// Stop shuts down the DRA plugin manager and waits for all background
+// goroutines to finish. It should be called when the manager is no longer
+// needed to avoid leaking goroutines and racing on state file cleanup.
+func (m *Manager) Stop() {
+	if m.draPlugins != nil {
+		m.draPlugins.Stop()
+	}
+}
+
 // Start starts the reconcile loop of the manager.
 func (m *Manager) Start(ctx context.Context, activePods ActivePodsFunc, getNode GetNodeFunc, sourcesReady config.SourcesReady) error {
 	m.initDRAPluginManager(ctx, getNode, defaultWipingDelay)

--- a/pkg/kubelet/cm/dra/manager_test.go
+++ b/pkg/kubelet/cm/dra/manager_test.go
@@ -348,6 +348,7 @@ func TestNewManagerImpl(t *testing.T) {
 			}
 
 			require.NoError(t, err)
+			defer manager.Stop()
 			assert.NotNil(t, manager.cache)
 			assert.NotNil(t, manager.kubeClient)
 		})
@@ -847,6 +848,7 @@ func TestGetResources(t *testing.T) {
 			tCtx := ktesting.Init(t)
 			manager, err := NewManager(tCtx.Logger(), kubeClient, t.TempDir())
 			require.NoError(t, err)
+			defer manager.Stop()
 
 			if test.claimInfo != nil {
 				manager.cache.add(test.claimInfo)
@@ -1216,6 +1218,7 @@ dra_operations_duration_seconds_count{is_error="false",operation_name="PrepareRe
 
 			manager, err := NewManager(tCtx.Logger(), fakeKubeClient, t.TempDir())
 			require.NoError(t, err, "create DRA manager")
+			defer manager.Stop()
 			manager.initDRAPluginManager(backgroundCtx, getFakeNode, time.Second /* very short wiping delay for testing */)
 
 			if test.claim != nil {
@@ -1302,6 +1305,7 @@ func TestPrepareResourcesWithPreparedAndNewClaim(t *testing.T) {
 
 	manager, err := NewManager(logger, fakeKubeClient, t.TempDir())
 	require.NoError(t, err)
+	defer manager.Stop()
 	manager.initDRAPluginManager(tCtx, getFakeNode, time.Second)
 
 	secondClaimName := fmt.Sprintf("%s-second", claimName)
@@ -1591,6 +1595,7 @@ dra_operations_duration_seconds_count{is_error="false",operation_name="Unprepare
 
 			manager, err := NewManager(tCtx.Logger(), fakeKubeClient, t.TempDir())
 			require.NoError(t, err, "create DRA manager")
+			defer manager.Stop()
 			manager.initDRAPluginManager(tCtx, getFakeNode, time.Second /* very short wiping delay for testing */)
 
 			plg := manager.GetWatcherHandler()
@@ -1657,6 +1662,7 @@ func TestPodMightNeedToUnprepareResources(t *testing.T) {
 	fakeKubeClient := fake.NewSimpleClientset()
 	manager, err := NewManager(tCtx.Logger(), fakeKubeClient, t.TempDir())
 	require.NoError(t, err, "create DRA manager")
+	defer manager.Stop()
 
 	claimInfo := &ClaimInfo{
 		ClaimInfoState: state.ClaimInfoState{PodUIDs: sets.New(podUID), ClaimName: claimName, Namespace: namespace},
@@ -1738,6 +1744,7 @@ func TestGetContainerClaimInfos(t *testing.T) {
 			tCtx := ktesting.Init(t)
 			manager, err := NewManager(tCtx.Logger(), nil, t.TempDir())
 			require.NoError(t, err, "create DRA manager")
+			defer manager.Stop()
 
 			if test.claimInfo != nil {
 				manager.cache.add(test.claimInfo)
@@ -1777,6 +1784,7 @@ func TestParallelPrepareUnprepareResources(t *testing.T) {
 	fakeKubeClient := fake.NewSimpleClientset()
 	manager, err := NewManager(tCtx.Logger(), fakeKubeClient, t.TempDir())
 	require.NoError(t, err, "create DRA manager")
+	defer manager.Stop()
 	manager.initDRAPluginManager(tCtx, getFakeNode, time.Second /* very short wiping delay for testing */)
 
 	plg := manager.GetWatcherHandler()
@@ -1880,6 +1888,7 @@ func TestHandleWatchResourcesStream(t *testing.T) {
 		// Fresh manager for each sub-test
 		manager, err := NewManager(tCtx.Logger(), nil, st.TempDir())
 		require.NoError(st, err)
+		defer manager.Stop()
 
 		for _, ci := range initialClaimInfos {
 			manager.cache.add(ci)
@@ -2537,6 +2546,7 @@ func TestUpdateAllocatedResourcesStatus(t *testing.T) {
 			logger := tCtx.Logger()
 			manager, err := NewManager(logger, nil, t.TempDir())
 			require.NoError(t, err)
+			defer manager.Stop()
 
 			for _, ci := range tc.claimInfos {
 				manager.cache.add(ci)
@@ -2619,6 +2629,7 @@ func TestUpdateAllocatedResourcesStatus_Subrequest(t *testing.T) {
 			tCtx := ktesting.Init(t)
 			manager, err := NewManager(tCtx.Logger(), nil, t.TempDir())
 			require.NoError(t, err)
+			defer manager.Stop()
 
 			// Setup claim info with device
 			claimInfo := &ClaimInfo{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test
/kind flake

#### What this PR does / why we need it:

With ResourceHealthStatus enabled (Beta, default on since 1.36), RegisterPlugin spawns a goroutine that runs WatchResources stream and writes to healthInfoCache's state file in the manager's state directory.

Tests called defer cancel() on the context but never DRAPluginManager.Stop() (which does wg.Wait()), so the goroutine could still be writing to t.TempDir() when the test framework's RemoveAll cleanup ran, causing:

  TempDir RemoveAll cleanup: unlinkat: directory not empty

Add Manager.Stop() that delegates to DRAPluginManager.Stop() and call defer manager.Stop() in all tests using initDRAPluginManager.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
Failing test:
```
I0710 18:31:53.480770  807168 manager_test.go:168] "Fake Server: WatchResources stream context canceled"
I0710 18:31:53.493389  807168 manager_test.go:168] "Fake Server: WatchResources stream context canceled"
I0710 18:31:53.498615  807168 manager_test.go:168] "Fake Server: WatchResources stream context canceled"
I0710 18:31:53.514156  807168 manager_test.go:168] "Fake Server: WatchResources stream context canceled"
I0710 18:31:53.523102  807168 manager_test.go:168] "Fake Server: WatchResources stream context canceled"
I0710 18:31:53.530244  807168 manager_test.go:168] "Fake Server: WatchResources stream context canceled"
I0710 18:31:53.535144  807168 manager_test.go:168] "Fake Server: WatchResources stream context canceled"
I0710 18:31:53.545745  807168 manager_test.go:168] "Fake Server: WatchResources stream context canceled"
I0710 18:31:53.553219  807168 manager_test.go:168] "Fake Server: WatchResources stream context canceled"
I0710 18:31:53.580473  807168 manager_test.go:168] "Fake Server: WatchResources stream context canceled"
I0710 18:31:53.589077  807168 manager_test.go:168] "Fake Server: WatchResources stream context canceled"
I0710 18:31:53.598261  807168 manager_test.go:168] "Fake Server: WatchResources stream context canceled"
I0710 18:31:53.605584  807168 manager_test.go:168] "Fake Server: WatchResources stream context canceled"
I0710 18:31:53.616542  807168 manager_test.go:168] "Fake Server: WatchResources stream context canceled"
--- FAIL: TestPrepareResources (0.15s)
    --- FAIL: TestPrepareResources/unknown_driver (0.01s)
        /home/user404/repos/kubernetes/staging/src/k8s.io/component-base/featuregate/testing/feature_gate.go:170: I0710 18:31:53.491576] Warning: setting GA feature gate. It will be removed in a future release. featureGate="DRAExtendedResource" value=true
        /home/user404/repos/kubernetes/staging/src/k8s.io/component-base/featuregate/testing/feature_gate.go:170: I0710 18:31:53.491694] Updated featureGates={"DRAConsumableCapacity":true,"DRAExtendedResource":true,"DRAWorkloadResourceClaims":false,"GenericWorkload":false}
        /home/user404/repos/kubernetes/staging/src/k8s.io/component-base/featuregate/testing/feature_gate.go:170: I0710 18:31:53.493724] Warning: setting GA feature gate. It will be removed in a future release. featureGate="DRAExtendedResource" value=true
        /home/user404/repos/kubernetes/staging/src/k8s.io/component-base/featuregate/testing/feature_gate.go:170: I0710 18:31:53.493862] Updated featureGates={"DRAConsumableCapacity":true,"DRAExtendedResource":true,"DRAWorkloadResourceClaims":false,"GenericWorkload":false}
        /home/user404/repos/kubernetes/pkg/kubelet/cm/dra/manager.go:1060: E0710 18:31:53.494129] DRA registration handler/dra-manager: Error receiving from WatchResources stream err="rpc error: code = Canceled desc = context canceled" pluginName=""
        /home/user404/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.0.linux-amd64/src/testing/testing.go:1464: TempDir RemoveAll cleanup: unlinkat /tmp/TestPrepareResourcesunknown_driver3235570682/001: directory not empty
I0710 18:31:53.764214  807168 manager_test.go:168] "Fake Server: WatchResources stream context canceled"
I0710 18:31:53.778928  807168 manager_test.go:168] "Fake Server: WatchResources stream context canceled"
I0710 18:31:53.783281  807168 manager_test.go:168] "Fake Server: WatchResources stream context canceled"
I0710 18:31:53.788953  807168 manager_test.go:168] "Fake Server: WatchResources stream context canceled"
I0710 18:31:53.815257  807168 manager_test.go:168] "Fake Server: WatchResources stream context canceled"
I0710 18:31:53.819731  807168 manager_test.go:168] "Fake Server: WatchResources stream context canceled"
I0710 18:31:53.825727  807168 manager_test.go:168] "Fake Server: WatchResources stream context canceled"
I0710 18:31:53.832395  807168 manager_test.go:168] "Fake Server: WatchResources stream context canceled"
I0710 18:31:53.837860  807168 manager_test.go:168] "Fake Server: WatchResources stream context canceled"
I0710 18:31:53.843699  807168 manager_test.go:168] "Fake Server: WatchResources stream context canceled"
I0710 18:31:53.866634  807168 manager_test.go:168] "Fake Server: WatchResources stream context canceled"
FAIL
FAIL	k8s.io/kubernetes/pkg/kubelet/cm/dra	1.219s
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
