### PR TITLE
E2E: replace runtime SkipUnlessProviderIs with declarative WithProvider

### DIFF
--- a/test/e2e/apimachinery/apiserver_identity.go
+++ b/test/e2e/apimachinery/apiserver_identity.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
 	admissionapi "k8s.io/pod-security-admission/api"
 )
@@ -84,9 +83,7 @@ var _ = SIGDescribe("kube-apiserver identity", feature.APIServerIdentity, func()
 	f := framework.NewDefaultFramework("kube-apiserver-identity")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
-	f.It("kube-apiserver identity should persist after restart", f.WithDisruptive(), func(ctx context.Context) {
-		e2eskipper.SkipUnlessProviderIs("gce")
-
+	f.It("kube-apiserver identity should persist after restart", f.WithDisruptive(), f.WithProvider("gce"), func(ctx context.Context) {
 		client := f.ClientSet
 
 		var controlPlaneNodes []v1.Node

--- a/test/e2e/apimachinery/etcd_failure.go
+++ b/test/e2e/apimachinery/etcd_failure.go
@@ -37,7 +37,7 @@ import (
 	"github.com/onsi/gomega"
 )
 
-var _ = SIGDescribe("Etcd failure", framework.WithDisruptive(), func() {
+var _ = SIGDescribe("Etcd failure", framework.WithDisruptive(), framework.WithProvider("gce", "aws"), func() {
 
 	f := framework.NewDefaultFramework("etcd-failure")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
@@ -46,9 +46,8 @@ var _ = SIGDescribe("Etcd failure", framework.WithDisruptive(), func() {
 		// This test requires:
 		// - SSH
 		// - master access
-		// ... so the provider check should be identical to the intersection of
+		// ... so the provider check above should be identical to the intersection of
 		// providers that provide those capabilities.
-		e2eskipper.SkipUnlessProviderIs("gce", "aws")
 		e2eskipper.SkipUnlessSSHKeyPresent()
 
 		err := e2erc.RunRC(ctx, testutils.RCConfig{

--- a/test/e2e/apps/daemon_restart.go
+++ b/test/e2e/apps/daemon_restart.go
@@ -39,7 +39,6 @@ import (
 	e2edebug "k8s.io/kubernetes/test/e2e/framework/debug"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2erc "k8s.io/kubernetes/test/e2e/framework/rc"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
 	testutils "k8s.io/kubernetes/test/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -209,7 +208,7 @@ func getContainerRestarts(ctx context.Context, c clientset.Interface, ns string,
 	return failedContainers, containerRestartNodes.List()
 }
 
-var _ = SIGDescribe("DaemonRestart", framework.WithDisruptive(), func() {
+var _ = SIGDescribe("DaemonRestart", framework.WithDisruptive(), framework.WithProvider(framework.ProvidersWithSSH...) /* These tests require SSH */, func() {
 
 	f := framework.NewDefaultFramework("daemonrestart")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
@@ -223,8 +222,6 @@ var _ = SIGDescribe("DaemonRestart", framework.WithDisruptive(), func() {
 	var tracker *podTracker
 
 	ginkgo.BeforeEach(func(ctx context.Context) {
-		// These tests require SSH
-		e2eskipper.SkipUnlessProviderIs(framework.ProvidersWithSSH...)
 		ns = f.Namespace.Name
 
 		// All the restart tests need an rc and a watch on pods of the rc.
@@ -274,10 +271,8 @@ var _ = SIGDescribe("DaemonRestart", framework.WithDisruptive(), func() {
 		go controller.Run(backgroundCtx.Done())
 	})
 
-	ginkgo.It("Controller Manager should not create/delete replicas across restart", func(ctx context.Context) {
+	f.It("Controller Manager should not create/delete replicas across restart", f.WithProvider("gce", "aws") /* Requires master ssh access. */, func(ctx context.Context) {
 
-		// Requires master ssh access.
-		e2eskipper.SkipUnlessProviderIs("gce", "aws")
 		nodes := framework.GetControlPlaneNodes(ctx, f.ClientSet)
 
 		// checks if there is at least one control-plane node
@@ -316,9 +311,7 @@ var _ = SIGDescribe("DaemonRestart", framework.WithDisruptive(), func() {
 		}
 	})
 
-	ginkgo.It("Scheduler should continue assigning pods to nodes across restart", func(ctx context.Context) {
-		// Requires master ssh access.
-		e2eskipper.SkipUnlessProviderIs("gce", "aws")
+	f.It("Scheduler should continue assigning pods to nodes across restart", f.WithProvider("gce", "aws") /* Requires master ssh access. */, func(ctx context.Context) {
 		nodes := framework.GetControlPlaneNodes(ctx, f.ClientSet)
 
 		// checks if there is at least one control-plane node

--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -162,8 +162,7 @@ var _ = SIGDescribe("Deployment", func() {
 	framework.ConformanceIt("deployment should support proportional scaling", func(ctx context.Context) {
 		testProportionalScalingDeployment(ctx, f)
 	})
-	ginkgo.It("should not disrupt a cloud load-balancer's connectivity during rollout", func(ctx context.Context) {
-		e2eskipper.SkipUnlessProviderIs("aws", "azure", "gce")
+	f.It("should not disrupt a cloud load-balancer's connectivity during rollout", f.WithProvider("aws", "azure", "gce"), func(ctx context.Context) {
 		e2eskipper.SkipIfIPv6("aws")
 		nodes, err := e2enode.GetReadySchedulableNodes(ctx, c)
 		framework.ExpectNoError(err)

--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -43,7 +43,6 @@ import (
 	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
 
@@ -74,9 +73,7 @@ var _ = SIGDescribe("ReplicationController", func() {
 		TestReplicationControllerServeImageOrFail(ctx, f, "basic", imageutils.GetE2EImage(imageutils.Agnhost))
 	})
 
-	ginkgo.It("should serve a basic image on each replica with a private image", func(ctx context.Context) {
-		// requires private images
-		e2eskipper.SkipUnlessProviderIs("gce")
+	f.It("should serve a basic image on each replica with a private image", f.WithProvider("gce") /* requires private images */, func(ctx context.Context) {
 		privateimage := imageutils.GetConfig(imageutils.AgnhostPrivate)
 		TestReplicationControllerServeImageOrFail(ctx, f, "private", privateimage.GetE2EImage())
 	})

--- a/test/e2e/apps/replica_set.go
+++ b/test/e2e/apps/replica_set.go
@@ -46,7 +46,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2ereplicaset "k8s.io/kubernetes/test/e2e/framework/replicaset"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
 
@@ -115,9 +114,7 @@ var _ = SIGDescribe("ReplicaSet", func() {
 		testReplicaSetServeImageOrFail(ctx, f, "basic", imageutils.GetE2EImage(imageutils.Agnhost))
 	})
 
-	ginkgo.It("should serve a basic image on each replica with a private image", func(ctx context.Context) {
-		// requires private images
-		e2eskipper.SkipUnlessProviderIs("gce")
+	f.It("should serve a basic image on each replica with a private image", f.WithProvider("gce") /* requires private images */, func(ctx context.Context) {
 		privateimage := imageutils.GetConfig(imageutils.AgnhostPrivate)
 		testReplicaSetServeImageOrFail(ctx, f, "private", privateimage.GetE2EImage())
 	})

--- a/test/e2e/framework/ginkgowrapper.go
+++ b/test/e2e/framework/ginkgowrapper.go
@@ -17,6 +17,7 @@ limitations under the License.
 package framework
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"reflect"
@@ -349,6 +350,24 @@ func expandGinkgoArgs(leafNode bool, offset ginkgo.Offset, text string, args []a
 		}
 	}
 
+	var providerChecks [][]string
+	skipUnlessProviderIs := func() {
+		for _, supportedProviders := range providerChecks {
+			if !ProviderIs(supportedProviders...) {
+				ginkgo.Skip(fmt.Sprintf("Only supported for providers %v (not %s)", supportedProviders, TestContext.Provider))
+			}
+		}
+	}
+	injectSkipUnlessProviderIs := func() {
+		if leafNode {
+			// Check directly inside It.
+			skipUnlessProviderIs()
+		} else {
+			// Insert BeforeEach with the same check.
+			ginkgo.BeforeEach(skipUnlessProviderIs)
+		}
+	}
+
 	haveEmptyStrings := false
 	for _, arg := range args {
 		switch arg := arg.(type) {
@@ -356,6 +375,17 @@ func expandGinkgoArgs(leafNode bool, offset ginkgo.Offset, text string, args []a
 			addFeatureGate(arg.name, arg.spec, true)
 		case label:
 			fullLabel := arg.String()
+			if arg.parts[0] == "Provider" {
+				providerChecks = append(providerChecks, strings.Split(arg.parts[1], ","))
+				// Only add text, not as label: Ginkgo labels must not contain commas.
+				// We could split up into separate labels, but then the semantic is not clear:
+				// [Provider:gce,aws] means "provider must be one of these two",
+				// but [Provider:gce] [Provider:aws] could be either that or "must be
+				// gce and aws", i.e. the test always needs to be skipped (for example,
+				// because there are different independent WithProvider calls in different places).
+				texts = append(texts, fmt.Sprintf("[%s]", fullLabel))
+				continue
+			}
 			addLabel(fullLabel)
 			if !leafNodeLabels.Has(fullLabel) {
 				texts = append(texts, fmt.Sprintf("[%s]", fullLabel))
@@ -377,6 +407,34 @@ func expandGinkgoArgs(leafNode bool, offset ginkgo.Offset, text string, args []a
 				haveEmptyStrings = true
 			}
 			texts = append(texts, arg)
+		case func(context.Context):
+			// Wrapping shows up in stack backtraces. Avoid it if possible.
+			if len(providerChecks) > 0 {
+				body := arg
+				arg = func(ctx context.Context) {
+					injectSkipUnlessProviderIs()
+					body(ctx)
+				}
+			}
+			ginkgoArgs = append(ginkgoArgs, arg)
+		case func(ginkgo.SpecContext):
+			if len(providerChecks) > 0 {
+				body := arg
+				arg = func(ctx ginkgo.SpecContext) {
+					injectSkipUnlessProviderIs()
+					body(ctx)
+				}
+			}
+			ginkgoArgs = append(ginkgoArgs, arg)
+		case func():
+			if len(providerChecks) > 0 {
+				body := arg
+				arg = func() {
+					injectSkipUnlessProviderIs()
+					body()
+				}
+			}
+			ginkgoArgs = append(ginkgoArgs, arg)
 		default:
 			ginkgoArgs = append(ginkgoArgs, arg)
 		}
@@ -637,6 +695,29 @@ func withEnvironment(name Environment) interface{} {
 		RecordBug(NewBug(fmt.Sprintf("WithEnvironment: unknown environment %q", name), 2))
 	}
 	return newLabel("Environment", string(name))
+}
+
+// WithProvider specifies that a certain test or group of tests depend on
+// features that are only available with one of the listed cluster providers.
+// It inserts the [Provider: <provider1>,<provider2>, ...] tag into the test name
+// and injects a runtime skip check at the start of the function.
+//
+// Filtering by provider is a legacy mechanism with unclear semantics: which
+// provider supports which features is undefined. Prefer defining features and
+// calling WithFeature instead.
+//
+// Note that this must come before the function in the Describe/Context/It call!
+func WithProvider(providers ...string) interface{} {
+	return withProvider(providers)
+}
+
+// WithProvider is a shorthand for the corresponding package function.
+func (f *Framework) WithProvider(providers ...string) interface{} {
+	return withProvider(providers)
+}
+
+func withProvider(providers []string) interface{} {
+	return newLabel("Provider", strings.Join(providers, ","))
 }
 
 // WithConformance specifies that a certain test or group of tests must pass in

--- a/test/e2e/framework/internal/unittests/withprovider/withprovider_test.go
+++ b/test/e2e/framework/internal/unittests/withprovider/withprovider_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package withprovider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+// TestWithProvider runs a small suite of specs tagged with
+// framework.WithProvider and checks that:
+//   - specs whose provider list doesn't match TestContext.Provider get
+//     skipped at runtime instead of running,
+//   - specs whose provider list does match run normally,
+//   - the "[Provider:...]" tag shows up in the spec text (for visibility in
+//     e.g. --list-tests output) but is not registered as a real, filterable
+//     Ginkgo label (unlike other tags such as [Slow]),
+//   - this works regardless of whether the It body takes no arguments,
+//     a context.Context or a ginkgo.SpecContext,
+//   - this also works when framework.WithProvider is passed to a Context
+//     instead of directly to the It's below it (the check is then injected
+//     as a BeforeEach instead of running directly in the It).
+func TestWithProvider(t *testing.T) {
+	oldProvider := framework.TestContext.Provider
+	framework.TestContext.Provider = "gce"
+	t.Cleanup(func() { framework.TestContext.Provider = oldProvider })
+
+	var ran []string
+	ginkgo.Describe("wrap", func() {
+		framework.It("aws only", framework.WithProvider("aws"), func() {
+			ran = append(ran, "aws only")
+		})
+		framework.It("gce only", framework.WithProvider("gce"), func() {
+			ran = append(ran, "gce only")
+		})
+		framework.It("aws or gce", framework.WithProvider("aws", "gce"), func() {
+			ran = append(ran, "aws or gce")
+		})
+		framework.It("aws only ctx", framework.WithProvider("aws"), func(ctx context.Context) {
+			ran = append(ran, "aws only ctx")
+		})
+		framework.It("gce only ctx", framework.WithProvider("gce"), func(ctx context.Context) {
+			ran = append(ran, "gce only ctx")
+		})
+		framework.It("aws only spec ctx", framework.WithProvider("aws"), func(ctx ginkgo.SpecContext) {
+			ran = append(ran, "aws only spec ctx")
+		})
+		framework.It("gce only spec ctx", framework.WithProvider("gce"), func(ctx ginkgo.SpecContext) {
+			ran = append(ran, "gce only spec ctx")
+		})
+		framework.Context("aws context", framework.WithProvider("aws"), func() {
+			framework.It("inner one", func() {
+				ran = append(ran, "context aws inner one")
+			})
+			framework.It("inner two", func() {
+				ran = append(ran, "context aws inner two")
+			})
+		})
+		framework.Context("gce context", framework.WithProvider("gce"), func() {
+			framework.It("inner", func() {
+				ran = append(ran, "context gce inner")
+			})
+		})
+	})
+
+	var report types.Report
+	ginkgo.ReportAfterSuite("capture report", func(r types.Report) {
+		report = r
+	})
+
+	suiteConfig, reporterConfig := framework.CreateGinkgoConfig()
+	fakeT := &testing.T{}
+	ginkgo.RunSpecs(fakeT, "WithProvider Suite", suiteConfig, reporterConfig)
+
+	assert.False(t, fakeT.Failed(), "suite run should not fail")
+	assert.ElementsMatch(t, []string{
+		"gce only",
+		"aws or gce",
+		"gce only ctx",
+		"gce only spec ctx",
+		"context gce inner",
+	}, ran, "only specs whose provider list includes the configured provider should run")
+
+	states := map[string]types.SpecState{}
+	labels := map[string][]string{}
+	for _, spec := range report.SpecReports {
+		states[spec.FullText()] = spec.State
+		labels[spec.FullText()] = spec.Labels()
+	}
+
+	assert.Equal(t, types.SpecStateSkipped, states["wrap aws only [Provider:aws]"])
+	assert.Equal(t, types.SpecStatePassed, states["wrap gce only [Provider:gce]"])
+	assert.Equal(t, types.SpecStatePassed, states["wrap aws or gce [Provider:aws,gce]"])
+	assert.Equal(t, types.SpecStateSkipped, states["wrap aws only ctx [Provider:aws]"])
+	assert.Equal(t, types.SpecStatePassed, states["wrap gce only ctx [Provider:gce]"])
+	assert.Equal(t, types.SpecStateSkipped, states["wrap aws only spec ctx [Provider:aws]"])
+	assert.Equal(t, types.SpecStatePassed, states["wrap gce only spec ctx [Provider:gce]"])
+	assert.Equal(t, types.SpecStateSkipped, states["wrap aws context [Provider:aws] inner one"])
+	assert.Equal(t, types.SpecStateSkipped, states["wrap aws context [Provider:aws] inner two"])
+	assert.Equal(t, types.SpecStatePassed, states["wrap gce context [Provider:gce] inner"])
+
+	// The provider constraint must be visible in the text, but not usable as
+	// a "--label-filter" label like [Slow] or [Serial] are.
+	assert.NotContains(t, labels["wrap aws only [Provider:aws]"], "Provider:aws")
+	assert.NotContains(t, labels["wrap aws context [Provider:aws] inner one"], "Provider:aws")
+}

--- a/test/e2e/framework/skipper/skipper.go
+++ b/test/e2e/framework/skipper/skipper.go
@@ -108,13 +108,6 @@ func SkipUnlessNodeCountIsAtMost(maxNodeCount int) {
 	}
 }
 
-// SkipUnlessProviderIs skips if the provider is not included in the supportedProviders.
-func SkipUnlessProviderIs(supportedProviders ...string) {
-	if !framework.ProviderIs(supportedProviders...) {
-		skipInternalf(1, "Only supported for providers %v (not %s)", supportedProviders, framework.TestContext.Provider)
-	}
-}
-
 // SkipUnlessMultizone skips if the cluster does not have multizone.
 func SkipUnlessMultizone(ctx context.Context, c clientset.Interface) {
 	zones, err := e2enode.GetClusterZones(ctx, c)

--- a/test/e2e/network/dns.go
+++ b/test/e2e/network/dns.go
@@ -32,7 +32,6 @@ import (
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	"k8s.io/kubernetes/test/e2e/network/common"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -79,9 +78,7 @@ var _ = common.SIGDescribe("DNS", func() {
 	})
 
 	// Added due to #8512. This is critical for GCE and GKE deployments.
-	ginkgo.It("should provide DNS for the cluster [Provider:GCE]", func(ctx context.Context) {
-		e2eskipper.SkipUnlessProviderIs("gce")
-
+	f.It("should provide DNS for the cluster", f.WithProvider("gce"), func(ctx context.Context) {
 		namesToResolve := []string{"google.com"}
 		// Windows containers do not have a route to the GCE metadata server by default.
 		if !framework.NodeOSDistroIs("windows") {

--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -545,8 +545,7 @@ var _ = common.SIGDescribe("Networking", func() {
 
 	})
 
-	f.It("should recreate its iptables rules if they are deleted", f.WithDisruptive(), func(ctx context.Context) {
-		e2eskipper.SkipUnlessProviderIs(framework.ProvidersWithSSH...)
+	f.It("should recreate its iptables rules if they are deleted", f.WithDisruptive(), f.WithProvider(framework.ProvidersWithSSH...), func(ctx context.Context) {
 		e2eskipper.SkipUnlessSSHKeyPresent()
 
 		hosts, err := e2essh.NodeSSHHosts(ctx, f.ClientSet)

--- a/test/e2e/node/crictl.go
+++ b/test/e2e/node/crictl.go
@@ -22,21 +22,15 @@ import (
 
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	"github.com/onsi/ginkgo/v2"
 )
 
-var _ = SIGDescribe("crictl", func() {
+var _ = SIGDescribe("crictl", framework.WithProvider("gce") /* `crictl` is not available on all cloud providers. */, func() {
 	f := framework.NewDefaultFramework("crictl")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
-
-	ginkgo.BeforeEach(func() {
-		// `crictl` is not available on all cloud providers.
-		e2eskipper.SkipUnlessProviderIs("gce")
-	})
 
 	ginkgo.It("should be able to run crictl on the node", func(ctx context.Context) {
 		nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, f.ClientSet, maxNodes)

--- a/test/e2e/node/gpu.go
+++ b/test/e2e/node/gpu.go
@@ -38,7 +38,6 @@ import (
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eresource "k8s.io/kubernetes/test/e2e/framework/resource"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	e2etestfiles "k8s.io/kubernetes/test/e2e/framework/testfiles"
 	admissionapi "k8s.io/pod-security-admission/api"
 
@@ -50,14 +49,13 @@ import (
 // the CI job definitions to see how many GPU(s) are available in the environment
 // Currently the CI jobs have 2 nodes each with 4 Nvidia T4's across both GCE and AWS harness(es).
 
-var _ = SIGDescribe(feature.GPUDevicePlugin, framework.WithSerial(), "Sanity test using nvidia-smi", func() {
+var _ = SIGDescribe(feature.GPUDevicePlugin, framework.WithSerial(), "Sanity test using nvidia-smi", framework.WithProvider("aws", "gce"), func() {
 
 	f := framework.NewDefaultFramework("nvidia-gpu1")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 	var podClient *e2epod.PodClient
 
 	ginkgo.BeforeEach(func() {
-		e2eskipper.SkipUnlessProviderIs("aws", "gce")
 		podClient = e2epod.NewPodClient(f)
 	})
 
@@ -79,14 +77,13 @@ var _ = SIGDescribe(feature.GPUDevicePlugin, framework.WithSerial(), "Sanity tes
 	})
 })
 
-var _ = SIGDescribe(feature.GPUDevicePlugin, framework.WithSerial(), "Test using a Pod", func() {
+var _ = SIGDescribe(feature.GPUDevicePlugin, framework.WithSerial(), "Test using a Pod", framework.WithProvider("aws", "gce"), func() {
 
 	f := framework.NewDefaultFramework("nvidia-gpu2")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 	var podClient *e2epod.PodClient
 
 	ginkgo.BeforeEach(func() {
-		e2eskipper.SkipUnlessProviderIs("aws", "gce")
 		podClient = e2epod.NewPodClient(f)
 	})
 
@@ -110,14 +107,10 @@ var _ = SIGDescribe(feature.GPUDevicePlugin, framework.WithSerial(), "Test using
 	})
 })
 
-var _ = SIGDescribe(feature.GPUDevicePlugin, framework.WithSerial(), "Test using a Job", func() {
+var _ = SIGDescribe(feature.GPUDevicePlugin, framework.WithSerial(), "Test using a Job", framework.WithProvider("aws", "gce"), func() {
 
 	f := framework.NewDefaultFramework("nvidia-gpu2")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
-
-	ginkgo.BeforeEach(func() {
-		e2eskipper.SkipUnlessProviderIs("aws", "gce")
-	})
 
 	f.It("should run gpu based jobs", func(ctx context.Context) {
 		SetupEnvironmentAndSkipIfNeeded(ctx, f, f.ClientSet)

--- a/test/e2e/node/kubelet.go
+++ b/test/e2e/node/kubelet.go
@@ -381,7 +381,7 @@ var _ = SIGDescribe("kubelet", func() {
 		//       If the nfs-server pod is deleted the client pod's mount can not be unmounted.
 		//       If the nfs-server pod is deleted and re-created, due to having a different ip
 		//       addr, the client pod's mount still cannot be unmounted.
-		ginkgo.Context("Host cleanup after disrupting NFS volume [NFS]", func() {
+		f.Context("Host cleanup after disrupting NFS volume [NFS]", f.WithProvider(framework.ProvidersWithSSH...), func() {
 			// issue #31272
 			var (
 				nfsServerPod *v1.Pod
@@ -402,7 +402,6 @@ var _ = SIGDescribe("kubelet", func() {
 			}
 
 			ginkgo.BeforeEach(func(ctx context.Context) {
-				e2eskipper.SkipUnlessProviderIs(framework.ProvidersWithSSH...)
 				_, nfsServerPod, nfsIP = e2evolume.NewNFSServer(ctx, c, ns, []string{"-G", "777", "/exports"})
 			})
 
@@ -519,8 +518,7 @@ var _ = SIGDescribe("kubelet", func() {
 			returns the last three lines of the kubelet log
 		*/
 
-		ginkgo.It("should return the last three lines of the kubelet logs", func(ctx context.Context) {
-			e2eskipper.SkipUnlessProviderIs(framework.ProvidersWithSSH...)
+		f.It("should return the last three lines of the kubelet logs", f.WithProvider(framework.ProvidersWithSSH...), func(ctx context.Context) {
 			ginkgo.By("Starting the command")
 			tk := e2ekubectl.NewTestKubeconfig(framework.TestContext.CertDir, framework.TestContext.Host, framework.TestContext.KubeConfig, framework.TestContext.KubeContext, framework.TestContext.KubectlPath, ns)
 
@@ -538,8 +536,7 @@ var _ = SIGDescribe("kubelet", func() {
 			returns kubelet logs for the current boot with the pattern container
 		*/
 
-		ginkgo.It("should return the kubelet logs for the current boot with the pattern container", func(ctx context.Context) {
-			e2eskipper.SkipUnlessProviderIs(framework.ProvidersWithSSH...)
+		f.It("should return the kubelet logs for the current boot with the pattern container", f.WithProvider(framework.ProvidersWithSSH...), func(ctx context.Context) {
 			ginkgo.By("Starting the command")
 			tk := e2ekubectl.NewTestKubeconfig(framework.TestContext.CertDir, framework.TestContext.Host, framework.TestContext.KubeConfig, framework.TestContext.KubeContext, framework.TestContext.KubectlPath, ns)
 
@@ -596,8 +593,7 @@ var _ = SIGDescribe("kubelet", func() {
 			returns the last three lines of the Microsoft-Windows-Security-SPP log
 		*/
 
-		ginkgo.It("should return the last three lines of the Microsoft-Windows-Security-SPP logs", func(ctx context.Context) {
-			e2eskipper.SkipUnlessProviderIs(framework.ProvidersWithSSH...)
+		f.It("should return the last three lines of the Microsoft-Windows-Security-SPP logs", f.WithProvider(framework.ProvidersWithSSH...), func(ctx context.Context) {
 			if len(windowsNodeName) == 0 {
 				ginkgo.Skip("No Windows node found")
 			}
@@ -618,8 +614,7 @@ var _ = SIGDescribe("kubelet", func() {
 			returns the lines of the Microsoft-Windows-Security-SPP log with the pattern Health
 		*/
 
-		ginkgo.It("should return the Microsoft-Windows-Security-SPP logs with the pattern Health", func(ctx context.Context) {
-			e2eskipper.SkipUnlessProviderIs(framework.ProvidersWithSSH...)
+		f.It("should return the Microsoft-Windows-Security-SPP logs with the pattern Health", f.WithProvider(framework.ProvidersWithSSH...), func(ctx context.Context) {
 			if len(windowsNodeName) == 0 {
 				ginkgo.Skip("No Windows node found")
 			}

--- a/test/e2e/node/node_problem_detector.go
+++ b/test/e2e/node/node_problem_detector.go
@@ -43,7 +43,7 @@ import (
 
 // This test checks if node-problem-detector (NPD) runs fine without error on
 // the up to 10 nodes in the cluster. NPD's functionality is tested in e2e_node tests.
-var _ = SIGDescribe("NodeProblemDetector", feature.NodeProblemDetector, func() {
+var _ = SIGDescribe("NodeProblemDetector", feature.NodeProblemDetector, framework.WithProvider(framework.ProvidersWithSSH...), framework.WithProvider("gce"), func() {
 	const (
 		pollInterval      = 1 * time.Second
 		pollTimeout       = 1 * time.Minute
@@ -54,8 +54,6 @@ var _ = SIGDescribe("NodeProblemDetector", feature.NodeProblemDetector, func() {
 
 	ginkgo.BeforeEach(func(ctx context.Context) {
 		e2eskipper.SkipUnlessSSHKeyPresent()
-		e2eskipper.SkipUnlessProviderIs(framework.ProvidersWithSSH...)
-		e2eskipper.SkipUnlessProviderIs("gce")
 		e2eskipper.SkipUnlessNodeOSDistroIs("gci", "ubuntu")
 		e2enode.WaitForTotalHealthy(ctx, f.ClientSet, time.Minute)
 	})

--- a/test/e2e/node/ssh.go
+++ b/test/e2e/node/ssh.go
@@ -31,15 +31,12 @@ import (
 
 const maxNodes = 100
 
-var _ = SIGDescribe("SSH", func() {
+var _ = SIGDescribe("SSH", framework.WithProvider(framework.ProvidersWithSSH...) /* When adding more providers here, also implement their functionality in e2essh.GetSigner(...). */, func() {
 
 	f := framework.NewDefaultFramework("ssh")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 	ginkgo.BeforeEach(func() {
-		// When adding more providers here, also implement their functionality in e2essh.GetSigner(...).
-		e2eskipper.SkipUnlessProviderIs(framework.ProvidersWithSSH...)
-
 		// This test SSH's into the node for which it needs the $HOME/.ssh/id_rsa key to be present. So
 		// we should skip if the environment does not have the key (not all CI systems support this use case)
 		e2eskipper.SkipUnlessSSHKeyPresent()

--- a/test/e2e/storage/csimock/csi_kubelet_restart.go
+++ b/test/e2e/storage/csimock/csi_kubelet_restart.go
@@ -32,17 +32,15 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 )
 
-var _ = utils.SIGDescribe("CSI Mock when kubelet restart", framework.WithSerial(), framework.WithDisruptive(), func() {
+// These tests requires SSH to nodes, so the provider check should be identical to there
+// (the limiting factor is the implementation of util.go's e2essh.GetSigner(...)).
+// Cluster must support node reboot.
+var _ = utils.SIGDescribe("CSI Mock when kubelet restart", framework.WithSerial(), framework.WithDisruptive(), framework.WithProvider(framework.ProvidersWithSSH...), func() {
 	f := framework.NewDefaultFramework("csi-mock-when-kubelet-restart")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 	m := newMockDriverSetup(f)
 
 	ginkgo.BeforeEach(func() {
-		// These tests requires SSH to nodes, so the provider check should be identical to there
-		// (the limiting factor is the implementation of util.go's e2essh.GetSigner(...)).
-
-		// Cluster must support node reboot
-		e2eskipper.SkipUnlessProviderIs(framework.ProvidersWithSSH...)
 		e2eskipper.SkipUnlessSSHKeyPresent()
 	})
 

--- a/test/e2e/storage/detach_mounted.go
+++ b/test/e2e/storage/detach_mounted.go
@@ -43,7 +43,7 @@ var (
 	durationForStuckMount = 110 * time.Second
 )
 
-var _ = utils.SIGDescribe(feature.Flexvolumes, "Detaching volumes", func() {
+var _ = utils.SIGDescribe(feature.Flexvolumes, "Detaching volumes", framework.WithProvider("gce", "local"), func() {
 	f := framework.NewDefaultFramework("flexvolume")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
@@ -55,7 +55,6 @@ var _ = utils.SIGDescribe(feature.Flexvolumes, "Detaching volumes", func() {
 	var suffix string
 
 	ginkgo.BeforeEach(func(ctx context.Context) {
-		e2eskipper.SkipUnlessProviderIs("gce", "local")
 		e2eskipper.SkipUnlessMasterOSDistroIs("debian", "ubuntu", "gci", "custom")
 		e2eskipper.SkipUnlessNodeOSDistroIs("debian", "ubuntu", "gci", "custom")
 		e2eskipper.SkipUnlessSSHKeyPresent()

--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -903,7 +903,7 @@ func InitGcePDCSIDriver() storageframework.TestDriver {
 	return &gcePDCSIDriver{
 		driverInfo: storageframework.DriverInfo{
 			Name:        GCEPDCSIDriverName,
-			TestTags:    []interface{}{framework.WithSerial()},
+			TestTags:    []interface{}{framework.WithSerial(), framework.WithProvider("gce")},
 			MaxFileSize: storageframework.FileSizeMedium,
 			SupportedSizeRange: e2evolume.SizeRange{
 				Min: "5Gi",
@@ -958,7 +958,6 @@ func (g *gcePDCSIDriver) GetDriverInfo() *storageframework.DriverInfo {
 }
 
 func (g *gcePDCSIDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) {
-	e2eskipper.SkipUnlessProviderIs("gce")
 	if pattern.FsType == "xfs" {
 		e2eskipper.SkipUnlessNodeOSDistroIs("ubuntu", "custom")
 	}

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -770,6 +770,7 @@ var _ storageframework.DynamicPVTestDriver = &cinderDriver{}
 func InitCinderDriver() storageframework.TestDriver {
 	return &cinderDriver{
 		driverInfo: storageframework.DriverInfo{
+			TestTags:         []any{framework.WithProvider("openstack")},
 			Name:             "cinder",
 			InTreePluginName: "kubernetes.io/cinder",
 			MaxFileSize:      storageframework.FileSizeMedium,
@@ -799,7 +800,6 @@ func (c *cinderDriver) GetDriverInfo() *storageframework.DriverInfo {
 }
 
 func (c *cinderDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) {
-	e2eskipper.SkipUnlessProviderIs("openstack")
 }
 
 func (c *cinderDriver) GetDynamicProvisionStorageClass(ctx context.Context, config *storageframework.PerTestConfig, fsType string) *storagev1.StorageClass {
@@ -840,6 +840,7 @@ func InitGcePdDriver() storageframework.TestDriver {
 	)
 	return &gcePdDriver{
 		driverInfo: storageframework.DriverInfo{
+			TestTags:         []any{framework.WithProvider("gce")},
 			Name:             "gcepd",
 			InTreePluginName: "kubernetes.io/gce-pd",
 			MaxFileSize:      storageframework.FileSizeMedium,
@@ -879,6 +880,7 @@ func InitWindowsGcePdDriver() storageframework.TestDriver {
 	)
 	return &gcePdDriver{
 		driverInfo: storageframework.DriverInfo{
+			TestTags:         []any{framework.WithProvider("gce")},
 			Name:             "windows-gcepd",
 			InTreePluginName: "kubernetes.io/gce-pd",
 			MaxFileSize:      storageframework.FileSizeMedium,
@@ -907,7 +909,6 @@ func (g *gcePdDriver) GetDriverInfo() *storageframework.DriverInfo {
 }
 
 func (g *gcePdDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) {
-	e2eskipper.SkipUnlessProviderIs("gce")
 	for _, tag := range pattern.TestTags {
 		if tag == feature.Windows {
 			e2eskipper.SkipUnlessNodeOSDistroIs("windows")
@@ -957,6 +958,7 @@ var _ storageframework.DynamicPVTestDriver = &vSphereDriver{}
 func InitVSphereDriver() storageframework.TestDriver {
 	return &vSphereDriver{
 		driverInfo: storageframework.DriverInfo{
+			TestTags:         []any{framework.WithProvider("vsphere")},
 			Name:             "vsphere",
 			InTreePluginName: "kubernetes.io/vsphere-volume",
 			MaxFileSize:      storageframework.FileSizeMedium,
@@ -987,7 +989,6 @@ func (v *vSphereDriver) GetDriverInfo() *storageframework.DriverInfo {
 }
 
 func (v *vSphereDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) {
-	e2eskipper.SkipUnlessProviderIs("vsphere")
 }
 
 func (v *vSphereDriver) GetDynamicProvisionStorageClass(ctx context.Context, config *storageframework.PerTestConfig, fsType string) *storagev1.StorageClass {
@@ -1022,6 +1023,7 @@ var _ storageframework.CustomTimeoutsTestDriver = &azureDiskDriver{}
 func InitAzureDiskDriver() storageframework.TestDriver {
 	return &azureDiskDriver{
 		driverInfo: storageframework.DriverInfo{
+			TestTags:         []any{framework.WithProvider("azure")},
 			Name:             "azure-disk",
 			InTreePluginName: "kubernetes.io/azure-disk",
 			MaxFileSize:      storageframework.FileSizeMedium,
@@ -1055,7 +1057,6 @@ func (a *azureDiskDriver) GetDriverInfo() *storageframework.DriverInfo {
 }
 
 func (a *azureDiskDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) {
-	e2eskipper.SkipUnlessProviderIs("azure")
 }
 
 func (a *azureDiskDriver) GetDynamicProvisionStorageClass(ctx context.Context, config *storageframework.PerTestConfig, fsType string) *storagev1.StorageClass {
@@ -1098,6 +1099,7 @@ var _ storageframework.DynamicPVTestDriver = &awsDriver{}
 func InitAwsDriver() storageframework.TestDriver {
 	return &awsDriver{
 		driverInfo: storageframework.DriverInfo{
+			TestTags:         []any{framework.WithProvider("aws")},
 			Name:             "aws",
 			InTreePluginName: "kubernetes.io/aws-ebs",
 			MaxFileSize:      storageframework.FileSizeMedium,
@@ -1137,7 +1139,6 @@ func (a *awsDriver) GetDriverInfo() *storageframework.DriverInfo {
 }
 
 func (a *awsDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) {
-	e2eskipper.SkipUnlessProviderIs("aws")
 }
 
 func (a *awsDriver) GetDynamicProvisionStorageClass(ctx context.Context, config *storageframework.PerTestConfig, fsType string) *storagev1.StorageClass {
@@ -1413,6 +1414,7 @@ var _ storageframework.DynamicPVTestDriver = &azureFileDriver{}
 func InitAzureFileDriver() storageframework.TestDriver {
 	return &azureFileDriver{
 		driverInfo: storageframework.DriverInfo{
+			TestTags:         []any{framework.WithProvider("azure")},
 			Name:             "azure-file",
 			InTreePluginName: "kubernetes.io/azure-file",
 			MaxFileSize:      storageframework.FileSizeMedium,
@@ -1440,7 +1442,6 @@ func (a *azureFileDriver) GetDriverInfo() *storageframework.DriverInfo {
 }
 
 func (a *azureFileDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) {
-	e2eskipper.SkipUnlessProviderIs("azure")
 }
 
 func (a *azureFileDriver) GetDynamicProvisionStorageClass(ctx context.Context, config *storageframework.PerTestConfig, fsType string) *storagev1.StorageClass {

--- a/test/e2e/storage/flexvolume.go
+++ b/test/e2e/storage/flexvolume.go
@@ -157,7 +157,7 @@ func getHostFromHostPort(hostPort string) string {
 	return host
 }
 
-var _ = utils.SIGDescribe("Flexvolumes", func() {
+var _ = utils.SIGDescribe("Flexvolumes", framework.WithProvider("gce", "local"), func() {
 	f := framework.NewDefaultFramework("flexvolume")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 
@@ -170,7 +170,6 @@ var _ = utils.SIGDescribe("Flexvolumes", func() {
 	var suffix string
 
 	ginkgo.BeforeEach(func(ctx context.Context) {
-		e2eskipper.SkipUnlessProviderIs("gce", "local")
 		e2eskipper.SkipUnlessMasterOSDistroIs("debian", "ubuntu", "gci", "custom")
 		e2eskipper.SkipUnlessNodeOSDistroIs("debian", "ubuntu", "gci", "custom")
 		e2eskipper.SkipUnlessSSHKeyPresent()

--- a/test/e2e/storage/flexvolume_mounted_volume_resize.go
+++ b/test/e2e/storage/flexvolume_mounted_volume_resize.go
@@ -40,7 +40,7 @@ import (
 	"path"
 )
 
-var _ = utils.SIGDescribe(feature.Flexvolumes, "Mounted flexvolume expand", framework.WithSlow(), func() {
+var _ = utils.SIGDescribe(feature.Flexvolumes, "Mounted flexvolume expand", framework.WithSlow(), framework.WithProvider("aws", "gce", "local"), func() {
 	var (
 		c                 clientset.Interface
 		ns                string
@@ -57,7 +57,6 @@ var _ = utils.SIGDescribe(feature.Flexvolumes, "Mounted flexvolume expand", fram
 	f := framework.NewDefaultFramework("mounted-flexvolume-expand")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 	ginkgo.BeforeEach(func(ctx context.Context) {
-		e2eskipper.SkipUnlessProviderIs("aws", "gce", "local")
 		e2eskipper.SkipUnlessMasterOSDistroIs("debian", "ubuntu", "gci", "custom")
 		e2eskipper.SkipUnlessNodeOSDistroIs("debian", "ubuntu", "gci", "custom")
 		e2eskipper.SkipUnlessSSHKeyPresent()

--- a/test/e2e/storage/flexvolume_online_resize.go
+++ b/test/e2e/storage/flexvolume_online_resize.go
@@ -41,7 +41,7 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 )
 
-var _ = utils.SIGDescribe(feature.Flexvolumes, "Mounted flexvolume volume expand", framework.WithSlow(), func() {
+var _ = utils.SIGDescribe(feature.Flexvolumes, "Mounted flexvolume volume expand", framework.WithSlow(), framework.WithProvider("aws", "gce", "local"), func() {
 	var (
 		c                 clientset.Interface
 		ns                string
@@ -58,7 +58,6 @@ var _ = utils.SIGDescribe(feature.Flexvolumes, "Mounted flexvolume volume expand
 	f := framework.NewDefaultFramework("mounted-flexvolume-expand")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 	ginkgo.BeforeEach(func(ctx context.Context) {
-		e2eskipper.SkipUnlessProviderIs("aws", "gce", "local")
 		e2eskipper.SkipUnlessMasterOSDistroIs("debian", "ubuntu", "gci", "custom")
 		e2eskipper.SkipUnlessNodeOSDistroIs("debian", "ubuntu", "gci", "custom")
 		e2eskipper.SkipUnlessSSHKeyPresent()

--- a/test/e2e/storage/non_graceful_node_shutdown.go
+++ b/test/e2e/storage/non_graceful_node_shutdown.go
@@ -56,7 +56,7 @@ This test performs the following:
 - Removes the `out-of-service` taint from the node.
 */
 
-var _ = utils.SIGDescribe(framework.WithDisruptive(), "[LinuxOnly] NonGracefulNodeShutdown", func() {
+var _ = utils.SIGDescribe(framework.WithDisruptive(), framework.WithProvider("gce"), "[LinuxOnly] NonGracefulNodeShutdown", func() {
 	var (
 		c  clientset.Interface
 		ns string
@@ -67,7 +67,6 @@ var _ = utils.SIGDescribe(framework.WithDisruptive(), "[LinuxOnly] NonGracefulNo
 	ginkgo.BeforeEach(func(ctx context.Context) {
 		c = f.ClientSet
 		ns = f.Namespace.Name
-		e2eskipper.SkipUnlessProviderIs("gce")
 		nodeList, err := e2enode.GetReadySchedulableNodes(ctx, c)
 		if err != nil {
 			framework.Logf("Failed to list node: %v", err)

--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -41,7 +41,6 @@ import (
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -331,9 +330,8 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 		})
 	})
 
-	ginkgo.Describe("DynamicProvisioner Default", func() {
+	f.Describe("DynamicProvisioner Default", f.WithProvider("openstack", "gce", "aws", "vsphere", "azure"), func() {
 		f.It("should create and delete default persistent volumes", f.WithSlow(), func(ctx context.Context) {
-			e2eskipper.SkipUnlessProviderIs("openstack", "gce", "aws", "vsphere", "azure")
 			e2epv.SkipIfNoDefaultStorageClass(ctx, c)
 
 			ginkgo.By("creating a claim with no annotation")
@@ -357,7 +355,6 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 
 		// Modifying the default storage class can be disruptive to other tests that depend on it
 		f.It("should be disabled by changing the default annotation", f.WithSerial(), f.WithDisruptive(), func(ctx context.Context) {
-			e2eskipper.SkipUnlessProviderIs("openstack", "gce", "aws", "vsphere", "azure")
 			e2epv.SkipIfNoDefaultStorageClass(ctx, c)
 
 			scName, scErr := e2epv.GetDefaultStorageClassName(ctx, c)
@@ -394,7 +391,6 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 
 		// Modifying the default storage class can be disruptive to other tests that depend on it
 		f.It("should be disabled by removing the default annotation", f.WithSerial(), f.WithDisruptive(), func(ctx context.Context) {
-			e2eskipper.SkipUnlessProviderIs("openstack", "gce", "aws", "vsphere", "azure")
 			e2epv.SkipIfNoDefaultStorageClass(ctx, c)
 
 			scName, scErr := e2epv.GetDefaultStorageClassName(ctx, c)
@@ -433,8 +429,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 	})
 
 	ginkgo.Describe("Invalid AWS KMS key", func() {
-		ginkgo.It("should report an error and create no PV", func(ctx context.Context) {
-			e2eskipper.SkipUnlessProviderIs("aws")
+		f.It("should report an error and create no PV", f.WithProvider("aws"), func(ctx context.Context) {
 			test := testsuites.StorageClassTest{
 				Client:      c,
 				Name:        "AWS EBS with invalid KMS key",

--- a/test/e2e/upgrades/storage/persistent_volumes.go
+++ b/test/e2e/upgrades/storage/persistent_volumes.go
@@ -25,7 +25,6 @@ import (
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	"k8s.io/kubernetes/test/e2e/upgrades"
 
 	"github.com/onsi/ginkgo/v2"
@@ -50,7 +49,7 @@ const (
 func (t *PersistentVolumeUpgradeTest) Setup(ctx context.Context, f *framework.Framework) {
 
 	var err error
-	e2eskipper.SkipUnlessProviderIs("gce", "openstack", "aws", "vsphere", "azure")
+	// At the moment, the user of this test limits execution to GCE.
 
 	ns := f.Namespace.Name
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The advantage is that during reviews of existing tests (e.g. by looking at --list-tests output) it is visible that a test has special requirements regarding the cluster.

The code is often also shorter.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Required for https://github.com/kubernetes/test-infra/pull/37410.

This changes the following test names: 
[name-changes.patch](https://github.com/user-attachments/files/30005675/name-changes.patch)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
