### PR TITLE
Replace `errors.New(fmt.Sprintf(...))` with `fmt.Errorf(...)`

### DIFF
--- a/cmd/kubeadm/app/util/staticpod/utils_linux.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_linux.go
@@ -29,7 +29,6 @@ import (
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	certphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
-	"k8s.io/kubernetes/cmd/kubeadm/app/util/errors"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/users"
 )
 
@@ -74,7 +73,7 @@ func RunComponentAsNonRoot(componentName string, pod *v1.Pod, usersAndGroups *us
 			cfg,
 		)
 	}
-	return errors.New(fmt.Sprintf("component name %q is not valid", componentName))
+	return fmt.Errorf("component name %q is not valid", componentName)
 }
 
 // runKubeAPIServerAsNonRoot updates the pod manifest and the hostVolume permissions to run kube-apiserver as non root.

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/matchconditions/matcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/matchconditions/matcher.go
@@ -18,7 +18,6 @@ package matchconditions
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -105,7 +104,7 @@ func (m *matcher) Match(ctx context.Context, versionedAttr *admission.VersionedA
 		if !ok {
 			// This shouldnt happen, but if it does treat same as eval error
 			klog.Error("Invalid type conversion to MatchCondition")
-			errorList = append(errorList, errors.New(fmt.Sprintf("internal error converting ExpressionAccessor to MatchCondition")))
+			errorList = append(errorList, fmt.Errorf("internal error converting ExpressionAccessor to MatchCondition"))
 			continue
 		}
 		if evalResult.Error != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
@@ -114,7 +114,7 @@ func (o *Options) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string)
 // Validate validates the provided options
 func (o *Options) Validate() error {
 	if len(o.args) != 0 {
-		return errors.New(fmt.Sprintf("extra arguments: %v", o.args))
+		return fmt.Errorf("extra arguments: %v", o.args)
 	}
 
 	if o.Output != "" && o.Output != "yaml" && o.Output != "json" {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Some code parts used `errors.New(fmt.Sprintf(...))` what is unnecessary since `fmt.Errorf` provides the same functionality directly. This PR addresses it and switches to `fmt.Errorf`.

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE
