### PR TITLE
E2E storage: don't register unsupported tests

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -66,7 +66,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	mockdriver "k8s.io/kubernetes/test/e2e/storage/drivers/csi-test/driver"
 	mockservice "k8s.io/kubernetes/test/e2e/storage/drivers/csi-test/mock/service"
@@ -203,10 +202,11 @@ func (h *hostpathCSIDriver) GetDriverInfo() *storageframework.DriverInfo {
 	return &h.driverInfo
 }
 
-func (h *hostpathCSIDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) {
+func (h *hostpathCSIDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) string {
 	if pattern.VolType == storageframework.CSIInlineVolume && len(h.volumeAttributes) == 0 {
-		e2eskipper.Skipf("%s has no volume attributes defined, doesn't support ephemeral inline volumes", h.driverInfo.Name)
+		return fmt.Sprintf("%s has no volume attributes defined, doesn't support ephemeral inline volumes", h.driverInfo.Name)
 	}
+	return ""
 }
 
 func (h *hostpathCSIDriver) GetDynamicProvisionStorageClass(ctx context.Context, config *storageframework.PerTestConfig, fsType string) *storagev1.StorageClass {
@@ -626,7 +626,8 @@ func (m *mockCSIDriver) GetDriverInfo() *storageframework.DriverInfo {
 	return &m.driverInfo
 }
 
-func (m *mockCSIDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) {
+func (m *mockCSIDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) string {
+	return ""
 }
 
 func (m *mockCSIDriver) GetDynamicProvisionStorageClass(ctx context.Context, config *storageframework.PerTestConfig, fsType string) *storagev1.StorageClass {
@@ -957,15 +958,19 @@ func (g *gcePDCSIDriver) GetDriverInfo() *storageframework.DriverInfo {
 	return &g.driverInfo
 }
 
-func (g *gcePDCSIDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) {
+func (g *gcePDCSIDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) string {
 	if pattern.FsType == "xfs" {
-		e2eskipper.SkipUnlessNodeOSDistroIs("ubuntu", "custom")
+		if !framework.NodeOSDistroIs("ubuntu", "custom") {
+			return "unsupported node OS"
+		}
+
 	}
 	for _, tag := range pattern.TestTags {
 		if tag == feature.Windows {
-			e2eskipper.Skipf("Skipping tests for windows since CSI does not support it yet")
+			return "Skipping tests for windows since CSI does not support it yet"
 		}
 	}
+	return ""
 }
 
 func (g *gcePDCSIDriver) GetDynamicProvisionStorageClass(ctx context.Context, config *storageframework.PerTestConfig, fsType string) *storagev1.StorageClass {

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -143,7 +143,8 @@ func (n *nfsDriver) GetDriverInfo() *storageframework.DriverInfo {
 	return &n.driverInfo
 }
 
-func (n *nfsDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) {
+func (n *nfsDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) string {
+	return ""
 }
 
 func (n *nfsDriver) GetVolumeSource(readOnly bool, fsType string, e2evolume storageframework.TestVolume) *v1.VolumeSource {
@@ -289,7 +290,8 @@ func (i *iSCSIDriver) GetDriverInfo() *storageframework.DriverInfo {
 	return &i.driverInfo
 }
 
-func (i *iSCSIDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) {
+func (i *iSCSIDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) string {
+	return ""
 }
 
 func (i *iSCSIDriver) GetVolumeSource(readOnly bool, fsType string, e2evolume storageframework.TestVolume) *v1.VolumeSource {
@@ -429,7 +431,8 @@ func (h *hostPathDriver) GetDriverInfo() *storageframework.DriverInfo {
 	return &h.driverInfo
 }
 
-func (h *hostPathDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) {
+func (h *hostPathDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) string {
+	return ""
 }
 
 func (h *hostPathDriver) GetVolumeSource(readOnly bool, fsType string, e2evolume storageframework.TestVolume) *v1.VolumeSource {
@@ -585,7 +588,8 @@ func (h *hostPathSymlinkDriver) GetDriverInfo() *storageframework.DriverInfo {
 	return &h.driverInfo
 }
 
-func (h *hostPathSymlinkDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) {
+func (h *hostPathSymlinkDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) string {
+	return ""
 }
 
 func (h *hostPathSymlinkDriver) GetVolumeSource(readOnly bool, fsType string, e2evolume storageframework.TestVolume) *v1.VolumeSource {
@@ -732,7 +736,8 @@ func (e *emptydirDriver) GetDriverInfo() *storageframework.DriverInfo {
 	return &e.driverInfo
 }
 
-func (e *emptydirDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) {
+func (e *emptydirDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) string {
+	return ""
 }
 
 func (e *emptydirDriver) GetVolumeSource(readOnly bool, fsType string, e2evolume storageframework.TestVolume) *v1.VolumeSource {
@@ -799,7 +804,8 @@ func (c *cinderDriver) GetDriverInfo() *storageframework.DriverInfo {
 	return &c.driverInfo
 }
 
-func (c *cinderDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) {
+func (c *cinderDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) string {
+	return ""
 }
 
 func (c *cinderDriver) GetDynamicProvisionStorageClass(ctx context.Context, config *storageframework.PerTestConfig, fsType string) *storagev1.StorageClass {
@@ -908,12 +914,15 @@ func (g *gcePdDriver) GetDriverInfo() *storageframework.DriverInfo {
 	return &g.driverInfo
 }
 
-func (g *gcePdDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) {
+func (g *gcePdDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) string {
 	for _, tag := range pattern.TestTags {
 		if tag == feature.Windows {
-			e2eskipper.SkipUnlessNodeOSDistroIs("windows")
+			if !framework.NodeOSDistroIs("windows") {
+				return "not supported on Windows"
+			}
 		}
 	}
+	return ""
 }
 
 func (g *gcePdDriver) GetDynamicProvisionStorageClass(ctx context.Context, config *storageframework.PerTestConfig, fsType string) *storagev1.StorageClass {
@@ -988,7 +997,8 @@ func (v *vSphereDriver) GetDriverInfo() *storageframework.DriverInfo {
 	return &v.driverInfo
 }
 
-func (v *vSphereDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) {
+func (v *vSphereDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) string {
+	return ""
 }
 
 func (v *vSphereDriver) GetDynamicProvisionStorageClass(ctx context.Context, config *storageframework.PerTestConfig, fsType string) *storagev1.StorageClass {
@@ -1056,7 +1066,8 @@ func (a *azureDiskDriver) GetDriverInfo() *storageframework.DriverInfo {
 	return &a.driverInfo
 }
 
-func (a *azureDiskDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) {
+func (a *azureDiskDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) string {
+	return ""
 }
 
 func (a *azureDiskDriver) GetDynamicProvisionStorageClass(ctx context.Context, config *storageframework.PerTestConfig, fsType string) *storagev1.StorageClass {
@@ -1138,7 +1149,8 @@ func (a *awsDriver) GetDriverInfo() *storageframework.DriverInfo {
 	return &a.driverInfo
 }
 
-func (a *awsDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) {
+func (a *awsDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) string {
+	return ""
 }
 
 func (a *awsDriver) GetDynamicProvisionStorageClass(ctx context.Context, config *storageframework.PerTestConfig, fsType string) *storagev1.StorageClass {
@@ -1300,7 +1312,8 @@ func (l *localDriver) GetDriverInfo() *storageframework.DriverInfo {
 	return &l.driverInfo
 }
 
-func (l *localDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) {
+func (l *localDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) string {
+	return ""
 }
 
 func (l *localDriver) PrepareTest(ctx context.Context, f *framework.Framework) *storageframework.PerTestConfig {
@@ -1441,7 +1454,8 @@ func (a *azureFileDriver) GetDriverInfo() *storageframework.DriverInfo {
 	return &a.driverInfo
 }
 
-func (a *azureFileDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) {
+func (a *azureFileDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) string {
+	return ""
 }
 
 func (a *azureFileDriver) GetDynamicProvisionStorageClass(ctx context.Context, config *storageframework.PerTestConfig, fsType string) *storagev1.StorageClass {

--- a/test/e2e/storage/external/external.go
+++ b/test/e2e/storage/external/external.go
@@ -301,7 +301,7 @@ func (d *driverDefinition) GetDriverInfo() *storageframework.DriverInfo {
 	return &d.DriverInfo
 }
 
-func (d *driverDefinition) SkipUnsupportedTest(pattern storageframework.TestPattern) {
+func (d *driverDefinition) SkipUnsupportedTest(pattern storageframework.TestPattern) string {
 	supported := false
 	// TODO (?): add support for more volume types
 	switch pattern.VolType {
@@ -315,9 +315,9 @@ func (d *driverDefinition) SkipUnsupportedTest(pattern storageframework.TestPatt
 		supported = len(d.InlineVolumes) != 0
 	}
 	if !supported {
-		e2eskipper.Skipf("Driver %q does not support volume type %q - skipping", d.DriverInfo.Name, pattern.VolType)
+		return fmt.Sprintf("Driver %q does not support volume type %q - skipping", d.DriverInfo.Name, pattern.VolType)
 	}
-
+	return ""
 }
 
 func (d *driverDefinition) GetDynamicProvisionStorageClass(ctx context.Context, e2econfig *storageframework.PerTestConfig, fsType string) *storagev1.StorageClass {

--- a/test/e2e/storage/framework/testdriver.go
+++ b/test/e2e/storage/framework/testdriver.go
@@ -36,16 +36,15 @@ type TestDriver interface {
 	// information.
 	GetDriverInfo() *DriverInfo
 
-	// SkipUnsupportedTest skips test if Testpattern is not
+	// SkipUnsupportedTest returns the reason for skipping test if Testpattern is not
 	// suitable to test with the TestDriver. It gets called after
 	// parsing parameters of the test suite and before the
-	// framework is initialized. Cheap tests that just check
-	// parameters like the cloud provider can and should be
-	// done in SkipUnsupportedTest to avoid setting up more
-	// expensive resources like framework.Framework. Tests that
+	// framework is initialized.
+	//
+	// Tests that
 	// depend on a connection to the cluster can be done in
 	// PrepareTest once the framework is ready.
-	SkipUnsupportedTest(TestPattern)
+	SkipUnsupportedTest(TestPattern) string
 
 	// PrepareTest is called at test execution time each time a new test case is about to start.
 	// It sets up all necessary resources and returns the per-test configuration.

--- a/test/e2e/storage/framework/testsuite.go
+++ b/test/e2e/storage/framework/testsuite.go
@@ -18,13 +18,18 @@ package framework
 
 import (
 	"fmt"
-
-	"github.com/onsi/ginkgo/v2"
+	"os"
 
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 )
+
+func DebugStorageTestsuite(format string, args ...any) {
+	if _, ok := os.LookupEnv("DEBUG_STORAGE_TESTSUITE"); !ok {
+		return
+	}
+	fmt.Printf(format, args...)
+}
 
 // TestSuite represents an interface for a set of tests which works with TestDriver.
 // Each testsuite should implement this interface.
@@ -36,10 +41,13 @@ type TestSuite interface {
 	// Called inside a Ginkgo context that reflects the current driver and test pattern,
 	// so the test suite can define tests directly with ginkgo.It.
 	DefineTests(TestDriver, TestPattern)
-	// SkipUnsupportedTests will skip the test suite based on the given TestPattern, TestDriver
+	// SkipUnsupportedTests will return a reason why the the given combination of TestPattern
+	// and TestDriver cannot be tested. No tests get registered.
+	//
 	// Testsuite should check if the given pattern and driver works for the "whole testsuite"
-	// Testcase specific check should happen inside defineTests
-	SkipUnsupportedTests(TestDriver, TestPattern)
+	// Testcase specific check should happen inside defineTests. Unsupported
+	// tests should not even get defined.
+	SkipUnsupportedTests(TestDriver, TestPattern) string
 }
 
 // RegisterTests register the driver + pattern combination to the inside TestSuite
@@ -52,12 +60,15 @@ func RegisterTests(suite TestSuite, driver TestDriver, pattern TestPattern) {
 	args = append(args, tsInfo.Name)
 	args = append(args, tsInfo.TestTags...)
 	args = append(args, func() {
-		ginkgo.BeforeEach(func() {
-			// skip all the invalid combination of driver and pattern
-			SkipInvalidDriverPatternCombination(driver, pattern)
-			// skip the unsupported test pattern and driver combination specific for this TestSuite
-			suite.SkipUnsupportedTests(driver, pattern)
-		})
+		reason := SkipInvalidDriverPatternCombination(driver, pattern)
+		if reason == "" {
+			reason = suite.SkipUnsupportedTests(driver, pattern)
+		}
+		if reason != "" {
+			DebugStorageTestsuite("Skipping registration: [Testpattern: %s] %s [Driver: %s] - %s\n", pattern.Name, tsInfo.Name, driver.GetDriverInfo().Name, reason)
+			return
+		}
+
 		// actually define the tests
 		// at this step the testsuite should not worry about if the pattern and driver
 		// does not fit for the whole testsuite. But driver&pattern check
@@ -96,12 +107,14 @@ type TestSuiteInfo struct {
 //
 // Test suites can also skip tests inside their own skipUnsupportedTests function or in
 // individual tests.
-func SkipInvalidDriverPatternCombination(driver TestDriver, pattern TestPattern) {
+func SkipInvalidDriverPatternCombination(driver TestDriver, pattern TestPattern) string {
 	dInfo := driver.GetDriverInfo()
 	var isSupported bool
 
 	// 0. Check with driver specific logic
-	driver.SkipUnsupportedTest(pattern)
+	if reason := driver.SkipUnsupportedTest(pattern); reason != "" {
+		return reason
+	}
 
 	// 1. Check if Whether volType is supported by driver from its interface
 	switch pattern.VolType {
@@ -118,17 +131,19 @@ func SkipInvalidDriverPatternCombination(driver TestDriver, pattern TestPattern)
 	}
 
 	if !isSupported {
-		e2eskipper.Skipf("Driver %s doesn't support %v -- skipping", dInfo.Name, pattern.VolType)
+		return fmt.Sprintf("Driver %s doesn't support %v", dInfo.Name, pattern.VolType)
 	}
 
 	// 2. Check if fsType is supported
 	if !dInfo.SupportedFsType.Has(pattern.FsType) {
-		e2eskipper.Skipf("Driver %s doesn't support %v -- skipping", dInfo.Name, pattern.FsType)
+		return fmt.Sprintf("Driver %s doesn't support %v", dInfo.Name, pattern.FsType)
 	}
 	if pattern.FsType == "xfs" && framework.NodeOSDistroIs("windows") {
-		e2eskipper.Skipf("Distro doesn't support xfs -- skipping")
+		return "Distro doesn't support xfs"
 	}
 	if pattern.FsType == "ntfs" && !framework.NodeOSDistroIs("windows") {
-		e2eskipper.Skipf("Distro %s doesn't support ntfs -- skipping", framework.TestContext.NodeOSDistro)
+		return fmt.Sprintf("Distro %s doesn't support ntfs", framework.TestContext.NodeOSDistro)
 	}
+
+	return ""
 }

--- a/test/e2e/storage/testsuites/base.go
+++ b/test/e2e/storage/testsuites/base.go
@@ -19,6 +19,7 @@ package testsuites
 import (
 	"context"
 	"flag"
+	"fmt"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +30,6 @@ import (
 	csitrans "k8s.io/csi-translation-lib"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2emetrics "k8s.io/kubernetes/test/e2e/framework/metrics"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 )
 
@@ -254,9 +254,10 @@ func (moc *migrationOpCheck) validateMigrationVolumeOpCounts(ctx context.Context
 }
 
 // Skip skipVolTypes patterns if the driver supports dynamic provisioning
-func skipVolTypePatterns(pattern storageframework.TestPattern, driver storageframework.TestDriver, skipVolTypes map[storageframework.TestVolType]bool) {
+func checkVolTypePatterns(pattern storageframework.TestPattern, driver storageframework.TestDriver, skipVolTypes map[storageframework.TestVolType]bool) string {
 	_, supportsProvisioning := driver.(storageframework.DynamicPVTestDriver)
 	if supportsProvisioning && skipVolTypes[pattern.VolType] {
-		e2eskipper.Skipf("Driver supports dynamic provisioning, skipping %s pattern", pattern.VolType)
+		return fmt.Sprintf("Driver supports dynamic provisioning, skipping %s pattern", pattern.VolType)
 	}
+	return ""
 }

--- a/test/e2e/storage/testsuites/capacity.go
+++ b/test/e2e/storage/testsuites/capacity.go
@@ -67,15 +67,16 @@ func (p *capacityTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInfo {
 	return p.tsInfo
 }
 
-func (p *capacityTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+func (p *capacityTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) string {
 	// Check preconditions.
 	if pattern.VolType != storageframework.DynamicPV {
-		e2eskipper.Skipf("Suite %q does not support %v", p.tsInfo.Name, pattern.VolType)
+		return fmt.Sprintf("Suite %q does not support %v", p.tsInfo.Name, pattern.VolType)
 	}
 	dInfo := driver.GetDriverInfo()
 	if !dInfo.Capabilities[storageframework.CapCapacity] {
-		e2eskipper.Skipf("Driver %s doesn't publish storage capacity -- skipping", dInfo.Name)
+		return fmt.Sprintf("Driver %s doesn't publish storage capacity", dInfo.Name)
 	}
+	return ""
 }
 
 func (p *capacityTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {

--- a/test/e2e/storage/testsuites/disruptive.go
+++ b/test/e2e/storage/testsuites/disruptive.go
@@ -18,6 +18,7 @@ package testsuites
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/onsi/ginkgo/v2"
 	v1 "k8s.io/api/core/v1"
@@ -27,7 +28,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	storageutils "k8s.io/kubernetes/test/e2e/storage/utils"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -43,7 +43,7 @@ func InitCustomDisruptiveTestSuite(patterns []storageframework.TestPattern) stor
 	return &disruptiveTestSuite{
 		tsInfo: storageframework.TestSuiteInfo{
 			Name:         "disruptive",
-			TestTags:     []interface{}{framework.WithDisruptive(), framework.WithLabel("LinuxOnly")},
+			TestTags:     []interface{}{framework.WithDisruptive(), framework.WithLabel("LinuxOnly"), framework.WithProvider(framework.ProvidersWithSSH...)},
 			TestPatterns: patterns,
 		},
 	}
@@ -67,12 +67,14 @@ func (s *disruptiveTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInfo 
 	return s.tsInfo
 }
 
-func (s *disruptiveTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
-	skipVolTypePatterns(pattern, driver, storageframework.NewVolTypeMap(storageframework.PreprovisionedPV))
-	if pattern.VolMode == v1.PersistentVolumeBlock && !driver.GetDriverInfo().Capabilities[storageframework.CapBlock] {
-		e2eskipper.Skipf("Driver %s doesn't support %v -- skipping", driver.GetDriverInfo().Name, pattern.VolMode)
+func (s *disruptiveTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) string {
+	if reason := checkVolTypePatterns(pattern, driver, storageframework.NewVolTypeMap(storageframework.PreprovisionedPV)); reason != "" {
+		return reason
 	}
-	e2eskipper.SkipUnlessSSHKeyPresent()
+	if pattern.VolMode == v1.PersistentVolumeBlock && !driver.GetDriverInfo().Capabilities[storageframework.CapBlock] {
+		return fmt.Sprintf("Driver %s doesn't support %v", driver.GetDriverInfo().Name, pattern.VolMode)
+	}
+	return ""
 }
 
 func (s *disruptiveTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {

--- a/test/e2e/storage/testsuites/ephemeral.go
+++ b/test/e2e/storage/testsuites/ephemeral.go
@@ -95,10 +95,11 @@ func (p *ephemeralTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInfo {
 	return p.tsInfo
 }
 
-func (p *ephemeralTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+func (p *ephemeralTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) string {
 	if pattern.VolMode == v1.PersistentVolumeBlock {
-		skipTestIfBlockNotSupported(driver)
+		return checkIfBlockNotSupported(driver)
 	}
+	return ""
 }
 
 func (p *ephemeralTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {

--- a/test/e2e/storage/testsuites/fsgroupchangepolicy.go
+++ b/test/e2e/storage/testsuites/fsgroupchangepolicy.go
@@ -74,25 +74,28 @@ func (s *fsGroupChangePolicyTestSuite) GetTestSuiteInfo() storageframework.TestS
 	return s.tsInfo
 }
 
-func (s *fsGroupChangePolicyTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
-	skipVolTypePatterns(pattern, driver, storageframework.NewVolTypeMap(storageframework.CSIInlineVolume, storageframework.GenericEphemeralVolume))
+func (s *fsGroupChangePolicyTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) string {
+	if reason := checkVolTypePatterns(pattern, driver, storageframework.NewVolTypeMap(storageframework.CSIInlineVolume, storageframework.GenericEphemeralVolume)); reason != "" {
+		return reason
+	}
 	dInfo := driver.GetDriverInfo()
 	if !dInfo.Capabilities[storageframework.CapFsGroup] {
-		e2eskipper.Skipf("Driver %q does not support FsGroup - skipping", dInfo.Name)
+		return fmt.Sprintf("Driver %q does not support FsGroup", dInfo.Name)
 	}
 
 	if pattern.VolMode == v1.PersistentVolumeBlock {
-		e2eskipper.Skipf("Test does not support non-filesystem volume mode - skipping")
+		return "Test does not support non-filesystem volume mode"
 	}
 
 	if pattern.VolType != storageframework.DynamicPV {
-		e2eskipper.Skipf("Suite %q does not support %v", s.tsInfo.Name, pattern.VolType)
+		return fmt.Sprintf("Suite %q does not support %v", s.tsInfo.Name, pattern.VolType)
 	}
 
 	_, ok := driver.(storageframework.DynamicPVTestDriver)
 	if !ok {
-		e2eskipper.Skipf("Driver %s doesn't support %v -- skipping", dInfo.Name, pattern.VolType)
+		return fmt.Sprintf("Driver %s doesn't support %v", dInfo.Name, pattern.VolType)
 	}
+	return ""
 }
 
 func (s *fsGroupChangePolicyTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {

--- a/test/e2e/storage/testsuites/multivolume.go
+++ b/test/e2e/storage/testsuites/multivolume.go
@@ -80,12 +80,15 @@ func (t *multiVolumeTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInfo
 	return t.tsInfo
 }
 
-func (t *multiVolumeTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+func (t *multiVolumeTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) string {
 	dInfo := driver.GetDriverInfo()
-	skipVolTypePatterns(pattern, driver, storageframework.NewVolTypeMap(storageframework.PreprovisionedPV))
-	if pattern.VolMode == v1.PersistentVolumeBlock && !dInfo.Capabilities[storageframework.CapBlock] {
-		e2eskipper.Skipf("Driver %s doesn't support %v -- skipping", dInfo.Name, pattern.VolMode)
+	if reason := checkVolTypePatterns(pattern, driver, storageframework.NewVolTypeMap(storageframework.PreprovisionedPV)); reason != "" {
+		return reason
 	}
+	if pattern.VolMode == v1.PersistentVolumeBlock && !dInfo.Capabilities[storageframework.CapBlock] {
+		return fmt.Sprintf("Driver %s doesn't support %v", dInfo.Name, pattern.VolMode)
+	}
+	return ""
 }
 
 func (t *multiVolumeTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -109,15 +109,16 @@ func (p *provisioningTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInf
 	return p.tsInfo
 }
 
-func (p *provisioningTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+func (p *provisioningTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) string {
 	// Check preconditions.
 	if pattern.VolType != storageframework.DynamicPV {
-		e2eskipper.Skipf("Suite %q does not support %v", p.tsInfo.Name, pattern.VolType)
+		return fmt.Sprintf("Suite %q does not support %v", p.tsInfo.Name, pattern.VolType)
 	}
 	dInfo := driver.GetDriverInfo()
 	if pattern.VolMode == v1.PersistentVolumeBlock && !dInfo.Capabilities[storageframework.CapBlock] {
-		e2eskipper.Skipf("Driver %s doesn't support %v -- skipping", dInfo.Name, pattern.VolMode)
+		return fmt.Sprintf("Driver %s doesn't support %v", dInfo.Name, pattern.VolMode)
 	}
+	return ""
 }
 
 func (p *provisioningTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {

--- a/test/e2e/storage/testsuites/pvcdeletionperf.go
+++ b/test/e2e/storage/testsuites/pvcdeletionperf.go
@@ -62,7 +62,8 @@ func (t *pvcDeletionPerformanceTestSuite) GetTestSuiteInfo() storageframework.Te
 	return t.tsInfo
 }
 
-func (t *pvcDeletionPerformanceTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+func (t *pvcDeletionPerformanceTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) string {
+	return ""
 }
 
 func (t *pvcDeletionPerformanceTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {

--- a/test/e2e/storage/testsuites/readwriteoncepod.go
+++ b/test/e2e/storage/testsuites/readwriteoncepod.go
@@ -18,6 +18,7 @@ package testsuites
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/onsi/ginkgo/v2"
 
@@ -33,7 +34,6 @@ import (
 	e2eevents "k8s.io/kubernetes/test/e2e/framework/events"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
 )
@@ -77,11 +77,12 @@ func (t *readWriteOncePodTestSuite) GetTestSuiteInfo() storageframework.TestSuit
 	return t.tsInfo
 }
 
-func (t *readWriteOncePodTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+func (t *readWriteOncePodTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) string {
 	driverInfo := driver.GetDriverInfo()
 	if !driverInfo.Capabilities[storageframework.CapReadWriteOncePod] {
-		e2eskipper.Skipf("Driver %q doesn't support ReadWriteOncePod - skipping", driverInfo.Name)
+		return fmt.Sprintf("Driver %q doesn't support ReadWriteOncePod", driverInfo.Name)
 	}
+	return ""
 }
 
 func (t *readWriteOncePodTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {

--- a/test/e2e/storage/testsuites/selinuxmount.go
+++ b/test/e2e/storage/testsuites/selinuxmount.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -80,10 +79,11 @@ func (s *seLinuxMountTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInf
 	return s.tsInfo
 }
 
-func (s *seLinuxMountTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+func (s *seLinuxMountTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) string {
 	if !driver.GetDriverInfo().Capabilities[storageframework.CapSELinuxMount] {
-		e2eskipper.Skipf("Driver %q does not support SELinuxMount - skipping", driver.GetDriverInfo().Name)
+		return fmt.Sprintf("Driver %q does not support SELinuxMount", driver.GetDriverInfo().Name)
 	}
+	return ""
 }
 
 func (s *seLinuxMountTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {

--- a/test/e2e/storage/testsuites/snapshot-metadata.go
+++ b/test/e2e/storage/testsuites/snapshot-metadata.go
@@ -32,7 +32,6 @@ import (
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	storageutils "k8s.io/kubernetes/test/e2e/storage/utils"
@@ -72,12 +71,13 @@ func (s *snapshotMetadataTestSuite) GetTestSuiteInfo() storageframework.TestSuit
 }
 
 // SkipUnsupportedTests implements framework.TestSuite.
-func (s *snapshotMetadataTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+func (s *snapshotMetadataTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) string {
 	_, ok := driver.(storageframework.SnapshotMetadataTestDriver)
 	driverInfo := driver.GetDriverInfo()
 	if !driverInfo.Capabilities[storageframework.CapSnapshotMetadata] || !ok {
-		e2eskipper.Skipf("Driver %q does not support snapshot metadata", driverInfo.Name)
+		return fmt.Sprintf("Driver %q does not support snapshot metadata", driverInfo.Name)
 	}
+	return ""
 }
 
 func constructVerifierCommand(

--- a/test/e2e/storage/testsuites/snapshottable.go
+++ b/test/e2e/storage/testsuites/snapshottable.go
@@ -90,18 +90,19 @@ func (s *snapshottableTestSuite) GetTestSuiteInfo() storageframework.TestSuiteIn
 	return s.tsInfo
 }
 
-func (s *snapshottableTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+func (s *snapshottableTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) string {
 	// Check preconditions.
 	dInfo := driver.GetDriverInfo()
 	ok := false
 	_, ok = driver.(storageframework.SnapshottableTestDriver)
 	if !dInfo.Capabilities[storageframework.CapSnapshotDataSource] || !ok {
-		e2eskipper.Skipf("Driver %q does not support snapshots - skipping", dInfo.Name)
+		return fmt.Sprintf("Driver %q does not support snapshots", dInfo.Name)
 	}
 	_, ok = driver.(storageframework.DynamicPVTestDriver)
 	if !ok {
-		e2eskipper.Skipf("Driver %q does not support dynamic provisioning - skipping", driver.GetDriverInfo().Name)
+		return fmt.Sprintf("Driver %q does not support dynamic provisioning", driver.GetDriverInfo().Name)
 	}
+	return ""
 }
 
 func (s *snapshottableTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {

--- a/test/e2e/storage/testsuites/snapshottable_stress.go
+++ b/test/e2e/storage/testsuites/snapshottable_stress.go
@@ -20,6 +20,7 @@ package testsuites
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/onsi/ginkgo/v2"
@@ -32,7 +33,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	storageutils "k8s.io/kubernetes/test/e2e/storage/utils"
@@ -87,11 +87,11 @@ func (t *snapshottableStressTestSuite) GetTestSuiteInfo() storageframework.TestS
 	return t.tsInfo
 }
 
-func (t *snapshottableStressTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+func (t *snapshottableStressTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) string {
 	driverInfo := driver.GetDriverInfo()
 	var ok bool
 	if driverInfo.VolumeSnapshotStressTestOptions == nil {
-		e2eskipper.Skipf("Driver %s doesn't specify snapshot stress test options -- skipping", driverInfo.Name)
+		return fmt.Sprintf("Driver %s doesn't specify snapshot stress test options", driverInfo.Name)
 	}
 	if driverInfo.VolumeSnapshotStressTestOptions.NumPods <= 0 {
 		framework.Failf("NumPods in snapshot stress test options must be a positive integer, received: %d", driverInfo.VolumeSnapshotStressTestOptions.NumPods)
@@ -101,13 +101,14 @@ func (t *snapshottableStressTestSuite) SkipUnsupportedTests(driver storageframew
 	}
 	_, ok = driver.(storageframework.SnapshottableTestDriver)
 	if !driverInfo.Capabilities[storageframework.CapSnapshotDataSource] || !ok {
-		e2eskipper.Skipf("Driver %q doesn't implement SnapshottableTestDriver - skipping", driverInfo.Name)
+		return fmt.Sprintf("Driver %q doesn't implement SnapshottableTestDriver", driverInfo.Name)
 	}
 
 	_, ok = driver.(storageframework.DynamicPVTestDriver)
 	if !ok {
-		e2eskipper.Skipf("Driver %s doesn't implement DynamicPVTestDriver -- skipping", driverInfo.Name)
+		return fmt.Sprintf("Driver %s doesn't implement DynamicPVTestDriver", driverInfo.Name)
 	}
+	return ""
 }
 
 func (t *snapshottableStressTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {

--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -90,8 +90,8 @@ func (s *subPathTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInfo {
 	return s.tsInfo
 }
 
-func (s *subPathTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
-	skipVolTypePatterns(pattern, driver, storageframework.NewVolTypeMap(
+func (s *subPathTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) string {
+	return checkVolTypePatterns(pattern, driver, storageframework.NewVolTypeMap(
 		storageframework.PreprovisionedPV,
 		storageframework.InlineVolume))
 }

--- a/test/e2e/storage/testsuites/topology.go
+++ b/test/e2e/storage/testsuites/topology.go
@@ -79,17 +79,18 @@ func (t *topologyTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInfo {
 	return t.tsInfo
 }
 
-func (t *topologyTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+func (t *topologyTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) string {
 	dInfo := driver.GetDriverInfo()
 	var ok bool
 	_, ok = driver.(storageframework.DynamicPVTestDriver)
 	if !ok {
-		e2eskipper.Skipf("Driver %s doesn't support %v -- skipping", dInfo.Name, pattern.VolType)
+		return fmt.Sprintf("Driver %s doesn't support %v", dInfo.Name, pattern.VolType)
 	}
 
 	if !dInfo.Capabilities[storageframework.CapTopology] {
-		e2eskipper.Skipf("Driver %q does not support topology - skipping", dInfo.Name)
+		return fmt.Sprintf("Driver %q does not support topology", dInfo.Name)
 	}
+	return ""
 }
 
 func (t *topologyTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {

--- a/test/e2e/storage/testsuites/volume_expand.go
+++ b/test/e2e/storage/testsuites/volume_expand.go
@@ -90,15 +90,16 @@ func (v *volumeExpandTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInf
 	return v.tsInfo
 }
 
-func (v *volumeExpandTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+func (v *volumeExpandTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) string {
 	// Check preconditions.
 	if !driver.GetDriverInfo().Capabilities[storageframework.CapControllerExpansion] {
-		e2eskipper.Skipf("Driver %q does not support volume expansion - skipping", driver.GetDriverInfo().Name)
+		return fmt.Sprintf("Driver %q does not support volume expansion", driver.GetDriverInfo().Name)
 	}
 	// Check preconditions.
 	if !driver.GetDriverInfo().Capabilities[storageframework.CapBlock] && pattern.VolMode == v1.PersistentVolumeBlock {
-		e2eskipper.Skipf("Driver %q does not support block volume mode - skipping", driver.GetDriverInfo().Name)
+		return fmt.Sprintf("Driver %q does not support block volume mode", driver.GetDriverInfo().Name)
 	}
+	return ""
 }
 
 func (v *volumeExpandTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {

--- a/test/e2e/storage/testsuites/volume_group_snapshot_class.go
+++ b/test/e2e/storage/testsuites/volume_group_snapshot_class.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
@@ -84,12 +83,13 @@ func (s *VolumeGroupSnapshotClassTestSuite) GetTestSuiteInfo() storageframework.
 }
 
 // SkipUnsupportedTests skips tests if the driver does not support group snapshots.
-func (s *VolumeGroupSnapshotClassTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+func (s *VolumeGroupSnapshotClassTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) string {
 	dInfo := driver.GetDriverInfo()
 	_, ok := driver.(storageframework.VolumeGroupSnapshottableTestDriver)
 	if !dInfo.Capabilities[storageframework.CapVolumeGroupSnapshot] || !ok {
-		e2eskipper.Skipf("Driver %q does not support group snapshots - skipping", dInfo.Name)
+		return fmt.Sprintf("Driver %q does not support group snapshots", dInfo.Name)
 	}
+	return ""
 }
 
 // DefineTests defines the test cases for VolumeGroupSnapshotClass default class selection.

--- a/test/e2e/storage/testsuites/volume_group_snapshottable.go
+++ b/test/e2e/storage/testsuites/volume_group_snapshottable.go
@@ -35,7 +35,6 @@ import (
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	e2estatefulset "k8s.io/kubernetes/test/e2e/framework/statefulset"
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
@@ -84,14 +83,15 @@ func InitCustomGroupSnapshottableTestSuite(patterns []storageframework.TestPatte
 }
 
 // SkipUnsupportedTests skips tests if the driver does not support group snapshots.
-func (s *VolumeGroupSnapshottableTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+func (s *VolumeGroupSnapshottableTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) string {
 	// Check preconditions.
 	dInfo := driver.GetDriverInfo()
 	ok := false
 	_, ok = driver.(storageframework.VolumeGroupSnapshottableTestDriver)
 	if !dInfo.Capabilities[storageframework.CapVolumeGroupSnapshot] || !ok {
-		e2eskipper.Skipf("Driver %q does not support group snapshots - skipping", dInfo.Name)
+		return fmt.Sprintf("Driver %q does not support group snapshots", dInfo.Name)
 	}
+	return ""
 }
 
 // GetTestSuiteInfo returns the test suite information for the VolumeGroupSnapshottableTestSuite.

--- a/test/e2e/storage/testsuites/volume_group_snapshottable_stress.go
+++ b/test/e2e/storage/testsuites/volume_group_snapshottable_stress.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	e2estatefulset "k8s.io/kubernetes/test/e2e/framework/statefulset"
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
@@ -89,11 +88,11 @@ func (t *volumeGroupSnapshottableStressTestSuite) GetTestSuiteInfo() storagefram
 	return t.tsInfo
 }
 
-func (t *volumeGroupSnapshottableStressTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+func (t *volumeGroupSnapshottableStressTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) string {
 	driverInfo := driver.GetDriverInfo()
 	var ok bool
 	if driverInfo.VolumeGroupSnapshotStressTestOptions == nil {
-		e2eskipper.Skipf("Driver %s doesn't specify volume group snapshot stress test options -- skipping", driverInfo.Name)
+		return fmt.Sprintf("Driver %s doesn't specify volume group snapshot stress test options", driverInfo.Name)
 	}
 	if driverInfo.VolumeGroupSnapshotStressTestOptions.NumPods <= 0 {
 		framework.Failf("NumPods in volume group snapshot stress test options must be a positive integer, received: %d", driverInfo.VolumeGroupSnapshotStressTestOptions.NumPods)
@@ -103,13 +102,14 @@ func (t *volumeGroupSnapshottableStressTestSuite) SkipUnsupportedTests(driver st
 	}
 	_, ok = driver.(storageframework.VolumeGroupSnapshottableTestDriver)
 	if !driverInfo.Capabilities[storageframework.CapVolumeGroupSnapshot] || !ok {
-		e2eskipper.Skipf("Driver %q doesn't implement VolumeGroupSnapshottableTestDriver - skipping", driverInfo.Name)
+		return fmt.Sprintf("Driver %q doesn't implement VolumeGroupSnapshottableTestDriver", driverInfo.Name)
 	}
 
 	_, ok = driver.(storageframework.DynamicPVTestDriver)
 	if !ok {
-		e2eskipper.Skipf("Driver %s doesn't implement DynamicPVTestDriver -- skipping", driverInfo.Name)
+		return fmt.Sprintf("Driver %s doesn't implement DynamicPVTestDriver", driverInfo.Name)
 	}
+	return ""
 }
 
 func (t *volumeGroupSnapshottableStressTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {

--- a/test/e2e/storage/testsuites/volume_io.go
+++ b/test/e2e/storage/testsuites/volume_io.go
@@ -89,8 +89,8 @@ func (t *volumeIOTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInfo {
 	return t.tsInfo
 }
 
-func (t *volumeIOTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
-	skipVolTypePatterns(pattern, driver, storageframework.NewVolTypeMap(
+func (t *volumeIOTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) string {
+	return checkVolTypePatterns(pattern, driver, storageframework.NewVolTypeMap(
 		storageframework.PreprovisionedPV,
 		storageframework.InlineVolume))
 }

--- a/test/e2e/storage/testsuites/volume_modify.go
+++ b/test/e2e/storage/testsuites/volume_modify.go
@@ -86,16 +86,17 @@ func (v *volumeModifyTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInf
 	return v.tsInfo
 }
 
-func (v *volumeModifyTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+func (v *volumeModifyTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) string {
 	_, ok := driver.(storageframework.VolumeAttributesClassTestDriver)
 	if !ok {
-		e2eskipper.Skipf("Driver %q does not support VolumeAttributesClass tests - skipping", driver.GetDriverInfo().Name)
+		return fmt.Sprintf("Driver %q does not support VolumeAttributesClass tests - skipping", driver.GetDriverInfo().Name)
 	}
 	// Skip block storage tests if the driver we are testing against does not support block volumes
 	// TODO: This should be made generic so that it doesn't have to be re-written for every test that uses the 	BlockVolModeDynamicPV testcase
 	if !driver.GetDriverInfo().Capabilities[storageframework.CapBlock] && pattern.VolMode == v1.PersistentVolumeBlock {
-		e2eskipper.Skipf("Driver %q does not support block volume mode - skipping", driver.GetDriverInfo().Name)
+		return fmt.Sprintf("Driver %q does not support block volume mode - skipping", driver.GetDriverInfo().Name)
 	}
+	return ""
 }
 
 func (v *volumeModifyTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {

--- a/test/e2e/storage/testsuites/volume_modify_stress.go
+++ b/test/e2e/storage/testsuites/volume_modify_stress.go
@@ -18,6 +18,7 @@ package testsuites
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/onsi/ginkgo/v2"
@@ -87,23 +88,24 @@ func (v *volumeModifyStressTestSuite) GetTestSuiteInfo() storageframework.TestSu
 	return v.tsInfo
 }
 
-func (v *volumeModifyStressTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+func (v *volumeModifyStressTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) string {
 	driverInfo := driver.GetDriverInfo()
 	if driverInfo.VolumeModifyStressTestOptions == nil {
-		e2eskipper.Skipf("Driver %s doesn't specify volume modify stress test options -- skipping", driverInfo.Name)
+		return fmt.Sprintf("Driver %s doesn't specify volume modify stress test options", driverInfo.Name)
 	}
 	if driverInfo.VolumeModifyStressTestOptions.NumPods <= 0 {
 		framework.Failf("NumPods in modify volume stress test options must be a positive integer, received: %d", driverInfo.VolumeModifyStressTestOptions.NumPods)
 	}
 	_, ok := driver.(storageframework.VolumeAttributesClassTestDriver)
 	if !ok {
-		e2eskipper.Skipf("Driver %q does not support VolumeAttributesClass tests - skipping", driver.GetDriverInfo().Name)
+		return fmt.Sprintf("Driver %q does not support VolumeAttributesClass tests", driver.GetDriverInfo().Name)
 	}
 	// Skip block storage tests if the driver we are testing against does not support block volumes
 	// TODO: This should be made generic so that it doesn't have to be re-written for every test that uses the 	BlockVolModeDynamicPV testcase
 	if !driverInfo.Capabilities[storageframework.CapBlock] && pattern.VolMode == v1.PersistentVolumeBlock {
-		e2eskipper.Skipf("Driver %q does not support block volume mode - skipping", driver.GetDriverInfo().Name)
+		return fmt.Sprintf("Driver %q does not support block volume mode", driver.GetDriverInfo().Name)
 	}
+	return ""
 }
 
 func (v *volumeModifyStressTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {

--- a/test/e2e/storage/testsuites/volume_stress.go
+++ b/test/e2e/storage/testsuites/volume_stress.go
@@ -20,6 +20,7 @@ package testsuites
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/onsi/ginkgo/v2"
@@ -31,7 +32,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
 )
@@ -80,10 +80,10 @@ func (t *volumeStressTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInf
 	return t.tsInfo
 }
 
-func (t *volumeStressTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+func (t *volumeStressTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) string {
 	dInfo := driver.GetDriverInfo()
 	if dInfo.StressTestOptions == nil {
-		e2eskipper.Skipf("Driver %s doesn't specify stress test options -- skipping", dInfo.Name)
+		return fmt.Sprintf("Driver %s doesn't specify stress test options", dInfo.Name)
 	}
 	if dInfo.StressTestOptions.NumPods <= 0 {
 		framework.Failf("NumPods in stress test options must be a positive integer, received: %d", dInfo.StressTestOptions.NumPods)
@@ -93,11 +93,12 @@ func (t *volumeStressTestSuite) SkipUnsupportedTests(driver storageframework.Tes
 	}
 
 	if _, ok := driver.(storageframework.DynamicPVTestDriver); !ok {
-		e2eskipper.Skipf("Driver %s doesn't implement DynamicPVTestDriver -- skipping", dInfo.Name)
+		return fmt.Sprintf("Driver %s doesn't implement DynamicPVTestDriver", dInfo.Name)
 	}
 	if !driver.GetDriverInfo().Capabilities[storageframework.CapBlock] && pattern.VolMode == v1.PersistentVolumeBlock {
-		e2eskipper.Skipf("Driver %q does not support block volume mode - skipping", dInfo.Name)
+		return fmt.Sprintf("Driver %q does not support block volume mode", dInfo.Name)
 	}
+	return ""
 }
 
 func (t *volumeStressTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {

--- a/test/e2e/storage/testsuites/volumelimits.go
+++ b/test/e2e/storage/testsuites/volumelimits.go
@@ -40,7 +40,6 @@ import (
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	storageutils "k8s.io/kubernetes/test/e2e/storage/utils"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -87,14 +86,15 @@ func (t *volumeLimitsTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInf
 	return t.tsInfo
 }
 
-func (t *volumeLimitsTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+func (t *volumeLimitsTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) string {
 	if pattern.VolType != storageframework.DynamicPV {
-		e2eskipper.Skipf("Suite %q does not support %v", t.tsInfo.Name, pattern.VolType)
+		return fmt.Sprintf("Suite %q does not support %v", t.tsInfo.Name, pattern.VolType)
 	}
 	dInfo := driver.GetDriverInfo()
 	if !dInfo.Capabilities[storageframework.CapVolumeLimits] {
-		e2eskipper.Skipf("Driver %s does not support volume limits", dInfo.Name)
+		return fmt.Sprintf("Driver %s does not support volume limits", dInfo.Name)
 	}
+	return ""
 }
 
 func (t *volumeLimitsTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {

--- a/test/e2e/storage/testsuites/volumemode.go
+++ b/test/e2e/storage/testsuites/volumemode.go
@@ -298,8 +298,7 @@ func (t *volumeModeTestSuite) DefineTests(driver storageframework.TestDriver, pa
 		framework.Failf("Volume mode test doesn't support volType: %v", pattern.VolType)
 	}
 
-	f.It("should fail to use a volume in a pod with mismatched mode", f.WithSlow(), func(ctx context.Context) {
-		skipTestIfBlockNotSupported(driver)
+	failMismatched := func(ctx context.Context) {
 		init(ctx)
 		testVolumeSizeRange := t.GetTestSuiteInfo().SupportedSizeRange
 		l.VolumeResource = *storageframework.CreateVolumeResource(ctx, driver, l.config, pattern, testVolumeSizeRange)
@@ -351,12 +350,12 @@ func (t *volumeModeTestSuite) DefineTests(driver storageframework.TestDriver, pa
 		p, err := l.cs.CoreV1().Pods(l.ns.Name).Get(ctx, pod.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "could not re-read the pod after event (or timeout)")
 		gomega.Expect(p.Status.Phase).To(gomega.Equal(v1.PodPending), "Pod phase isn't pending")
-	})
+	}
+	if reason := checkIfBlockNotSupported(driver); reason == "" {
+		f.It("should fail to use a volume in a pod with mismatched mode", f.WithSlow(), failMismatched)
+	}
 
-	ginkgo.It("should not mount / map unused volumes in a pod [LinuxOnly]", func(ctx context.Context) {
-		if pattern.VolMode == v1.PersistentVolumeBlock {
-			skipTestIfBlockNotSupported(driver)
-		}
+	notMapUnused := func(ctx context.Context) {
 		init(ctx)
 		testVolumeSizeRange := t.GetTestSuiteInfo().SupportedSizeRange
 		l.VolumeResource = *storageframework.CreateVolumeResource(ctx, driver, l.config, pattern, testVolumeSizeRange)
@@ -415,7 +414,10 @@ func (t *volumeModeTestSuite) DefineTests(driver storageframework.TestDriver, pa
 		for _, path := range devicePaths {
 			gomega.Expect(path).NotTo(gomega.ContainSubstring(safeVolumePlugin), fmt.Sprintf("no %s volume should be symlinked into pod directory", volumePlugin))
 		}
-	})
+	}
+	if reason := checkIfBlockNotSupported(driver); pattern.VolMode != v1.PersistentVolumeBlock || reason == "" {
+		ginkgo.It("should not mount / map unused volumes in a pod [LinuxOnly]", notMapUnused)
+	}
 }
 
 func generateConfigsForPreprovisionedPVTest(scName string, volBindMode storagev1.VolumeBindingMode,

--- a/test/e2e/storage/testsuites/volumemode.go
+++ b/test/e2e/storage/testsuites/volumemode.go
@@ -85,7 +85,8 @@ func (t *volumeModeTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInfo 
 	return t.tsInfo
 }
 
-func (t *volumeModeTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+func (t *volumeModeTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) string {
+	return ""
 }
 
 func (t *volumeModeTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {

--- a/test/e2e/storage/testsuites/volumeperf.go
+++ b/test/e2e/storage/testsuites/volumeperf.go
@@ -88,7 +88,8 @@ func (t *volumePerformanceTestSuite) GetTestSuiteInfo() storageframework.TestSui
 	return t.tsInfo
 }
 
-func (t *volumePerformanceTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+func (t *volumePerformanceTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) string {
+	return ""
 }
 
 func (t *volumePerformanceTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {

--- a/test/e2e/storage/testsuites/volumes.go
+++ b/test/e2e/storage/testsuites/volumes.go
@@ -93,10 +93,11 @@ func (t *volumesTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInfo {
 	return t.tsInfo
 }
 
-func (t *volumesTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+func (t *volumesTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) string {
 	if pattern.VolMode == v1.PersistentVolumeBlock {
-		skipTestIfBlockNotSupported(driver)
+		return checkIfBlockNotSupported(driver)
 	}
+	return ""
 }
 
 func skipExecTest(driver storageframework.TestDriver) {
@@ -107,10 +108,17 @@ func skipExecTest(driver storageframework.TestDriver) {
 }
 
 func skipTestIfBlockNotSupported(driver storageframework.TestDriver) {
+	if reason := checkIfBlockNotSupported(driver); reason != "" {
+		e2eskipper.Skipf("%s", reason)
+	}
+}
+
+func checkIfBlockNotSupported(driver storageframework.TestDriver) string {
 	dInfo := driver.GetDriverInfo()
 	if !dInfo.Capabilities[storageframework.CapBlock] {
-		e2eskipper.Skipf("Driver %q does not provide raw block - skipping", dInfo.Name)
+		return fmt.Sprintf("Driver %q does not provide raw block", dInfo.Name)
 	}
+	return ""
 }
 
 func (t *volumesTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {

--- a/test/e2e/storage/testsuites/volumes.go
+++ b/test/e2e/storage/testsuites/volumes.go
@@ -100,19 +100,6 @@ func (t *volumesTestSuite) SkipUnsupportedTests(driver storageframework.TestDriv
 	return ""
 }
 
-func skipExecTest(driver storageframework.TestDriver) {
-	dInfo := driver.GetDriverInfo()
-	if !dInfo.Capabilities[storageframework.CapExec] {
-		e2eskipper.Skipf("Driver %q does not support exec - skipping", dInfo.Name)
-	}
-}
-
-func skipTestIfBlockNotSupported(driver storageframework.TestDriver) {
-	if reason := checkIfBlockNotSupported(driver); reason != "" {
-		e2eskipper.Skipf("%s", reason)
-	}
-}
-
 func checkIfBlockNotSupported(driver storageframework.TestDriver) string {
 	dInfo := driver.GetDriverInfo()
 	if !dInfo.Capabilities[storageframework.CapBlock] {
@@ -195,9 +182,9 @@ func (t *volumesTestSuite) DefineTests(driver storageframework.TestDriver, patte
 	})
 
 	// Exec works only on filesystem volumes
-	if pattern.VolMode != v1.PersistentVolumeBlock {
+	if pattern.VolMode != v1.PersistentVolumeBlock &&
+		driver.GetDriverInfo().Capabilities[storageframework.CapExec] {
 		ginkgo.It("should allow exec of files on the volume", func(ctx context.Context) {
-			skipExecTest(driver)
 			init(ctx)
 			ginkgo.DeferCleanup(cleanup)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

A test that always skips itself at runtime doesn't even need to be registered. They cause overhead (larger JUnit files) and make it difficult to analyze which tests should have been running and weren't (https://github.com/kubernetes/test-infra/pull/37410).

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

See https://github.com/kubernetes/kubernetes/pull/140528#issuecomment-5005702682.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
