### PR TITLE
Drop unnecessary `[Feature:Ingress]` tag from e2e

### DIFF
--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -209,11 +209,6 @@ var (
 	// InPlacePodVerticalScaling is used for testing in-place pod vertical scaling (https://kep.k8s.io/1287).
 	InPlacePodVerticalScaling = framework.WithFeature(framework.ValidFeatures.Add("InPlacePodVerticalScaling"))
 
-	// Owner: sig-network
-	// Marks tests that require a conforming implementation of
-	// Ingress.networking.k8s.io to be present.
-	Ingress = framework.WithFeature(framework.ValidFeatures.Add("Ingress"))
-
 	// Owner: sig-storage
 	// Marks tests that only work with a sigs.k8s.io/kind cluster
 	Kind = framework.WithFeature(framework.ValidFeatures.Add("Kind"))

--- a/test/e2e/network/ingressclass.go
+++ b/test/e2e/network/ingressclass.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
-	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/network/common"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -41,8 +40,8 @@ import (
 	"github.com/onsi/gomega"
 )
 
-var _ = common.SIGDescribe("IngressClass", feature.Ingress, func() {
-	f := framework.NewDefaultFramework("ingressclass")
+var _ = common.SIGDescribe("DefaultIngressClass", func() {
+	f := framework.NewDefaultFramework("defaultingressclass")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 	var cs clientset.Interface
 	ginkgo.BeforeEach(func() {
@@ -166,6 +165,15 @@ var _ = common.SIGDescribe("IngressClass", feature.Ingress, func() {
 		}); err != nil {
 			framework.Failf("Failed to create ingress when two ingressClasses are marked as default ,got error %v", err)
 		}
+	})
+})
+
+var _ = common.SIGDescribe("IngressClass", func() {
+	f := framework.NewDefaultFramework("ingressclass")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+	var cs clientset.Interface
+	ginkgo.BeforeEach(func() {
+		cs = f.ClientSet
 	})
 
 	f.It("should allow IngressClass to have Namespace-scoped parameters", f.WithSerial(), func(ctx context.Context) {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
As of #140508 we no longer install ingress-gce in CI, and yet somehow [`pull-kubernetes-e2e-gci-gce-ingress` still passes?](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/140508/pull-kubernetes-e2e-gci-gce-ingress/2076854944173920256)

We used to have actual Ingress tests, but they were GCE-specific and were removed in #124519 (with the associated framework code removed in #137131). There wasn't really even a lot there that we could have turned into a shared cloud-provider-gce-and-cloud-provider-kind set of tests, because of course the whole problem with Ingress is that it's egregiously backend-specific.

Of the 4 remaining tests tagged `[Feature:Ingress]`, 1 just tests API validation, and the other 3 test the `DefaultIngressClass` admission controller, which is enabled by default and thus shouldn't need a feature flag.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
