### PR TITLE
scheduler: flush pending PodGroup members after others have been assumed

### DIFF
--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -80,6 +80,11 @@ func (sched *Scheduler) scheduleOnePodGroup(ctx context.Context, podGroupInfo *f
 	// Pod group constraints will be re-evaluated on a PlacementFeasible phase.
 	// Now, verify if it has any pods left.
 	if len(podGroupInfo.QueuedPodInfos) == 0 {
+		// Finish the in-flight attempt so members that arrived while these pods were
+		// being skipped can be requeued instead of remaining pending indefinitely.
+		if err := sched.SchedulingQueue.AddAttemptedPodGroupIfNeeded(logger, podGroupInfo, sched.SchedulingQueue.SchedulingCycle(), fwk.NewStatus(fwk.Success)); err != nil {
+			utilruntime.HandleErrorWithContext(ctx, err, "Failed to finish skipped pod group scheduling attempt", "podGroup", klog.KObj(podGroupInfo))
+		}
 		return
 	}
 

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -402,6 +402,104 @@ func TestSkipPodGroupPodSchedule(t *testing.T) {
 	}
 }
 
+func TestScheduleOnePodGroup_FinishesAttemptWhenAllPoppedPodsAreAssumed(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
+
+	tests := []struct {
+		name                       string
+		memberArrivesWhileInFlight bool
+	}{
+		{
+			name:                       "pending member is requeued",
+			memberArrivesWhileInFlight: true,
+		},
+		{
+			name:                       "later member starts a new queued PodGroup",
+			memberArrivesWhileInFlight: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			podGroup := st.MakePodGroup().Name("pg").Obj()
+			p1 := st.MakePod().Name("p1").UID("p1").PodGroupName(podGroup.Name).SchedulerName("test-scheduler").Obj()
+			p2 := st.MakePod().Name("p2").UID("p2").PodGroupName(podGroup.Name).SchedulerName("test-scheduler").Obj()
+
+			registry := frameworkruntime.Registry{
+				queuesort.Name:     queuesort.New,
+				defaultbinder.Name: defaultbinder.New,
+			}
+			profileCfg := config.KubeSchedulerProfile{
+				SchedulerName: "test-scheduler",
+				Plugins: &config.Plugins{
+					QueueSort: config.PluginSet{
+						Enabled: []config.Plugin{{Name: queuesort.Name}},
+					},
+					Bind: config.PluginSet{
+						Enabled: []config.Plugin{{Name: defaultbinder.Name}},
+					},
+				},
+			}
+			schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
+				frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create new framework: %v", err)
+			}
+
+			cache := internalcache.New(ctx, nil, true)
+			cache.AddPodGroup(podGroup)
+			cache.AddPodGroupMember(p1)
+			assumedP1 := p1.DeepCopy()
+			assumedP1.Spec.NodeName = "node1"
+			if err := cache.AssumePod(logger, assumedP1); err != nil {
+				t.Fatalf("Failed to assume pod: %v", err)
+			}
+
+			queue := internalqueue.NewTestQueue(ctx, schedFwk.QueueSortFunc())
+			queue.AddPodGroup(logger, podGroup)
+			queue.Add(ctx, p1)
+			entity, err := queue.Pop(logger)
+			if err != nil {
+				t.Fatalf("Failed to pop pod group: %v", err)
+			}
+			podGroupInfo := entity.(*framework.QueuedPodGroupInfo)
+
+			if tt.memberArrivesWhileInFlight {
+				// A member arriving while its PodGroup is scheduling waits for
+				// that scheduling attempt to finish.
+				queue.Add(ctx, p2)
+				if pendingPods := queue.PendingPodGroupPods(); len(pendingPods) != 1 || pendingPods[0].UID != p2.UID {
+					t.Fatalf("Expected pod %q to be pending, got %v", p2.Name, pendingPods)
+				}
+			}
+
+			sched := &Scheduler{
+				Profiles:         profile.Map{"test-scheduler": schedFwk},
+				Cache:            cache,
+				nodeInfoSnapshot: internalcache.NewEmptySnapshot(),
+				SchedulingQueue:  queue,
+			}
+			sched.scheduleOnePodGroup(ctx, podGroupInfo)
+
+			if !tt.memberArrivesWhileInFlight {
+				queue.Add(ctx, p2)
+			}
+			if pendingPods := queue.PendingPodGroupPods(); len(pendingPods) != 0 {
+				t.Errorf("Expected no pending PodGroup members, got %v", pendingPods)
+			}
+			requeuedPodGroup, ok := queue.GetPodGroup(podGroup.Name, podGroup.Namespace)
+			if !ok {
+				t.Fatalf("Expected PodGroup to be queued")
+			}
+			if len(requeuedPodGroup.QueuedPodInfos) != 1 || requeuedPodGroup.QueuedPodInfos[0].Pod.UID != p2.UID {
+				t.Errorf("Expected queued PodGroup to contain pod %q, got %v", p2.Name, requeuedPodGroup.QueuedPodInfos)
+			}
+		})
+	}
+}
+
 func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 	p1 := st.MakePod().Name("p1").UID("p1").PodGroupName("pg").SchedulerName("test-scheduler").Obj()
 	p2 := st.MakePod().Name("p2").UID("p2").PodGroupName("pg").SchedulerName("test-scheduler").Obj()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake

/wg workload-aware-scheduling

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR fixes a bug where the scheduler could get stuck scheduling members of a PodGroup when they fail to asynchronously bind, e.g. https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-integration-master/2076036168746536960.

In `scheduleOnePodGroup`, the scheduling cycle short-circuits if all of the observed PodGroup members have either been deleted or assumed without resetting the state for the active queue. If the scheduler sees that all current members of the group have already been assumed, then `scheduleOnePodGroup` returns without requeueing the PodGroup while the PodGroup is still considered in-flight in the active queue. When other member Pods fail to asynchronously bind, they pile up in the queue's `pendingPodGroupPods` without ever moving to the active queue.

Calling `AddAttemptedPodGroupIfNeeded` cleanly ends that scheduling attempt and will requeue the PodGroup and its pending Pods.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
https://github.com/kubernetes/kubernetes/issues/140263

#### Special notes for your reviewer:

I used Copilot to help find and fix this issue.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The scheduler is less likely to get stuck scheduling large PodGroups when member Pods transiently fail to bind to Nodes (as is common when many Pods share the same ResourceClaim).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
