### PR TITLE
DRA: skip counter check for persisted shared allow-multiple devices

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -4931,6 +4931,55 @@ func TestAllocator(t *testing.T,
 			node:          node(node1, region1),
 			expectResults: []any{},
 		},
+		"partitionable-consumable-capacity-shared-device-counter-not-recharged": {
+			features: Features{
+				PartitionableDevices: true,
+				ConsumableCapacity:   true,
+			},
+			// device1 already has a persisted shared allocation. It is represented
+			// only by a share ID, with no AggregatedCapacity entry.
+			allocatedSharedDeviceIDs: sets.New(
+				internal.MakeSharedDeviceID(MakeDeviceID(driverA, pool1, device1), &fixedShareID),
+			),
+			claimsToAllocate: objects(
+				claimWithRequests(claim0, nil, request(req0, classA, 1)),
+			),
+			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device1, nil, nil).
+						withAllowMultipleAllocations().
+						withDeviceCounterConsumption(
+							deviceCounterConsumption(
+								counterSet1,
+								map[string]resource.Quantity{
+									"c": resource.MustParse("1"),
+								},
+							),
+						),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(
+						counterSet1,
+						map[string]resource.Quantity{
+							"c": resource.MustParse("1"),
+						},
+					),
+				),
+			),
+			node: node(node1, region1),
+			expectResults: []any{
+				allocationResult(
+					localNodeSelector(node1),
+					deviceRequestAllocationResult(
+						req0,
+						driverA,
+						pool1,
+						device1,
+					).withConsumedCapacity(&fixedShareID, nil),
+				),
+			},
+		},
 		"consumable-capacity-multi-allocatable-device-with-zero-request-policy": {
 			features: Features{
 				ConsumableCapacity: true,

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -4915,6 +4915,22 @@ func TestAllocator(t *testing.T,
 				),
 			},
 		},
+		"consumable-capacity-range-policy-step-request-overflow": {
+			features: Features{
+				ConsumableCapacity: true,
+			},
+			claimsToAllocate: objects(
+				claim(claim0).withRequests(deviceRequest(req0, classA, 1).withCapacityRequest(resource.NewQuantity(9223372036854775807, resource.BinarySI))),
+			),
+			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
+					device(device1, nil, nil).withAllowMultipleAllocations().withCapacityRequestPolicyRange(map[resourceapi.QualifiedName]resource.Quantity{capacity0: four}),
+				),
+			),
+			node:          node(node1, region1),
+			expectResults: []any{},
+		},
 		"consumable-capacity-multi-allocatable-device-with-zero-request-policy": {
 			features: Features{
 				ConsumableCapacity: true,

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -330,6 +330,17 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 	// We can estimate the size based on what we need to allocate.
 	alloc.allocatingDevices = make(map[DeviceID]sets.Set[int], minDevicesTotal)
 
+	// Precompute the set of devices that have a persisted shared allocation
+	// (recorded only by share ID, without an AggregatedCapacity entry). Such a
+	// device's shared counters are already accounted for, so a further
+	// allocation must skip the counter availability check to avoid
+	// double-charging them. See deviceCapacityInUse.
+	sharedDeviceIDs := sets.New[DeviceID]()
+	for sharedID := range alloc.allocatedState.AllocatedSharedDeviceIDs {
+		sharedDeviceIDs.Insert(sharedID.GetDeviceID())
+	}
+	alloc.sharedDeviceIDs = sharedDeviceIDs
+
 	alloc.logger.V(6).Info("Gathered information about devices", "numAllocatedDevices", len(alloc.allocatedState.AllocatedDevices), "minDevicesToBeAllocated", minDevicesTotal)
 
 	// In practice, there aren't going to be many different CEL
@@ -658,7 +669,13 @@ type allocator struct {
 	// The map is indexed by device ID, and each value represents the accumulated capacity
 	// requested by all allocations targeting that device.
 	allocatingCapacity ConsumedCapacityCollection
-	result             []internalAllocationResult
+	// sharedDeviceIDs is the set of devices that have a persisted shared
+	// allocation, recorded only by share ID without an AggregatedCapacity
+	// entry. Such a device's shared counters are already accounted for, so a
+	// further allocation must skip the counter availability check to avoid
+	// double-charging them. Precomputed once from the allocated state.
+	sharedDeviceIDs sets.Set[DeviceID]
+	result           []internalAllocationResult
 }
 
 // counterSets is a map with the name of counter sets to the counters in
@@ -1752,8 +1769,17 @@ func (alloc *allocator) deviceInUse(deviceID DeviceID) bool {
 }
 
 func (alloc *allocator) deviceCapacityInUse(deviceID DeviceID) bool {
-	_, found := alloc.allocatedState.AggregatedCapacity[deviceID]
-	return found || alloc.allocatingCapacityForAnyClaim(deviceID)
+	if _, found := alloc.allocatedState.AggregatedCapacity[deviceID]; found {
+		return true
+	}
+	if alloc.allocatingCapacityForAnyClaim(deviceID) {
+		return true
+	}
+	// A persisted shared allocation (recorded only by share ID, with no
+	// AggregatedCapacity entry) already accounts for the device's shared
+	// counters. Recognize it so a further allocation of the same device
+	// skips the counter check instead of double-charging the counters.
+	return alloc.sharedDeviceIDs.Has(deviceID)
 }
 
 func (alloc *allocator) allocatingDeviceForAnyClaim(deviceID DeviceID) bool {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/consumable_capacity.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/consumable_capacity.go
@@ -18,6 +18,8 @@ package experimental
 
 import (
 	"errors"
+	"math"
+	"math/bits"
 
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -111,6 +113,11 @@ func fillEmptyRequest(capacity resourceapi.DeviceCapacity) resource.Quantity {
 //   - If Step is specified, it rounds requestedVal up to the nearest multiple of Step
 //     starting from Min.
 //   - If no Step is specified and requestedVal >= Min, it returns requestedVal as is.
+//
+// The computation uses saturating int64 arithmetic so that a request far larger
+// than the device capacity cannot wrap to a negative value. Such a request can
+// never be satisfied by a real device, so a saturated (still positive) value is
+// correct and will be rejected by the policy/capacity checks downstream.
 func roundUpRange(requestedVal *resource.Quantity, validRange *resourceapi.CapacityRequestPolicyRange) resource.Quantity {
 	if requestedVal.Cmp(*validRange.Min) < 0 {
 		return validRange.Min.DeepCopy()
@@ -121,14 +128,55 @@ func roundUpRange(requestedVal *resource.Quantity, validRange *resourceapi.Capac
 	requestedInt64 := requestedVal.Value()
 	step := validRange.Step.Value()
 	min := validRange.Min.Value()
-	added := (requestedInt64 - min)
+
+	added := requestedInt64 - min
 	n := added / step
 	mod := added % step
 	if mod != 0 {
 		n += 1
 	}
-	val := min + step*n
+
+	val := saturatingAdd(min, saturatingMul(step, n))
 	return *resource.NewQuantity(val, resource.BinarySI)
+}
+
+// saturatingMul returns a*b, saturating at the int64 minimum/maximum on overflow.
+func saturatingMul(a, b int64) int64 {
+	if a == 0 || b == 0 {
+		return 0
+	}
+	neg := (a < 0) != (b < 0)
+	ua, ub := a, b
+	if a < 0 {
+		ua = -a
+	}
+	if b < 0 {
+		ub = -b
+	}
+	hi, lo := bits.Mul64(uint64(ua), uint64(ub))
+	if hi != 0 || lo > math.MaxInt64 {
+		if neg {
+			return math.MinInt64
+		}
+		return math.MaxInt64
+	}
+	res := int64(lo)
+	if neg {
+		res = -res
+	}
+	return res
+}
+
+// saturatingAdd returns a+b, saturating at the int64 minimum/maximum on overflow.
+func saturatingAdd(a, b int64) int64 {
+	s := a + b
+	if (b > 0 && s < a) || (b < 0 && s > a) {
+		if b > 0 {
+			return math.MaxInt64
+		}
+		return math.MinInt64
+	}
+	return s
 }
 
 // roundUpValidValues returns the first value in validValues that is greater than or equal to requestedVal.

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
@@ -327,6 +327,17 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 	// We can estimate the size based on what we need to allocate.
 	alloc.allocatingDevices = make(map[DeviceID]sets.Set[int], minDevicesTotal)
 
+	// Precompute the set of devices that have a persisted shared allocation
+	// (recorded only by share ID, without an AggregatedCapacity entry). Such a
+	// device's shared counters are already accounted for, so a further
+	// allocation must skip the counter availability check to avoid
+	// double-charging them. See deviceCapacityInUse.
+	sharedDeviceIDs := sets.New[DeviceID]()
+	for sharedID := range alloc.allocatedState.AllocatedSharedDeviceIDs {
+		sharedDeviceIDs.Insert(sharedID.GetDeviceID())
+	}
+	alloc.sharedDeviceIDs = sharedDeviceIDs
+
 	alloc.logger.V(6).Info("Gathered information about devices", "numAllocatedDevices", len(alloc.allocatedState.AllocatedDevices), "minDevicesToBeAllocated", minDevicesTotal)
 
 	// In practice, there aren't going to be many different CEL
@@ -655,7 +666,13 @@ type allocator struct {
 	// The map is indexed by device ID, and each value represents the accumulated capacity
 	// requested by all allocations targeting that device.
 	allocatingCapacity ConsumedCapacityCollection
-	result             []internalAllocationResult
+	// sharedDeviceIDs is the set of devices that have a persisted shared
+	// allocation, recorded only by share ID without an AggregatedCapacity
+	// entry. Such a device's shared counters are already accounted for, so a
+	// further allocation must skip the counter availability check to avoid
+	// double-charging them. Precomputed once from the allocated state.
+	sharedDeviceIDs sets.Set[DeviceID]
+	result           []internalAllocationResult
 }
 
 // counterSets is a map with the name of counter sets to the counters in
@@ -1624,8 +1641,17 @@ func (alloc *allocator) deviceInUse(deviceID DeviceID) bool {
 }
 
 func (alloc *allocator) deviceCapacityInUse(deviceID DeviceID) bool {
-	_, found := alloc.allocatedState.AggregatedCapacity[deviceID]
-	return found || alloc.allocatingCapacityForAnyClaim(deviceID)
+	if _, found := alloc.allocatedState.AggregatedCapacity[deviceID]; found {
+		return true
+	}
+	if alloc.allocatingCapacityForAnyClaim(deviceID) {
+		return true
+	}
+	// A persisted shared allocation (recorded only by share ID, with no
+	// AggregatedCapacity entry) already accounts for the device's shared
+	// counters. Recognize it so a further allocation of the same device
+	// skips the counter check instead of double-charging the counters.
+	return alloc.sharedDeviceIDs.Has(deviceID)
 }
 
 func (alloc *allocator) allocatingDeviceForAnyClaim(deviceID DeviceID) bool {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/consumable_capacity.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/consumable_capacity.go
@@ -18,6 +18,8 @@ package incubating
 
 import (
 	"errors"
+	"math"
+	"math/bits"
 
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -111,6 +113,11 @@ func fillEmptyRequest(capacity resourceapi.DeviceCapacity) resource.Quantity {
 //   - If Step is specified, it rounds requestedVal up to the nearest multiple of Step
 //     starting from Min.
 //   - If no Step is specified and requestedVal >= Min, it returns requestedVal as is.
+//
+// The computation uses saturating int64 arithmetic so that a request far larger
+// than the device capacity cannot wrap to a negative value. Such a request can
+// never be satisfied by a real device, so a saturated (still positive) value is
+// correct and will be rejected by the policy/capacity checks downstream.
 func roundUpRange(requestedVal *resource.Quantity, validRange *resourceapi.CapacityRequestPolicyRange) resource.Quantity {
 	if requestedVal.Cmp(*validRange.Min) < 0 {
 		return validRange.Min.DeepCopy()
@@ -121,14 +128,55 @@ func roundUpRange(requestedVal *resource.Quantity, validRange *resourceapi.Capac
 	requestedInt64 := requestedVal.Value()
 	step := validRange.Step.Value()
 	min := validRange.Min.Value()
-	added := (requestedInt64 - min)
+
+	added := requestedInt64 - min
 	n := added / step
 	mod := added % step
 	if mod != 0 {
 		n += 1
 	}
-	val := min + step*n
+
+	val := saturatingAdd(min, saturatingMul(step, n))
 	return *resource.NewQuantity(val, resource.BinarySI)
+}
+
+// saturatingMul returns a*b, saturating at the int64 minimum/maximum on overflow.
+func saturatingMul(a, b int64) int64 {
+	if a == 0 || b == 0 {
+		return 0
+	}
+	neg := (a < 0) != (b < 0)
+	ua, ub := a, b
+	if a < 0 {
+		ua = -a
+	}
+	if b < 0 {
+		ub = -b
+	}
+	hi, lo := bits.Mul64(uint64(ua), uint64(ub))
+	if hi != 0 || lo > math.MaxInt64 {
+		if neg {
+			return math.MinInt64
+		}
+		return math.MaxInt64
+	}
+	res := int64(lo)
+	if neg {
+		res = -res
+	}
+	return res
+}
+
+// saturatingAdd returns a+b, saturating at the int64 minimum/maximum on overflow.
+func saturatingAdd(a, b int64) int64 {
+	s := a + b
+	if (b > 0 && s < a) || (b < 0 && s > a) {
+		if b > 0 {
+			return math.MaxInt64
+		}
+		return math.MinInt64
+	}
+	return s
 }
 
 // roundUpValidValues returns the first value in validValues that is greater than or equal to requestedVal.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

When a device allows multiple allocations and consumes shared counters, a persisted shared allocation recorded only by share ID (without an `AggregatedCapacity` entry) was not recognized by `deviceCapacityInUse`. As a result the counter availability check still ran and re-charged the device's already-accounted shared counters, leading to a false `Insufficient counters` rejection of a further allocation that shares the same device.

This PR precomputes the set of devices that have a persisted shared allocation (from `AllocatedSharedDeviceIDs`) when constructing the allocator, and makes `deviceCapacityInUse` also report those devices as in use so the counter check is skipped. Applies to the incubating and experimental allocator variants (stable does not support ConsumableCapacity).

Related-to: #140433

#### Special notes for your reviewer

- This is independent of the reserved-state rollback in #140431, which addresses state that is not rolled back within one allocation search. This issue concerns persisted shared state reconstructed between scheduling cycles.
- Adds a regression test case `partitionable-consumable-capacity-shared-device-counter-not-recharged` to the shared `allocatortesting` table, exercised by both the incubating and experimental variants.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a DRA structured allocator bug where a device with a persisted shared allocation (recorded only by share ID) had its shared counters double-charged, causing valid further allocations sharing that device to be wrongly rejected with "Insufficient counters".
```

/sig node
/wg device-management