### PR TITLE
Plr instrumentation

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -4217,6 +4217,19 @@
   componentEndpoints:
   - component: kubelet
     endpoint: /metrics
+- name: pod_level_resources_admission_total
+  subsystem: kubelet
+  help: Total number of pods admitted during Kubelet admission, categorized by resource
+    configuration mode (pod_and_container_level, pod_level, container_level, or empty
+    for unconfigured/BestEffort) and QoS class.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - config_mode
+  - qos_class
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: pod_pending_resizes
   subsystem: kubelet
   help: 'Number of pending resizes for pods. Label ''priority_bucket'' classifies

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2929,6 +2929,7 @@ func (kl *Kubelet) HandlePodAdditions(ctx context.Context, pods []*v1.Pod) {
 				recordAdmissionRejection(reason)
 				continue
 			}
+			recordPodLevelResourcesAdmission(pod)
 
 			if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 				// Backfill the queue of pending resizes, but only after all the pods have

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2970,3 +2970,30 @@ func resolveRecursiveReadOnly(m v1.VolumeMount, runtimeSupportsRRO bool) (bool, 
 		return false, fmt.Errorf("unknown recursive read-only mode %q", rroMode)
 	}
 }
+
+func recordPodLevelResourcesAdmission(pod *v1.Pod) {
+	hasResources := func(containers []v1.Container) bool {
+		for _, c := range containers {
+			if len(c.Resources.Requests) > 0 || len(c.Resources.Limits) > 0 {
+				return true
+			}
+		}
+		return false
+	}
+
+	hasPodLevel := resourcehelper.IsPodLevelResourcesSet(pod)
+	hasContainerLevel := hasResources(pod.Spec.Containers) || hasResources(pod.Spec.InitContainers)
+
+	var configMode string
+	switch {
+	case hasPodLevel && hasContainerLevel:
+		configMode = "pod_and_container_level"
+	case hasPodLevel:
+		configMode = "pod_level"
+	case hasContainerLevel:
+		configMode = "container_level"
+	}
+
+	qosLabel := strings.ToLower(string(v1qos.GetPodQOS(pod)))
+	metrics.PodLevelResourcesAdmissionTotal.WithLabelValues(configMode, qosLabel).Inc()
+}

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -47,6 +47,7 @@ import (
 	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/component-base/metrics/testutil"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/cri-streaming/pkg/streaming/portforward"
@@ -9294,6 +9295,113 @@ func TestMakemountsSubpathCleanupAccumulation(t *testing.T) {
 
 			require.ElementsMatch(t, tc.expectedCleanedSubPaths, tracker.cleanedSubPaths,
 				"expected cleaned subpaths %v but got %v", tc.expectedCleanedSubPaths, tracker.cleanedSubPaths)
+		})
+	}
+}
+
+func TestRecordPodLevelResourcesAdmission(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResources, true)
+	_ = legacyregistry.Register(metrics.PodLevelResourcesAdmissionTotal)
+
+	testCases := []struct {
+		name           string
+		pod            *v1.Pod
+		expectedMetric string
+	}{
+		{
+			name: "pod and container level resources",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU: resource.MustParse("1"),
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceMemory: resource.MustParse("100Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedMetric: `
+# HELP kubelet_pod_level_resources_admission_total [ALPHA] Total number of pods admitted during Kubelet admission, categorized by resource configuration mode (pod_and_container_level, pod_level, container_level, or empty for unconfigured/BestEffort) and QoS class.
+# TYPE kubelet_pod_level_resources_admission_total counter
+kubelet_pod_level_resources_admission_total{config_mode="pod_and_container_level",qos_class="burstable"} 1
+`,
+		},
+		{
+			name: "pod level only resources",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU: resource.MustParse("1"),
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Name: "c1",
+						},
+					},
+				},
+			},
+			expectedMetric: `
+# HELP kubelet_pod_level_resources_admission_total [ALPHA] Total number of pods admitted during Kubelet admission, categorized by resource configuration mode (pod_and_container_level, pod_level, container_level, or empty for unconfigured/BestEffort) and QoS class.
+# TYPE kubelet_pod_level_resources_admission_total counter
+kubelet_pod_level_resources_admission_total{config_mode="pod_level",qos_class="burstable"} 1
+`,
+		},
+		{
+			name: "container level only resources",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceMemory: resource.MustParse("100Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedMetric: `
+# HELP kubelet_pod_level_resources_admission_total [ALPHA] Total number of pods admitted during Kubelet admission, categorized by resource configuration mode (pod_and_container_level, pod_level, container_level, or empty for unconfigured/BestEffort) and QoS class.
+# TYPE kubelet_pod_level_resources_admission_total counter
+kubelet_pod_level_resources_admission_total{config_mode="container_level",qos_class="burstable"} 1
+`,
+		},
+		{
+			name: "no resources best effort",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "c1",
+						},
+					},
+				},
+			},
+			expectedMetric: `
+# HELP kubelet_pod_level_resources_admission_total [ALPHA] Total number of pods admitted during Kubelet admission, categorized by resource configuration mode (pod_and_container_level, pod_level, container_level, or empty for unconfigured/BestEffort) and QoS class.
+# TYPE kubelet_pod_level_resources_admission_total counter
+kubelet_pod_level_resources_admission_total{config_mode="",qos_class="besteffort"} 1
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			metrics.PodLevelResourcesAdmissionTotal.Reset()
+			recordPodLevelResourcesAdmission(tc.pod)
+
+			testMetric(t, metrics.PodLevelResourcesAdmissionTotal.FQName(), tc.expectedMetric)
 		})
 	}
 }

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -9303,6 +9303,11 @@ func TestRecordPodLevelResourcesAdmission(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResources, true)
 	_ = legacyregistry.Register(metrics.PodLevelResourcesAdmissionTotal)
 
+	metricHeader := `
+# HELP kubelet_pod_level_resources_admission_total [ALPHA] Total number of pods admitted during Kubelet admission, categorized by resource configuration mode (pod_and_container_level, pod_level, container_level, or empty for unconfigured/BestEffort) and QoS class.
+# TYPE kubelet_pod_level_resources_admission_total counter
+`
+
 	testCases := []struct {
 		name           string
 		pod            *v1.Pod
@@ -9328,11 +9333,7 @@ func TestRecordPodLevelResourcesAdmission(t *testing.T) {
 					},
 				},
 			},
-			expectedMetric: `
-# HELP kubelet_pod_level_resources_admission_total [ALPHA] Total number of pods admitted during Kubelet admission, categorized by resource configuration mode (pod_and_container_level, pod_level, container_level, or empty for unconfigured/BestEffort) and QoS class.
-# TYPE kubelet_pod_level_resources_admission_total counter
-kubelet_pod_level_resources_admission_total{config_mode="pod_and_container_level",qos_class="burstable"} 1
-`,
+			expectedMetric: `kubelet_pod_level_resources_admission_total{config_mode="pod_and_container_level",qos_class="burstable"} 1`,
 		},
 		{
 			name: "pod level only resources",
@@ -9350,11 +9351,7 @@ kubelet_pod_level_resources_admission_total{config_mode="pod_and_container_level
 					},
 				},
 			},
-			expectedMetric: `
-# HELP kubelet_pod_level_resources_admission_total [ALPHA] Total number of pods admitted during Kubelet admission, categorized by resource configuration mode (pod_and_container_level, pod_level, container_level, or empty for unconfigured/BestEffort) and QoS class.
-# TYPE kubelet_pod_level_resources_admission_total counter
-kubelet_pod_level_resources_admission_total{config_mode="pod_level",qos_class="burstable"} 1
-`,
+			expectedMetric: `kubelet_pod_level_resources_admission_total{config_mode="pod_level",qos_class="burstable"} 1`,
 		},
 		{
 			name: "container level only resources",
@@ -9371,11 +9368,7 @@ kubelet_pod_level_resources_admission_total{config_mode="pod_level",qos_class="b
 					},
 				},
 			},
-			expectedMetric: `
-# HELP kubelet_pod_level_resources_admission_total [ALPHA] Total number of pods admitted during Kubelet admission, categorized by resource configuration mode (pod_and_container_level, pod_level, container_level, or empty for unconfigured/BestEffort) and QoS class.
-# TYPE kubelet_pod_level_resources_admission_total counter
-kubelet_pod_level_resources_admission_total{config_mode="container_level",qos_class="burstable"} 1
-`,
+			expectedMetric: `kubelet_pod_level_resources_admission_total{config_mode="container_level",qos_class="burstable"} 1`,
 		},
 		{
 			name: "no resources best effort",
@@ -9388,11 +9381,7 @@ kubelet_pod_level_resources_admission_total{config_mode="container_level",qos_cl
 					},
 				},
 			},
-			expectedMetric: `
-# HELP kubelet_pod_level_resources_admission_total [ALPHA] Total number of pods admitted during Kubelet admission, categorized by resource configuration mode (pod_and_container_level, pod_level, container_level, or empty for unconfigured/BestEffort) and QoS class.
-# TYPE kubelet_pod_level_resources_admission_total counter
-kubelet_pod_level_resources_admission_total{config_mode="",qos_class="besteffort"} 1
-`,
+			expectedMetric: `kubelet_pod_level_resources_admission_total{config_mode="",qos_class="besteffort"} 1`,
 		},
 	}
 
@@ -9401,7 +9390,8 @@ kubelet_pod_level_resources_admission_total{config_mode="",qos_class="besteffort
 			metrics.PodLevelResourcesAdmissionTotal.Reset()
 			recordPodLevelResourcesAdmission(tc.pod)
 
-			testMetric(t, metrics.PodLevelResourcesAdmissionTotal.FQName(), tc.expectedMetric)
+			expected := metricHeader + tc.expectedMetric + "\n"
+			testMetric(t, metrics.PodLevelResourcesAdmissionTotal.FQName(), expected)
 		})
 	}
 }

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -212,7 +212,6 @@ const (
 	PodRequestsGetKey        = "pod_requests_get_total"
 	PodRequestsWatchKey      = "pod_requests_watch_total"
 
-
 	// Metric keys for pod level resources metrics.
 	PodLevelResourcesAdmissionTotalKey = "pod_level_resources_admission_total"
 )

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -211,6 +211,10 @@ const (
 	PodRequestsListKey       = "pod_requests_list_total"
 	PodRequestsGetKey        = "pod_requests_get_total"
 	PodRequestsWatchKey      = "pod_requests_watch_total"
+
+
+	// Metric keys for pod level resources metrics.
+	PodLevelResourcesAdmissionTotalKey = "pod_level_resources_admission_total"
 )
 
 // PriorityBucket represents the priority bucket label value for pod resize metrics.
@@ -1398,6 +1402,25 @@ var (
 		},
 		[]string{"server_api_version", "status_code"},
 	)
+	// PodLevelResourcesAdmissionTotal tracks feature adoption metrics for KEP-2837 (Pod-Level Resources) upon pod admission.
+	// Only admitted pods are recorded.
+	// config_mode categorizes how resources are specified on the pod:
+	//   - "pod_and_container_level": Both pod-level and container-level resources are set.
+	//   - "pod_level": Only pod-level resources are set.
+	//   - "container_level": Only container-level resources are set.
+	//   - "": Neither pod-level nor container-level resources are set (BestEffort QoS).
+	// Bounded cardinality: max 12 series (4 config_modes * 3 qos_classes).
+	// Note: This metric is ALPHA and temporary. It is intended to track feature adoption while the
+	// feature is new and is scheduled to be removed 2-3 releases after the Pod-Level Resources feature reaches GA.
+	PodLevelResourcesAdmissionTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      KubeletSubsystem,
+			Name:           PodLevelResourcesAdmissionTotalKey,
+			Help:           "Total number of pods admitted during Kubelet admission, categorized by resource configuration mode (pod_and_container_level, pod_level, container_level, or empty for unconfigured/BestEffort) and QoS class.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"config_mode", "qos_class"},
+	)
 )
 
 var registerMetrics sync.Once
@@ -1533,6 +1556,9 @@ func Register() {
 		legacyregistry.MustRegister(PodRequestsList)
 		legacyregistry.MustRegister(PodRequestsGet)
 		legacyregistry.MustRegister(PodRequestsWatch)
+		if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources) {
+			legacyregistry.MustRegister(PodLevelResourcesAdmissionTotal)
+		}
 	})
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR implements instrumentation for Pod Level Resources (PLR) as outlined in KEP-2837. It adds necessary metrics to monitor resource usage and admission at the pod level within the Kubelet.

#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/issues/2837
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added a new alpha Kubelet metric, pod_level_resources_admission_total, to track feature adoption for KEP-2837 (Pod-Level Resources) upon pod admission, categorized by resource configuration mode and QoS class
```



