### PR TITLE
fix: log volume metrics failures at Error with dedup

### DIFF
--- a/pkg/kubelet/server/stats/volume_stat_calculator.go
+++ b/pkg/kubelet/server/stats/volume_stat_calculator.go
@@ -45,6 +45,11 @@ type volumeStatCalculator struct {
 	stopO         sync.Once
 	latest        atomic.Value
 	eventRecorder record.EventRecorder
+	// lastMetricsErrors tracks the last non-NotSupported GetMetrics error string per
+	// volume name for this pod. Used to log at Error only when the failure is new or
+	// changes, while still logging repeats at high verbosity for debugging.
+	// Safe without a mutex: only the single calcAndStoreStats loop (and tests) mutate it.
+	lastMetricsErrors map[string]string
 }
 
 // PodVolumeStats encapsulates the VolumeStats for a pod.
@@ -57,11 +62,12 @@ type PodVolumeStats struct {
 // newVolumeStatCalculator creates a new VolumeStatCalculator
 func newVolumeStatCalculator(statsProvider Provider, jitterPeriod time.Duration, pod *v1.Pod, eventRecorder record.EventRecorder) *volumeStatCalculator {
 	return &volumeStatCalculator{
-		statsProvider: statsProvider,
-		jitterPeriod:  jitterPeriod,
-		pod:           pod,
-		stopChannel:   make(chan struct{}),
-		eventRecorder: eventRecorder,
+		statsProvider:     statsProvider,
+		jitterPeriod:      jitterPeriod,
+		pod:               pod,
+		stopChannel:       make(chan struct{}),
+		eventRecorder:     eventRecorder,
+		lastMetricsErrors: make(map[string]string),
 	}
 }
 
@@ -142,10 +148,11 @@ func (s *volumeStatCalculator) calcAndStoreStats(logger klog.Logger) {
 		if err != nil {
 			// Expected for Volumes that don't support Metrics
 			if !volume.IsNotSupported(err) {
-				logger.V(4).Info("Failed to calculate volume metrics", "pod", klog.KObj(s.pod), "podUID", s.pod.UID, "volumeName", name, "err", err)
+				s.logVolumeMetricsError(logger, name, err)
 			}
 			continue
 		}
+		delete(s.lastMetricsErrors, name)
 		// Lookup the volume spec and add a 'PVCReference' for volumes that reference a PVC
 		volSpec := volumesSpec[name]
 		var pvcRef *stats.PVCReference
@@ -177,6 +184,19 @@ func (s *volumeStatCalculator) calcAndStoreStats(logger klog.Logger) {
 	// Store the new stats
 	s.latest.Store(PodVolumeStats{EphemeralVolumes: ephemeralStats,
 		PersistentVolumes: persistentStats})
+}
+
+// logVolumeMetricsError logs GetMetrics failures. New or changed errors are logged at
+// Error so they are visible at default verbosity; identical repeats are V(4) only to
+// avoid spam from the periodic calculator loop.
+func (s *volumeStatCalculator) logVolumeMetricsError(logger klog.Logger, volumeName string, err error) {
+	errMsg := err.Error()
+	if prev, ok := s.lastMetricsErrors[volumeName]; !ok || prev != errMsg {
+		logger.Error(err, "Failed to calculate volume metrics", "pod", klog.KObj(s.pod), "podUID", s.pod.UID, "volumeName", volumeName)
+		s.lastMetricsErrors[volumeName] = errMsg
+		return
+	}
+	logger.V(4).Info("Failed to calculate volume metrics", "pod", klog.KObj(s.pod), "podUID", s.pod.UID, "volumeName", volumeName, "err", err)
 }
 
 // parsePodVolumeStats converts (internal) volume.Metrics to (external) stats.VolumeStats structures

--- a/pkg/kubelet/server/stats/volume_stat_calculator_test.go
+++ b/pkg/kubelet/server/stats/volume_stat_calculator_test.go
@@ -238,6 +238,54 @@ func WatchEvent(eventChan <-chan string) (string, error) {
 	}
 }
 
+func TestVolumeMetricsErrorLoggingState(t *testing.T) {
+	ktesting.Init(t).SyncTest("", testVolumeMetricsErrorLoggingState)
+}
+
+func testVolumeMetricsErrorLoggingState(tCtx ktesting.TContext) {
+	t := tCtx.TB()
+	logger := tCtx.Logger()
+
+	mockStats := statstest.NewMockProvider(t)
+	errVol := &fakeVolumeWithMetricsError{err: fmt.Errorf("nfs: connection refused")}
+	volumes := map[string]volume.Volume{vol0: errVol}
+	mockStats.EXPECT().ListVolumesForPod(fakePod.UID).Return(volumes, true).Maybe()
+	mockStats.EXPECT().ListBlockVolumesForPod(fakePod.UID).Return(nil, false).Maybe()
+
+	fakeEventRecorder := record.FakeRecorder{}
+	statsCalculator := newVolumeStatCalculator(mockStats, time.Minute, fakePod, &fakeEventRecorder)
+
+	// First failure: track the error message for Error-level logging.
+	statsCalculator.calcAndStoreStats(logger)
+	assert.Equal(t, map[string]string{vol0: "nfs: connection refused"}, statsCalculator.lastMetricsErrors)
+	vs, ok := statsCalculator.GetLatest()
+	assert.True(t, ok)
+	assert.Empty(t, vs.EphemeralVolumes)
+	assert.Empty(t, vs.PersistentVolumes)
+
+	// Identical failure: still tracked (repeat logs go to V(4) only).
+	statsCalculator.calcAndStoreStats(logger)
+	assert.Equal(t, map[string]string{vol0: "nfs: connection refused"}, statsCalculator.lastMetricsErrors)
+
+	// Changed failure message: update tracked error.
+	errVol.err = fmt.Errorf("nfs: timeout")
+	statsCalculator.calcAndStoreStats(logger)
+	assert.Equal(t, map[string]string{vol0: "nfs: timeout"}, statsCalculator.lastMetricsErrors)
+
+	// Success clears the tracked error so a later failure logs at Error again.
+	errVol.err = nil
+	statsCalculator.calcAndStoreStats(logger)
+	assert.Empty(t, statsCalculator.lastMetricsErrors)
+	vs, ok = statsCalculator.GetLatest()
+	assert.True(t, ok)
+	assert.NotEmpty(t, append(vs.EphemeralVolumes, vs.PersistentVolumes...))
+
+	// NotSupported errors are expected and must not be tracked.
+	errVol.err = volume.NewNotSupportedError()
+	statsCalculator.calcAndStoreStats(logger)
+	assert.Empty(t, statsCalculator.lastMetricsErrors)
+}
+
 // Fake volume/metrics provider
 var _ volume.Volume = &fakeVolume{}
 
@@ -339,4 +387,18 @@ func expectedBlockStats() kubestats.FsStats {
 		InodesFree:     &null,
 		InodesUsed:     &null,
 	}
+}
+
+// fakeVolumeWithMetricsError returns a controllable GetMetrics error.
+type fakeVolumeWithMetricsError struct {
+	err error
+}
+
+func (v *fakeVolumeWithMetricsError) GetPath() string { return "" }
+
+func (v *fakeVolumeWithMetricsError) GetMetrics() (*volume.Metrics, error) {
+	if v.err != nil {
+		return nil, v.err
+	}
+	return expectedMetrics(), nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Volume metrics collection runs periodically in the kubelet. When `GetMetrics` fails (for example temporary NFS errors), the failure was only logged at V(4), so operators could not see it at default verbosity while investigating missing/zero volume usage metrics.

This PR:
- Logs **new or changed** metrics failures at **Error** (visible at default verbosity)
- Logs **identical repeated** failures at **V(4)** only, to avoid spam from the periodic calculator loop
- Clears tracked state on success so a later failure is logged at Error again
- Leaves `NotSupported` silent (expected for volumes without metrics)

State is stored on the **per-pod** `volumeStatCalculator`, so there is no cross-pod global map or leak across pods.

This incorporates review feedback from the earlier stale PR kubernetes/kubernetes#119169.

#### Which issue(s) this PR fixes:

Fixes kubernetes/kubernetes#118062

#### Special notes for your reviewer:

- No mutex on `lastMetricsErrors`: only the single calculator loop (and unit tests) mutate it
- Unit coverage in `TestVolumeMetricsErrorLoggingState`

#### Does this PR introduce a user-facing change?

```release-note
kubelet now logs volume metrics collection failures at Error on first occurrence (and when the error changes), with V(4) for identical repeats, to aid debugging without log spam.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
