### PR TITLE
kube-scheduler: redact extender TLS key data from the component config log

### DIFF
--- a/cmd/kube-scheduler/app/options/configfile.go
+++ b/cmd/kube-scheduler/app/options/configfile.go
@@ -18,6 +18,7 @@ package options
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"os"
@@ -28,6 +29,10 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/scheme"
 	configv1 "k8s.io/kubernetes/pkg/scheduler/apis/config/v1"
 )
+
+// redactedBytes serializes to the literal string "REDACTED" when encoded as
+// base64 in YAML or JSON output.
+var redactedBytes, _ = base64.StdEncoding.DecodeString("REDACTED")
 
 // LoadConfigFromFile loads scheduler config from the specified file path
 func LoadConfigFromFile(logger klog.Logger, file string) (*config.KubeSchedulerConfiguration, error) {
@@ -85,16 +90,19 @@ func LogOrWriteConfig(logger klog.Logger, fileName string, cfg *config.KubeSched
 	}
 	cfg.Profiles = completedProfiles
 
-	buf, err := encodeConfig(cfg)
-	if err != nil {
-		return err
-	}
-
 	if loggerV.Enabled() {
+		buf, err := encodeConfig(redactSecrets(cfg))
+		if err != nil {
+			return err
+		}
 		loggerV.Info("Using component config", "config", buf.String())
 	}
 
 	if len(fileName) > 0 {
+		buf, err := encodeConfig(cfg)
+		if err != nil {
+			return err
+		}
 		configFile, err := os.Create(fileName)
 		if err != nil {
 			return err
@@ -107,4 +115,19 @@ func LogOrWriteConfig(logger klog.Logger, fileName string, cfg *config.KubeSched
 		os.Exit(0)
 	}
 	return nil
+}
+
+// redactSecrets returns a copy of cfg with inline extender TLS key material
+// replaced by a placeholder, so that the config can be logged without
+// disclosing secrets. The datapolicy tag on KeyData cannot take effect here
+// because the whole config is flattened into a single string before it
+// reaches the logger.
+func redactSecrets(cfg *config.KubeSchedulerConfiguration) *config.KubeSchedulerConfiguration {
+	redacted := cfg.DeepCopy()
+	for i := range redacted.Extenders {
+		if tlsConfig := redacted.Extenders[i].TLSConfig; tlsConfig != nil && len(tlsConfig.KeyData) > 0 {
+			tlsConfig.KeyData = redactedBytes
+		}
+	}
+	return redacted
 }

--- a/cmd/kube-scheduler/app/options/configfile_test.go
+++ b/cmd/kube-scheduler/app/options/configfile_test.go
@@ -17,17 +17,23 @@ limitations under the License.
 package options
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
+	configv1 "k8s.io/kubernetes/pkg/scheduler/apis/config/v1"
 )
 
 const (
@@ -133,5 +139,33 @@ func TestLoadConfigFromFile(t *testing.T) {
 			}
 		})
 
+	}
+}
+
+func TestLogOrWriteConfigRedactsExtenderKeyData(t *testing.T) {
+	logger := ktesting.NewLogger(t, ktesting.NewConfig(ktesting.Verbosity(2), ktesting.BufferLogs(true)))
+	keyData := []byte("-----BEGIN PRIVATE KEY-----\nsecret-bytes\n-----END PRIVATE KEY-----")
+	cfg := &config.KubeSchedulerConfiguration{
+		TypeMeta: metav1.TypeMeta{APIVersion: configv1.SchemeGroupVersion.String()},
+		Extenders: []config.Extender{{
+			URLPrefix:   "https://extender.example.com",
+			EnableHTTPS: true,
+			TLSConfig:   &config.ExtenderTLSConfig{KeyData: keyData},
+		}},
+	}
+
+	if err := LogOrWriteConfig(logger, "", cfg, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	output := logger.GetSink().(ktesting.Underlier).GetBuffer().String()
+	if strings.Contains(output, base64.StdEncoding.EncodeToString(keyData)) {
+		t.Error("extender TLS key data leaked into the logged config")
+	}
+	if !strings.Contains(output, "keyData: REDACTED") {
+		t.Errorf("expected redacted keyData in the logged config, got:\n%s", output)
+	}
+	if !bytes.Equal(cfg.Extenders[0].TLSConfig.KeyData, keyData) {
+		t.Error("LogOrWriteConfig mutated the caller's config")
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig scheduling

#### What this PR does / why we need it:

`kube-scheduler` logs the full resolved `KubeSchedulerConfiguration` as YAML at `-v=2` (`LogOrWriteConfig`). If an extender is configured with inline TLS credentials, the client private key (`tlsConfig.keyData`) is emitted into the startup log as base64. The `datapolicy:"security-key"` tag on `KeyData` cannot take effect on this path because the whole config is flattened into a single YAML string before it reaches the logger.

This PR encodes a redacted copy of the config for the log line, replacing non-empty `keyData` with a placeholder that renders as `keyData: REDACTED` — the same convention `kubectl config view` uses for kubeconfig secrets. `--write-config-to` still writes the full config, since that output is meant to be reusable as a config file.

#### Which issue(s) this PR fixes:

Fixes #140096

#### Special notes for your reviewer:

Only `keyData` is redacted; `certData`/`caData` are certificate material rather than secrets, and leaving them intact keeps the logged config useful for debugging. The added unit test exercises `LogOrWriteConfig` end-to-end via a buffered ktesting logger at v=2 and verifies the key bytes do not reach the log, the placeholder does, and the caller's config is not mutated.

#### Does this PR introduce a user-facing change?

```release-note
kube-scheduler no longer logs the extender TLS private key (`tlsConfig.keyData`) when logging its component configuration at verbosity >=2.
```