### PR TITLE
Close watch response body on negotiation failure

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -838,6 +838,7 @@ func (r *Request) newStreamWatcher(ctx context.Context, resp *http.Response) (wa
 	}
 	objectDecoder, streamingSerializer, framer, err := r.contentConfig.Negotiator.StreamDecoder(mediaType, params)
 	if err != nil {
+		resp.Body.Close()
 		return nil, err
 	}
 

--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -327,6 +327,16 @@ func TestRequestURIContext(t *testing.T) {
 
 type NotAnAPIObject struct{}
 
+type closeTrackingReadCloser struct {
+	io.Reader
+	closed bool
+}
+
+func (r *closeTrackingReadCloser) Close() error {
+	r.closed = true
+	return nil
+}
+
 func (obj NotAnAPIObject) GroupVersionKind() *schema.GroupVersionKind       { return nil }
 func (obj NotAnAPIObject) SetGroupVersionKind(gvk *schema.GroupVersionKind) {}
 
@@ -2255,6 +2265,28 @@ func TestWatchUnknownContentType(t *testing.T) {
 	_, err := s.Get().Prefix("path/to/watch/thing").Watch(context.Background())
 	if err == nil {
 		t.Fatalf("Expected to fail due to lack of known stream serialization for content type")
+	}
+}
+
+func TestWatchUnknownContentTypeClosesBody(t *testing.T) {
+	body := &closeTrackingReadCloser{Reader: strings.NewReader("unexpected watch body")}
+	req := &Request{contentConfig: defaultContentConfig()}
+	resp := &http.Response{
+		Header: http.Header{
+			"Content-Type": []string{"foobar"},
+		},
+		Body: body,
+	}
+
+	watcher, err := req.newStreamWatcher(context.Background(), resp)
+	if err == nil {
+		if watcher != nil {
+			watcher.Stop()
+		}
+		t.Fatal("Expected to fail due to lack of known stream serialization for content type")
+	}
+	if !body.closed {
+		t.Fatal("Expected response body to be closed when stream negotiation fails")
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig api-machinery

#### What this PR does / why we need it:
When Request.Watch receives a 200 response but cannot negotiate a stream decoder for the response content type, newStreamWatcher returns the negotiation error without closing the response body. This can leak the underlying connection.

This closes the response body on the stream-negotiation error path and adds a regression test for the unknown content-type case.

#### Which issue(s) this PR fixes:
Fixes #140464

#### Special notes for your reviewer:
None.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Verification
```
go test ./rest -run 'TestWatchUnknownContentType|TestWatchUnknownContentTypeClosesBody'\ngo test ./rest\n```