### PR TITLE
apiserver: deflake TestTimeTravelHealthcheck

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory_test.go
@@ -375,6 +375,7 @@ func TestTimeTravelHealthcheck(t *testing.T) {
 
 	ready := make(chan struct{})
 	signal := make(chan struct{})
+	probeStarted := make(chan struct{})
 
 	var counter uint64
 	newETCD3Client = func(c storagebackend.TransportConfig) (*kubernetes.Client, error) {
@@ -390,6 +391,7 @@ func TestTimeTravelHealthcheck(t *testing.T) {
 				// the race limiter to server the new request from the cache or allow
 				// it to go through
 				if val == 1 {
+					close(probeStarted)
 					select {
 					case <-ctx.Done():
 						return nil, ctx.Err()
@@ -422,6 +424,7 @@ func TestTimeTravelHealthcheck(t *testing.T) {
 		close(signal)
 	}()
 
+	<-probeStarted
 	// wait until the rate limit allows new connections
 	time.Sleep(cfg.HealthcheckTimeout / 2)
 


### PR DESCRIPTION

#### What type of PR is this?
/kind flake
/sig api-machinery

#### What this PR does / why we need it:
the sleep that waits out the rate limiter starts at goroutine spawn, but the limiter token is taken when the goroutine runs. late scheduling means the sleep ends too early and the second healthcheck() gets the cached error, which is the failure shown. i fixed it by waiting until the first probe is in flight before sleeping
#### Which issue(s) this PR is related to:
Ref #140526 
#### Special notes for your reviewer:
I reproduced this by adding a 150ms sleep at the start of the goroutine to simulate a slow machine. the current test fails with the same errors as the example, but passes with my change. i also ran the test with -count=5. 
#### Does this PR introduce a user-facing change?
```release-note
NONE
```