### PR TITLE
Fix unformatted UID in dynamicresources test error message

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -4226,7 +4226,7 @@ func createReactor(tracker cgotesting.ObjectTracker, failPatch bool) func(action
 				uidCounter++
 			}
 			if inUseUIDs.Has(obj.GetUID()) {
-				return true, nil, errors.New("UID %s already in use")
+				return true, nil, fmt.Errorf("UID %s already in use", obj.GetUID())
 			}
 			inUseUIDs.Insert(obj.GetUID())
 			obj.SetResourceVersion(fmt.Sprintf("%d", resourceVersionCounter))


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it:**

The fake client reactor in `dynamicresources_test.go` reports duplicate UIDs with `errors.New("UID %s already in use")`, so the message is emitted with a literal `%s` and never says which UID collided. This switches it to `fmt.Errorf` and includes the UID, making the failure actionable when it trips.

**Which issue(s) this PR fixes:**

NONE

**Special notes for your reviewer:**

Test-only change; no behavior change outside the error message.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```
