### PR TITLE
apimachinery: transcode BOM'd UTF-16 YAML to UTF-8

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go
@@ -19,12 +19,14 @@ package yaml
 import (
 	"bufio"
 	"bytes"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"strings"
 	"unicode"
+	"unicode/utf16"
 	"unicode/utf8"
 
 	jsonutil "k8s.io/apimachinery/pkg/util/json"
@@ -276,10 +278,14 @@ func (e YAMLSyntaxError) Error() string {
 // or JSON documents from the given reader as a stream. bufferSize determines
 // how far into the stream the decoder will look to figure out whether this
 // is a JSON stream (has whitespace followed by an open brace).
+//
+// Input that begins with a UTF-16 BOM is transcoded to UTF-8 first so that
+// line-oriented YAML framing (which assumes UTF-8 newlines) does not corrupt
+// the stream. This matches kubectl/cli-runtime file loading behavior.
 func NewYAMLOrJSONDecoder(r io.Reader, bufferSize int) *YAMLOrJSONDecoder {
 	d := &YAMLOrJSONDecoder{}
 
-	reader, _, mightBeJSON := GuessJSONStream(r, bufferSize)
+	reader, _, mightBeJSON := GuessJSONStream(readerWithUTF8(r), bufferSize)
 	d.stream = reader
 	if mightBeJSON {
 		d.json = json.NewDecoder(reader)
@@ -395,9 +401,57 @@ type YAMLReader struct {
 }
 
 func NewYAMLReader(r *bufio.Reader) *YAMLReader {
-	return &YAMLReader{
-		reader: &LineReader{reader: r},
+	utf8Reader := readerWithUTF8(r)
+	br, ok := utf8Reader.(*bufio.Reader)
+	if !ok {
+		br = bufio.NewReader(utf8Reader)
 	}
+	return &YAMLReader{
+		reader: &LineReader{reader: br},
+	}
+}
+
+// readerWithUTF8 returns a reader that yields UTF-8 bytes.
+// If r begins with a UTF-16 LE/BE BOM, the remainder is decoded to UTF-8.
+// Otherwise r is returned buffered and unchanged (including UTF-8 BOM).
+func readerWithUTF8(r io.Reader) io.Reader {
+	br := bufio.NewReader(r)
+	bom, err := br.Peek(2)
+	if len(bom) < 2 {
+		return br
+	}
+	if err != nil && err != io.EOF { //nolint:errorlint
+		return br
+	}
+
+	var order binary.ByteOrder
+	switch {
+	case bom[0] == 0xff && bom[1] == 0xfe:
+		order = binary.LittleEndian
+	case bom[0] == 0xfe && bom[1] == 0xff:
+		order = binary.BigEndian
+	default:
+		return br
+	}
+
+	// Consume the BOM; remaining bytes are UTF-16 code units.
+	if _, err := br.Discard(2); err != nil {
+		return br
+	}
+	rest, err := io.ReadAll(br)
+	if err != nil {
+		return io.MultiReader(bytes.NewReader(bom), bytes.NewReader(rest), br)
+	}
+	if len(rest)%2 != 0 {
+		// Incomplete UTF-16; pass the original bytes through unchanged.
+		return bytes.NewReader(append(append([]byte{}, bom...), rest...))
+	}
+
+	u16s := make([]uint16, len(rest)/2)
+	for i := range u16s {
+		u16s[i] = order.Uint16(rest[i*2:])
+	}
+	return bytes.NewReader([]byte(string(utf16.Decode(u16s))))
 }
 
 // Read returns a full YAML document.

--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
@@ -19,6 +19,7 @@ package yaml
 import (
 	"bufio"
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"math/rand"
@@ -26,6 +27,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"unicode/utf16"
 )
 
 func TestYAMLDecoderReadBytesLength(t *testing.T) {
@@ -555,5 +557,79 @@ func TestUnmarshal(t *testing.T) {
 	}
 	if _, ok := otherType[123].(float64); !ok {
 		t.Fatalf(`Expected number to be float64 but got "%T"`, otherType[123])
+	}
+}
+
+// encodeUTF16LEWithBOM encodes s as UTF-16 LE with a BOM, matching the
+// encoding Windows PowerShell 5.1 produces for `>` redirects.
+func encodeUTF16LEWithBOM(s string) []byte {
+	encoded := utf16.Encode([]rune(s))
+	out := make([]byte, 2+len(encoded)*2)
+	out[0], out[1] = 0xff, 0xfe
+	for i, u := range encoded {
+		binary.LittleEndian.PutUint16(out[2+i*2:], u)
+	}
+	return out
+}
+
+func TestYAMLOrJSONDecoderUTF16LEWithBOM(t *testing.T) {
+	const src = "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: utf16-test\n"
+	data := encodeUTF16LEWithBOM(src)
+
+	var out map[string]interface{}
+	err := NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096).Decode(&out)
+	if err != nil {
+		t.Fatalf("Decode UTF-16 LE YAML: %v", err)
+	}
+	if out["kind"] != "ConfigMap" {
+		t.Fatalf("expected kind=ConfigMap, got %#v", out["kind"])
+	}
+	meta, ok := out["metadata"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected metadata map, got %#v", out["metadata"])
+	}
+	if meta["name"] != "utf16-test" {
+		t.Fatalf("expected name=utf16-test, got %#v", meta["name"])
+	}
+}
+
+func TestYAMLReaderUTF16LEWithBOM(t *testing.T) {
+	const src = "apiVersion: v1\nkind: Service\nmetadata:\n  name: svc\n"
+	data := encodeUTF16LEWithBOM(src)
+
+	chunk, err := NewYAMLReader(bufio.NewReader(bytes.NewReader(data))).Read()
+	if err != nil && err != io.EOF { //nolint:errorlint
+		t.Fatalf("YAMLReader.Read: %v", err)
+	}
+	// Before the fix, LineReader appended an extra 0x0a and grew the stream by
+	// one byte (odd length), which broke UTF-16 decoding downstream.
+	if len(chunk)%2 == 1 && bytes.HasPrefix(chunk, []byte{0xff, 0xfe}) {
+		t.Fatalf("reader corrupted UTF-16 stream: in=%d out=%d (odd length with BOM retained)", len(data), len(chunk))
+	}
+
+	var out map[string]interface{}
+	if err := Unmarshal(chunk, &out); err != nil {
+		t.Fatalf("Unmarshal YAMLReader chunk: %v", err)
+	}
+	if out["kind"] != "Service" {
+		t.Fatalf("expected kind=Service, got %#v", out["kind"])
+	}
+}
+
+func TestYAMLOrJSONDecoderUTF16BEWithBOM(t *testing.T) {
+	const src = "kind: Pod\nmetadata:\n  name: be\n"
+	runes := utf16.Encode([]rune(src))
+	data := make([]byte, 2+len(runes)*2)
+	data[0], data[1] = 0xfe, 0xff
+	for i, u := range runes {
+		binary.BigEndian.PutUint16(data[2+i*2:], u)
+	}
+
+	var out map[string]interface{}
+	if err := NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096).Decode(&out); err != nil {
+		t.Fatalf("Decode UTF-16 BE YAML: %v", err)
+	}
+	if out["kind"] != "Pod" {
+		t.Fatalf("expected kind=Pod, got %#v", out["kind"])
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`YAMLReader`/`LineReader` split on UTF-8 `\n` and re-append a single-byte newline. For BOM'd UTF-16 LE (what Windows PowerShell `>` writes), that corrupts the stream into an odd length and surfaces as a misleading `yaml: incomplete UTF-16 character` error.

This PR transcodes BOM'd UTF-16 LE/BE to UTF-8 at `NewYAMLOrJSONDecoder` / `NewYAMLReader` entry (stdlib only), aligning non-kubectl consumers with cli-runtime's BOM handling.

#### Which issue(s) this PR is related to:

Fixes #140531

#### Special notes for your reviewer:

/sig api-machinery

Unit tests cover the PowerShell UTF-16 LE case from the issue and UTF-16 BE.

#### Does this PR introduce a user-facing change?

```release-note
apimachinery YAML/JSON decoding now accepts BOM'd UTF-16 input by transcoding to UTF-8, fixing failures on manifests written by Windows PowerShell redirects.
```