### PR TITLE
kubelet: reject pod with volume nodeAffinity mismatch (KEP-5381)

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2216,10 +2216,11 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 
 	// Wait for volumes to attach/mount
 	if err := kl.volumeManager.WaitForAttachAndMount(ctx, pod); err != nil {
-		var volumeAttachLimitErr *volumemanager.VolumeAttachLimitExceededError
-		if errors.As(err, &volumeAttachLimitErr) {
-			kl.rejectPod(ctx, pod, volumemanager.VolumeAttachmentLimitExceededReason, volumeAttachLimitErr.Error())
-			recordAdmissionRejection(volumemanager.VolumeAttachmentLimitExceededReason)
+		var rejectError *volumemanager.RejectingPodError
+		if errors.As(err, &rejectError) {
+			reason := rejectError.Reason
+			kl.rejectPod(ctx, pod, reason, err.Error())
+			recordAdmissionRejection(reason)
 			return true, nil, nil
 		}
 		if !wait.Interrupted(err) {

--- a/pkg/kubelet/volumemanager/cache/desired_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/desired_state_of_world.go
@@ -28,7 +28,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/util/sets"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/component-base/metrics"
 	"k8s.io/klog/v2"
@@ -120,14 +120,13 @@ type DesiredStateOfWorld interface {
 	// volume, false is returned.
 	VolumeExistsWithSpecName(podName types.UniquePodName, volumeSpecName string) bool
 
-	// AddErrorToPod adds the given error to the given pod in the cache.
-	// It will be returned by subsequent GetPodErrors().
-	// Each error string is stored only once.
-	AddErrorToPod(podName types.UniquePodName, err string)
+	// MarkPodError marks the given pod with the given error for the volumeName in the cache.
+	// It will be returned by subsequent [PopPodError].
+	// Only the latest error for each volume is preserved.
+	MarkPodError(podName types.UniquePodName, volumeName string, err error)
 
-	// PopPodErrors returns accumulated errors on a given pod and clears
-	// them.
-	PopPodErrors(podName types.UniquePodName) []string
+	// PopPodError returns the latest error on a given pod and clears it.
+	PopPodError(podName types.UniquePodName) error
 
 	// GetPodsWithErrors returns names of pods that have stored errors.
 	GetPodsWithErrors() []types.UniquePodName
@@ -155,7 +154,7 @@ func NewDesiredStateOfWorld(volumePluginMgr *volume.VolumePluginMgr, seLinuxTran
 	return &desiredStateOfWorld{
 		volumesToMount:    make(map[v1.UniqueVolumeName]volumeToMount),
 		volumePluginMgr:   volumePluginMgr,
-		podErrors:         make(map[types.UniquePodName]sets.Set[string]),
+		podErrors:         make(map[types.UniquePodName]map[string]error),
 		seLinuxTranslator: seLinuxTranslator,
 	}
 }
@@ -170,7 +169,7 @@ type desiredStateOfWorld struct {
 	// plugin objects.
 	volumePluginMgr *volume.VolumePluginMgr
 	// podErrors are errors caught by desiredStateOfWorldPopulator about volumes for a given pod.
-	podErrors map[types.UniquePodName]sets.Set[string]
+	podErrors map[types.UniquePodName]map[string]error
 	// seLinuxTranslator translates v1.SELinuxOptions to a file SELinux label.
 	seLinuxTranslator util.SELinuxLabelTranslator
 
@@ -251,12 +250,6 @@ type podToMount struct {
 	// mountRequestTime stores time at which mount was requested
 	mountRequestTime time.Time
 }
-
-const (
-	// Maximum errors to be stored per pod in desiredStateOfWorld.podErrors to
-	// prevent unbound growth.
-	maxPodErrors = 10
-)
 
 func (dsw *desiredStateOfWorld) AddPodToVolume(
 	logger klog.Logger,
@@ -615,28 +608,40 @@ func (dsw *desiredStateOfWorld) GetVolumesToMount() []VolumeToMount {
 	return volumesToMount
 }
 
-func (dsw *desiredStateOfWorld) AddErrorToPod(podName types.UniquePodName, err string) {
+func (dsw *desiredStateOfWorld) MarkPodError(podName types.UniquePodName, volumeName string, err error) {
 	dsw.Lock()
 	defer dsw.Unlock()
 
 	if errs, found := dsw.podErrors[podName]; found {
-		if errs.Len() <= maxPodErrors {
-			errs.Insert(err)
-		}
-		return
+		errs[volumeName] = err
+	} else {
+		dsw.podErrors[podName] = map[string]error{volumeName: err}
 	}
-	dsw.podErrors[podName] = sets.New[string](err)
 }
 
-func (dsw *desiredStateOfWorld) PopPodErrors(podName types.UniquePodName) []string {
+func (dsw *desiredStateOfWorld) PopPodError(podName types.UniquePodName) error {
 	dsw.Lock()
 	defer dsw.Unlock()
 
 	if errs, found := dsw.podErrors[podName]; found {
 		delete(dsw.podErrors, podName)
-		return sets.List(errs)
+		if len(errs) == 1 { // special case for single error to avoid sorting
+			for _, err := range errs {
+				return err
+			}
+		}
+		names := make([]string, 0, len(errs))
+		for name := range errs {
+			names = append(names, name)
+		}
+		slices.Sort(names)
+		errorList := make([]error, 0, len(errs))
+		for _, name := range names {
+			errorList = append(errorList, errs[name])
+		}
+		return utilerrors.NewAggregate(errorList)
 	}
-	return []string{}
+	return nil
 }
 
 func (dsw *desiredStateOfWorld) GetPodsWithErrors() []types.UniquePodName {

--- a/pkg/kubelet/volumemanager/cache/desired_state_of_world_test.go
+++ b/pkg/kubelet/volumemanager/cache/desired_state_of_world_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cache
 
 import (
+	"errors"
 	"maps"
 	"slices"
 	"testing"
@@ -1578,5 +1579,49 @@ func verifyDesiredSizeLimitInVolumeDsw(
 				}
 			}
 		}
+	}
+}
+
+func TestPodError(t *testing.T) {
+	cases := []struct {
+		name string
+		mark map[string]error
+		pop  string
+	}{
+		{
+			name: "no",
+		},
+		{
+			name: "single",
+			mark: map[string]error{"vol1": errors.New("single error")},
+			pop:  "single error",
+		},
+		{
+			name: "multiple",
+			mark: map[string]error{
+				"vol1": errors.New("first error"),
+				"vol2": errors.New("second error"),
+			},
+			pop: "[first error, second error]",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			volumePluginMgr := volume.VolumePluginMgr{}
+			seLinuxTranslator := util.NewFakeSELinuxLabelTranslator()
+			dsw := NewDesiredStateOfWorld(&volumePluginMgr, seLinuxTranslator)
+
+			for vol, err := range c.mark {
+				dsw.MarkPodError("test-pod", vol, err)
+			}
+			poped := dsw.PopPodError("test-pod")
+			if poped != nil {
+				if c.pop != poped.Error() {
+					t.Errorf("expected pop error %q, got %q", c.pop, poped.Error())
+				}
+			} else if c.pop != "" {
+				t.Errorf("expected pop error %q, got nil", c.pop)
+			}
+		})
 	}
 }

--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
@@ -266,7 +266,7 @@ func (dswp *desiredStateOfWorldPopulator) findAndRemoveDeletedPods(logger klog.L
 	podsWithError := dswp.desiredStateOfWorld.GetPodsWithErrors()
 	for _, podName := range podsWithError {
 		if _, podExists := dswp.podManager.GetPodByUID(types.UID(podName)); !podExists {
-			dswp.desiredStateOfWorld.PopPodErrors(podName)
+			_ = dswp.desiredStateOfWorld.PopPodError(podName)
 		}
 	}
 }
@@ -300,7 +300,7 @@ func (dswp *desiredStateOfWorldPopulator) processPodVolumes(ctx context.Context,
 			dswp.createVolumeSpec(ctx, podVolume, pod, mounts, devices)
 		if err != nil {
 			logger.Error(err, "Error processing volume", "pod", klog.KObj(pod), "volumeName", podVolume.Name)
-			dswp.desiredStateOfWorld.AddErrorToPod(uniquePodName, err.Error())
+			dswp.desiredStateOfWorld.MarkPodError(uniquePodName, podVolume.Name, err)
 			allVolumesAdded = false
 			continue
 		}
@@ -310,7 +310,7 @@ func (dswp *desiredStateOfWorldPopulator) processPodVolumes(ctx context.Context,
 			logger, uniquePodName, pod, volumeSpec, podVolume.Name, volumeGIDValue, seLinuxContainerContexts[podVolume.Name])
 		if err != nil {
 			logger.Error(err, "Failed to add volume to desiredStateOfWorld", "pod", klog.KObj(pod), "volumeName", podVolume.Name, "volumeSpecName", volumeSpec.Name())
-			dswp.desiredStateOfWorld.AddErrorToPod(uniquePodName, err.Error())
+			dswp.desiredStateOfWorld.MarkPodError(uniquePodName, podVolume.Name, err)
 			allVolumesAdded = false
 			continue
 		}
@@ -326,7 +326,7 @@ func (dswp *desiredStateOfWorldPopulator) processPodVolumes(ctx context.Context,
 		// (e.g. DownwardAPI)
 		dswp.actualStateOfWorld.MarkRemountRequired(logger, uniquePodName)
 		// Remove any stored errors for the pod, everything went well in this processPodVolumes
-		dswp.desiredStateOfWorld.PopPodErrors(uniquePodName)
+		_ = dswp.desiredStateOfWorld.PopPodError(uniquePodName)
 	} else if dswp.podHasBeenSeenOnce(uniquePodName) {
 		// For the Pod which has been processed at least once, even though some volumes
 		// may not have been reprocessed successfully this round, we still mark it as processed to avoid

--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator_test.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator_test.go
@@ -615,12 +615,11 @@ func TestEphemeralVolumeOwnerCheck(t *testing.T) {
 	if dswp.pods.processedPods[podName] {
 		t.Fatalf("%s should not have been processed by the populator", podName)
 	}
-	require.Equal(t,
-		[]string{fmt.Sprintf("PVC %s/%s was not created for pod %s/%s (pod is not owner)",
+	require.EqualError(t, dswp.desiredStateOfWorld.PopPodError(podName),
+		fmt.Sprintf("PVC %s/%s was not created for pod %s/%s (pod is not owner)",
 			pvc.Namespace, pvc.Name,
 			pod.Namespace, pod.Name,
-		)},
-		dswp.desiredStateOfWorld.PopPodErrors(podName),
+		),
 	)
 }
 

--- a/pkg/kubelet/volumemanager/reconciler/reconciler_common.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler_common.go
@@ -18,6 +18,7 @@ package reconciler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -25,8 +26,11 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/component-helpers/storage/volume"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/volumemanager/cache"
 	"k8s.io/kubernetes/pkg/util/goroutinemap/exponentialbackoff"
 	volumepkg "k8s.io/kubernetes/pkg/volume"
@@ -178,7 +182,7 @@ func (rc *reconciler) mountOrAttachVolumes(logger klog.Logger) {
 			// The volume is mounted, but with an unexpected SELinux context.
 			// It will get unmounted in unmountVolumes / unmountDetachDevices and
 			// then removed from actualStateOfWorld.
-			rc.desiredStateOfWorld.AddErrorToPod(volumeToMount.PodName, err.Error())
+			rc.desiredStateOfWorld.MarkPodError(volumeToMount.PodName, volumeToMount.OuterVolumeSpecNames[0], err)
 			continue
 		} else if cache.IsVolumeNotAttachedError(err) {
 			rc.waitForVolumeAttach(logger, volumeToMount)
@@ -229,6 +233,26 @@ func (rc *reconciler) mountAttachedVolumes(logger klog.Logger, volumeToMount cac
 	}
 }
 
+var ErrNodeAffinityMismatch = errors.New("node affinity mismatch")
+
+func (rc *reconciler) rejectNodeAffinityMismatch(logger klog.Logger, volumeToMount cache.VolumeToMount) {
+	pv := volumeToMount.VolumeSpec.PersistentVolume
+	if pv == nil {
+		return
+	}
+	labels, err := rc.volumePluginMgr.Host.GetNodeLabels()
+	if err != nil {
+		logger.Error(err, "Failed to get node labels")
+		return
+	}
+	err = volume.CheckNodeAffinity(pv, labels)
+	if err != nil {
+		logger.V(1).Info("Rejecting pod because it's volume has node affinity that does not match current node",
+			"pod", klog.KObj(volumeToMount.Pod), "pv", klog.KObj(pv), "error", err)
+		rc.desiredStateOfWorld.MarkPodError(volumeToMount.PodName, volumeToMount.OuterVolumeSpecNames[0], ErrNodeAffinityMismatch)
+	}
+}
+
 func (rc *reconciler) waitForVolumeAttach(logger klog.Logger, volumeToMount cache.VolumeToMount) {
 	if rc.controllerAttachDetachEnabled || !volumeToMount.PluginIsAttachable {
 		//// lets not spin a goroutine and unnecessarily trigger exponential backoff if this happens
@@ -246,6 +270,12 @@ func (rc *reconciler) waitForVolumeAttach(logger klog.Logger, volumeToMount cach
 			rc.actualStateOfWorld)
 		if err != nil && !isExpectedError(err) {
 			logger.Error(err, volumeToMount.GenerateErrorDetailed(fmt.Sprintf("operationExecutor.VerifyControllerAttachedVolume failed (controllerAttachDetachEnabled %v)", rc.controllerAttachDetachEnabled), err).Error(), "pod", klog.KObj(volumeToMount.Pod))
+		}
+		if utilfeature.DefaultFeatureGate.Enabled(features.MutablePVNodeAffinity) && operationexecutor.IsMountFailedPreconditionError(err) {
+			// Reject pods that cannot pass affinity check, which will stuck in Pending status forever,
+			// But only for unattached pods, to avoid interrupting running pods.
+			// Hopefully scheduler will assign them to other nodes the next time.
+			rc.rejectNodeAffinityMismatch(logger, volumeToMount)
 		}
 		if err == nil {
 			logger.Info(volumeToMount.GenerateMsgDetailed("operationExecutor.VerifyControllerAttachedVolume started", ""), "pod", klog.KObj(volumeToMount.Pod))

--- a/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
@@ -712,7 +712,7 @@ func Test_Run_Positive_VolumeAttachAndMap(t *testing.T) {
 	seLinuxTranslator := util.NewFakeSELinuxLabelTranslator()
 	dsw := cache.NewDesiredStateOfWorld(volumePluginMgr, seLinuxTranslator)
 	asw := cache.NewActualStateOfWorld(nodeName, volumePluginMgr)
-	kubeClient := createtestClientWithPVPVC(gcepv, gcepvc)
+	kubeClient := createTestClientWithPVPVC(gcepv, gcepvc)
 	fakeRecorder := &record.FakeRecorder{}
 	fakeHandler := volumetesting.NewBlockVolumePathHandler()
 	oex := operationexecutor.NewOperationExecutor(operationexecutor.NewOperationGenerator(
@@ -826,7 +826,7 @@ func Test_Run_Positive_BlockVolumeMapControllerAttachEnabled(t *testing.T) {
 	seLinuxTranslator := util.NewFakeSELinuxLabelTranslator()
 	dsw := cache.NewDesiredStateOfWorld(volumePluginMgr, seLinuxTranslator)
 	asw := cache.NewActualStateOfWorld(nodeName, volumePluginMgr)
-	kubeClient := createtestClientWithPVPVC(gcepv, gcepvc, v1.AttachedVolume{
+	kubeClient := createTestClientWithPVPVC(gcepv, gcepvc, v1.AttachedVolume{
 		Name:       "fake-plugin/fake-device1",
 		DevicePath: "/fake/path",
 	})
@@ -928,7 +928,7 @@ func Test_Run_Positive_BlockVolumeAttachMapUnmapDetach(t *testing.T) {
 	seLinuxTranslator := util.NewFakeSELinuxLabelTranslator()
 	dsw := cache.NewDesiredStateOfWorld(volumePluginMgr, seLinuxTranslator)
 	asw := cache.NewActualStateOfWorld(nodeName, volumePluginMgr)
-	kubeClient := createtestClientWithPVPVC(gcepv, gcepvc)
+	kubeClient := createTestClientWithPVPVC(gcepv, gcepvc)
 	fakeRecorder := &record.FakeRecorder{}
 	fakeHandler := volumetesting.NewBlockVolumePathHandler()
 	oex := operationexecutor.NewOperationExecutor(operationexecutor.NewOperationGenerator(
@@ -1051,7 +1051,7 @@ func Test_Run_Positive_VolumeUnmapControllerAttachEnabled(t *testing.T) {
 	seLinuxTranslator := util.NewFakeSELinuxLabelTranslator()
 	dsw := cache.NewDesiredStateOfWorld(volumePluginMgr, seLinuxTranslator)
 	asw := cache.NewActualStateOfWorld(nodeName, volumePluginMgr)
-	kubeClient := createtestClientWithPVPVC(gcepv, gcepvc, v1.AttachedVolume{
+	kubeClient := createTestClientWithPVPVC(gcepv, gcepvc, v1.AttachedVolume{
 		Name:       "fake-plugin/fake-device1",
 		DevicePath: "/fake/path",
 	})
@@ -1332,7 +1332,7 @@ func Test_Run_Positive_VolumeFSResizeControllerAttachEnabled(t *testing.T) {
 			seLinuxTranslator := util.NewFakeSELinuxLabelTranslator()
 			dsw := cache.NewDesiredStateOfWorld(volumePluginMgr, seLinuxTranslator)
 			asw := cache.NewActualStateOfWorld(nodeName, volumePluginMgr)
-			kubeClient := createtestClientWithPVPVC(pv, pvc, v1.AttachedVolume{
+			kubeClient := createTestClientWithPVPVC(pv, pvc, v1.AttachedVolume{
 				Name:       v1.UniqueVolumeName(fmt.Sprintf("fake-plugin/%s", tc.pvName)),
 				DevicePath: "fake/path",
 			})
@@ -1593,7 +1593,7 @@ func Test_UncertainDeviceGlobalMounts(t *testing.T) {
 
 				dsw := cache.NewDesiredStateOfWorld(volumePluginMgr, seLinuxTranslator)
 				asw := cache.NewActualStateOfWorld(nodeName, volumePluginMgr)
-				kubeClient := createtestClientWithPVPVC(pv, pvc, v1.AttachedVolume{
+				kubeClient := createTestClientWithPVPVC(pv, pvc, v1.AttachedVolume{
 					Name:       v1.UniqueVolumeName(fmt.Sprintf("fake-plugin/%s", tc.volumeName)),
 					DevicePath: "fake/path",
 				})
@@ -1818,7 +1818,7 @@ func Test_UncertainVolumeMountState(t *testing.T) {
 				seLinuxTranslator := util.NewFakeSELinuxLabelTranslator()
 				dsw := cache.NewDesiredStateOfWorld(volumePluginMgr, seLinuxTranslator)
 				asw := cache.NewActualStateOfWorld(nodeName, volumePluginMgr)
-				kubeClient := createtestClientWithPVPVC(pv, pvc, v1.AttachedVolume{
+				kubeClient := createTestClientWithPVPVC(pv, pvc, v1.AttachedVolume{
 					Name:       v1.UniqueVolumeName(fmt.Sprintf("fake-plugin/%s", tc.volumeName)),
 					DevicePath: "fake/path",
 				})
@@ -2108,7 +2108,7 @@ func runReconciler(ctx context.Context, reconciler Reconciler) {
 	go reconciler.Run(ctx, wait.NeverStop)
 }
 
-func createtestClientWithPVPVC(pv *v1.PersistentVolume, pvc *v1.PersistentVolumeClaim, attachedVolumes ...v1.AttachedVolume) *fake.Clientset {
+func createTestClientWithPVPVC(pv *v1.PersistentVolume, pvc *v1.PersistentVolumeClaim, attachedVolumes ...v1.AttachedVolume) *fake.Clientset {
 	fakeClient := &fake.Clientset{}
 	if len(attachedVolumes) == 0 {
 		attachedVolumes = append(attachedVolumes, v1.AttachedVolume{

--- a/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
@@ -26,10 +26,14 @@ import (
 	"testing"
 	"time"
 
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	csitrans "k8s.io/csi-translation-lib"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/volume/csimigration"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/mount-utils"
 
 	v1 "k8s.io/api/core/v1"
@@ -469,6 +473,127 @@ func Test_Run_Negative_VolumeMountControllerAttachEnabled(t *testing.T) {
 		0 /* expectedWaitForAttachCallCount */, fakePlugin))
 	assert.NoError(t, volumetesting.VerifyMountDeviceCallCount(
 		0 /* expectedMountDeviceCallCount */, fakePlugin))
+}
+
+// Populates desiredStateOfWorld cache with one volume/pod.
+// Enables controllerAttachDetachEnabled.
+// volume is reported in-use but not attached
+// Calls Run()
+// Verifies that there is not wait-for-mount call
+// Verifies that there is no exponential-backoff triggered
+// Verifies when nodeAffinity mismatches, proper error is reported
+func Test_Run_Negative_VolumeNotAttached(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod1",
+			UID:  "pod1uid",
+		},
+	}
+	mode := v1.PersistentVolumeBlock
+	gcepv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{UID: "001", Name: "volume-name"},
+		Spec: v1.PersistentVolumeSpec{
+			Capacity:               v1.ResourceList{v1.ResourceName(v1.ResourceStorage): resource.MustParse("10G")},
+			PersistentVolumeSource: v1.PersistentVolumeSource{GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{PDName: "fake-device1"}},
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+				v1.ReadOnlyMany,
+			},
+			VolumeMode: &mode,
+			ClaimRef:   &v1.ObjectReference{Namespace: "ns", Name: "pvc-volume-name"},
+		},
+	}
+
+	gcepvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{UID: "pvc-001", Name: "pvc-volume-name", Namespace: "ns"},
+		Spec: v1.PersistentVolumeClaimSpec{
+			VolumeName: "volume-name",
+			VolumeMode: &mode,
+		},
+		Status: v1.PersistentVolumeClaimStatus{
+			Phase:    v1.ClaimBound,
+			Capacity: gcepv.Spec.Capacity,
+		},
+	}
+
+	// Arrange
+	volumePluginMgr, _ := volumetesting.GetTestKubeletVolumePluginMgr(t)
+	seLinuxTranslator := util.NewFakeSELinuxLabelTranslator()
+	dsw := cache.NewDesiredStateOfWorld(volumePluginMgr, seLinuxTranslator)
+	asw := cache.NewActualStateOfWorld(nodeName, volumePluginMgr)
+	kubeClient := createTestClientWithPVPVC(gcepv, gcepvc)
+	fakeRecorder := &record.FakeRecorder{}
+	fakeHandler := volumetesting.NewBlockVolumePathHandler()
+	oex := operationexecutor.NewOperationExecutor(operationexecutor.NewOperationGenerator(
+		kubeClient,
+		volumePluginMgr,
+		fakeRecorder,
+		fakeHandler))
+	reconciler := NewReconciler(
+		kubeClient,
+		true, /* controllerAttachDetachEnabled */
+		reconcilerLoopSleepDuration,
+		waitForAttachTimeout,
+		nodeName,
+		dsw,
+		asw,
+		hasAddedPods,
+		oex,
+		mount.NewFakeMounter(nil),
+		hostutil.NewFakeHostUtil(nil),
+		volumePluginMgr,
+		kubeletPodsDir)
+
+	volumeSpec := &volume.Spec{
+		PersistentVolume: gcepv,
+	}
+	podName := util.GetUniquePodName(pod)
+	generatedVolumeName, err := dsw.AddPodToVolume(
+		logger, podName, pod, volumeSpec, volumeSpec.Name(), "" /* volumeGIDValue */, nil /* seLinuxLabel */)
+	dsw.MarkVolumesReportedInUse([]v1.UniqueVolumeName{generatedVolumeName})
+
+	// Assert
+	if err != nil {
+		t.Fatalf("AddPodToVolume failed. Expected: <no error> Actual: <%v>", err)
+	}
+
+	// Act
+	runReconciler(ctx, reconciler)
+	require.NoError(t, dsw.PopPodError(podName))
+
+	// modify PV to have node affinity that does not match this node
+	gcepv.Spec.NodeAffinity = &v1.VolumeNodeAffinity{
+		Required: &v1.NodeSelector{
+			NodeSelectorTerms: []v1.NodeSelectorTerm{
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      "kubernetes.io/hostname",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"some-other-node"},
+						},
+					},
+				},
+			},
+		},
+	}
+	time.Sleep(2 * time.Second)
+	require.NoError(t, dsw.PopPodError(podName)) // nothing happens if feature gate is disabled
+
+	// Enable MutablePVNodeAffinity feature gate, and we will get error, which will fail the pod eventually
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.MutablePVNodeAffinity, true)
+	err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 2*time.Second, true, func(ctx context.Context) (done bool, err error) {
+		err = dsw.PopPodError(podName)
+		if err == nil {
+			return false, nil
+		}
+		if assert.ErrorIs(t, err, ErrNodeAffinityMismatch) {
+			return true, nil
+		}
+		return false, err
+	})
+	require.NoError(t, err, "pod error was not set correctly")
 }
 
 // Populates desiredStateOfWorld cache with one volume/pod.

--- a/pkg/kubelet/volumemanager/reconciler/reconstruct_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconstruct_test.go
@@ -297,7 +297,7 @@ func TestReconstructVolumesMount(t *testing.T) {
 			outerName := filepath.Base(tc.volumePath)
 			pod, pv, pvc := getPodPVCAndPV(tc.volumeMode, "pod1", outerName, "pvc1")
 			volumeSpec := &volume.Spec{PersistentVolume: pv}
-			kubeClient := createtestClientWithPVPVC(pv, pvc, v1.AttachedVolume{
+			kubeClient := createTestClientWithPVPVC(pv, pvc, v1.AttachedVolume{
 				Name:       v1.UniqueVolumeName(fmt.Sprintf("fake-plugin/%s", outerName)),
 				DevicePath: "fake/path",
 			})

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"slices"
 	"strconv"
-	"strings"
 	"time"
 
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -89,6 +88,9 @@ const (
 	// VolumeAttachmentLimitExceededReason is the reason for rejecting a pod
 	// when the node has reached its volume attachment limit.
 	VolumeAttachmentLimitExceededReason = "VolumeAttachmentLimitExceeded"
+	// VolumeNodeAffinityReason is the reason for rejecting a pod when the node
+	// does not match the volume's node affinity.
+	VolumeNodeAffinityReason = "VolumeNodeAffinity"
 )
 
 // VolumeManager runs a set of asynchronous loops that figure out which volumes
@@ -283,16 +285,13 @@ type volumeManager struct {
 	intreeToCSITranslator csimigration.InTreeToCSITranslator
 }
 
-type VolumeAttachLimitExceededError struct {
-	UnmountedVolumes  []string
-	UnattachedVolumes []string
-	VolumesNotInDSW   []string
-	OriginalError     error
+type RejectingPodError struct {
+	Reason string
+	Desc   string
 }
 
-func (e *VolumeAttachLimitExceededError) Error() string {
-	return fmt.Sprintf("Node has reached its volume attachment limit, rejecting pod. unmounted volumes=%v, unattached volumes=%v, failed to process volumes=%v: %v",
-		e.UnmountedVolumes, e.UnattachedVolumes, e.VolumesNotInDSW, e.OriginalError)
+func (e *RejectingPodError) Error() string {
+	return fmt.Sprintf("Volume predicate %s failed: %s", e.Reason, e.Desc)
 }
 
 func (vm *volumeManager) Run(ctx context.Context, sourcesReady config.SourcesReady) {
@@ -449,11 +448,9 @@ func (vm *volumeManager) WaitForAttachAndMount(ctx context.Context, pod *v1.Pod)
 				}
 				if attachablePlugin.VerifyExhaustedResource(volumeToMount.VolumeSpec) {
 					// Return error to the kubelet, which will then trigger the pod termination logic.
-					return &VolumeAttachLimitExceededError{
-						UnmountedVolumes:  unmountedVolumes,
-						UnattachedVolumes: unattachedVolumes,
-						VolumesNotInDSW:   volumesNotInDSW,
-						OriginalError:     err,
+					err = &RejectingPodError{
+						Reason: VolumeAttachmentLimitExceededReason,
+						Desc:   "Node has reached its volume attachment limit",
 					}
 				}
 			}
@@ -554,8 +551,14 @@ func (vm *volumeManager) getUnattachedVolumes(uniquePodName types.UniquePodName)
 // volumes are mounted.
 func (vm *volumeManager) verifyVolumesMountedFunc(podName types.UniquePodName, expectedVolumes []string) wait.ConditionWithContextFunc {
 	return func(_ context.Context) (done bool, err error) {
-		if errs := vm.desiredStateOfWorld.PopPodErrors(podName); len(errs) > 0 {
-			return true, errors.New(strings.Join(errs, "; "))
+		if err := vm.desiredStateOfWorld.PopPodError(podName); err != nil {
+			if errors.Is(err, reconciler.ErrNodeAffinityMismatch) {
+				err = &RejectingPodError{
+					Reason: VolumeNodeAffinityReason,
+					Desc:   err.Error(),
+				}
+			}
+			return true, err
 		}
 		return len(vm.getUnmountedVolumes(podName, expectedVolumes)) == 0, nil
 	}
@@ -565,8 +568,8 @@ func (vm *volumeManager) verifyVolumesMountedFunc(podName types.UniquePodName, e
 // pod.
 func (vm *volumeManager) verifyVolumesUnmountedFunc(podName types.UniquePodName) wait.ConditionWithContextFunc {
 	return func(_ context.Context) (done bool, err error) {
-		if errs := vm.desiredStateOfWorld.PopPodErrors(podName); len(errs) > 0 {
-			return true, errors.New(strings.Join(errs, "; "))
+		if err := vm.desiredStateOfWorld.PopPodError(podName); err != nil {
+			return true, err
 		}
 		return !vm.actualStateOfWorld.PodHasMountedVolumes(podName), nil
 	}

--- a/pkg/kubelet/volumemanager/volume_manager_fake.go
+++ b/pkg/kubelet/volumemanager/volume_manager_fake.go
@@ -59,7 +59,9 @@ func (f *FakeVolumeManager) Run(ctx context.Context, sourcesReady config.Sources
 // WaitForAttachAndMount is not implemented
 func (f *FakeVolumeManager) WaitForAttachAndMount(ctx context.Context, pod *v1.Pod) error {
 	if f.volumeAttachLimitExceeded {
-		return &VolumeAttachLimitExceededError{}
+		return &RejectingPodError{
+			Reason: VolumeAttachmentLimitExceededReason,
+		}
 	}
 	return nil
 }

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -19,7 +19,6 @@ package volumemanager
 import (
 	"context"
 	"fmt"
-	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -38,7 +37,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
-	utiltesting "k8s.io/client-go/util/testing"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/config"
@@ -89,15 +87,7 @@ func TestGetMountedVolumesForPodAndGetVolumesInUse(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			tmpDir, err := utiltesting.MkTmpdir("volumeManagerTest")
-			if err != nil {
-				t.Fatalf("can't make a temp dir: %v", err)
-			}
-			defer func() {
-				if err := os.RemoveAll(tmpDir); err != nil {
-					t.Fatalf("failed to remove temp dir: %v", err)
-				}
-			}()
+			tmpDir := t.TempDir()
 			podManager := kubepod.NewBasicPodManager()
 
 			node, pod, pv, claim := createObjects(test.pvMode, test.podMode)
@@ -118,7 +108,7 @@ func TestGetMountedVolumesForPodAndGetVolumesInUse(t *testing.T) {
 				tCtx.Done(),
 				manager)
 
-			err = manager.WaitForAttachAndMount(ctx, pod)
+			err := manager.WaitForAttachAndMount(ctx, pod)
 			if err != nil && !test.expectError {
 				t.Errorf("Expected success: %v", err)
 			}
@@ -152,11 +142,7 @@ func TestGetMountedVolumesForPodAndGetVolumesInUse(t *testing.T) {
 
 func TestWaitForAttachAndMountError(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
-	tmpDir, err := utiltesting.MkTmpdir("volumeManagerTest")
-	if err != nil {
-		t.Fatalf("can't make a temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	podManager := kubepod.NewBasicPodManager()
 
 	pod := &v1.Pod{
@@ -239,7 +225,7 @@ func TestWaitForAttachAndMountError(t *testing.T) {
 
 	podManager.SetPods([]*v1.Pod{pod})
 
-	err = manager.WaitForAttachAndMount(ctx, pod)
+	err := manager.WaitForAttachAndMount(ctx, pod)
 	if err == nil {
 		t.Errorf("Expected error, got none")
 	}
@@ -252,15 +238,7 @@ func TestWaitForAttachAndMountError(t *testing.T) {
 func TestWaitForAttachAndMountVolumeAttachLimitExceededError(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.MutableCSINodeAllocatableCount, true)
 
-	tmpDir, err := utiltesting.MkTmpdir("volumeManagerTest")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		if err := os.RemoveAll(tmpDir); err != nil {
-			t.Errorf("Failed to remove temporary directory %s: %v", tmpDir, err)
-		}
-	})
-
+	tmpDir := t.TempDir()
 	podManager := kubepod.NewBasicPodManager()
 
 	pod := &v1.Pod{
@@ -329,7 +307,7 @@ func TestWaitForAttachAndMountVolumeAttachLimitExceededError(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(tCtx, 1*time.Second)
 	defer cancel()
-	err = manager.WaitForAttachAndMount(ctx, pod)
+	err := manager.WaitForAttachAndMount(ctx, pod)
 
 	require.Error(t, err, "Expected an error but got none")
 
@@ -343,11 +321,7 @@ func TestWaitForAttachAndMountVolumeAttachLimitExceededError(t *testing.T) {
 
 func TestInitialPendingVolumesForPodAndGetVolumesInUse(t *testing.T) {
 	tCtx := ktesting.Init(t)
-	tmpDir, err := utiltesting.MkTmpdir("volumeManagerTest")
-	if err != nil {
-		t.Fatalf("can't make a temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	podManager := kubepod.NewBasicPodManager()
 
 	node, pod, pv, claim := createObjects(v1.PersistentVolumeFilesystem, v1.PersistentVolumeFilesystem)
@@ -374,8 +348,8 @@ func TestInitialPendingVolumesForPodAndGetVolumesInUse(t *testing.T) {
 	// delayed claim binding
 	go delayClaimBecomesBound(t, kubeClient, claim.GetNamespace(), claim.Name)
 
-	err = wait.PollUntilContextTimeout(tCtx, 100*time.Millisecond, 1*time.Second, true, func(ctx context.Context) (bool, error) {
-		err = manager.WaitForAttachAndMount(ctx, pod)
+	err := wait.PollUntilContextTimeout(tCtx, 100*time.Millisecond, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+		err := manager.WaitForAttachAndMount(ctx, pod)
 		if err != nil {
 			// Few "PVC not bound" errors are expected
 			return false, nil
@@ -390,11 +364,7 @@ func TestInitialPendingVolumesForPodAndGetVolumesInUse(t *testing.T) {
 
 func TestGetExtraSupplementalGroupsForPod(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
-	tmpDir, err := utiltesting.MkTmpdir("volumeManagerTest")
-	if err != nil {
-		t.Fatalf("can't make a temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	podManager := kubepod.NewBasicPodManager()
 
 	node, pod, _, claim := createObjects(v1.PersistentVolumeFilesystem, v1.PersistentVolumeFilesystem)
@@ -462,7 +432,7 @@ func TestGetExtraSupplementalGroupsForPod(t *testing.T) {
 			tCtx.Done(),
 			manager)
 
-		err = manager.WaitForAttachAndMount(ctx, pod)
+		err := manager.WaitForAttachAndMount(ctx, pod)
 		if err != nil {
 			t.Errorf("Expected success: %v", err)
 			continue

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -311,12 +312,56 @@ func TestWaitForAttachAndMountVolumeAttachLimitExceededError(t *testing.T) {
 
 	require.Error(t, err, "Expected an error but got none")
 
-	var attachErr *VolumeAttachLimitExceededError
-	require.ErrorAs(t, err, &attachErr, "Error should be of type VolumeAttachLimitExceededError")
-	require.Equal(t, []string{"vol1"}, attachErr.UnmountedVolumes, "UnmountedVolumes mismatch")
-	require.Equal(t, []string{"vol1"}, attachErr.UnattachedVolumes, "UnattachedVolumes mismatch")
-	require.Empty(t, attachErr.VolumesNotInDSW, "VolumesNotInDSW should be empty")
-	require.ErrorIs(t, attachErr.OriginalError, context.DeadlineExceeded, "OriginalError should be context.DeadlineExceeded")
+	var rejectingErr *RejectingPodError
+	require.ErrorAs(t, err, &rejectingErr)
+	assert.Equal(t, VolumeAttachmentLimitExceededReason, rejectingErr.Reason)
+	assert.Equal(t, "Node has reached its volume attachment limit", rejectingErr.Desc)
+}
+
+func TestNodeAffitifyMismatch(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.MutablePVNodeAffinity, true)
+
+	tmpDir := t.TempDir()
+	podManager := kubepod.NewBasicPodManager()
+
+	node, pod, pv, claim := createObjects(v1.PersistentVolumeFilesystem, v1.PersistentVolumeFilesystem)
+	node.Status.VolumesAttached = []v1.AttachedVolume{} // volume should be not attached to trigger the error
+
+	// Set PV's NodeAffinity to not match the scheduled node
+	pv.Spec.NodeAffinity = &v1.VolumeNodeAffinity{
+		Required: &v1.NodeSelector{
+			NodeSelectorTerms: []v1.NodeSelectorTerm{
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      "kubernetes.io/hostname",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"some-other-node"},
+						},
+					},
+				},
+			},
+		},
+	}
+	kubeClient := fake.NewClientset(node, pod, pv, claim)
+	manager := newTestVolumeManager(t, tmpDir, podManager, kubeClient, node)
+
+	tCtx := ktesting.Init(t)
+	sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
+	go manager.Run(tCtx, sourcesReady)
+	podManager.SetPods([]*v1.Pod{pod})
+
+	go simulateVolumeInUseUpdate(
+		v1.UniqueVolumeName("fake/fake-device"),
+		tCtx.Done(),
+		manager)
+
+	err := manager.WaitForAttachAndMount(tCtx, pod)
+
+	var rejectingErr *RejectingPodError
+	require.ErrorAs(t, err, &rejectingErr)
+	assert.Equal(t, VolumeNodeAffinityReason, rejectingErr.Reason)
+	assert.Equal(t, "node affinity mismatch", rejectingErr.Desc)
 }
 
 func TestInitialPendingVolumesForPodAndGetVolumesInUse(t *testing.T) {

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -374,8 +374,8 @@ func TestInitialPendingVolumesForPodAndGetVolumesInUse(t *testing.T) {
 	// delayed claim binding
 	go delayClaimBecomesBound(t, kubeClient, claim.GetNamespace(), claim.Name)
 
-	err = wait.Poll(100*time.Millisecond, 1*time.Second, func() (bool, error) {
-		err = manager.WaitForAttachAndMount(tCtx, pod)
+	err = wait.PollUntilContextTimeout(tCtx, 100*time.Millisecond, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+		err = manager.WaitForAttachAndMount(ctx, pod)
 		if err != nil {
 			// Few "PVC not bound" errors are expected
 			return false, nil


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This re-proposes the kubelet-side part of KEP-5381 (mutable PV nodeAffinity) that was split out of #134339 at the last minute.

#134339 already landed the `MutablePVNodeAffinity` feature gate, the API change allowing `PersistentVolume.Spec.NodeAffinity` to be mutated, and the API doc update. What was left behind is the kubelet enforcement: when a PV's `NodeAffinity` is updated (e.g. a CSI driver migrates the data to a different topology), the scheduler may still act on the stale affinity and bind a pod to a node that no longer matches. This PR makes the kubelet reject such a pod so the scheduler can retry elsewhere.

Details:

- The volume reconciler checks node affinity for **unattached** volumes only, and marks a pod error (`ErrNodeAffinityMismatch`) on mismatch. Attached/mounted volumes are left alone to avoid interrupting already-running pods.
- The volume manager surfaces this as a `RejectingPodError`, generalized from the former `VolumeAttachLimitExceededError`, carrying a rejection `Reason` (`VolumeNodeAffinity`). The kubelet rejects the pod using that reason.
- Enforcement is gated on `MutablePVNodeAffinity` (alpha, off by default in 1.35), so behavior is unchanged when the gate is disabled.

The remaining commits are pre-existing test cleanups in the same files (`wait.Poll` → `PollUntilContextTimeout`, `t.TempDir()`, and a test-helper rename) kept separate for reviewability.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/enhancements/issues/5381

Follow-up to #134339, which this was originally part of before the kubelet enforcement was split out.

#### Special notes for your reviewer:

The functional change is the single commit "kubelet: reject pod with volume nodeAffinity mismatch"; the other four commits are test-only refactors and a new reconciler unit test.

/cc @jsafrane @gnufied
This is the kubelet enforcement we discussed on #134339 before I dropped these commits.

/sig storage

#### Does this PR introduce a user-facing change?

```release-note
Kubelet now rejects a pod when an unattached volume's PersistentVolume node affinity does not match the node, when the MutablePVNodeAffinity feature gate is enabled. This lets the scheduler reschedule the pod after a PV's node affinity is updated.
```
