### PR TITLE
DRA: use saturating arithmetic in roundUpRange to avoid int64 overflow

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -4915,6 +4915,22 @@ func TestAllocator(t *testing.T,
 				),
 			},
 		},
+		"consumable-capacity-range-policy-step-request-overflow": {
+			features: Features{
+				ConsumableCapacity: true,
+			},
+			claimsToAllocate: objects(
+				claim(claim0).withRequests(deviceRequest(req0, classA, 1).withCapacityRequest(resource.NewQuantity(9223372036854775807, resource.BinarySI))),
+			),
+			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
+					device(device1, nil, nil).withAllowMultipleAllocations().withCapacityRequestPolicyRange(map[resourceapi.QualifiedName]resource.Quantity{capacity0: four}),
+				),
+			),
+			node:          node(node1, region1),
+			expectResults: []any{},
+		},
 		"consumable-capacity-multi-allocatable-device-with-zero-request-policy": {
 			features: Features{
 				ConsumableCapacity: true,

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/consumable_capacity.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/consumable_capacity.go
@@ -18,6 +18,8 @@ package experimental
 
 import (
 	"errors"
+	"math"
+	"math/bits"
 
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -111,6 +113,11 @@ func fillEmptyRequest(capacity resourceapi.DeviceCapacity) resource.Quantity {
 //   - If Step is specified, it rounds requestedVal up to the nearest multiple of Step
 //     starting from Min.
 //   - If no Step is specified and requestedVal >= Min, it returns requestedVal as is.
+//
+// The computation uses saturating int64 arithmetic so that a request far larger
+// than the device capacity cannot wrap to a negative value. Such a request can
+// never be satisfied by a real device, so a saturated (still positive) value is
+// correct and will be rejected by the policy/capacity checks downstream.
 func roundUpRange(requestedVal *resource.Quantity, validRange *resourceapi.CapacityRequestPolicyRange) resource.Quantity {
 	if requestedVal.Cmp(*validRange.Min) < 0 {
 		return validRange.Min.DeepCopy()
@@ -121,14 +128,55 @@ func roundUpRange(requestedVal *resource.Quantity, validRange *resourceapi.Capac
 	requestedInt64 := requestedVal.Value()
 	step := validRange.Step.Value()
 	min := validRange.Min.Value()
-	added := (requestedInt64 - min)
+
+	added := requestedInt64 - min
 	n := added / step
 	mod := added % step
 	if mod != 0 {
 		n += 1
 	}
-	val := min + step*n
+
+	val := saturatingAdd(min, saturatingMul(step, n))
 	return *resource.NewQuantity(val, resource.BinarySI)
+}
+
+// saturatingMul returns a*b, saturating at the int64 minimum/maximum on overflow.
+func saturatingMul(a, b int64) int64 {
+	if a == 0 || b == 0 {
+		return 0
+	}
+	neg := (a < 0) != (b < 0)
+	ua, ub := a, b
+	if a < 0 {
+		ua = -a
+	}
+	if b < 0 {
+		ub = -b
+	}
+	hi, lo := bits.Mul64(uint64(ua), uint64(ub))
+	if hi != 0 || lo > math.MaxInt64 {
+		if neg {
+			return math.MinInt64
+		}
+		return math.MaxInt64
+	}
+	res := int64(lo)
+	if neg {
+		res = -res
+	}
+	return res
+}
+
+// saturatingAdd returns a+b, saturating at the int64 minimum/maximum on overflow.
+func saturatingAdd(a, b int64) int64 {
+	s := a + b
+	if (b > 0 && s < a) || (b < 0 && s > a) {
+		if b > 0 {
+			return math.MaxInt64
+		}
+		return math.MinInt64
+	}
+	return s
 }
 
 // roundUpValidValues returns the first value in validValues that is greater than or equal to requestedVal.

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/consumable_capacity.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/consumable_capacity.go
@@ -18,6 +18,8 @@ package incubating
 
 import (
 	"errors"
+	"math"
+	"math/bits"
 
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -111,6 +113,11 @@ func fillEmptyRequest(capacity resourceapi.DeviceCapacity) resource.Quantity {
 //   - If Step is specified, it rounds requestedVal up to the nearest multiple of Step
 //     starting from Min.
 //   - If no Step is specified and requestedVal >= Min, it returns requestedVal as is.
+//
+// The computation uses saturating int64 arithmetic so that a request far larger
+// than the device capacity cannot wrap to a negative value. Such a request can
+// never be satisfied by a real device, so a saturated (still positive) value is
+// correct and will be rejected by the policy/capacity checks downstream.
 func roundUpRange(requestedVal *resource.Quantity, validRange *resourceapi.CapacityRequestPolicyRange) resource.Quantity {
 	if requestedVal.Cmp(*validRange.Min) < 0 {
 		return validRange.Min.DeepCopy()
@@ -121,14 +128,55 @@ func roundUpRange(requestedVal *resource.Quantity, validRange *resourceapi.Capac
 	requestedInt64 := requestedVal.Value()
 	step := validRange.Step.Value()
 	min := validRange.Min.Value()
-	added := (requestedInt64 - min)
+
+	added := requestedInt64 - min
 	n := added / step
 	mod := added % step
 	if mod != 0 {
 		n += 1
 	}
-	val := min + step*n
+
+	val := saturatingAdd(min, saturatingMul(step, n))
 	return *resource.NewQuantity(val, resource.BinarySI)
+}
+
+// saturatingMul returns a*b, saturating at the int64 minimum/maximum on overflow.
+func saturatingMul(a, b int64) int64 {
+	if a == 0 || b == 0 {
+		return 0
+	}
+	neg := (a < 0) != (b < 0)
+	ua, ub := a, b
+	if a < 0 {
+		ua = -a
+	}
+	if b < 0 {
+		ub = -b
+	}
+	hi, lo := bits.Mul64(uint64(ua), uint64(ub))
+	if hi != 0 || lo > math.MaxInt64 {
+		if neg {
+			return math.MinInt64
+		}
+		return math.MaxInt64
+	}
+	res := int64(lo)
+	if neg {
+		res = -res
+	}
+	return res
+}
+
+// saturatingAdd returns a+b, saturating at the int64 minimum/maximum on overflow.
+func saturatingAdd(a, b int64) int64 {
+	s := a + b
+	if (b > 0 && s < a) || (b < 0 && s > a) {
+		if b > 0 {
+			return math.MaxInt64
+		}
+		return math.MinInt64
+	}
+	return s
 }
 
 // roundUpValidValues returns the first value in validValues that is greater than or equal to requestedVal.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

The structured DRA allocator's `roundUpRange` converted `resource.Quantity` values to `int64` and computed `min + step*n` with plain `int64` arithmetic. For a capacity request near `math.MaxInt64` with a `Step`, this wrapped to a negative value, so a device could be allocated for a request it cannot satisfy and its consumed capacity was recorded as a negative quantity (corrupting the running total for a shared allow-multiple device).

This PR computes the rounded value with saturating `int64` arithmetic so very large requests stay positive and are correctly rejected by the downstream policy/capacity checks. Applies to the incubating and experimental allocator variants (stable does not support ConsumableCapacity).

Related-to: #140441

#### Special notes for your reviewer

- A capacity request is not bounded by API validation, so the overflow is reachable today (the default feature config selects the incubating allocator).
- Adds a regression test case `consumable-capacity-range-policy-step-request-overflow` to the shared `allocatortesting` table, exercised by both the incubating and experimental variants.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a DRA structured allocator bug where a very large consumable-capacity request could overflow int64 arithmetic, causing a device to be allocated for a request it cannot satisfy and its consumed capacity to be recorded as negative.
```

/sig node
/wg device-management