### PR TITLE
Make PodGroupMemberPodsOrderingFunc deterministic to fix Windows flake

### DIFF
--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -880,14 +880,17 @@ func PodGroupMemberPodsOrderingFunc(a, b *QueuedPodInfo) int {
 	} else if a.Timestamp.After(b.Timestamp) {
 		return 1
 	}
-	// On platforms with low-resolution clocks (e.g. Windows), pods added in quick
-	// succession may share the same timestamp. Fall back to pod name to guarantee
-	// a deterministic, stable order.
-	if a.Pod.Name < b.Pod.Name {
+	// Priorities, attempts and timestamps are equal. Use a deterministic,
+	// stable tie-breaker based on pod identity instead of returning 0, so the
+	// resulting order does not depend on the iteration order of the underlying
+	// pod map (which varies across platforms, e.g. on Windows) when pods share
+	// priority, attempts and timestamp.
+	if an, bn := a.Pod.Namespace+"/"+a.Pod.Name, b.Pod.Namespace+"/"+b.Pod.Name; an < bn {
 		return -1
-	} else if a.Pod.Name > b.Pod.Name {
+	} else if an > bn {
 		return 1
 	}
+
 	return 0
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind flake
/kind cleanup

#### What this PR does / why we need it

`PodGroupMemberPodsOrderingFunc` returned `0` when pods had equal priority, attempts and timestamp. Because a pod group's `QueuedPodInfos` are stored in a map, the iteration order (and therefore the order after a stable sort) varied between platforms, causing `TestSubmitPodGroupAlgorithmResult/One_unschedulable` to flake on Windows, where the random map order produced a different assignment of results to pods.

This PR adds a deterministic tie-breaker based on pod identity (namespace/name) for the equal case, so the comparator is now a total order and the resulting order no longer depends on the map iteration order. The sort stays stable.

Related-to: #140420

#### Special notes for your reviewer

- Pure ordering-logic change; no scheduling behavior change for pods that actually differ in priority/attempts/timestamp.
- Verified `TestSubmitPodGroupAlgorithmResult` and the pod-group ordering tests pass.

#### Does this PR introduce a user-facing change?

```release-note
None
```

/sig scheduling