### PR TITLE
kubectl: stop pruning non-namespaced resources by default when a namespace is specified

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
@@ -1002,20 +1002,18 @@ func TestApplyPruneObjectsWithAllowlist(t *testing.T) {
 				"namespace/test-apply pruned",
 			},
 		},
-		// Deprecated: kubectl apply will no longer prune non-namespaced resources by default when used with the --namespace flag in a future release
-		// namespace is a non-namespaced resource and will not be pruned in the future
+		// namespace is a non-namespaced resource and is not pruned by default when a namespace is specified
 		"prune with namespace and without allowlist should delete resources that are not in the specified file": {
 			currentResources:        []runtime.Object{rc, rc2, cm, ns},
 			namespace:               "test",
-			expectedPrunedResources: []string{"test/test-cm", "test/test-rc2", "/test-apply"},
+			expectedPrunedResources: []string{"test/test-cm", "test/test-rc2"},
 			expectedOutputs: []string{
 				"replicationcontroller/test-rc unchanged",
 				"configmap/test-cm pruned",
 				"replicationcontroller/test-rc2 pruned",
-				"namespace/test-apply pruned",
 			},
 		},
-		// Even namespace is a non-namespaced resource, it will be pruned if specified in pruneAllowList in the future
+		// Even though namespace is a non-namespaced resource, it is pruned if specified in pruneAllowlist
 		"prune with namespace and allowlist should delete all matching resources": {
 			currentResources:        []runtime.Object{rc, cm, ns},
 			pruneAllowlist:          []string{"core/v1/ConfigMap", "core/v1/Namespace"},
@@ -1089,7 +1087,9 @@ func TestApplyPruneObjectsWithAllowlist(t *testing.T) {
 	for testCaseName, tc := range testCases {
 		for _, testingOpenAPISchema := range testingOpenAPISchemas {
 			t.Run(testCaseName, func(t *testing.T) {
-				tf := cmdtesting.NewTestFactory().WithNamespace("test")
+				// the namespace flag is owned by the root command, not the apply
+				// command, so the namespace is set on the factory instead
+				tf := cmdtesting.NewTestFactory().WithNamespace(tc.namespace)
 				defer tf.Cleanup()
 
 				tf.UnstructuredClient = &fake.RESTClient{
@@ -1124,7 +1124,6 @@ func TestApplyPruneObjectsWithAllowlist(t *testing.T) {
 				cmd := NewCmdApply("kubectl", tf, ioStreams)
 				cmd.Flags().Set("filename", filenameRC)
 				cmd.Flags().Set("prune", "true")
-				cmd.Flags().Set("namespace", tc.namespace)
 				cmd.Flags().Set("all", "true")
 				for _, allow := range tc.pruneAllowlist {
 					cmd.Flags().Set("prune-allowlist", allow)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
@@ -71,7 +71,7 @@ func newPruner(o *ApplyOptions) pruner {
 
 func (p *pruner) pruneAll(o *ApplyOptions) error {
 
-	namespacedRESTMappings, nonNamespacedRESTMappings, err := prune.GetRESTMappings(o.Mapper, o.PruneResources, o.Namespace != "")
+	namespacedRESTMappings, nonNamespacedRESTMappings, err := prune.GetRESTMappings(o.Mapper, o.PruneResources, o.EnforceNamespace)
 	if err != nil {
 		return fmt.Errorf("error retrieving RESTMappings to prune: %v", err)
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
@@ -755,7 +755,7 @@ func (o *DiffOptions) Run() error {
 	})
 
 	if o.pruner != nil {
-		prunedObjs, err := o.pruner.pruneAll(o.tracker, o.CmdNamespace != "")
+		prunedObjs, err := o.pruner.pruneAll(o.tracker, o.EnforceNamespace)
 		if err != nil {
 			klog.Warningf("pruning failed and could not be evaluated err: %v", err)
 		}

--- a/staging/src/k8s.io/kubectl/pkg/util/prune/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/prune/prune.go
@@ -22,7 +22,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/klog/v2"
 )
 
 // default allowlist of namespaced resources
@@ -65,10 +64,8 @@ func (pr Resource) String() string {
 func GetRESTMappings(mapper meta.RESTMapper, pruneResources []Resource, namespaceSpecified bool) (namespaced, nonNamespaced []*meta.RESTMapping, err error) {
 	if len(pruneResources) == 0 {
 		pruneResources = defaultNamespacedPruneResources
-		// TODO in kubectl v1.29, add back non-namespaced resource only if namespace is not specified
-		pruneResources = append(pruneResources, defaultNonNamespacedPruneResources...)
-		if namespaceSpecified {
-			klog.Warning("Deprecated: kubectl apply will no longer prune non-namespaced resources by default when used with the --namespace flag in a future release. To preserve the current behaviour, list the resources you want to target explicitly in the --prune-allowlist flag.")
+		if !namespaceSpecified {
+			pruneResources = append(pruneResources, defaultNonNamespacedPruneResources...)
 		}
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/util/prune/prune_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/prune/prune_test.go
@@ -68,10 +68,8 @@ func TestGetRESTMappings(t *testing.T) {
 			pr:                 []Resource{},
 			namespaceSpecified: true,
 			expectedns:         14,
-			// it will be 0 non-namespaced resources after the deprecation period has passed.
-			// for details, refer to https://github.com/kubernetes/kubernetes/pull/110907/.
-			expectednns: 2,
-			expectederr: nil,
+			expectednns:        0,
+			expectederr:        nil,
 		},
 		{
 			mapper: &testRESTMapper{},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig cli

**What this PR does / why we need it:**

`kubectl apply --prune` with an explicit `--namespace` still prunes non-namespaced resources (Namespace, PersistentVolume) from the default allowlist, which can delete namespaces entirely unrelated to what was applied. The deprecation warning announcing this behavior change was added in #110907 (v1.25), and the TODO in the code targeted v1.29, so the deprecation period has long passed.

This completes the deprecation:

- `prune.GetRESTMappings` now only includes the non-namespaced default allowlist entries when no namespace is specified, and the deprecation warning is removed.
- `kubectl apply` and `kubectl diff` now pass `EnforceNamespace` instead of `Namespace != ""`, since the namespace resolved from kubeconfig is never empty (it defaults to `default`), which made the old check always true.
- Resources explicitly listed in `--prune-allowlist` are unaffected; a user who lists e.g. `core/v1/Namespace` still gets namespaces pruned.

Also fixes the namespace wiring in `TestApplyPruneObjectsWithAllowlist`: the test set the `namespace` flag on the apply command, but that flag is owned by the root command, so the call silently failed and every case ran with the same namespace. The namespace is now set on the test factory.

This picks up where #119687 and #127541 left off; both had positive reviews but were closed by the lifecycle bot for inactivity.

**Which issue(s) this PR fixes:**

Fixes #110905

**Special notes for your reviewer:**

Per the review discussion on #127541, `EnforceNamespace` is the correct signal for "namespace explicitly specified": `Namespace != ""` is always true because kubeconfig resolution falls back to `default`.

**Does this PR introduce a user-facing change?**

```release-note
ACTION REQUIRED: `kubectl apply --prune` and `kubectl diff --prune` no longer prune non-namespaced resources (Namespace, PersistentVolume) by default when the `--namespace` flag is specified. To continue pruning non-namespaced resources, list them explicitly using the `--prune-allowlist` flag.
```
