### PR TITLE
apimachinery: add k8s-label-key format validation for Condition.Type

### DIFF
--- a/pkg/apis/certificates/validation/validation.go
+++ b/pkg/apis/certificates/validation/validation.go
@@ -28,7 +28,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"net/mail"
-	"strconv"
 	"strings"
 	"time"
 
@@ -825,13 +824,13 @@ func ValidatePodCertificateRequestStatusUpdate(newReq, oldReq *certificates.PodC
 		case certificates.PodCertificateRequestConditionTypeIssued, certificates.PodCertificateRequestConditionTypeDenied, certificates.PodCertificateRequestConditionTypeFailed:
 			numKnownConditions++
 			if numKnownConditions > 1 {
-				allErrors = append(allErrors, field.Invalid(field.NewPath("status", "conditions", formatIndex(i), "type"), cond.Type, `There may be at most one condition with type "Issued", "Denied", or "Failed"`))
+				allErrors = append(allErrors, field.Invalid(field.NewPath("status", "conditions").Index(i).Child("type"), cond.Type, `There may be at most one condition with type "Issued", "Denied", or "Failed"`))
 			}
 			if cond.Status != metav1.ConditionTrue {
-				allErrors = append(allErrors, field.NotSupported(field.NewPath("status", "conditions", formatIndex(i), "status"), cond.Status, []metav1.ConditionStatus{metav1.ConditionTrue}))
+				allErrors = append(allErrors, field.NotSupported(field.NewPath("status", "conditions").Index(i).Child("status"), cond.Status, []metav1.ConditionStatus{metav1.ConditionTrue}))
 			}
 		default:
-			allErrors = append(allErrors, field.NotSupported(field.NewPath("status", "conditions", formatIndex(i), "type"), cond.Type, []string{certificates.PodCertificateRequestConditionTypeIssued, certificates.PodCertificateRequestConditionTypeDenied, certificates.PodCertificateRequestConditionTypeFailed}))
+			allErrors = append(allErrors, field.NotSupported(field.NewPath("status", "conditions").Index(i).Child("type"), cond.Type, []string{certificates.PodCertificateRequestConditionTypeIssued, certificates.PodCertificateRequestConditionTypeDenied, certificates.PodCertificateRequestConditionTypeFailed}))
 		}
 	}
 
@@ -1046,10 +1045,6 @@ func pcrIsFailed(pcr *certificates.PodCertificateRequest) bool {
 		}
 	}
 	return false
-}
-
-func formatIndex(i int) string {
-	return "[" + strconv.Itoa(i) + "]"
 }
 
 // Similar to apivalidation.ValidateImmutableField but we can supply our own detail string.

--- a/pkg/apis/certificates/validation/validation_test.go
+++ b/pkg/apis/certificates/validation/validation_test.go
@@ -2542,7 +2542,7 @@ func TestValidatePodCertificateRequestStatusUpdate(t *testing.T) {
 				},
 			},
 			wantErrors: field.ErrorList{
-				field.NotSupported(field.NewPath("status", "conditions", "[0]", "type"), "Unknown", []string{capi.PodCertificateRequestConditionTypeIssued, capi.PodCertificateRequestConditionTypeDenied, capi.PodCertificateRequestConditionTypeFailed}),
+				field.NotSupported(field.NewPath("status", "conditions").Index(0).Child("type"), "Unknown", []string{capi.PodCertificateRequestConditionTypeIssued, capi.PodCertificateRequestConditionTypeDenied, capi.PodCertificateRequestConditionTypeFailed}),
 			},
 		},
 		{
@@ -2595,7 +2595,7 @@ func TestValidatePodCertificateRequestStatusUpdate(t *testing.T) {
 				},
 			},
 			wantErrors: field.ErrorList{
-				field.NotSupported(field.NewPath("status", "conditions", "[0]", "status"), metav1.ConditionFalse, []metav1.ConditionStatus{metav1.ConditionTrue}),
+				field.NotSupported(field.NewPath("status", "conditions").Index(0).Child("status"), metav1.ConditionFalse, []metav1.ConditionStatus{metav1.ConditionTrue}),
 			},
 		},
 		{
@@ -2648,7 +2648,7 @@ func TestValidatePodCertificateRequestStatusUpdate(t *testing.T) {
 				},
 			},
 			wantErrors: field.ErrorList{
-				field.NotSupported(field.NewPath("status", "conditions", "[0]", "status"), metav1.ConditionFalse, []metav1.ConditionStatus{metav1.ConditionTrue}),
+				field.NotSupported(field.NewPath("status", "conditions").Index(0).Child("status"), metav1.ConditionFalse, []metav1.ConditionStatus{metav1.ConditionTrue}),
 			},
 		},
 		{
@@ -2701,7 +2701,7 @@ func TestValidatePodCertificateRequestStatusUpdate(t *testing.T) {
 				},
 			},
 			wantErrors: field.ErrorList{
-				field.NotSupported(field.NewPath("status", "conditions", "[0]", "status"), metav1.ConditionFalse, []metav1.ConditionStatus{metav1.ConditionTrue}),
+				field.NotSupported(field.NewPath("status", "conditions").Index(0).Child("status"), metav1.ConditionFalse, []metav1.ConditionStatus{metav1.ConditionTrue}),
 			},
 		},
 		{
@@ -3157,7 +3157,7 @@ func TestValidatePodCertificateRequestStatusUpdate(t *testing.T) {
 				},
 			},
 			wantErrors: field.ErrorList{
-				field.Invalid(field.NewPath("status", "conditions", "[1]", "type"), "Failed", `There may be at most one condition with type "Issued", "Denied", or "Failed"`),
+				field.Invalid(field.NewPath("status", "conditions").Index(1).Child("type"), "Failed", `There may be at most one condition with type "Issued", "Denied", or "Failed"`),
 			},
 		},
 		{
@@ -3221,7 +3221,7 @@ func TestValidatePodCertificateRequestStatusUpdate(t *testing.T) {
 				},
 			},
 			wantErrors: field.ErrorList{
-				field.Invalid(field.NewPath("status", "conditions", "[1]", "type"), "Denied", `There may be at most one condition with type "Issued", "Denied", or "Failed"`),
+				field.Invalid(field.NewPath("status", "conditions").Index(1).Child("type"), "Denied", `There may be at most one condition with type "Issued", "Denied", or "Failed"`),
 			},
 		},
 		{
@@ -3285,7 +3285,7 @@ func TestValidatePodCertificateRequestStatusUpdate(t *testing.T) {
 				},
 			},
 			wantErrors: field.ErrorList{
-				field.Invalid(field.NewPath("status", "conditions", "[1]", "type"), "Failed", `There may be at most one condition with type "Issued", "Denied", or "Failed"`),
+				field.Invalid(field.NewPath("status", "conditions").Index(1).Child("type"), "Failed", `There may be at most one condition with type "Issued", "Denied", or "Failed"`),
 			},
 		},
 		{

--- a/pkg/apis/lifecycle/validation/validation_test.go
+++ b/pkg/apis/lifecycle/validation/validation_test.go
@@ -170,14 +170,13 @@ func TestValidateEvictionRequestStatusUpdate(t *testing.T) {
 			oldInput: mkValidEvictionRequestStatus(),
 			input: mkValidEvictionRequestStatus(func(obj *lifecycle.EvictionRequestStatus) {
 				obj.Conditions = append(obj.Conditions, metav1.Condition{
-					Type:               "-bad-name",
+					Type:               "good-name",
 					Status:             metav1.ConditionTrue,
 					Reason:             "-Reason",
 					LastTransitionTime: metav1.Time{Time: clock.Now()},
 				})
 			}),
 			errors: []*field.Error{
-				field.Invalid(field.NewPath("status", "conditions").Index(0).Child("type"), "", "name part must consist of alphanumeric characters, '-', '_' or '.', and "),
 				field.Invalid(field.NewPath("status", "conditions").Index(0).Child("reason"), "", "a condition reason must start with alphabetic character, optionally followed by a string of alphanumeric characters or '_,:', and "),
 			},
 		},
@@ -850,14 +849,13 @@ func TestValidateEvictionStatusUpdate(t *testing.T) {
 			oldInput: mkValidEvictionStatus(1),
 			input: mkValidEvictionStatus(1, func(obj *lifecycle.EvictionStatus) {
 				obj.Conditions = append(obj.Conditions, metav1.Condition{
-					Type:               "-bad-name",
+					Type:               "good-name",
 					Status:             metav1.ConditionTrue,
 					Reason:             "-Reason",
 					LastTransitionTime: metav1.Time{Time: clock.Now()},
 				})
 			}),
 			errors: []*field.Error{
-				field.Invalid(field.NewPath("status", "conditions").Index(0).Child("type"), "", "name part must consist of alphanumeric characters, '-', '_' or '.', and "),
 				field.Invalid(field.NewPath("status", "conditions").Index(0).Child("reason"), "", "a condition reason must start with alphabetic character, optionally followed by a string of alphanumeric characters or '_,:', and "),
 			},
 		},

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
@@ -197,6 +197,7 @@ message Condition {
   // +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`
   // +kubebuilder:validation:MaxLength=316
   // +k8s:alpha(since: "1.37")=+k8s:required
+  // +k8s:alpha(since: "1.37")=+k8s:format=k8s-label-key
   optional string type = 1;
 
   // status of the condition, one of True, False, Unknown.

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
@@ -236,7 +236,7 @@ message Condition {
   // +kubebuilder:validation:MinLength=1
   // +kubebuilder:validation:Pattern=`^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$`
   // +k8s:alpha(since: "1.37")=+k8s:required
-  // +k8s:alpha(since: "1.37")=+k8s:maxBytes=1024
+  // +k8s:alpha(since: "1.38")=+k8s:maxBytes=1024
   optional string reason = 5;
 
   // message is a human readable message indicating details about the transition.

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -1650,6 +1650,7 @@ type Condition struct {
 	// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`
 	// +kubebuilder:validation:MaxLength=316
 	// +k8s:alpha(since: "1.37")=+k8s:required
+	// +k8s:alpha(since: "1.37")=+k8s:format=k8s-label-key
 	Type string `json:"type" protobuf:"bytes,1,opt,name=type"`
 	// status of the condition, one of True, False, Unknown.
 	// +required

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -1685,7 +1685,7 @@ type Condition struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:Pattern=`^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$`
 	// +k8s:alpha(since: "1.37")=+k8s:required
-	// +k8s:alpha(since: "1.37")=+k8s:maxBytes=1024
+	// +k8s:alpha(since: "1.38")=+k8s:maxBytes=1024
 	Reason string `json:"reason" protobuf:"bytes,5,opt,name=reason"`
 	// message is a human readable message indicating details about the transition.
 	// This may be an empty string.

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -346,7 +346,7 @@ func ValidateCondition(condition metav1.Condition, fldPath *field.Path) field.Er
 	if len(condition.Type) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("type"), "is required").MarkCoveredByDeclarative())
 	} else {
-		allErrs = append(allErrs, ValidateLabelName(condition.Type, fldPath.Child("type"))...)
+		allErrs = append(allErrs, ValidateLabelName(condition.Type, fldPath.Child("type")).WithOrigin("format=k8s-label-key").MarkCoveredByDeclarative()...)
 	}
 
 	// status is set and is an accepted value

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/zz_generated.validations.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/zz_generated.validations.go
@@ -60,6 +60,9 @@ func Validate_Condition(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if e := validate.LabelKey(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/error_matcher.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/error_matcher.go
@@ -48,6 +48,7 @@ type ErrorMatcher struct {
 	matchSource                   bool
 	matchAncestorShortCircuit     bool
 	matchShortCircuit             bool
+	matchCoveredByDeclarative     bool
 	// normalizationRules holds the pre-compiled regex patterns for path normalization.
 	normalizationRules []NormalizationRule
 }
@@ -117,6 +118,9 @@ func (m ErrorMatcher) Matches(want, got *Error) bool {
 		return false
 	}
 	if m.matchShortCircuit && want.ShortCircuit != got.ShortCircuit {
+		return false
+	}
+	if m.matchCoveredByDeclarative && want.CoveredByDeclarative != got.CoveredByDeclarative {
 		return false
 	}
 
@@ -193,6 +197,10 @@ func (m ErrorMatcher) Render(e *Error) string {
 	if m.matchShortCircuit {
 		comma()
 		fmt.Fprintf(&buf, "ShortCircuit=%t", e.ShortCircuit)
+	}
+	if m.matchCoveredByDeclarative {
+		comma()
+		fmt.Fprintf(&buf, "CoveredByDeclarative=%t", e.CoveredByDeclarative)
 	}
 	return "{" + buf.String() + "}"
 }
@@ -286,6 +294,12 @@ func (m ErrorMatcher) MatchAncestorShortCircuit() ErrorMatcher {
 // MatchShortCircuit returns a derived ErrorMatcher which also matches by the ShortCircuit value.
 func (m ErrorMatcher) MatchShortCircuit() ErrorMatcher {
 	m.matchShortCircuit = true
+	return m
+}
+
+// ByCoveredByDeclarative returns a derived ErrorMatcher which also matches by the CoveredByDeclarative value.
+func (m ErrorMatcher) ByCoveredByDeclarative() ErrorMatcher {
+	m.matchCoveredByDeclarative = true
 	return m
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
@@ -214,15 +214,18 @@ func gatherDeclarativeValidationMismatches(imperativeErrs, declarativeErrs field
 	fuzzyMatcher := field.ErrorMatcher{}.ByType().ByOrigin().RequireOriginWhenInvalid().ByFieldNormalized(opts.NormalizationRules)
 	fuzzyMatcherWithShortCircuit := fuzzyMatcher.MatchAncestorShortCircuit()
 
-	// Dedupe imperative errors using the fuzzy matcher (type, field, and origin) as they are
-	// not intended and come from (buggy) duplicate validation calls.
+	// Dedupe imperative errors using the fuzzy matcher (type, field, origin, and coveredByDeclarative flag)
+	// as they are not intended and come from (buggy) duplicate validation calls.
+	// Matching by CoveredByDeclarative ensures we don't deduplicate and accidentally drop generic
+	// covered validations that happen to produce the same error signature as tighter semantic constraints.
 	// This is necessary as without deduping we could get unmatched
 	// imperative errors for cases that are correct (matching).
+	dedupeMatcher := fuzzyMatcher.ByCoveredByDeclarative()
 	dedupedImperativeErrs := field.ErrorList{}
 	for _, err := range imperativeErrs {
 		found := false
 		for _, existingErr := range dedupedImperativeErrs {
-			if fuzzyMatcher.Matches(existingErr, err) {
+			if dedupeMatcher.Matches(existingErr, err) {
 				found = true
 				break
 			}

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1_test.go
@@ -76,6 +76,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 		},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
@@ -76,6 +76,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 		},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
@@ -76,6 +76,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 		},

--- a/test/declarative_validation/certificates/podcertificaterequest/declarative_validation_test.go
+++ b/test/declarative_validation/certificates/podcertificaterequest/declarative_validation_test.go
@@ -163,8 +163,19 @@ func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 					},
 					ExpectedErrs: field.ErrorList{
 						field.Required(field.NewPath("status", "conditions").Index(0).Child("type"), "").MarkAlpha(),
-						// handwritten validation doesn't support empty type and uses .[0] notation
-						field.NotSupported(field.NewPath("status", "conditions").Child("[0]", "type"), "", []string{"Issued", "Denied", "Failed"}).MarkFromImperative(),
+						// handwritten validation doesn't support empty type
+						field.NotSupported(field.NewPath("status", "conditions").Index(0).Child("type"), "", []string{"Issued", "Denied", "Failed"}).MarkFromImperative(),
+					},
+				},
+				{
+					Name: "invalid type",
+					Conditions: []metav1.Condition{
+						meta.MkCondition(meta.TweakType("-InvalidType")),
+					},
+					ExpectedErrs: field.ErrorList{
+						field.Invalid(field.NewPath("status", "conditions").Index(0).Child("type"), "-InvalidType", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
+						// handwritten validation rejects any type outside the known set
+						field.NotSupported(field.NewPath("status", "conditions").Index(0).Child("type"), "-InvalidType", []string{"Issued", "Denied", "Failed"}).MarkFromImperative(),
 					},
 				},
 				{
@@ -175,8 +186,8 @@ func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 					},
 					ExpectedErrs: field.ErrorList{
 						field.Duplicate(field.NewPath("status", "conditions").Index(1), map[string]interface{}{"type": certificates.PodCertificateRequestConditionTypeDenied, "status": "True", "reason": "Foo", "message": "Bar"}).MarkAlpha(),
-						// handwritten validation doesn't allow multiple known conditions and uses .[1] notation
-						field.Invalid(field.NewPath("status", "conditions").Child("[1]", "type"), certificates.PodCertificateRequestConditionTypeDenied, `There may be at most one condition with type "Issued", "Denied", or "Failed"`).MarkFromImperative(),
+						// handwritten validation doesn't allow multiple known conditions
+						field.Invalid(field.NewPath("status", "conditions").Index(1).Child("type"), certificates.PodCertificateRequestConditionTypeDenied, `There may be at most one condition with type "Issued", "Denied", or "Failed"`).MarkFromImperative(),
 					},
 				},
 				{
@@ -262,7 +273,7 @@ func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 					ExpectedErrs: field.ErrorList{
 						field.Required(field.NewPath("status", "conditions").Index(0).Child("status"), "").MarkAlpha(),
 						// handwritten validation requires "True"
-						field.NotSupported(field.NewPath("status", "conditions").Child("[0]", "status"), "", []string{"True"}).MarkFromImperative(),
+						field.NotSupported(field.NewPath("status", "conditions").Index(0).Child("status"), "", []string{"True"}).MarkFromImperative(),
 					},
 				},
 				{
@@ -280,7 +291,7 @@ func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 							[]string{"False", "True", "Unknown"},
 						).MarkAlpha(),
 						// handwritten validation requires "True"
-						field.NotSupported(field.NewPath("status", "conditions").Child("[0]", "status"), "Invalid", []string{"True"}).MarkFromImperative(),
+						field.NotSupported(field.NewPath("status", "conditions").Index(0).Child("status"), "Invalid", []string{"True"}).MarkFromImperative(),
 					},
 				},
 				{
@@ -293,7 +304,7 @@ func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 					},
 					ExpectedErrs: field.ErrorList{
 						// handwritten validation requires "True"
-						field.NotSupported(field.NewPath("status", "conditions").Child("[0]", "status"), "Unknown", []string{"True"}).MarkFromImperative(),
+						field.NotSupported(field.NewPath("status", "conditions").Index(0).Child("status"), "Unknown", []string{"True"}).MarkFromImperative(),
 					},
 				},
 				{
@@ -306,7 +317,7 @@ func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 					},
 					ExpectedErrs: field.ErrorList{
 						// handwritten validation requires "True"
-						field.NotSupported(field.NewPath("status", "conditions").Child("[0]", "status"), "False", []string{"True"}).MarkFromImperative(),
+						field.NotSupported(field.NewPath("status", "conditions").Index(0).Child("status"), "False", []string{"True"}).MarkFromImperative(),
 					},
 				},
 			}

--- a/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1_test.go
@@ -76,6 +76,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 		},

--- a/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1beta1_test.go
@@ -76,6 +76,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 		},

--- a/test/declarative_validation/lifecycle/eviction/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/lifecycle/eviction/zz_generated.validations.v1alpha1_test.go
@@ -94,6 +94,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.observedGeneration": {

--- a/test/declarative_validation/lifecycle/evictionrequest/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/lifecycle/evictionrequest/zz_generated.validations.v1alpha1_test.go
@@ -103,6 +103,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.observedGeneration": {

--- a/test/declarative_validation/meta/conditions.go
+++ b/test/declarative_validation/meta/conditions.go
@@ -61,6 +61,90 @@ func GenerateConditionTestCases(fldPath *field.Path) []ConditionTestCase {
 			},
 		},
 		{
+			Name: "invalid type format not a k8s label key",
+			Conditions: []metav1.Condition{
+				MkCondition(
+					TweakType("-InvalidType"),
+				),
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(
+					fldPath.Index(0).Child("type"),
+					"-InvalidType",
+					"",
+				).WithOrigin("format=k8s-label-key").MarkAlpha(),
+			},
+		},
+		{
+			Name: "invalid type format uppercase prefix",
+			Conditions: []metav1.Condition{
+				MkCondition(
+					TweakType("Example.com/Ready"),
+				),
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(
+					fldPath.Index(0).Child("type"),
+					"Example.com/Ready",
+					"",
+				).WithOrigin("format=k8s-label-key").MarkAlpha(),
+			},
+		},
+		{
+			Name: "invalid type format underscore in prefix",
+			Conditions: []metav1.Condition{
+				MkCondition(
+					TweakType("example_com/Ready"),
+				),
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(
+					fldPath.Index(0).Child("type"),
+					"example_com/Ready",
+					"",
+				).WithOrigin("format=k8s-label-key").MarkAlpha(),
+			},
+		},
+		{
+			Name: "invalid type format multiple slashes",
+			Conditions: []metav1.Condition{
+				MkCondition(
+					TweakType("example.com/foo/Ready"),
+				),
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(
+					fldPath.Index(0).Child("type"),
+					"example.com/foo/Ready",
+					"",
+				).WithOrigin("format=k8s-label-key").MarkAlpha(),
+			},
+		},
+		{
+			Name: "invalid type format empty prefix",
+			Conditions: []metav1.Condition{
+				MkCondition(
+					TweakType("/Ready"),
+				),
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(
+					fldPath.Index(0).Child("type"),
+					"/Ready",
+					"",
+				).WithOrigin("format=k8s-label-key").MarkAlpha(),
+			},
+		},
+		{
+			Name: "valid type format with prefix as a k8s label key",
+			Conditions: []metav1.Condition{
+				MkCondition(
+					TweakType("example.com/Ready"),
+				),
+			},
+			ExpectedErrs: nil,
+		},
+		{
 			Name: "invalid missing status",
 			Conditions: []metav1.Condition{
 				MkCondition(TweakStatus("")),

--- a/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1_test.go
@@ -76,6 +76,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 		},

--- a/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1beta1_test.go
@@ -76,6 +76,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 		},

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1_test.go
@@ -80,6 +80,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 		},

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1alpha3_test.go
@@ -80,6 +80,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 		},

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1beta2_test.go
@@ -80,6 +80,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 		},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1_test.go
@@ -235,6 +235,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.devices[*].conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.devices[*].networkData.hardwareAddress": {

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta1_test.go
@@ -235,6 +235,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.devices[*].conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.devices[*].networkData.hardwareAddress": {

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta2_test.go
@@ -235,6 +235,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.devices[*].conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.devices[*].networkData.hardwareAddress": {

--- a/test/declarative_validation/resource/resourcepoolstatusrequest/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/resource/resourcepoolstatusrequest/zz_generated.validations.v1alpha3_test.go
@@ -98,6 +98,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.poolCount": {

--- a/test/declarative_validation/scheduling/compositepodgroup/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/scheduling/compositepodgroup/zz_generated.validations.v1alpha3_test.go
@@ -134,6 +134,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 		},

--- a/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1alpha3_test.go
@@ -153,6 +153,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.resourceClaimStatuses": {

--- a/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1beta1_test.go
@@ -153,6 +153,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.resourceClaimStatuses": {

--- a/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1_test.go
@@ -76,6 +76,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 		},

--- a/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1beta1_test.go
@@ -76,6 +76,7 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"status.conditions[*].type": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
 				{ErrorType: "FieldValueRequired"},
 			},
 		},


### PR DESCRIPTION
/kind feature
/sig api-machinery

  #### What this PR does / why we need it:

   Migrates `metav1.Condition.Type` validation to Declarative Validation.

   This PR:
   - Adds a declarative validation tag to `Condition.Type`: `+k8s:format=k8s-label-key`
   - Marks the corresponding handwritten validation as covered by declarative validation
   - Adds declarative validation test coverage for invalid `Type` format values
   - Regenerates validation code and generated declarative validation tests

   #### Which issue(s) this PR is related to:

Part of #139638

Closes https://github.com/kubernetes/kubernetes/pull/139897


co-author @thesauravpoddar
