### PR TITLE
Promote declarative validation tags to Stable

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
@@ -374,7 +374,7 @@ func (ektv eachKeyTagValidator) Docs() TagDoc {
 		Tag:            ektv.TagName(),
 		Scopes:         sets.List(ektv.ValidScopes()),
 		StabilityLevel: TagStabilityLevelStable,
-		Description:    "Declares a validation for each value in a map or list.",
+		Description:    "Declares a validation for each key in a map.",
 		Payloads: []TagPayloadDoc{{
 			Description: "<validation-tag>",
 			Docs:        "The tag to evaluate for each key.",

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
@@ -255,7 +255,7 @@ func (evtv eachValTagValidator) getMapValidations(t *types.Type, validations Val
 func (evtv eachValTagValidator) Docs() TagDoc {
 	doc := TagDoc{
 		Tag:            evtv.TagName(),
-		StabilityLevel: TagStabilityLevelAlpha,
+		StabilityLevel: TagStabilityLevelStable,
 		Scopes:         sets.List(evtv.ValidScopes()),
 		Description:    "Declares a validation for each value in a map or list.",
 		Payloads: []TagPayloadDoc{{
@@ -373,7 +373,7 @@ func (ektv eachKeyTagValidator) Docs() TagDoc {
 	doc := TagDoc{
 		Tag:            ektv.TagName(),
 		Scopes:         sets.List(ektv.ValidScopes()),
-		StabilityLevel: TagStabilityLevelBeta,
+		StabilityLevel: TagStabilityLevelStable,
 		Description:    "Declares a validation for each value in a map or list.",
 		Payloads: []TagPayloadDoc{{
 			Description: "<validation-tag>",

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/immutable.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/immutable.go
@@ -61,7 +61,7 @@ func (immutableTagValidator) GetValidations(context Context, _ codetags.Tag) (Va
 func (itv immutableTagValidator) Docs() TagDoc {
 	return TagDoc{
 		Tag:            itv.TagName(),
-		StabilityLevel: TagStabilityLevelBeta,
+		StabilityLevel: TagStabilityLevelStable,
 		Scopes:         sets.List(itv.ValidScopes()),
 		Description:    "Indicates that a field may not be updated.",
 	}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
@@ -144,7 +144,7 @@ func (maxBytesTagValidator) GetValidations(context Context, tag codetags.Tag) (V
 func (mbtv maxBytesTagValidator) Docs() TagDoc {
 	return TagDoc{
 		Tag:            mbtv.TagName(),
-		StabilityLevel: TagStabilityLevelBeta,
+		StabilityLevel: TagStabilityLevelStable,
 		Scopes:         sets.List(mbtv.ValidScopes()),
 		Description: `Indicates that a string field has a limit on its length in bytes.
 		This could only allow as few as N/4 multi-byte characters.

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/list.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/list.go
@@ -348,7 +348,7 @@ func (utv uniqueTagValidator) GetValidations(context Context, tag codetags.Tag) 
 func (utv uniqueTagValidator) Docs() TagDoc {
 	doc := TagDoc{
 		Tag:            utv.TagName(),
-		StabilityLevel: TagStabilityLevelBeta,
+		StabilityLevel: TagStabilityLevelStable,
 		Scopes:         sets.List(utv.ValidScopes()),
 		Description:    "Declares that a list field's elements are unique. This tag can be used with listType=atomic to add uniqueness constraints, or independently to specify uniqueness semantics.",
 		Payloads: []TagPayloadDoc{{
@@ -397,7 +397,7 @@ func (cutv customUniqueTagValidator) GetValidations(context Context, tag codetag
 func (cutv customUniqueTagValidator) Docs() TagDoc {
 	doc := TagDoc{
 		Tag:            cutv.TagName(),
-		StabilityLevel: TagStabilityLevelBeta,
+		StabilityLevel: TagStabilityLevelStable,
 		Scopes:         sets.List(cutv.ValidScopes()),
 		Description:    "Indicates that uniqueness validation for this list is implemented via custom, handwritten validation. This disables generation of uniqueness validation for this list.",
 		Payloads:       nil,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/mode.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/mode.go
@@ -131,7 +131,7 @@ func (mdtv *modeDiscriminatorTagValidator) GetValidations(context Context, tag c
 func (mdtv *modeDiscriminatorTagValidator) Docs() TagDoc {
 	return TagDoc{
 		Tag:            mdtv.TagName(),
-		StabilityLevel: TagStabilityLevelBeta,
+		StabilityLevel: TagStabilityLevelStable,
 		Scopes:         sets.List(mdtv.ValidScopes()),
 		Description:    "Indicates that this field is a discriminator for state-based validation.",
 		Args: []TagArgDoc{{
@@ -222,7 +222,7 @@ func (imtv *ifModeTagValidator) GetValidations(context Context, tag codetags.Tag
 func (imtv *ifModeTagValidator) Docs() TagDoc {
 	return TagDoc{
 		Tag:            imtv.TagName(),
-		StabilityLevel: TagStabilityLevelBeta,
+		StabilityLevel: TagStabilityLevelStable,
 		Scopes:         sets.List(imtv.ValidScopes()),
 		Description:    "Indicates that this field's validation depends on a mode discriminator.",
 		Args: []TagArgDoc{{

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/options.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/options.go
@@ -84,7 +84,7 @@ func (itv ifTagValidator) GetValidations(context Context, tag codetags.Tag) (Val
 func (itv ifTagValidator) Docs() TagDoc {
 	doc := TagDoc{
 		Tag:            itv.TagName(),
-		StabilityLevel: TagStabilityLevelBeta,
+		StabilityLevel: TagStabilityLevelStable,
 		Args: []TagArgDoc{{
 			Description: "<option>",
 			Type:        codetags.ArgTypeString,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/update.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/update.go
@@ -179,7 +179,7 @@ func constraintName(c validate.UpdateConstraint) string {
 func (utc updateTagCollector) Docs() TagDoc {
 	return TagDoc{
 		Tag:            utc.TagName(),
-		StabilityLevel: TagStabilityLevelBeta,
+		StabilityLevel: TagStabilityLevelStable,
 		Scopes:         sets.List(utc.ValidScopes()),
 		PayloadsType:   codetags.ValueTypeString,
 		Description: "Provides constraints on the allowed update operations of a field. " +


### PR DESCRIPTION
Promotes the following validation-gen tags to Stable per KEP-5073: eachKey, eachVal, ifEnabled, ifDisabled, immutable, maxBytes, unique, customUnique, forbidden, update, and the union/mode discriminators.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
Promotes the following validation-gen tags to Stable per KEP-5073. These tags are mature, tested, and not expected to change in backward-incompatible ways, so they can now be used in stable APIs without an +k8s:alpha/+k8s:beta prefix
- `+k8s:eachKey `
- `+k8s:eachVal`
- `+k8s:ifEnabled `
- `+k8s:ifDisabled`
- `+k8s:immutable`
- `+k8s:maxBytes`
- `+k8s:unique`
- `+k8s:customUnique`
- `+k8s:update`

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
