### PR TITLE
Document that DRA device request Count is unbounded up to MaxInt64

### DIFF
--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -1232,6 +1232,13 @@ type ExactDeviceRequest struct {
 	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
 	// If AllocationMode is ExactCount and this field is not specified, the default is one.
 	//
+	// The field is intentionally not upper-bounded by API validation and may be as
+	// large as math.MaxInt64. Consumers (for example out-of-tree schedulers and quota
+	// or fair-share accounting) must treat it as untrusted input and aggregate or
+	// multiply it using checked or saturating arithmetic: a single request can already
+	// exceed any real cluster, so unschedulability must not be relied upon to protect
+	// accounting code from overflow.
+	//
 	// +optional
 	// +oneOf=AllocationMode
 	Count int64 `json:"count,omitempty" protobuf:"bytes,4,opt,name=count"`
@@ -1361,6 +1368,13 @@ type DeviceSubRequest struct {
 
 	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
 	// If AllocationMode is ExactCount and this field is not specified, the default is one.
+	//
+	// The field is intentionally not upper-bounded by API validation and may be as
+	// large as math.MaxInt64. Consumers (for example out-of-tree schedulers and quota
+	// or fair-share accounting) must treat it as untrusted input and aggregate or
+	// multiply it using checked or saturating arithmetic: a single request can already
+	// exceed any real cluster, so unschedulability must not be relied upon to protect
+	// accounting code from overflow.
 	//
 	// +optional
 	// +oneOf=AllocationMode


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind documentation

#### What this PR does / why we need it

`ExactDeviceRequest.Count` and `DeviceSubRequest.Count` are validated only for a lower bound, so the API accepts the entire positive `int64` range, including `math.MaxInt64`. Several independent out-of-tree DRA consumers (scheduler and quota/fair-share accounting such as Kueue, Volcano, and KAI-Scheduler) have each independently written unchecked `int64` aggregation of `Count`, wrapping to negative values for impossible requests.

This PR documents the intended contract on both `Count` fields:
- the value is not upper-bounded and may be as large as `math.MaxInt64`;
- consumers must treat it as untrusted input and use checked or saturating arithmetic when aggregating or multiplying it;
- unschedulability must not be relied upon to protect accounting code from overflow.

This is the smaller, documentation-only part of issue 140424 (approach A). A hard API upper bound (approach B) is a separate, larger question that would change validation on a GA field and needs a KEP plus SIG API Machinery review, so it is intentionally out of scope here.

Related-to: #140424

#### Special notes for your reviewer

- Pure documentation change; no behavioral or API change, so no release-note and no compatibility impact.
- Whether in-tree consumers should also be audited for unchecked aggregation is secondary and can be split out.

#### Does this PR introduce a user-facing change?

```release-note
None
```

/sig node
/sig api-machinery
/wg device-management