### PR TITLE
Automated cherry pick of #140377: e2e: storage snapshot tests should read custom timeouts from manifest

### DIFF
--- a/test/e2e/storage/testsuites/snapshottable.go
+++ b/test/e2e/storage/testsuites/snapshottable.go
@@ -108,7 +108,7 @@ func (s *snapshottableTestSuite) DefineTests(driver storageframework.TestDriver,
 
 	// Beware that it also registers an AfterEach which renders f unusable. Any code using
 	// f must run inside an It or Context callback.
-	f := framework.NewDefaultFramework("snapshotting")
+	f := framework.NewFrameworkWithCustomTimeouts("snapshotting", storageframework.GetDriverTimeouts(driver))
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 	ginkgo.Describe("volume snapshot controller", func() {

--- a/test/e2e/storage/testsuites/snapshottable_stress.go
+++ b/test/e2e/storage/testsuites/snapshottable_stress.go
@@ -120,7 +120,7 @@ func (t *snapshottableStressTestSuite) DefineTests(driver storageframework.TestD
 
 	// Beware that it also registers an AfterEach which renders f unusable. Any code using
 	// f must run inside an It or Context callback.
-	f := framework.NewDefaultFramework("snapshottable-stress")
+	f := framework.NewFrameworkWithCustomTimeouts("snapshottable-stress", storageframework.GetDriverTimeouts(driver))
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 	init := func(ctx context.Context) {


### PR DESCRIPTION
Cherry pick of #140377 on release-1.35.

#140377: e2e: storage snapshot tests should read custom timeouts from manifest

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
NONE
```