### PR TITLE
Fix overhead counting in total resources calculations

### DIFF
--- a/staging/src/k8s.io/component-helpers/resource/helpers.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers.go
@@ -158,14 +158,10 @@ func PodRequests(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 		if opts.InPlacePodLevelResourcesVerticalScalingEnabled && opts.UseStatusResources && (pod.Status.Resources != nil || pod.Status.AllocatedResources != nil) {
 			var statusRequests, allocatedRequests v1.ResourceList
 			if pod.Status.Resources != nil {
-				statusRequests = pod.Status.Resources.Requests.DeepCopy()
+				statusRequests = subtractResourceList(pod.Status.Resources.Requests, pod.Spec.Overhead)
 			}
 			if pod.Status.AllocatedResources != nil {
-				allocatedRequests = pod.Status.AllocatedResources.DeepCopy()
-			}
-			if pod.Spec.Overhead != nil {
-				subtractResourceList(statusRequests, pod.Spec.Overhead)
-				subtractResourceList(allocatedRequests, pod.Spec.Overhead)
+				allocatedRequests = subtractResourceList(pod.Status.AllocatedResources, pod.Spec.Overhead)
 			}
 			effectiveReqs = effectivePodLevelResources(pod, pod.Spec.Resources.Requests, statusRequests, allocatedRequests)
 		}
@@ -402,13 +398,7 @@ func PodLimits(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 	if !opts.SkipPodLevelResources && IsPodLevelResourcesSet(pod) {
 		effectiveLims := pod.Spec.Resources.Limits
 		if opts.InPlacePodLevelResourcesVerticalScalingEnabled && opts.UseStatusResources && pod.Status.Resources != nil {
-			var statusLimits v1.ResourceList
-			if pod.Status.Resources.Limits != nil {
-				statusLimits = pod.Status.Resources.Limits.DeepCopy()
-			}
-			if pod.Spec.Overhead != nil {
-				subtractResourceList(statusLimits, pod.Spec.Overhead)
-			}
+			statusLimits := subtractResourceList(pod.Status.Resources.Limits, pod.Spec.Overhead)
 			effectiveLims = effectivePodLevelResources(pod, pod.Spec.Resources.Limits, statusLimits)
 		}
 		applyPodLevelResources(limits, effectiveLims)
@@ -473,18 +463,23 @@ func addResourceList(list, newList v1.ResourceList) {
 	}
 }
 
-// subtractResourceList subtracts the resources in newList from list.
-// If the subtraction results in a value less than zero, it sets it to zero.
-func subtractResourceList(list, newList v1.ResourceList) {
+// subtractResourceList returns a copy of list with the resources in newList subtracted.
+// If list is nil, it returns nil. If subtraction results in a value less than zero, it sets it to zero.
+func subtractResourceList(list, newList v1.ResourceList) v1.ResourceList {
+	if list == nil {
+		return nil
+	}
+	result := list.DeepCopy()
 	for name, quantity := range newList {
-		if value, ok := list[name]; ok {
+		if value, ok := result[name]; ok {
 			value.Sub(quantity)
 			if value.Sign() < 0 {
 				value.Set(0)
 			}
-			list[name] = value
+			result[name] = value
 		}
 	}
+	return result
 }
 
 // maxResourceList sets list to the greater of list/newList for every resource in newList

--- a/staging/src/k8s.io/component-helpers/resource/helpers.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers.go
@@ -158,10 +158,14 @@ func PodRequests(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 		if opts.InPlacePodLevelResourcesVerticalScalingEnabled && opts.UseStatusResources && (pod.Status.Resources != nil || pod.Status.AllocatedResources != nil) {
 			var statusRequests, allocatedRequests v1.ResourceList
 			if pod.Status.Resources != nil {
-				statusRequests = subtractResourceList(pod.Status.Resources.Requests, pod.Spec.Overhead)
+				statusRequests = pod.Status.Resources.Requests
 			}
 			if pod.Status.AllocatedResources != nil {
-				allocatedRequests = subtractResourceList(pod.Status.AllocatedResources, pod.Spec.Overhead)
+				allocatedRequests = pod.Status.AllocatedResources
+			}
+			if pod.Spec.Overhead != nil {
+				statusRequests = subtractResourceList(statusRequests, pod.Spec.Overhead)
+				allocatedRequests = subtractResourceList(allocatedRequests, pod.Spec.Overhead)
 			}
 			effectiveReqs = effectivePodLevelResources(pod, pod.Spec.Resources.Requests, statusRequests, allocatedRequests)
 		}
@@ -313,6 +317,10 @@ func AggregateContainerRequests(pod *v1.Pod, opts PodResourcesOptions) v1.Resour
 			specReqs = aggregateContainerResourcesByFn(pod, opts, containerSpecRequests)
 			allocatedReqs = pod.Status.AllocatedResources
 			actuatedReqs = pod.Status.Resources.Requests
+			if pod.Spec.Overhead != nil {
+				allocatedReqs = subtractResourceList(allocatedReqs, pod.Spec.Overhead)
+				actuatedReqs = subtractResourceList(actuatedReqs, pod.Spec.Overhead)
+			}
 		} else {
 			specReqs = aggregateContainerResourcesByFn(pod, opts, containerSpecRequests)
 			allocatedReqs = aggregateContainerResourcesByFn(pod, opts, containerAllocatedRequests)
@@ -398,7 +406,10 @@ func PodLimits(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 	if !opts.SkipPodLevelResources && IsPodLevelResourcesSet(pod) {
 		effectiveLims := pod.Spec.Resources.Limits
 		if opts.InPlacePodLevelResourcesVerticalScalingEnabled && opts.UseStatusResources && pod.Status.Resources != nil {
-			statusLimits := subtractResourceList(pod.Status.Resources.Limits, pod.Spec.Overhead)
+			statusLimits := pod.Status.Resources.Limits
+			if pod.Spec.Overhead != nil {
+				statusLimits = subtractResourceList(statusLimits, pod.Spec.Overhead)
+			}
 			effectiveLims = effectivePodLevelResources(pod, pod.Spec.Resources.Limits, statusLimits)
 		}
 		applyPodLevelResources(limits, effectiveLims)
@@ -437,6 +448,9 @@ func AggregateContainerLimits(pod *v1.Pod, opts PodResourcesOptions) v1.Resource
 		if opts.InPlacePodLevelResourcesVerticalScalingEnabled && pod.Status.Resources != nil && pod.Status.Resources.Limits != nil {
 			specLimits = aggregateContainerResourcesByFn(pod, opts, containerSpecLimits)
 			actuatedLimits = pod.Status.Resources.Limits
+			if pod.Spec.Overhead != nil {
+				actuatedLimits = subtractResourceList(actuatedLimits, pod.Spec.Overhead)
+			}
 		} else {
 			specLimits = aggregateContainerResourcesByFn(pod, opts, containerSpecLimits)
 			actuatedLimits = aggregateContainerResourcesByFn(pod, opts, containerActuatedLimits)

--- a/staging/src/k8s.io/component-helpers/resource/helpers.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers.go
@@ -155,8 +155,19 @@ func PodRequests(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 
 	if !opts.SkipPodLevelResources && IsPodLevelRequestsSet(pod) {
 		effectiveReqs := pod.Spec.Resources.Requests
-		if opts.InPlacePodLevelResourcesVerticalScalingEnabled && opts.UseStatusResources && pod.Status.Resources != nil {
-			effectiveReqs = effectivePodLevelResources(pod, pod.Spec.Resources.Requests, pod.Status.Resources.Requests, pod.Status.AllocatedResources)
+		if opts.InPlacePodLevelResourcesVerticalScalingEnabled && opts.UseStatusResources && (pod.Status.Resources != nil || pod.Status.AllocatedResources != nil) {
+			var statusRequests, allocatedRequests v1.ResourceList
+			if pod.Status.Resources != nil {
+				statusRequests = pod.Status.Resources.Requests.DeepCopy()
+			}
+			if pod.Status.AllocatedResources != nil {
+				allocatedRequests = pod.Status.AllocatedResources.DeepCopy()
+			}
+			if pod.Spec.Overhead != nil {
+				subtractResourceList(statusRequests, pod.Spec.Overhead)
+				subtractResourceList(allocatedRequests, pod.Spec.Overhead)
+			}
+			effectiveReqs = effectivePodLevelResources(pod, pod.Spec.Resources.Requests, statusRequests, allocatedRequests)
 		}
 
 		applyPodLevelResources(reqs, effectiveReqs)
@@ -391,7 +402,14 @@ func PodLimits(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 	if !opts.SkipPodLevelResources && IsPodLevelResourcesSet(pod) {
 		effectiveLims := pod.Spec.Resources.Limits
 		if opts.InPlacePodLevelResourcesVerticalScalingEnabled && opts.UseStatusResources && pod.Status.Resources != nil {
-			effectiveLims = effectivePodLevelResources(pod, pod.Spec.Resources.Limits, pod.Status.Resources.Limits)
+			var statusLimits v1.ResourceList
+			if pod.Status.Resources.Limits != nil {
+				statusLimits = pod.Status.Resources.Limits.DeepCopy()
+			}
+			if pod.Spec.Overhead != nil {
+				subtractResourceList(statusLimits, pod.Spec.Overhead)
+			}
+			effectiveLims = effectivePodLevelResources(pod, pod.Spec.Resources.Limits, statusLimits)
 		}
 		applyPodLevelResources(limits, effectiveLims)
 	}
@@ -450,6 +468,20 @@ func addResourceList(list, newList v1.ResourceList) {
 			list[name] = quantity.DeepCopy()
 		} else {
 			value.Add(quantity)
+			list[name] = value
+		}
+	}
+}
+
+// subtractResourceList subtracts the resources in newList from list.
+// If the subtraction results in a value less than zero, it sets it to zero.
+func subtractResourceList(list, newList v1.ResourceList) {
+	for name, quantity := range newList {
+		if value, ok := list[name]; ok {
+			value.Sub(quantity)
+			if value.Sign() < 0 {
+				value.Set(0)
+			}
 			list[name] = value
 		}
 	}

--- a/staging/src/k8s.io/component-helpers/resource/helpers_test.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers_test.go
@@ -1690,6 +1690,8 @@ func TestPodLevelResourceRequests(t *testing.T) {
 		overhead         v1.ResourceList
 		initContainers   []v1.Container
 		containers       []v1.Container
+		statusRequests   *v1.ResourceRequirements
+		allocated        v1.ResourceList
 		expectedRequests v1.ResourceList
 	}{
 		{
@@ -2039,10 +2041,170 @@ func TestPodLevelResourceRequests(t *testing.T) {
 			opts:             PodResourcesOptions{SkipPodLevelResources: false},
 			expectedRequests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("4Mi"), v1.ResourceHugePagesPrefix + "2Mi": resource.MustParse("10Mi"), v1.ResourceHugePagesPrefix + "1Gi": resource.MustParse("1Gi")},
 		},
+		{
+			name: "status resources include overhead for all pod-level resources",
+			opts: PodResourcesOptions{
+				UseStatusResources: true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			podResources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			overhead: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("100m"),
+				v1.ResourceMemory: resource.MustParse("10Mi"),
+			},
+			statusRequests: &v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1100m"),
+					v1.ResourceMemory: resource.MustParse("110Mi"),
+				},
+			},
+			allocated: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1100m"),
+				v1.ResourceMemory: resource.MustParse("110Mi"),
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1100m"),
+				v1.ResourceMemory: resource.MustParse("110Mi"),
+			},
+		},
+		{
+			name: "status resources include overhead for only one pod-level resource",
+			opts: PodResourcesOptions{
+				UseStatusResources: true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			podResources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			overhead: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("100m"),
+				v1.ResourceMemory: resource.MustParse("10Mi"),
+			},
+			statusRequests: &v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("1100m"),
+				},
+			},
+			allocated: v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("1100m"),
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1100m"),
+				v1.ResourceMemory: resource.MustParse("110Mi"),
+			},
+		},
+		{
+			name: "status resources without overhead still receive overhead",
+			opts: PodResourcesOptions{
+				UseStatusResources: true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			podResources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			overhead: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("100m"),
+				v1.ResourceMemory: resource.MustParse("10Mi"),
+			},
+			statusRequests: &v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			allocated: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1"),
+				v1.ResourceMemory: resource.MustParse("100Mi"),
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1100m"),
+				v1.ResourceMemory: resource.MustParse("110Mi"),
+			},
+		},
+		{
+			name: "allocated resources include overhead when status requests do not",
+			opts: PodResourcesOptions{
+				UseStatusResources: true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			podResources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			overhead: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("100m"),
+				v1.ResourceMemory: resource.MustParse("10Mi"),
+			},
+			statusRequests: &v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			allocated: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1100m"),
+				v1.ResourceMemory: resource.MustParse("110Mi"),
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1100m"),
+				v1.ResourceMemory: resource.MustParse("110Mi"),
+			},
+		},
+		{
+			name: "allocated resources include stale overhead during resize",
+			opts: PodResourcesOptions{
+				UseStatusResources: true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			podResources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			overhead: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("100m"),
+				v1.ResourceMemory: resource.MustParse("10Mi"),
+			},
+			statusRequests: &v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			allocated: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1050m"),
+				v1.ResourceMemory: resource.MustParse("105Mi"),
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1100m"),
+				v1.ResourceMemory: resource.MustParse("110Mi"),
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			podReqs := PodRequests(getPodLevelResourcesPod(tc.podResources, tc.overhead, tc.containers, tc.initContainers), tc.opts)
+			pod := getPodLevelResourcesPod(tc.podResources, tc.overhead, tc.containers, tc.initContainers)
+			if tc.statusRequests != nil {
+				pod.Status.Resources = tc.statusRequests
+			}
+			if tc.allocated != nil {
+				pod.Status.AllocatedResources = tc.allocated
+			}
+			podReqs := PodRequests(pod, tc.opts)
 			if !equality.Semantic.DeepEqual(podReqs, tc.expectedRequests) {
 				t.Errorf("got=%v, want=%v, diff=%s", podReqs, tc.expectedRequests, diff.Diff(podReqs, tc.expectedRequests))
 			}
@@ -3005,6 +3167,35 @@ func TestPodRequestsAndLimitsVerticalScalingWrappers(t *testing.T) {
 			expectedLimits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("5")},
 		},
 		{
+			name: "pod level requests/limits with PLR vertical scaling enabled, status.resources nil, status.allocatedResources set",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
+						Limits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("4")},
+					},
+					Containers: []v1.Container{
+						{
+							Name: "c1",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
+								Limits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
+							},
+						},
+					},
+				},
+				Status: v1.PodStatus{
+					AllocatedResources: v1.ResourceList{v1.ResourceCPU: resource.MustParse("3")},
+				},
+			},
+			opts: PodResourcesOptions{
+				UseStatusResources: true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			expectedRequests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("3")},
+			expectedLimits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("4")},
+		},
+		{
 			name: "pod level requests/limits with PLR vertical scaling enabled and infeasible resize",
 			pod: &v1.Pod{
 				Spec: v1.PodSpec{
@@ -3130,6 +3321,55 @@ func TestPodRequestsAndLimitsVerticalScalingWrappers(t *testing.T) {
 				v1.ResourceMemory: resource.MustParse("100Mi"),
 			},
 			expectedLimits: v1.ResourceList{},
+		},
+		{
+			name: "pod level requests/limits with PLR vertical scaling enabled, overhead set, and status populated",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Overhead: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("1"),
+						v1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+					Resources: &v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("2"),
+							v1.ResourceMemory: resource.MustParse("2Gi"),
+						},
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("4"),
+							v1.ResourceMemory: resource.MustParse("4Gi"),
+						},
+					},
+				},
+				Status: v1.PodStatus{
+					AllocatedResources: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("3"),
+						v1.ResourceMemory: resource.MustParse("2.5Gi"),
+					},
+					Resources: &v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("3"),
+							v1.ResourceMemory: resource.MustParse("2.5Gi"),
+						},
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("5"),
+							v1.ResourceMemory: resource.MustParse("4.5Gi"),
+						},
+					},
+				},
+			},
+			opts: PodResourcesOptions{
+				UseStatusResources: true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("3"),
+				v1.ResourceMemory: resource.MustParse("2.5Gi"),
+			},
+			expectedLimits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("5"),
+				v1.ResourceMemory: resource.MustParse("4.5Gi"),
+			},
 		},
 	}
 

--- a/staging/src/k8s.io/component-helpers/resource/helpers_test.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers_test.go
@@ -2167,7 +2167,7 @@ func TestPodLevelResourceRequests(t *testing.T) {
 		{
 			name: "status requests - spec is highest (2 CPU, 200Mi mem)",
 			opts: PodResourcesOptions{
-				UseStatusResources:                             true,
+				UseStatusResources: true,
 				InPlacePodLevelResourcesVerticalScalingEnabled: true,
 			},
 			podResources: v1.ResourceRequirements{
@@ -2198,7 +2198,7 @@ func TestPodLevelResourceRequests(t *testing.T) {
 		{
 			name: "status requests - allocated is highest",
 			opts: PodResourcesOptions{
-				UseStatusResources:                             true,
+				UseStatusResources: true,
 				InPlacePodLevelResourcesVerticalScalingEnabled: true,
 			},
 			podResources: v1.ResourceRequirements{
@@ -2229,7 +2229,7 @@ func TestPodLevelResourceRequests(t *testing.T) {
 		{
 			name: "status requests - actual status requests is highest",
 			opts: PodResourcesOptions{
-				UseStatusResources:                             true,
+				UseStatusResources: true,
 				InPlacePodLevelResourcesVerticalScalingEnabled: true,
 			},
 			podResources: v1.ResourceRequirements{
@@ -2260,7 +2260,7 @@ func TestPodLevelResourceRequests(t *testing.T) {
 		{
 			name: "status requests - status resources unset",
 			opts: PodResourcesOptions{
-				UseStatusResources:                             true,
+				UseStatusResources: true,
 				InPlacePodLevelResourcesVerticalScalingEnabled: true,
 			},
 			podResources: v1.ResourceRequirements{
@@ -2281,7 +2281,7 @@ func TestPodLevelResourceRequests(t *testing.T) {
 		{
 			name: "status requests - status.resources nil, status.allocatedResources set",
 			opts: PodResourcesOptions{
-				UseStatusResources:                             true,
+				UseStatusResources: true,
 				InPlacePodLevelResourcesVerticalScalingEnabled: true,
 			},
 			podResources: v1.ResourceRequirements{
@@ -2306,7 +2306,7 @@ func TestPodLevelResourceRequests(t *testing.T) {
 		{
 			name: "status requests - infeasible resize",
 			opts: PodResourcesOptions{
-				UseStatusResources:                             true,
+				UseStatusResources: true,
 				InPlacePodLevelResourcesVerticalScalingEnabled: true,
 			},
 			podResources: v1.ResourceRequirements{
@@ -2339,6 +2339,43 @@ func TestPodLevelResourceRequests(t *testing.T) {
 			expectedRequests: v1.ResourceList{
 				v1.ResourceCPU:    resource.MustParse("2100m"),
 				v1.ResourceMemory: resource.MustParse("250Mi"),
+			},
+		},
+		{
+			name: "status requests with overhead when pod-level spec is unset",
+			opts: PodResourcesOptions{
+				UseStatusResources: true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			podResources: v1.ResourceRequirements{},
+			overhead: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("100m"),
+				v1.ResourceMemory: resource.MustParse("10Mi"),
+			},
+			containers: []v1.Container{
+				{
+					Name: "c1",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("1"),
+							v1.ResourceMemory: resource.MustParse("100Mi"),
+						},
+					},
+				},
+			},
+			statusRequests: &v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1100m"),
+					v1.ResourceMemory: resource.MustParse("110Mi"),
+				},
+			},
+			allocated: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("2100m"),
+				v1.ResourceMemory: resource.MustParse("210Mi"),
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("2100m"),
+				v1.ResourceMemory: resource.MustParse("210Mi"),
 			},
 		},
 	}
@@ -2700,7 +2737,7 @@ func TestPodLevelResourceLimits(t *testing.T) {
 		{
 			name: "status limits include overhead for all pod-level resources",
 			opts: PodResourcesOptions{
-				UseStatusResources:                             true,
+				UseStatusResources: true,
 				InPlacePodLevelResourcesVerticalScalingEnabled: true,
 			},
 			podResources: v1.ResourceRequirements{
@@ -2727,7 +2764,7 @@ func TestPodLevelResourceLimits(t *testing.T) {
 		{
 			name: "status limits include overhead for only one pod-level resource",
 			opts: PodResourcesOptions{
-				UseStatusResources:                             true,
+				UseStatusResources: true,
 				InPlacePodLevelResourcesVerticalScalingEnabled: true,
 			},
 			podResources: v1.ResourceRequirements{
@@ -2753,7 +2790,7 @@ func TestPodLevelResourceLimits(t *testing.T) {
 		{
 			name: "status limits - spec is highest (2 CPU, 200Mi mem)",
 			opts: PodResourcesOptions{
-				UseStatusResources:                             true,
+				UseStatusResources: true,
 				InPlacePodLevelResourcesVerticalScalingEnabled: true,
 			},
 			podResources: v1.ResourceRequirements{
@@ -2780,7 +2817,7 @@ func TestPodLevelResourceLimits(t *testing.T) {
 		{
 			name: "status limits - actual status limits is highest",
 			opts: PodResourcesOptions{
-				UseStatusResources:                             true,
+				UseStatusResources: true,
 				InPlacePodLevelResourcesVerticalScalingEnabled: true,
 			},
 			podResources: v1.ResourceRequirements{
@@ -2807,7 +2844,7 @@ func TestPodLevelResourceLimits(t *testing.T) {
 		{
 			name: "status limits - status resources unset",
 			opts: PodResourcesOptions{
-				UseStatusResources:                             true,
+				UseStatusResources: true,
 				InPlacePodLevelResourcesVerticalScalingEnabled: true,
 			},
 			podResources: v1.ResourceRequirements{
@@ -2828,7 +2865,7 @@ func TestPodLevelResourceLimits(t *testing.T) {
 		{
 			name: "status limits - allocated is highest (ignored by limits)",
 			opts: PodResourcesOptions{
-				UseStatusResources:                             true,
+				UseStatusResources: true,
 				InPlacePodLevelResourcesVerticalScalingEnabled: true,
 			},
 			podResources: v1.ResourceRequirements{
@@ -2859,7 +2896,7 @@ func TestPodLevelResourceLimits(t *testing.T) {
 		{
 			name: "status limits - status.resources nil, status.allocatedResources set",
 			opts: PodResourcesOptions{
-				UseStatusResources:                             true,
+				UseStatusResources: true,
 				InPlacePodLevelResourcesVerticalScalingEnabled: true,
 			},
 			podResources: v1.ResourceRequirements{
@@ -2884,7 +2921,7 @@ func TestPodLevelResourceLimits(t *testing.T) {
 		{
 			name: "status limits - infeasible resize",
 			opts: PodResourcesOptions{
-				UseStatusResources:                             true,
+				UseStatusResources: true,
 				InPlacePodLevelResourcesVerticalScalingEnabled: true,
 			},
 			podResources: v1.ResourceRequirements{
@@ -2913,6 +2950,39 @@ func TestPodLevelResourceLimits(t *testing.T) {
 			expectedLimits: v1.ResourceList{
 				v1.ResourceCPU:    resource.MustParse("4100m"),
 				v1.ResourceMemory: resource.MustParse("450Mi"),
+			},
+		},
+		{
+			name: "status limits with overhead when pod-level spec is unset",
+			opts: PodResourcesOptions{
+				UseStatusResources: true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			podResources: v1.ResourceRequirements{},
+			overhead: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("100m"),
+				v1.ResourceMemory: resource.MustParse("10Mi"),
+			},
+			containers: []v1.Container{
+				{
+					Name: "c1",
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("1"),
+							v1.ResourceMemory: resource.MustParse("100Mi"),
+						},
+					},
+				},
+			},
+			statusResources: &v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1100m"),
+					v1.ResourceMemory: resource.MustParse("110Mi"),
+				},
+			},
+			expectedLimits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1100m"),
+				v1.ResourceMemory: resource.MustParse("110Mi"),
 			},
 		},
 	}

--- a/staging/src/k8s.io/component-helpers/resource/helpers_test.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers_test.go
@@ -1692,6 +1692,7 @@ func TestPodLevelResourceRequests(t *testing.T) {
 		containers       []v1.Container
 		statusRequests   *v1.ResourceRequirements
 		allocated        v1.ResourceList
+		conditions       []v1.PodCondition
 		expectedRequests v1.ResourceList
 	}{
 		{
@@ -2102,37 +2103,6 @@ func TestPodLevelResourceRequests(t *testing.T) {
 			},
 		},
 		{
-			name: "status resources without overhead still receive overhead",
-			opts: PodResourcesOptions{
-				UseStatusResources: true,
-				InPlacePodLevelResourcesVerticalScalingEnabled: true,
-			},
-			podResources: v1.ResourceRequirements{
-				Requests: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("1"),
-					v1.ResourceMemory: resource.MustParse("100Mi"),
-				},
-			},
-			overhead: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("100m"),
-				v1.ResourceMemory: resource.MustParse("10Mi"),
-			},
-			statusRequests: &v1.ResourceRequirements{
-				Requests: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("1"),
-					v1.ResourceMemory: resource.MustParse("100Mi"),
-				},
-			},
-			allocated: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("1"),
-				v1.ResourceMemory: resource.MustParse("100Mi"),
-			},
-			expectedRequests: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("1100m"),
-				v1.ResourceMemory: resource.MustParse("110Mi"),
-			},
-		},
-		{
 			name: "allocated resources include overhead when status requests do not",
 			opts: PodResourcesOptions{
 				UseStatusResources: true,
@@ -2194,6 +2164,183 @@ func TestPodLevelResourceRequests(t *testing.T) {
 				v1.ResourceMemory: resource.MustParse("110Mi"),
 			},
 		},
+		{
+			name: "status requests - spec is highest (2 CPU, 200Mi mem)",
+			opts: PodResourcesOptions{
+				UseStatusResources:                             true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			podResources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("200Mi"),
+				},
+			},
+			overhead: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("100m"),
+				v1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+			statusRequests: &v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1100m"),
+					v1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			allocated: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1100m"),
+				v1.ResourceMemory: resource.MustParse("100Mi"),
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("2100m"),
+				v1.ResourceMemory: resource.MustParse("250Mi"),
+			},
+		},
+		{
+			name: "status requests - allocated is highest",
+			opts: PodResourcesOptions{
+				UseStatusResources:                             true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			podResources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			overhead: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("100m"),
+				v1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+			statusRequests: &v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("2100m"),
+					v1.ResourceMemory: resource.MustParse("250Mi"),
+				},
+			},
+			allocated: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("3100m"),
+				v1.ResourceMemory: resource.MustParse("350Mi"),
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("3100m"),
+				v1.ResourceMemory: resource.MustParse("350Mi"),
+			},
+		},
+		{
+			name: "status requests - actual status requests is highest",
+			opts: PodResourcesOptions{
+				UseStatusResources:                             true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			podResources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			overhead: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("100m"),
+				v1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+			statusRequests: &v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("4100m"),
+					v1.ResourceMemory: resource.MustParse("450Mi"),
+				},
+			},
+			allocated: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("2100m"),
+				v1.ResourceMemory: resource.MustParse("250Mi"),
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("4100m"),
+				v1.ResourceMemory: resource.MustParse("450Mi"),
+			},
+		},
+		{
+			name: "status requests - status resources unset",
+			opts: PodResourcesOptions{
+				UseStatusResources:                             true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			podResources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("200Mi"),
+				},
+			},
+			overhead: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("100m"),
+				v1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("2100m"),
+				v1.ResourceMemory: resource.MustParse("250Mi"),
+			},
+		},
+		{
+			name: "status requests - status.resources nil, status.allocatedResources set",
+			opts: PodResourcesOptions{
+				UseStatusResources:                             true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			podResources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("200Mi"),
+				},
+			},
+			overhead: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("100m"),
+				v1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+			allocated: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("3100m"),
+				v1.ResourceMemory: resource.MustParse("350Mi"),
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("3100m"),
+				v1.ResourceMemory: resource.MustParse("350Mi"),
+			},
+		},
+		{
+			name: "status requests - infeasible resize",
+			opts: PodResourcesOptions{
+				UseStatusResources:                             true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			podResources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("10"),
+					v1.ResourceMemory: resource.MustParse("1000Mi"),
+				},
+			},
+			overhead: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("100m"),
+				v1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+			statusRequests: &v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("2100m"),
+					v1.ResourceMemory: resource.MustParse("250Mi"),
+				},
+			},
+			allocated: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("2100m"),
+				v1.ResourceMemory: resource.MustParse("250Mi"),
+			},
+			conditions: []v1.PodCondition{
+				{
+					Type:   v1.PodResizePending,
+					Status: v1.ConditionTrue,
+					Reason: v1.PodReasonInfeasible,
+				},
+			},
+			expectedRequests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("2100m"),
+				v1.ResourceMemory: resource.MustParse("250Mi"),
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -2204,9 +2351,586 @@ func TestPodLevelResourceRequests(t *testing.T) {
 			if tc.allocated != nil {
 				pod.Status.AllocatedResources = tc.allocated
 			}
+			if len(tc.conditions) > 0 {
+				pod.Status.Conditions = tc.conditions
+			}
 			podReqs := PodRequests(pod, tc.opts)
 			if !equality.Semantic.DeepEqual(podReqs, tc.expectedRequests) {
 				t.Errorf("got=%v, want=%v, diff=%s", podReqs, tc.expectedRequests, diff.Diff(podReqs, tc.expectedRequests))
+			}
+		})
+	}
+}
+
+func TestPodLevelResourceLimits(t *testing.T) {
+	restartAlways := v1.ContainerRestartPolicyAlways
+	testCases := []struct {
+		name            string
+		opts            PodResourcesOptions
+		podResources    v1.ResourceRequirements
+		overhead        v1.ResourceList
+		initContainers  []v1.Container
+		containers      []v1.Container
+		statusResources *v1.ResourceRequirements
+		allocated       v1.ResourceList
+		conditions      []v1.PodCondition
+		expectedLimits  v1.ResourceList
+	}{
+		{
+			name:           "nil",
+			expectedLimits: v1.ResourceList{},
+		},
+		{
+			name:           "pod level memory resource limit with SkipPodLevelResources true",
+			podResources:   v1.ResourceRequirements{Limits: v1.ResourceList{v1.ResourceMemory: resource.MustParse("2Mi")}},
+			opts:           PodResourcesOptions{SkipPodLevelResources: true},
+			expectedLimits: v1.ResourceList{},
+		},
+		{
+			name:           "pod level memory resource limit with SkipPodLevelResources false",
+			podResources:   v1.ResourceRequirements{Limits: v1.ResourceList{v1.ResourceMemory: resource.MustParse("2Mi")}},
+			opts:           PodResourcesOptions{SkipPodLevelResources: false},
+			expectedLimits: v1.ResourceList{v1.ResourceMemory: resource.MustParse("2Mi")},
+		},
+		{
+			name:         "pod level memory and container level cpu resource limits with SkipPodLevelResources false",
+			podResources: v1.ResourceRequirements{Limits: v1.ResourceList{v1.ResourceMemory: resource.MustParse("2Mi")}},
+			containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2m")}},
+				},
+			},
+			opts:           PodResourcesOptions{SkipPodLevelResources: false},
+			expectedLimits: v1.ResourceList{v1.ResourceMemory: resource.MustParse("2Mi"), v1.ResourceCPU: resource.MustParse("2m")},
+		},
+		{
+			name:         "pod level unsupported resource limits set at both pod-level and container-level with SkipPodLevelResources false",
+			podResources: v1.ResourceRequirements{Limits: v1.ResourceList{v1.ResourceStorage: resource.MustParse("2Mi")}},
+			containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{Limits: v1.ResourceList{v1.ResourceStorage: resource.MustParse("3Mi")}},
+				},
+			},
+			opts:           PodResourcesOptions{SkipPodLevelResources: false},
+			expectedLimits: v1.ResourceList{v1.ResourceStorage: resource.MustParse("3Mi")},
+		},
+		{
+			name:         "pod level unsupported resource limits set at pod-level with SkipPodLevelResources false",
+			podResources: v1.ResourceRequirements{Limits: v1.ResourceList{v1.ResourceStorage: resource.MustParse("2Mi")}},
+			containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{Limits: v1.ResourceList{v1.ResourceMemory: resource.MustParse("3Mi")}},
+				},
+			},
+			opts:           PodResourcesOptions{SkipPodLevelResources: false},
+			expectedLimits: v1.ResourceList{v1.ResourceMemory: resource.MustParse("3Mi")},
+		},
+		{
+			name: "only container level resource limits set with SkipPodLevelResources false",
+			containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("3Mi"),
+							v1.ResourceCPU:    resource.MustParse("2m"),
+						},
+					},
+				},
+			},
+			opts:           PodResourcesOptions{SkipPodLevelResources: false},
+			expectedLimits: v1.ResourceList{v1.ResourceMemory: resource.MustParse("3Mi"), v1.ResourceCPU: resource.MustParse("2m")},
+		},
+		{
+			name: "both container-level and pod-level resource limits set with SkipPodLevelResources false",
+			podResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("6Mi"),
+					v1.ResourceCPU:    resource.MustParse("8m"),
+				},
+			},
+			containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("3Mi"),
+							v1.ResourceCPU:    resource.MustParse("2m"),
+						},
+					},
+				},
+			},
+			opts:           PodResourcesOptions{SkipPodLevelResources: false},
+			expectedLimits: v1.ResourceList{v1.ResourceMemory: resource.MustParse("6Mi"), v1.ResourceCPU: resource.MustParse("8m")},
+		},
+		{
+			name: "container-level resource limits and init container set with SkipPodLevelResources false",
+			containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("3Mi"),
+							v1.ResourceCPU:    resource.MustParse("2m"),
+						},
+					},
+				},
+			},
+			initContainers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("5Mi"),
+							v1.ResourceCPU:    resource.MustParse("4m"),
+						},
+					},
+				},
+			},
+			opts:           PodResourcesOptions{SkipPodLevelResources: false},
+			expectedLimits: v1.ResourceList{v1.ResourceMemory: resource.MustParse("5Mi"), v1.ResourceCPU: resource.MustParse("4m")},
+		},
+		{
+			name: "container-level resource limits and init container set with SkipPodLevelResources true",
+			containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("3Mi"),
+							v1.ResourceCPU:    resource.MustParse("2m"),
+						},
+					},
+				},
+			},
+			initContainers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("5Mi"),
+							v1.ResourceCPU:    resource.MustParse("4m"),
+						},
+					},
+				},
+			},
+			opts:           PodResourcesOptions{SkipPodLevelResources: true},
+			expectedLimits: v1.ResourceList{v1.ResourceMemory: resource.MustParse("5Mi"), v1.ResourceCPU: resource.MustParse("4m")},
+		},
+		{
+			name: "container-level resource limits and sidecar container set with SkipPodLevelResources false",
+			containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("3Mi"),
+							v1.ResourceCPU:    resource.MustParse("2m"),
+						},
+					},
+				},
+			},
+			initContainers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("5Mi"),
+							v1.ResourceCPU:    resource.MustParse("4m"),
+						},
+					},
+					RestartPolicy: &restartAlways,
+				},
+			},
+			opts:           PodResourcesOptions{SkipPodLevelResources: false},
+			expectedLimits: v1.ResourceList{v1.ResourceMemory: resource.MustParse("8Mi"), v1.ResourceCPU: resource.MustParse("6m")},
+		},
+		{
+			name: "container-level resource limits, init and sidecar container set with SkipPodLevelResources false",
+			containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("3Mi"),
+							v1.ResourceCPU:    resource.MustParse("2m"),
+						},
+					},
+				},
+			},
+			initContainers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("5Mi"),
+							v1.ResourceCPU:    resource.MustParse("4m"),
+						},
+					},
+					RestartPolicy: &restartAlways,
+				},
+				{
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("6Mi"),
+							v1.ResourceCPU:    resource.MustParse("8m"),
+						},
+					},
+				},
+			},
+			opts:           PodResourcesOptions{SkipPodLevelResources: false},
+			expectedLimits: v1.ResourceList{v1.ResourceMemory: resource.MustParse("11Mi"), v1.ResourceCPU: resource.MustParse("12m")},
+		},
+		{
+			name: "pod-level resource limits, container-level limits, init and sidecar container set with SkipPodLevelResources false",
+			podResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("15Mi"),
+					v1.ResourceCPU:    resource.MustParse("18m"),
+				},
+			},
+			containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("3Mi"),
+							v1.ResourceCPU:    resource.MustParse("2m"),
+						},
+					},
+				},
+			},
+			initContainers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("5Mi"),
+							v1.ResourceCPU:    resource.MustParse("4m"),
+						},
+					},
+					RestartPolicy: &restartAlways,
+				},
+				{
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("6Mi"),
+							v1.ResourceCPU:    resource.MustParse("8m"),
+						},
+					},
+				},
+			},
+			opts:           PodResourcesOptions{SkipPodLevelResources: false},
+			expectedLimits: v1.ResourceList{v1.ResourceMemory: resource.MustParse("15Mi"), v1.ResourceCPU: resource.MustParse("18m")},
+		},
+		{
+			name: "pod-level resource limits, hugepage limit single page size",
+			podResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceMemory:                  resource.MustParse("10Mi"),
+					v1.ResourceHugePagesPrefix + "2Mi": resource.MustParse("2Mi"),
+				},
+			},
+			opts:           PodResourcesOptions{SkipPodLevelResources: false},
+			expectedLimits: v1.ResourceList{v1.ResourceMemory: resource.MustParse("10Mi"), v1.ResourceHugePagesPrefix + "2Mi": resource.MustParse("2Mi")},
+		},
+		{
+			name: "pod-level resource limits, hugepage limit multiple page sizes",
+			podResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:                     resource.MustParse("1"),
+					v1.ResourceHugePagesPrefix + "2Mi": resource.MustParse("2Mi"),
+					v1.ResourceHugePagesPrefix + "1Gi": resource.MustParse("1Gi"),
+				},
+			},
+			opts:           PodResourcesOptions{SkipPodLevelResources: false},
+			expectedLimits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceHugePagesPrefix + "2Mi": resource.MustParse("2Mi"), v1.ResourceHugePagesPrefix + "1Gi": resource.MustParse("1Gi")},
+		},
+		{
+			name: "pod-level resource limits, container-level limits, hugepage limit single page size",
+			podResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:                     resource.MustParse("1"),
+					v1.ResourceHugePagesPrefix + "2Mi": resource.MustParse("10Mi"),
+				},
+			},
+			containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceHugePagesPrefix + "2Mi": resource.MustParse("6Mi"),
+						},
+					},
+				},
+			},
+			opts:           PodResourcesOptions{SkipPodLevelResources: false},
+			expectedLimits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceHugePagesPrefix + "2Mi": resource.MustParse("10Mi")},
+		},
+		{
+			name: "pod-level resource limits, container-level limits, hugepage limit multiple page sizes",
+			podResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:                     resource.MustParse("1"),
+					v1.ResourceHugePagesPrefix + "2Mi": resource.MustParse("10Mi"),
+					v1.ResourceHugePagesPrefix + "1Gi": resource.MustParse("2Gi"),
+				},
+			},
+			containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:                     resource.MustParse("1"),
+							v1.ResourceHugePagesPrefix + "1Gi": resource.MustParse("2Gi"),
+						},
+					},
+				},
+			},
+			opts:           PodResourcesOptions{SkipPodLevelResources: false},
+			expectedLimits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceHugePagesPrefix + "2Mi": resource.MustParse("10Mi"), v1.ResourceHugePagesPrefix + "1Gi": resource.MustParse("2Gi")},
+		},
+		{
+			name: "pod-level resource limits, container-level limits, hugepage limit multiple page sizes between pod-level and container-level",
+			podResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:                     resource.MustParse("1"),
+					v1.ResourceHugePagesPrefix + "2Mi": resource.MustParse("10Mi"),
+				},
+			},
+			containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceMemory:                  resource.MustParse("4Mi"),
+							v1.ResourceHugePagesPrefix + "1Gi": resource.MustParse("1Gi"),
+						},
+					},
+				},
+			},
+			opts:           PodResourcesOptions{SkipPodLevelResources: false},
+			expectedLimits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("4Mi"), v1.ResourceHugePagesPrefix + "2Mi": resource.MustParse("10Mi"), v1.ResourceHugePagesPrefix + "1Gi": resource.MustParse("1Gi")},
+		},
+		{
+			name: "status limits include overhead for all pod-level resources",
+			opts: PodResourcesOptions{
+				UseStatusResources:                             true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			podResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			overhead: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("100m"),
+				v1.ResourceMemory: resource.MustParse("10Mi"),
+			},
+			statusResources: &v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1100m"),
+					v1.ResourceMemory: resource.MustParse("110Mi"),
+				},
+			},
+			expectedLimits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1100m"),
+				v1.ResourceMemory: resource.MustParse("110Mi"),
+			},
+		},
+		{
+			name: "status limits include overhead for only one pod-level resource",
+			opts: PodResourcesOptions{
+				UseStatusResources:                             true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			podResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			overhead: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("100m"),
+				v1.ResourceMemory: resource.MustParse("10Mi"),
+			},
+			statusResources: &v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("1100m"),
+				},
+			},
+			expectedLimits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1100m"),
+				v1.ResourceMemory: resource.MustParse("110Mi"),
+			},
+		},
+		{
+			name: "status limits - spec is highest (2 CPU, 200Mi mem)",
+			opts: PodResourcesOptions{
+				UseStatusResources:                             true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			podResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("200Mi"),
+				},
+			},
+			overhead: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("100m"),
+				v1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+			statusResources: &v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1100m"),
+					v1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			expectedLimits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("2100m"),
+				v1.ResourceMemory: resource.MustParse("250Mi"),
+			},
+		},
+		{
+			name: "status limits - actual status limits is highest",
+			opts: PodResourcesOptions{
+				UseStatusResources:                             true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			podResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			overhead: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("100m"),
+				v1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+			statusResources: &v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("3100m"),
+					v1.ResourceMemory: resource.MustParse("350Mi"),
+				},
+			},
+			expectedLimits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("3100m"),
+				v1.ResourceMemory: resource.MustParse("350Mi"),
+			},
+		},
+		{
+			name: "status limits - status resources unset",
+			opts: PodResourcesOptions{
+				UseStatusResources:                             true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			podResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("200Mi"),
+				},
+			},
+			overhead: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("100m"),
+				v1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+			expectedLimits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("2100m"),
+				v1.ResourceMemory: resource.MustParse("250Mi"),
+			},
+		},
+		{
+			name: "status limits - allocated is highest (ignored by limits)",
+			opts: PodResourcesOptions{
+				UseStatusResources:                             true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			podResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			overhead: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("100m"),
+				v1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+			statusResources: &v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("2100m"),
+					v1.ResourceMemory: resource.MustParse("200Mi"),
+				},
+			},
+			allocated: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("5100m"),
+				v1.ResourceMemory: resource.MustParse("500Mi"),
+			},
+			expectedLimits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("2100m"),
+				v1.ResourceMemory: resource.MustParse("200Mi"),
+			},
+		},
+		{
+			name: "status limits - status.resources nil, status.allocatedResources set",
+			opts: PodResourcesOptions{
+				UseStatusResources:                             true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			podResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("4"),
+					v1.ResourceMemory: resource.MustParse("400Mi"),
+				},
+			},
+			overhead: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("100m"),
+				v1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+			allocated: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("3100m"),
+				v1.ResourceMemory: resource.MustParse("350Mi"),
+			},
+			expectedLimits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("4100m"),
+				v1.ResourceMemory: resource.MustParse("450Mi"),
+			},
+		},
+		{
+			name: "status limits - infeasible resize",
+			opts: PodResourcesOptions{
+				UseStatusResources:                             true,
+				InPlacePodLevelResourcesVerticalScalingEnabled: true,
+			},
+			podResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("10"),
+					v1.ResourceMemory: resource.MustParse("1000Mi"),
+				},
+			},
+			overhead: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("100m"),
+				v1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+			statusResources: &v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("4100m"),
+					v1.ResourceMemory: resource.MustParse("450Mi"),
+				},
+			},
+			conditions: []v1.PodCondition{
+				{
+					Type:   v1.PodResizePending,
+					Status: v1.ConditionTrue,
+					Reason: v1.PodReasonInfeasible,
+				},
+			},
+			expectedLimits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("4100m"),
+				v1.ResourceMemory: resource.MustParse("450Mi"),
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := getPodLevelResourcesPod(tc.podResources, tc.overhead, tc.containers, tc.initContainers)
+			if tc.statusResources != nil {
+				pod.Status.Resources = tc.statusResources
+			}
+			if tc.allocated != nil {
+				pod.Status.AllocatedResources = tc.allocated
+			}
+			if len(tc.conditions) > 0 {
+				pod.Status.Conditions = tc.conditions
+			}
+			podLimits := PodLimits(pod, tc.opts)
+			if !equality.Semantic.DeepEqual(podLimits, tc.expectedLimits) {
+				t.Errorf("got=%v, want=%v, diff=%s", podLimits, tc.expectedLimits, diff.Diff(podLimits, tc.expectedLimits))
 			}
 		})
 	}


### PR DESCRIPTION
Fix the double counting of overhead 
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR addresses the double counting of pod overhead resources in PodRequests. AllocatedResources and Resources in Pod Status includes overhead already. By subtracting the overhead from these calculations, we ensure accurate resource reporting.

#### Which issue(s) this PR is related to:
[139627](https://github.com/kubernetes/kubernetes/issues/135082)
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
The deferred resizing test related to memory resizing runs fine:
	
3. Resize pod3 to request more memory than available (2/3), along with a decrease in CPU (1/24), verify the resize is deferred.

```
make WHAT="test/e2e/e2e.test" && ./_output/bin/e2e.test -context kind-kind -ginkgo.focus="pod-resize-retry-deferred-test" -ginkgo.label-filter="" -ginkgo.v

------------------------------
[sig-node] Pod InPlace Resize Container (deferred-resizes) [FeatureGate:InPlacePodVerticalScaling] pod-resize-retry-deferred-test-2 [Serial] [sig-node, Serial, FeatureGate:InPlacePodVerticalScaling]

[sig-node] Pod InPlace Resize Container (deferred-resizes) [FeatureGate:InPlacePodVerticalScaling] pod-resize-retry-deferred-test-1 [Serial] [sig-node, Serial, FeatureGate:InPlacePodVerticalScaling]

[sig-node] Pod InPlace Resize Container (deferred-resizes) [FeatureGate:InPlacePodVerticalScaling] pod-resize-retry-deferred-test-3 [Serial] [sig-node, Serial, FeatureGate:InPlacePodVerticalScaling]

Ran 3 of 7662 Specs in 49.368 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 7659 Skipped
PASS

```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix an issue where pod overhead was double-counted in status and allocated resources.
```


