### PR TITLE
Issue 140496/add assumed in this cycle

### DIFF
--- a/pkg/scheduler/backend/cache/podgroupstate.go
+++ b/pkg/scheduler/backend/cache/podgroupstate.go
@@ -411,6 +411,12 @@ func (pgs *podGroupState) AssumedPods() sets.Set[types.UID] {
 	return sets.KeySet(pgs.podGroupStateData.assumedPods)
 }
 
+// AssumedInThisCycleCount returns 0 because the live cache does not track transient
+// scheduling cycle state; cycle-scoped assumptions only exist in snapshots.
+func (pgs *podGroupState) AssumedInThisCycleCount() int {
+	return 0
+}
+
 // AssignedPods returns the UIDs of all pods already assigned (bound) for this group.
 func (pgs *podGroupState) AssignedPods() sets.Set[types.UID] {
 	pgs.lock.RLock()
@@ -508,16 +514,63 @@ func (cpgs *compositePodGroupState) GetChildren() []fwk.EntityKey {
 // during the cycle without modifying the live state of pods.
 type podGroupStateSnapshot struct {
 	podGroupStateData
+	assumedThisCycle sets.Set[types.UID]
+}
+
+// addPod registers a pod into the group. Bound pods purge any existing assume state
+// to prevent duplicate accounting when a previously queued pod binds externally.
+func (s *podGroupStateSnapshot) addPod(pod *v1.Pod) {
+	s.podGroupStateData.addPod(pod)
+	if pod.Spec.NodeName != "" && s.assumedThisCycle != nil {
+		s.assumedThisCycle.Delete(pod.UID)
+	}
+}
+
+// deletePod purges the pod across all tracking buckets to prevent memory leaks
+// and ghost scheduling counts after cluster removal.
+func (s *podGroupStateSnapshot) deletePod(podUID types.UID) {
+	s.podGroupStateData.deletePod(podUID)
+	if s.assumedThisCycle != nil {
+		s.assumedThisCycle.Delete(podUID)
+	}
+}
+
+// updatePod refreshes pod state. Transitioning to a bound node removes the pod
+// from assumedPods since its reservation phase is complete.
+func (s *podGroupStateSnapshot) updatePod(oldPod, newPod *v1.Pod) {
+	s.podGroupStateData.updatePod(oldPod, newPod)
+	if oldPod.Spec.NodeName == "" && newPod.Spec.NodeName != "" && s.assumedThisCycle != nil {
+		s.assumedThisCycle.Delete(newPod.UID)
+	}
 }
 
 // assumePod marks a pod within the pod group state snapshot as assumed.
 func (s *podGroupStateSnapshot) assumePod(pod *v1.Pod) {
+	// Avoid re-counting pods assumed in previous scheduling cycles.
+	_, wasAlreadyAssumed := s.assumedPods[pod.UID]
+
 	s.podGroupStateData.assumePod(pod)
+	// If the pod was not successfully assumed (e.g., it was already assigned or not found in the group),
+	// we should not count it.
+	_, ok := s.assumedPods[pod.UID]
+	if !ok || wasAlreadyAssumed {
+		return
+	}
+
+	if s.assumedThisCycle == nil {
+		s.assumedThisCycle = sets.New[types.UID](pod.UID)
+	} else {
+		s.assumedThisCycle.Insert(pod.UID)
+	}
 }
 
 // forgetPod removes a pod from the assumed state within the snapshot.
 func (s *podGroupStateSnapshot) forgetPod(podUID types.UID) {
 	s.podGroupStateData.forgetPod(podUID)
+
+	if s.assumedThisCycle != nil {
+		s.assumedThisCycle.Delete(podUID)
+	}
 }
 
 // AllPods returns the UIDs of all pods known to the scheduler for this group.
@@ -533,6 +586,12 @@ func (s *podGroupStateSnapshot) UnscheduledPods() map[string]*v1.Pod {
 // AssumedPods returns the UIDs of all assumed pods for this group.
 func (s *podGroupStateSnapshot) AssumedPods() sets.Set[types.UID] {
 	return sets.KeySet(s.podGroupStateData.assumedPods)
+}
+
+// AssumedInThisCycleCount returns the number of pods assumed during the current
+// scheduling cycle to allow isolating pods scheduled in prior cycles.
+func (s *podGroupStateSnapshot) AssumedInThisCycleCount() int {
+	return len(s.assumedThisCycle)
 }
 
 // AssignedPods returns the UIDs of all assigned (bound) pods for this group.
@@ -555,9 +614,16 @@ func (s *podGroupStateSnapshot) ScheduledPodsCount() int {
 	return s.podGroupStateData.scheduledPodsCount()
 }
 
-// Clone returns a pod group state snapshot with cloned podGroupStateData.
+// Clone returns a pod group state snapshot with cloned podGroupStateData and assumedThisCycle.
 func (s *podGroupStateSnapshot) Clone() *podGroupStateSnapshot {
-	return &podGroupStateSnapshot{podGroupStateData: s.podGroupStateData.clone()}
+	var assumedThisCycle sets.Set[types.UID]
+	if s.assumedThisCycle != nil {
+		assumedThisCycle = s.assumedThisCycle.Clone()
+	}
+	return &podGroupStateSnapshot{
+		podGroupStateData: s.podGroupStateData.clone(),
+		assumedThisCycle:  assumedThisCycle,
+	}
 }
 
 // compositePodGroupStateSnapshot is an immutable, point-in-time copy of a compositePodGroupState.

--- a/pkg/scheduler/backend/cache/podgroupstate_test.go
+++ b/pkg/scheduler/backend/cache/podgroupstate_test.go
@@ -270,3 +270,226 @@ func TestCompositePodGroupState_Children(t *testing.T) {
 		t.Errorf("Unexpected children result (-want,+got):\n%s", diff)
 	}
 }
+
+func TestPodGroupState_AssumedInThisCycleCount(t *testing.T) {
+	pod1 := st.MakePod().Namespace("ns1").Name("p1").UID("p1").PodGroupName("pg1").Obj()
+	pod2 := st.MakePod().Namespace("ns1").Name("p2").UID("p2").PodGroupName("pg1").Obj()
+	unknownPod := st.MakePod().Namespace("ns1").Name("unknown").UID("unknown").PodGroupName("pg1").Obj()
+
+	tests := []struct {
+		name              string
+		action            func(snap *podGroupStateSnapshot)
+		expectedCount     int
+		testSnapshotClone bool
+	}{
+		{
+			name:          "initial snapshot has count 0",
+			action:        func(snap *podGroupStateSnapshot) {},
+			expectedCount: 0,
+		},
+		{
+			name:          "assuming a pod in the snapshot increments count",
+			action:        func(snap *podGroupStateSnapshot) { snap.assumePod(pod2) },
+			expectedCount: 1,
+		},
+		{
+			name: "forgetting the assumed pod decrements count",
+			action: func(snap *podGroupStateSnapshot) {
+				snap.assumePod(pod2)
+				snap.forgetPod(pod2.UID)
+			},
+			expectedCount: 0,
+		},
+		{
+			name:          "assuming an unknown pod does not increment count (desync scenario)",
+			action:        func(snap *podGroupStateSnapshot) { snap.assumePod(unknownPod) },
+			expectedCount: 0,
+		},
+		{
+			name:          "re-assuming an already assumed pod does not increment count (spurious assume)",
+			action:        func(snap *podGroupStateSnapshot) { snap.assumePod(pod1) },
+			expectedCount: 0,
+		},
+		{
+			name:          "forgetting a pod assumed before the snapshot does not affect count",
+			action:        func(snap *podGroupStateSnapshot) { snap.forgetPod(pod1.UID) },
+			expectedCount: 0,
+		},
+		{
+			name: "re-assuming a pod assumed during the snapshot does not increment count",
+			action: func(snap *podGroupStateSnapshot) {
+				snap.assumePod(pod2)
+				snap.assumePod(pod2)
+			},
+			expectedCount: 1,
+		},
+		{
+			name:          "forgetting a pod that was never assumed does not affect count",
+			action:        func(snap *podGroupStateSnapshot) { snap.forgetPod(pod2.UID) },
+			expectedCount: 0,
+		},
+		{
+			name:              "cloning a snapshot preserves assumedThisCycle count",
+			action:            func(snap *podGroupStateSnapshot) { snap.assumePod(pod2) },
+			expectedCount:     1,
+			testSnapshotClone: true,
+		},
+		{
+			name: "deletePod on assumed pod in snapshot decrements count",
+			action: func(snap *podGroupStateSnapshot) {
+				snap.assumePod(pod2)
+				snap.deletePod(pod2.UID)
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "addPod with node name on assumed pod in snapshot decrements count",
+			action: func(snap *podGroupStateSnapshot) {
+				snap.assumePod(pod2)
+				boundPod2 := pod2.DeepCopy()
+				boundPod2.Spec.NodeName = "node1"
+				snap.addPod(boundPod2)
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "updatePod assigning an assumed pod in snapshot decrements count",
+			action: func(snap *podGroupStateSnapshot) {
+				snap.assumePod(pod2)
+				boundPod2 := pod2.DeepCopy()
+				boundPod2.Spec.NodeName = "node1"
+				snap.updatePod(pod2, boundPod2)
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "addPod without node name on assumed pod in snapshot preserves count",
+			action: func(snap *podGroupStateSnapshot) {
+				snap.assumePod(pod2)
+				snap.addPod(pod2)
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "updatePod without assigning an assumed pod in snapshot preserves count",
+			action: func(snap *podGroupStateSnapshot) {
+				snap.assumePod(pod2)
+				updatedPod2 := pod2.DeepCopy()
+				updatedPod2.Labels = map[string]string{"foo": "bar"}
+				snap.updatePod(pod2, updatedPod2)
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "deletePod on initial snapshot with nil assumedThisCycle does not panic",
+			action: func(snap *podGroupStateSnapshot) {
+				snap.deletePod(pod2.UID)
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "addPod with node name on initial snapshot with nil assumedThisCycle does not panic",
+			action: func(snap *podGroupStateSnapshot) {
+				boundPod2 := pod2.DeepCopy()
+				boundPod2.Spec.NodeName = "node1"
+				snap.addPod(boundPod2)
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "updatePod assigning pod on initial snapshot with nil assumedThisCycle does not panic",
+			action: func(snap *podGroupStateSnapshot) {
+				boundPod2 := pod2.DeepCopy()
+				boundPod2.Spec.NodeName = "node1"
+				snap.updatePod(pod2, boundPod2)
+			},
+			expectedCount: 0,
+		},
+		{
+			name:          "forgetting a pod when no pod was ever added",
+			action:        func(snap *podGroupStateSnapshot) { snap.forgetPod(unknownPod.UID) },
+			expectedCount: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Set up a fresh podGroupState for every subtest
+			pgs := newPodGroupState()
+			pgs.addPod(pod1)
+			pgs.addPod(pod2)
+
+			// Live state should always return 0 for AssumedInThisCycleCount.
+			pgs.assumePod(pod1)
+			if diff := cmp.Diff(0, pgs.AssumedInThisCycleCount()); diff != "" {
+				t.Fatalf("unexpected live podGroupState AssumedInThisCycleCount result (-want,+got):\n%s", diff)
+			}
+
+			// Spawn an isolated snapshot for this scenario
+			snap := pgs.snapshot()
+
+			tc.action(snap)
+
+			if diff := cmp.Diff(tc.expectedCount, snap.AssumedInThisCycleCount()); diff != "" {
+				t.Errorf("unexpected AssumedInThisCycleCount result (-want,+got):\n%s", diff)
+			}
+
+			if tc.testSnapshotClone {
+				cloned := snap.Clone()
+				if diff := cmp.Diff(tc.expectedCount, cloned.AssumedInThisCycleCount()); diff != "" {
+					t.Errorf("unexpected AssumedInThisCycleCount in cloned snapshot (-want,+got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestPodGroupState_EmptyGroupState(t *testing.T) {
+	pgs := newPodGroupState()
+	snap := pgs.snapshot()
+
+	if diff := cmp.Diff(0, snap.AssumedInThisCycleCount()); diff != "" {
+		t.Errorf("unexpected AssumedInThisCycleCount on empty group state (-want,+got):\n%s", diff)
+	}
+
+	snap.forgetPod("non-existent-uid")
+	if diff := cmp.Diff(0, snap.AssumedInThisCycleCount()); diff != "" {
+		t.Errorf("unexpected AssumedInThisCycleCount after forgetting pod on empty group state (-want,+got):\n%s", diff)
+	}
+}
+
+func TestPodGroupStateSnapshot_CloneIndependence(t *testing.T) {
+	pgs := newPodGroupState()
+	pod1 := st.MakePod().Namespace("ns1").Name("p1").UID("p1").PodGroupName("pg1").Obj()
+	pod2 := st.MakePod().Namespace("ns1").Name("p2").UID("p2").PodGroupName("pg1").Obj()
+	pgs.addPod(pod1)
+	pgs.addPod(pod2)
+
+	pgs1 := pgs.snapshot()
+	pgs1.assumePod(pod1)
+
+	pgs2 := pgs1.Clone()
+
+	if diff := cmp.Diff(1, pgs1.AssumedInThisCycleCount()); diff != "" {
+		t.Fatalf("unexpected pgs1 initial count (-want,+got):\n%s", diff)
+	}
+	if diff := cmp.Diff(1, pgs2.AssumedInThisCycleCount()); diff != "" {
+		t.Fatalf("unexpected pgs2 initial count (-want,+got):\n%s", diff)
+	}
+
+	pgs1.assumePod(pod2)
+	if diff := cmp.Diff(2, pgs1.AssumedInThisCycleCount()); diff != "" {
+		t.Errorf("unexpected pgs1 count after assuming pod2 (-want,+got):\n%s", diff)
+	}
+	if diff := cmp.Diff(1, pgs2.AssumedInThisCycleCount()); diff != "" {
+		t.Errorf("pgs2 count should be unaffected by pgs1 mutation (-want,+got):\n%s", diff)
+	}
+
+	pgs2.forgetPod(pod1.UID)
+	if diff := cmp.Diff(2, pgs1.AssumedInThisCycleCount()); diff != "" {
+		t.Errorf("pgs1 count should be unaffected by pgs2 mutation (-want,+got):\n%s", diff)
+	}
+	if diff := cmp.Diff(0, pgs2.AssumedInThisCycleCount()); diff != "" {
+		t.Errorf("unexpected pgs2 count after forgetting pod1 (-want,+got):\n%s", diff)
+	}
+}

--- a/pkg/scheduler/framework/autoscaler_contract/lister_contract_test.go
+++ b/pkg/scheduler/framework/autoscaler_contract/lister_contract_test.go
@@ -121,6 +121,10 @@ func (c *podGroupStateContract) AssumedPods() sets.Set[types.UID] {
 	return nil
 }
 
+func (c *podGroupStateContract) AssumedInThisCycleCount() int {
+	return 0
+}
+
 func (c *podGroupStateContract) AssignedPods() sets.Set[types.UID] {
 	return nil
 }

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -803,10 +803,13 @@ func Test_isSchedulableAfterCompositePodGroupAdded(t *testing.T) {
 
 type mockPodGroupState struct {
 	fwk.PodGroupState
-	scheduledPodsCount int
+	scheduledPodsCount      int
+	assumedInThisCycleCount int
 }
 
 func (m *mockPodGroupState) ScheduledPodsCount() int { return m.scheduledPodsCount }
+
+func (m *mockPodGroupState) AssumedInThisCycleCount() int { return m.assumedInThisCycleCount }
 
 type mockPodGroupStateLister struct {
 	state *mockPodGroupState

--- a/staging/src/k8s.io/kube-scheduler/framework/listers.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/listers.go
@@ -234,6 +234,9 @@ type PodGroupState interface {
 	// AssumedPods returns the UIDs of all pods for this group in the "assumed" state,
 	// i.e., passed the Reserve gate.
 	AssumedPods() sets.Set[types.UID]
+	// AssumedInThisCycleCount returns the number of pods in this group that entered the "assumed" state
+	// in this scheduling cycle.
+	AssumedInThisCycleCount() int
 	// AssignedPods returns the UIDs of all pods already assigned (bound) for this group.
 	AssignedPods() sets.Set[types.UID]
 	// ScheduledPods returns the pods that are either assumed or assigned for this pod group.


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
In the scheduler's coscheduling/gangscheduling logic, evaluating whether a pod group satisfies its `MinCount` constraint requires distinguishing between pods scheduled in previous cycles and pods assumed during the current simulation cycle.

Currently, calculating already-scheduled pods requires building a set of unscheduled UIDs and doing an \(O(N)\) lookup across all scheduled pods in the snapshot.

This PR introduces `AssumedInThisCycleCount()` to the `PodGroupState` interface and implements it in `podGroupStateSnapshot`. When `assumePod(pod)` or `forgetPod(podUID)` is called during a scheduling simulation, the snapshot tracks the UIDs in `assumedThisCycle`. This allows calculating pods scheduled in prior cycles simply as:
`alreadyScheduledCount := podGroupState.ScheduledPodsCount() - podGroupState.AssumedInThisCycleCount()`

#### Which issue(s) this PR fixes:
Fixes #140496

#### Special notes for your reviewer:

#### Release note:
```release-note
kube-scheduler: Added per-cycle assumption tracking to pod group snapshots to differentiate pods assumed in the current scheduling cycle from those scheduled previously. 
```