### PR TITLE
[FG: InPlacePodVerticalScalingExclusiveCPUs] cpumanager: Add state checkpoint unit tests

### DIFF
--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -39,7 +39,10 @@ import (
 	"k8s.io/utils/cpuset"
 )
 
-const testingCheckpoint = "cpumanager_checkpoint_test"
+const (
+	testingCheckpoint = "cpumanager_checkpoint_test"
+	stateDir          = "cpumanager_state_test"
+)
 
 type FeatureGateCombination map[featuregate.Feature]bool
 
@@ -941,5 +944,271 @@ func removeAll(dir string, t *testing.T) {
 	t.Helper()
 	if err := os.RemoveAll(dir); err != nil {
 		t.Fatalf("unable to remove dir %s: %v", dir, err)
+	}
+}
+
+func TestSetPodCPUSet(t *testing.T) {
+	testCases := []struct {
+		description        string
+		featureGateEnabled bool
+		cpuSet             []int
+		expected           string
+	}{
+		{
+			description:        "Assign CPUSet to given pod with PodLevelResourceManagers feature gate enabled",
+			featureGateEnabled: true,
+			cpuSet:             []int{1, 2, 3, 4, 8},
+			expected:           "1-4,8",
+		},
+		{
+			description:        "Assign CPUSet to given pod with PodLevelResourceManagers feature gate disabled",
+			featureGateEnabled: false,
+			cpuSet:             []int{1, 2, 3, 4, 8},
+			expected:           "",
+		},
+	}
+
+	logger, _ := ktesting.NewTestContext(t)
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResourceManagers, testCase.featureGateEnabled)
+
+			tmpDir, err := os.MkdirTemp("", stateDir)
+			require.NoError(t, err)
+
+			// Remove previous checkpoint's dir during subtest cleanup
+			t.Cleanup(func() {
+				require.NoErrorf(t, os.RemoveAll(tmpDir), "unable to remove dir %s", tmpDir)
+			})
+
+			state1, err := NewCheckpointState(logger, tmpDir, testingCheckpoint, "static", containermap.ContainerMap{})
+			require.NoError(t, err)
+
+			state1.SetPodCPUSet("pod1", cpuset.New(testCase.cpuSet...))
+
+			state2, err := NewCheckpointState(logger, tmpDir, testingCheckpoint, "static", containermap.ContainerMap{})
+			require.NoError(t, err)
+
+			actual, _ := state2.GetPodCPUSet("pod1")
+			require.Equal(t, testCase.expected, actual.String())
+		})
+	}
+}
+
+func TestSetPodCPUAssignments(t *testing.T) {
+	testCases := []struct {
+		description        string
+		featureGateEnabled bool
+		podEntries         PodCPUAssignments
+		expected           map[string]string
+	}{
+		{
+			description:        "Assign CPUSet to pods with PodLevelResourceManagers feature gate enabled",
+			featureGateEnabled: true,
+			podEntries: PodCPUAssignments{
+				"pod1": {CPUSet: cpuset.New(4, 7)},
+				"pod2": {CPUSet: cpuset.New(1, 2, 3)},
+			},
+			expected: map[string]string{
+				"pod1": "4,7",
+				"pod2": "1-3",
+			},
+		},
+		{
+			description:        "Assign CPUSet to pods with PodLevelResourceManagers feature gate disabled",
+			featureGateEnabled: false,
+			podEntries: PodCPUAssignments{
+				"pod1": {CPUSet: cpuset.New(3, 5)},
+			},
+			expected: map[string]string{},
+		},
+	}
+
+	logger, _ := ktesting.NewTestContext(t)
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResourceManagers, testCase.featureGateEnabled)
+
+			tmpDir, err := os.MkdirTemp("", stateDir)
+			require.NoError(t, err)
+
+			// Remove previous checkpoint's dir during subtest cleanup
+			t.Cleanup(func() {
+				require.NoErrorf(t, os.RemoveAll(tmpDir), "unable to remove dir %s", tmpDir)
+			})
+
+			state1, err := NewCheckpointState(logger, tmpDir, testingCheckpoint, "static", containermap.ContainerMap{})
+			require.NoError(t, err)
+
+			state1.SetPodCPUAssignments(testCase.podEntries)
+
+			state2, err := NewCheckpointState(logger, tmpDir, testingCheckpoint, "static", containermap.ContainerMap{})
+			require.NoError(t, err)
+
+			actual := state2.GetPodCPUAssignments()
+			require.Len(t, actual, len(testCase.expected))
+
+			for pod, entry := range actual {
+				require.Equal(t, testCase.expected[pod], entry.CPUSet.String())
+			}
+		})
+	}
+}
+
+func TestGetBaselineCPUSet(t *testing.T) {
+	testCases := []struct {
+		description        string
+		featureGateEnabled bool
+		content            string
+		expected           ContainerCPUBaselines
+	}{
+		{
+			description:        "Get baseline CPUSet with InPlacePodVerticalScalingExclusiveCPUs feature gate enabled when baselines field included",
+			featureGateEnabled: true,
+			content: `{
+				"data": "{\"policyName\":\"static\",\"defaultCPUSet\":\"1-3\",\"entries\":{\"pod\":{\"container\":\"4-5\"}},\"podEntries\":{\"pod\":{\"cpuSet\":\"4-6\"}},\"baselines\":{\"pod\":{\"container\":{\"baseline\":\"5\"}}}}",
+				"dataChecksum": 4038000775
+			}`,
+			expected: ContainerCPUBaselines{
+				"pod": {
+					"container": {
+						Baseline: cpuset.New(5),
+					},
+				},
+			},
+		},
+		{
+			description:        "Get baseline CPUSet with InPlacePodVerticalScalingExclusiveCPUs feature gate enabled when baselines field excluded",
+			featureGateEnabled: true,
+			content: `{
+				"data": "{\"policyName\":\"static\",\"defaultCPUSet\":\"1-3\",\"entries\":{\"pod\":{\"container\":\"4-5\"}},\"podEntries\":{\"pod\":{\"cpuSet\":\"4-6\"}}}",
+				"dataChecksum": 234652157
+			}`,
+			expected: ContainerCPUBaselines{
+				"pod": {
+					"container": {
+						Baseline: cpuset.New(4, 5), // Must be equal to value from entries
+					},
+				},
+			},
+		},
+		{
+			description:        "Get baseline CPUSet with InPlacePodVerticalScalingExclusiveCPUs feature gate disabled",
+			featureGateEnabled: false,
+			content: `{
+				"data": "{\"policyName\":\"static\",\"defaultCPUSet\":\"1-3\",\"entries\":{\"pod\":{\"container\":\"4-5\"}},\"podEntries\":{\"pod\":{\"cpuSet\":\"4-6\"}}}",
+				"dataChecksum": 234652157
+			}`,
+			expected: ContainerCPUBaselines{
+				"pod": {
+					"container": {
+						Baseline: cpuset.New(),
+					},
+				},
+			},
+		},
+	}
+
+	logger, _ := ktesting.NewTestContext(t)
+	tmpDir, err := os.MkdirTemp("", stateDir)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoErrorf(t, os.RemoveAll(tmpDir), "unable to remove dir %s", tmpDir)
+	})
+
+	cpm, err := checkpointmanager.NewCheckpointManager(tmpDir)
+	require.NoErrorf(t, err, "could not create testing checkpoint manager: %v", err)
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingExclusiveCPUs, testCase.featureGateEnabled)
+
+			err = cpm.RemoveCheckpoint(testingCheckpoint)
+			require.NoErrorf(t, err, "could not remove previous checkpoint: %v", err)
+
+			checkpoint := &testutil.MockCheckpoint{Content: testCase.content}
+			err = cpm.CreateCheckpoint(testingCheckpoint, checkpoint)
+			require.NoErrorf(t, err, "could not create testing checkpoint: %v", err)
+
+			state, err := NewCheckpointState(logger, tmpDir, testingCheckpoint, "static", containermap.ContainerMap{})
+			require.NoError(t, err)
+
+			originals, _ := state.GetBaselineCPUSet("pod", "container")
+			require.Equal(t, testCase.expected["pod"]["container"].Baseline, originals)
+		})
+	}
+}
+
+func TestDeletePod(t *testing.T) {
+	testCases := []struct {
+		description        string
+		featureGateEnabled bool
+		content            string
+		podUIDs            []string // Pods to delete
+		expected           map[string]string
+	}{
+		{
+			description:        "Delete existing pod(s) CPUSet with PodLevelResourceManagers feature gate enabled",
+			featureGateEnabled: true,
+			content: `{
+				"data": "{\"policyName\":\"static\",\"defaultCPUSet\":\"1-3\",\"entries\":{\"pod1\":{\"container\":\"4-5\"},\"pod2\":{\"container\":\"7-8\"}},\"podEntries\":{\"pod1\":{\"cpuSet\":\"4-6\"},\"pod2\":{\"cpuSet\":\"7-9\"}}}",
+				"dataChecksum": 2086345991
+			}`,
+			podUIDs: []string{"pod1"},
+			expected: map[string]string{
+				"pod2": "7-9",
+			},
+		},
+		{
+			description:        "Delete nonexisting pod(s) CPUSet with PodLevelResourceManagers feature gate enabled",
+			featureGateEnabled: true,
+			content: `{
+				"data": "{\"policyName\":\"static\",\"defaultCPUSet\":\"1-3\",\"entries\":{\"pod1\":{\"container\":\"4-5\"},\"pod2\":{\"container\":\"7-8\"}},\"podEntries\":{\"pod1\":{\"cpuSet\":\"4-6\"},\"pod2\":{\"cpuSet\":\"7-9\"}}}",
+				"dataChecksum": 2086345991
+			}`,
+			podUIDs: []string{"pod3", "pod4"},
+			expected: map[string]string{
+				"pod1": "4-6",
+				"pod2": "7-9",
+			},
+		},
+	}
+
+	logger, _ := ktesting.NewTestContext(t)
+	tmpDir, err := os.MkdirTemp("", stateDir)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoErrorf(t, os.RemoveAll(tmpDir), "unable to remove dir %s", tmpDir)
+	})
+
+	cpm, err := checkpointmanager.NewCheckpointManager(tmpDir)
+	require.NoErrorf(t, err, "could not create testing checkpoint manager: %v", err)
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResourceManagers, testCase.featureGateEnabled)
+
+			err = cpm.RemoveCheckpoint(testingCheckpoint)
+			require.NoErrorf(t, err, "could not remove previous checkpoint: %v", err)
+
+			checkpoint := &testutil.MockCheckpoint{Content: testCase.content}
+			err = cpm.CreateCheckpoint(testingCheckpoint, checkpoint)
+			require.NoErrorf(t, err, "could not create testing checkpoint: %v", err)
+
+			state, err := NewCheckpointState(logger, tmpDir, testingCheckpoint, "static", containermap.ContainerMap{})
+			require.NoError(t, err)
+
+			for _, uid := range testCase.podUIDs {
+				state.DeletePod(uid)
+			}
+			actual := state.GetPodCPUAssignments()
+
+			require.Len(t, actual, len(testCase.expected))
+			for pod, entry := range actual {
+				require.Equal(t, testCase.expected[pod], entry.CPUSet.String())
+			}
+		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

Enhancement of #140432.

This PR introduces unit tests for yet uncovered methods in CPU manager - mainly setters and getters.

#### Which issue(s) this PR is related to:
Enhances both #140432 #140314 
Related to KEP: https://github.com/kubernetes/enhancements/issues/5554

#### Special notes for your reviewer:
--
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
