### PR TITLE
node: topologymanager: e2e: retry non-gu cpuset log check

### DIFF
--- a/test/e2e_node/topology_manager_test.go
+++ b/test/e2e_node/topology_manager_test.go
@@ -1485,9 +1485,10 @@ func runNonGuPodTest(ctx context.Context, f *framework.Framework, cpuCap int64, 
 	framework.ExpectNoError(err)
 	expAllowedCPUs = expAllowedCPUs.Difference(strictReservedCPUs)
 	expAllowedCPUsListRegex = fmt.Sprintf("^%s\n$", expAllowedCPUs.String())
-	err = e2epod.NewPodClient(f).MatchContainerOutput(ctx, pod.Name, pod.Spec.Containers[0].Name, expAllowedCPUsListRegex)
-	framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
-		pod.Spec.Containers[0].Name, pod.Name)
+	gomega.Eventually(ctx, func() error {
+		return e2epod.NewPodClient(f).MatchContainerOutput(ctx, pod.Name, pod.Spec.Containers[0].Name, expAllowedCPUsListRegex)
+	}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(gomega.Succeed(),
+		"expected log not found in container [%s] of pod [%s]", pod.Spec.Containers[0].Name, pod.Name)
 
 	ginkgo.By("by deleting the pods and waiting for container removal")
 	deletePods(ctx, f, []string{pod.Name})


### PR DESCRIPTION
## Summary
- harden `runNonGuPodTest` in `topology_manager_test.go` against transient empty container logs
- replace the one-shot `MatchContainerOutput` assertion with `Eventually(...).Should(Succeed())`
- keep the expected cpuset regex and test intent unchanged

## Test plan
- [x] `go test -c ./test/e2e_node` *(compile attempted; local run previously hit temporary disk quota in this environment)*


Made with [Cursor](https://cursor.com)