### PR TITLE
kubelet: migrate certificate store to contextual logging

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1031,7 +1031,7 @@ func buildKubeletClientConfig(ctx context.Context, s *options.KubeletServer, tp 
 
 		kubeClientConfigOverrides(s, clientConfig)
 
-		clientCertificateManager, err := buildClientCertificateManager(certConfig, clientConfig, s.CertDirectory, nodeName)
+		clientCertificateManager, err := buildClientCertificateManager(logger, certConfig, clientConfig, s.CertDirectory, nodeName)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1133,7 +1133,7 @@ func updateDialer(clientConfig *restclient.Config) (func(), error) {
 // buildClientCertificateManager creates a certificate manager that will use certConfig to request a client certificate
 // if no certificate is available, or the most recent clientConfig (which is assumed to point to the cert that the manager will
 // write out).
-func buildClientCertificateManager(certConfig, clientConfig *restclient.Config, certDir string, nodeName types.NodeName) (certificate.Manager, error) {
+func buildClientCertificateManager(logger klog.Logger, certConfig, clientConfig *restclient.Config, certDir string, nodeName types.NodeName) (certificate.Manager, error) {
 	newClientsetFn := func(current *tls.Certificate) (clientset.Interface, error) {
 		// If we have a valid certificate, use that to fetch CSRs. Otherwise use the bootstrap
 		// credentials. In the future it would be desirable to change the behavior of bootstrap
@@ -1147,6 +1147,7 @@ func buildClientCertificateManager(certConfig, clientConfig *restclient.Config, 
 	}
 
 	return kubeletcertificate.NewKubeletClientCertificateManager(
+		logger,
 		certDir,
 		nodeName,
 

--- a/cmd/kubelet/app/server_bootstrap_test.go
+++ b/cmd/kubelet/app/server_bootstrap_test.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/component-base/featuregate"
 	capihelper "k8s.io/kubernetes/pkg/apis/certificates/v1"
 	"k8s.io/kubernetes/pkg/controller/certificates/authority"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 // Test_buildClientCertificateManager validates that we can build a local client cert
@@ -88,7 +89,8 @@ func Test_buildClientCertificateManager(t *testing.T) {
 	}
 
 	nodeName := types.NodeName("test")
-	m, err := buildClientCertificateManager(config1, config2, testDir, nodeName)
+	tCtx := ktesting.Init(t)
+	m, err := buildClientCertificateManager(tCtx.Logger(), config1, config2, testDir, nodeName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +158,8 @@ func Test_buildClientCertificateManager_populateCertDir(t *testing.T) {
 		Host:      "http://localhost",
 	}
 	nodeName := types.NodeName("test")
-	if _, err := buildClientCertificateManager(config1, config2, testDir, nodeName); err != nil {
+	tCtx := ktesting.Init(t)
+	if _, err := buildClientCertificateManager(tCtx.Logger(), config1, config2, testDir, nodeName); err != nil {
 		t.Fatal(err)
 	}
 	fi := getFileInfo(testDir)
@@ -167,7 +170,7 @@ func Test_buildClientCertificateManager_populateCertDir(t *testing.T) {
 	// an invalid cert should be ignored
 	config2.CertData = []byte("invalid contents")
 	config2.KeyData = []byte("invalid contents")
-	if _, err := buildClientCertificateManager(config1, config2, testDir, nodeName); err == nil {
+	if _, err := buildClientCertificateManager(tCtx.Logger(), config1, config2, testDir, nodeName); err == nil {
 		t.Fatal("unexpected non error")
 	}
 	fi = getFileInfo(testDir)
@@ -178,7 +181,7 @@ func Test_buildClientCertificateManager_populateCertDir(t *testing.T) {
 	// an expired client certificate should be written to disk, because the cert manager can
 	// use config1 to refresh it and the cert manager won't return it for clients.
 	config2.CertData, config2.KeyData = genClientCert(t, time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
-	if _, err := buildClientCertificateManager(config1, config2, testDir, nodeName); err != nil {
+	if _, err := buildClientCertificateManager(tCtx.Logger(), config1, config2, testDir, nodeName); err != nil {
 		t.Fatal(err)
 	}
 	fi = getFileInfo(testDir)
@@ -188,7 +191,7 @@ func Test_buildClientCertificateManager_populateCertDir(t *testing.T) {
 
 	// a valid, non-expired client certificate should be written to disk
 	config2.CertData, config2.KeyData = genClientCert(t, time.Now().Add(-time.Hour), time.Now().Add(24*time.Hour))
-	if _, err := buildClientCertificateManager(config1, config2, testDir, nodeName); err != nil {
+	if _, err := buildClientCertificateManager(tCtx.Logger(), config1, config2, testDir, nodeName); err != nil {
 		t.Fatal(err)
 	}
 	fi = getFileInfo(testDir)

--- a/pkg/kubelet/certificate/bootstrap/bootstrap.go
+++ b/pkg/kubelet/certificate/bootstrap/bootstrap.go
@@ -66,7 +66,7 @@ func LoadClientConfig(logger klog.Logger, kubeconfigPath, bootstrapPath, certDir
 		return clientConfig, restclient.CopyConfig(clientConfig), nil
 	}
 
-	store, err := certificate.NewFileStore("kubelet-client", certDir, certDir, "", "")
+	store, err := certificate.NewFileStoreWithLogger(logger, "kubelet-client", certDir, certDir, "", "")
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to build bootstrap cert store")
 	}
@@ -130,7 +130,7 @@ func LoadClientCert(ctx context.Context, kubeconfigPath, bootstrapPath, certDir 
 		return fmt.Errorf("unable to create certificates signing request client: %v", err)
 	}
 
-	store, err := certificate.NewFileStore("kubelet-client", certDir, certDir, "", "")
+	store, err := certificate.NewFileStoreWithLogger(logger, "kubelet-client", certDir, certDir, "", "")
 	if err != nil {
 		return fmt.Errorf("unable to build bootstrap cert store")
 	}

--- a/pkg/kubelet/certificate/bootstrap/bootstrap_test.go
+++ b/pkg/kubelet/certificate/bootstrap/bootstrap_test.go
@@ -195,7 +195,8 @@ users:
 		t.Fatalf("Unable to create the test directory %q: %v", dir, err)
 	}
 
-	store, err := certificate.NewFileStore("kubelet-client", dir, dir, "", "")
+	logger, _ := ktesting.NewTestContext(t)
+	store, err := certificate.NewFileStoreWithLogger(logger, "kubelet-client", dir, dir, "", "")
 	if err != nil {
 		t.Errorf("unable to build bootstrap cert store")
 	}
@@ -273,7 +274,6 @@ users:
 		},
 	}
 
-	logger, _ := ktesting.NewTestContext(t)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			certConfig, clientConfig, err := LoadClientConfig(logger, test.kubeconfigPath, test.bootstrapPath, test.certDir)

--- a/pkg/kubelet/certificate/kubelet.go
+++ b/pkg/kubelet/certificate/kubelet.go
@@ -72,14 +72,16 @@ func newGetTemplateFn(nodeName types.NodeName, getAddresses func() []v1.NodeAddr
 
 // NewKubeletServerCertificateManager creates a certificate manager for the kubelet when retrieving a server certificate
 // or returns an error.
-func NewKubeletServerCertificateManager(kubeClient clientset.Interface, kubeCfg *kubeletconfig.KubeletConfiguration, nodeName types.NodeName, getAddresses func() []v1.NodeAddress, certDirectory string) (certificate.Manager, error) {
+func NewKubeletServerCertificateManager(logger klog.Logger, kubeClient clientset.Interface, kubeCfg *kubeletconfig.KubeletConfiguration, nodeName types.NodeName, getAddresses func() []v1.NodeAddress, certDirectory string) (certificate.Manager, error) {
+	logger = logger.WithName("serverCertificateManager")
 	var clientsetFn certificate.ClientsetFunc
 	if kubeClient != nil {
 		clientsetFn = func(current *tls.Certificate) (clientset.Interface, error) {
 			return kubeClient, nil
 		}
 	}
-	certificateStore, err := certificate.NewFileStore(
+	certificateStore, err := certificate.NewFileStoreWithLogger(
+		logger,
 		"kubelet-server",
 		certDirectory,
 		certDirectory,
@@ -197,6 +199,7 @@ func addressesToHostnamesAndIPs(addresses []v1.NodeAddress) (dnsNames []string, 
 // client that can be used to sign new certificates (or rotate). If a CSR
 // client is set later, it may begin rotating/renewing the client cert.
 func NewKubeletClientCertificateManager(
+	logger klog.Logger,
 	certDirectory string,
 	nodeName types.NodeName,
 	bootstrapCertData []byte,
@@ -205,8 +208,10 @@ func NewKubeletClientCertificateManager(
 	keyFile string,
 	clientsetFn certificate.ClientsetFunc,
 ) (certificate.Manager, error) {
+	logger = logger.WithName("clientCertificateManager")
 
-	certificateStore, err := certificate.NewFileStore(
+	certificateStore, err := certificate.NewFileStoreWithLogger(
+		logger,
 		"kubelet-client",
 		certDirectory,
 		certDirectory,

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -931,7 +931,7 @@ func NewMainKubelet(ctx context.Context,
 
 		// kubelet configuration that automatically rotates serving certs
 		if kubeCfg.ServerTLSBootstrap && utilfeature.DefaultFeatureGate.Enabled(features.RotateKubeletServerCertificate) {
-			klet.serverCertificateManager, err = kubeletcertificate.NewKubeletServerCertificateManager(klet.kubeClient, kubeCfg, klet.nodeName, func() []v1.NodeAddress {
+			klet.serverCertificateManager, err = kubeletcertificate.NewKubeletServerCertificateManager(logger, klet.kubeClient, kubeCfg, klet.nodeName, func() []v1.NodeAddress {
 				return klet.getLastObservedNodeAddresses(ctx)
 			}, certDirectory)
 			if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Several binaries in Kubernetes (such as the Kubelet) have been converted to structured and contextual logging. However, some helper packages, such as the `client-go` certificate store, still output unstructured or context-unaware logs because they relied on the legacy `NewFileStore` API constructor.

This PR migrates all remaining usages of `certificate.NewFileStore` in the Kubelet certificate package and related bootstrapping code to `certificate.NewFileStoreWithLogger`, passing the active context-aware logger down the call stack. This ensures certificate-related log events are properly structured and carry the correct runtime context of the Kubelet.

#### Which issue(s) this PR is related to:

Related to https://github.com/kubernetes/kubernetes/issues/126379

#### Special notes for your reviewer:

- **Stateless Refactoring**: This is a mechanical signature update to pass the active logger down the call stack. No functional behavior is changed.
- **Clean test suite**: All unit tests in the affected packages (`pkg/kubelet/certificate`, `pkg/kubelet/certificate/bootstrap`, and `cmd/kubelet/app`) have been updated and pass successfully.

#### Does this PR introduce a user-facing change?

NONE

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```