### PR TITLE
apiserver: fix potential nil pointer dereference in Store.Watch

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -1498,6 +1498,7 @@ func (e *Store) Watch(ctx context.Context, options *metainternalversion.ListOpti
 	predicate := e.PredicateFunc(label, field)
 
 	resourceVersion := ""
+	var sendInitialEvents *bool
 	if options != nil {
 		resourceVersion = options.ResourceVersion
 		predicate.AllowWatchBookmarks = options.AllowWatchBookmarks
@@ -1508,8 +1509,9 @@ func (e *Store) Watch(ctx context.Context, options *metainternalversion.ListOpti
 			}
 			predicate.ShardSelector = sel
 		}
+		sendInitialEvents = options.SendInitialEvents
 	}
-	return e.WatchPredicate(ctx, predicate, resourceVersion, options.SendInitialEvents)
+	return e.WatchPredicate(ctx, predicate, resourceVersion, sendInitialEvents)
 }
 
 // WatchPredicate starts a watch for the items that matches.

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -2521,6 +2521,78 @@ func TestStoreDeleteCollectionWithWatch(t *testing.T) {
 	}
 }
 
+func TestStoreWatchOptions(t *testing.T) {
+	testContext := genericapirequest.WithNamespace(genericapirequest.NewContext(), "test")
+
+	table := map[string]struct {
+		options *metainternalversion.ListOptions
+	}{
+		"all": {
+			options: &metainternalversion.ListOptions{
+				LabelSelector:   labels.Everything(),
+				FieldSelector:   fields.Everything(),
+				ResourceVersion: "0",
+			},
+		},
+		"noLabelSelector": {
+			options: &metainternalversion.ListOptions{
+				FieldSelector:   fields.Everything(),
+				ResourceVersion: "0",
+			},
+		},
+		"noFieldSelector": {
+			options: &metainternalversion.ListOptions{
+				LabelSelector:   labels.Everything(),
+				ResourceVersion: "0",
+			},
+		},
+		"noResourceVersion": {
+			options: &metainternalversion.ListOptions{
+				LabelSelector: labels.Everything(),
+				FieldSelector: fields.Everything(),
+			},
+		},
+		"nil": {
+			options: nil,
+		},
+	}
+
+	for name, m := range table {
+		t.Run(name, func(t *testing.T) {
+			ctx := testContext
+
+			podA := &example.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "test",
+				},
+				Spec: example.PodSpec{NodeName: "machine"},
+			}
+
+			destroyFunc, registry := NewTestGenericStoreRegistry(t)
+			defer destroyFunc()
+
+			wi, err := registry.Watch(ctx, m.options)
+			if err != nil {
+				t.Errorf("%v: unexpected error: %v", name, err)
+			} else {
+				obj, err := registry.Create(testContext, podA, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+				if err != nil {
+					got, open := <-wi.ResultChan()
+					if !open {
+						t.Errorf("%v: unexpected channel close", name)
+					} else {
+						if e, a := obj, got.Object; !reflect.DeepEqual(e, a) {
+							t.Errorf("Expected %#v, got %#v", e, a)
+						}
+					}
+				}
+				wi.Stop()
+			}
+		})
+	}
+}
+
 func TestStoreWatch(t *testing.T) {
 	testContext := genericapirequest.WithNamespace(genericapirequest.NewContext(), "test")
 	noNamespaceContext := genericapirequest.NewContext()


### PR DESCRIPTION


#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
set option.SendInitialEvents inside Store.Watch so it stays nil when no options are passed.

uses the approved pr #135784 (but inactive), rebased onto current master. 
#### Which issue(s) this PR is related to:
Fixes #135772 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```