### PR TITLE
apiserver: fix leaky connection issue when using proxy tunnel to webhook

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/accessors.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/accessors.go
@@ -354,7 +354,11 @@ func (v *validatingWebhookAccessor) GetValidatingWebhook() (*v1.ValidatingWebhoo
 // to create a HookClient and the purpose of the config struct is to share that with other packages
 // that need to create a HookClient.
 func hookClientConfigForWebhook(w WebhookAccessor) webhookutil.ClientConfig {
-	ret := webhookutil.ClientConfig{Name: w.GetName(), CABundle: w.GetClientConfig().CABundle}
+	ret := webhookutil.ClientConfig{
+		Name:           w.GetName(),
+		CABundle:       w.GetClientConfig().CABundle,
+		TimeoutSeconds: w.GetTimeoutSeconds(),
+	}
 	if w.GetClientConfig().URL != nil {
 		ret.URL = *w.GetClientConfig().URL
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/accessors_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/accessors_test.go
@@ -111,3 +111,47 @@ func TestValidatingWebhookAccessor(t *testing.T) {
 		})
 	}
 }
+
+func TestHookClientConfigForWebhookIncludesTimeout(t *testing.T) {
+	tests := []struct {
+		name     string
+		accessor WebhookAccessor
+		expected *int32
+	}{
+		{
+			name: "mutating",
+			accessor: NewMutatingWebhookAccessor("uid", "config", &v1.MutatingWebhook{
+				TimeoutSeconds: new(int32(3)),
+			}),
+			expected: new(int32(3)),
+		},
+		{
+			name: "validating",
+			accessor: NewValidatingWebhookAccessor("uid", "config", &v1.ValidatingWebhook{
+				TimeoutSeconds: new(int32(4)),
+			}),
+			expected: new(int32(4)),
+		},
+		{
+			name:     "validating - v2",
+			accessor: NewValidatingWebhookAccessor("uid", "config", &v1.ValidatingWebhook{}),
+			expected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			config := hookClientConfigForWebhook(tc.accessor)
+			to := config.TimeoutSeconds
+			if tc.expected == nil {
+				if to != nil {
+					t.Fatalf("expected nil but got timeout seconds %d", *to)
+				}
+			} else {
+				if to == nil || *to != *tc.expected {
+					t.Fatalf("expected timeoutSeconds %d, got %v", *tc.expected, to)
+				}
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
@@ -45,6 +45,9 @@ import (
 
 var directDialer utilnet.DialFunc = http.DefaultTransport.(*http.Transport).DialContext
 
+// defaultDialTimeout matches http.DefaultTransport dial timeout
+const defaultDialTimeout = 30 * time.Second
+
 func init() {
 	client.Metrics.RegisterMetrics(legacyregistry.Registerer())
 }
@@ -110,7 +113,10 @@ func lookupServiceName(name string) (EgressType, error) {
 }
 
 func tunnelHTTPConnect(proxyConn net.Conn, proxyAddress, addr string) (net.Conn, error) {
-	fmt.Fprintf(proxyConn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", addr, "127.0.0.1")
+	if _, err := fmt.Fprintf(proxyConn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", addr, "127.0.0.1"); err != nil {
+		_ = proxyConn.Close()
+		return nil, fmt.Errorf("writing CONNECT to %s via proxy %s failed: %w", addr, proxyAddress, err)
+	}
 
 	// As described in https://go.dev/issue/74633 a misbehaving proxy server
 	// can cause memory exhaustion in the client. The fix in https://go.dev/cl/698915
@@ -121,12 +127,13 @@ func tunnelHTTPConnect(proxyConn net.Conn, proxyAddress, addr string) (net.Conn,
 
 	res, err := http.ReadResponse(br, nil)
 	if err != nil {
-		proxyConn.Close()
+		_ = proxyConn.Close()
 		return nil, fmt.Errorf("reading HTTP response from CONNECT to %s via proxy %s failed: %v",
 			addr, proxyAddress, err)
 	}
 	if res.StatusCode != 200 {
-		proxyConn.Close()
+		_ = proxyConn.Close()
+		_ = res.Body.Close()
 		return nil, fmt.Errorf("proxy error from %s while dialing %s, code %d: %v",
 			proxyAddress, addr, res.StatusCode, res.Status)
 	}
@@ -136,7 +143,8 @@ func tunnelHTTPConnect(proxyConn net.Conn, proxyAddress, addr string) (net.Conn,
 	// TLS, and in TLS the client speaks first, so we know there's
 	// no unbuffered data. But we can double-check.
 	if br.Buffered() > 0 {
-		proxyConn.Close()
+		_ = proxyConn.Close()
+		_ = res.Body.Close()
 		return nil, fmt.Errorf("unexpected %d bytes of buffered data from CONNECT proxy %q",
 			br.Buffered(), proxyAddress)
 	}
@@ -145,6 +153,10 @@ func tunnelHTTPConnect(proxyConn net.Conn, proxyAddress, addr string) (net.Conn,
 
 type proxier interface {
 	// proxy returns a connection to addr.
+	//
+	// The provided Context must be non-nil and is used only while connecting to addr.
+	// If the context expires before the connection is established, an error is returned.
+	// Once successfully connected, expiration of the context will not affect the connection.
 	proxy(ctx context.Context, addr string) (net.Conn, error)
 }
 
@@ -156,17 +168,61 @@ type httpConnectProxier struct {
 }
 
 func (t *httpConnectProxier) proxy(ctx context.Context, addr string) (net.Conn, error) {
-	return tunnelHTTPConnect(t.conn, t.proxyAddress, addr)
+	var (
+		connectDone = make(chan struct{})
+		connectConn net.Conn
+		connectErr  error
+	)
+
+	go func() {
+		connectConn, connectErr = tunnelHTTPConnect(t.conn, t.proxyAddress, addr)
+		close(connectDone)
+	}()
+
+	select {
+	case <-connectDone:
+		return connectConn, connectErr
+
+	case <-ctx.Done():
+		// The CONNECT handshake may have completed concurrently with
+		// cancellation. Prefer the completed result before closing the
+		// connection.
+		select {
+		case <-connectDone:
+			return connectConn, connectErr
+		default:
+		}
+
+		_ = t.conn.Close()
+		return nil, fmt.Errorf("proxy CONNECT to %s failed: %w", addr, context.Cause(ctx))
+	}
 }
 
 var _ proxier = &grpcProxier{}
 
 type grpcProxier struct {
 	tunnel client.Tunnel
+	cancel context.CancelCauseFunc
 }
 
 func (g *grpcProxier) proxy(ctx context.Context, addr string) (net.Conn, error) {
-	return g.tunnel.DialContext(ctx, "tcp", addr)
+	c, err := g.tunnel.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		g.cancel(err)
+		return nil, err
+	}
+	return &grpcConn{Conn: c, cancel: g.cancel}, nil
+}
+
+type grpcConn struct {
+	net.Conn
+	cancel context.CancelCauseFunc
+}
+
+func (g *grpcConn) Close() error {
+	err := g.Conn.Close()
+	g.cancel(err)
+	return err
 }
 
 type proxyServerConnector interface {
@@ -213,31 +269,27 @@ type udsGRPCConnector struct {
 }
 
 // connect establishes a connection to a proxy over gRPC.
-// TODO At the moment, it does not use the provided context.
-func (u *udsGRPCConnector) connect(_ context.Context) (proxier, error) {
+func (u *udsGRPCConnector) connect(connectCtx context.Context) (proxier, error) {
 	udsName := u.udsName
-	dialOption := grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+	dialOption := grpc.WithContextDialer(func(_ context.Context, addr string) (net.Conn, error) {
 		var d net.Dialer
-		c, err := d.DialContext(ctx, "unix", udsName)
+		c, err := d.DialContext(connectCtx, "unix", udsName)
 		if err != nil {
 			klog.Errorf("failed to create connection to uds name %s, error: %v", udsName, err)
 		}
 		return c, err
 	})
 
-	// CreateSingleUseGrpcTunnel() unfortunately couples dial and connection contexts. Because of that,
-	// we cannot use ctx just for dialing and control the connection lifetime separately.
-	// See https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/357.
-	tunnelCtx := context.TODO()
-	tunnel, err := client.CreateSingleUseGrpcTunnel(tunnelCtx, udsName, dialOption,
+	tunnelCtx, cancel := context.WithCancelCause(context.Background())
+	tunnel, err := client.CreateSingleUseGrpcTunnelWithContext(connectCtx, tunnelCtx, udsName, dialOption,
 		grpc.WithBlock(),
 		grpc.WithReturnConnectionError(),
-		grpc.WithTimeout(30*time.Second), // matches http.DefaultTransport dial timeout
 		grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
+		cancel(err)
 		return nil, err
 	}
-	return &grpcProxier{tunnel: tunnel}, nil
+	return &grpcProxier{tunnel: tunnel, cancel: cancel}, nil
 }
 
 type dialerCreator struct {
@@ -256,6 +308,14 @@ func (d *dialerCreator) createDialer() utilnet.DialFunc {
 		return directDialer
 	}
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		if _, ok := ctx.Deadline(); !ok {
+			// Match the http default transport's dial timeout for
+			// callers without a deadline.
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, defaultDialTimeout)
+			defer cancel()
+		}
+
 		ctx, span := tracing.Start(ctx, fmt.Sprintf("Proxy via %s protocol over %s", d.options.protocol, d.options.transport), attribute.String("address", addr))
 		defer span.End(500 * time.Millisecond)
 		start := egressmetrics.Metrics.Clock().Now()

--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector_test.go
@@ -17,15 +17,19 @@ limitations under the License.
 package egressselector
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"google.golang.org/grpc"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
@@ -199,6 +203,12 @@ func (f *fakeProxier) proxy(_ context.Context, _ string) (net.Conn, error) {
 		return nil, fmt.Errorf("fake error")
 	}
 	return nil, nil
+}
+
+type proxyServerConnectorFunc func(context.Context) (proxier, error)
+
+func (f proxyServerConnectorFunc) connect(ctx context.Context) (proxier, error) {
+	return f(ctx)
 }
 
 func TestMetrics(t *testing.T) {
@@ -403,4 +413,283 @@ func TestGetTLSConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHTTPConnectProxierReturnsOnContextDeadline(t *testing.T) {
+	clientConn, proxyConn := net.Pipe()
+	defer func() {
+		_ = clientConn.Close()
+		_ = proxyConn.Close()
+	}()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := (&httpConnectProxier{
+			conn:         clientConn,
+			proxyAddress: "proxy",
+		}).proxy(ctx, "webhook.default.svc:443")
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected CONNECT to fail when proxy does not return 200 OK")
+		}
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected context deadline exceeded, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for HTTP CONNECT proxy to return")
+	}
+}
+
+func TestHTTPConnectProxierReturnsOnContextCancel(t *testing.T) {
+	clientConn, proxyConn := net.Pipe()
+	defer func() {
+		_ = clientConn.Close()
+		_ = proxyConn.Close()
+	}()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	requestReadCh := make(chan error, 1)
+	go func() {
+		req, err := http.ReadRequest(bufio.NewReader(proxyConn))
+		if err == nil {
+			_ = req.Body.Close()
+		}
+		requestReadCh <- err
+	}()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := (&httpConnectProxier{
+			conn:         clientConn,
+			proxyAddress: "proxy",
+		}).proxy(ctx, "webhook.default.svc:443")
+		errCh <- err
+	}()
+
+	select {
+	case err := <-requestReadCh:
+		if err != nil {
+			t.Fatalf("failed to read CONNECT request: %v", err)
+		}
+
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for CONNECT request")
+	}
+
+	select {
+	case <-errCh:
+		t.Fatal("should be blocked in building tunnel")
+	default:
+	}
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context canceled, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for HTTP CONNECT proxy to return")
+	}
+}
+
+func TestDialerCreatorContextDeadline(t *testing.T) {
+	captureDeadline := func(t *testing.T, ctx context.Context) time.Time {
+		t.Helper()
+
+		var deadline time.Time
+		dialer := (&dialerCreator{connector: proxyServerConnectorFunc(func(ctx context.Context) (proxier, error) {
+			deadline, _ = ctx.Deadline()
+			return &fakeProxier{}, nil
+		})}).createDialer()
+
+		if _, err := dialer(ctx, "tcp", "webhook.default.svc:443"); err != nil {
+			t.Fatalf("unexpected dial error: %v", err)
+		}
+		if deadline.IsZero() {
+			t.Fatal("expected dial context to have a deadline")
+		}
+		return deadline
+	}
+
+	t.Run("adds default deadline", func(t *testing.T) {
+		_ = captureDeadline(t, context.Background())
+	})
+
+	t.Run("preserves existing deadline", func(t *testing.T) {
+		want := time.Now().Add(time.Hour)
+		ctx, cancel := context.WithDeadline(context.Background(), want)
+		defer cancel()
+
+		got := captureDeadline(t, ctx)
+		if !got.Equal(want) {
+			t.Fatalf("expected deadline %v, got %v", want, got)
+		}
+	})
+}
+
+type fakeGRPCTunnel struct {
+	dial func(context.Context, string, string) (net.Conn, error)
+}
+
+func (f *fakeGRPCTunnel) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	return f.dial(ctx, network, address)
+}
+
+func (*fakeGRPCTunnel) Done() <-chan struct{} {
+	return nil
+}
+
+func TestGRPCProxierCancelsTunnel(t *testing.T) {
+	t.Run("dial failure", func(t *testing.T) {
+		dialErr := errors.New("dial failed")
+		tunnelCtx, cancel := context.WithCancelCause(context.Background())
+		proxier := &grpcProxier{
+			tunnel: &fakeGRPCTunnel{dial: func(context.Context, string, string) (net.Conn, error) {
+				return nil, dialErr
+			}},
+			cancel: cancel,
+		}
+
+		if _, err := proxier.proxy(t.Context(), "webhook.default.svc:443"); !errors.Is(err, dialErr) {
+			t.Fatalf("expected dial error %v, got %v", dialErr, err)
+		}
+
+		if cause := context.Cause(tunnelCtx); !errors.Is(cause, dialErr) {
+			t.Fatalf("expected tunnel cancellation cause %v, got %v", dialErr, cause)
+		}
+	})
+
+	t.Run("connection close", func(t *testing.T) {
+		clientConn, serverConn := net.Pipe()
+		defer func() {
+			_ = clientConn.Close()
+			_ = serverConn.Close()
+		}()
+
+		tunnelCtx, cancel := context.WithCancelCause(context.Background())
+		proxier := &grpcProxier{
+			tunnel: &fakeGRPCTunnel{dial: func(context.Context, string, string) (net.Conn, error) {
+				return clientConn, nil
+			}},
+			cancel: cancel,
+		}
+
+		conn, err := proxier.proxy(t.Context(), "webhook.default.svc:443")
+		if err != nil {
+			t.Fatalf("unexpected dial error: %v", err)
+		}
+		if err := conn.Close(); err != nil {
+			t.Fatalf("unexpected close error: %v", err)
+		}
+		if cause := context.Cause(tunnelCtx); !errors.Is(cause, context.Canceled) {
+			t.Fatalf("expected tunnel to be canceled when connection closes, got %v", cause)
+		}
+	})
+}
+
+func TestUDSGRPCConnectorTunnelOutlivesConnectContext(t *testing.T) {
+	udsName := filepath.Join(t.TempDir(), "proxy.sock")
+	listener, err := net.Listen("unix", udsName)
+	if err != nil {
+		t.Fatalf("failed to listen on UDS: %v", err)
+	}
+
+	proxyServer := &testGRPCProxyServer{t: t}
+	grpcServer := grpc.NewServer()
+	client.RegisterProxyServiceServer(grpcServer, proxyServer)
+
+	serveErrCh := make(chan error, 1)
+	go func() {
+		serveErrCh <- grpcServer.Serve(listener)
+	}()
+
+	t.Cleanup(func() {
+		grpcServer.Stop()
+		select {
+		case err := <-serveErrCh:
+			if err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+				t.Logf("gRPC proxy server failed: %v", err)
+			}
+		case <-time.After(30 * time.Second):
+			t.Fatal("failed to wait for gRPC proxy server to exit")
+		}
+	})
+
+	canceledCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if _, err := (&udsGRPCConnector{udsName: udsName}).connect(canceledCtx); err == nil {
+		t.Fatal("expected canceled connect context to stop connection setup")
+	}
+
+	connectCtx, cancelConnect := context.WithCancel(t.Context())
+	defer cancelConnect()
+	proxier, err := (&udsGRPCConnector{udsName: udsName}).connect(connectCtx)
+	if err != nil {
+		t.Fatalf("failed to connect to gRPC proxy: %v", err)
+	}
+
+	// tunnel context should be detached from connecting one.
+	cancelConnect()
+
+	dialCtx, cancelDial := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancelDial()
+	conn, err := proxier.proxy(dialCtx, "webhook.default.svc:443")
+	if err != nil {
+		t.Fatalf("tunnel did not survive connect context cancellation: %v", err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("failed to close tunneled connection: %v", err)
+	}
+}
+
+type testGRPCProxyServer struct {
+	t *testing.T
+	client.UnimplementedProxyServiceServer
+}
+
+func (s *testGRPCProxyServer) Proxy(stream client.ProxyService_ProxyServer) error {
+	dialPacket, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+
+	s.t.Logf("received packet: %s", dialPacket.String())
+
+	if dialPacket.Type != client.PacketType_DIAL_REQ {
+		return fmt.Errorf("expected DIAL_REQ, got %v", dialPacket.Type)
+	}
+	if err := stream.Send(&client.Packet{
+		Type: client.PacketType_DIAL_RSP,
+		Payload: &client.Packet_DialResponse{DialResponse: &client.DialResponse{
+			ConnectID: 1,
+			Random:    dialPacket.GetDialRequest().Random,
+		}},
+	}); err != nil {
+		return err
+	}
+
+	closePacket, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+	if closePacket.Type != client.PacketType_CLOSE_REQ {
+		return fmt.Errorf("expected CLOSE_REQ, got %v", closePacket.Type)
+	}
+	return stream.Send(&client.Packet{
+		Type: client.PacketType_CLOSE_RSP,
+		Payload: &client.Packet_CloseResponse{CloseResponse: &client.CloseResponse{
+			ConnectID: closePacket.GetCloseRequest().ConnectID,
+		}},
+	})
 }

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/client.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/client.go
@@ -26,11 +26,13 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/apiserver/pkg/util/x509metrics"
@@ -45,10 +47,11 @@ const (
 
 // ClientConfig defines parameters required for creating a hook client.
 type ClientConfig struct {
-	Name     string
-	URL      string
-	CABundle []byte
-	Service  *ClientConfigService
+	Name           string
+	URL            string
+	CABundle       []byte
+	Service        *ClientConfigService
+	TimeoutSeconds *int32
 }
 
 // ClientConfigService defines service discovery parameters of the webhook.
@@ -166,6 +169,21 @@ func (cm *ClientManager) hookClientConfig(cc ClientConfig) (*rest.Config, error)
 			x509MissingSANCounter,
 			x509InsecureSHA1Counter,
 		))
+
+		if cc.TimeoutSeconds != nil {
+			timeout := time.Duration(*cc.TimeoutSeconds) * time.Second
+			cfg.Timeout = timeout
+
+			// Apply the timeout to the dialer as well because net/http detaches the
+			// request context before dialing, allowing the dial to outlive cfg.Timeout.
+			delegateDialer := dialerForConfig(cfg)
+			cfg.Dial = func(ctx context.Context, network, address string) (net.Conn, error) {
+				ctx, cancel := context.WithTimeout(ctx, timeout)
+				defer cancel()
+
+				return delegateDialer(ctx, network, address)
+			}
+		}
 		return cfg, nil
 	}
 
@@ -198,11 +216,7 @@ func (cm *ClientManager) hookClientConfig(cc ClientConfig) (*rest.Config, error)
 		}
 
 		if !utilfeature.DefaultFeatureGate.Enabled(features.WebhookRoundTripLoadBalancing) {
-			delegateDialer := cfg.Dial
-			if delegateDialer == nil {
-				var d net.Dialer
-				delegateDialer = d.DialContext
-			}
+			delegateDialer := dialerForConfig(cfg)
 			cfg.Dial = func(ctx context.Context, network, addr string) (net.Conn, error) {
 				if addr == host {
 					u, err := cm.serviceResolver.ResolveEndpoint(cc.Service.Namespace, cc.Service.Name, port)
@@ -260,6 +274,14 @@ func (cm *ClientManager) hookClientConfig(cc ClientConfig) (*rest.Config, error)
 	}
 
 	return complete(cfg)
+}
+
+func dialerForConfig(cfg *rest.Config) utilnet.DialFunc {
+	if cfg.Dial != nil {
+		return cfg.Dial
+	}
+	var d net.Dialer
+	return d.DialContext
 }
 
 func isLocalHost(u *url.URL) bool {

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/client_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/client_test.go
@@ -18,19 +18,31 @@ package webhook
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/pem"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"golang.org/x/net/http2"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/apis/apiserver"
 	"k8s.io/apiserver/pkg/features"
+	"k8s.io/apiserver/pkg/server/egressselector"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/rest"
+	certutil "k8s.io/client-go/util/cert"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/component-base/tracing"
+	netutils "k8s.io/utils/net"
 )
 
 func TestWebhookClientConfig(t *testing.T) {
@@ -100,13 +112,16 @@ func allowHTTP2(nextProtos []string) bool {
 	return false
 }
 
-type fakeAuthInfoResolver struct{}
+type fakeAuthInfoResolver struct {
+	dial func(ctx context.Context, network, address string) (net.Conn, error)
+}
 
 func (f *fakeAuthInfoResolver) ClientConfigFor(server string) (*rest.Config, error) {
 	return &rest.Config{
 		TLSClientConfig: rest.TLSClientConfig{
 			ServerName: "example.com",
 		},
+		Dial: f.dial,
 	}, nil
 }
 
@@ -115,7 +130,84 @@ func (f *fakeAuthInfoResolver) ClientConfigForService(serviceName, namespace str
 		TLSClientConfig: rest.TLSClientConfig{
 			ServerName: "example.com",
 		},
+		Dial: f.dial,
 	}, nil
+}
+
+func TestWebhookClientConfigTimeout(t *testing.T) {
+	timeoutSeconds := int32(2)
+	timeout := time.Duration(timeoutSeconds) * time.Second
+
+	authInfoResolver := &fakeAuthInfoResolver{
+		dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				t.Fatal("expected webhook dial context to have a deadline")
+			}
+			remaining := time.Until(deadline)
+			if remaining > timeout {
+				t.Fatalf("expected webhook dial deadline within %v, got %v", timeout, remaining)
+			}
+			return nil, context.Canceled
+		},
+	}
+
+	cm, err := NewClientManager([]schema.GroupVersion{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cm.SetAuthenticationInfoResolver(authInfoResolver)
+	cm.SetServiceResolver(NewDefaultServiceResolver())
+
+	cfg, err := cm.hookClientConfig(ClientConfig{
+		URL:            "https://webhook.example.com",
+		TimeoutSeconds: new(timeoutSeconds),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Timeout != timeout {
+		t.Fatalf("expected webhook client timeout %v, got %v", timeout, cfg.Timeout)
+	}
+	if _, err := cfg.Dial(context.Background(), "tcp", "webhook.example.com:443"); err == nil {
+		t.Fatal("expected delegate dialer to return an error")
+	}
+}
+
+func TestWebhookClientCacheKeyIncludesTimeout(t *testing.T) {
+	cm, err := NewClientManager([]schema.GroupVersion{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cm.SetAuthenticationInfoResolver(&fakeAuthInfoResolver{})
+	cm.SetServiceResolver(NewDefaultServiceResolver())
+
+	timeout1 := int32(1)
+	config := ClientConfig{
+		URL:            "https://webhook.example.com",
+		TimeoutSeconds: new(timeout1),
+	}
+	client1, err := cm.HookClient(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client1Again, err := cm.HookClient(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client1 != client1Again {
+		t.Fatal("expected identical webhook configs to reuse a cached client")
+	}
+
+	timeout2 := int32(2)
+	config.TimeoutSeconds = new(timeout2)
+	client2, err := cm.HookClient(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client1 == client2 {
+		t.Fatal("expected webhook configs with different timeouts to use different clients")
+	}
 }
 
 // fakeDynamicServiceResolver returns the next endpoint in the list for each request.
@@ -250,4 +342,312 @@ func TestWebhookClientIdleConnectionIPReuse(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWebhookClientHTTPConnectTimeout(t *testing.T) {
+	var webhookHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("webhook response"))
+	})
+
+	timeoutSeconds := int32(2)
+	timeout := time.Duration(timeoutSeconds) * time.Second
+	waitCh := make(chan struct{})
+	var wrapperProxyHandler httpHandlerWrapper = func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer close(waitCh)
+
+			t.Logf("HTTP CONNECT proxy received request: %s %s", r.Method, r.URL)
+			t.Log("Waiting for client cancellation...")
+
+			select {
+			case <-r.Context().Done():
+				t.Logf("HTTP CONNECT proxy received client cancellation signal: %v", r.Context().Err())
+			case <-time.After(timeout * 5):
+				t.Fatal("proxy handler did not receive client cancellation after timeout")
+			}
+		})
+	}
+
+	proxy := newWebhookBasedonHTTPConnectProxy(t, webhookHandler, wrapperProxyHandler)
+	es := newHTTPConnectEgressSelector(t, proxy.url, proxy.tlsConfig)
+
+	cm, err := NewClientManager([]schema.GroupVersion{})
+	if err != nil {
+		t.Fatalf("failed to create webhook client manager: %v", err)
+	}
+	cm.SetAuthenticationInfoResolver(&fakeAuthInfoResolver{})
+	cm.SetServiceResolver(NewDefaultServiceResolver())
+	cm.SetAuthenticationInfoResolverWrapper(NewDefaultAuthenticationInfoResolverWrapper(
+		nil,
+		es,
+		&rest.Config{},
+		tracing.NewNoopTracerProvider(),
+	))
+
+	client, err := cm.HookClient(ClientConfig{
+		Name:           "test-webhook",
+		CABundle:       proxy.caBundle,
+		TimeoutSeconds: &timeoutSeconds,
+		Service: &ClientConfigService{
+			Name:      "webhook",
+			Namespace: "default",
+			Path:      "/mutate",
+			Port:      443,
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create webhook REST client: %v", err)
+	}
+
+	_, err = client.Post().Body([]byte("{}")).DoRaw(context.Background())
+	if err == nil {
+		t.Fatalf("expected webhook request through HTTP CONNECT proxy to timeout, but it succeeded")
+	}
+	select {
+	case <-waitCh: // wait for the proxy handler to finish
+	case <-time.After(30 * time.Second):
+		t.Fatal("proxy handler should exit in time")
+	}
+}
+
+func TestWebhookClientHTTPConnect(t *testing.T) {
+	timeoutSeconds := int32(5)
+
+	var webhookCalls int32
+	var webhookHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&webhookCalls, 1)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("webhook response"))
+	})
+
+	var connectCalls int32
+	var wrapperProxyHandler httpHandlerWrapper = func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&connectCalls, 1)
+			h.ServeHTTP(w, r)
+		})
+	}
+
+	proxy := newWebhookBasedonHTTPConnectProxy(t, webhookHandler, wrapperProxyHandler)
+	es := newHTTPConnectEgressSelector(t, proxy.url, proxy.tlsConfig)
+
+	cm, err := NewClientManager([]schema.GroupVersion{})
+	if err != nil {
+		t.Fatalf("failed to create webhook client manager: %v", err)
+	}
+	cm.SetAuthenticationInfoResolver(&fakeAuthInfoResolver{})
+	cm.SetServiceResolver(NewDefaultServiceResolver())
+	cm.SetAuthenticationInfoResolverWrapper(NewDefaultAuthenticationInfoResolverWrapper(
+		nil,
+		es,
+		&rest.Config{},
+		tracing.NewNoopTracerProvider(),
+	))
+
+	client, err := cm.HookClient(ClientConfig{
+		Name:           "test-webhook",
+		CABundle:       proxy.caBundle,
+		TimeoutSeconds: &timeoutSeconds,
+		Service: &ClientConfigService{
+			Name:      "webhook",
+			Namespace: "default",
+			Path:      "/mutate",
+			Port:      443,
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create webhook REST client: %v", err)
+	}
+
+	n := 4
+	for i := range n {
+		_, err := client.Post().Body([]byte("{}")).DoRaw(context.Background())
+		if err != nil {
+			t.Fatalf("webhook request %d through HTTP CONNECT proxy failed: %v", i+1, err)
+		}
+	}
+
+	if calls := atomic.LoadInt32(&webhookCalls); calls != int32(n) {
+		t.Fatalf("expected webhook backend to receive %d requests, got %d", n, calls)
+	}
+	if calls := atomic.LoadInt32(&connectCalls); calls != int32(1) {
+		t.Fatalf("expected HTTP CONNECT proxy to receive 1 CONNECT request, got %d", calls)
+	}
+}
+
+type httpConnectProxy struct {
+	url       string
+	tlsConfig *apiserver.TLSConfig
+	caBundle  []byte
+}
+
+type httpHandlerWrapper func(http.Handler) http.Handler
+
+// newWebhookBasedonHTTPConnectProxy returns a new HTTP CONNECT proxy that
+// forwards requests to the given webhookHandler.
+func newWebhookBasedonHTTPConnectProxy(t *testing.T, webhookHandler http.Handler, wrapperProxyHandler httpHandlerWrapper) httpConnectProxy {
+	t.Helper()
+
+	certPEM, keyPEM, err := certutil.GenerateSelfSignedCertKey(
+		"example.com",
+		[]net.IP{netutils.ParseIPSloppy("127.0.0.1")},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("failed to generate proxy serving certificate: %v", err)
+	}
+
+	tempDir := t.TempDir()
+
+	certPath := filepath.Join(tempDir, "proxy.crt")
+	if err := os.WriteFile(certPath, certPEM, 0600); err != nil {
+		t.Fatalf("failed to write proxy cert file: %v", err)
+	}
+
+	keyPath := filepath.Join(tempDir, "proxy.key")
+	if err := os.WriteFile(keyPath, keyPEM, 0600); err != nil {
+		t.Fatalf("failed to write proxy key file: %v", err)
+	}
+
+	proxyCert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("failed to load proxy serving certificate: %v", err)
+	}
+
+	backendListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen on webhook backend address: %v", err)
+	}
+	backendServer := &http.Server{Handler: webhookHandler}
+	go func() {
+		tlsListener := tls.NewListener(backendListener, &tls.Config{
+			Certificates: []tls.Certificate{proxyCert},
+		})
+		_ = backendServer.Serve(tlsListener)
+	}()
+
+	proxyListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen on proxy address: %v", err)
+	}
+
+	handler := newHTTPConnectProxyHandler(t, backendListener.Addr().String())
+	if wrapperProxyHandler != nil {
+		handler = wrapperProxyHandler(handler)
+	}
+
+	proxyServer := &http.Server{Handler: handler}
+	go func() {
+		tlsListener := tls.NewListener(proxyListener, &tls.Config{
+			Certificates: []tls.Certificate{proxyCert},
+		})
+		_ = proxyServer.Serve(tlsListener)
+	}()
+
+	t.Cleanup(func() {
+		_ = proxyServer.Close()
+		_ = backendServer.Close()
+	})
+
+	return httpConnectProxy{
+		url: "https://" + proxyListener.Addr().String(),
+		tlsConfig: &apiserver.TLSConfig{
+			CABundle:   certPath,
+			ClientCert: certPath,
+			ClientKey:  keyPath,
+		},
+		caBundle: certPEM,
+	}
+}
+
+// newHTTPConnectProxyHandler returns an HTTP handler that implements a simple
+// HTTP CONNECT proxy.
+func newHTTPConnectProxyHandler(t *testing.T, backendAddress string) http.Handler {
+	t.Helper()
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodConnect {
+			http.Error(w, "CONNECT required", http.StatusMethodNotAllowed)
+			return
+		}
+
+		backendConn, err := net.Dial("tcp", backendAddress)
+		if err != nil {
+			http.Error(w, "failed to connect webhook backend", http.StatusBadGateway)
+			return
+		}
+		defer func() {
+			_ = backendConn.Close()
+		}()
+
+		hijacker, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "response writer does not support hijacking", http.StatusInternalServerError)
+			return
+		}
+
+		clientConn, _, err := hijacker.Hijack()
+		if err != nil {
+			t.Logf("failed to hijack HTTP CONNECT client connection: %v", err)
+			return
+		}
+		defer func() {
+			_ = clientConn.Close()
+		}()
+
+		if _, err := clientConn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n")); err != nil {
+			t.Logf("failed to write HTTP CONNECT 200 response: %v", err)
+			return
+		}
+
+		proxyConnections(clientConn, backendConn)
+	})
+}
+
+func proxyConnections(clientConn, backendConn net.Conn) {
+	var wg sync.WaitGroup
+	var closeOnce sync.Once
+
+	closeConns := func() {
+		_ = clientConn.Close()
+		_ = backendConn.Close()
+	}
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(clientConn, backendConn)
+		closeOnce.Do(closeConns)
+	}()
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(backendConn, clientConn)
+		closeOnce.Do(closeConns)
+	}()
+	wg.Wait()
+}
+
+func newHTTPConnectEgressSelector(t *testing.T, proxyURL string, proxyTLSConfig *apiserver.TLSConfig) *egressselector.EgressSelector {
+	es, err := egressselector.NewEgressSelector(&apiserver.EgressSelectorConfiguration{
+		EgressSelections: []apiserver.EgressSelection{
+			{
+				Name: "cluster",
+				Connection: apiserver.Connection{
+					ProxyProtocol: apiserver.ProtocolHTTPConnect,
+					Transport: &apiserver.Transport{
+						TCP: &apiserver.TCPTransport{
+							URL:       proxyURL,
+							TLSConfig: proxyTLSConfig,
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create egress selector: %v", err)
+	}
+	return es
 }

--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -1467,8 +1467,8 @@ func testWebhook(ctx context.Context, f *framework.Framework) {
 		framework.Failf("expect error %q, got %q", "webhook", err.Error())
 	}
 	// ensure the error is a timeout
-	if !strings.Contains(err.Error(), "deadline") {
-		framework.Failf("expect error %q, got %q", "deadline", err.Error())
+	if !strings.Contains(err.Error(), "deadline") && !strings.Contains(err.Error(), "Client.Timeout exceeded") {
+		framework.Failf("expect a deadline or client timeout error, got %q", err.Error())
 	}
 	// ensure the pod was not actually created
 	if _, err := client.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{}); !apierrors.IsNotFound(err) {

--- a/test/integration/apiserver/egressselector/webhook_timeout_test.go
+++ b/test/integration/apiserver/egressselector/webhook_timeout_test.go
@@ -1,0 +1,233 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package egressselector
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	kubeapiserverapptesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/test/integration/framework"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	webhookName           = "timeout.egress-selector.integration.test"
+	webhookNamespace      = "egress-selector-webhook-timeout"
+	webhookServiceName    = "egress-selector-webhook"
+	webhookLabel          = "egress-selector-webhook-timeout"
+	webhookTimeoutSeconds = 5
+)
+
+// TestWebhookDialTimeout verifies that a webhook call routed through an HTTP
+// CONNECT egress proxy is bounded by the webhook's TimeoutSeconds. The proxy
+// used here never answers the CONNECT request, so the webhook call must time out
+// and the apiserver must close its connection to the proxy instead of leaking it.
+func TestWebhookDialTimeout(t *testing.T) {
+	udsName, connectRequestDone := runStallingHTTPConnectProxy(t)
+
+	server := kubeapiserverapptesting.StartTestServerOrDie(
+		t,
+		kubeapiserverapptesting.NewDefaultTestServerOptions(),
+		[]string{fmt.Sprintf("--egress-selector-config-file=%s", writeEgressSelectorConfig(t, udsName))},
+		framework.SharedEtcd(),
+	)
+	t.Cleanup(server.TearDownFn)
+
+	client, err := kubernetes.NewForConfig(server.ClientConfig)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	registerStallingWebhook(t, client)
+
+	waitForWebhookTimeout(t, client)
+
+	select {
+	case <-connectRequestDone:
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatal("HTTP CONNECT request context was not canceled after the webhook timeout")
+	}
+}
+
+// writeEgressSelectorConfig writes an egress selector configuration that
+// routes all cluster traffic (which includes webhook calls) through an HTTP
+// CONNECT proxy listening on the given unix domain socket, and returns the
+// config file path.
+func writeEgressSelectorConfig(t *testing.T, udsName string) string {
+	t.Helper()
+
+	config := fmt.Sprintf(`
+apiVersion: apiserver.k8s.io/v1beta1
+kind: EgressSelectorConfiguration
+egressSelections:
+- name: cluster
+  connection:
+    proxyProtocol: HTTPConnect
+    transport:
+      uds:
+        udsName: %s
+`, udsName)
+
+	path := filepath.Join(t.TempDir(), "egress-selector.yaml")
+	if err := os.WriteFile(path, []byte(config), 0644); err != nil {
+		t.Fatalf("failed to write egress selector config: %v", err)
+	}
+	return path
+}
+
+// registerStallingWebhook creates a validating webhook scoped to a dedicated
+// namespace and backed by a service reachable through the egress proxy.
+func registerStallingWebhook(t *testing.T, client kubernetes.Interface) {
+	t.Helper()
+
+	if _, err := client.CoreV1().Namespaces().Create(t.Context(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: webhookNamespace},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create webhook namespace: %v", err)
+	}
+
+	if _, err := client.CoreV1().Services(webhookNamespace).Create(t.Context(), &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: webhookServiceName},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{Port: 443}},
+		},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create webhook service: %v", err)
+	}
+
+	if _, err := client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(
+		t.Context(),
+		&admissionregistrationv1.ValidatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: webhookLabel},
+			Webhooks: []admissionregistrationv1.ValidatingWebhook{{
+				Name: webhookName,
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					Service: &admissionregistrationv1.ServiceReference{
+						Namespace: webhookNamespace,
+						Name:      webhookServiceName,
+						Path:      new("/validate"),
+						Port:      ptr.To[int32](443),
+					},
+				},
+				Rules: []admissionregistrationv1.RuleWithOperations{{
+					Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+					Rule: admissionregistrationv1.Rule{
+						APIGroups:   []string{""},
+						APIVersions: []string{"v1"},
+						Resources:   []string{"configmaps"},
+					},
+				}},
+				FailurePolicy:  ptr.To(admissionregistrationv1.Fail),
+				SideEffects:    ptr.To(admissionregistrationv1.SideEffectClassNone),
+				TimeoutSeconds: ptr.To[int32](webhookTimeoutSeconds),
+				NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+					corev1.LabelMetadataName: webhookNamespace,
+				}},
+				AdmissionReviewVersions: []string{"v1"},
+			}},
+		},
+		metav1.CreateOptions{},
+	); err != nil {
+		t.Fatalf("failed to create validating webhook configuration: %v", err)
+	}
+}
+
+// waitForWebhookTimeout creates ConfigMaps until the webhook configuration
+// becomes active and rejects one with a timeout error.
+func waitForWebhookTimeout(t *testing.T, client kubernetes.Interface) {
+	t.Helper()
+
+	var lastErr error
+	err := wait.PollUntilContextTimeout(t.Context(), 100*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+		_, lastErr = client.CoreV1().ConfigMaps(webhookNamespace).Create(ctx, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: webhookLabel + "-",
+			},
+		}, metav1.CreateOptions{})
+		if lastErr == nil {
+			return false, nil
+		}
+		if !strings.Contains(lastErr.Error(), webhookName) {
+			return false, lastErr
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("failed waiting for the webhook to reject a ConfigMap (last error: %v): %v", lastErr, err)
+	}
+	webhookURL := fmt.Sprintf("https://%s.%s.svc:443/validate?timeout=%ds", webhookServiceName, webhookNamespace, webhookTimeoutSeconds)
+	gotErr := lastErr.Error()
+	if strings.Contains(gotErr, webhookURL) &&
+		(strings.HasSuffix(gotErr, context.DeadlineExceeded.Error()) ||
+			strings.HasSuffix(gotErr, "(Client.Timeout exceeded while awaiting headers)")) {
+		return
+	}
+	t.Fatalf("unexpected webhook timeout error: %q", gotErr)
+}
+
+// runStallingHTTPConnectProxy starts an HTTP CONNECT proxy on a unix domain
+// socket that never answers CONNECT requests. It returns the socket path and
+// a channel that receives an event whenever a stalled CONNECT request is
+// canceled.
+func runStallingHTTPConnectProxy(t *testing.T) (string, <-chan struct{}) {
+	t.Helper()
+
+	udsName := filepath.Join(t.TempDir(), "proxy.sock")
+	listener, err := net.Listen("unix", udsName)
+	if err != nil {
+		t.Fatalf("failed to listen on UDS: %v", err)
+	}
+
+	connectRequestDone := make(chan struct{}, 16)
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodConnect {
+			http.Error(w, "CONNECT required", http.StatusMethodNotAllowed)
+			return
+		}
+		<-r.Context().Done()
+		t.Logf("HTTP CONNECT request canceled: %v", r.Context().Err())
+		connectRequestDone <- struct{}{}
+	})}
+	serveErrCh := make(chan error, 1)
+	go func() {
+		serveErrCh <- server.Serve(listener)
+	}()
+
+	t.Cleanup(func() {
+		if err := server.Close(); err != nil {
+			t.Logf("failed to close HTTP CONNECT proxy: %v", err)
+		}
+		if err := <-serveErrCh; err != nil && !errors.Is(err, http.ErrServerClosed) {
+			t.Logf("HTTP CONNECT proxy failed: %v", err)
+		}
+	})
+
+	return udsName, connectRequestDone
+}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Current http tunnel dial function could not be canceled when webhook request has been canceled. So, if the downtream is experiencing CPU saturation or networking issue, http tunnel will be stuck in dialing.

```plain
incoming API request
  -> kube-apiserver admission chain
    -> mutating/validating webhook HTTP client
      -> egress selector / HTTP CONNECT proxy
        -> konnectivity server/agent path
          -> webhook service/pod
```

For example, we have 1 second timeout for gatekeeper mutating webhook. But we got this log in kube-apiserver. Both the kube-apiserver and proxy server will maintain a lot of `established` connections until tunnel is ready.

```plain
Proxy via http_connect protocol over tcp" address:172.20.7.121:8443 20308ms...
```

To fix this, we can wrap the dialer and apply the webhook timeout to it.

Manually benchmarking result:

* Env: 
   * Only one kube-apiserver + proxy + konnectivity-server.
      * They're running in the same node (v16cores)
      * There is stress process to consume 90% CPU resources
   * Gatekeeper webhook
      * One mutating webhook for all resources update and timeout in 1 second
      * One validating webhook for all resources update and timeout in 3 seconds
   * Only one konnectivity-agent and it's limited in 0.02 vcores (simulating slow tunnel)

* Traffic
  * Max rate 50 req/s to update resources

* Before this patch: proxy will have 10,000+ connections after 5 minutes
* With this patch: proxy will maintain around 400 connections

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

There are several places using egressselector's dial function:

* https://github.com/kubernetes/kubernetes/blob/473f341c9ede5a7ce51c4915cd21460e070af3aa/pkg/kubelet/client/kubelet_client.go#L90
* https://github.com/kubernetes/kubernetes/blob/473f341c9ede5a7ce51c4915cd21460e070af3aa/cmd/kube-apiserver/app/server.go#L269
* https://github.com/kubernetes/kubernetes/blob/473f341c9ede5a7ce51c4915cd21460e070af3aa/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go#L239

This patch is only working for webhook datapath. If it's acceptable, I can make changes for rest of places.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
