### PR TITLE
Fix RetryOnConflict returning nil for context cancellation

### DIFF
--- a/staging/src/k8s.io/client-go/util/retry/util.go
+++ b/staging/src/k8s.io/client-go/util/retry/util.go
@@ -49,17 +49,19 @@ func OnError(backoff wait.Backoff, retriable func(error) bool, fn func() error) 
 	var lastErr error
 	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
 		err := fn()
+		if err != nil {
+			lastErr = err
+		}
 		switch {
 		case err == nil:
 			return true, nil
 		case retriable(err):
-			lastErr = err
 			return false, nil
 		default:
 			return false, err
 		}
 	})
-	if wait.Interrupted(err) {
+	if wait.Interrupted(err) && lastErr != nil {
 		err = lastErr
 	}
 	return err

--- a/staging/src/k8s.io/client-go/util/retry/util_test.go
+++ b/staging/src/k8s.io/client-go/util/retry/util_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package retry
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -53,6 +54,14 @@ func TestRetryOnConflict(t *testing.T) {
 		return testErr
 	})
 	if err != testErr {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// returns immediately on context cancellation
+	err = RetryOnConflict(opts, func() error {
+		return context.Canceled
+	})
+	if err != context.Canceled {
 		t.Errorf("unexpected error: %v", err)
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig api-machinery

#### What this PR does / why we need it:
`RetryOnConflict` delegates to `OnError`, which translated any `wait.Interrupted(err)` result to `lastErr`. `lastErr` was only set for retriable errors, so a non-retriable interrupted error like `context.Canceled` could be replaced with nil.

This records the last non-nil error from the callback before classifying it, preserving context cancellation and other non-retriable interrupted errors while keeping the existing retry-exhaustion behavior.

#### Which issue(s) this PR fixes:
Addresses #140402

#### Special notes for your reviewer:
Added a regression test for `RetryOnConflict` returning `context.Canceled` directly.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Verification
```
$ go test ./staging/src/k8s.io/client-go/util/retry
ok  	k8s.io/client-go/util/retry	0.278s
```

I also attempted `make test WHAT=./staging/src/k8s.io/client-go/util/retry`, but this local macOS environment has Bash 3.2 and Kubernetes requires Bash >= 4.2 for that wrapper. The package-level `go test` above passed.