### PR TITLE
Fix JSON-Schema URL in v1 and v1beta1 JSONSchemaProps doc comments

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/types_jsonschema.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/types_jsonschema.go
@@ -36,7 +36,8 @@ const (
 	FieldValueForbidden FieldValueErrorReason = "FieldValueForbidden"
 )
 
-// JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).
+// JSONSchemaProps is a JSON-Schema following Specification Draft 4.
+// See: https://json-schema.org/
 type JSONSchemaProps struct {
 	ID          string        `json:"id,omitempty" protobuf:"bytes,1,opt,name=id"`
 	Schema      JSONSchemaURL `json:"$schema,omitempty" protobuf:"bytes,2,opt,name=schema"`

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types_jsonschema.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types_jsonschema.go
@@ -36,7 +36,8 @@ const (
 	FieldValueForbidden FieldValueErrorReason = "FieldValueForbidden"
 )
 
-// JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).
+// JSONSchemaProps is a JSON-Schema following Specification Draft 4.
+// See: https://json-schema.org/
 type JSONSchemaProps struct {
 	ID          string        `json:"id,omitempty" protobuf:"bytes,1,opt,name=id"`
 	Schema      JSONSchemaURL `json:"$schema,omitempty" protobuf:"bytes,2,opt,name=schema"`


### PR DESCRIPTION
This PR was created with the assistance of generative AI.

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Fixes the broken `http://json-schema.org/` URL in the `JSONSchemaProps` doc comments for the v1 and v1beta1 API versions.

The internal types fix was submitted by @kfess in PR #136159 (which has `lgtm`), but the v1 and v1beta1 versions still have the broken URL. Since the [website reference page](https://kubernetes.io/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1/) is generated from `v1/types_jsonschema.go`, this fix is needed for the upstream source to be correct.

Changed format from `(http://json-schema.org/)` to `See: https://json-schema.org/` (matching the approach in PR #136159) to properly render the URL as a hyperlink.

#### Which issue(s) this PR is related to:

Related to #53971 (broken link on website), in conjunction with PR #136159

#### Does this PR introduce a user-facing change?

```release-note
Fixed JSONSchemaProps v1 and v1beta1 doc comments to properly render JSON Schema URL as a valid link
```