### PR TITLE
Fix CRD stored version integration test flake

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/etcd.go
@@ -38,7 +38,7 @@ func CreateCRDUsingRemovedAPI(etcdClient *clientv3.Client, etcdStoragePrefix str
 	if err != nil {
 		return nil, err
 	}
-	return waitForCRDReady(crd, apiExtensionsClient, dynamicClientSet)
+	return WaitForCRDWatchCacheReady(crd, apiExtensionsClient, dynamicClientSet)
 }
 
 // CreateCRDUsingRemovedAPIWatchUnsafe creates a CRD directly using etcd.  This is must *ONLY* be used for checks of compatibility

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/resources.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/resources.go
@@ -357,8 +357,8 @@ func waitForCRDReadyWatchUnsafe(crd *apiextensionsv1.CustomResourceDefinition, a
 	return crd, nil
 }
 
-// waitForCRDReady creates the given CRD and makes sure its watch cache is primed on the server.
-func waitForCRDReady(crd *apiextensionsv1.CustomResourceDefinition, apiExtensionsClient clientset.Interface, dynamicClientSet dynamic.Interface) (*apiextensionsv1.CustomResourceDefinition, error) {
+// WaitForCRDWatchCacheReady waits until the given CRD's watch cache is primed on the server.
+func WaitForCRDWatchCacheReady(crd *apiextensionsv1.CustomResourceDefinition, apiExtensionsClient clientset.Interface, dynamicClientSet dynamic.Interface) (*apiextensionsv1.CustomResourceDefinition, error) {
 	v1CRD, err := waitForCRDReadyWatchUnsafe(crd, apiExtensionsClient)
 	if err != nil {
 		return nil, err
@@ -375,7 +375,11 @@ func waitForCRDReady(crd *apiextensionsv1.CustomResourceDefinition, apiExtension
 	// This way all the tests that are checking for watches don't have to worry about RV too old problems because crazy things *could* happen
 	// before like the created RV could be too old to watch.
 	err = wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
-		return isWatchCachePrimed(v1CRD, dynamicClientSet)
+		ready, err := isWatchCachePrimed(v1CRD, dynamicClientSet)
+		if errors.IsTooManyRequests(err) || errors.IsServiceUnavailable(err) {
+			return false, nil
+		}
+		return ready, err
 	})
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/versioning_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/versioning_test.go
@@ -231,6 +231,18 @@ func testStoragedVersionInCRDStatus(t *testing.T, ns string, noxuDefinition *api
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
+	storageWatcher, err := newNamespacedCustomResourceVersionedClient(ns, dynamicClient, crd, "v1beta1").Watch(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer storageWatcher.Stop()
+	watchClosed := make(chan struct{})
+	go func() {
+		for range storageWatcher.ResultChan() {
+		}
+		close(watchClosed)
+	}()
+
 	// Changing CRD storage version should be reflected immediately
 	crd.Spec.Versions = versionsV1Beta2Storage
 	_, err = apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), crd, metav1.UpdateOptions{})
@@ -243,6 +255,18 @@ func testStoragedVersionInCRDStatus(t *testing.T, ns string, noxuDefinition *api
 	}
 	if e, a := []string{"v1beta1", "v1beta2"}, crd.Status.StoredVersions; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
+	}
+
+	// Changing the storage version recreates the REST storage asynchronously. Wait for the old storage's
+	// watch to close before priming the new watch cache so the finalizer can reliably list remaining instances.
+	select {
+	case <-watchClosed:
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatal("timed out waiting for the old storage watch to close")
+	}
+	crd, err = fixtures.WaitForCRDWatchCacheReady(crd, apiExtensionClient, dynamicClient)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	err = fixtures.DeleteV1CustomResourceDefinition(crd, apiExtensionClient)


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

`TestStoragedVersionInClusterScopedCRDStatus` can delete its CRD while the REST storage and watch cache are still being recreated after a storage-version change. The finalizer can then receive `storage is (re)initializing` while listing remaining custom resources and time out waiting for CRD cleanup.

This change establishes a watch on the old storage before updating the CRD, waits for that watch to close when the old storage is destroyed, and primes the replacement watch cache before deleting the CRD. Transient 429 and 503 responses during watch-cache initialization are retried.

Failing periodic job: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-integration-master/2076510297404739584

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Verification:
- `TestStoragedVersionInClusterScopedCRDStatus`, 10 consecutive runs
- `stress -p 24 -count 1000`, 1000 runs with 0 failures

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```