### PR TITLE
Rename endpoint_slice_controller_changes to add _total suffix

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -2773,7 +2773,7 @@
     endpoint: /metrics
 - name: changes
   subsystem: endpoint_slice_controller
-  help: Number of EndpointSlice changes
+  help: Number of EndpointSlice changes. Deprecated in favor of endpoint_slice_controller_changes_total.
   type: Counter
   deprecatedVersion: 1.38.0
   stabilityLevel: ALPHA

--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -2775,7 +2775,7 @@
   subsystem: endpoint_slice_controller
   help: Number of EndpointSlice changes
   type: Counter
-  deprecatedVersion: 1.37.0
+  deprecatedVersion: 1.38.0
   stabilityLevel: ALPHA
   labels:
   - operation

--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -2775,6 +2775,17 @@
   subsystem: endpoint_slice_controller
   help: Number of EndpointSlice changes
   type: Counter
+  deprecatedVersion: 1.37.0
+  stabilityLevel: ALPHA
+  labels:
+  - operation
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
+- name: changes_total
+  subsystem: endpoint_slice_controller
+  help: Number of EndpointSlice changes
+  type: Counter
   stabilityLevel: ALPHA
   labels:
   - operation

--- a/hack/tools/instrumentation/documentation/documentation.md
+++ b/hack/tools/instrumentation/documentation/documentation.md
@@ -1983,6 +1983,13 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li><li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.37.0</span></li></ul>
+	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">endpoint_slice_controller_changes_total</div>
+	<div class="metric_help">Number of EndpointSlice changes</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">endpoint_slice_controller_endpointslices_changed_per_sync</div>

--- a/hack/tools/instrumentation/documentation/documentation.md
+++ b/hack/tools/instrumentation/documentation/documentation.md
@@ -1983,7 +1983,7 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li><li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.37.0</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li><li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.38.0</span></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">endpoint_slice_controller_changes_total</div>
 	<div class="metric_help">Number of EndpointSlice changes</div>

--- a/staging/src/k8s.io/component-base/metrics/testutil/promlint.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/promlint.go
@@ -57,7 +57,7 @@ var exceptionMetrics = []string{
 
 	// attach-detach controller
 	"attach_detach_controller_attachdetach_controller_forced_detaches", // counter metrics should have "_total" suffix
-	"endpoint_slice_controller_changes",                                // counter metrics should have "_total" suffix
+	"endpoint_slice_controller_changes",                                // counter metrics should have "_total" suffix; renamed to endpoint_slice_controller_changes_total
 	"endpoint_slice_controller_syncs",                                  // counter metrics should have "_total" suffix
 	"endpoint_slice_mirroring_controller_changes",                      // counter metrics should have "_total" suffix
 

--- a/staging/src/k8s.io/endpointslice/metrics/metrics.go
+++ b/staging/src/k8s.io/endpointslice/metrics/metrics.go
@@ -99,8 +99,6 @@ var (
 	)
 
 	// EndpointSliceChangesTotal tracks the number of changes to Endpoint Slices.
-	// Introduced at ALPHA; a follow-up can graduate it to BETA after the
-	// required soak period (new metrics cannot be introduced at BETA).
 	EndpointSliceChangesTotal = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem:      EndpointSliceSubsystem,

--- a/staging/src/k8s.io/endpointslice/metrics/metrics.go
+++ b/staging/src/k8s.io/endpointslice/metrics/metrics.go
@@ -91,7 +91,7 @@ var (
 		&metrics.CounterOpts{
 			Subsystem:         EndpointSliceSubsystem,
 			Name:              "changes",
-			Help:              "Number of EndpointSlice changes",
+			Help:              "Number of EndpointSlice changes. Deprecated in favor of endpoint_slice_controller_changes_total.",
 			StabilityLevel:    metrics.ALPHA,
 			DeprecatedVersion: "1.38.0",
 		},

--- a/staging/src/k8s.io/endpointslice/metrics/metrics.go
+++ b/staging/src/k8s.io/endpointslice/metrics/metrics.go
@@ -93,7 +93,7 @@ var (
 			Name:              "changes",
 			Help:              "Number of EndpointSlice changes",
 			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.37.0",
+			DeprecatedVersion: "1.38.0",
 		},
 		[]string{"operation"},
 	)

--- a/staging/src/k8s.io/endpointslice/metrics/metrics.go
+++ b/staging/src/k8s.io/endpointslice/metrics/metrics.go
@@ -84,10 +84,27 @@ var (
 	)
 
 	// EndpointSliceChanges tracks the number of changes to Endpoint Slices.
+	//
+	// Deprecated: use EndpointSliceChangesTotal. The old name lacks the
+	// conventional _total suffix required for counters.
 	EndpointSliceChanges = metrics.NewCounterVec(
 		&metrics.CounterOpts{
+			Subsystem:         EndpointSliceSubsystem,
+			Name:              "changes",
+			Help:              "Number of EndpointSlice changes",
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.37.0",
+		},
+		[]string{"operation"},
+	)
+
+	// EndpointSliceChangesTotal tracks the number of changes to Endpoint Slices.
+	// Introduced at ALPHA; a follow-up can graduate it to BETA after the
+	// required soak period (new metrics cannot be introduced at BETA).
+	EndpointSliceChangesTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
 			Subsystem:      EndpointSliceSubsystem,
-			Name:           "changes",
+			Name:           "changes_total",
 			Help:           "Number of EndpointSlice changes",
 			StabilityLevel: metrics.ALPHA,
 		},
@@ -144,6 +161,7 @@ func RegisterMetrics() {
 		legacyregistry.MustRegister(NumEndpointSlices)
 		legacyregistry.MustRegister(DesiredEndpointSlices)
 		legacyregistry.MustRegister(EndpointSliceChanges)
+		legacyregistry.MustRegister(EndpointSliceChangesTotal)
 		legacyregistry.MustRegister(EndpointSlicesChangedPerSync)
 		legacyregistry.MustRegister(EndpointSliceSyncs)
 		legacyregistry.MustRegister(ServicesCountByTrafficDistribution)

--- a/staging/src/k8s.io/endpointslice/reconciler.go
+++ b/staging/src/k8s.io/endpointslice/reconciler.go
@@ -165,6 +165,7 @@ func (r *Reconciler) deleteEndpointSlice(service *corev1.Service, endpointSlice 
 
 	r.endpointSliceTracker.ExpectDeletion(endpointSlice)
 	metrics.EndpointSliceChanges.WithLabelValues("delete").Inc()
+	metrics.EndpointSliceChangesTotal.WithLabelValues("delete").Inc()
 	return nil
 }
 
@@ -456,6 +457,7 @@ func (r *Reconciler) finalize(
 			}
 			r.endpointSliceTracker.Update(createdSlice)
 			metrics.EndpointSliceChanges.WithLabelValues("create").Inc()
+			metrics.EndpointSliceChangesTotal.WithLabelValues("create").Inc()
 		}
 	}
 
@@ -467,6 +469,7 @@ func (r *Reconciler) finalize(
 		}
 		r.endpointSliceTracker.Update(updatedSlice)
 		metrics.EndpointSliceChanges.WithLabelValues("update").Inc()
+		metrics.EndpointSliceChangesTotal.WithLabelValues("update").Inc()
 	}
 
 	for _, endpointSlice := range slicesToDelete {

--- a/staging/src/k8s.io/endpointslice/reconciler_test.go
+++ b/staging/src/k8s.io/endpointslice/reconciler_test.go
@@ -1210,21 +1210,21 @@ func TestReconcilerDeleteEndpointSlice(t *testing.T) {
 					}
 					expectTrackedGeneration(t, r.endpointSliceTracker, cachedSlice, expectedGeneration)
 
-				//nolint:staticcheck // intentionally asserting the deprecated metric during the deprecation period
-				deleted, err := testutil.GetCounterMetricValue(metrics.EndpointSliceChanges.WithLabelValues("delete"))
-				if err != nil {
-					t.Fatalf("Failed to get EndpointSlice deletion metric: %v", err)
-				}
-				if deleted != testCase.wantDeleteMetric {
-					t.Errorf("Expected EndpointSlice deletion metric %v, got %v", testCase.wantDeleteMetric, deleted)
-				}
-				deletedTotal, err := testutil.GetCounterMetricValue(metrics.EndpointSliceChangesTotal.WithLabelValues("delete"))
-				if err != nil {
-					t.Fatalf("Failed to get EndpointSlice deletion total metric: %v", err)
-				}
-				if deletedTotal != testCase.wantDeleteMetric {
-					t.Errorf("Expected EndpointSlice deletion total metric %v, got %v", testCase.wantDeleteMetric, deletedTotal)
-				}
+					//nolint:staticcheck // intentionally asserting the deprecated metric during the deprecation period
+					deleted, err := testutil.GetCounterMetricValue(metrics.EndpointSliceChanges.WithLabelValues("delete"))
+					if err != nil {
+						t.Fatalf("Failed to get EndpointSlice deletion metric: %v", err)
+					}
+					if deleted != testCase.wantDeleteMetric {
+						t.Errorf("Expected EndpointSlice deletion metric %v, got %v", testCase.wantDeleteMetric, deleted)
+					}
+					deletedTotal, err := testutil.GetCounterMetricValue(metrics.EndpointSliceChangesTotal.WithLabelValues("delete"))
+					if err != nil {
+						t.Fatalf("Failed to get EndpointSlice deletion total metric: %v", err)
+					}
+					if deletedTotal != testCase.wantDeleteMetric {
+						t.Errorf("Expected EndpointSlice deletion total metric %v, got %v", testCase.wantDeleteMetric, deletedTotal)
+					}
 					if deletePath.name == "finalize" {
 						changed, err := testutil.GetHistogramMetricValue(metrics.EndpointSlicesChangedPerSync.WithLabelValues("Disabled", ""))
 						if err != nil {

--- a/staging/src/k8s.io/endpointslice/reconciler_test.go
+++ b/staging/src/k8s.io/endpointslice/reconciler_test.go
@@ -1210,13 +1210,20 @@ func TestReconcilerDeleteEndpointSlice(t *testing.T) {
 					}
 					expectTrackedGeneration(t, r.endpointSliceTracker, cachedSlice, expectedGeneration)
 
-					deleted, err := testutil.GetCounterMetricValue(metrics.EndpointSliceChanges.WithLabelValues("delete"))
-					if err != nil {
-						t.Fatalf("Failed to get EndpointSlice deletion metric: %v", err)
-					}
-					if deleted != testCase.wantDeleteMetric {
-						t.Errorf("Expected EndpointSlice deletion metric %v, got %v", testCase.wantDeleteMetric, deleted)
-					}
+				deleted, err := testutil.GetCounterMetricValue(metrics.EndpointSliceChanges.WithLabelValues("delete"))
+				if err != nil {
+					t.Fatalf("Failed to get EndpointSlice deletion metric: %v", err)
+				}
+				if deleted != testCase.wantDeleteMetric {
+					t.Errorf("Expected EndpointSlice deletion metric %v, got %v", testCase.wantDeleteMetric, deleted)
+				}
+				deletedTotal, err := testutil.GetCounterMetricValue(metrics.EndpointSliceChangesTotal.WithLabelValues("delete"))
+				if err != nil {
+					t.Fatalf("Failed to get EndpointSlice deletion total metric: %v", err)
+				}
+				if deletedTotal != testCase.wantDeleteMetric {
+					t.Errorf("Expected EndpointSlice deletion total metric %v, got %v", testCase.wantDeleteMetric, deletedTotal)
+				}
 					if deletePath.name == "finalize" {
 						changed, err := testutil.GetHistogramMetricValue(metrics.EndpointSlicesChangedPerSync.WithLabelValues("Disabled", ""))
 						if err != nil {
@@ -1545,26 +1552,6 @@ endpoint_slice_controller_endpoints_removed_per_sync_count 1
 `
 
 	if err := testutil.CollectAndCompare(metrics.EndpointsRemovedPerSync, strings.NewReader(want), "endpoint_slice_controller_endpoints_removed_per_sync"); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestReconcileEndpointSlicesMetrics_ChangesTotal_CollectAndCompare(t *testing.T) {
-	resetMetrics()
-	client := newClientset()
-	namespace := "test"
-	svc, _ := newServiceAndEndpointMeta("foo", namespace)
-
-	r := newReconciler(client, []*corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}}, defaultMaxEndpointsPerSlice)
-	reconcileHelper(t, r, &svc, []*corev1.Pod{}, []*discovery.EndpointSlice{}, time.Now())
-
-	want := `
-# HELP endpoint_slice_controller_changes_total [ALPHA] Number of EndpointSlice changes
-# TYPE endpoint_slice_controller_changes_total counter
-endpoint_slice_controller_changes_total{operation="create"} 1
-`
-
-	if err := testutil.CollectAndCompare(metrics.EndpointSliceChangesTotal, strings.NewReader(want), "endpoint_slice_controller_changes_total"); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -2712,17 +2699,32 @@ func expectMetrics(t *testing.T, em expectedMetrics) {
 	if actualCreated != float64(em.numCreated) {
 		t.Errorf("Expected endpointSliceChangesCreated to be %d, got %v", em.numCreated, actualCreated)
 	}
+	actualCreatedTotal, err := testutil.GetCounterMetricValue(metrics.EndpointSliceChangesTotal.WithLabelValues("create"))
+	handleErr(t, err, "endpointSliceChangesTotalCreated")
+	if actualCreatedTotal != float64(em.numCreated) {
+		t.Errorf("Expected endpointSliceChangesTotalCreated to be %d, got %v", em.numCreated, actualCreatedTotal)
+	}
 
 	actualUpdated, err := testutil.GetCounterMetricValue(metrics.EndpointSliceChanges.WithLabelValues("update"))
 	handleErr(t, err, "endpointSliceChangesUpdated")
 	if actualUpdated != float64(em.numUpdated) {
 		t.Errorf("Expected endpointSliceChangesUpdated to be %d, got %v", em.numUpdated, actualUpdated)
 	}
+	actualUpdatedTotal, err := testutil.GetCounterMetricValue(metrics.EndpointSliceChangesTotal.WithLabelValues("update"))
+	handleErr(t, err, "endpointSliceChangesTotalUpdated")
+	if actualUpdatedTotal != float64(em.numUpdated) {
+		t.Errorf("Expected endpointSliceChangesTotalUpdated to be %d, got %v", em.numUpdated, actualUpdatedTotal)
+	}
 
 	actualDeleted, err := testutil.GetCounterMetricValue(metrics.EndpointSliceChanges.WithLabelValues("delete"))
 	handleErr(t, err, "desiredEndpointSlices")
 	if actualDeleted != float64(em.numDeleted) {
 		t.Errorf("Expected endpointSliceChangesDeleted to be %d, got %v", em.numDeleted, actualDeleted)
+	}
+	actualDeletedTotal, err := testutil.GetCounterMetricValue(metrics.EndpointSliceChangesTotal.WithLabelValues("delete"))
+	handleErr(t, err, "endpointSliceChangesTotalDeleted")
+	if actualDeletedTotal != float64(em.numDeleted) {
+		t.Errorf("Expected endpointSliceChangesTotalDeleted to be %d, got %v", em.numDeleted, actualDeletedTotal)
 	}
 
 	actualSlicesChangedPerSync, err := testutil.GetHistogramMetricValue(metrics.EndpointSlicesChangedPerSync.WithLabelValues("Disabled", ""))

--- a/staging/src/k8s.io/endpointslice/reconciler_test.go
+++ b/staging/src/k8s.io/endpointslice/reconciler_test.go
@@ -1549,6 +1549,26 @@ endpoint_slice_controller_endpoints_removed_per_sync_count 1
 	}
 }
 
+func TestReconcileEndpointSlicesMetrics_ChangesTotal_CollectAndCompare(t *testing.T) {
+	resetMetrics()
+	client := newClientset()
+	namespace := "test"
+	svc, _ := newServiceAndEndpointMeta("foo", namespace)
+
+	r := newReconciler(client, []*corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}}, defaultMaxEndpointsPerSlice)
+	reconcileHelper(t, r, &svc, []*corev1.Pod{}, []*discovery.EndpointSlice{}, time.Now())
+
+	want := `
+# HELP endpoint_slice_controller_changes_total [ALPHA] Number of EndpointSlice changes
+# TYPE endpoint_slice_controller_changes_total counter
+endpoint_slice_controller_changes_total{operation="create"} 1
+`
+
+	if err := testutil.CollectAndCompare(metrics.EndpointSliceChangesTotal, strings.NewReader(want), "endpoint_slice_controller_changes_total"); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestReconcileEndpointSlicesMetrics_GaugeUpdates(t *testing.T) {
 	resetMetrics()
 	client := newClientset()
@@ -2771,6 +2791,7 @@ func resetMetrics() {
 	metrics.EndpointsAddedPerSync.Reset()
 	metrics.EndpointsRemovedPerSync.Reset()
 	metrics.EndpointSliceChanges.Reset()
+	metrics.EndpointSliceChangesTotal.Reset()
 	metrics.EndpointSlicesChangedPerSync.Reset()
 	metrics.EndpointSliceSyncs.Reset()
 	metrics.ServicesCountByTrafficDistribution.Reset()

--- a/staging/src/k8s.io/endpointslice/reconciler_test.go
+++ b/staging/src/k8s.io/endpointslice/reconciler_test.go
@@ -1210,6 +1210,7 @@ func TestReconcilerDeleteEndpointSlice(t *testing.T) {
 					}
 					expectTrackedGeneration(t, r.endpointSliceTracker, cachedSlice, expectedGeneration)
 
+				//nolint:staticcheck // intentionally asserting the deprecated metric during the deprecation period
 				deleted, err := testutil.GetCounterMetricValue(metrics.EndpointSliceChanges.WithLabelValues("delete"))
 				if err != nil {
 					t.Fatalf("Failed to get EndpointSlice deletion metric: %v", err)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig instrumentation
/sig network

#### What this PR does / why we need it:

`endpoint_slice_controller_changes` is a counter that lacks the conventional `_total` suffix, which blocks any future graduation past Alpha (see #136306 / #136368).

This PR:
- Introduces `endpoint_slice_controller_changes_total` at **ALPHA** (metrics cannot be introduced at BETA).
- Deprecates the old `endpoint_slice_controller_changes` name in 1.37 (`DeprecatedVersion`), keeping it at ALPHA for the deprecation grace period.
- Increments both metrics during the transition so there is no gap in telemetry.
- Updates generated metric documentation accordingly.

A follow-up can graduate `endpoint_slice_controller_changes_total` to BETA after the required soak period.

#### Which issue(s) this PR fixes:

Related to #136306

#### Special notes for your reviewer:

Addresses review feedback from @tico88612 (rename + deprecation instead of graduating the misnamed metric) and @rexagod (do not introduce the replacement metric at BETA).

#### Does this PR introduce a user-facing change?

```release-note
The `endpoint_slice_controller_changes` metric is deprecated in favor of `endpoint_slice_controller_changes_total`. Both metrics are emitted during the deprecation period.
```