### PR TITLE
Automated cherry pick of #140419: Fix ConvertToNative for Mutating admission policies

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch/json_patch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch/json_patch_test.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -401,6 +402,82 @@ func TestJSONPatch(t *testing.T) {
 				Containers: []corev1.Container{{Name: "a"}},
 			}}}},
 			expectedErr: "JSON Patch: replace operation does not apply: doc is missing key: /spec/template/spec/containers/-: missing value",
+		},
+		{
+			name: "jsonPatch with constant complex struct object as value",
+			expression: `[
+					JSONPatch{op: "add", path: "/spec/template/spec/containers/1", value: Object.spec.template.spec.containers{name: "sidecar", image: "busybox:1.36", command: ["sh", "-c", "sleep 3600"], resources: Object.spec.template.spec.containers.resources{limits: {"cpu": "200m", "memory": "256Mi"}}}},
+				]`,
+			gvr: deploymentGVR,
+			object: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "main-app", Image: "nginx:1.24"},
+							},
+						},
+					},
+				},
+			},
+			expectedResult: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "main-app", Image: "nginx:1.24"},
+								{
+									Name:    "sidecar",
+									Image:   "busybox:1.36",
+									Command: []string{"sh", "-c", "sleep 3600"},
+									Resources: corev1.ResourceRequirements{
+										Limits: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("200m"),
+											corev1.ResourceMemory: resource.MustParse("256Mi"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "jsonPatch with constant complex list of struct objects as value",
+			expression: `[
+					JSONPatch{op: "add", path: "/spec/template/spec/initContainers", value: [
+						Object.spec.template.spec.initContainers{name: "init-1", image: "alpine:3.18", command: ["echo", "init1"]},
+						Object.spec.template.spec.initContainers{name: "init-2", image: "alpine:3.18", command: ["echo", "init2"]},
+					]},
+				]`,
+			gvr: deploymentGVR,
+			object: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "main-app", Image: "nginx:1.24"},
+							},
+						},
+					},
+				},
+			},
+			expectedResult: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							InitContainers: []corev1.Container{
+								{Name: "init-1", Image: "alpine:3.18", Command: []string{"echo", "init1"}},
+								{Name: "init-2", Image: "alpine:3.18", Command: []string{"echo", "init2"}},
+							},
+							Containers: []corev1.Container{
+								{Name: "main-app", Image: "nginx:1.24"},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/cel/mutation/dynamic/objects.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/mutation/dynamic/objects.go
@@ -121,7 +121,7 @@ func (v *ObjectVal) ConvertToNative(typeDesc reflect.Type) (any, error) {
 		result[k] = converted
 	}
 	switch typeDesc {
-	case reflect.TypeOf(result):
+	case reflect.TypeFor[map[string]any]():
 		return result, nil
 	// CEL's builtin data literal values all support conversion to structpb.Value, which
 	// can then be serialized to JSON. This is convenient for CEL expressions that return

--- a/staging/src/k8s.io/apiserver/pkg/cel/mutation/dynamic/objects.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/mutation/dynamic/objects.go
@@ -120,17 +120,20 @@ func (v *ObjectVal) ConvertToNative(typeDesc reflect.Type) (any, error) {
 		}
 		result[k] = converted
 	}
-	if typeDesc == reflect.TypeOf(result) {
+	switch typeDesc {
+	case reflect.TypeOf(result):
 		return result, nil
-	}
 	// CEL's builtin data literal values all support conversion to structpb.Value, which
 	// can then be serialized to JSON. This is convenient for CEL expressions that return
 	// an arbitrary JSON value, such as our MutatingAdmissionPolicy JSON Patch valueExpression
 	// field, so we support the conversion here, for Object data literals, as well.
-	if typeDesc == reflect.TypeOf(&structpb.Value{}) {
+	case reflect.TypeFor[*structpb.Struct]():
 		return structpb.NewStruct(result)
+	case reflect.TypeFor[*structpb.Value]():
+		return structpb.NewValue(result)
+	default:
+		return nil, fmt.Errorf("unable to convert to %v", typeDesc)
 	}
-	return nil, fmt.Errorf("unable to convert to %v", typeDesc)
 }
 
 // ConvertToType supports type conversions between CEL value types supported by the expression language.

--- a/test/integration/apiserver/cel/mutatingadmissionpolicy_test.go
+++ b/test/integration/apiserver/cel/mutatingadmissionpolicy_test.go
@@ -123,6 +123,53 @@ func TestMutatingAdmissionPolicy(t *testing.T) {
 			},
 		},
 		{
+			name: "jsonPatch with constant complex struct object as value",
+			policies: []*v1.MutatingAdmissionPolicy{
+				mutatingPolicy("json-patch-complex-struct-object", v1.NeverReinvocationPolicy, matchEndpointResources, nil, v1.Mutation{
+					PatchType: v1.PatchTypeJSONPatch,
+					JSONPatch: &v1.JSONPatch{
+						Expression: `[
+							JSONPatch{op: "add", path: "/subsets/0/addresses", value: [Object.subsets.addresses{ip: "10.0.0.1"}]}
+						]`,
+					},
+				}),
+			},
+			bindings: []*v1.MutatingAdmissionPolicyBinding{
+				mutatingBinding("json-patch-complex-struct-object", nil, nil),
+			},
+			requestOperation: v1.Create,
+			requestResource:  corev1.SchemeGroupVersion.WithResource("endpoints"),
+			requestObject: &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "json-patch-complex-struct-object",
+					Namespace: "default",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						NotReadyAddresses: []corev1.EndpointAddress{
+							{IP: "1.2.3.4"},
+						},
+					},
+				},
+			},
+			expected: &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "json-patch-complex-struct-object",
+					Namespace: "default",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{IP: "10.0.0.1"},
+						},
+						NotReadyAddresses: []corev1.EndpointAddress{
+							{IP: "1.2.3.4"},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "multiple policies",
 			policies: []*v1.MutatingAdmissionPolicy{
 				mutatingPolicy("multi-policy-1", v1.NeverReinvocationPolicy, matchEndpointResources, nil, v1.Mutation{
@@ -560,6 +607,7 @@ func TestMutatingAdmissionPolicy(t *testing.T) {
 							DryRun:       []string{metav1.DryRunAll},
 							FieldManager: "integration-test",
 						}, tc.subresources...)
+						require.NoError(t, err)
 					case v1.Update:
 						resultObj, err = rsrcClient.Update(ctx, unstructuredRequestObj, metav1.UpdateOptions{
 							DryRun:       []string{metav1.DryRunAll},
@@ -1300,6 +1348,9 @@ func withMutatingWaitReadyConstraintAndExpression(policy *v1.MutatingAdmissionPo
 		if m.ApplyConfiguration != nil {
 			bypass := `object.metadata.?labels["mutation-marker"].hasValue() ? Object{} : `
 			m.ApplyConfiguration.Expression = bypass + m.ApplyConfiguration.Expression
+		} else if m.JSONPatch != nil {
+			bypass := `object.metadata.?labels["mutation-marker"].hasValue() ? [] : `
+			m.JSONPatch.Expression = bypass + m.JSONPatch.Expression
 		}
 	}
 	policy.Spec.Mutations = append([]v1.Mutation{{


### PR DESCRIPTION
Cherry pick of #140419 on release-1.36.

#140419: Fix ConvertToNative for Mutating admission policies

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug
/kind cleanup


```release-note
NONE
```