### PR TITLE
resource: omit not-yet-actuated pod-level resource on infeasible resize

### DIFF
--- a/staging/src/k8s.io/component-helpers/resource/helpers.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers.go
@@ -169,11 +169,15 @@ func PodRequests(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 
 		for resourceName, quantity := range pod.Spec.Resources.Requests {
 			if IsSupportedPodLevelResource(resourceName) {
-				reqs[resourceName] = quantity
-				if effectiveReqs != nil {
-					reqs[resourceName] = effectiveReqs[resourceName]
+				if effectiveReqs == nil {
+					reqs[resourceName] = quantity
+				} else if effectiveReq, ok := effectiveReqs[resourceName]; ok {
+					reqs[resourceName] = effectiveReq
 				}
-
+				// If the resource is absent from the effective requests (for example an
+				// infeasible resize that adds a pod-level resource not yet actuated), omit
+				// it instead of inserting a zero-valued quantity, matching the behavior of
+				// the container-level aggregation.
 			}
 		}
 	}
@@ -366,10 +370,15 @@ func PodLimits(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 		}
 		for resourceName, quantity := range pod.Spec.Resources.Limits {
 			if IsSupportedPodLevelResource(resourceName) {
-				limits[resourceName] = quantity
-				if effectiveLims != nil {
-					limits[resourceName] = effectiveLims[resourceName]
+				if effectiveLims == nil {
+					limits[resourceName] = quantity
+				} else if effectiveLim, ok := effectiveLims[resourceName]; ok {
+					limits[resourceName] = effectiveLim
 				}
+				// If the resource is absent from the effective limits (for example an
+				// infeasible resize that adds a pod-level resource not yet actuated), omit
+				// it instead of inserting a zero-valued quantity, matching the behavior of
+				// the container-level aggregation.
 			}
 		}
 	}

--- a/staging/src/k8s.io/component-helpers/resource/helpers_test.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers_test.go
@@ -1976,6 +1976,143 @@ func TestPodLevelResourceRequests(t *testing.T) {
 	}
 }
 
+func TestPodLevelResourceRequestsWithPodStatus(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		opts                  PodResourcesOptions
+		podResources          v1.ResourceRequirements
+		podStatusResources    *v1.ResourceRequirements
+		podAllocatedResources v1.ResourceList
+		podResizeStatus       []v1.PodCondition
+		containers            []v1.Container
+		expectedRequests      v1.ResourceList
+	}{
+		{
+			name: "infeasible pod-level resize adding a request must omit the not-yet-actuated resource",
+			podResources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+			podStatusResources: &v1.ResourceRequirements{
+				Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
+			},
+			podAllocatedResources: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
+			podResizeStatus: []v1.PodCondition{{
+				Type:   v1.PodResizePending,
+				Status: v1.ConditionTrue,
+				Reason: v1.PodReasonInfeasible,
+			}},
+			containers: []v1.Container{{Name: "c1"}},
+			opts: PodResourcesOptions{
+				UseStatusResources: true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			// The added memory request is not actuated yet (resize is infeasible), so it
+			// must be omitted rather than reported as memory=0.
+			expectedRequests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
+		},
+		{
+			name: "feasible pod-level resize adding a request uses the max of spec and actuated",
+			podResources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+			podStatusResources: &v1.ResourceRequirements{
+				Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
+			},
+			podAllocatedResources: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
+			containers:            []v1.Container{{Name: "c1"}},
+			opts: PodResourcesOptions{
+				UseStatusResources: true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("2"),
+				v1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &v1.Pod{
+				Spec: v1.PodSpec{
+					Resources:  &tc.podResources,
+					Containers: tc.containers,
+				},
+				Status: v1.PodStatus{
+					Resources:          tc.podStatusResources,
+					AllocatedResources: tc.podAllocatedResources,
+					Conditions:         tc.podResizeStatus,
+				},
+			}
+			got := PodRequests(p, tc.opts)
+			if !equality.Semantic.DeepEqual(got, tc.expectedRequests) {
+				t.Errorf("got=%v, want=%v, diff=%s", got, tc.expectedRequests, diff.Diff(got, tc.expectedRequests))
+			}
+		})
+	}
+}
+
+func TestPodLevelResourceLimitsWithPodStatus(t *testing.T) {
+	testCases := []struct {
+		name               string
+		opts               PodResourcesOptions
+		podResources       v1.ResourceRequirements
+		podStatusResources *v1.ResourceRequirements
+		podResizeStatus    []v1.PodCondition
+		containers         []v1.Container
+		expectedLimits     v1.ResourceList
+	}{
+		{
+			name: "infeasible pod-level resize adding a limit must omit the not-yet-actuated resource",
+			podResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+			podStatusResources: &v1.ResourceRequirements{
+				Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
+			},
+			podResizeStatus: []v1.PodCondition{{
+				Type:   v1.PodResizePending,
+				Status: v1.ConditionTrue,
+				Reason: v1.PodReasonInfeasible,
+			}},
+			containers: []v1.Container{{Name: "c1"}},
+			opts: PodResourcesOptions{
+				UseStatusResources: true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			// A zero-valued limit is not the same as "no limit"; the not-yet-actuated
+			// memory limit must be omitted rather than reported as memory=0.
+			expectedLimits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &v1.Pod{
+				Spec: v1.PodSpec{
+					Resources:  &tc.podResources,
+					Containers: tc.containers,
+				},
+				Status: v1.PodStatus{
+					Resources:  tc.podStatusResources,
+					Conditions: tc.podResizeStatus,
+				},
+			}
+			got := PodLimits(p, tc.opts)
+			if !equality.Semantic.DeepEqual(got, tc.expectedLimits) {
+				t.Errorf("got=%v, want=%v, diff=%s", got, tc.expectedLimits, diff.Diff(got, tc.expectedLimits))
+			}
+		})
+	}
+}
+
 func TestIsSupportedPodLevelResource(t *testing.T) {
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`PodRequests` and `PodLimits` in `component-helpers/resource` build the pod-level result by iterating over the *spec* resources and indexing into the effective (max of spec/actuated/allocated) resource map:

```go
reqs[resourceName] = quantity
if effectiveReqs != nil {
    reqs[resourceName] = effectiveReqs[resourceName]
}
```

For an **infeasible** resize, `determineEffectiveRequests`/`determineEffectiveLimits` return only the actuated (and, for requests, allocated) resources, so a resource that the resize *adds* but that is not yet actuated is absent from the effective map. Indexing a Go map with a missing key yields a zero-valued `resource.Quantity`, which is then written into the result as e.g. `memory: 0`.

The container-level aggregation does not have this problem: it iterates over the effective list, so a missing resource is simply omitted rather than set to zero.

This is a correctness/consistency fix (an infeasible resize does not reserve the added resource, so the omitted value is the correct footprint). Reporting `memory: 0` instead of omitting the key shows up in `pod.status.allocatedResources`, is not the same as "no limit" for a limit, and produces spurious inequality when resource maps are compared during resize reconciliation.

This PR aligns the pod-level loop with the container-level path: it only takes the value from the effective map when the key is present, and otherwise omits it. Tests are added for the requests and limits paths; they fail on `master` (result contains `memory: 0`) and pass with the fix, and the existing `component-helpers/resource` suite stays green.

**Which issue(s) this PR fixes**:

Fixes #140474

**Special notes for your reviewer**:

The two feature gates involved (`InPlacePodLevelResourcesVerticalScaling`, `PodLevelResources`) are alpha/off-by-default, so current exposure is narrow, but the behavior is worth fixing before the feature graduates. The remaining question — whether a not-yet-actuated resource should be omitted (as done here, matching the container path) or fall back to the spec value — is a small design choice; I went with omission for consistency and am happy to adjust.

**Does this PR introduce a user-facing change?**

```release-note
Fixed pod-level resource requests/limits reporting a zero-valued resource (for example `memory: 0`) instead of omitting it when an in-place pod resize is infeasible.
```
