### PR TITLE
Fix label Gt/Lt selectors silently dropping values above int64

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
@@ -18,6 +18,7 @@ package labels
 
 import (
 	"fmt"
+	"math/big"
 	"slices"
 	"sort"
 	"strconv"
@@ -267,10 +268,14 @@ func (r *Requirement) Matches(ls Labels) bool {
 		if !exists {
 			return false
 		}
-		lsValue, err := strconv.ParseInt(val, 10, 64)
-		if err != nil {
+		// Parse as an arbitrary-precision integer: a label value is allowed to be
+		// up to 63 characters, so it can exceed int64 range even though the
+		// requirement operand is constrained to int64. Parsing the label value as
+		// int64 would make such a value fail to match instead of comparing it.
+		lsValue, ok := new(big.Int).SetString(val, 10)
+		if !ok {
 			//nolint:logcheck // Extending the API is not worth it for contextual, structured logging of this.
-			klog.V(10).InfoS("ParseInt failed", "value", val, "label", ls, "err", err)
+			klog.V(10).InfoS("ParseInt failed", "value", val, "label", ls)
 			return false
 		}
 
@@ -281,16 +286,14 @@ func (r *Requirement) Matches(ls Labels) bool {
 			return false
 		}
 
-		var rValue int64
-		for i := range r.strValues {
-			rValue, err = strconv.ParseInt(r.strValues[i], 10, 64)
-			if err != nil {
-				//nolint:logcheck // Extending the API is not worth it for contextual, structured logging of this.
-				klog.V(10).InfoS("ParseInt failed: for 'Gt', 'Lt' operators, the value must be an integer", "value", r.strValues[i], "requirement", r, "err", err)
-				return false
-			}
+		rValue, ok := new(big.Int).SetString(r.strValues[0], 10)
+		if !ok {
+			//nolint:logcheck // Extending the API is not worth it for contextual, structured logging of this.
+			klog.V(10).InfoS("ParseInt failed: for 'Gt', 'Lt' operators, the value must be an integer", "value", r.strValues[0], "requirement", r)
+			return false
 		}
-		return (r.operator == selection.GreaterThan && lsValue > rValue) || (r.operator == selection.LessThan && lsValue < rValue)
+		cmp := lsValue.Cmp(rValue)
+		return (r.operator == selection.GreaterThan && cmp > 0) || (r.operator == selection.LessThan && cmp < 0)
 	default:
 		return false
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector_test.go
@@ -129,6 +129,12 @@ func TestSelectorMatches(t *testing.T) {
 	expectNoMatch(t, "!x", Set{"x": "z"})
 	expectNoMatch(t, "x>1", Set{"x": "0"})
 	expectNoMatch(t, "x<1", Set{"x": "2"})
+	// Gt/Lt must compare label values as arbitrary-precision integers: a label
+	// value larger than math.MaxInt64 is still greater than the (int64) operand.
+	expectMatch(t, "x>1", Set{"x": "18446744073709551615"})
+	expectMatch(t, "x>9223372036854775807", Set{"x": "9223372036854775808"})
+	expectNoMatch(t, "x<1", Set{"x": "18446744073709551615"})
+	expectMatch(t, "x<1", Set{"x": "-18446744073709551615"})
 
 	labelset := Set{
 		"foo": "bar",


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

For the `Gt`/`Lt` label selector operators, `Requirement.Matches` parses the label value with `strconv.ParseInt(val, 10, 64)` and treats an out-of-range value the same as a non-integer — it returns "no match":

```go
lsValue, err := strconv.ParseInt(val, 10, 64)
if err != nil {
    klog.V(10).Infof("ParseInt failed ...")
    return false
}
```

A label value may be up to 63 characters, so it can be a perfectly valid integer that exceeds `math.MaxInt64`. Such a value silently fails to match a selector that it clearly satisfies:

```go
sel, _ := labels.Parse("id>1000")
sel.Matches(labels.Set{"id": "18446744073709551615"}) // false, but 1.8e19 > 1000
sel.Matches(labels.Set{"id": "9223372036854775808"})  // false (MaxInt64+1)
sel.Matches(labels.Set{"id": "9223372036854775807"})  // true  (MaxInt64, boundary)
```

Values holding large numeric IDs (uint64, Snowflake/flake-style IDs, etc.) are common, so a `id>N` selector can silently drop objects it should select. The result is wrong, not an error, so it's easy to miss.

This PR compares the label value and the requirement operand as arbitrary-precision integers (`math/big`) so values outside int64 range compare correctly. The requirement operand is still constrained to int64 at parse time (`NewRequirement`), so this only changes the label-value side. Non-integer and empty label values still don't match, exactly as before.

Added `TestSelectorMatches` cases covering values at and above `math.MaxInt64` for both `Gt` and `Lt`, including a large negative value.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

`Gt`/`Lt` is not on the hot matching path (`In`/`Equals` are), so the extra `big.Int` allocation only occurs for these operators. Behavior for in-range values is unchanged (`big.Int.Cmp` agrees with the previous int64 comparison).

**Does this PR introduce a user-facing change?**

```release-note
Fixed label selectors with the `Gt`/`Lt` operators silently failing to match label values larger than math.MaxInt64 (for example large uint64 IDs). Such values are now compared as arbitrary-precision integers.
```
