### PR TITLE
Stop leaked reconciler goroutines in Uncertain reconciler tests

### DIFF
--- a/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
@@ -1480,7 +1480,6 @@ func getTestPod(claimName string) *v1.Pod {
 }
 
 func Test_UncertainDeviceGlobalMounts(t *testing.T) {
-	logger, ctx := ktesting.NewTestContext(t)
 	var tests = []struct {
 		name                   string
 		deviceState            operationexecutor.DeviceMountState
@@ -1532,8 +1531,9 @@ func Test_UncertainDeviceGlobalMounts(t *testing.T) {
 			testName := fmt.Sprintf("%s [%s]", tc.name, mode)
 			uniqueTestString := fmt.Sprintf("global-mount-%s", testName)
 			uniquePodDir := fmt.Sprintf("%s-%x", kubeletPodsDir, hasher.Sum([]byte(uniqueTestString)))
-			t.Run(testName+"[", func(t *testing.T) {
-				t.Parallel()
+		t.Run(testName+"[", func(t *testing.T) {
+			t.Parallel()
+			logger, ctx := ktesting.NewTestContext(t)
 				pv := &v1.PersistentVolume{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: tc.volumeName,
@@ -1630,11 +1630,12 @@ func Test_UncertainDeviceGlobalMounts(t *testing.T) {
 				dsw.MarkVolumesReportedInUse([]v1.UniqueVolumeName{volumeName})
 
 				// Start the reconciler to fill ASW.
-				stopChan, stoppedChan := make(chan struct{}), make(chan struct{})
-				go func() {
-					reconciler.Run(ctx, stopChan)
-					close(stoppedChan)
-				}()
+			stopChan, stoppedChan := make(chan struct{}), make(chan struct{})
+			defer close(stopChan)
+			go func() {
+				reconciler.Run(ctx, stopChan)
+				close(stoppedChan)
+			}()
 				waitForVolumeToExistInASW(t, volumeName, asw)
 				if tc.volumeName == volumetesting.TimeoutAndFailOnMountDeviceVolumeName {
 					// Wait upto 10s for reconciler to catch up
@@ -1677,7 +1678,6 @@ func Test_UncertainDeviceGlobalMounts(t *testing.T) {
 }
 
 func Test_UncertainVolumeMountState(t *testing.T) {
-	logger, ctx := ktesting.NewTestContext(t)
 	var tests = []struct {
 		name                   string
 		volumeState            operationexecutor.VolumeMountState
@@ -1746,8 +1746,9 @@ func Test_UncertainVolumeMountState(t *testing.T) {
 			testName := fmt.Sprintf("%s [%s]", tc.name, mode)
 			uniqueTestString := fmt.Sprintf("local-mount-%s", testName)
 			uniquePodDir := fmt.Sprintf("%s-%x", kubeletPodsDir, hasher.Sum([]byte(uniqueTestString)))
-			t.Run(testName, func(t *testing.T) {
-				t.Parallel()
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+			logger, ctx := ktesting.NewTestContext(t)
 				pv := &v1.PersistentVolume{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: tc.volumeName,
@@ -1855,11 +1856,12 @@ func Test_UncertainVolumeMountState(t *testing.T) {
 				dsw.MarkVolumesReportedInUse([]v1.UniqueVolumeName{volumeName})
 
 				// Start the reconciler to fill ASW.
-				stopChan, stoppedChan := make(chan struct{}), make(chan struct{})
-				go func() {
-					reconciler.Run(ctx, stopChan)
-					close(stoppedChan)
-				}()
+			stopChan, stoppedChan := make(chan struct{}), make(chan struct{})
+			defer close(stopChan)
+			go func() {
+				reconciler.Run(ctx, stopChan)
+				close(stoppedChan)
+			}()
 				waitForVolumeToExistInASW(t, volumeName, asw)
 				// all of these tests rely on device to be globally mounted and hence waiting for global
 				// mount ensures that unmountDevice is called as expected.


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it

`Test_UncertainDeviceGlobalMounts` and `Test_UncertainVolumeMountState` run their table cases as parallel subtests, each of which starts a reconciler goroutine with a stop channel that was never closed. Every finished subtest therefore leaked a reconciler that kept spinning at the test's 1ns loop interval, starving the remaining subtests and causing timeouts (flaky `Test_UncertainVolumeMountState` / `Test_UncertainDeviceGlobalMounts`).

This PR closes the stop channel when each subtest returns (`defer close(stopChan)`) and creates the ktesting context per subtest, matching the pattern already used by `Test_Run_Positive_VolumeFSResizeControllerAttachEnabled`.

Related-to: #140352

#### Special notes for your reviewer

- Test-only change; no production code touched.
- Verified `Test_UncertainDeviceGlobalMounts`/`Test_UncertainVolumeMountState` and the full `pkg/kubelet/volumemanager/reconciler` package pass.

#### Does this PR introduce a user-facing change?

```release-note
None
```

/sig storage
/area kubelet