### PR TITLE
etcd3: stream unfiltered paginated lists with RangeStream

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -735,9 +735,12 @@ func (s *store) GetCurrentResourceVersion(ctx context.Context) (uint64, error) {
 // shouldStream determines whether a list request should use etcd RangeStream.
 func shouldStream(opts storage.ListOptions) bool {
 	// Only recursive lists stream, a non-recursive request reads a single object.
-	// Streaming's main goal is to bound unbounded reads, limited and continue requests are
-	// already bounded by pagination, so we are opting out of streaming for them for now.
-	if !opts.Recursive || opts.Predicate.Limit > 0 || opts.Predicate.Continue != "" {
+	if !opts.Recursive {
+		return false
+	}
+	// etcd is unaware of selector matches, so a filtered page can't carry a proper limit.
+	// Stream only unfiltered pages.
+	if opts.Predicate.Limit > 0 && !opts.Predicate.Empty() {
 		return false
 	}
 	return utilfeature.DefaultFeatureGate.Enabled(features.EtcdRangeStream) &&
@@ -794,7 +797,7 @@ func (s *store) GetList(ctx context.Context, key string, opts storage.ListOption
 
 	chunks := s.pagedChunks(ctx, keyPrefix, opts, withRev, limit, continueKey)
 	if shouldStream(opts) {
-		streamChunks, supported := s.streamChunks(ctx, keyPrefix, withRev)
+		streamChunks, supported := s.streamChunks(ctx, keyPrefix, withRev, limit, continueKey)
 		if supported {
 			chunks = streamChunks
 		} else {
@@ -913,14 +916,23 @@ func (s *store) listReadError(ctx context.Context, err error, withRev int64, pag
 }
 
 // streamChunks reads the list as a single etcd RangeStream, pinned to withRev when
-// nonzero. supported is false when the etcd server does not implement RangeStream.
-func (s *store) streamChunks(ctx context.Context, keyPrefix string, withRev int64) (chunks iter.Seq2[listChunk, error], supported bool) {
+// nonzero, capped at limit keys and resumed from continueKey when set.
+// supported is false when the etcd server does not implement RangeStream.
+func (s *store) streamChunks(ctx context.Context, keyPrefix string, withRev, limit int64, continueKey string) (chunks iter.Seq2[listChunk, error], supported bool) {
 	startTime := time.Now()
+	paging := continueKey != ""
+	startKey := keyPrefix
+	if paging {
+		startKey = continueKey
+	}
 	streamOpts := []clientv3.OpOption{clientv3.WithRange(clientv3.GetPrefixRangeEnd(keyPrefix))}
 	if withRev > 0 {
 		streamOpts = append(streamOpts, clientv3.WithRev(withRev))
 	}
-	stream, streamErr := s.client.KV.GetStream(ctx, keyPrefix, streamOpts...)
+	if limit > 0 {
+		streamOpts = append(streamOpts, clientv3.WithLimit(limit))
+	}
+	stream, streamErr := s.client.KV.GetStream(ctx, startKey, streamOpts...)
 	var first clientv3.RangeStreamResponse
 	var firstOk bool
 	if streamErr == nil {
@@ -937,7 +949,7 @@ func (s *store) streamChunks(ctx context.Context, keyPrefix string, withRev int6
 			metrics.RecordEtcdRequest("listStream", s.groupResource, err, startTime)
 		}()
 		if err = streamErr; err != nil {
-			yield(listChunk{}, s.listReadError(ctx, err, withRev, false, "", keyPrefix))
+			yield(listChunk{}, s.listReadError(ctx, err, withRev, paging, continueKey, keyPrefix))
 			return
 		}
 		estimator := s.getResourceSizeEstimator()
@@ -948,7 +960,7 @@ func (s *store) streamChunks(ctx context.Context, keyPrefix string, withRev int6
 		resp, ok := first, firstOk
 		for ok {
 			if err = resp.Err(); err != nil {
-				yield(listChunk{}, s.listReadError(ctx, err, withRev, false, "", keyPrefix))
+				yield(listChunk{}, s.listReadError(ctx, err, withRev, paging, continueKey, keyPrefix))
 				return
 			}
 			rangeResp := resp.RangeResponse
@@ -960,7 +972,9 @@ func (s *store) streamChunks(ctx context.Context, keyPrefix string, withRev int6
 				revision = &rangeResp.Header.Revision
 			}
 			next, nextOk := <-stream
-			if !yield(listChunk{kvs: rangeResp.Kvs, revision: revision, count: rangeResp.Count, hasMore: nextOk}, nil) {
+			// On the final chunk, More means the limit truncated the range, so there
+			// is a next page even though the stream ended.
+			if !yield(listChunk{kvs: rangeResp.Kvs, revision: revision, count: rangeResp.Count, hasMore: nextOk || rangeResp.More}, nil) {
 				return
 			}
 			resp, ok = next, nextOk

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -554,7 +554,7 @@ func checkStorageCallsInvariants(transformer *storagetesting.PrefixTransformer, 
 				estimatedGetCalls++
 			}
 		}
-		if reads := recorder.GetReadsAndReset(); reads != estimatedGetCalls {
+		if reads := recorder.GetReadsAndReset() + recorder.GetStreamReadsAndReset(); reads != estimatedGetCalls {
 			t.Fatalf("unexpected reads: %d, want: %d", reads, estimatedGetCalls)
 		}
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/recorder.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/recorder.go
@@ -49,7 +49,8 @@ func (r *KVRecorder) GetReadsAndReset() uint64 {
 func (r *KVRecorder) GetStream(ctx context.Context, key string, opts ...clientv3.OpOption) (clientv3.GetStreamChan, error) {
 	atomic.AddUint64(&r.streamReads, 1)
 	if r.lists != nil {
-		r.lists.record(ctx, RecordedList{Key: key, ListOptions: kubernetes.ListOptions{Revision: clientv3.OpGet(key, opts...).Rev()}})
+		op := clientv3.OpGet(key, opts...)
+		r.lists.record(ctx, RecordedList{Key: key, ListOptions: kubernetes.ListOptions{Revision: op.Rev(), Limit: op.Limit()}})
 	}
 	return r.KV.GetStream(ctx, key, opts...)
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
@@ -1087,8 +1087,8 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 				}
 				return []RecordedList{
 					{
-						Key:         "/registry/pods/second/",
-						ListOptions: kubernetes.ListOptions{Revision: int64(continueRV), Limit: 1, Continue: "/registry/pods/second/foo"},
+						Key:         "/registry/pods/second/foo",
+						ListOptions: kubernetes.ListOptions{Revision: int64(continueRV), Limit: 1},
 					},
 				}
 			},
@@ -1110,8 +1110,8 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 				}
 				return []RecordedList{
 					{
-						Key:         "/registry/pods/second/",
-						ListOptions: kubernetes.ListOptions{Revision: int64(continueRV), Limit: 1, Continue: "/registry/pods/second/foo"},
+						Key:         "/registry/pods/second/foo",
+						ListOptions: kubernetes.ListOptions{Revision: int64(continueRV), Limit: 1},
 					},
 				}
 			},
@@ -1892,8 +1892,8 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 				}
 				return []RecordedList{
 					{
-						Key:         "/registry/pods/",
-						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, createdPods[0].ResourceVersion), Limit: 1, Continue: "/registry/pods/first/bar\x00"},
+						Key:         "/registry/pods/first/bar\x00",
+						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, createdPods[0].ResourceVersion), Limit: 1},
 					},
 				}
 			},
@@ -1915,8 +1915,8 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 				}
 				return []RecordedList{
 					{
-						Key:         "/registry/pods/",
-						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, createdPods[1].ResourceVersion), Limit: 1, Continue: "/registry/pods/first/bar\x00"},
+						Key:         "/registry/pods/first/bar\x00",
+						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, createdPods[1].ResourceVersion), Limit: 1},
 					},
 				}
 			},
@@ -1938,8 +1938,8 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 				}
 				return []RecordedList{
 					{
-						Key:         "/registry/pods/",
-						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, createdPods[2].ResourceVersion), Limit: 2, Continue: "/registry/pods/second/bar\x00"},
+						Key:         "/registry/pods/second/bar\x00",
+						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, createdPods[2].ResourceVersion), Limit: 2},
 					},
 				}
 			},
@@ -1964,8 +1964,8 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 				}
 				return []RecordedList{
 					{
-						Key:         "/registry/pods/",
-						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, createdPods[4].ResourceVersion), Limit: 1, Continue: "/registry/pods/first/bar\x00"},
+						Key:         "/registry/pods/first/bar\x00",
+						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, createdPods[4].ResourceVersion), Limit: 1},
 					},
 				}
 			},
@@ -1990,8 +1990,8 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 				}
 				return []RecordedList{
 					{
-						Key:         "/registry/pods/",
-						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, createdPods[5].ResourceVersion), Limit: 2, Continue: "/registry/pods/second/bar\x00"},
+						Key:         "/registry/pods/second/bar\x00",
+						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, createdPods[5].ResourceVersion), Limit: 2},
 					},
 				}
 			},
@@ -2013,8 +2013,8 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 				}
 				return []RecordedList{
 					{
-						Key:         "/registry/pods/",
-						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, updatedPod.ResourceVersion), Limit: 4, Continue: "/registry/pods/second/foo\x00"},
+						Key:         "/registry/pods/second/foo\x00",
+						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, updatedPod.ResourceVersion), Limit: 4},
 					},
 				}
 			},
@@ -2039,8 +2039,8 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 				}
 				return []RecordedList{
 					{
-						Key:         "/registry/pods/",
-						ListOptions: kubernetes.ListOptions{Revision: int64(continueRV) + 1, Limit: 1, Continue: "/registry/pods/first/bar\x00"},
+						Key:         "/registry/pods/first/bar\x00",
+						ListOptions: kubernetes.ListOptions{Revision: int64(continueRV) + 1, Limit: 1},
 					},
 				}
 			},
@@ -2061,8 +2061,8 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 				}
 				return []RecordedList{
 					{
-						Key:         "/registry/pods/",
-						ListOptions: kubernetes.ListOptions{Continue: "/registry/pods/first/bar\x00"},
+						Key:         "/registry/pods/first/bar\x00",
+						ListOptions: kubernetes.ListOptions{},
 					},
 				}
 			},
@@ -2087,8 +2087,8 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 				}
 				return []RecordedList{
 					{
-						Key:         "/registry/pods/",
-						ListOptions: kubernetes.ListOptions{Continue: "/registry/pods/first/bar\x00", Limit: 2},
+						Key:         "/registry/pods/first/bar\x00",
+						ListOptions: kubernetes.ListOptions{Limit: 2},
 					},
 				}
 			},
@@ -2109,8 +2109,8 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 				}
 				return []RecordedList{
 					{
-						Key:         "/registry/pods/",
-						ListOptions: kubernetes.ListOptions{Continue: "/registry/pods/second/foo\x00"},
+						Key:         "/registry/pods/second/foo\x00",
+						ListOptions: kubernetes.ListOptions{},
 					},
 				}
 			},


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Streams recursive lists with a limit or continue token via RangeStream, except when a selector is also set, since etcd caps a stream at Limit keys not Limit matches and cannot refill a filtered page.

#### Scalability Test Results

`pull-kubernetes-gce-master-scale-performance-5000-experimental`, 
- Off = RangeStream off
- unbounded-only = currently what's merged with master. There are some paginated lists from CL2 and the consistency checker is paginated. 
- full streaming = this PR.

| metric | off | unbounded-only | full streaming |
|---|---|---|---|
| runs (n) | 3 | 1 | 1 |
| etcd heap in-use median (MB) | 306-315 | 316 | 307 |
| etcd heap in-use max (MB) | 794 | 837 | 458 |
| etcd CPU peak (cores, single-run) | 1.50 | 1.97 | 2.75 |
| pods `list` served (unary) | 283 | 283 | 0 |
| pods `listStream` served | 0 | 0 | 316 |

<img width="1945" height="2660" alt="image" src="https://github.com/user-attachments/assets/ab49cb7c-11b3-4956-ba15-8eb6bd570e66" />

Full streaming's plateau-median heap sits inside off's run-to-run spread, and apiserver heap, RSS, and CPU track off as well. The feature is fully live, pods LIST flips from unary `list` to `listStream` with zero fallback errors, and the only movement is a small single-run rise in etcd CPU peak.

Runs: off [1](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/139476/pull-kubernetes-gce-master-scale-performance-5000-experimental/2075579658681716736) [2](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/139476/pull-kubernetes-gce-master-scale-performance-5000-experimental/2071719755345039360) [3](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/139476/pull-kubernetes-gce-master-scale-performance-5000-experimental/2071777797344333824), unbounded-only [PASS](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/140479/pull-kubernetes-gce-master-scale-performance-5000-experimental/2077611616131616768), full streaming [PASS](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/140479/pull-kubernetes-gce-master-scale-performance-5000-experimental/2077976382972891136)

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
