### PR TITLE
[FG: InPlacePodVerticalScalingExclusiveCPUs] Add scaling exclusive CPUs checkpoint tests

### DIFF
--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -166,8 +166,8 @@ func TestCheckpointStateRestore(t *testing.T) {
 		},
 		// In below test case V2 part of checkpoint is intentionally corrupted to verify that it is not used.
 		{
-			"Restore valid checkpoint",
-			nil,
+			"Restore valid checkpoint with InPlacePodVerticalScalingExclusiveCPUs disabled",
+			FeatureGateCombination{features.InPlacePodVerticalScalingExclusiveCPUs: false},
 			`{
 				"policyName": "other",
 				"defaultCPUSet": "1-9",
@@ -186,6 +186,40 @@ func TestCheckpointStateRestore(t *testing.T) {
 					},
 				},
 				defaultCPUSet: cpuset.New(7, 8, 9),
+			},
+		},
+		// In below test case V2 part of checkpoint is intentionally corrupted to verify that it is not used.
+		{
+			"Restore valid checkpoint with InPlacePodVerticalScalingExclusiveCPUs enabled",
+			FeatureGateCombination{features.InPlacePodVerticalScalingExclusiveCPUs: true},
+			`{
+				"policyName": "other",
+				"defaultCPUSet": "1-9",
+				"checksum": 1234,
+				"data": "{\"policyName\":\"static\",\"defaultCPUSet\":\"7-9\",\"entries\":{\"pod\":{\"container1\":\"4-6\",\"container2\":\"1-3\"}}}",
+				"dataChecksum": 1420829534
+			}`,
+			"static",
+			containermap.ContainerMap{},
+			"",
+			&stateMemory{
+				assignments: ContainerCPUAssignments{
+					"pod": map[string]cpuset.CPUSet{
+						"container1": cpuset.New(4, 5, 6),
+						"container2": cpuset.New(1, 2, 3),
+					},
+				},
+				defaultCPUSet: cpuset.New(7, 8, 9),
+				baselines: ContainerCPUBaselines{
+					"pod": {
+						"container1": {
+							Baseline: cpuset.New(4, 5, 6),
+						},
+						"container2": {
+							Baseline: cpuset.New(1, 2, 3),
+						},
+					},
+				},
 			},
 		},
 		{
@@ -327,8 +361,8 @@ func TestCheckpointStateRestore(t *testing.T) {
 			nil,
 		},
 		{
-			"Restore checkpoint from v2 (migration)",
-			nil,
+			"Restore checkpoint from v2 (migration) with InPlacePodVerticalScalingExclusiveCPUs disabled",
+			FeatureGateCombination{features.InPlacePodVerticalScalingExclusiveCPUs: false},
 			`{
 				"policyName": "static",
 				"defaultCPUSet": "7-9",
@@ -354,8 +388,48 @@ func TestCheckpointStateRestore(t *testing.T) {
 			},
 		},
 		{
-			"Restore checkpoint from v3 (migration) with PodLevelResourceManagers disabled",
-			FeatureGateCombination{features.PodLevelResourceManagers: false},
+			"Restore checkpoint from v2 (migration) with InPlacePodVerticalScalingExclusiveCPUs enabled",
+			FeatureGateCombination{features.InPlacePodVerticalScalingExclusiveCPUs: true},
+			`{
+				"policyName": "static",
+				"defaultCPUSet": "7-9",
+				"entries": {
+					"pod": {
+						"container1": "4-6",
+						"container2": "1-3"
+					}
+				},
+				"checksum": 1942532442
+			}`,
+			"static",
+			containermap.ContainerMap{},
+			"",
+			&stateMemory{
+				assignments: ContainerCPUAssignments{
+					"pod": map[string]cpuset.CPUSet{
+						"container1": cpuset.New(4, 5, 6),
+						"container2": cpuset.New(1, 2, 3),
+					},
+				},
+				defaultCPUSet: cpuset.New(7, 8, 9),
+				baselines: ContainerCPUBaselines{
+					"pod": {
+						"container1": {
+							Baseline: cpuset.New(4, 5, 6),
+						},
+						"container2": {
+							Baseline: cpuset.New(1, 2, 3),
+						},
+					},
+				},
+			},
+		},
+		{
+			"Restore checkpoint from v3 (migration) with PodLevelResourceManagers disabled and InPlacePodVerticalScalingExclusiveCPUs disabled",
+			FeatureGateCombination{
+				features.PodLevelResourceManagers:               false,
+				features.InPlacePodVerticalScalingExclusiveCPUs: false,
+			},
 			`{
 				"policyName": "static",
 				"defaultCPUSet": "1-2",
@@ -386,8 +460,56 @@ func TestCheckpointStateRestore(t *testing.T) {
 			},
 		},
 		{
-			"Restore checkpoint from v3 (migration) with PodLevelResourceManagers enabled",
-			FeatureGateCombination{features.PodLevelResourceManagers: true},
+			"Restore checkpoint from v3 (migration) with PodLevelResourceManagers disabled and InPlacePodVerticalScalingExclusiveCPUs enabled",
+			FeatureGateCombination{
+				features.PodLevelResourceManagers:               false,
+				features.InPlacePodVerticalScalingExclusiveCPUs: true,
+			},
+			`{
+				"policyName": "static",
+				"defaultCPUSet": "1-2",
+				"entries": {
+					"pod1": {
+						"container1": "5-6",
+						"container2": "3-4"
+					}
+				},
+				"podEntries": {
+					"pod2": {
+						"cpuSet":"7-9"
+					}
+				},
+				"checksum": 766259872
+			}`,
+			"static",
+			containermap.ContainerMap{},
+			"",
+			&stateMemory{
+				assignments: ContainerCPUAssignments{
+					"pod1": map[string]cpuset.CPUSet{
+						"container1": cpuset.New(5, 6),
+						"container2": cpuset.New(3, 4),
+					},
+				},
+				defaultCPUSet: cpuset.New(1, 2),
+				baselines: ContainerCPUBaselines{
+					"pod1": {
+						"container1": {
+							Baseline: cpuset.New(5, 6),
+						},
+						"container2": {
+							Baseline: cpuset.New(3, 4),
+						},
+					},
+				},
+			},
+		},
+		{
+			"Restore checkpoint from v3 (migration) with PodLevelResourceManagers enabled and InPlacePodVerticalScalingExclusiveCPUs disabled",
+			FeatureGateCombination{
+				features.PodLevelResourceManagers:               true,
+				features.InPlacePodVerticalScalingExclusiveCPUs: false,
+			},
 			`{
 				"policyName": "static",
 				"defaultCPUSet": "1-2",
@@ -422,16 +544,69 @@ func TestCheckpointStateRestore(t *testing.T) {
 				},
 			},
 		},
+		{
+			"Restore checkpoint from v3 (migration) with PodLevelResourceManagers enabled and InPlacePodVerticalScalingExclusiveCPUs enabled",
+			FeatureGateCombination{
+				features.PodLevelResourceManagers:               true,
+				features.InPlacePodVerticalScalingExclusiveCPUs: true,
+			},
+			`{
+				"policyName": "static",
+				"defaultCPUSet": "1-2",
+				"entries": {
+					"pod1": {
+						"container1": "5-6",
+						"container2": "3-4"
+					}
+				},
+				"podEntries": {
+					"pod2": {
+						"cpuSet":"7-9"
+					}
+				},
+				"checksum": 766259872
+			}`,
+			"static",
+			containermap.ContainerMap{},
+			"",
+			&stateMemory{
+				assignments: ContainerCPUAssignments{
+					"pod1": map[string]cpuset.CPUSet{
+						"container1": cpuset.New(5, 6),
+						"container2": cpuset.New(3, 4),
+					},
+				},
+				defaultCPUSet: cpuset.New(1, 2),
+				podAssignments: PodCPUAssignments{
+					"pod2": PodEntry{
+						CPUSet: cpuset.New(7, 8, 9),
+					},
+				},
+				baselines: ContainerCPUBaselines{
+					"pod1": {
+						"container1": {
+							Baseline: cpuset.New(5, 6),
+						},
+						"container2": {
+							Baseline: cpuset.New(3, 4),
+						},
+					},
+				},
+			},
+		},
 		// In below testcase V2 part of checkpoint is intentionally corrupted to verify that it is not used.
 		{
-			"Restore valid v4 checkpoint with PodLevelResourceManagers disabled",
-			FeatureGateCombination{features.PodLevelResourceManagers: false},
+			"Restore valid v4 checkpoint with PodLevelResourceManagers disabled and InPlacePodVerticalScalingExclusiveCPUs disabled",
+			FeatureGateCombination{
+				features.PodLevelResourceManagers:               false,
+				features.InPlacePodVerticalScalingExclusiveCPUs: false,
+			},
 			`{
 				"policyName": "other",
 				"defaultCPUSet": "1-9",
 				"checksum": 1234,
-				"data": "{\"policyName\":\"static\",\"defaultCPUSet\":\"1-3\",\"entries\":{\"pod\":{\"container1\":\"4-6\",\"container2\":\"7-9\"}},\"podEntries\":{\"pod\":{\"cpuSet\":\"4-10\"}}}",
-				"dataChecksum": 2328898362
+				"data": "{\"policyName\":\"static\",\"defaultCPUSet\":\"1-3\",\"entries\":{\"pod\":{\"container1\":\"4-6\",\"container2\":\"7-9\"}},\"podEntries\":{\"pod\":{\"cpuSet\":\"4-10\"}},\"baselines\":{\"pod\":{\"container1\":{\"baseline\":\"4-5\"},\"container2\":{\"baseline\":\"7-8\"}}}}",
+				"dataChecksum": 1032795074
 			}`,
 			"static",
 			containermap.ContainerMap{},
@@ -448,14 +623,54 @@ func TestCheckpointStateRestore(t *testing.T) {
 		},
 		// In below testcase V2 part of checkpoint is intentionally corrupted to verify that it is not used.
 		{
-			"Restore valid v4 checkpoint with PodLevelResourceManagers enabled",
-			FeatureGateCombination{features.PodLevelResourceManagers: true},
+			"Restore valid v4 checkpoint with PodLevelResourceManagers disabled and InPlacePodVerticalScalingExclusiveCPUs enabled",
+			FeatureGateCombination{
+				features.PodLevelResourceManagers:               false,
+				features.InPlacePodVerticalScalingExclusiveCPUs: true,
+			},
 			`{
 				"policyName": "other",
 				"defaultCPUSet": "1-9",
 				"checksum": 1234,
-				"data": "{\"policyName\":\"static\",\"defaultCPUSet\":\"1-3\",\"entries\":{\"pod\":{\"container1\":\"4-6\",\"container2\":\"7-9\"}},\"podEntries\":{\"pod\":{\"cpuSet\":\"4-10\"}}}",
-				"dataChecksum": 2328898362
+				"data": "{\"policyName\":\"static\",\"defaultCPUSet\":\"1-3\",\"entries\":{\"pod\":{\"container1\":\"4-6\",\"container2\":\"7-9\"}},\"podEntries\":{\"pod\":{\"cpuSet\":\"4-10\"}},\"baselines\":{\"pod\":{\"container1\":{\"baseline\":\"4-5\"},\"container2\":{\"baseline\":\"7-8\"}}}}",
+				"dataChecksum": 1032795074
+			}`,
+			"static",
+			containermap.ContainerMap{},
+			"",
+			&stateMemory{
+				assignments: ContainerCPUAssignments{
+					"pod": map[string]cpuset.CPUSet{
+						"container1": cpuset.New(4, 5, 6),
+						"container2": cpuset.New(7, 8, 9),
+					},
+				},
+				defaultCPUSet: cpuset.New(1, 2, 3),
+				baselines: ContainerCPUBaselines{
+					"pod": {
+						"container1": {
+							Baseline: cpuset.New(4, 5),
+						},
+						"container2": {
+							Baseline: cpuset.New(7, 8),
+						},
+					},
+				},
+			},
+		},
+		// In below testcase V2 part of checkpoint is intentionally corrupted to verify that it is not used.
+		{
+			"Restore valid v4 checkpoint with PodLevelResourceManagers enabled and InPlacePodVerticalScalingExclusiveCPUs disabled",
+			FeatureGateCombination{
+				features.PodLevelResourceManagers:               true,
+				features.InPlacePodVerticalScalingExclusiveCPUs: false,
+			},
+			`{
+				"policyName": "other",
+				"defaultCPUSet": "1-9",
+				"checksum": 1234,
+				"data": "{\"policyName\":\"static\",\"defaultCPUSet\":\"1-3\",\"entries\":{\"pod\":{\"container1\":\"4-6\",\"container2\":\"7-9\"}},\"podEntries\":{\"pod\":{\"cpuSet\":\"4-10\"}},\"baselines\":{\"pod\":{\"container1\":{\"baseline\":\"4-5\"},\"container2\":{\"baseline\":\"7-8\"}}}}",
+				"dataChecksum": 1032795074
 			}`,
 			"static",
 			containermap.ContainerMap{},
@@ -475,6 +690,48 @@ func TestCheckpointStateRestore(t *testing.T) {
 				},
 			},
 		},
+		// In below testcase V2 part of checkpoint is intentionally corrupted to verify that it is not used.
+		{
+			"Restore valid v4 checkpoint with PodLevelResourceManagers enabled and InPlacePodVerticalScalingExclusiveCPUs enabled",
+			FeatureGateCombination{
+				features.PodLevelResourceManagers:               true,
+				features.InPlacePodVerticalScalingExclusiveCPUs: true,
+			},
+			`{
+				"policyName": "other",
+				"defaultCPUSet": "1-9",
+				"checksum": 1234,
+				"data": "{\"policyName\":\"static\",\"defaultCPUSet\":\"1-3\",\"entries\":{\"pod\":{\"container1\":\"4-6\",\"container2\":\"7-9\"}},\"podEntries\":{\"pod\":{\"cpuSet\":\"4-10\"}},\"baselines\":{\"pod\":{\"container1\":{\"baseline\":\"4-5\"},\"container2\":{\"baseline\":\"7-8\"}}}}",
+				"dataChecksum": 1032795074
+			}`,
+			"static",
+			containermap.ContainerMap{},
+			"",
+			&stateMemory{
+				assignments: ContainerCPUAssignments{
+					"pod": map[string]cpuset.CPUSet{
+						"container1": cpuset.New(4, 5, 6),
+						"container2": cpuset.New(7, 8, 9),
+					},
+				},
+				defaultCPUSet: cpuset.New(1, 2, 3),
+				podAssignments: PodCPUAssignments{
+					"pod": PodEntry{
+						CPUSet: cpuset.New(4, 5, 6, 7, 8, 9, 10),
+					},
+				},
+				baselines: ContainerCPUBaselines{
+					"pod": {
+						"container1": {
+							Baseline: cpuset.New(4, 5),
+						},
+						"container2": {
+							Baseline: cpuset.New(7, 8),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	// create temp dir
@@ -488,6 +745,7 @@ func TestCheckpointStateRestore(t *testing.T) {
 	// list of all features verified in this test
 	featureGateList := []featuregate.Feature{
 		features.PodLevelResourceManagers,
+		features.InPlacePodVerticalScalingExclusiveCPUs,
 	}
 	// iterate over all possible enabled/disabled feature combinations
 	for _, fgComb := range allFeatureGateCombinations(featureGateList) {
@@ -542,19 +800,40 @@ func TestCheckpointStateRestore(t *testing.T) {
 
 func TestCheckpointStateStore(t *testing.T) {
 	testCases := []struct {
-		description   string
-		expectedState *stateMemory
+		description    string
+		fgRequirements FeatureGateCombination
+		expectedState  *stateMemory
 	}{
 		{
-			"Store default cpu set",
-			&stateMemory{defaultCPUSet: cpuset.New(1, 2, 3)},
+			description:    "Store default cpu set",
+			fgRequirements: nil,
+			expectedState:  &stateMemory{defaultCPUSet: cpuset.New(1, 2, 3)},
 		},
 		{
-			"Store assignments",
-			&stateMemory{
+			description:    "Store assignments",
+			fgRequirements: FeatureGateCombination{features.InPlacePodVerticalScalingExclusiveCPUs: false},
+			expectedState: &stateMemory{
 				assignments: map[string]map[string]cpuset.CPUSet{
 					"pod": {
 						"container1": cpuset.New(1, 5, 8),
+					},
+				},
+			},
+		},
+		{
+			description:    "Store baselines",
+			fgRequirements: FeatureGateCombination{features.InPlacePodVerticalScalingExclusiveCPUs: true},
+			expectedState: &stateMemory{
+				assignments: map[string]map[string]cpuset.CPUSet{
+					"pod": {
+						"container1": cpuset.New(1, 5, 8),
+					},
+				},
+				baselines: ContainerCPUBaselines{
+					"pod": {
+						"container1": {
+							Baseline: cpuset.New(1, 5),
+						},
 					},
 				},
 			},
@@ -573,28 +852,57 @@ func TestCheckpointStateStore(t *testing.T) {
 		t.Fatalf("could not create testing checkpoint manager: %v", err)
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			// ensure there is no previous checkpoint
-			cpm.RemoveCheckpoint(testingCheckpoint)
-
-			logger, _ := ktesting.NewTestContext(t)
-			cs1, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "none", nil)
-			if err != nil {
-				t.Fatalf("could not create testing checkpointState instance: %v", err)
+	// list of all features verified in this test
+	featureGateList := []featuregate.Feature{
+		features.PodLevelResourceManagers,
+		features.InPlacePodVerticalScalingExclusiveCPUs,
+	}
+	// iterate over all possible enabled/disabled feature combinations
+	for _, fgComb := range allFeatureGateCombinations(featureGateList) {
+		// run all testcases for current feature combination
+		t.Run(describe(fgComb), func(t *testing.T) {
+			for _, key := range slices.Sorted(maps.Keys(fgComb)) {
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, key, fgComb[key])
 			}
 
-			// set values of cs1 instance so they are stored in checkpoint and can be read by cs2
-			cs1.SetDefaultCPUSet(tc.expectedState.defaultCPUSet)
-			cs1.SetCPUAssignments(tc.expectedState.assignments)
+			for _, tc := range testCases {
+				// verify feature gate requirements for testcase
+				skip := false
+				for fg, requiredState := range tc.fgRequirements {
+					state, exist := fgComb[fg]
+					if !exist || requiredState != state {
+						skip = true
+					}
+				}
+				if skip {
+					continue
+				}
 
-			// restore checkpoint with previously stored values
-			cs2, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "none", nil)
-			if err != nil {
-				t.Fatalf("could not create testing checkpointState instance: %v", err)
+				t.Run(tc.description, func(t *testing.T) {
+					// ensure there is no previous checkpoint
+					err = cpm.RemoveCheckpoint(testingCheckpoint)
+					require.NoErrorf(t, err, "could not remove previous checkpoint: %v", err)
+
+					logger, _ := ktesting.NewTestContext(t)
+					cs1, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "none", nil)
+					if err != nil {
+						t.Fatalf("could not create testing checkpointState instance: %v", err)
+					}
+
+					// set values of cs1 instance so they are stored in checkpoint and can be read by cs2
+					cs1.SetDefaultCPUSet(tc.expectedState.defaultCPUSet)
+					cs1.SetCPUAssignments(tc.expectedState.assignments)
+					cs1.SetCPUBaselines(tc.expectedState.baselines)
+
+					// restore checkpoint with previously stored values
+					cs2, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "none", nil)
+					if err != nil {
+						t.Fatalf("could not create testing checkpointState instance: %v", err)
+					}
+
+					AssertStateEqual(t, cs2, tc.expectedState)
+				})
 			}
-
-			AssertStateEqual(t, cs2, tc.expectedState)
 		})
 	}
 }
@@ -650,7 +958,8 @@ func TestCheckpointStateHelpers(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			// ensure there is no previous checkpoint
-			cpm.RemoveCheckpoint(testingCheckpoint)
+			err = cpm.RemoveCheckpoint(testingCheckpoint)
+			require.NoErrorf(t, err, "could not remove previous checkpoint: %v", err)
 
 			logger, _ := ktesting.NewTestContext(t)
 			state, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "none", nil)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This is an enhancement of https://github.com/kubernetes/kubernetes/pull/140314 by store/restore checkpoint tests.

Extend TestCheckpointStateRestore and TestCheckpointStateStore to cover the InPlacePodVerticalScalingExclusiveCPUs feature gate and the baselines field in checkpoint serialization. Existing test cases are split into all feature gate combinations, and new cases verify that baselines are correctly stored and restored when the feature gate is enabled.

#### Which issue(s) this PR is related to:

Enhances https://github.com/kubernetes/kubernetes/pull/140314
Related to KEP: https://github.com/kubernetes/enhancements/issues/5554

Previously implemented in https://github.com/esotsal/kubernetes/pull/14

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
