### PR TITLE
resource: document overflow-safe arithmetic for device request Count

### DIFF
--- a/pkg/apis/resource/types.go
+++ b/pkg/apis/resource/types.go
@@ -989,8 +989,16 @@ type ExactDeviceRequest struct {
 	// +optional
 	AllocationMode DeviceAllocationMode
 
-	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
-	// If AllocationMode is ExactCount and this field is not specified, the default is one.
+	// Count is used only when the allocation mode is "ExactCount".
+	// Must be greater than zero.
+	//
+	// Consumers must treat this field as untrusted input and use
+	// overflow-safe arithmetic when aggregating or multiplying Count
+	// values. Consumers must not rely on unschedulability to protect
+	// accounting code.
+	//
+	// If AllocationMode is ExactCount and this field is not specified,
+	// the default is one.
 	//
 	// +optional
 	// +oneOf=AllocationMode
@@ -1113,8 +1121,16 @@ type DeviceSubRequest struct {
 	// +optional
 	AllocationMode DeviceAllocationMode
 
-	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
-	// If AllocationMode is ExactCount and this field is not specified, the default is one.
+	// Count is used only when the allocation mode is "ExactCount".
+	// Must be greater than zero.
+	//
+	// Consumers must treat this field as untrusted input and use
+	// overflow-safe arithmetic when aggregating or multiplying Count
+	// values. Consumers must not rely on unschedulability to protect
+	// accounting code.
+	//
+	// If AllocationMode is ExactCount and this field is not specified,
+	// the default is one.
 	//
 	// +optional
 	// +oneOf=AllocationMode

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -1229,8 +1229,16 @@ type ExactDeviceRequest struct {
 	// +k8s:beta(since: "1.37")=+k8s:optional
 	AllocationMode DeviceAllocationMode `json:"allocationMode,omitempty" protobuf:"bytes,3,opt,name=allocationMode"`
 
-	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
-	// If AllocationMode is ExactCount and this field is not specified, the default is one.
+	// Count is used only when the allocation mode is "ExactCount".
+	// Must be greater than zero.
+	//
+	// Consumers must treat this field as untrusted input and use
+	// overflow-safe arithmetic when aggregating or multiplying Count
+	// values. Consumers must not rely on unschedulability to protect
+	// accounting code.
+	//
+	// If AllocationMode is ExactCount and this field is not specified,
+	// the default is one.
 	//
 	// +optional
 	// +oneOf=AllocationMode
@@ -1359,8 +1367,16 @@ type DeviceSubRequest struct {
 	// +k8s:beta(since: "1.37")=+k8s:optional
 	AllocationMode DeviceAllocationMode `json:"allocationMode,omitempty" protobuf:"bytes,4,opt,name=allocationMode"`
 
-	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
-	// If AllocationMode is ExactCount and this field is not specified, the default is one.
+	// Count is used only when the allocation mode is "ExactCount".
+	// Must be greater than zero.
+	//
+	// Consumers must treat this field as untrusted input and use
+	// overflow-safe arithmetic when aggregating or multiplying Count
+	// values. Consumers must not rely on unschedulability to protect
+	// accounting code.
+	//
+	// If AllocationMode is ExactCount and this field is not specified,
+	// the default is one.
 	//
 	// +optional
 	// +oneOf=AllocationMode

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -1034,8 +1034,16 @@ type DeviceRequest struct {
 	// +k8s:beta(since: "1.37")=+k8s:optional
 	AllocationMode DeviceAllocationMode `json:"allocationMode,omitempty" protobuf:"bytes,4,opt,name=allocationMode"`
 
-	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
-	// If AllocationMode is ExactCount and this field is not specified, the default is one.
+	// Count is used only when the allocation mode is "ExactCount".
+	// Must be greater than zero.
+	//
+	// Consumers must treat this field as untrusted input and use
+	// overflow-safe arithmetic when aggregating or multiplying Count
+	// values. Consumers must not rely on unschedulability to protect
+	// accounting code.
+	//
+	// If AllocationMode is ExactCount and this field is not specified,
+	// the default is one.
 	//
 	// This field can only be set when deviceClassName is set and no subrequests
 	// are specified in the firstAvailable list.
@@ -1202,8 +1210,16 @@ type DeviceSubRequest struct {
 	// +k8s:beta(since: "1.37")=+k8s:optional
 	AllocationMode DeviceAllocationMode `json:"allocationMode,omitempty" protobuf:"bytes,4,opt,name=allocationMode"`
 
-	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
-	// If AllocationMode is ExactCount and this field is not specified, the default is one.
+	// Count is used only when the allocation mode is "ExactCount".
+	// Must be greater than zero.
+	//
+	// Consumers must treat this field as untrusted input and use
+	// overflow-safe arithmetic when aggregating or multiplying Count
+	// values. Consumers must not rely on unschedulability to protect
+	// accounting code.
+	//
+	// If AllocationMode is ExactCount and this field is not specified,
+	// the default is one.
 	//
 	// +optional
 	// +oneOf=AllocationMode

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -1217,8 +1217,16 @@ type ExactDeviceRequest struct {
 	// +k8s:beta(since: "1.37")=+k8s:optional
 	AllocationMode DeviceAllocationMode `json:"allocationMode,omitempty" protobuf:"bytes,3,opt,name=allocationMode"`
 
-	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
-	// If AllocationMode is ExactCount and this field is not specified, the default is one.
+	// Count is used only when the allocation mode is "ExactCount".
+	// Must be greater than zero.
+	//
+	// Consumers must treat this field as untrusted input and use
+	// overflow-safe arithmetic when aggregating or multiplying Count
+	// values. Consumers must not rely on unschedulability to protect
+	// accounting code.
+	//
+	// If AllocationMode is ExactCount and this field is not specified,
+	// the default is one.
 	//
 	// +optional
 	// +oneOf=AllocationMode
@@ -1348,8 +1356,16 @@ type DeviceSubRequest struct {
 	// +k8s:beta(since: "1.37")=+k8s:optional
 	AllocationMode DeviceAllocationMode `json:"allocationMode,omitempty" protobuf:"bytes,4,opt,name=allocationMode"`
 
-	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
-	// If AllocationMode is ExactCount and this field is not specified, the default is one.
+	// Count is used only when the allocation mode is "ExactCount".
+	// Must be greater than zero.
+	//
+	// Consumers must treat this field as untrusted input and use
+	// overflow-safe arithmetic when aggregating or multiplying Count
+	// values. Consumers must not rely on unschedulability to protect
+	// accounting code.
+	//
+	// If AllocationMode is ExactCount and this field is not specified,
+	// the default is one.
 	//
 	// +optional
 	// +oneOf=AllocationMode


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Updates the GoDoc for `ExactDeviceRequest.Count` and `DeviceSubRequest.Count` across the internal and versioned resource APIs to clarify that:
- consumers should treat `Count` as untrusted input,
- aggregation and multiplication of `Count` values should use overflow-safe arithmetic, and
- consumers should not rely on unschedulability to protect accounting code.

This is a documentation-only change and does not modify validation or runtime behavior.

#### Which issue(s) this PR is related to:

Fixes #140424
#### Special notes for your reviewer:

The same documentation update has been applied consistently across the internal API and all maintained versioned resource API types.
#### Does this PR introduce a user-facing change?

```release-note
NONE