### PR TITLE
Make SelectionPredicate.Empty aware of sharding

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/continue_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/continue_test.go
@@ -21,6 +21,16 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/sharding"
+	"k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/utils/ptr"
 )
 
 func encodeContinueOrDie(apiVersion string, resourceVersion int64, nextKey string) string {
@@ -108,6 +118,69 @@ func Test_decodeContinue(t *testing.T) {
 			}
 			if gotRv != tt.wantRv {
 				t.Errorf("decodeContinue() gotRv = %v, want %v", gotRv, tt.wantRv)
+			}
+		})
+	}
+}
+
+func TestPrepareContinueTokenRemainingItemCount(t *testing.T) {
+	tests := []struct {
+		name                      string
+		enableShardedListAndWatch bool
+		label                     labels.Selector
+		field                     fields.Selector
+		shardSelector             sharding.Selector
+		wantRemaining             *int64
+	}{
+		{
+			name:          "empty predicate reports remaining count",
+			label:         labels.Everything(),
+			field:         fields.Everything(),
+			wantRemaining: ptr.To[int64](3),
+		},
+		{
+			name:          "label selector omits remaining count",
+			label:         labels.SelectorFromSet(labels.Set{"name": "foo"}),
+			field:         fields.Everything(),
+			wantRemaining: nil,
+		},
+		{
+			name:                      "shard selector omits remaining count when ShardedListAndWatch enabled",
+			enableShardedListAndWatch: true,
+			label:                     labels.Everything(),
+			field:                     fields.Everything(),
+			shardSelector:             shardSelectorMatchingEverything(),
+			wantRemaining:             nil,
+		},
+		{
+			name:                      "shard selector reports remaining count when ShardedListAndWatch disabled",
+			enableShardedListAndWatch: false,
+			label:                     labels.Everything(),
+			field:                     fields.Everything(),
+			shardSelector:             shardSelectorMatchingEverything(),
+			wantRemaining:             ptr.To[int64](3),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ShardedListAndWatch, tt.enableShardedListAndWatch)
+			opts := ListOptions{
+				Predicate: SelectionPredicate{
+					Label:         tt.label,
+					Field:         tt.field,
+					ShardSelector: tt.shardSelector,
+					Limit:         2,
+				},
+			}
+			continueValue, remaining, err := PrepareContinueToken("/test/pod-2", "/test/", 12345, 5, true, opts)
+			if err != nil {
+				t.Fatalf("PrepareContinueToken() returned unexpected error: %v", err)
+			}
+			if len(continueValue) == 0 {
+				t.Error("PrepareContinueToken() returned empty continue token")
+			}
+			if diff := cmp.Diff(tt.wantRemaining, remaining); diff != "" {
+				t.Errorf("PrepareContinueToken() unexpected remainingItemCount (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -35,6 +35,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/sharding"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/apis/example"
 	"k8s.io/apiserver/pkg/features"
@@ -627,4 +630,98 @@ func initStoreData(ctx context.Context, store storage.Interface) ([]interface{},
 		created = append(created, item.key)
 	}
 	return created, nil
+}
+
+func TestWatchWithShardSelector(t *testing.T) {
+	// The shard [boundary, 2^64) contains exactly the higher of the two UID hashes.
+	uidA, uidB := "uid-a", "uid-b"
+	hashA, hashB := "0x"+sharding.HashField(uidA), "0x"+sharding.HashField(uidB)
+	inShardUID, outOfShardUID, boundary := uidA, uidB, hashA
+	if sharding.HexLess(hashA, hashB) {
+		inShardUID, outOfShardUID, boundary = uidB, uidA, hashB
+	}
+	shardSelector := sharding.NewSelector(sharding.ShardRangeRequirement{
+		Key:   "object.metadata.uid",
+		Start: boundary,
+		End:   "0x10000000000000000",
+	})
+
+	newPod := func(name, uid string) *example.Pod {
+		return &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "test-ns", UID: types.UID(uid)}}
+	}
+	expectAddedEvent := func(t *testing.T, w watch.Interface, name string) {
+		t.Helper()
+		select {
+		case event := <-w.ResultChan():
+			if event.Type != watch.Added {
+				t.Fatalf("expected %s event, got %s", watch.Added, event.Type)
+			}
+			pod, ok := event.Object.(*example.Pod)
+			if !ok {
+				t.Fatalf("expected *example.Pod, got %T", event.Object)
+			}
+			if pod.Name != name {
+				t.Fatalf("expected event for pod %q, got %q", name, pod.Name)
+			}
+		case <-time.After(wait.ForeverTestTimeout):
+			t.Fatalf("timed out waiting for event for pod %q", name)
+		}
+	}
+
+	testCases := []struct {
+		name                  string
+		gateEnabled           bool
+		expectOutOfShardEvent bool
+	}{
+		{
+			name:                  "gate enabled filters out-of-shard events",
+			gateEnabled:           true,
+			expectOutOfShardEvent: false,
+		},
+		{
+			name:                  "gate disabled ignores the shard selector",
+			gateEnabled:           false,
+			expectOutOfShardEvent: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ShardedListAndWatch, tc.gateEnabled)
+			ctx, store, _ := testSetup(t)
+
+			marker := &example.Pod{}
+			if err := store.Create(ctx, "/pods/test-ns/marker", newPod("marker", "uid-marker"), marker, 0); err != nil {
+				t.Fatalf("Create marker failed: %v", err)
+			}
+
+			w, err := store.Watch(ctx, "/pods", storage.ListOptions{
+				ResourceVersion: marker.ResourceVersion,
+				Recursive:       true,
+				Predicate: storage.SelectionPredicate{
+					Label:         labels.Everything(),
+					Field:         fields.Everything(),
+					GetAttrs:      storage.DefaultNamespaceScopedAttr,
+					ShardSelector: shardSelector,
+				},
+			})
+			if err != nil {
+				t.Fatalf("Watch failed: %v", err)
+			}
+			defer w.Stop()
+
+			// pod-out is created first so that receiving pod-in's event first
+			// proves pod-out's event was filtered rather than still in flight.
+			if err := store.Create(ctx, "/pods/test-ns/pod-out", newPod("pod-out", outOfShardUID), &example.Pod{}, 0); err != nil {
+				t.Fatalf("Create pod-out failed: %v", err)
+			}
+			if err := store.Create(ctx, "/pods/test-ns/pod-in", newPod("pod-in", inShardUID), &example.Pod{}, 0); err != nil {
+				t.Fatalf("Create pod-in failed: %v", err)
+			}
+
+			if tc.expectOutOfShardEvent {
+				expectAddedEvent(t, w, "pod-out")
+			}
+			expectAddedEvent(t, w, "pod-in")
+		})
+	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/selection_predicate.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/selection_predicate.go
@@ -99,7 +99,7 @@ func (s *SelectionPredicate) Matches(obj runtime.Object) (bool, error) {
 			return matched, err
 		}
 	}
-	if s.Empty() {
+	if s.labelFieldEmpty() {
 		return true, nil
 	}
 	labels, fields, err := s.GetAttrs(obj)
@@ -153,7 +153,17 @@ func (s *SelectionPredicate) MatchesSingle() (string, bool) {
 
 // Empty returns true if the predicate performs no filtering.
 func (s *SelectionPredicate) Empty() bool {
-	return s.Label.Empty() && s.Field.Empty()
+	// Check the selector before the feature gate: Empty is called per event on
+	// watch paths, and the nil check is free while the gate lookup is not.
+	if s.ShardSelector != nil && !s.ShardSelector.Empty() &&
+		utilfeature.DefaultFeatureGate.Enabled(features.ShardedListAndWatch) {
+		return false
+	}
+	return s.labelFieldEmpty()
+}
+
+func (s *SelectionPredicate) labelFieldEmpty() bool {
+	return (s.Label == nil || s.Label.Empty()) && (s.Field == nil || s.Field.Empty())
 }
 
 // For any index defined by IndexFields, if a matcher can match only (a subset)

--- a/staging/src/k8s.io/apiserver/pkg/storage/selection_predicate_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/selection_predicate_test.go
@@ -22,11 +22,17 @@ import (
 	"reflect"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/sharding"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 )
 
 type Ignored struct {
@@ -120,6 +126,157 @@ func TestSelectionPredicate(t *testing.T) {
 				t.Errorf("%v: expected %v, got %v", name, e, a)
 			}
 		}
+	}
+}
+
+// shardSelectorMatchingEverything matches all objects but, unlike
+// sharding.Everything(), is not Empty().
+func shardSelectorMatchingEverything() sharding.Selector {
+	return sharding.NewSelector(sharding.ShardRangeRequirement{
+		Key:   "object.metadata.uid",
+		Start: "0x0000000000000000",
+		End:   "0x10000000000000000",
+	})
+}
+
+func shardSelectorExcludingUID(uid string) sharding.Selector {
+	return sharding.NewSelector(sharding.ShardRangeRequirement{
+		Key:   "object.metadata.uid",
+		Start: "0x0000000000000000",
+		End:   "0x" + sharding.HashField(uid),
+	})
+}
+
+func TestSelectionPredicateEmpty(t *testing.T) {
+	mustParseLabel := func(s string) labels.Selector {
+		parsed, err := labels.Parse(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return parsed
+	}
+	testCases := map[string]struct {
+		enableShardedListAndWatch bool
+		label                     labels.Selector
+		field                     fields.Selector
+		shardSelector             sharding.Selector
+		expectEmpty               bool
+	}{
+		"no selectors, gate off": {
+			enableShardedListAndWatch: false,
+			label:                     labels.Everything(),
+			field:                     fields.Everything(),
+			expectEmpty:               true,
+		},
+		"nil selectors, gate off": {
+			enableShardedListAndWatch: false,
+			expectEmpty:               true,
+		},
+		"nil selectors, gate on": {
+			enableShardedListAndWatch: true,
+			expectEmpty:               true,
+		},
+		"no selectors, gate on": {
+			enableShardedListAndWatch: true,
+			label:                     labels.Everything(),
+			field:                     fields.Everything(),
+			expectEmpty:               true,
+		},
+		"empty shard selector, gate on": {
+			enableShardedListAndWatch: true,
+			label:                     labels.Everything(),
+			field:                     fields.Everything(),
+			shardSelector:             sharding.Everything(),
+			expectEmpty:               true,
+		},
+		"non-empty shard selector, gate on": {
+			enableShardedListAndWatch: true,
+			label:                     labels.Everything(),
+			field:                     fields.Everything(),
+			shardSelector:             shardSelectorMatchingEverything(),
+			expectEmpty:               false,
+		},
+		"non-empty shard selector, gate off": {
+			enableShardedListAndWatch: false,
+			label:                     labels.Everything(),
+			field:                     fields.Everything(),
+			shardSelector:             shardSelectorMatchingEverything(),
+			expectEmpty:               true,
+		},
+		"label selector, gate on": {
+			enableShardedListAndWatch: true,
+			label:                     mustParseLabel("name=foo"),
+			field:                     fields.Everything(),
+			expectEmpty:               false,
+		},
+		"field selector, gate off": {
+			enableShardedListAndWatch: false,
+			label:                     labels.Everything(),
+			field:                     fields.OneTermEqualSelector("metadata.name", "foo"),
+			expectEmpty:               false,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ShardedListAndWatch, tc.enableShardedListAndWatch)
+			sp := &SelectionPredicate{
+				Label:         tc.label,
+				Field:         tc.field,
+				ShardSelector: tc.shardSelector,
+			}
+			if got := sp.Empty(); got != tc.expectEmpty {
+				t.Errorf("Empty() = %v, want %v", got, tc.expectEmpty)
+			}
+		})
+	}
+}
+
+func TestSelectionPredicateMatchesShardOnly(t *testing.T) {
+	uid := "shard-only-uid"
+	obj := &metav1.PartialObjectMetadata{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID(uid)},
+	}
+	testCases := map[string]struct {
+		enableShardedListAndWatch bool
+		shardSelector             sharding.Selector
+		expectMatch               bool
+	}{
+		"in shard, gate on": {
+			enableShardedListAndWatch: true,
+			shardSelector:             shardSelectorMatchingEverything(),
+			expectMatch:               true,
+		},
+		"out of shard, gate on": {
+			enableShardedListAndWatch: true,
+			shardSelector:             shardSelectorExcludingUID(uid),
+			expectMatch:               false,
+		},
+		"out of shard, gate off": {
+			enableShardedListAndWatch: false,
+			shardSelector:             shardSelectorExcludingUID(uid),
+			expectMatch:               true,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ShardedListAndWatch, tc.enableShardedListAndWatch)
+			sp := &SelectionPredicate{
+				Label:         labels.Everything(),
+				Field:         fields.Everything(),
+				ShardSelector: tc.shardSelector,
+				GetAttrs: func(runtime.Object) (labels.Set, fields.Set, error) {
+					t.Error("GetAttrs must not be called for empty label/field selectors")
+					return nil, nil, errors.New("GetAttrs must not be called")
+				},
+			}
+			match, err := sp.Matches(obj)
+			if err != nil {
+				t.Fatalf("Matches() returned unexpected error: %v", err)
+			}
+			if match != tc.expectMatch {
+				t.Errorf("Matches() = %v, want %v", match, tc.expectMatch)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes https://github.com/kubernetes/kubernetes/issues/140510

This fixes `SelectionPredicate.Empty()` to accurately report a selector matches everything.

This fixes a few issues in ShardedListAndWatch: 

- etcd3-served watches with shard-only predicates skipped shard filtering entirely
- truncated sharded lists reported an inaccurate remainingItemCount

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fixed two bugs in the alpha ShardedListAndWatch feature: shard selectors are now applied to watch requests served directly from etcd, and paginated list responses filtered by a shard selector no longer report an inaccurate `remainingItemCount`.
```
