### PR TITLE
resource: omit unactuated pod-level resource keys in PodRequests/PodLimits

### DIFF
--- a/staging/src/k8s.io/component-helpers/resource/helpers.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers.go
@@ -169,11 +169,19 @@ func PodRequests(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 
 		for resourceName, quantity := range pod.Spec.Resources.Requests {
 			if IsSupportedPodLevelResource(resourceName) {
-				reqs[resourceName] = quantity
-				if effectiveReqs != nil {
-					reqs[resourceName] = effectiveReqs[resourceName]
+				if effectiveReqs == nil {
+					reqs[resourceName] = quantity
+					continue
 				}
-
+				// Only propagate keys that are present in the effective (actuated)
+				// requests. A key present in the spec but absent from the effective
+				// map (e.g. a request added by a not-yet-actuated resize) is omitted,
+				// matching container-level aggregation, which iterates the effective
+				// map and never inserts unactuated keys. Assigning effectiveReqs[name]
+				// unconditionally would insert an explicit zero instead.
+				if effVal, ok := effectiveReqs[resourceName]; ok {
+					reqs[resourceName] = effVal
+				}
 			}
 		}
 	}
@@ -366,9 +374,18 @@ func PodLimits(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 		}
 		for resourceName, quantity := range pod.Spec.Resources.Limits {
 			if IsSupportedPodLevelResource(resourceName) {
-				limits[resourceName] = quantity
-				if effectiveLims != nil {
-					limits[resourceName] = effectiveLims[resourceName]
+				if effectiveLims == nil {
+					limits[resourceName] = quantity
+					continue
+				}
+				// Only propagate keys that are present in the effective (actuated)
+				// limits. A key present in the spec but absent from the effective
+				// map (e.g. a limit added by a not-yet-actuated resize) is omitted,
+				// matching container-level aggregation, which iterates the effective
+				// map and never inserts unactuated keys. Assigning effectiveLims[name]
+				// unconditionally would insert an explicit zero instead.
+				if effVal, ok := effectiveLims[resourceName]; ok {
+					limits[resourceName] = effVal
 				}
 			}
 		}

--- a/staging/src/k8s.io/component-helpers/resource/helpers_test.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 )
 
@@ -2714,4 +2715,103 @@ func getPod(cname string, resources podResources) *v1.Pod {
 			Overhead: overhead,
 		},
 	}
+}
+
+// TestPodLevelResourcesOmitUnactuatedResizeKey covers the case where a pod-level
+// resource key is present in the spec but absent from the actuated (status)
+// resources, as happens for a resize that adds a new request/limit and is marked
+// infeasible. determineEffective{Requests,Limits} returns an effective map that
+// omits the not-yet-actuated key; PodRequests/PodLimits must omit it too rather
+// than inserting an explicit zero, so that the pod-level result stays consistent
+// with container-level aggregation (which iterates the effective map and never
+// inserts unactuated keys).
+func TestPodLevelResourcesOmitUnactuatedResizeKey(t *testing.T) {
+	opts := PodResourcesOptions{
+		UseStatusResources:                             true,
+		InPlacePodLevelResourcesVerticalScalingEnabled: true,
+	}
+
+	// Spec asks for cpu+memory at the pod level (and on the container, mirroring
+	// it), but only cpu has been actuated. The memory limit/request was added by
+	// a resize that is pending as infeasible.
+	specList := v1.ResourceList{
+		v1.ResourceCPU:    resource.MustParse("100m"),
+		v1.ResourceMemory: resource.MustParse("1Gi"),
+	}
+	actuatedList := v1.ResourceList{
+		v1.ResourceCPU: resource.MustParse("100m"),
+	}
+	pod := &v1.Pod{
+		Spec: v1.PodSpec{
+			Resources: &v1.ResourceRequirements{
+				Requests: specList.DeepCopy(),
+				Limits:   specList.DeepCopy(),
+			},
+			Containers: []v1.Container{
+				{
+					Name: "c1",
+					Resources: v1.ResourceRequirements{
+						Requests: specList.DeepCopy(),
+						Limits:   specList.DeepCopy(),
+					},
+				},
+			},
+		},
+		Status: v1.PodStatus{
+			Resources: &v1.ResourceRequirements{
+				Requests: actuatedList.DeepCopy(),
+				Limits:   actuatedList.DeepCopy(),
+			},
+			AllocatedResources: actuatedList.DeepCopy(),
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name: "c1",
+					Resources: &v1.ResourceRequirements{
+						Requests: actuatedList.DeepCopy(),
+						Limits:   actuatedList.DeepCopy(),
+					},
+				},
+			},
+			Conditions: []v1.PodCondition{
+				{
+					Type:   v1.PodResizePending,
+					Status: v1.ConditionTrue,
+					Reason: v1.PodReasonInfeasible,
+				},
+			},
+		},
+	}
+
+	keys := func(rl v1.ResourceList) sets.Set[v1.ResourceName] {
+		s := sets.New[v1.ResourceName]()
+		for name := range rl {
+			s.Insert(name)
+		}
+		return s
+	}
+
+	t.Run("requests", func(t *testing.T) {
+		podReqs := PodRequests(pod, opts)
+		// Property 1 (regression): the unactuated key is omitted, not zero-filled.
+		if _, found := podReqs[v1.ResourceMemory]; found {
+			t.Errorf("pod-level requests should omit the unactuated memory key, got %v", podReqs)
+		}
+		// Property 2 (invariant): pod-level and container-level aggregation agree
+		// on the set of keys for the same input.
+		containerReqs := AggregateContainerRequests(pod, opts)
+		if podKeys, ctrKeys := keys(podReqs), keys(containerReqs); !podKeys.Equal(ctrKeys) {
+			t.Errorf("pod-level vs container-level request key mismatch: pod=%v container=%v", sets.List(podKeys), sets.List(ctrKeys))
+		}
+	})
+
+	t.Run("limits", func(t *testing.T) {
+		podLims := PodLimits(pod, opts)
+		if _, found := podLims[v1.ResourceMemory]; found {
+			t.Errorf("pod-level limits should omit the unactuated memory key, got %v", podLims)
+		}
+		containerLims := AggregateContainerLimits(pod, opts)
+		if podKeys, ctrKeys := keys(podLims), keys(containerLims); !podKeys.Equal(ctrKeys) {
+			t.Errorf("pod-level vs container-level limit key mismatch: pod=%v container=%v", sets.List(podKeys), sets.List(ctrKeys))
+		}
+	})
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig node

**What this PR does / why we need it**:

`PodRequests` / `PodLimits` build pod-level aggregation by iterating `pod.Spec.Resources.{Requests,Limits}` and assigning `effective[name]` for each supported pod-level resource. When a key is present in the spec but absent from the effective (actuated) map, `effective[name]` returns a zero-valued quantity, so the key is inserted with an explicit zero. This occurs when an in-place resize adds a pod-level request/limit and is marked infeasible: `determineEffective{Requests,Limits}` returns the actuated-only map without the added key.

Container-level aggregation (`AggregateContainerRequests` / `AggregateContainerLimits`) iterates the effective map and never inserts unactuated keys, so the two paths produced different key sets for the same input. This PR makes the pod-level path only propagate keys present in the effective map, so it matches container-level aggregation.

**Which issue(s) this PR fixes**:

Fixes #140476

**Special notes for your reviewer**:

- This is a consistency fix, not a behavior change on any enforcement path. No in-tree cgroup writer enables `UseStatusResources` (`ResourceConfigForPod` / `calculateSandboxResources` do not), and the consumers that do enable it read through `.Cpu()` / `.Memory()`, where an explicit zero and an absent key compare equal. So this is not currently observable in cgroup enforcement; it is a consistency fix ahead of the pod-level resize GA work.
- Observable change: status paths that surface these maps (e.g. `PodLimits` used for status reporting) will now omit the unactuated key rather than reporting it as `0`. For all in-tree accessor-based consumers this is equivalent; an out-of-tree consumer that serializes the map and checks key presence would see the key omitted rather than read `0`. Called out explicitly in case that matters to anyone.
- `TestPodLevelResourcesOmitUnactuatedResizeKey` pins both properties: (1) the unactuated key is omitted, and (2) pod-level and container-level aggregation produce the same key set on the same infeasible-resize input. The test fails on the pre-fix code and passes after.

**Does this PR introduce a user-facing change?**

```release-note
Fixed an inconsistency where pod-level resource aggregation reported an explicit zero for a resource present in the pod spec but not yet actuated (for example during an infeasible in-place resize); the resource key is now omitted, matching container-level aggregation.
```
