### PR TITLE
client-go: prevent unbounded goroutine growth in EventBroadcaster

### DIFF
--- a/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
@@ -25,6 +25,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -50,6 +51,7 @@ const (
 	finishTime       = 6 * time.Minute
 	refreshTime      = 30 * time.Minute
 	maxQueuedEvents  = 1000
+	recordWorkers    = 8
 )
 
 var defaultSleepDuration = 10 * time.Second
@@ -71,6 +73,8 @@ type eventBroadcasterImpl struct {
 	eventCache    map[eventKey]*eventsv1.Event
 	sleepDuration time.Duration
 	sink          EventSink
+	eventQueue    chan *eventsv1.Event
+	cancel        func()
 }
 
 // EventSinkImpl wraps EventsV1Interface to implement EventSink.
@@ -116,26 +120,50 @@ func newBroadcaster(sink EventSink, sleepDuration time.Duration, eventCache map[
 		eventCache:    eventCache,
 		sleepDuration: sleepDuration,
 		sink:          sink,
+		eventQueue:    make(chan *eventsv1.Event, maxQueuedEvents),
 	}
 }
 
 func (e *eventBroadcasterImpl) Shutdown() {
+	e.mu.Lock()
+	if e.cancel != nil {
+		e.cancel()
+		e.cancel = nil
+	}
+	e.mu.Unlock()
 	e.Broadcaster.Shutdown()
 }
 
 // refreshExistingEventSeries refresh events TTL
 func (e *eventBroadcasterImpl) refreshExistingEventSeries(ctx context.Context) {
-	// TODO: Investigate whether lock contention won't be a problem
+	type eventSnapshot struct {
+		key   eventKey
+		event *eventsv1.Event
+	}
+
+	var snapshots []eventSnapshot
 	e.mu.Lock()
-	defer e.mu.Unlock()
 	for isomorphicKey, event := range e.eventCache {
 		if event.Series != nil {
-			if recordedEvent, retry := recordEvent(ctx, e.sink, event); !retry {
-				if recordedEvent != nil {
-					e.eventCache[isomorphicKey] = recordedEvent
-				}
-			}
+			snapshots = append(snapshots, eventSnapshot{key: isomorphicKey, event: event.DeepCopy()})
 		}
+	}
+	e.mu.Unlock()
+
+	for _, snapshot := range snapshots {
+		recordedEvent, retry := recordEvent(ctx, e.sink, snapshot.event.DeepCopy())
+		if retry || recordedEvent == nil {
+			continue
+		}
+
+		e.mu.Lock()
+		cachedEvent, exists := e.eventCache[snapshot.key]
+		// The sink call ran without the lock. Do not overwrite counts or
+		// timestamps which were aggregated while it was in flight.
+		if exists && apiequality.Semantic.DeepEqual(cachedEvent, snapshot.event) {
+			e.eventCache[snapshot.key] = recordedEvent
+		}
+		e.mu.Unlock()
 	}
 }
 
@@ -143,20 +171,42 @@ func (e *eventBroadcasterImpl) refreshExistingEventSeries(ctx context.Context) {
 // - write final count to the apiserver
 // - delete a singleton event (i.e. series field is nil) from the cache
 func (e *eventBroadcasterImpl) finishSeries(ctx context.Context) {
-	// TODO: Investigate whether lock contention won't be a problem
+	type eventSnapshot struct {
+		key          eventKey
+		event        *eventsv1.Event
+		shouldRecord bool
+	}
+
+	now := time.Now()
+	var snapshots []eventSnapshot
 	e.mu.Lock()
-	defer e.mu.Unlock()
 	for isomorphicKey, event := range e.eventCache {
 		eventSerie := event.Series
 		if eventSerie != nil {
-			if eventSerie.LastObservedTime.Time.Before(time.Now().Add(-finishTime)) {
-				if _, retry := recordEvent(ctx, e.sink, event); !retry {
-					delete(e.eventCache, isomorphicKey)
-				}
+			if eventSerie.LastObservedTime.Time.Before(now.Add(-finishTime)) {
+				snapshots = append(snapshots, eventSnapshot{key: isomorphicKey, event: event.DeepCopy(), shouldRecord: true})
 			}
-		} else if event.EventTime.Time.Before(time.Now().Add(-finishTime)) {
-			delete(e.eventCache, isomorphicKey)
+		} else if event.EventTime.Time.Before(now.Add(-finishTime)) {
+			snapshots = append(snapshots, eventSnapshot{key: isomorphicKey, event: event.DeepCopy()})
 		}
+	}
+	e.mu.Unlock()
+
+	for _, snapshot := range snapshots {
+		if snapshot.shouldRecord {
+			if _, retry := recordEvent(ctx, e.sink, snapshot.event.DeepCopy()); retry {
+				continue
+			}
+		}
+
+		e.mu.Lock()
+		cachedEvent, exists := e.eventCache[snapshot.key]
+		// An event observed while the sink call was in flight means the series
+		// is active again and must remain in the cache.
+		if exists && apiequality.Semantic.DeepEqual(cachedEvent, snapshot.event) {
+			delete(e.eventCache, snapshot.key)
+		}
+		e.mu.Unlock()
 	}
 }
 
@@ -170,39 +220,52 @@ func (e *eventBroadcasterImpl) NewRecorder(scheme *runtime.Scheme, reportingCont
 func (e *eventBroadcasterImpl) recordToSink(ctx context.Context, event *eventsv1.Event, clock clock.Clock) {
 	// Make a copy before modification, because there could be multiple listeners.
 	eventCopy := event.DeepCopy()
-	go func() {
-		evToRecord := func() *eventsv1.Event {
-			e.mu.Lock()
-			defer e.mu.Unlock()
-			eventKey := getKey(eventCopy)
-			isomorphicEvent, isIsomorphic := e.eventCache[eventKey]
-			if isIsomorphic {
-				if isomorphicEvent.Series != nil {
-					isomorphicEvent.Series.Count++
-					isomorphicEvent.Series.LastObservedTime = metav1.MicroTime{Time: clock.Now()}
-					return nil
-				}
-				isomorphicEvent.Series = &eventsv1.EventSeries{
-					Count:            2,
-					LastObservedTime: metav1.MicroTime{Time: clock.Now()},
-				}
-				// Make a copy of the Event to make sure that recording it
-				// doesn't mess with the object stored in cache.
-				return isomorphicEvent.DeepCopy()
+	record := func() *eventsv1.Event {
+		e.mu.Lock()
+		defer e.mu.Unlock()
+		eventKey := getKey(eventCopy)
+		isomorphicEvent, isIsomorphic := e.eventCache[eventKey]
+		if isIsomorphic {
+			if isomorphicEvent.Series != nil {
+				isomorphicEvent.Series.Count++
+				isomorphicEvent.Series.LastObservedTime = metav1.MicroTime{Time: clock.Now()}
+				return nil
 			}
-			e.eventCache[eventKey] = eventCopy
-			// Make a copy of the Event to make sure that recording it doesn't
-			// mess with the object stored in cache.
-			return eventCopy.DeepCopy()
-		}()
-		if evToRecord != nil {
-			// TODO: Add a metric counting the number of recording attempts
-			e.attemptRecording(ctx, evToRecord)
-			// We don't want the new recorded Event to be reflected in the
-			// client's cache because server-side mutations could mess with the
-			// aggregation mechanism used by the client.
+			isomorphicEvent.Series = &eventsv1.EventSeries{
+				Count:            2,
+				LastObservedTime: metav1.MicroTime{Time: clock.Now()},
+			}
+			// Make a copy of the Event to make sure that recording it
+			// doesn't mess with the object stored in cache.
+			return isomorphicEvent.DeepCopy()
 		}
+		e.eventCache[eventKey] = eventCopy
+		// Make a copy of the Event to make sure that recording it doesn't
+		// mess with the object stored in cache.
+		return eventCopy.DeepCopy()
 	}()
+	if record != nil {
+		select {
+		case e.eventQueue <- record:
+		default:
+			klog.FromContext(ctx).Error(nil, "Unable to record event: too many queued events, dropped event", "event", record)
+		}
+	}
+}
+
+// recordingWorker delivers queued events to the sink until the context is
+// canceled.
+func (e *eventBroadcasterImpl) recordingWorker(ctx context.Context) {
+	defer utilruntime.HandleCrash()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case record := <-e.eventQueue:
+			// TODO: Add a metric counting the number of recording attempts
+			e.attemptRecording(ctx, record)
+		}
+	}
 }
 
 func (e *eventBroadcasterImpl) attemptRecording(ctx context.Context, event *eventsv1.Event) {
@@ -372,6 +435,9 @@ func (e *eventBroadcasterImpl) startRecordingEvents(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	for range recordWorkers {
+		go e.recordingWorker(ctx)
+	}
 	go func() {
 		<-ctx.Done()
 		stopWatcher()
@@ -390,9 +456,20 @@ func (e *eventBroadcasterImpl) StartRecordingToSink(stopCh <-chan struct{}) {
 
 // StartRecordingToSinkWithContext starts sending events received from the specified eventBroadcaster to the given sink.
 func (e *eventBroadcasterImpl) StartRecordingToSinkWithContext(ctx context.Context) error {
-	go wait.UntilWithContext(ctx, e.refreshExistingEventSeries, refreshTime)
-	go wait.UntilWithContext(ctx, e.finishSeries, finishTime)
-	return e.startRecordingEvents(ctx)
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.cancel != nil {
+		return fmt.Errorf("broadcaster is already recording to a sink")
+	}
+	cctx, cancel := context.WithCancel(ctx)
+	if err := e.startRecordingEvents(cctx); err != nil {
+		cancel()
+		return err
+	}
+	go wait.UntilWithContext(cctx, e.refreshExistingEventSeries, refreshTime)
+	go wait.UntilWithContext(cctx, e.finishSeries, finishTime)
+	e.cancel = cancel
+	return nil
 }
 
 type eventBroadcasterAdapterImpl struct {

--- a/staging/src/k8s.io/client-go/tools/events/event_recorder.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_recorder.go
@@ -24,7 +24,6 @@ import (
 	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/record/util"
 	"k8s.io/client-go/tools/reference"
@@ -91,10 +90,14 @@ func (recorder *recorderImpl) eventf(logger klog.Logger, regarding runtime.Objec
 		return
 	}
 	event := recorder.makeEvent(refRegarding, refRelated, timestamp, annotations, eventtype, reason, message, recorder.reportingController, recorder.reportingInstance, action)
-	go func() {
-		defer utilruntime.HandleCrash()
-		recorder.Action(watch.Added, event)
-	}()
+	sent, err := recorder.ActionOrDrop(watch.Added, event)
+	if err != nil {
+		logger.Error(err, "Unable to record event (will not retry!)")
+		return
+	}
+	if !sent {
+		logger.Error(nil, "Unable to record event: too many queued events, dropped event", "event", event)
+	}
 }
 
 func (recorder *recorderImpl) makeEvent(refRegarding *v1.ObjectReference, refRelated *v1.ObjectReference, timestamp metav1.MicroTime, annotations map[string]string, eventtype, reason, message string, reportingController string, reportingInstance string, action string) *eventsv1.Event {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

**Background**

Under high rates of scheduling failures, kube-scheduler can accumulate goroutines continuously and eventually experience significant memory growth or OOM.

For each scheduling failure, `Scheduler.handleSchedulingFailure` calls `fwk.EventRecorder().Eventf(...)` to emit a `FailedScheduling` Event. These Events are then processed by the `EventBroadcaster` write path, which creates a goroutine per Event without a concurrency bound.

The main execution path is:

```
Scheduler.scheduleOne
  └─ Scheduler.handleSchedulingFailure
       └─ fwk.EventRecorder().Eventf(..., "FailedScheduling", ..., msg)
            └─ client-go events.recorderImpl.Eventf
                 └─ EventBroadcaster watcher handler
                      └─ eventBroadcasterImpl.recordToSink
                           ├─ event.DeepCopy()
                           └─ go func()                 // one goroutine per Event
                                ├─ e.mu.Lock()          // shared event cache mutex
                                ├─ update/aggregate eventCache
                                └─ attemptRecording()
                                     └─ recordEvent()
                                          └─ EventSink.Create / Patch
                                               └─ apiserver Event API
```

The scheduler emits a failure Event from [schedule_one.go](https://github.com/kubernetes/kubernetes/blob/843726939e910e30714ae425d083cd91be4b2437/pkg/scheduler/schedule_one.go#L1282-L1283):

https://github.com/kubernetes/kubernetes/blob/843726939e910e30714ae425d083cd91be4b2437/pkg/scheduler/schedule_one.go#L1282-L1283



The unbounded goroutine creation happens in `eventBroadcasterImpl.recordToSink`:
https://github.com/kubernetes/kubernetes/blob/843726939e910e30714ae425d083cd91be4b2437/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go#L170-L197


In addition, EventSeries refresh and cleanup hold the same `e.mu` while issuing Event API requests. Slow Event writes or a large event cache can therefore extend lock hold times and amplify contention.

```
High FailedScheduling event rate
  → one goroutine created per Event
  → goroutines wait on mutex / rate limiter / Event API
  → Events and formatted messages remain retained
  → goroutine count and heap usage grow without bound
```

This PR prevents unbounded goroutine and memory growth in the events v1 broadcaster during event storms or when the API server is slow.


**kube-scheduler monitoring**

cpu usage:
<img width="2984" height="746" alt="image" src="https://github.com/user-attachments/assets/a3b54c53-1da1-4139-a31b-c80f4b1766dc" />

memory usage:
<img width="2986" height="752" alt="image" src="https://github.com/user-attachments/assets/54bbcf7d-7a4a-4963-8fb4-7ec9d893677a" />


goroutines:
<img width="1882" height="600" alt="image" src="https://github.com/user-attachments/assets/3f26a4a6-3bf5-4e3d-8b46-d6e52548204a" />


heap profiling:
<img width="3822" height="1246" alt="image" src="https://github.com/user-attachments/assets/04403ca6-f3d4-40db-98fe-831c4b38282c" />

cpu profiling:
<img width="3832" height="1730" alt="image" src="https://github.com/user-attachments/assets/e25a9d2c-d20c-4ea3-8647-2576731fe40a" />


goroutines profiling:

Error stack trace encountered while fetching kube-scheduler goroutines: goroutines profiling failed to fetch.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes https://github.com/kubernetes/kubernetes/issues/140393

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
