### PR TITLE
Add PodGroupPostFilter for DRA

### DIFF
--- a/cmd/kube-scheduler/app/server_test.go
+++ b/cmd/kube-scheduler/app/server_test.go
@@ -271,6 +271,7 @@ leaderElection:
 					// With this (and only this?!) config comes DynamicResources after DefaultPreemption.
 					plugins.PreEnqueue.Enabled[1], plugins.PreEnqueue.Enabled[2] = plugins.PreEnqueue.Enabled[2], plugins.PreEnqueue.Enabled[1]
 					plugins.PostFilter.Enabled[0], plugins.PostFilter.Enabled[1] = plugins.PostFilter.Enabled[1], plugins.PostFilter.Enabled[0]
+					plugins.PodGroupPostFilter.Enabled[0], plugins.PodGroupPostFilter.Enabled[1] = plugins.PodGroupPostFilter.Enabled[1], plugins.PodGroupPostFilter.Enabled[0]
 					plugins.Filter.Enabled = []config.Plugin{
 						{Name: "NodeResourcesFit"},
 						{Name: "NodePorts"},

--- a/pkg/scheduler/apis/config/testing/defaults/defaults.go
+++ b/pkg/scheduler/apis/config/testing/defaults/defaults.go
@@ -110,6 +110,7 @@ var ExpandedPluginsV1 = &config.Plugins{
 	},
 	PodGroupPostFilter: config.PluginSet{
 		Enabled: []config.Plugin{
+			{Name: names.DynamicResources},
 			{Name: names.DefaultPreemption},
 		},
 	},

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -129,6 +129,9 @@ type podGroupStateData struct {
 	// CycleState is only available during synchronous scheduling phases and is
 	// cleared before asynchronous phases begin.
 	pendingAllocations sets.Set[types.UID]
+
+	// podsStateData stores the stateData of each pod in the PodGroup.
+	podsStateData map[types.NamespacedName]*stateData
 }
 
 func (d *podGroupStateData) Clone() fwk.StateData {
@@ -220,6 +223,7 @@ var _ fwk.PreEnqueuePlugin = &DynamicResources{}
 var _ fwk.PreFilterPlugin = &DynamicResources{}
 var _ fwk.FilterPlugin = &DynamicResources{}
 var _ fwk.PostFilterPlugin = &DynamicResources{}
+var _ fwk.PodGroupPostFilterPlugin = &DynamicResources{}
 var _ fwk.ScorePlugin = &DynamicResources{}
 var _ fwk.ReservePlugin = &DynamicResources{}
 var _ fwk.EnqueueExtensions = &DynamicResources{}
@@ -461,6 +465,13 @@ func (pl *DynamicResources) PreFilter(ctx context.Context, state fwk.CycleState,
 	podGroupState, err := getPodGroupStateData(state)
 	if err != nil {
 		return nil, statusError(logger, err)
+	}
+	// If podGroupState exists add pod's state to it, so it can be use in PodGroupPostFilter.
+	if podGroupState != nil {
+		if podGroupState.podsStateData == nil {
+			podGroupState.podsStateData = make(map[types.NamespacedName]*stateData)
+		}
+		podGroupState.podsStateData[types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}] = s
 	}
 
 	userClaims, err := pl.podResourceClaims(pod)
@@ -716,6 +727,7 @@ func getPodGroupStateData(cs fwk.CycleState) (*podGroupStateData, error) {
 	if errors.Is(err, fwk.ErrNotFound) {
 		podGroupState := &podGroupStateData{
 			pendingAllocations: make(sets.Set[types.UID]),
+			podsStateData:      make(map[types.NamespacedName]*stateData),
 		}
 		podGroupCycleState.Write(stateKey, podGroupState)
 		return podGroupState, nil
@@ -912,6 +924,7 @@ func (pl *DynamicResources) Filter(ctx context.Context, cs fwk.CycleState, pod *
 		for _, index := range unavailableClaims {
 			state.unavailableClaims.Insert(index)
 		}
+
 		return statusUnschedulable(logger, "resourceclaim not available on the node", "pod", klog.KObj(pod))
 	}
 
@@ -929,9 +942,9 @@ func (pl *DynamicResources) Filter(ctx context.Context, cs fwk.CycleState, pod *
 
 // PostFilter checks whether there are allocated claims that could get
 // deallocated to help get the Pod schedulable. If yes, it picks one and
-// requests its deallocation.  This only gets called when filtering found no
+// requests its deallocation. This only gets called when filtering found no
 // suitable node.
-func (pl *DynamicResources) PostFilter(ctx context.Context, cs fwk.CycleState, pod *v1.Pod, filteredNodeStatusMap fwk.NodeToStatusReader) (*fwk.PostFilterResult, *fwk.Status) {
+func (pl *DynamicResources) PostFilter(ctx context.Context, cs fwk.CycleState, pod *v1.Pod, _ fwk.NodeToStatusReader) (*fwk.PostFilterResult, *fwk.Status) {
 	logger := klog.FromContext(ctx)
 	if !pl.enabled {
 		logger.V(5).Info("Nothing to do in PostFilter, plugin disabled", "pod", klog.KObj(pod))
@@ -951,6 +964,13 @@ func (pl *DynamicResources) PostFilter(ctx context.Context, cs fwk.CycleState, p
 		logger.V(5).Info("No new claims to deallocate", "pod", klog.KObj(pod))
 		return nil, fwk.NewStatus(fwk.Unschedulable)
 	}
+
+	_, status := pl.deallocateOrDeletePodClaims(ctx, pod, state)
+	return nil, status
+}
+
+func (pl *DynamicResources) deallocateOrDeletePodClaims(ctx context.Context, pod *v1.Pod, state *stateData) (bool, *fwk.Status) {
+	logger := klog.FromContext(ctx)
 	extendedResourceClaim := state.claims.extendedResourceClaim()
 
 	// Iterating over a map is random. This is intentional here, we want to
@@ -959,23 +979,22 @@ func (pl *DynamicResources) PostFilter(ctx context.Context, cs fwk.CycleState, p
 		claim := state.claims.get(index)
 		if claim == extendedResourceClaim {
 			if extendedResourceClaim != nil && !isSpecialClaimName(extendedResourceClaim.Name) {
-				// Handled below.
 				break
 			}
 			continue
 		}
 
 		if len(claim.Status.ReservedFor) == 0 ||
-			len(claim.Status.ReservedFor) == 1 && claim.Status.ReservedFor[0].UID == pod.UID {
+			(len(claim.Status.ReservedFor) == 1 && claim.Status.ReservedFor[0].UID == pod.UID) {
 			claim := claim.DeepCopy()
 			claim.Status.ReservedFor = nil
 			claim.Status.Allocation = nil
 			claim.Status.Devices = nil
 			logger.V(5).Info("Deallocation of ResourceClaim", "pod", klog.KObj(pod), "resourceclaim", klog.KObj(claim))
 			if _, err := pl.clientset.ResourceV1().ResourceClaims(claim.Namespace).UpdateStatus(ctx, claim, metav1.UpdateOptions{}); err != nil {
-				return nil, statusError(logger, err)
+				return true, statusError(logger, err)
 			}
-			return nil, fwk.NewStatus(fwk.Unschedulable, "deallocation of ResourceClaim completed")
+			return true, fwk.NewStatus(fwk.Unschedulable, "deallocation of ResourceClaim completed")
 		}
 	}
 
@@ -984,25 +1003,12 @@ func (pl *DynamicResources) PostFilter(ctx context.Context, cs fwk.CycleState, p
 		// is reserved or allocated at prior scheduling cycle, then it should be deleted.
 		extendedResourceClaim := extendedResourceClaim.DeepCopy()
 		if err := pl.deleteClaim(ctx, extendedResourceClaim); err != nil {
-			return nil, statusError(logger, err)
+			return true, statusError(logger, err)
 		}
-		return nil, fwk.NewStatus(fwk.Unschedulable, "deletion of ResourceClaim completed")
+		return true, fwk.NewStatus(fwk.Unschedulable, "deletion of ResourceClaim completed")
 	}
 
-	// If we make it here we know that not all pods of the PodGroup could be scheduled.
-	// To let the scheduler try to find new devices in case binding the current allocation
-	// failed in some previous cycle, remove the PodGroup from its claims' status.reservedFor.
-	// Note that more Pods may exist than a PodGroup's minCount, but performing
-	// a cleanup after a previous cycle is safe as long as there are no assumed
-	// nor assigned pods yet.
-	if pl.fts.EnableDRAWorkloadResourceClaims {
-		status := pl.unreservePodGroupClaims(ctx, pod)
-		if status != nil {
-			return nil, status
-		}
-	}
-
-	return nil, fwk.NewStatus(fwk.Unschedulable)
+	return false, fwk.NewStatus(fwk.Unschedulable)
 }
 
 func (pl *DynamicResources) unreservePodGroupClaims(ctx context.Context, pod *v1.Pod) *fwk.Status {
@@ -1070,6 +1076,85 @@ func (pl *DynamicResources) unreservePodGroupClaims(ctx context.Context, pod *v1
 	}
 
 	return nil
+}
+
+// PodGroupPostFilter checks whether there are allocated claims that could get
+// deallocated/deleted/unreserved to help get the PodGroup schedulable.
+// This only gets called when pod group cycle could not find a placement for PodGroup.
+func (pl *DynamicResources) PodGroupPostFilter(
+	ctx context.Context,
+	state fwk.PodGroupCycleState,
+	pgInfo fwk.PodGroupInfo,
+	_ fwk.PodGroupSchedulingFunc,
+) (*fwk.PodGroupPostFilterResult, *fwk.Status) {
+	logger := klog.FromContext(ctx)
+	if !pl.enabled {
+		logger.V(5).Info("Nothing to do in PodGroupPostFilter, plugin disabled", "podGroup", pgInfo.GetName())
+		return nil, fwk.NewStatus(fwk.Unschedulable)
+	}
+
+	if pl.fts.EnableTopologyAwareWorkloadScheduling && pgInfo.GetPodGroup() != nil && pgInfo.GetPodGroup().Spec.SchedulingConstraints != nil {
+		logger.V(5).Info("DRA PodGroupPostFilter is not supporting topology-aware workloads", "podGroup", pgInfo.GetName())
+		return nil, fwk.NewStatus(fwk.Unschedulable)
+	}
+
+	podGroupState, err := getPodGroupStateDataFromPodGroupCycleState(state)
+	if err != nil {
+		return nil, statusError(logger, err)
+	}
+
+	unreservePodGroup := false
+	// 1. Process pod-level claims deallocations/deletions.
+	// This mimics running PostFilter for each of the pods in pod group.
+	if podGroupState != nil && len(podGroupState.podsStateData) > 0 {
+		for _, pod := range pgInfo.GetUnscheduledPods() {
+			podState := podGroupState.podsStateData[types.NamespacedName{Namespace: pod.GetNamespace(), Name: pod.GetName()}]
+			if podState == nil {
+				continue
+			}
+			foundClaim, status := pl.deallocateOrDeletePodClaims(ctx, pod, podState)
+			if status.IsError() {
+				return nil, status
+			}
+			if !foundClaim {
+				// If we make it here we know that not all pods of the PodGroup could be scheduled.
+				unreservePodGroup = true
+			}
+		}
+	}
+
+	// 2. If at least one pod with claims did not deallocate/delete, try to unreserve PodGroup claims.
+	if unreservePodGroup && pl.fts.EnableDRAWorkloadResourceClaims && len(pgInfo.GetUnscheduledPods()) > 0 {
+		// To let the scheduler try to find new devices in case binding the current allocation
+		// failed in some previous cycle, remove the PodGroup from its claims' status.reservedFor.
+		// Note that more Pods may exist than a PodGroup's minCount, but performing
+		// a cleanup after a previous cycle is safe as long as there are no assumed
+		// nor assigned pods yet.
+		status := pl.unreservePodGroupClaims(ctx, pgInfo.GetUnscheduledPods()[0])
+		if status != nil {
+			return nil, status
+		}
+	}
+
+	return nil, fwk.NewStatus(fwk.Unschedulable, "deallocation and deletion of ResourceClaims completed")
+}
+
+func getPodGroupStateDataFromPodGroupCycleState(pgState fwk.PodGroupCycleState) (*podGroupStateData, error) {
+	if pgState == nil {
+		return nil, nil
+	}
+	state, err := pgState.Read(stateKey)
+	if errors.Is(err, fwk.ErrNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	s, ok := state.(*podGroupStateData)
+	if !ok {
+		return nil, errors.New("state is not podGroupStateData")
+	}
+	return s, nil
 }
 
 func (pl *DynamicResources) Score(ctx context.Context, cs fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) (int64, *fwk.Status) {

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -227,6 +227,16 @@ var (
 				PodResourceClaims(v1.PodResourceClaim{Name: resourceName, ResourceClaimName: &claimName}).
 				PodGroupName(podGroupName).
 				Obj()
+	groupedPodWithClaimName2 = st.MakePod().Name(podName + "-2").Namespace(namespace).
+					UID(podUID + "-2").
+					PodResourceClaims(v1.PodResourceClaim{Name: resourceName, ResourceClaimName: &claimName}).
+					PodGroupName(podGroupName).
+					Obj()
+	groupedPodWithPodLevelClaim = st.MakePod().Name(podName + "-podlevel").Namespace(namespace).
+					UID(podUID + "-podlevel").
+					PodResourceClaims(v1.PodResourceClaim{Name: resourceName2, ResourceClaimName: &claimName2}).
+					PodGroupName(podGroupName).
+					Obj()
 	groupedPodWithTwoClaimNames = st.MakePod().Name(podName).Namespace(namespace).
 					UID(podUID).
 					PodResourceClaims(v1.PodResourceClaim{Name: resourceName, ResourceClaimName: &claimName}).
@@ -251,6 +261,11 @@ var (
 				UID(types.UID(podGroupUID)).
 				ResourceClaims(schedulingapi.PodGroupResourceClaim{Name: resourceName, ResourceClaimName: &claimName}).
 				Obj()
+	podGroupWithClaimNameAndConstraints = st.MakePodGroup().Name(podGroupName).Namespace(namespace).
+						UID(types.UID(podGroupUID)).
+						ResourceClaims(schedulingapi.PodGroupResourceClaim{Name: resourceName, ResourceClaimName: &claimName}).
+						TopologyKey("kubernetes.io/hostname").
+						Obj()
 	podGroupWithClaimTemplate = st.MakePodGroup().Name(podGroupName).Namespace(namespace).
 					UID(types.UID(podGroupUID)).
 					ResourceClaims(schedulingapi.PodGroupResourceClaim{Name: resourceName, ResourceClaimTemplateName: &claimName}).
@@ -644,6 +659,11 @@ var (
 			Allocation(allocationResult).
 			ReservedForPod(podName, types.UID(podUID)).
 			Obj()
+	inUseClaimForPodLevel = st.FromResourceClaim(claim2).
+				OwnerReference(podName+"-podlevel", podUID+"-podlevel", podKind).
+				Allocation(allocationResult).
+				ReservedForPod(podName+"-podlevel", types.UID(podUID+"-podlevel")).
+				Obj()
 	inUseClaimByPodGroup = st.FromResourceClaim(pendingPodGroupClaim).
 				Allocation(allocationResult).
 				ReservedForPodGroup(podGroupName, types.UID(podGroupUID)).
@@ -1150,22 +1170,23 @@ func (p perNodeScoreResult) forNode(nodeName string) int64 {
 }
 
 type want struct {
-	preenqueue             result
-	preFilterResult        *fwk.PreFilterResult
-	prefilter              result
-	filter                 perNodeResult
-	prescore               result
-	scoreResult            perNodeScoreResult
-	score                  perNodeResult
-	normalizeScoreResult   fwk.NodeScoreList
-	normalizeScore         result
-	reserve                result
-	unreserve              result
-	preBindPreFlightStatus *fwk.Status
-	prebind                result
-	postbind               result
-	postFilterResult       *fwk.PostFilterResult
-	postfilter             result
+	preenqueue               result
+	preFilterResult          *fwk.PreFilterResult
+	prefilter                result
+	filter                   perNodeResult
+	prescore                 result
+	scoreResult              perNodeScoreResult
+	score                    perNodeResult
+	normalizeScoreResult     fwk.NodeScoreList
+	normalizeScore           result
+	reserve                  result
+	unreserve                result
+	preBindPreFlightStatus   *fwk.Status
+	prebind                  result
+	postbind                 result
+	postFilterResult         *fwk.PostFilterResult
+	podGroupPostFilterResult *fwk.PodGroupPostFilterResult
+	postfilter               result
 
 	// unreserveAfterBindFailure, if set, triggers a call to Unreserve
 	// after PreBind, as if the actual Bind had failed.
@@ -2179,7 +2200,7 @@ func testPlugin(tCtx ktesting.TContext) {
 							return claim
 						},
 					},
-					status: fwk.NewStatus(fwk.Unschedulable, `deallocation of ResourceClaim completed`),
+					status: fwk.NewStatus(fwk.Unschedulable, `deallocation and deletion of ResourceClaims completed`),
 				},
 			},
 		},
@@ -2242,7 +2263,7 @@ func testPlugin(tCtx ktesting.TContext) {
 							return claim
 						},
 					},
-					status: fwk.NewStatus(fwk.Unschedulable, `deallocation of ResourceClaim completed`),
+					status: fwk.NewStatus(fwk.Unschedulable, `deallocation and deletion of ResourceClaims completed`),
 				},
 			},
 		},
@@ -3787,11 +3808,29 @@ func testPlugin(tCtx ktesting.TContext) {
 			} else if len(potentialNodes) == 0 {
 				initialObjects = testCtx.listAll(tCtx)
 				initialObjects = testCtx.updateAPIServer(tCtx, initialObjects, tc.prepare.postfilter)
-				result, status := testCtx.p.PostFilter(tCtx, testCtx.state, tc.pod, nil /* filteredNodeStatusMap not used by plugin */)
-				tCtx.Run("postfilter", func(tCtx ktesting.TContext) {
-					assert.Equal(tCtx, tc.want.postFilterResult, result)
-					testCtx.verify(tCtx, tc.want.postfilter, initialObjects, tc.pod, nil, status)
-				})
+				if len(tc.podGroups) > 0 {
+					pgInfo := &framework.PodGroupInfo{
+						Name:            tc.podGroups[0].Name,
+						Namespace:       tc.podGroups[0].Namespace,
+						UnscheduledPods: []*v1.Pod{tc.pod},
+						PodGroup:        tc.podGroups[0],
+					}
+					mockSchedulingFunc := func(ctx context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
+						return nil, fwk.NewStatus(fwk.Unschedulable)
+					}
+					podGroupCycleState := testCtx.state.GetPodGroupSchedulingCycle()
+					result, status := testCtx.p.PodGroupPostFilter(tCtx, podGroupCycleState, pgInfo, mockSchedulingFunc)
+					tCtx.Run("postfilter", func(tCtx ktesting.TContext) {
+						assert.Equal(tCtx, tc.want.podGroupPostFilterResult, result)
+						testCtx.verify(tCtx, tc.want.postfilter, initialObjects, tc.pod, nil, status)
+					})
+				} else {
+					result, status := testCtx.p.PostFilter(tCtx, testCtx.state, tc.pod, nil /* filteredNodeStatusMap not used by plugin */)
+					tCtx.Run("postfilter", func(tCtx ktesting.TContext) {
+						assert.Equal(tCtx, tc.want.postFilterResult, result)
+						testCtx.verify(tCtx, tc.want.postfilter, initialObjects, tc.pod, nil, status)
+					})
+				}
 			}
 			if tc.metrics != nil {
 				tc.metrics(tCtx, registry)
@@ -4174,7 +4213,12 @@ func setup(tCtx ktesting.TContext, args *config.DynamicResourcesArgs, nodes []*v
 		nodeInfo.SetNode(node)
 		tc.nodeInfos = append(tc.nodeInfos, nodeInfo)
 	}
-	tc.state = framework.NewCycleState()
+	state := framework.NewCycleState()
+	if len(podGroups) > 0 {
+		pgCycleState := framework.NewCycleState()
+		state.SetPodGroupSchedulingCycle(pgCycleState)
+	}
+	tc.state = state
 
 	return tc
 }
@@ -5249,5 +5293,253 @@ func TestDynamicResources_DeferredResizeSkipped(t *testing.T) {
 
 	if _, postStatus := pl.PostFilter(ctx, nil, pod, nil); postStatus.Code() != fwk.Unschedulable || postStatus.Message() != "" {
 		t.Errorf("PostFilter: got status (code: %v, msg: %q), want (Unschedulable, \"\")", postStatus.Code(), postStatus.Message())
+	}
+}
+
+func TestPodGroupPostFilter(t *testing.T) {
+	tCtx := ktesting.Init(t)
+
+	type testCase struct {
+		pluginEnabled                         bool
+		enableDRAWorkloadResourceClaims       bool
+		enableDRAExtendedResource             bool
+		enableTopologyAwareWorkloadScheduling bool
+		podGroups                             []*schedulingapi.PodGroup
+		claims                                []*resourceapi.ResourceClaim
+		classes                               []*resourceapi.DeviceClass
+		objs                                  []apiruntime.Object
+
+		// Inputs to PodGroupPostFilter
+		unscheduledPods       []*v1.Pod
+		unavailableClaimNames []string
+
+		// Expected results
+		wantStatus   *fwk.Status
+		verifyClaims func(tCtx ktesting.TContext, testCtx *testContext)
+	}
+
+	testcases := map[string]testCase{
+		"disabled": {
+			pluginEnabled:   false,
+			podGroups:       []*schedulingapi.PodGroup{podGroupWithClaimName},
+			unscheduledPods: []*v1.Pod{groupedPodWithClaimName},
+			wantStatus:      fwk.NewStatus(fwk.Unschedulable),
+		},
+		"empty": {
+			pluginEnabled:   true,
+			podGroups:       []*schedulingapi.PodGroup{podGroupWithClaimName},
+			unscheduledPods: []*v1.Pod{groupedPodWithClaimName},
+			claims:          []*resourceapi.ResourceClaim{pendingClaim},
+			wantStatus:      fwk.NewStatus(fwk.Unschedulable),
+		},
+		"deallocate-pod-level-claim": {
+			pluginEnabled:                   true,
+			enableDRAWorkloadResourceClaims: true,
+			podGroups:                       []*schedulingapi.PodGroup{podGroupWithClaimName},
+			unscheduledPods:                 []*v1.Pod{groupedPodWithClaimName},
+			claims:                          []*resourceapi.ResourceClaim{inUseClaim},
+			objs:                            []apiruntime.Object{groupedPodWithClaimName},
+			unavailableClaimNames:           []string{inUseClaim.Name},
+			wantStatus:                      fwk.NewStatus(fwk.Unschedulable, "deallocation and deletion of ResourceClaims completed"),
+			verifyClaims: func(tCtx ktesting.TContext, testCtx *testContext) {
+				claim, err := testCtx.client.ResourceV1().ResourceClaims(inUseClaim.Namespace).Get(tCtx, inUseClaim.Name, metav1.GetOptions{})
+				require.NoError(tCtx, err)
+				assert.Nil(tCtx, claim.Status.Allocation)
+				assert.Nil(tCtx, claim.Status.ReservedFor)
+			},
+		},
+		"delete-pod-level-extended-claim": {
+			pluginEnabled:             true,
+			enableDRAExtendedResource: true,
+			podGroups:                 []*schedulingapi.PodGroup{podGroupWithClaimName},
+			unscheduledPods:           []*v1.Pod{groupedPodWithClaimName},
+			claims: func() []*resourceapi.ResourceClaim {
+				// Create an extended resource claim owned by the pod
+				claim := inUseClaim.DeepCopy()
+				claim.Name = "pod-extended-resources"
+				if claim.Annotations == nil {
+					claim.Annotations = make(map[string]string)
+				}
+				claim.Annotations[resourceapi.ExtendedResourceClaimAnnotation] = "true"
+				claim.OwnerReferences = []metav1.OwnerReference{
+					{
+						APIVersion: "v1",
+						Kind:       "Pod",
+						Name:       groupedPodWithClaimName.Name,
+						UID:        groupedPodWithClaimName.UID,
+						Controller: new(true),
+					},
+				}
+				return []*resourceapi.ResourceClaim{claim, pendingClaim}
+			}(),
+			objs:                  []apiruntime.Object{groupedPodWithClaimName},
+			unavailableClaimNames: []string{"pod-extended-resources"},
+			wantStatus:            fwk.NewStatus(fwk.Unschedulable, "deallocation and deletion of ResourceClaims completed"),
+			verifyClaims: func(tCtx ktesting.TContext, testCtx *testContext) {
+				_, err := testCtx.client.ResourceV1().ResourceClaims(inUseClaim.Namespace).Get(tCtx, "pod-extended-resources", metav1.GetOptions{})
+				assert.Error(tCtx, err) // Should be deleted!
+			},
+		},
+		"unreserve-podgroup-claim": {
+			pluginEnabled:                   true,
+			enableDRAWorkloadResourceClaims: true,
+			podGroups:                       []*schedulingapi.PodGroup{podGroupWithClaimName},
+			unscheduledPods:                 []*v1.Pod{groupedPodWithClaimName},
+			claims:                          []*resourceapi.ResourceClaim{inUseClaimByPodGroup},
+			objs:                            []apiruntime.Object{groupedPodWithClaimName},
+			wantStatus:                      fwk.NewStatus(fwk.Unschedulable, "ResourceClaim unreserved for PodGroup"),
+			verifyClaims: func(tCtx ktesting.TContext, testCtx *testContext) {
+				claim, err := testCtx.client.ResourceV1().ResourceClaims(inUseClaimByPodGroup.Namespace).Get(tCtx, inUseClaimByPodGroup.Name, metav1.GetOptions{})
+				require.NoError(tCtx, err)
+				assert.Empty(tCtx, claim.Status.ReservedFor)
+			},
+		},
+		"unreserve-podgroup-multiple-unscheduled-pods": {
+			pluginEnabled:                   true,
+			enableDRAWorkloadResourceClaims: true,
+			podGroups:                       []*schedulingapi.PodGroup{podGroupWithClaimName},
+			unscheduledPods:                 []*v1.Pod{groupedPodWithClaimName, groupedPodWithClaimName2},
+			claims:                          []*resourceapi.ResourceClaim{inUseClaimByPodGroup},
+			objs:                            []apiruntime.Object{groupedPodWithClaimName, groupedPodWithClaimName2},
+			wantStatus:                      fwk.NewStatus(fwk.Unschedulable, "ResourceClaim unreserved for PodGroup"),
+			verifyClaims: func(tCtx ktesting.TContext, testCtx *testContext) {
+				claim, err := testCtx.client.ResourceV1().ResourceClaims(inUseClaimByPodGroup.Namespace).Get(tCtx, inUseClaimByPodGroup.Name, metav1.GetOptions{})
+				require.NoError(tCtx, err)
+				assert.Empty(tCtx, claim.Status.ReservedFor)
+			},
+		},
+		"mixed-pod-level-and-podgroup-claims": {
+			pluginEnabled:                   true,
+			enableDRAWorkloadResourceClaims: true,
+			podGroups:                       []*schedulingapi.PodGroup{podGroupWithClaimName},
+			unscheduledPods:                 []*v1.Pod{groupedPodWithClaimName, groupedPodWithPodLevelClaim},
+			claims:                          []*resourceapi.ResourceClaim{inUseClaimByPodGroup, inUseClaimForPodLevel},
+			objs:                            []apiruntime.Object{groupedPodWithClaimName, groupedPodWithPodLevelClaim},
+			unavailableClaimNames:           []string{inUseClaimForPodLevel.Name},
+			wantStatus:                      fwk.NewStatus(fwk.Unschedulable, "ResourceClaim unreserved for PodGroup"),
+			verifyClaims: func(tCtx ktesting.TContext, testCtx *testContext) {
+				claimByPG, err := testCtx.client.ResourceV1().ResourceClaims(inUseClaimByPodGroup.Namespace).Get(tCtx, inUseClaimByPodGroup.Name, metav1.GetOptions{})
+				require.NoError(tCtx, err)
+				assert.Empty(tCtx, claimByPG.Status.ReservedFor)
+
+				claim2, err := testCtx.client.ResourceV1().ResourceClaims(inUseClaimForPodLevel.Namespace).Get(tCtx, inUseClaimForPodLevel.Name, metav1.GetOptions{})
+				require.NoError(tCtx, err)
+				assert.Nil(tCtx, claim2.Status.Allocation)
+				assert.Nil(tCtx, claim2.Status.ReservedFor)
+			},
+		},
+		"skip-unreserve-feature-disabled": {
+			pluginEnabled:                   true,
+			enableDRAWorkloadResourceClaims: false,
+			podGroups:                       []*schedulingapi.PodGroup{podGroupWithClaimName},
+			unscheduledPods:                 []*v1.Pod{groupedPodWithClaimName},
+			claims:                          []*resourceapi.ResourceClaim{inUseClaimByPodGroup},
+			objs:                            []apiruntime.Object{groupedPodWithClaimName},
+			wantStatus:                      fwk.NewStatus(fwk.Unschedulable),
+			verifyClaims: func(tCtx ktesting.TContext, testCtx *testContext) {
+				claim, err := testCtx.client.ResourceV1().ResourceClaims(inUseClaimByPodGroup.Namespace).Get(tCtx, inUseClaimByPodGroup.Name, metav1.GetOptions{})
+				require.NoError(tCtx, err)
+				assert.NotEmpty(tCtx, claim.Status.ReservedFor)
+			},
+		},
+		"skip-unreserve-topology-aware-podgroup": {
+			pluginEnabled:                         true,
+			enableDRAWorkloadResourceClaims:       true,
+			enableTopologyAwareWorkloadScheduling: true,
+			podGroups:                             []*schedulingapi.PodGroup{podGroupWithClaimNameAndConstraints},
+			unscheduledPods:                       []*v1.Pod{groupedPodWithClaimName},
+			claims:                                []*resourceapi.ResourceClaim{inUseClaimByPodGroup},
+			objs:                                  []apiruntime.Object{groupedPodWithClaimName},
+			wantStatus:                            fwk.NewStatus(fwk.Unschedulable),
+			verifyClaims: func(tCtx ktesting.TContext, testCtx *testContext) {
+				claim, err := testCtx.client.ResourceV1().ResourceClaims(inUseClaimByPodGroup.Namespace).Get(tCtx, inUseClaimByPodGroup.Name, metav1.GetOptions{})
+				require.NoError(tCtx, err)
+				assert.NotEmpty(tCtx, claim.Status.ReservedFor)
+			},
+		},
+	}
+
+	for name, tc := range testcases {
+		tCtx.Run(name, func(tCtx ktesting.TContext) {
+			featuregatetesting.SetFeatureGatesDuringTest(tCtx, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+				features.DRAWorkloadResourceClaims:       tc.enableDRAWorkloadResourceClaims,
+				features.TopologyAwareWorkloadScheduling: tc.enableTopologyAwareWorkloadScheduling,
+				features.GenericWorkload:                 true,
+			})
+
+			feats := feature.Features{
+				EnableDRAAdminAccess:                  true,
+				EnableDRADeviceBindingConditions:      true,
+				EnableDRAResourceClaimDeviceStatus:    true,
+				EnableDRASchedulerFilterTimeout:       true,
+				EnableDynamicResourceAllocation:       tc.pluginEnabled,
+				EnableDRAWorkloadResourceClaims:       tc.enableDRAWorkloadResourceClaims,
+				EnableDRAExtendedResource:             tc.enableDRAExtendedResource,
+				EnableTopologyAwareWorkloadScheduling: tc.enableTopologyAwareWorkloadScheduling,
+			}
+
+			testCtx := setup(tCtx, nil, []*v1.Node{workerNode}, tc.claims, tc.classes, tc.podGroups, tc.objs, feats, false, nil)
+			testCtx.p.enabled = tc.pluginEnabled
+
+			podGroupCycleState := framework.NewCycleState()
+			podGroupState := &podGroupStateData{
+				pendingAllocations: sets.New[types.UID](),
+				podsStateData:      make(map[types.NamespacedName]*stateData),
+			}
+			podGroupCycleState.Write(stateKey, podGroupState)
+
+			if tc.pluginEnabled {
+				claimsList, err := testCtx.client.ResourceV1().ResourceClaims("").List(tCtx, metav1.ListOptions{})
+				require.NoError(tCtx, err)
+				var testClaims []*resourceapi.ResourceClaim
+				for i := range claimsList.Items {
+					testClaims = append(testClaims, &claimsList.Items[i])
+				}
+
+				for _, pod := range tc.unscheduledPods {
+					// Initialize the stateData of the pod with unavailable claims
+					s := &stateData{}
+					userClaims, err := testCtx.p.podResourceClaims(pod)
+					require.NoError(tCtx, err)
+					extendedResourceClaim := findExtendedResourceClaim(pod, testClaims)
+					s.claims = newClaimStore(userClaims, extendedResourceClaim, nil)
+
+					if len(tc.unavailableClaimNames) > 0 {
+						s.unavailableClaims = sets.New[int]()
+						for _, name := range tc.unavailableClaimNames {
+							for index, claim := range s.claims.all() {
+								if claim.Name == name {
+									s.unavailableClaims.Insert(index)
+								}
+							}
+						}
+					}
+					podGroupState.podsStateData[types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}] = s
+				}
+			}
+
+			pgInfo := &framework.PodGroupInfo{
+				Name:            tc.podGroups[0].Name,
+				Namespace:       tc.podGroups[0].Namespace,
+				UnscheduledPods: tc.unscheduledPods,
+				PodGroup:        tc.podGroups[0],
+			}
+
+			mockSchedulingFunc := func(ctx context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
+				return nil, fwk.NewStatus(fwk.Unschedulable)
+			}
+
+			_, gotStatus := testCtx.p.PodGroupPostFilter(tCtx, podGroupCycleState, pgInfo, mockSchedulingFunc)
+
+			if tc.wantStatus.AsError() != nil {
+				require.ErrorContains(tCtx, gotStatus.AsError(), tc.wantStatus.AsError().Error())
+			} else {
+				assert.Equal(tCtx, tc.wantStatus, gotStatus)
+			}
+
+			if tc.verifyClaims != nil {
+				tc.verifyClaims(tCtx, testCtx)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR is adding podGroupPostFilter to DRA. We need it because with [#139674](https://github.com/kubernetes/kubernetes/pull/139674) PodGroupPostFilter extension point was introduced and for pod groups it will be called instead of postFilter.
This PR was written in part with the assistance of generative AI.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #140534

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig scheduling
/wg workload-aware-scheduling