### PR TITLE
Fix OpenAPI spec for binding creation to return Status instead of Binding

### DIFF
--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -170,8 +170,26 @@ func (r *BindingREST) Destroy() {
 	// we don't destroy it here explicitly.
 }
 
+// ProducesMIMETypes returns the list of MIME types the specified HTTP verb (GET, POST, DELETE, PATCH) can respond with.
+func (r *BindingREST) ProducesMIMETypes(verb string) []string {
+  // Return nil to use the default MIME types from the serializer
+  return nil
+}
+
+// ProducesObject returns the type of object produced by this storage for the given verb.
+// Binding creation returns a Status object, not a Binding object.
+func (r *BindingREST) ProducesObject(verb string) interface{} {
+    switch verb {
+    case "POST", "CREATE":
+        return &metav1.Status{}
+    default:
+        return &api.Binding{}
+    }
+}
+
 var _ = rest.NamedCreater(&BindingREST{})
 var _ = rest.SubresourceObjectMetaPreserver(&BindingREST{})
+var _ = rest.StorageMetadata(&BindingREST{})
 
 // Create ensures a pod is bound to a specific host.
 func (r *BindingREST) Create(ctx context.Context, name string, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (out runtime.Object, err error) {
@@ -299,6 +317,7 @@ func (r *BindingREST) assignPod(ctx context.Context, podUID types.UID, podResour
 }
 
 var _ = rest.Creater(&LegacyBindingREST{})
+var _ = rest.StorageMetadata(&LegacyBindingREST{})
 
 // LegacyBindingREST implements the REST endpoint for binding pods to nodes when etcd is in use.
 type LegacyBindingREST struct {
@@ -332,6 +351,16 @@ func (r *LegacyBindingREST) Create(ctx context.Context, obj runtime.Object, crea
 
 func (r *LegacyBindingREST) GetSingularName() string {
 	return "binding"
+}
+
+// ProducesMIMETypes returns the list of MIME types the specified HTTP verb (GET, POST, DELETE, PATCH) can respond with.
+func (r *LegacyBindingREST) ProducesMIMETypes(verb string) []string {
+  return r.bindingRest.ProducesMIMETypes(verb)
+}
+
+// ProducesObject returns the type of object produced by this storage for the given verb.
+func (r *LegacyBindingREST) ProducesObject(verb string) interface{} {
+  return r.bindingRest.ProducesObject(verb)
 }
 
 // StatusREST implements the REST endpoint for changing the status of a pod.


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Fixes the OpenAPI specification for the binding creation endpoint to correctly specify that it returns a `v1.Status` object rather than a `v1.Binding` object.

#### Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes-client/python/issues/547
Related to kubernetes-client/python issue with `create_namespaced_binding()`

#### Release note
```release-note
Fixed the OpenAPI specification for the binding creation endpoint to correctly specify that it returns a `v1.Status` object rather than a `v1.Binding` object.
```

#### Special notes for your reviewer:
The [actual API server implementation (BindingREST.Create)](https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/core/pod/storage/storage.go)) seems to always have returned a Status object:
```go
out = &metav1.Status{Status: metav1.StatusSuccess}
```

However, the OpenAPI spec incorrectly claimed it returns a Binding object, causing client libraries to fail when deserializing the response.

A concrete example is the Python client library that for a long time (at least since its v7.0 release which targeted Kubernetes v1.11, both released in 2018) have had an issue with its `api.create_namespaced_binding()` function, where the client fails to deserialize the returned data:
```python
ValueError: Invalid value for `target`, must not be `None`
```

This PR implements the `ProducesObject` interface method on `BindingREST` to explicitly declare that POST operations return Status objects.

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
- [BindingREST.Create implementation](https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/core/pod/storage/storage.go)
- [Python client issue #547](https://github.com/kubernetes-client/python/issues/547)