### PR TITLE
certificates: use contextual panic handling in cleaners

### DIFF
--- a/pkg/controller/certificates/cleaner/cleaner.go
+++ b/pkg/controller/certificates/cleaner/cleaner.go
@@ -77,7 +77,7 @@ func NewCSRCleanerController(
 
 // Run the main goroutine responsible for watching and syncing jobs.
 func (ccc *CSRCleanerController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting CSR cleaner controller")

--- a/pkg/controller/certificates/cleaner/pcrcleaner.go
+++ b/pkg/controller/certificates/cleaner/pcrcleaner.go
@@ -63,7 +63,7 @@ func NewPCRCleanerController(
 }
 
 func (c *PCRCleanerController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting PodCertificateRequest cleaner controller")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig auth
/wg structured-logging

#### What this PR does / why we need it

This updates the CSR and PodCertificateRequest cleaner controllers to use `utilruntime.HandleCrashWithContext(ctx)` instead of the non-contextual `utilruntime.HandleCrash()`.

Both controller `Run` methods already receive a `context.Context` and use it for contextual logging and worker execution. Passing that context to the panic handler ensures that recovered panic logging uses the controller's contextual logger.

This is part of the contextual logging migration tracked in #126379.

#### Which issue(s) this PR is related to

Related to #126379

#### Special notes for your reviewer

This is a mechanical two-call-site cleanup. It does not change controller signatures or controller behavior outside panic logging.

Local validation:

* `git diff --check`
* `./hack/verify-gofmt.sh`
* `./hack/verify-boilerplate.sh`
* `go test -count=1 ./pkg/controller/certificates/cleaner/...`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
