### PR TITLE
kubelet/dra: fail prepareResources on a claim being unprepared

### DIFF
--- a/pkg/kubelet/cm/dra/claiminfo.go
+++ b/pkg/kubelet/cm/dra/claiminfo.go
@@ -41,6 +41,12 @@ import (
 type ClaimInfo struct {
 	state.ClaimInfoState
 	prepared bool
+	// unpreparing is true from the moment unprepareResources commits to
+	// calling NodeUnprepareResources for the last referencing pod until
+	// the cache entry is deleted. While set, prepareResources must not
+	// attach new pods to this claim: the claim resources are being unprepared
+	// and new pods shouldn't prepare this claim until it has been fully unprepared.
+	unpreparing bool
 }
 
 // claimInfoCache is a cache of processed resource claims keyed by namespace/claimname.
@@ -115,6 +121,18 @@ func (info *ClaimInfo) setPrepared() {
 // isPrepared checks if claim info is prepared or not.
 func (info *ClaimInfo) isPrepared() bool {
 	return info.prepared
+}
+
+// setUnpreparing marks the claim info as being torn down, so
+// prepareResources refuses to attach new pods to it.
+func (info *ClaimInfo) setUnpreparing() {
+	info.unpreparing = true
+}
+
+// isUnpreparing reports whether unprepareResources is in the process
+// of calling NodeUnprepareResources on this claim.
+func (info *ClaimInfo) isUnpreparing() bool {
+	return info.unpreparing
 }
 
 // cdiDevicesAsList returns a list of CDIDevices from the provided claim info.

--- a/pkg/kubelet/cm/dra/manager.go
+++ b/pkg/kubelet/cm/dra/manager.go
@@ -348,6 +348,12 @@ func (m *Manager) prepareResources(ctx context.Context, pod *v1.Pod) error {
 				if claimInfo.ClaimUID != resourceClaim.UID {
 					return fmt.Errorf("old ResourceClaim with same name %s and different UID %s still exists (previous pod force-deleted?!)", resourceClaim.Name, claimInfo.ClaimUID)
 				}
+				// Reject attaching a new pod to a claim if unprepareResources
+				// has already started as cache entry will be deleted when resources
+				// are fully unprepared.
+				if claimInfo.isUnpreparing() {
+					return fmt.Errorf("ResourceClaim %s is being unprepared", resourceClaim.Name)
+				}
 				logger.V(6).Info("Found existing claim info cache entry", "podClaim", podClaim.Name, "claim", klog.KObj(resourceClaim), "claimInfoEntry", claimInfo)
 			}
 
@@ -662,6 +668,14 @@ func (m *Manager) unprepareResources(ctx context.Context, podUID types.UID, name
 			// This claimInfo name will be used to update ClaimInfo cache
 			// after NodeUnprepareResources GRPC succeeds
 			claimNamesMap[claimInfo.ClaimUID] = claimInfo.ClaimName
+
+			// Mark the claim as being unprepared while we hold the cache
+			// lock. NodeUnprepareResources runs below without the lock
+			// held; any concurrent prepareResources for a different pod
+			// that finds this entry must refuse to attach itself, since
+			// the resources are being unprepared and the cache entry
+			// will be deleted on completion.
+			claimInfo.setUnpreparing()
 
 			// Loop through all drivers and prepare for calling NodeUnprepareResources.
 			claim := &drapb.Claim{

--- a/pkg/kubelet/cm/dra/manager_test.go
+++ b/pkg/kubelet/cm/dra/manager_test.go
@@ -1360,6 +1360,59 @@ func TestPrepareResourcesWithPreparedAndNewClaim(t *testing.T) {
 	}
 }
 
+// TestPrepareResourcesWithUnpreparingClaim is a regression test for the race
+// where reconcileLoop-initiated (or otherwise concurrent) unprepareResources
+// has committed to calling NodeUnprepareResources on a claim, released the
+// cache lock during the RPC, and prepareResources for a different pod would
+// otherwise attach itself to the still-cached-but-being-torn-down claim.
+// PrepareResources must refuse to touch a claim marked as unpreparing.
+func TestPrepareResourcesWithUnpreparingClaim(t *testing.T) {
+	logger, tCtx := ktesting.NewTestContext(t)
+	fakeKubeClient := fake.NewClientset()
+
+	manager, err := NewManager(logger, fakeKubeClient, t.TempDir())
+	require.NoError(t, err)
+	manager.initDRAPluginManager(tCtx, getFakeNode, time.Second)
+
+	pod := genTestPod()
+	claim := genTestClaim(claimName, driverName, deviceName, podUID)
+	_, err = fakeKubeClient.ResourceV1().ResourceClaims(namespace).Create(tCtx, claim, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	draServerInfo, err := setupFakeDRADriverGRPCServer(tCtx, false, nil, genPrepareResourcesResponse(claim.UID), nil, nil)
+	require.NoError(t, err)
+	defer draServerInfo.teardownFn()
+
+	plg := manager.GetWatcherHandler()
+	require.NoError(t, plg.RegisterPlugin(tCtx, driverName, draServerInfo.socketName, []string{drapb.DRAPluginService}, nil))
+
+	// Seed the cache with a claimInfo that is fully prepared for another
+	// pod and marked as unpreparing (mimicking the state after
+	// unprepareResources has committed to calling NodeUnprepareResources
+	// but before the terminal cache delete). The other pod is still
+	// referenced so we can also check its reference survives.
+	existing := genTestClaimInfo(claimUID, []string{"another-pod-uid"}, true, nil)
+	existing.setUnpreparing()
+	manager.cache.add(existing)
+
+	err = manager.PrepareResources(tCtx, pod)
+	require.Error(t, err, "PrepareResources must fail while the claim is being unprepared")
+
+	assert.Equal(t, uint32(0), draServerInfo.server.prepareResourceCalls.Load(),
+		"driver must not be called while the claim is being unprepared")
+
+	// The seeded claimInfo must be untouched: no new pod reference, still
+	// unpreparing, still prepared, other pod's reference intact.
+	cached, ok := manager.cache.get(claimName, namespace)
+	require.True(t, ok, "claim info must still be in the cache")
+	assert.False(t, cached.PodUIDs.Has(string(pod.UID)),
+		"failing PrepareResources must not have added this pod to PodUIDs")
+	assert.True(t, cached.PodUIDs.Has("another-pod-uid"),
+		"other pod's reference must survive")
+	assert.True(t, cached.isUnpreparing(),
+		"unpreparing flag must still be set")
+}
+
 func TestUnprepareResources(t *testing.T) {
 	fakeKubeClient := fake.NewSimpleClientset()
 	for _, test := range []struct {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`unprepareResources` releases the cache lock while calling `NodeUnprepareResources` so a concurrent `prepareResources` for a different pod could take the lock, see `prepared==true`, `addPodReference`, and skip the driver call, then `unprepareResources` would un-prepare resources used by this pod.

Added `unpreparing` flag on `ClaimInfo`. `unprepareResources` sets it in the first per-claim withLock, once it has committed to calling `NodeUnprepareResources` for the last referencing pod. `prepareResources` checks it when it finds an existing cache entry and returns an error so the operation is retried after the entry has been deleted.

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?
```release-note
kubelet/DRA: fixed a race where PrepareResources could attach a pod to a ResourceClaim that was concurrently being unprepared, leaving the pod running with unprepared devices.
```
