### PR TITLE
kubelet/prober: fix exec readiness probe failure during pod termination

### DIFF
--- a/pkg/kubelet/prober/prober_manager.go
+++ b/pkg/kubelet/prober/prober_manager.go
@@ -187,6 +187,15 @@ func (m *manager) AddPod(ctx context.Context, pod *v1.Pod) {
 	defer m.workerLock.Unlock()
 
 	logger := klog.FromContext(ctx)
+	// Detach cancellation from the incoming context. The ctx passed here
+	// originates from the pod worker's sync context (podSyncStatus.ctx),
+	// which is cancelled when the pod enters terminating state. Probe workers
+	// must outlive a single SyncPod call — in particular, readiness probes
+	// must continue to run during graceful termination so that endpoints are
+	// correctly removed. Using WithoutCancel preserves the logger/trace
+	// values while preventing the parent's cancellation from propagating to
+	// probe goroutines.
+	probeCtx := context.WithoutCancel(ctx)
 	key := probeKey{podUID: pod.UID}
 	for _, c := range append(pod.Spec.Containers, getRestartableInitContainers(pod)...) {
 		key.containerName = c.Name
@@ -200,7 +209,7 @@ func (m *manager) AddPod(ctx context.Context, pod *v1.Pod) {
 			}
 			w := newWorker(m, startup, pod, c)
 			m.workers[key] = w
-			go w.run(ctx)
+			go w.run(probeCtx)
 		}
 
 		if c.ReadinessProbe != nil {
@@ -212,7 +221,7 @@ func (m *manager) AddPod(ctx context.Context, pod *v1.Pod) {
 			}
 			w := newWorker(m, readiness, pod, c)
 			m.workers[key] = w
-			go w.run(ctx)
+			go w.run(probeCtx)
 		}
 
 		if c.LivenessProbe != nil {
@@ -224,7 +233,7 @@ func (m *manager) AddPod(ctx context.Context, pod *v1.Pod) {
 			}
 			w := newWorker(m, liveness, pod, c)
 			m.workers[key] = w
-			go w.run(ctx)
+			go w.run(probeCtx)
 		}
 	}
 }

--- a/pkg/kubelet/prober/prober_manager_test.go
+++ b/pkg/kubelet/prober/prober_manager_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package prober
 
 import (
+	"context"
 	"fmt"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -29,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	execprobe "k8s.io/kubernetes/pkg/probe/exec"
 	"k8s.io/kubernetes/pkg/kubelet/prober/results"
 	"k8s.io/kubernetes/pkg/probe"
 	"k8s.io/kubernetes/test/utils/ktesting"
@@ -692,4 +695,77 @@ func cleanup(t *testing.T, m *manager) {
 	if err := wait.Poll(interval, wait.ForeverTestTimeout, condition); err != nil {
 		t.Fatalf("Error during cleanup: %v", err)
 	}
+}
+
+// TestAddPodContextCancellationDoesNotAffectProbeWorkers is a regression test for
+// https://github.com/kubernetes/kubernetes/issues/140509
+//
+// When AddPod is called with a context that is later cancelled (as happens when
+// the pod worker's sync context is cancelled during pod termination), the probe
+// workers must NOT be affected. In particular, exec-based readiness probes must
+// continue to run so that the pod's Ready condition is correctly updated to False,
+// allowing endpoints controllers to remove the pod from service.
+func TestAddPodContextCancellationDoesNotAffectProbeWorkers(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+
+	m := newTestManager()
+	defer cleanup(t, m)
+
+	// Use the REAL exec prober (not the fake) so the full path
+	// prober.probe() → exec.Probe() → execInContainer.Start() → runner.RunInContainer(ctx, ...)
+	// is exercised. This is the path where the context cancellation bug manifests.
+	var ctxWasCancelled atomic.Bool
+	var probeCalled atomic.Bool
+	m.prober.runner = &contextCheckingRunner{
+		onRun: func(runCtx context.Context) {
+			probeCalled.Store(true)
+			if runCtx.Err() != nil {
+				ctxWasCancelled.Store(true)
+			}
+		},
+	}
+	// Replace the fake exec prober with the real one that calls through to runner
+	m.prober.exec = execprobe.New()
+
+	// Create a pod with exec readiness probe
+	testPod := getTestPod()
+	setTestProbe(testPod, readiness, v1.Probe{PeriodSeconds: 1})
+
+	// Set pod status so the probe worker can find a running container
+	m.statusManager.SetPodStatus(logger, testPod, getTestRunningStatus())
+
+	// Create a cancellable context to simulate the pod worker's sync context
+	podCtx, cancel := context.WithCancel(context.Background())
+
+	// Add the pod — starts probe worker goroutine with podCtx
+	m.AddPod(podCtx, testPod)
+
+	// Simulate: pod enters terminating state → sync context is cancelled
+	cancel()
+
+	// Wait for the probe worker to execute at least one probe cycle via RunInContainer
+	err := wait.PollImmediate(100*time.Millisecond, 5*time.Second, func() (bool, error) {
+		return probeCalled.Load(), nil
+	})
+	if err != nil {
+		t.Fatal("Probe worker never executed RunInContainer after context cancellation — worker likely exited")
+	}
+
+	// The key assertion: the context passed to RunInContainer must NOT be cancelled
+	if ctxWasCancelled.Load() {
+		t.Error("RunInContainer received a cancelled context after parent ctx was cancelled. " +
+			"This is the bug from issue #140509: exec probes fail with 'context canceled' during termination")
+	}
+}
+
+// contextCheckingRunner implements kubecontainer.CommandRunner for testing.
+type contextCheckingRunner struct {
+	onRun func(ctx context.Context)
+}
+
+func (r *contextCheckingRunner) RunInContainer(ctx context.Context, id kubecontainer.ContainerID, cmd []string, timeout time.Duration) ([]byte, error) {
+	if r.onRun != nil {
+		r.onRun(ctx)
+	}
+	return []byte("ok"), nil
 }


### PR DESCRIPTION
When a pod enters the terminating state, the pod worker cancels its sync context (podSyncStatus.ctx). Since commit b6f6731ab61 ("migrate prober to contextual logging"), AddPod passes this cancellable context directly to probe worker goroutines via go w.run(ctx). This causes exec-based readiness probes to fail with "context canceled" instead of actually executing, leaving the pod's Ready condition stuck at True.

Fix by using context.WithoutCancel(ctx) when launching probe worker goroutines. This preserves the logger and trace values from the parent context while isolating probe workers from the parent's cancellation signal. Probe workers have their own lifecycle management (stopCh) and must continue running during graceful termination so that readiness probes can correctly report the pod as not-ready, allowing endpoints controllers to remove it from service.

This fix targets release-1.35 only. The issue does not exist on master or release-1.36, where commit e94e67337df ("tighten podworkers context flow") restructured the entire pod worker context lifecycle, eliminating the persistent podSyncStatus.ctx field.


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind regression

#### What this PR does / why we need it:
This issue does not exist on master or release-1.36. Commit e94e67337df ("tighten podworkers context flow") restructured the entire pod worker context lifecycle on master, eliminating `podSyncStatus.ctx`. The fix here is the minimal backport-friendly approach for release-1.35 only.

#### Which issue(s) this PR is related to:
Fixes: #140509

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
- Unit tests: go test ./pkg/kubelet/prober/... -count=1 — all pass
- E2E with kind v1.35 using [reproduction repo](https://github.com/ryan-vance-cresta/k8s-readiness-probe-regression):
  - Before: Ready=True stuck, event: context canceled
  - After: Ready=False within 1s, event: Readiness probe failed
  - 
#### Does this PR introduce a user-facing change?
no
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
