### PR TITLE
Fix Quantity.String() dropping the suffix for DecimalSI values above 10^18

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -451,7 +451,14 @@ func (q *Quantity) CanonicalizeBytes(out []byte) (result, suffix []byte) {
 	switch format {
 	case DecimalExponent, DecimalSI:
 		number, exponent := q.AsCanonicalBytes(out)
-		suffix, _ := quantitySuffixer.constructBytes(10, exponent, format)
+		suffix, ok := quantitySuffixer.constructBytes(10, exponent, format)
+		if !ok {
+			// DecimalSI only defines suffixes up to "E" (10^18). For a larger
+			// exponent there is no suffix, so fall back to decimal exponent
+			// notation ("e") instead of dropping the exponent, which would
+			// silently corrupt the value (e.g. "1000E" serializing to "1").
+			suffix, _ = quantitySuffixer.constructBytes(10, exponent, DecimalExponent)
+		}
 		return number, suffix
 	default:
 		// format must be BinarySI

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -463,7 +463,19 @@ func (q *Quantity) CanonicalizeBytes(out []byte) (result, suffix []byte) {
 	default:
 		// format must be BinarySI
 		number, exponent := rounded.AsCanonicalBase1024Bytes(out)
-		suffix, _ := quantitySuffixer.constructBytes(2, exponent*10, format)
+		suffix, ok := quantitySuffixer.constructBytes(2, exponent*10, format)
+		if !ok {
+			// BinarySI only defines suffixes up to "Ei" (2^60). For a larger
+			// exponent there is no suffix, so fall back to decimal exponent
+			// notation ("e") instead of dropping the suffix, which would
+			// silently corrupt the value (e.g. 2^70 serializing to "1").
+			// The base-1024 mantissa/exponent cannot be reused for "e"
+			// notation, so recompute the canonical mantissa and exponent in
+			// base 10.
+			number, exponent := rounded.AsCanonicalBytes(out)
+			suffix, _ := quantitySuffixer.constructBytes(10, exponent, DecimalExponent)
+			return number, suffix
+		}
 		return number, suffix
 	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_overflow_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_overflow_test.go
@@ -42,7 +42,6 @@ const (
 	saturatePos = "want math.MaxInt64 once positive overflow saturates instead of wrapping (#141166)"
 	saturateNeg = "want math.MinInt64 once negative overflow saturates instead of wrapping or reading zero (#141166)"
 	// String drops the DecimalSI suffix above 10^18.
-	suffixDrop = "String drops the suffix for DecimalSI values above 10^18 (#140459)"
 )
 
 type accessorCase struct {
@@ -203,7 +202,7 @@ func quantityAccessorCases() []accessorCase {
 			wantScaledKilo: 1000000000000000000,
 			wantAsInt64:    0, wantAsInt64OK: false,
 			wantFloat:  1e21,
-			wantString: "1", stringTODO: `want "1e21"; ` + suffixDrop,
+			wantString: "1e21",
 		},
 		{
 			name: "five-times-ten-to-21-parsed", load: func() Quantity { return MustParse("5000E") },
@@ -213,7 +212,7 @@ func quantityAccessorCases() []accessorCase {
 			wantScaledKilo: 5000000000000000000,
 			wantAsInt64:    0, wantAsInt64OK: false,
 			wantFloat:  5e21,
-			wantString: "5", stringTODO: `want "5e21"; ` + suffixDrop,
+			wantString: "5e21",
 		},
 		{
 			name: "ten-to-100-parsed", load: func() Quantity { return MustParse("1e100") },
@@ -233,7 +232,7 @@ func quantityAccessorCases() []accessorCase {
 			wantScaledKilo: 1000000000000000000,
 			wantAsInt64:    0, wantAsInt64OK: false,
 			wantFloat:  1e21,
-			wantString: "1", stringTODO: `want "1e21"; ` + suffixDrop,
+			wantString: "1e21",
 		},
 		{
 			// NewScaledQuantity(MaxInt64, 1) is MaxInt64*10; Value wraps to -10,
@@ -299,7 +298,7 @@ func quantityAccessorCases() []accessorCase {
 			wantScaledKilo: -1000000000000000000,
 			wantAsInt64:    0, wantAsInt64OK: false,
 			wantFloat:  -1e21,
-			wantString: "-1", stringTODO: `want "-1e21"; ` + suffixDrop,
+			wantString: "-1e21",
 		},
 
 		// --- Negative rounding (#138510): magnitude fits int64 but the sign flips. ---

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -718,6 +718,13 @@ func TestQuantityString(t *testing.T) {
 		{decQuantity(10800, -4, DecimalSI), "1080m", ""},
 		{decQuantity(300, 6, DecimalSI), "300M", ""},
 		{decQuantity(1, 12, DecimalSI), "1T", ""},
+		// DecimalSI has no suffix beyond "E" (10^18). Larger exponents must fall
+		// back to exponent notation instead of dropping the magnitude, otherwise
+		// e.g. "1000E" would serialize to "1" (a 10^21 corruption).
+		{decQuantity(1, 18, DecimalSI), "1E", ""},
+		{decQuantity(1, 21, DecimalSI), "1e21", "1000E"},
+		{decQuantity(5, 21, DecimalSI), "5e21", "5000E"},
+		{decQuantity(1, 24, DecimalSI), "1e24", "1000000E"},
 		{decQuantity(1234567, 6, DecimalSI), "1234567M", ""},
 		{decQuantity(1234567, -3, BinarySI), "1234567m", ""},
 		{decQuantity(3, 3, DecimalSI), "3k", ""},

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -794,6 +794,26 @@ func TestQuantityString(t *testing.T) {
 	}
 }
 
+func TestQuantityStringBelowNano(t *testing.T) {
+	// DecimalSI has no suffix below "n" (10^-9), so these values take the same
+	// exponent-notation fallback as the >"E" cases above. They are not reachable
+	// from a parse (parsing rounds up to nano), only from Go callers such as
+	// NewScaledQuantity, which is why they are not in the TestQuantityString
+	// table: its round-trip checks require parse-stable strings.
+	table := []struct {
+		in     Quantity
+		expect string
+	}{
+		{decQuantity(1, -12, DecimalSI), "1e-12"},
+		{decQuantity(1, -10, DecimalSI), "100e-12"},
+	}
+	for _, item := range table {
+		if e, a := item.expect, item.in.String(); e != a {
+			t.Errorf("%#v: expected %v, got %v", item.in, e, a)
+		}
+	}
+}
+
 func TestQuantityParseEmit(t *testing.T) {
 	table := []struct {
 		in     string

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -725,6 +725,14 @@ func TestQuantityString(t *testing.T) {
 		{decQuantity(1, 21, DecimalSI), "1e21", "1000E"},
 		{decQuantity(5, 21, DecimalSI), "5e21", "5000E"},
 		{decQuantity(1, 24, DecimalSI), "1e24", "1000000E"},
+		// BinarySI has no suffix beyond "Ei" (2^60). A value whose canonical
+		// base-1024 exponent exceeds that (a multiple of 2^70 or larger) has no
+		// binary suffix, so it must fall back to decimal exponent notation
+		// instead of dropping the suffix, otherwise e.g. 2^70 would serialize
+		// to "1". These values round-trip through parse.
+		{decQuantity(1, 70, BinarySI), "10e69", ""},
+		{decQuantity(2, 70, BinarySI), "20e69", ""},
+		{decQuantity(1, 72, BinarySI), "1e72", ""},
 		{decQuantity(1234567, 6, DecimalSI), "1234567M", ""},
 		{decQuantity(1234567, -3, BinarySI), "1234567m", ""},
 		{decQuantity(3, 3, DecimalSI), "3k", ""},

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -726,10 +726,13 @@ func TestQuantityString(t *testing.T) {
 		{decQuantity(5, 21, DecimalSI), "5e21", "5000E"},
 		{decQuantity(1, 24, DecimalSI), "1e24", "1000000E"},
 		// BinarySI has no suffix beyond "Ei" (2^60). A value whose canonical
-		// base-1024 exponent exceeds that (a multiple of 2^70 or larger) has no
-		// binary suffix, so it must fall back to decimal exponent notation
-		// instead of dropping the suffix, otherwise e.g. 2^70 would serialize
-		// to "1". These values round-trip through parse.
+		// base-1024 exponent exceeds that has no binary suffix, so it must
+		// fall back to an exact decimal representation instead of dropping
+		// the suffix, otherwise e.g. 2^70 would serialize to "1". Exponent
+		// notation is used when trailing decimal zeros allow it; a plain
+		// integer like 2^70 serializes as its full decimal digits (see
+		// TestBinarySIPastEiArithmeticRoundTrip). These values round-trip
+		// through parse.
 		{decQuantity(1, 70, BinarySI), "10e69", ""},
 		{decQuantity(2, 70, BinarySI), "20e69", ""},
 		{decQuantity(1, 72, BinarySI), "1e72", ""},
@@ -802,6 +805,39 @@ func TestQuantityString(t *testing.T) {
 	}
 }
 
+// A valid BinarySI quantity grown past Ei by arithmetic has no binary
+// suffix; before the fallback it serialized as "1", silently losing the
+// magnitude. 2^70 has no trailing decimal zeros, so the fallback emits the
+// exact base-10 integer rather than exponent notation.
+func TestBinarySIPastEiArithmeticRoundTrip(t *testing.T) {
+	q := MustParse("1Ei")
+	q.Mul(1024) // 2^70
+
+	if e, a := "1180591620717411303424", q.String(); e != a {
+		t.Errorf("String() = %q, want %q", a, e)
+	}
+
+	data, err := q.MarshalJSON()
+	if err != nil {
+		t.Fatalf("MarshalJSON: %v", err)
+	}
+	if e, a := `"1180591620717411303424"`, string(data); e != a {
+		t.Errorf("MarshalJSON = %s, want %s", a, e)
+	}
+
+	var back Quantity
+	if err := back.UnmarshalJSON(data); err != nil {
+		t.Fatalf("UnmarshalJSON: %v", err)
+	}
+	if q.Cmp(back) != 0 {
+		t.Errorf("JSON round trip changed the value: %s vs %s", q.String(), back.String())
+	}
+
+	reparsed := MustParse(q.String())
+	if q.Cmp(reparsed) != 0 {
+		t.Errorf("String round trip changed the value: %s vs %s", q.String(), reparsed.String())
+	}
+}
 func TestQuantityStringBelowNano(t *testing.T) {
 	// DecimalSI has no suffix below "n" (10^-9), so these values take the same
 	// exponent-notation fallback as the >"E" cases above. They are not reachable


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`resource.Quantity.String()` silently drops the magnitude for `DecimalSI` quantities whose canonical base-10 exponent exceeds `10^18`, corrupting the value and breaking the `String()`/JSON round-trip invariant.

`CanonicalizeBytes` discarded the `ok` return value of `constructBytes`:

```go
suffix, _ := quantitySuffixer.constructBytes(10, exponent, format)
return number, suffix
```

The `DecimalSI` suffix table only defines suffixes up to `E` (`10^18`). For a larger canonical exponent, `constructBytes` returns `(nil, false)`, but because `ok` is ignored an empty suffix is appended and the exponent is lost:

```
resource.MustParse("1000E").String()   // "1"      (should be 1e21)
resource.MustParse("5000E").String()   // "5"      (should be 5e21)
resource.MustParse("1000000E").String()// "1"      (should be 1e24)
```

The value is stored faithfully (`AsDec()` returns the true `10^21`, and `Cmp`/`Add` operate on the true magnitude), so it passes validation and is only corrupted at serialization — it then round-trips through `String()`, `MarshalJSON()`, `ToUnstructured()`, JSON and YAML to a number `10^21` smaller, with no error. `DecimalExponent` is unaffected (it already renders `1e21` correctly). `BinarySI` is capped only at *parse* time (to `MaxInt64`); arithmetic is not capped, so a `BinarySI` quantity can grow past `Ei` (2^60) and hit the same missing-suffix path. This PR fixes that branch too — a value past `Ei` (e.g. 2^70) now falls back to decimal exponent notation instead of dropping the suffix (which serialized it to `1`).

This PR keeps the `ok` result and falls back to decimal exponent notation (`e`) when no `DecimalSI` suffix exists, preserving the magnitude:

```
resource.MustParse("1000E").String()   // "1e21"
resource.MustParse("5000E").String()   // "5e21"
resource.MustParse("1000000E").String()// "1e24"
```

Values that already have a suffix (`1E`, `999E`, `100E`, …) are unchanged. Added `TestQuantityString` cases covering exponents at and above `10^18`, including the re-parse (round-trip) and negative-value checks already performed by that test.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

An alternative would be to cap `DecimalSI` at parse time (as `BinarySI` is), matching the godoc note that over-large numbers "will be capped". That is a lossy, larger behavior change; this PR takes the minimal, non-lossy path of restoring the `String()` round-trip invariant without changing what values can be parsed or stored. Happy to switch approaches if preferred.

**Does this PR introduce a user-facing change?**

```release-note
Fixed `resource.Quantity.String()` (and `MarshalJSON`/`ToUnstructured`) silently dropping the magnitude for `DecimalSI` quantities larger than 10^18 (for example `1000E`), and for `BinarySI` quantities grown past `Ei` via arithmetic (for example 2^70), which corrupted the value and broke round-tripping through String/JSON/YAML. Such quantities now serialize to an exact base-10 representation: decimal exponent notation where trailing zeros allow it (for example `1e21`), otherwise the full decimal integer (for example 2^70 becomes `1180591620717411303424`).
```


