### PR TITLE
fix: Close response body when watch content-type negotiation fails

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -838,6 +838,12 @@ func (r *Request) newStreamWatcher(ctx context.Context, resp *http.Response) (wa
 	}
 	objectDecoder, streamingSerializer, framer, err := r.contentConfig.Negotiator.StreamDecoder(mediaType, params)
 	if err != nil {
+		// The response body must be closed here to avoid leaking the
+		// connection. Unlike the error paths in Watch, do not drain the body
+		// before closing: this can be a streaming response held open by the
+		// server, so draining could block indefinitely, and the connection
+		// cannot be reused anyway.
+		_ = resp.Body.Close()
 		return nil, err
 	}
 

--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -54,6 +54,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/scheme"
 	restclientwatch "k8s.io/client-go/rest/watch"
@@ -2220,15 +2221,7 @@ func TestWatchNonDefaultContentType(t *testing.T) {
 }
 
 func TestWatchUnknownContentType(t *testing.T) {
-	var table = []struct {
-		t   watch.EventType
-		obj runtime.Object
-	}{
-		{watch.Added, &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "first"}}},
-		{watch.Modified, &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "second"}}},
-		{watch.Deleted, &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "last"}}},
-	}
-
+	handlerDone := make(chan struct{})
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		flusher, ok := w.(http.Flusher)
 		if !ok {
@@ -2241,20 +2234,40 @@ func TestWatchUnknownContentType(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		flusher.Flush()
 
-		encoder := restclientwatch.NewEncoder(streaming.NewEncoder(w, scheme.Codecs.LegacyCodec(v1.SchemeGroupVersion)), scheme.Codecs.LegacyCodec(v1.SchemeGroupVersion))
-		for _, item := range table {
-			if err := encoder.Encode(&watch.Event{Type: item.t, Object: item.obj}); err != nil {
-				panic(err)
-			}
-			flusher.Flush()
-		}
+		// Negotiation fails on the Content-Type header alone, so no events
+		// are written. Hold the stream open like a real watch: the client
+		// must not block waiting for the stream to end before returning the
+		// negotiation error.
+		<-handlerDone
 	}))
 	defer testServer.Close()
+	defer close(handlerDone)
 
 	s := testRESTClient(t, testServer)
-	_, err := s.Get().Prefix("path/to/watch/thing").Watch(context.Background())
-	if err == nil {
-		t.Fatalf("Expected to fail due to lack of known stream serialization for content type")
+	respCount := newCount()
+	inner := s.Client.Transport
+	s.Client.Transport = clientFunc(func(req *http.Request) (*http.Response, error) {
+		resp, err := inner.RoundTrip(req)
+		if err == nil {
+			resp.Body = &readTracker{delegated: resp.Body, count: respCount}
+		}
+		return resp, err
+	})
+	watchErr := make(chan error, 1)
+	go func() {
+		_, err := s.Get().Prefix("path/to/watch/thing").Watch(context.Background())
+		watchErr <- err
+	}()
+	select {
+	case err := <-watchErr:
+		if err == nil {
+			t.Fatalf("Expected to fail due to lack of known stream serialization for content type")
+		}
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatal("Watch did not return; blocked on the open watch stream?")
+	}
+	if got := respCount.getCloseCount(); got != 1 {
+		t.Errorf("Expected response body Close to be invoked 1 time, but got: %d", got)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig api-machinery

**What this PR does / why we need it**:

When `Request.Watch` gets a 200 response but the negotiator has no stream decoder for the response content type, `newStreamWatcher` returns the error without closing `resp.Body`, leaking the connection.

The fix closes the body on that error path without draining it: a watch response can be a stream held open by the server, so draining could block indefinitely, and the connection cannot be reused anyway. The test holds the stream open to pin that Watch returns promptly.

Structured as two commits: the first extends `TestWatchUnknownContentType` with the in-package `readTracker` close counter and fails without the fix, the second is the fix. Test output without the fix:

```
=== RUN   TestWatchUnknownContentType
    request_test.go:2271: Expected response body Close to be invoked 1 time, but got: 0
--- FAIL: TestWatchUnknownContentType (0.00s)
```

With the fix, `-race` and stress are clean:

```
$ go test -race ./rest/...             # k8s.io/client-go
ok  	k8s.io/client-go/rest	18.041s
ok  	k8s.io/client-go/rest/watch	1.701s
$ stress -p 8 -count 200 rest.test -test.run 'TestWatch'
1m45s: 200 runs total, 0 failures
```

**Which issue(s) this PR fixes**:

Fixes #140464

**Special notes for your reviewer**:

Follow-up to #131706, which cleaned up response body handling in the watch tests. Originally identified as a TODO in #131505.

/cc @liggitt @jpbetz

**Does this PR introduce a user-facing change?**

```release-note
Fixed a response body leak in the watch client when the server returns an unsupported content type.
```
