### PR TITLE
E2E framework: make Ginkgo wrapper tags comparable again

### DIFF
--- a/test/e2e/framework/ginkgowrapper.go
+++ b/test/e2e/framework/ginkgowrapper.go
@@ -355,7 +355,7 @@ func expandGinkgoArgs(leafNode bool, offset ginkgo.Offset, text string, args []a
 		case featureGate:
 			addFeatureGate(arg.name, arg.spec, true)
 		case label:
-			fullLabel := strings.Join(arg.parts, ":")
+			fullLabel := arg.String()
 			addLabel(fullLabel)
 			if !leafNodeLabels.Has(fullLabel) {
 				texts = append(texts, fmt.Sprintf("[%s]", fullLabel))
@@ -783,37 +783,27 @@ func withKubeletMinVersion(version string) interface{} {
 	return newLabel("KubeletMinVersion", version)
 }
 
+// label must be comparable, some code uses that to detect feature.Windows.
 type label struct {
 	// parts get concatenated with ":" to build the full label.
-	parts []string
+	parts [2]string
+	len   int
+}
+
+func (l label) String() string {
+	if l.len == 2 {
+		return l.parts[0] + ":" + l.parts[1]
+	}
+	return l.parts[0]
 }
 
 func newLabel(parts ...string) label {
-	return label{
-		parts: parts,
-	}
-}
-
-// TagsEqual can be used to check whether two tags are the same.
-// It's safe to compare e.g. the result of WithSlow() against the result
-// of WithSerial(), the result will be false. False is also returned
-// when a parameter is some completely different value.
-func TagsEqual(a, b interface{}) bool {
-	switch a := a.(type) {
-	case label:
-		b, ok := b.(label)
-		if !ok {
-			return false
-		}
-		return slices.Equal(a.parts, b.parts)
-	case featureGate:
-		b, ok := b.(featureGate)
-		if !ok {
-			return false
-		}
-		return a == b
+	switch len(parts) {
+	case 1:
+		return label{parts: [2]string{parts[0], ""}, len: 1}
+	case 2:
+		return label{parts: [2]string{parts[0], parts[1]}, len: 2}
 	default:
-		// Unknown tag, cannot compare.
-		return false
+		panic(fmt.Sprintf("invalid number of part strings: %v", parts))
 	}
 }

--- a/test/e2e/framework/ginkgowrapper_test.go
+++ b/test/e2e/framework/ginkgowrapper_test.go
@@ -29,7 +29,7 @@ func TestTagsEqual(t *testing.T) {
 		expectEqual bool
 	}{
 		{1, 2, false},
-		{2, 2, false},
+		{2, 2, true},
 		{WithSlow(), 2, false},
 		{WithSlow(), WithSerial(), false},
 		{WithSerial(), WithSlow(), false},
@@ -43,7 +43,7 @@ func TestTagsEqual(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(fmt.Sprintf("%v=%v", tc.a, tc.b), func(t *testing.T) {
-			actualEqual := TagsEqual(tc.a, tc.b)
+			actualEqual := tc.a == tc.b
 			if actualEqual != tc.expectEqual {
 				t.Errorf("expected %v, got %v", tc.expectEqual, actualEqual)
 			}

--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -963,7 +963,7 @@ func (g *gcePDCSIDriver) SkipUnsupportedTest(pattern storageframework.TestPatter
 		e2eskipper.SkipUnlessNodeOSDistroIs("ubuntu", "custom")
 	}
 	for _, tag := range pattern.TestTags {
-		if framework.TagsEqual(tag, feature.Windows) {
+		if tag == feature.Windows {
 			e2eskipper.Skipf("Skipping tests for windows since CSI does not support it yet")
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/blob/df4913fe88c2a5ae73ada501df3aabb1216286e2/test/e2e/storage/drivers/in_tree.go#L912 was still doing a direct comparison and would have failed if reached. Because it hard to enforce that all code uses the dedicated TagsEqual, let's instead make the struct comparable again by restricting the number of parts to at most two - that's sufficient and can be increased if needed.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
