### PR TITLE
e2e_node: Handle containerd CRIU preflight errors

### DIFF
--- a/test/e2e_node/checkpoint_container.go
+++ b/test/e2e_node/checkpoint_container.go
@@ -218,8 +218,15 @@ var _ = SIGDescribe("Checkpoint Container", feature.CheckpointContainer, func() 
 			// '(rpc error: code = Unknown desc = checkpoint/restore support not available)'
 			// if the container engine explicitly disabled the checkpoint/restore support
 			// or
+			// '(rpc error: code = Unknown desc = failed to checkpoint container "...": criu support is disabled by configuration)'
+			// if containerd explicitly disabled CRIU support
+			// or
 			// '(rpc error: code = Unknown desc = CRIU binary not found or too old (<31600). Failed to checkpoint container'
-			// if the CRIU binary was not found if it is too old
+			// if the CRIU binary was not found or is too old
+			// or
+			// '(rpc error: code = Unknown desc = failed to checkpoint container "...": criu binary not found in shim path or system PATH)'
+			// '(rpc error: code = Unknown desc = failed to checkpoint container "...": checkpoint/restore requires at least CRIU 31600, current version is ...)'
+			// for newer containerd CRIU preflight checks
 			if (int(statusError.ErrStatus.Code)) == http.StatusInternalServerError {
 				if strings.Contains(
 					statusError.ErrStatus.Message,
@@ -244,7 +251,20 @@ var _ = SIGDescribe("Checkpoint Container", feature.CheckpointContainer, func() 
 				}
 				if strings.Contains(
 					statusError.ErrStatus.Message,
-					"(rpc error: code = Unknown desc = CRIU binary not found or too old (<31600). Failed to checkpoint container",
+					"criu support is disabled by configuration",
+				) {
+					ginkgo.Skip("Container engine reports CRIU support is disabled")
+					return
+				}
+				if strings.Contains(
+					statusError.ErrStatus.Message,
+					"CRIU binary not found or too old (<31600). Failed to checkpoint container",
+				) || strings.Contains(
+					statusError.ErrStatus.Message,
+					"criu binary not found in shim path or system PATH",
+				) || strings.Contains(
+					statusError.ErrStatus.Message,
+					"checkpoint/restore requires at least CRIU",
 				) {
 					ginkgo.Skip("Container engine reports missing or too old CRIU binary")
 					return


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

Containerd now validates CRIU before checkpointing and reports missing,
outdated, or disabled CRIU using new error messages.

The checkpoint node e2e test only recognizes the previous messages, causing
environments without usable CRIU—such as COS nodes—to fail instead of
following the existing skip behavior.

This PR recognizes the new containerd messages while retaining support for
the previous runtime error forms. Other checkpoint failures continue to fail
the test.

#### Which issue(s) this PR is related to:

#140560

#### Special notes for your reviewer:

The affected jobs track containerd `main`. CRIU is not available on their COS
nodes, so this preserves the test's existing handling of that environment.

Validation:

- `go test -c -o /tmp/e2e_node-140560.test ./test/e2e_node`
- `git diff --check`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A