### PR TITLE
kubelet-config: (v1beta1) improve documentation readability

### DIFF
--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -71022,7 +71022,7 @@ func schema_k8sio_kubelet_config_v1beta1_CredentialProvider(ref common.Reference
 					},
 					"matchImages": {
 						SchemaProps: spec.SchemaProps{
-							Description: "matchImages is a required list of strings used to match against images in order to determine if this provider should be invoked. If one of the strings matches the requested image from the kubelet, the plugin will be invoked and given a chance to provide credentials. Images are expected to contain the registry domain and URL path.\n\nEach entry in matchImages is a pattern which can optionally contain a port and a path. Globs can be used in the domain, but not in the port or the path. Globs are supported as subdomains like '*.k8s.io' or 'k8s.*.io', and top-level-domains such as 'k8s.*'. Matching partial subdomains like 'app*.k8s.io' is also supported. Each glob can only match a single subdomain segment, so *.io does not match *.k8s.io.\n\nA match exists between an image and a matchImage when all of the below are true: - Both contain the same number of domain parts and each part matches. - The URL path of an imageMatch must be a prefix of the target image URL path. - If the imageMatch contains a port, then the port must match in the image as well.\n\nExample values of matchImages:\n  - 123456789.dkr.ecr.us-east-1.amazonaws.com\n  - *.azurecr.io\n  - gcr.io\n  - *.*.registry.io\n  - registry.io:8080/path",
+							Description: "matchImages is a required list of strings used to match against images in order to determine if this provider should be invoked. If one of the strings matches the requested image from the kubelet, the plugin will be invoked and given a chance to provide credentials. Images are expected to contain the registry domain and URL path.\n\nEach entry in matchImages is a pattern which can optionally contain a port and a path. Globs can be used in the domain, but not in the port or the path. Globs are supported as subdomains like `*.k8s.io` or `k8s.*.io`, and top-level-domains such as `k8s.*`. Matching partial subdomains like `app*.k8s.io` is also supported. Each glob can only match a single subdomain segment, so `*.io` does not match `*.k8s.io`.\n\nA match exists between an image and a matchImage when all of the below are true: - Both contain the same number of domain parts and each part matches. - The URL path of an imageMatch must be a prefix of the target image URL path. - If the imageMatch contains a port, then the port must match in the image as well.\n\nExample values of matchImages:\n  - `123456789.dkr.ecr.us-east-1.amazonaws.com`\n  - `*.azurecr.io`\n  - `gcr.io`\n  - `*.*.registry.io`\n  - `registry.io:8080/path`",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -71642,14 +71642,14 @@ func schema_k8sio_kubelet_config_v1beta1_KubeletConfiguration(ref common.Referen
 					},
 					"authentication": {
 						SchemaProps: spec.SchemaProps{
-							Description: "authentication specifies how requests to the Kubelet's server are authenticated. Defaults:\n  anonymous:\n    enabled: false\n  webhook:\n    enabled: true\n    cacheTTL: \"2m\"",
+							Description: "authentication specifies how requests to the Kubelet's server are authenticated.\n\n\tDefaults:\n\t\tanonymous:\n\t\t\tenabled: false\n\t\twebhook:\n\t\t\tenabled: true\n\t\t\tcacheTTL: \"2m\"",
 							Default:     map[string]interface{}{},
 							Ref:         ref(kubeletconfigv1beta1.KubeletAuthentication{}.OpenAPIModelName()),
 						},
 					},
 					"authorization": {
 						SchemaProps: spec.SchemaProps{
-							Description: "authorization specifies how requests to the Kubelet's server are authorized. Defaults:\n  mode: Webhook\n  webhook:\n    cacheAuthorizedTTL: \"5m\"\n    cacheUnauthorizedTTL: \"30s\"",
+							Description: "authorization specifies how requests to the Kubelet's server are authorized.\n\n\tDefaults:\n\t\tmode: Webhook\n\t\twebhook:\n\t\t\tcacheAuthorizedTTL: \"5m\"\n\t\t\tcacheUnauthorizedTTL: \"30s\"",
 							Default:     map[string]interface{}{},
 							Ref:         ref(kubeletconfigv1beta1.KubeletAuthorization{}.OpenAPIModelName()),
 						},
@@ -72399,7 +72399,7 @@ func schema_k8sio_kubelet_config_v1beta1_KubeletConfiguration(ref common.Referen
 					},
 					"reservedMemory": {
 						SchemaProps: spec.SchemaProps{
-							Description: "reservedMemory specifies a comma-separated list of memory reservations for NUMA nodes. The parameter makes sense only in the context of the memory manager feature. The memory manager will not allocate reserved memory for container workloads. For example, if you have a NUMA0 with 10Gi of memory and the reservedMemory was specified to reserve 1Gi of memory at NUMA0, the memory manager will assume that only 9Gi is available for allocation. You can specify a different amount of NUMA node and memory types. You can omit this parameter at all, but you should be aware that the amount of reserved memory from all NUMA nodes should be equal to the amount of memory specified by the [node allocatable](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#node-allocatable). If at least one node allocatable parameter has a non-zero value, you will need to specify at least one NUMA node. Also, avoid specifying:\n\n1. Duplicates, the same NUMA node, and memory type, but with a different value. 2. zero limits for any memory type. 3. NUMAs nodes IDs that do not exist under the machine. 4. memory types except for memory and hugepages-<size>\n\nDefault: nil",
+							Description: "reservedMemory specifies a comma-separated list of memory reservations for NUMA nodes. The parameter makes sense only in the context of the memory manager feature. The memory manager will not allocate reserved memory for container workloads. For example, if you have a NUMA0 with 10Gi of memory and the reservedMemory was specified to reserve 1Gi of memory at NUMA0, the memory manager will assume that only 9Gi is available for allocation. You can specify a different amount of NUMA node and memory types. You can omit this parameter at all, but you should be aware that the amount of reserved memory from all NUMA nodes should be equal to the amount of memory specified by the [node allocatable](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#node-allocatable). If at least one node allocatable parameter has a non-zero value, you will need to specify at least one NUMA node. Also, avoid specifying:\n\n1. Duplicates, the same NUMA node, and memory type, but with a different value. 2. zero limits for any memory type. 3. NUMAs nodes IDs that do not exist under the machine. 4. memory types except for memory and hugepages-SIZE\n\nDefault: nil",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -222,20 +222,24 @@ type KubeletConfiguration struct {
 	// +optional
 	ServerTLSBootstrap bool `json:"serverTLSBootstrap,omitempty"`
 	// authentication specifies how requests to the Kubelet's server are authenticated.
+	//```yaml
 	// Defaults:
 	//   anonymous:
 	//     enabled: false
 	//   webhook:
 	//     enabled: true
 	//     cacheTTL: "2m"
+	//```
 	// +optional
 	Authentication KubeletAuthentication `json:"authentication"`
 	// authorization specifies how requests to the Kubelet's server are authorized.
+	// ```yaml
 	// Defaults:
 	//   mode: Webhook
 	//   webhook:
 	//     cacheAuthorizedTTL: "5m"
 	//     cacheUnauthorizedTTL: "30s"
+	//```
 	// +optional
 	Authorization KubeletAuthorization `json:"authorization"`
 	// registryPullQPS is the limit of registry pulls per second.
@@ -873,7 +877,7 @@ type KubeletConfiguration struct {
 	// 1. Duplicates, the same NUMA node, and memory type, but with a different value.
 	// 2. zero limits for any memory type.
 	// 3. NUMAs nodes IDs that do not exist under the machine.
-	// 4. memory types except for memory and hugepages-<size>
+	// 4. memory types except for memory and hugepages-SIZE
 	//
 	// Default: nil
 	// +optional
@@ -1111,9 +1115,9 @@ type CredentialProvider struct {
 	//
 	// Each entry in matchImages is a pattern which can optionally contain a port and a path.
 	// Globs can be used in the domain, but not in the port or the path. Globs are supported
-	// as subdomains like '*.k8s.io' or 'k8s.*.io', and top-level-domains such as 'k8s.*'.
-	// Matching partial subdomains like 'app*.k8s.io' is also supported. Each glob can only match
-	// a single subdomain segment, so *.io does not match *.k8s.io.
+	// as subdomains like `*.k8s.io` or `k8s.*.io`, and top-level-domains such as `k8s.*`.
+	// Matching partial subdomains like `app*.k8s.io` is also supported. Each glob can only match
+	// a single subdomain segment, so `*.io` does not match `*.k8s.io`.
 	//
 	// A match exists between an image and a matchImage when all of the below are true:
 	// - Both contain the same number of domain parts and each part matches.
@@ -1121,11 +1125,11 @@ type CredentialProvider struct {
 	// - If the imageMatch contains a port, then the port must match in the image as well.
 	//
 	// Example values of matchImages:
-	//   - 123456789.dkr.ecr.us-east-1.amazonaws.com
-	//   - *.azurecr.io
-	//   - gcr.io
-	//   - *.*.registry.io
-	//   - registry.io:8080/path
+	//   - `123456789.dkr.ecr.us-east-1.amazonaws.com`
+	//   - `*.azurecr.io`
+	//   - `gcr.io`
+	//   - `*.*.registry.io`
+	//   - `registry.io:8080/path`
 	MatchImages []string `json:"matchImages"`
 
 	// defaultCacheDuration is the default duration the plugin will cache credentials in-memory

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -222,14 +222,14 @@ type KubeletConfiguration struct {
 	// +optional
 	ServerTLSBootstrap bool `json:"serverTLSBootstrap,omitempty"`
 	// authentication specifies how requests to the Kubelet's server are authenticated.
-	//```yaml
+	// ```yaml
 	// Defaults:
 	//   anonymous:
 	//     enabled: false
 	//   webhook:
 	//     enabled: true
 	//     cacheTTL: "2m"
-	//```
+	// ```
 	// +optional
 	Authentication KubeletAuthentication `json:"authentication"`
 	// authorization specifies how requests to the Kubelet's server are authorized.

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -222,24 +222,22 @@ type KubeletConfiguration struct {
 	// +optional
 	ServerTLSBootstrap bool `json:"serverTLSBootstrap,omitempty"`
 	// authentication specifies how requests to the Kubelet's server are authenticated.
-	// ```yaml
-	// Defaults:
-	//   anonymous:
-	//     enabled: false
-	//   webhook:
-	//     enabled: true
-	//     cacheTTL: "2m"
-	// ```
+	//
+	//	Defaults:
+	//		anonymous:
+	//			enabled: false
+	//		webhook:
+	//			enabled: true
+	//			cacheTTL: "2m"
 	// +optional
 	Authentication KubeletAuthentication `json:"authentication"`
 	// authorization specifies how requests to the Kubelet's server are authorized.
-	// ```yaml
-	// Defaults:
-	//   mode: Webhook
-	//   webhook:
-	//     cacheAuthorizedTTL: "5m"
-	//     cacheUnauthorizedTTL: "30s"
-	//```
+	//
+	//	Defaults:
+	//		mode: Webhook
+	//		webhook:
+	//			cacheAuthorizedTTL: "5m"
+	//			cacheUnauthorizedTTL: "30s"
 	// +optional
 	Authorization KubeletAuthorization `json:"authorization"`
 	// registryPullQPS is the limit of registry pulls per second.


### PR DESCRIPTION



#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

1. fix inconsistent indentation
from 
<img width="781" height="267" alt="image" src="https://github.com/user-attachments/assets/97db9411-fb30-44d9-a681-a318f18cc0d1" />
results

<img width="791" height="527" alt="image" src="https://github.com/user-attachments/assets/ce20a441-0b79-45ee-b86c-65857b23777c" />


2. prevent wildcard asterisks from being parsed as emphasis

 from
<img width="697" height="133" alt="image" src="https://github.com/user-attachments/assets/215c25a8-02f8-4ee2-bfbe-aad5493e2a12" />
<img width="463" height="203" alt="image" src="https://github.com/user-attachments/assets/006fd3ff-eb9c-4141-9495-6f1a020e0af1" />

results
<img width="547" height="117" alt="image" src="https://github.com/user-attachments/assets/7c767f4a-2c94-4ae0-a3ce-ddfc732063f8" />
<img width="505" height="157" alt="image" src="https://github.com/user-attachments/assets/dae64b48-676e-4d26-a5d1-dc6015e71457" />



3. escape angle-bracketed placeholders to prevent hidden text
from
<img width="474" height="101" alt="image" src="https://github.com/user-attachments/assets/c2c1d916-66b9-4839-924e-f6506fa535a9" />
results
<img width="408" height="102" alt="image" src="https://github.com/user-attachments/assets/0b71f161-37ad-4fd1-ac90-49febfa7922e" />



#### Which issue(s) this PR is related to:
N/A
but, References: https://github.com/kubernetes-sigs/reference-docs/pull/455#issuecomment-4583177156

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
kubelet-config: (v1beta1) improve documentation readability
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: