### PR TITLE
DRA: reject an out-of-range consumable-capacity request

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -5463,6 +5463,107 @@ func TestAllocator(t *testing.T,
 				),
 			},
 		},
+		"consumable-capacity-range-policy-request-above-int64-rejected": {
+			features: Features{
+				ConsumableCapacity: true,
+			},
+			// A capacity request above MaxInt64 cannot be rounded on the integer Step path
+			// without reading it through Quantity.Value(), which wraps. The request is not
+			// representable, so allocation aborts with a specific error instead of skipping.
+			claimsToAllocate: objects(
+				claim(claim0).withRequests(deviceRequest(req0, classA, 1).withCapacityRequest(new(resource.MustParse("18446744073709551616")))),
+			),
+			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
+					device(device1, nil, nil).withAllowMultipleAllocations().withCapacityRequestPolicyRange(map[resourceapi.QualifiedName]resource.Quantity{capacity0: four}),
+				),
+			),
+			node:        node(node1, region1),
+			expectError: gomega.MatchError(gomega.ContainSubstring("cannot be represented")),
+		},
+		"consumable-capacity-range-policy-rounded-value-overflow-rejected": {
+			features: Features{
+				ConsumableCapacity: true,
+			},
+			// Rounding a MaxInt64 request up to the next Step multiple passes MaxInt64 and
+			// would wrap to a negative value. The rounded value is not representable, so
+			// allocation aborts with a specific error instead of acting on the wrapped read.
+			claimsToAllocate: objects(
+				claim(claim0).withRequests(deviceRequest(req0, classA, 1).withCapacityRequest(new(resource.MustParse("9223372036854775807")))),
+			),
+			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
+					device(device1, nil, nil).withAllowMultipleAllocations().withCapacityRequestPolicyRange(map[resourceapi.QualifiedName]resource.Quantity{capacity0: four}),
+				),
+			),
+			node:        node(node1, region1),
+			expectError: gomega.MatchError(gomega.ContainSubstring("cannot be represented")),
+		},
+		"consumable-capacity-range-policy-overflow-aborts-not-skip": {
+			features: Features{
+				ConsumableCapacity: true,
+			},
+			// device-1 has a Step range, so a request above MaxInt64 overflows its integer
+			// rounding. device-2 has no Step and could satisfy the same request by exact
+			// comparison, but a not-representable request is fail-closed: allocation aborts
+			// rather than skipping device-1 to allocate device-2. Aborting on the first
+			// overflowing device is what stops the backtracking a user-controlled
+			// out-of-range request would otherwise force.
+			claimsToAllocate: objects(
+				claim(claim0).withRequests(deviceRequest(req0, classA, 1).withCapacityRequest(new(resource.MustParse("18446744073709551616")))),
+			),
+			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
+					device(device1, nil, nil).withAllowMultipleAllocations().withCapacityRequestPolicyRange(map[resourceapi.QualifiedName]resource.Quantity{capacity0: four}),
+					device(device2, map[resourceapi.QualifiedName]resource.Quantity{capacity0: resource.MustParse("36893488147419103232")}, nil).withAllowMultipleAllocations(),
+				),
+			),
+			node:        node(node1, region1),
+			expectError: gomega.MatchError(gomega.ContainSubstring("cannot be represented")),
+		},
+		"consumable-capacity-range-policy-allocation-mode-all-overflow-aborts": {
+			features: Features{
+				ConsumableCapacity: true,
+			},
+			// The all-devices pre-scan in validateDeviceRequest validates capacity too. An
+			// out-of-range request must abort there, not silently drop the overflowing
+			// device from the set and allocate whatever remains. The count-mode cases above
+			// exercise allocateOne; this one exercises the AllocationModeAll pre-scan.
+			claimsToAllocate: objects(
+				claim(claim0).withRequests(allDeviceRequest(req0, classA).withCapacityRequest(new(resource.MustParse("18446744073709551616")))),
+			),
+			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
+					device(device1, nil, nil).withAllowMultipleAllocations().withCapacityRequestPolicyRange(map[resourceapi.QualifiedName]resource.Quantity{capacity0: four}),
+				),
+			),
+			node:        node(node1, region1),
+			expectError: gomega.MatchError(gomega.ContainSubstring("cannot be represented")),
+		},
+		"consumable-capacity-negative-request-aborts": {
+			features: Features{
+				ConsumableCapacity: true,
+			},
+			// A stored request or slice from before stricter validation could carry a
+			// negative capacity, which admission does not re-check on existing objects. A
+			// negative value must abort rather than record negative consumed capacity and
+			// over-allocate the device.
+			claimsToAllocate: objects(
+				claim(claim0).withRequests(deviceRequest(req0, classA, 1).withCapacityRequest(new(resource.MustParse("-5")))),
+			),
+			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
+					device(device1, map[resourceapi.QualifiedName]resource.Quantity{capacity0: resource.MustParse("10")}, nil).withAllowMultipleAllocations(),
+				),
+			),
+			node:        node(node1, region1),
+			expectError: gomega.MatchError(gomega.ContainSubstring("negative")),
+		},
 		"consumable-capacity-multi-allocatable-device-with-valid-values-policy": {
 			features: Features{
 				ConsumableCapacity: true,

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -598,9 +598,7 @@ func (alloc *allocator) validateDeviceRequest(request requestAccessor, parentReq
 							device := slice.Spec.Devices[deviceIndex]
 							success, err := alloc.CmpRequestOverCapacity(requestData.request, slice, device)
 							if err != nil {
-								alloc.logger.V(7).Info("Skip comparing device capacity request",
-									"device", device, "request", requestData.request.name(), "err", err)
-								continue
+								return requestData, fmt.Errorf("claim %s, request %s: checking capacity for device %s: %w", klog.KObj(claim), requestData.request.name(), device.Name, err)
 							}
 							if !success {
 								alloc.logger.V(7).Info("Device capacity not enough", "device", device)
@@ -1274,9 +1272,7 @@ func (alloc *allocator) allocateOne(r deviceIndices, allocateSubRequest bool, st
 					device := slice.Spec.Devices[deviceIndex]
 					success, err := alloc.CmpRequestOverCapacity(requestData.request, slice, device)
 					if err != nil {
-						alloc.logger.V(7).Info("Skip comparing device capacity request",
-							"device", deviceID, "request", requestData.request.name(), "err", err)
-						continue
+						return false, fmt.Errorf("claim %s, request %s: checking capacity for device %s: %w", klog.KObj(claim), requestData.request.name(), deviceID, err)
 					}
 					if !success {
 						alloc.logger.V(7).Info("Device capacity not enough", "device", deviceID)
@@ -1573,12 +1569,11 @@ func (alloc *allocator) allocateDevice(r deviceIndices, device deviceWithID, mus
 	if alloc.features.ConsumableCapacity {
 		// Validate whether resource request over capacity
 		success, err := alloc.CmpRequestOverCapacity(requestData.request, device.slice, *device.Device)
-		// The error should not occur at this point as it should be detected in the previous step.
 		if err != nil {
-			alloc.logger.V(7).Info("Failed to compare device capacity request on allocateDevice",
-				"device", device, "request", requestData.request.name(), "err", err)
+			// The overflow guard already ran during validation, so an error here is
+			// unexpected. Roll back and surface it rather than swallowing it.
 			alloc.rollbackDevice(r, device, baseRequestName, subRequestName, state)
-			return false, nil, nil
+			return false, nil, fmt.Errorf("claim %s, request %s: rechecking capacity for device %s: %w", klog.KObj(claim), requestData.request.name(), device.id, err)
 		}
 		if !success {
 			alloc.logger.V(7).Info("Device capacity not enough", "device", device)
@@ -1587,7 +1582,11 @@ func (alloc *allocator) allocateDevice(r deviceIndices, device deviceWithID, mus
 		}
 
 		if allowMultipleAllocations {
-			consumedCapacity = GetConsumedCapacityFromRequest(request.capacities(), device.Capacity, alloc.features.FractionalCapacityRange)
+			consumedCapacity, err = GetConsumedCapacityFromRequest(request.capacities(), device.Capacity, alloc.features.FractionalCapacityRange)
+			if err != nil {
+				alloc.rollbackDevice(r, device, baseRequestName, subRequestName, state)
+				return false, nil, fmt.Errorf("claim %s, request %s: computing consumed capacity for device %s: %w", klog.KObj(claim), requestData.request.name(), device.id, err)
+			}
 			shareID = GenerateNewShareID()
 			alloc.logger.V(7).Info("Device capacity allocated", "device", device.id,
 				"consumed capacity", klog.Format(consumedCapacity))

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/consumable_capacity.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/consumable_capacity.go
@@ -18,6 +18,7 @@ package experimental
 
 import (
 	"errors"
+	"fmt"
 	"math"
 
 	resourceapi "k8s.io/api/resource/v1"
@@ -25,14 +26,37 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+// errCapacityRequestNotRepresentable signals that a capacity request, or the
+// value it rounds up to, cannot be represented by a device's range arithmetic
+// (it passes MaxInt64 on the integer path, or the milli-value range on the
+// fractional path). The allocator treats this as a fatal error that aborts the
+// allocation rather than a per-device mismatch to skip, so an unrepresentable
+// request is rejected outright instead of driving a device-by-device retry.
+var errCapacityRequestNotRepresentable = errors.New("capacity request cannot be represented in the device's range arithmetic")
+
+// errNegativeCapacity signals that a resolved consumed capacity is negative. A negative
+// value is not valid capacity and would under-count the device and over-allocate it. It
+// can reach the allocator from a stored ResourceSlice or ResourceClaim created before
+// stricter validation, which admission does not re-check, so the allocator rejects it
+// rather than recording it.
+var errNegativeCapacity = errors.New("capacity value is negative")
+
 // CmpRequestOverCapacity checks whether the new capacity request can be added within the given capacity,
 // and checks whether the requested value is against the capacity requestPolicy.
 func CmpRequestOverCapacity(currentConsumedCapacity ConsumedCapacity, deviceRequestCapacity *resourceapi.CapacityRequirements,
 	allowMultipleAllocations *bool, capacity map[resourceapi.QualifiedName]resourceapi.DeviceCapacity, allocatingCapacity ConsumedCapacity, fractionalCapacityRange bool) (bool, error) {
 	if requestsContainNonExistCapacity(deviceRequestCapacity, capacity) {
-		return false, errors.New("some requested capacity has not been defined")
+		// This device does not define a requested capacity. A different device may,
+		// so report it as not satisfiable rather than a fatal error: false with a nil
+		// error means "skip this device", a non-nil error means "abort allocation".
+		return false, nil
 	}
-	clone := currentConsumedCapacity.Clone()
+	// First resolve every requested capacity. A request that cannot be represented is a
+	// fatal error that must abort regardless of map iteration order, so representability
+	// is checked for all capacities before any soft "not satisfiable" return below.
+	// Interleaving the two in one loop would let the outcome, skip or abort, depend on
+	// which capacity the map happens to visit first.
+	consumed := make(map[resourceapi.QualifiedName]resource.Quantity, len(capacity))
 	for name, cap := range capacity {
 		var requestedValPtr *resource.Quantity
 		if deviceRequestCapacity != nil && deviceRequestCapacity.Requests != nil {
@@ -40,7 +64,26 @@ func CmpRequestOverCapacity(currentConsumedCapacity ConsumedCapacity, deviceRequ
 				requestedValPtr = &requestedVal
 			}
 		}
-		consumedCapacity := calculateConsumedCapacity(requestedValPtr, cap, fractionalCapacityRange)
+		consumedCapacity, err := calculateConsumedCapacity(requestedValPtr, cap, fractionalCapacityRange)
+		if err != nil {
+			// The request is not representable in this capacity's range arithmetic.
+			// Surface a fatal error so the allocator aborts instead of retrying other
+			// devices, which a user-controlled out-of-range request could abuse.
+			return false, fmt.Errorf("capacity %q: %w", name, err)
+		}
+		if consumedCapacity.Sign() < 0 {
+			// A negative capacity cannot come from a request the allocator should honor;
+			// recording it would over-allocate the device. Abort rather than skip, since a
+			// stored object from before stricter validation is a data problem, not a
+			// per-device mismatch that another device could satisfy.
+			return false, fmt.Errorf("capacity %q: %w", name, errNegativeCapacity)
+		}
+		consumed[name] = consumedCapacity
+	}
+	// The policy and capacity checks are soft: they skip this device rather than abort.
+	clone := currentConsumedCapacity.Clone()
+	for name, cap := range capacity {
+		consumedCapacity := consumed[name]
 		if violatesPolicy(consumedCapacity, cap.RequestPolicy, fractionalCapacityRange) {
 			return false, nil
 		}
@@ -81,20 +124,20 @@ func requestsContainNonExistCapacity(deviceRequestCapacity *resourceapi.Capacity
 // If no requestPolicy, return capacity.Value.
 // If no requestVal, fill the quantity by fillEmptyRequest function
 // Otherwise, use requestPolicy to calculate the consumed capacity from request if applicable.
-func calculateConsumedCapacity(requestedVal *resource.Quantity, capacity resourceapi.DeviceCapacity, fractionalCapacityRange bool) resource.Quantity {
+func calculateConsumedCapacity(requestedVal *resource.Quantity, capacity resourceapi.DeviceCapacity, fractionalCapacityRange bool) (resource.Quantity, error) {
 	if requestedVal == nil {
-		return fillEmptyRequest(capacity)
+		return fillEmptyRequest(capacity), nil
 	}
 	if capacity.RequestPolicy == nil {
-		return requestedVal.DeepCopy()
+		return requestedVal.DeepCopy(), nil
 	}
 	switch {
 	case capacity.RequestPolicy.ValidRange != nil && capacity.RequestPolicy.ValidRange.Min != nil:
 		return roundUpRange(requestedVal, capacity.RequestPolicy.ValidRange, fractionalCapacityRange)
 	case capacity.RequestPolicy.ValidValues != nil:
-		return roundUpValidValues(requestedVal, capacity.RequestPolicy.ValidValues)
+		return roundUpValidValues(requestedVal, capacity.RequestPolicy.ValidValues), nil
 	}
-	return *requestedVal
+	return *requestedVal, nil
 }
 
 // fillEmptyRequest
@@ -117,23 +160,23 @@ func fillEmptyRequest(capacity resourceapi.DeviceCapacity) resource.Quantity {
 // fit within the milli-value int64 range and step >= 1m, milli-value arithmetic is used.
 // Otherwise Value() arithmetic is used.
 //
-// If the rounded milli-value exceeds the int64 milli-value range, the result is
-// capped at the maximum representable milli value.
+// It returns errCapacityRequestNotRepresentable when the request, or the value it
+// rounds up to, cannot be represented: past MaxInt64 on the integer path, or past
+// the milli-value range on the fractional path. The caller aborts allocation with
+// that error rather than acting on a wrapped read or a silently capped value.
 func roundUpRange(requestedVal *resource.Quantity, validRange *resourceapi.CapacityRequestPolicyRange,
-	enableFractionalCapacityRange bool) resource.Quantity {
+	enableFractionalCapacityRange bool) (resource.Quantity, error) {
 	if requestedVal.Cmp(*validRange.Min) < 0 {
-		return validRange.Min.DeepCopy()
+		return validRange.Min.DeepCopy(), nil
 	}
 	if validRange.Step == nil {
-		return *requestedVal
+		return *requestedVal, nil
 	}
 	if useMilli(validRange, enableFractionalCapacityRange) {
 		requestedMilli, err := safeMilliValue(*requestedVal)
 		format := validRange.Step.Format
 		if err != nil {
-			// This is violated value.
-			// It will be rejected by violateValidRange check
-			return *requestedVal
+			return resource.Quantity{}, fmt.Errorf("%w: request %s is not a representable milli value", errCapacityRequestNotRepresentable, requestedVal.String())
 		}
 		stepMilli := validRange.Step.MilliValue()
 		minMilli := validRange.Min.MilliValue()
@@ -143,19 +186,24 @@ func roundUpRange(requestedVal *resource.Quantity, validRange *resourceapi.Capac
 			n++
 		}
 		if n > (math.MaxInt64-minMilli)/stepMilli {
-			// Round to maximum value
-			return *resource.NewMilliQuantity(math.MaxInt64, format)
+			return resource.Quantity{}, fmt.Errorf("%w: rounding request %s up to the next step passes the milli-value range", errCapacityRequestNotRepresentable, requestedVal.String())
 		}
 		valMilli := minMilli + stepMilli*n
 		// Return in the same format as the step quantity. If the result is a
 		// whole number, use NewQuantity to keep the representation compact and
 		// compatible with quantities parsed from whole-number strings.
 		if valMilli%1000 == 0 {
-			return *resource.NewQuantity(valMilli/1000, format)
+			return *resource.NewQuantity(valMilli/1000, format), nil
 		}
-		return *resource.NewMilliQuantity(valMilli, format)
+		return *resource.NewMilliQuantity(valMilli, format), nil
 	}
 	// Integer arithmetic path.
+	// A request above MaxInt64 cannot be read with Value() without wrapping, so it
+	// cannot be rounded in int64. Report that it is not representable rather than
+	// acting on the wrapped read.
+	if requestedVal.CmpInt64(math.MaxInt64) > 0 {
+		return resource.Quantity{}, fmt.Errorf("%w: request %s exceeds MaxInt64", errCapacityRequestNotRepresentable, requestedVal.String())
+	}
 	requestedInt := requestedVal.Value()
 	stepInt := validRange.Step.Value()
 	minInt := validRange.Min.Value()
@@ -164,9 +212,14 @@ func roundUpRange(requestedVal *resource.Quantity, validRange *resourceapi.Capac
 	if added%stepInt != 0 {
 		n++
 	}
-	// TODO (#140441): minInt+stepInt*n can overflow int64 for a large capacity request,
-	// and allocate a device which it should not.
-	return *resource.NewQuantity(minInt+stepInt*n, validRange.Step.Format)
+	// minInt+stepInt*n overflows int64 once the rounded value passes MaxInt64. It cannot
+	// be represented or compared reliably, so report the request as not representable. The
+	// guard needs minInt >= 0 so that MaxInt64-minInt does not itself overflow; a negative
+	// min is out of the non-negative API contract and keeps the existing arithmetic here.
+	if minInt >= 0 && n > (math.MaxInt64-minInt)/stepInt {
+		return resource.Quantity{}, fmt.Errorf("%w: rounding request %s up to the next step passes MaxInt64", errCapacityRequestNotRepresentable, requestedVal.String())
+	}
+	return *resource.NewQuantity(minInt+stepInt*n, validRange.Step.Format), nil
 }
 
 // roundUpValidValues returns the first value in validValues that is greater than or equal to requestedVal.
@@ -186,7 +239,7 @@ func roundUpValidValues(requestedVal *resource.Quantity, validValues []resource.
 // GetConsumedCapacityFromRequest returns valid consumed capacity,
 // according to claim request and defined capacity.
 func GetConsumedCapacityFromRequest(requestedCapacity *resourceapi.CapacityRequirements,
-	consumableCapacity map[resourceapi.QualifiedName]resourceapi.DeviceCapacity, fractionalCapacityRange bool) map[resourceapi.QualifiedName]resource.Quantity {
+	consumableCapacity map[resourceapi.QualifiedName]resourceapi.DeviceCapacity, fractionalCapacityRange bool) (map[resourceapi.QualifiedName]resource.Quantity, error) {
 	consumedCapacity := make(map[resourceapi.QualifiedName]resource.Quantity)
 	for name, cap := range consumableCapacity {
 		var requestedValPtr *resource.Quantity
@@ -195,10 +248,16 @@ func GetConsumedCapacityFromRequest(requestedCapacity *resourceapi.CapacityRequi
 				requestedValPtr = &requestedVal
 			}
 		}
-		capacity := calculateConsumedCapacity(requestedValPtr, cap, fractionalCapacityRange)
+		capacity, err := calculateConsumedCapacity(requestedValPtr, cap, fractionalCapacityRange)
+		if err != nil {
+			// Feasibility already ran, so this should not happen. Return the error
+			// rather than a raw request so a future caller cannot record an
+			// unrepresentable value as consumed capacity.
+			return nil, fmt.Errorf("capacity %q: %w", name, err)
+		}
 		consumedCapacity[name] = capacity
 	}
-	return consumedCapacity
+	return consumedCapacity, nil
 }
 
 // violatesPolicy checks whether the request violate the requestPolicy.

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/consumable_capacity_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/consumable_capacity_test.go
@@ -34,9 +34,14 @@ const (
 )
 
 var (
-	one   = resource.MustParse("1")
-	two   = resource.MustParse("2")
-	three = resource.MustParse("3")
+	one        = resource.MustParse("1")
+	two        = resource.MustParse("2")
+	three      = resource.MustParse("3")
+	zero       = resource.MustParse("0")
+	maxInt64Q  = resource.MustParse("9223372036854775807")
+	maxInt64P1 = resource.MustParse("9223372036854775808")
+	twoPow64P3 = resource.MustParse("18446744073709551619")
+	maxInt64M1 = resource.MustParse("9223372036854775806")
 
 	pointTwoFive = resource.MustParse("250m")
 	pointFour    = resource.MustParse("400m")
@@ -110,8 +115,9 @@ func TestConsumableCapacity(t *testing.T) {
 				Value: one, // no request and no policy (no default), expect capacity value
 			},
 		}
-		consumedCapacity := GetConsumedCapacityFromRequest(requestedCapacity, consumableCapacity, false)
 		g := NewWithT(t)
+		consumedCapacity, err := GetConsumedCapacityFromRequest(requestedCapacity, consumableCapacity, false)
+		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(consumedCapacity).To(HaveLen(3))
 		for name, val := range consumedCapacity {
 			g.Expect(string(name)).Should(BeElementOf([]string{capacity0, capacity1, "dummy"}))
@@ -126,6 +132,38 @@ func TestConsumableCapacity(t *testing.T) {
 	t.Run("safe-milli-value", testSafeMilliValue)
 
 	t.Run("use-milli", testUseMilli)
+
+	t.Run("cmp-request-over-capacity-fatal-beats-soft", testCmpRequestOverCapacityFatalBeatsSoft)
+}
+
+// testCmpRequestOverCapacityFatalBeatsSoft pins that a representability error takes
+// precedence over a soft policy or capacity mismatch on the same device. The allocator
+// enforces that precedence by resolving representability for all capacities before it
+// runs the soft checks, so the outcome does not depend on Go's unspecified map order.
+func testCmpRequestOverCapacityFatalBeatsSoft(t *testing.T) {
+	g := NewWithT(t)
+	capacity := map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
+		capacity0: {Value: one}, // no policy; the request of 2 over-fills the value of 1 (soft)
+		capacity1: {
+			Value: maxInt64P1,
+			RequestPolicy: &resourceapi.CapacityRequestPolicy{
+				ValidRange: &resourceapi.CapacityRequestPolicyRange{Min: &zero, Step: &two},
+			},
+		},
+	}
+	request := &resourceapi.CapacityRequirements{
+		Requests: map[resourceapi.QualifiedName]resource.Quantity{
+			capacity0: two,       // over capacity0's value of 1: soft, skip this device
+			capacity1: maxInt64Q, // rounding MaxInt64 up to the next step of 2 passes MaxInt64: fatal
+		},
+	}
+	// Go's map order is unspecified, so run the check repeatedly to make an
+	// order-dependent regression very likely to surface rather than to rely on one order.
+	for range 64 {
+		ok, err := CmpRequestOverCapacity(NewConsumedCapacity(), request, nil, capacity, NewConsumedCapacity(), false)
+		g.Expect(ok).To(BeFalseBecause("an unrepresentable request must not be considered satisfiable"))
+		g.Expect(err).To(MatchError(errCapacityRequestNotRepresentable), "a representability error must take precedence over the soft over-capacity mismatch")
+	}
 }
 
 func testSafeMilliValue(t *testing.T) {
@@ -313,8 +351,34 @@ func testCalculateConsumedCapacity(t *testing.T) {
 		requestPolicy           *resourceapi.CapacityRequestPolicy
 		fractionalCapacityRange bool
 		expectResult            resource.Quantity
+		expectErr               bool
 	}{
 		"empty": {requestedVal: nil, capacityValue: one, requestPolicy: &resourceapi.CapacityRequestPolicy{}, expectResult: one},
+		// A request above MaxInt64 cannot be read with Value() without wrapping, so
+		// calculateConsumedCapacity returns a fatal error rather than acting on a
+		// wrapped read (#140441).
+		"request-above-maxint64-is-rejected": {
+			requestedVal:  &twoPow64P3,
+			capacityValue: twoPow64P3,
+			requestPolicy: &resourceapi.CapacityRequestPolicy{Default: &zero, ValidRange: &resourceapi.CapacityRequestPolicyRange{Min: &zero, Step: &three}},
+			expectErr:     true,
+		},
+		// Rounding MaxInt64 up to the next step passes MaxInt64 and would wrap; return a
+		// fatal error instead of a wrapped value.
+		"rounded-value-above-maxint64-is-rejected": {
+			requestedVal:  &maxInt64Q,
+			capacityValue: maxInt64P1,
+			requestPolicy: &resourceapi.CapacityRequestPolicy{Default: &zero, ValidRange: &resourceapi.CapacityRequestPolicyRange{Min: &zero, Step: &two}},
+			expectErr:     true,
+		},
+		// Maximum safe boundary: MaxInt64-1 with min=1, step=2 rounds to exactly MaxInt64,
+		// which still fits, so it is accepted. Guards on > (not >=) so this is not rejected.
+		"max-safe-boundary-rounds-to-maxint64": {
+			requestedVal:  &maxInt64M1,
+			capacityValue: maxInt64Q,
+			requestPolicy: &resourceapi.CapacityRequestPolicy{Default: &one, ValidRange: &resourceapi.CapacityRequestPolicyRange{Min: &one, Step: &two}},
+			expectResult:  maxInt64Q,
+		},
 		"min in range": {
 			requestedVal:  nil,
 			capacityValue: two,
@@ -399,8 +463,9 @@ func testCalculateConsumedCapacity(t *testing.T) {
 			requestPolicy: &resourceapi.CapacityRequestPolicy{Default: &one, ValidValues: []resource.Quantity{one, two}},
 			expectResult:  three,
 		},
-		// overflow guard: min=1, step=1, requested is huge; rounding n overflows, caps at MaxInt64m
-		"fractional step overflow cap rounds to MaxInt64 milli": {
+		// A request that cannot be converted to a milli value safely is rejected with a
+		// fatal error rather than passed through unrounded.
+		"fractional-step-request-not-milli-representable-is-rejected": {
 			requestedVal:  &tooBigForMilli,
 			capacityValue: tooBigForMilli,
 			requestPolicy: &resourceapi.CapacityRequestPolicy{
@@ -411,12 +476,11 @@ func testCalculateConsumedCapacity(t *testing.T) {
 				},
 			},
 			fractionalCapacityRange: true,
-			// requested can't be converted to milli safely, so roundUpRange returns
-			// requestedVal unchanged; calculateConsumedCapacity uses that as-is.
-			expectResult: tooBigForMilli,
+			expectErr:               true,
 		},
-		// overflow guard via large but milli-representable requested value.
-		"fractional step overflow cap: large milli-representable request capped at MaxInt64m": {
+		// A milli-representable request whose rounded value passes the milli-value range is
+		// rejected with a fatal error rather than silently capped.
+		"fractional-step-rounded-value-passes-milli-range-is-rejected": {
 			requestedVal: func() *resource.Quantity {
 				q := resource.NewMilliQuantity(math.MaxInt64-1, resource.DecimalSI)
 				return q
@@ -430,7 +494,7 @@ func testCalculateConsumedCapacity(t *testing.T) {
 				},
 			},
 			fractionalCapacityRange: true,
-			expectResult:            *resource.NewMilliQuantity(math.MaxInt64, resource.DecimalSI),
+			expectErr:               true,
 		},
 	}
 	for name, tc := range testcases {
@@ -440,8 +504,13 @@ func testCalculateConsumedCapacity(t *testing.T) {
 				Value:         tc.capacityValue,
 				RequestPolicy: tc.requestPolicy,
 			}
-			consumedCapacity := calculateConsumedCapacity(tc.requestedVal, capacity, tc.fractionalCapacityRange)
-			g.Expect(consumedCapacity.Cmp(tc.expectResult)).To(BeZero())
+			consumedCapacity, err := calculateConsumedCapacity(tc.requestedVal, capacity, tc.fractionalCapacityRange)
+			if tc.expectErr {
+				g.Expect(err).To(MatchError(errCapacityRequestNotRepresentable))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(consumedCapacity.Cmp(tc.expectResult)).To(BeZero())
+			}
 		})
 	}
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
@@ -595,9 +595,7 @@ func (alloc *allocator) validateDeviceRequest(request requestAccessor, parentReq
 							device := slice.Spec.Devices[deviceIndex]
 							success, err := alloc.CmpRequestOverCapacity(requestData.request, slice, device)
 							if err != nil {
-								alloc.logger.V(7).Info("Skip comparing device capacity request",
-									"device", device, "request", requestData.request.name(), "err", err)
-								continue
+								return requestData, fmt.Errorf("claim %s, request %s: checking capacity for device %s: %w", klog.KObj(claim), requestData.request.name(), device.Name, err)
 							}
 							if !success {
 								alloc.logger.V(7).Info("Device capacity not enough", "device", device)
@@ -1137,9 +1135,7 @@ func (alloc *allocator) allocateOne(r deviceIndices, allocateSubRequest bool, st
 					device := slice.Spec.Devices[deviceIndex]
 					success, err := alloc.CmpRequestOverCapacity(requestData.request, slice, device)
 					if err != nil {
-						alloc.logger.V(7).Info("Skip comparing device capacity request",
-							"device", deviceID, "request", requestData.request.name(), "err", err)
-						continue
+						return false, fmt.Errorf("claim %s, request %s: checking capacity for device %s: %w", klog.KObj(claim), requestData.request.name(), deviceID, err)
 					}
 					if !success {
 						alloc.logger.V(7).Info("Device capacity not enough", "device", deviceID)
@@ -1436,12 +1432,11 @@ func (alloc *allocator) allocateDevice(r deviceIndices, device deviceWithID, mus
 	if alloc.features.ConsumableCapacity {
 		// Validate whether resource request over capacity
 		success, err := alloc.CmpRequestOverCapacity(requestData.request, device.slice, *device.Device)
-		// The error should not occur at this point as it should be detected in the previous step.
 		if err != nil {
-			alloc.logger.V(7).Info("Failed to compare device capacity request on allocateDevice",
-				"device", device, "request", requestData.request.name(), "err", err)
+			// The overflow guard already ran during validation, so an error here is
+			// unexpected. Roll back and surface it rather than swallowing it.
 			alloc.rollbackDevice(r, device, baseRequestName, subRequestName, state)
-			return false, nil, nil
+			return false, nil, fmt.Errorf("claim %s, request %s: rechecking capacity for device %s: %w", klog.KObj(claim), requestData.request.name(), device.id, err)
 		}
 		if !success {
 			alloc.logger.V(7).Info("Device capacity not enough", "device", device)
@@ -1450,7 +1445,11 @@ func (alloc *allocator) allocateDevice(r deviceIndices, device deviceWithID, mus
 		}
 
 		if allowMultipleAllocations {
-			consumedCapacity = GetConsumedCapacityFromRequest(request.capacities(), device.Capacity, alloc.features.FractionalCapacityRange)
+			consumedCapacity, err = GetConsumedCapacityFromRequest(request.capacities(), device.Capacity, alloc.features.FractionalCapacityRange)
+			if err != nil {
+				alloc.rollbackDevice(r, device, baseRequestName, subRequestName, state)
+				return false, nil, fmt.Errorf("claim %s, request %s: computing consumed capacity for device %s: %w", klog.KObj(claim), requestData.request.name(), device.id, err)
+			}
 			shareID = GenerateNewShareID()
 			alloc.logger.V(7).Info("Device capacity allocated", "device", device.id,
 				"consumed capacity", klog.Format(consumedCapacity))

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/consumable_capacity.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/consumable_capacity.go
@@ -18,6 +18,7 @@ package incubating
 
 import (
 	"errors"
+	"fmt"
 	"math"
 
 	resourceapi "k8s.io/api/resource/v1"
@@ -25,14 +26,37 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+// errCapacityRequestNotRepresentable signals that a capacity request, or the
+// value it rounds up to, cannot be represented by a device's range arithmetic
+// (it passes MaxInt64 on the integer path, or the milli-value range on the
+// fractional path). The allocator treats this as a fatal error that aborts the
+// allocation rather than a per-device mismatch to skip, so an unrepresentable
+// request is rejected outright instead of driving a device-by-device retry.
+var errCapacityRequestNotRepresentable = errors.New("capacity request cannot be represented in the device's range arithmetic")
+
+// errNegativeCapacity signals that a resolved consumed capacity is negative. A negative
+// value is not valid capacity and would under-count the device and over-allocate it. It
+// can reach the allocator from a stored ResourceSlice or ResourceClaim created before
+// stricter validation, which admission does not re-check, so the allocator rejects it
+// rather than recording it.
+var errNegativeCapacity = errors.New("capacity value is negative")
+
 // CmpRequestOverCapacity checks whether the new capacity request can be added within the given capacity,
 // and checks whether the requested value is against the capacity requestPolicy.
 func CmpRequestOverCapacity(currentConsumedCapacity ConsumedCapacity, deviceRequestCapacity *resourceapi.CapacityRequirements,
 	allowMultipleAllocations *bool, capacity map[resourceapi.QualifiedName]resourceapi.DeviceCapacity, allocatingCapacity ConsumedCapacity, fractionalCapacityRange bool) (bool, error) {
 	if requestsContainNonExistCapacity(deviceRequestCapacity, capacity) {
-		return false, errors.New("some requested capacity has not been defined")
+		// This device does not define a requested capacity. A different device may,
+		// so report it as not satisfiable rather than a fatal error: false with a nil
+		// error means "skip this device", a non-nil error means "abort allocation".
+		return false, nil
 	}
-	clone := currentConsumedCapacity.Clone()
+	// First resolve every requested capacity. A request that cannot be represented is a
+	// fatal error that must abort regardless of map iteration order, so representability
+	// is checked for all capacities before any soft "not satisfiable" return below.
+	// Interleaving the two in one loop would let the outcome, skip or abort, depend on
+	// which capacity the map happens to visit first.
+	consumed := make(map[resourceapi.QualifiedName]resource.Quantity, len(capacity))
 	for name, cap := range capacity {
 		var requestedValPtr *resource.Quantity
 		if deviceRequestCapacity != nil && deviceRequestCapacity.Requests != nil {
@@ -40,7 +64,26 @@ func CmpRequestOverCapacity(currentConsumedCapacity ConsumedCapacity, deviceRequ
 				requestedValPtr = &requestedVal
 			}
 		}
-		consumedCapacity := calculateConsumedCapacity(requestedValPtr, cap, fractionalCapacityRange)
+		consumedCapacity, err := calculateConsumedCapacity(requestedValPtr, cap, fractionalCapacityRange)
+		if err != nil {
+			// The request is not representable in this capacity's range arithmetic.
+			// Surface a fatal error so the allocator aborts instead of retrying other
+			// devices, which a user-controlled out-of-range request could abuse.
+			return false, fmt.Errorf("capacity %q: %w", name, err)
+		}
+		if consumedCapacity.Sign() < 0 {
+			// A negative capacity cannot come from a request the allocator should honor;
+			// recording it would over-allocate the device. Abort rather than skip, since a
+			// stored object from before stricter validation is a data problem, not a
+			// per-device mismatch that another device could satisfy.
+			return false, fmt.Errorf("capacity %q: %w", name, errNegativeCapacity)
+		}
+		consumed[name] = consumedCapacity
+	}
+	// The policy and capacity checks are soft: they skip this device rather than abort.
+	clone := currentConsumedCapacity.Clone()
+	for name, cap := range capacity {
+		consumedCapacity := consumed[name]
 		if violatesPolicy(consumedCapacity, cap.RequestPolicy, fractionalCapacityRange) {
 			return false, nil
 		}
@@ -81,20 +124,20 @@ func requestsContainNonExistCapacity(deviceRequestCapacity *resourceapi.Capacity
 // If no requestPolicy, return capacity.Value.
 // If no requestVal, fill the quantity by fillEmptyRequest function
 // Otherwise, use requestPolicy to calculate the consumed capacity from request if applicable.
-func calculateConsumedCapacity(requestedVal *resource.Quantity, capacity resourceapi.DeviceCapacity, fractionalCapacityRange bool) resource.Quantity {
+func calculateConsumedCapacity(requestedVal *resource.Quantity, capacity resourceapi.DeviceCapacity, fractionalCapacityRange bool) (resource.Quantity, error) {
 	if requestedVal == nil {
-		return fillEmptyRequest(capacity)
+		return fillEmptyRequest(capacity), nil
 	}
 	if capacity.RequestPolicy == nil {
-		return requestedVal.DeepCopy()
+		return requestedVal.DeepCopy(), nil
 	}
 	switch {
 	case capacity.RequestPolicy.ValidRange != nil && capacity.RequestPolicy.ValidRange.Min != nil:
 		return roundUpRange(requestedVal, capacity.RequestPolicy.ValidRange, fractionalCapacityRange)
 	case capacity.RequestPolicy.ValidValues != nil:
-		return roundUpValidValues(requestedVal, capacity.RequestPolicy.ValidValues)
+		return roundUpValidValues(requestedVal, capacity.RequestPolicy.ValidValues), nil
 	}
-	return *requestedVal
+	return *requestedVal, nil
 }
 
 // fillEmptyRequest
@@ -117,22 +160,22 @@ func fillEmptyRequest(capacity resourceapi.DeviceCapacity) resource.Quantity {
 // fit within the milli-value int64 range and step >= 1m, milli-value arithmetic is used.
 // Otherwise Value() arithmetic is used.
 //
-// If the rounded milli-value exceeds the int64 milli-value range, the result is
-// capped at the maximum representable milli value.
-func roundUpRange(requestedVal *resource.Quantity, validRange *resourceapi.CapacityRequestPolicyRange, fractionalCapacityRange bool) resource.Quantity {
+// It returns errCapacityRequestNotRepresentable when the request, or the value it
+// rounds up to, cannot be represented: past MaxInt64 on the integer path, or past
+// the milli-value range on the fractional path. The caller aborts allocation with
+// that error rather than acting on a wrapped read or a silently capped value.
+func roundUpRange(requestedVal *resource.Quantity, validRange *resourceapi.CapacityRequestPolicyRange, fractionalCapacityRange bool) (resource.Quantity, error) {
 	if requestedVal.Cmp(*validRange.Min) < 0 {
-		return validRange.Min.DeepCopy()
+		return validRange.Min.DeepCopy(), nil
 	}
 	if validRange.Step == nil {
-		return *requestedVal
+		return *requestedVal, nil
 	}
 	if useMilli(validRange, fractionalCapacityRange) {
 		requestedMilli, err := safeMilliValue(*requestedVal)
 		format := validRange.Step.Format
 		if err != nil {
-			// This is violated value.
-			// It will be rejected by violateValidRange check
-			return *requestedVal
+			return resource.Quantity{}, fmt.Errorf("%w: request %s is not a representable milli value", errCapacityRequestNotRepresentable, requestedVal.String())
 		}
 		stepMilli := validRange.Step.MilliValue()
 		minMilli := validRange.Min.MilliValue()
@@ -142,19 +185,24 @@ func roundUpRange(requestedVal *resource.Quantity, validRange *resourceapi.Capac
 			n++
 		}
 		if n > (math.MaxInt64-minMilli)/stepMilli {
-			// Round to maximum value
-			return *resource.NewMilliQuantity(math.MaxInt64, format)
+			return resource.Quantity{}, fmt.Errorf("%w: rounding request %s up to the next step passes the milli-value range", errCapacityRequestNotRepresentable, requestedVal.String())
 		}
 		valMilli := minMilli + stepMilli*n
 		// Return in the same format as the step quantity. If the result is a
 		// whole number, use NewQuantity to keep the representation compact and
 		// compatible with quantities parsed from whole-number strings.
 		if valMilli%1000 == 0 {
-			return *resource.NewQuantity(valMilli/1000, format)
+			return *resource.NewQuantity(valMilli/1000, format), nil
 		}
-		return *resource.NewMilliQuantity(valMilli, format)
+		return *resource.NewMilliQuantity(valMilli, format), nil
 	}
 	// Integer arithmetic path.
+	// A request above MaxInt64 cannot be read with Value() without wrapping, so it
+	// cannot be rounded in int64. Report that it is not representable rather than
+	// acting on the wrapped read.
+	if requestedVal.CmpInt64(math.MaxInt64) > 0 {
+		return resource.Quantity{}, fmt.Errorf("%w: request %s exceeds MaxInt64", errCapacityRequestNotRepresentable, requestedVal.String())
+	}
 	requestedInt := requestedVal.Value()
 	stepInt := validRange.Step.Value()
 	minInt := validRange.Min.Value()
@@ -163,9 +211,14 @@ func roundUpRange(requestedVal *resource.Quantity, validRange *resourceapi.Capac
 	if added%stepInt != 0 {
 		n++
 	}
-	// TODO (#140441): minInt+stepInt*n can overflow int64 for a large capacity request,
-	// and allocate a device which it should not.
-	return *resource.NewQuantity(minInt+stepInt*n, validRange.Step.Format)
+	// minInt+stepInt*n overflows int64 once the rounded value passes MaxInt64. It cannot
+	// be represented or compared reliably, so report the request as not representable. The
+	// guard needs minInt >= 0 so that MaxInt64-minInt does not itself overflow; a negative
+	// min is out of the non-negative API contract and keeps the existing arithmetic here.
+	if minInt >= 0 && n > (math.MaxInt64-minInt)/stepInt {
+		return resource.Quantity{}, fmt.Errorf("%w: rounding request %s up to the next step passes MaxInt64", errCapacityRequestNotRepresentable, requestedVal.String())
+	}
+	return *resource.NewQuantity(minInt+stepInt*n, validRange.Step.Format), nil
 }
 
 // roundUpValidValues returns the first value in validValues that is greater than or equal to requestedVal.
@@ -185,7 +238,7 @@ func roundUpValidValues(requestedVal *resource.Quantity, validValues []resource.
 // GetConsumedCapacityFromRequest returns valid consumed capacity,
 // according to claim request and defined capacity.
 func GetConsumedCapacityFromRequest(requestedCapacity *resourceapi.CapacityRequirements,
-	consumableCapacity map[resourceapi.QualifiedName]resourceapi.DeviceCapacity, fractionalCapacityRange bool) map[resourceapi.QualifiedName]resource.Quantity {
+	consumableCapacity map[resourceapi.QualifiedName]resourceapi.DeviceCapacity, fractionalCapacityRange bool) (map[resourceapi.QualifiedName]resource.Quantity, error) {
 	consumedCapacity := make(map[resourceapi.QualifiedName]resource.Quantity)
 	for name, cap := range consumableCapacity {
 		var requestedValPtr *resource.Quantity
@@ -194,10 +247,16 @@ func GetConsumedCapacityFromRequest(requestedCapacity *resourceapi.CapacityRequi
 				requestedValPtr = &requestedVal
 			}
 		}
-		capacity := calculateConsumedCapacity(requestedValPtr, cap, fractionalCapacityRange)
+		capacity, err := calculateConsumedCapacity(requestedValPtr, cap, fractionalCapacityRange)
+		if err != nil {
+			// Feasibility already ran, so this should not happen. Return the error
+			// rather than a raw request so a future caller cannot record an
+			// unrepresentable value as consumed capacity.
+			return nil, fmt.Errorf("capacity %q: %w", name, err)
+		}
 		consumedCapacity[name] = capacity
 	}
-	return consumedCapacity
+	return consumedCapacity, nil
 }
 
 // violatesPolicy checks whether the request violate the requestPolicy.

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/consumable_capacity_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/consumable_capacity_test.go
@@ -34,9 +34,14 @@ const (
 )
 
 var (
-	one   = resource.MustParse("1")
-	two   = resource.MustParse("2")
-	three = resource.MustParse("3")
+	one        = resource.MustParse("1")
+	two        = resource.MustParse("2")
+	three      = resource.MustParse("3")
+	zero       = resource.MustParse("0")
+	maxInt64Q  = resource.MustParse("9223372036854775807")
+	maxInt64P1 = resource.MustParse("9223372036854775808")
+	twoPow64P3 = resource.MustParse("18446744073709551619")
+	maxInt64M1 = resource.MustParse("9223372036854775806")
 
 	pointTwoFive = resource.MustParse("250m")
 	pointFour    = resource.MustParse("400m")
@@ -110,8 +115,9 @@ func TestConsumableCapacity(t *testing.T) {
 				Value: one, // no request and no policy (no default), expect capacity value
 			},
 		}
-		consumedCapacity := GetConsumedCapacityFromRequest(requestedCapacity, consumableCapacity, false)
 		g := NewWithT(t)
+		consumedCapacity, err := GetConsumedCapacityFromRequest(requestedCapacity, consumableCapacity, false)
+		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(consumedCapacity).To(HaveLen(3))
 		for name, val := range consumedCapacity {
 			g.Expect(string(name)).Should(BeElementOf([]string{capacity0, capacity1, "dummy"}))
@@ -126,6 +132,38 @@ func TestConsumableCapacity(t *testing.T) {
 	t.Run("safe-milli-value", testSafeMilliValue)
 
 	t.Run("use-milli", testUseMilli)
+
+	t.Run("cmp-request-over-capacity-fatal-beats-soft", testCmpRequestOverCapacityFatalBeatsSoft)
+}
+
+// testCmpRequestOverCapacityFatalBeatsSoft pins that a representability error takes
+// precedence over a soft policy or capacity mismatch on the same device. The allocator
+// enforces that precedence by resolving representability for all capacities before it
+// runs the soft checks, so the outcome does not depend on Go's unspecified map order.
+func testCmpRequestOverCapacityFatalBeatsSoft(t *testing.T) {
+	g := NewWithT(t)
+	capacity := map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
+		capacity0: {Value: one}, // no policy; the request of 2 over-fills the value of 1 (soft)
+		capacity1: {
+			Value: maxInt64P1,
+			RequestPolicy: &resourceapi.CapacityRequestPolicy{
+				ValidRange: &resourceapi.CapacityRequestPolicyRange{Min: &zero, Step: &two},
+			},
+		},
+	}
+	request := &resourceapi.CapacityRequirements{
+		Requests: map[resourceapi.QualifiedName]resource.Quantity{
+			capacity0: two,       // over capacity0's value of 1: soft, skip this device
+			capacity1: maxInt64Q, // rounding MaxInt64 up to the next step of 2 passes MaxInt64: fatal
+		},
+	}
+	// Go's map order is unspecified, so run the check repeatedly to make an
+	// order-dependent regression very likely to surface rather than to rely on one order.
+	for range 64 {
+		ok, err := CmpRequestOverCapacity(NewConsumedCapacity(), request, nil, capacity, NewConsumedCapacity(), false)
+		g.Expect(ok).To(BeFalseBecause("an unrepresentable request must not be considered satisfiable"))
+		g.Expect(err).To(MatchError(errCapacityRequestNotRepresentable), "a representability error must take precedence over the soft over-capacity mismatch")
+	}
 }
 
 func testSafeMilliValue(t *testing.T) {
@@ -313,8 +351,34 @@ func testCalculateConsumedCapacity(t *testing.T) {
 		requestPolicy           *resourceapi.CapacityRequestPolicy
 		fractionalCapacityRange bool
 		expectResult            resource.Quantity
+		expectErr               bool
 	}{
 		"empty": {requestedVal: nil, capacityValue: one, requestPolicy: &resourceapi.CapacityRequestPolicy{}, expectResult: one},
+		// A request above MaxInt64 cannot be read with Value() without wrapping, so
+		// calculateConsumedCapacity returns a fatal error rather than acting on a
+		// wrapped read (#140441).
+		"request-above-maxint64-is-rejected": {
+			requestedVal:  &twoPow64P3,
+			capacityValue: twoPow64P3,
+			requestPolicy: &resourceapi.CapacityRequestPolicy{Default: &zero, ValidRange: &resourceapi.CapacityRequestPolicyRange{Min: &zero, Step: &three}},
+			expectErr:     true,
+		},
+		// Rounding MaxInt64 up to the next step passes MaxInt64 and would wrap; return a
+		// fatal error instead of a wrapped value.
+		"rounded-value-above-maxint64-is-rejected": {
+			requestedVal:  &maxInt64Q,
+			capacityValue: maxInt64P1,
+			requestPolicy: &resourceapi.CapacityRequestPolicy{Default: &zero, ValidRange: &resourceapi.CapacityRequestPolicyRange{Min: &zero, Step: &two}},
+			expectErr:     true,
+		},
+		// Maximum safe boundary: MaxInt64-1 with min=1, step=2 rounds to exactly MaxInt64,
+		// which still fits, so it is accepted. Guards on > (not >=) so this is not rejected.
+		"max-safe-boundary-rounds-to-maxint64": {
+			requestedVal:  &maxInt64M1,
+			capacityValue: maxInt64Q,
+			requestPolicy: &resourceapi.CapacityRequestPolicy{Default: &one, ValidRange: &resourceapi.CapacityRequestPolicyRange{Min: &one, Step: &two}},
+			expectResult:  maxInt64Q,
+		},
 		"min in range": {
 			requestedVal:  nil,
 			capacityValue: two,
@@ -399,8 +463,9 @@ func testCalculateConsumedCapacity(t *testing.T) {
 			requestPolicy: &resourceapi.CapacityRequestPolicy{Default: &one, ValidValues: []resource.Quantity{one, two}},
 			expectResult:  three,
 		},
-		// overflow guard: min=1, step=1, requested is huge; rounding n overflows, caps at MaxInt64m
-		"fractional step overflow cap rounds to MaxInt64 milli": {
+		// A request that cannot be converted to a milli value safely is rejected with a
+		// fatal error rather than passed through unrounded.
+		"fractional-step-request-not-milli-representable-is-rejected": {
 			requestedVal:  &tooBigForMilli,
 			capacityValue: tooBigForMilli,
 			requestPolicy: &resourceapi.CapacityRequestPolicy{
@@ -411,17 +476,16 @@ func testCalculateConsumedCapacity(t *testing.T) {
 				},
 			},
 			fractionalCapacityRange: true,
-			// requested can't be converted to milli safely, so roundUpRange returns
-			// requestedVal unchanged; calculateConsumedCapacity uses that as-is.
-			expectResult: tooBigForMilli,
+			expectErr:               true,
 		},
-		// overflow guard via large but milli-representable requested value.
+		// A milli-representable request whose rounded value passes the milli-value range is
+		// rejected with a fatal error rather than silently capped.
 		// min=100m, step=100m, request=MaxInt64-1 milli:
 		//   added = MaxInt64-1 - 100 = MaxInt64-101
 		//   n     = (MaxInt64-101) / 100 = 92233720368547757  (added%100 == 6, so n++)
 		//   n     = 92233720368547758
-		//   guard = (MaxInt64-100)/100 = 92233720368547757  → n > guard → cap at MaxInt64m
-		"fractional step overflow cap: large milli-representable request capped at MaxInt64m": {
+		//   guard = (MaxInt64-100)/100 = 92233720368547757  → n > guard → not representable
+		"fractional-step-rounded-value-passes-milli-range-is-rejected": {
 			requestedVal: func() *resource.Quantity {
 				q := resource.NewMilliQuantity(math.MaxInt64-1, resource.DecimalSI)
 				return q
@@ -435,7 +499,7 @@ func testCalculateConsumedCapacity(t *testing.T) {
 				},
 			},
 			fractionalCapacityRange: true,
-			expectResult:            *resource.NewMilliQuantity(math.MaxInt64, resource.DecimalSI),
+			expectErr:               true,
 		},
 	}
 	for name, tc := range testcases {
@@ -445,8 +509,13 @@ func testCalculateConsumedCapacity(t *testing.T) {
 				Value:         tc.capacityValue,
 				RequestPolicy: tc.requestPolicy,
 			}
-			consumedCapacity := calculateConsumedCapacity(tc.requestedVal, capacity, tc.fractionalCapacityRange)
-			g.Expect(consumedCapacity.Cmp(tc.expectResult)).To(BeZero())
+			consumedCapacity, err := calculateConsumedCapacity(tc.requestedVal, capacity, tc.fractionalCapacityRange)
+			if tc.expectErr {
+				g.Expect(err).To(MatchError(errCapacityRequestNotRepresentable))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(consumedCapacity.Cmp(tc.expectResult)).To(BeZero())
+			}
 		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig node
/wg device-management

**What this PR does / why we need it**:

`roundUpRange` rounds a consumable-capacity request up to a Step multiple using `Quantity.Value()` int64 arithmetic. A request near `MaxInt64` makes `min + step*n` wrap to a negative value that sits below the request and passes the capacity check, and a request above `MaxInt64` wraps in `Value()` itself and reads as a satisfiable-looking value. On the fractional path the request can pass the milli-value range in the same way. The value cannot then be rounded or compared reliably.

Today the request comes from the ResourceSlice, so in practice it is well-formed. Shared consumable capacity (#140084) takes the request from the user's ResourceClaim, so an out-of-range request becomes user-reachable, and skipping the device to try the next one would let such a request drive the scheduler into backtracking.

`roundUpRange` and its helpers now return `(Quantity, error)`. A request, or a rounded value, that cannot be represented (past `MaxInt64` on the integer path, or past the milli-value range on the fractional path) returns `errCapacityRequestNotRepresentable`, and the allocator aborts the allocation with that error instead of skipping the device. A request for a capacity the device does not define still skips, since another device may define it. The int64 and milli fast paths are unchanged for representable inputs. Both allocators are covered by allocatortesting cases and the per-allocator unit tables.

**Which issue(s) this PR fixes**:

Fixes #140441

**Special notes for your reviewer**:

- For a device that defines all the requested capacity names, representability is resolved for every capacity before the policy and capacity checks, so a request that overflows aborts regardless of Go's map iteration order, rather than being masked by another capacity the map happens to visit first. A request naming a capacity the device does not define is a separate, earlier skip, since another device may define it.
- Aborting on the first device whose arithmetic overflows is fail-closed: a later device that could satisfy the request by exact comparison is not tried. That is what removes the backtracking, and an allocatortesting case pins it. A unit test pins the fatal-over-soft ordering within a device.
- The allocator rejects a resolved capacity that is negative before recording it: a stored ResourceSlice or ResourceClaim from before stricter validation could carry one, and admission does not re-check existing objects, so relying on admission alone is not enough. Overflow stays the allocator's job because it depends on the device's int64-versus-milli math that admission cannot see. Broader magnitude validation of a user-facing request belongs in #140084, and a malformed RequestPolicy is tracked in #140472.
- Split out of the #140161 review at @pohly's suggestion, as the non-fractional `Value()` path. @sunya-ch handled the fractional milli-value path in #140161 and left a `TODO (#140441)` that this PR resolves.
- #140161 has merged; this PR is rebased onto it.

**Does this PR introduce a user-facing change?**

```release-note
Fixed capacity accounting in the DRA consumable-capacity allocator. A capacity request that a device's integer or milli-value range arithmetic cannot represent, or that resolves to a negative value, is now rejected instead of being treated as satisfiable and wrongly allocating a device or capping it to a smaller value.
```
