### PR TITLE
fix: Wrap watch decode errors with %w instead of %v

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/watch/streamwatcher.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/streamwatcher.go
@@ -126,7 +126,7 @@ func (sw *StreamWatcher) receive() {
 					case <-sw.done:
 					case sw.result <- Event{
 						Type:   Error,
-						Object: sw.reporter.AsObject(fmt.Errorf("unable to decode an event from the watch stream: %v", err)),
+						Object: sw.reporter.AsObject(fmt.Errorf("unable to decode an event from the watch stream: %w", err)),
 					}:
 					}
 				}

--- a/staging/src/k8s.io/apimachinery/pkg/watch/streamwatcher_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/streamwatcher_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package watch_test
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -102,6 +104,28 @@ func TestStreamWatcherError(t *testing.T) {
 		t.Fatalf("unexpected open channel")
 	}
 
+	sw.Stop()
+	_, ok = <-sw.ResultChan()
+	if ok {
+		t.Fatalf("unexpected open channel")
+	}
+}
+
+func TestStreamWatcherErrorUnwrap(t *testing.T) {
+	fd := fakeDecoder{err: fmt.Errorf("decoding failed: %w", context.Canceled)}
+	fr := &fakeReporter{}
+	//nolint:logcheck // Intentionally uses the old API.
+	sw := NewStreamWatcher(fd, fr)
+	evt, ok := <-sw.ResultChan()
+	if !ok {
+		t.Fatalf("unexpected close")
+	}
+	if evt.Type != Error {
+		t.Fatalf("expected error event, got %#v", evt)
+	}
+	if !errors.Is(fr.err, context.Canceled) {
+		t.Errorf("expected reported error to wrap %v, got: %v", context.Canceled, fr.err)
+	}
 	sw.Stop()
 	_, ok = <-sw.ResultChan()
 	if ok {

--- a/staging/src/k8s.io/client-go/rest/watch/decoder.go
+++ b/staging/src/k8s.io/client-go/rest/watch/decoder.go
@@ -61,7 +61,7 @@ func (d *Decoder) Decode() (watch.EventType, runtime.Object, error) {
 
 	obj, err := runtime.Decode(d.embeddedDecoder, got.Object.Raw)
 	if err != nil {
-		return "", nil, fmt.Errorf("unable to decode watch event: %v", err)
+		return "", nil, fmt.Errorf("unable to decode watch event: %w", err)
 	}
 	return watch.EventType(got.Type), obj, nil
 }

--- a/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
+++ b/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
@@ -18,6 +18,7 @@ package watch
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -27,6 +28,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	runtimejson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -103,6 +105,49 @@ func TestDecoder(t *testing.T) {
 
 		decoder.Close()
 	}
+}
+
+// errorDecoder implements runtime.Decoder and always fails with the given error.
+type errorDecoder struct {
+	err error
+}
+
+func (d *errorDecoder) Decode(data []byte, defaults *schema.GroupVersionKind, into runtime.Object) (runtime.Object, *schema.GroupVersionKind, error) {
+	return nil, nil, d.err
+}
+
+func TestDecoder_EmbeddedDecodeErrorUnwrap(t *testing.T) {
+	out, in := io.Pipe()
+	embeddedErr := errors.New("embedded decode failure")
+	decoder := NewDecoder(streaming.NewDecoder(out, getDecoder()), &errorDecoder{err: embeddedErr})
+
+	go func() {
+		expect := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
+		data, err := runtime.Encode(scheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), expect)
+		if err != nil {
+			t.Errorf("Unexpected error %v", err)
+			return
+		}
+		event := metav1.WatchEvent{
+			Type:   string(watch.Added),
+			Object: runtime.RawExtension{Raw: json.RawMessage(data)},
+		}
+		if err := json.NewEncoder(in).Encode(&event); err != nil {
+			t.Errorf("Unexpected error %v", err)
+		}
+		if err := in.Close(); err != nil {
+			t.Errorf("Unexpected error %v", err)
+		}
+	}()
+
+	_, _, err := decoder.Decode()
+	if err == nil {
+		t.Fatal("Expected decode error")
+	}
+	if !errors.Is(err, embeddedErr) {
+		t.Errorf("Expected error to wrap %v, got: %v", embeddedErr, err)
+	}
+	decoder.Close()
 }
 
 func TestDecoder_SourceClose(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig api-machinery

**What this PR does / why we need it**:

`StreamWatcher.receive` and the client watch `Decoder` wrap decode errors with `%v`, which severs the error chain. Consumers can't use `errors.Is` or `errors.As` to detect the underlying cause (for example `context.Canceled` during shutdown) and end up string-matching the message. Config Sync does exactly that today: it matches the literal "unable to decode an event from the watch stream: context canceled" text in its remediator watch code.

This changes `%v` to `%w` in both places. The error message is unchanged; only unwrapping behavior improves.

Structured as two commits: the first adds tests that fail without the fix, the second is the fix. Test output without the fix:

```
--- FAIL: TestStreamWatcherErrorUnwrap
    streamwatcher_test.go:127: expected reported error to wrap context canceled, got: unable to decode an event from the watch stream: decoding failed: context canceled
--- FAIL: TestDecoder_EmbeddedDecodeErrorUnwrap
    decoder_test.go:146: Expected error to wrap embedded decode failure, got: unable to decode watch event: embedded decode failure
```

With the fix, `-race` and stress are clean:

```
$ go test -race ./pkg/watch/...        # k8s.io/apimachinery
ok  	k8s.io/apimachinery/pkg/watch	1.493s
$ go test -race ./rest/watch/...       # k8s.io/client-go
ok  	k8s.io/client-go/rest/watch	1.706s
$ stress -p 8 -count 200 watch.test -test.run 'TestStreamWatcher'
26s: 200 runs total, 0 failures
$ stress -p 8 -count 200 restwatch.test -test.run 'TestDecoder'
27s: 200 runs total, 0 failures
```

**Which issue(s) this PR fixes**:

Part of #140465 (bug 3). Originally identified as a TODO in #131505.

**Special notes for your reviewer**:

Follow-up to the merged 2025 watch shutdown work (#131266, #131321, #131706). Same shape of change as #131321.

/cc @pohly @wojtek-t

**Does this PR introduce a user-facing change?**

```release-note
Watch decode errors reported by the client now support errors.Is/errors.As unwrapping of the underlying error. The error message is unchanged.
```
