### PR TITLE
coordination: enable commentstart kube-api-linter rule

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -147,7 +147,7 @@ linters:
       # Commentstart - Ignore commentstart issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "godoc for field .* should start with '.* ...'"
-        path: "staging/src/k8s.io/api/(apps|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(apps|batch|certificates|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
       
       # notimestamp: Legacy 'Timestamp' fields retained for backward compatibility
       - text: 'notimestamp: naming convention "notimestamp": field TokenRequestStatus.ExpirationTimestamp: prefer use of the term ''time'' over ''timestamp'''

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -162,7 +162,7 @@ linters:
       # Commentstart - Ignore commentstart issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "godoc for field .* should start with '.* ...'"
-        path: "staging/src/k8s.io/api/(apps|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(apps|batch|certificates|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
       
       # notimestamp: Legacy 'Timestamp' fields retained for backward compatibility
       - text: 'notimestamp: naming convention "notimestamp": field TokenRequestStatus.ExpirationTimestamp: prefer use of the term ''time'' over ''timestamp'''

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -23,7 +23,7 @@
 # Commentstart - Ignore commentstart issues for existing API group
 # TODO: For each existing API group, we aim to remove it over time.
 - text: "godoc for field .* should start with '.* ...'"
-  path: "staging/src/k8s.io/api/(apps|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+  path: "staging/src/k8s.io/api/(apps|batch|certificates|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
 
 # notimestamp: Legacy 'Timestamp' fields retained for backward compatibility
 - text: 'notimestamp: naming convention "notimestamp": field TokenRequestStatus.ExpirationTimestamp: prefer use of the term ''time'' over ''timestamp'''

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -18643,7 +18643,7 @@ func schema_k8sio_api_coordination_v1_Lease(ref common.ReferenceCallback) common
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Description: "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
 							Default:     map[string]interface{}{},
 							Ref:         ref(metav1.ObjectMeta{}.OpenAPIModelName()),
 						},
@@ -18755,14 +18755,14 @@ func schema_k8sio_api_coordination_v1_LeaseSpec(ref common.ReferenceCallback) co
 					},
 					"strategy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Strategy indicates the strategy for picking the leader for coordinated leader election. If the field is not specified, there is no active coordination for this lease. (Alpha) Using this field requires the CoordinatedLeaderElection feature gate to be enabled.",
+							Description: "strategy indicates the strategy for picking the leader for coordinated leader election. If the field is not specified, there is no active coordination for this lease. (Alpha) Using this field requires the CoordinatedLeaderElection feature gate to be enabled.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"preferredHolder": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PreferredHolder signals to a lease holder that the lease has a more optimal holder and should be given up. This field can only be set if Strategy is also set.",
+							Description: "preferredHolder signals to a lease holder that the lease has a more optimal holder and should be given up. This field can only be set if Strategy is also set.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -18798,7 +18798,7 @@ func schema_k8sio_api_coordination_v1alpha2_LeaseCandidate(ref common.ReferenceC
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Description: "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
 							Default:     map[string]interface{}{},
 							Ref:         ref(metav1.ObjectMeta{}.OpenAPIModelName()),
 						},
@@ -18878,7 +18878,7 @@ func schema_k8sio_api_coordination_v1alpha2_LeaseCandidateSpec(ref common.Refere
 				Properties: map[string]spec.Schema{
 					"leaseName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "LeaseName is the name of the lease for which this candidate is contending. This field is immutable.",
+							Description: "leaseName is the name of the lease for which this candidate is contending. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -18886,19 +18886,19 @@ func schema_k8sio_api_coordination_v1alpha2_LeaseCandidateSpec(ref common.Refere
 					},
 					"pingTime": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PingTime is the last time that the server has requested the LeaseCandidate to renew. It is only done during leader election to check if any LeaseCandidates have become ineligible. When PingTime is updated, the LeaseCandidate will respond by updating RenewTime.",
+							Description: "pingTime is the last time that the server has requested the LeaseCandidate to renew. It is only done during leader election to check if any LeaseCandidates have become ineligible. When PingTime is updated, the LeaseCandidate will respond by updating RenewTime.",
 							Ref:         ref(metav1.MicroTime{}.OpenAPIModelName()),
 						},
 					},
 					"renewTime": {
 						SchemaProps: spec.SchemaProps{
-							Description: "RenewTime is the time that the LeaseCandidate was last updated. Any time a Lease needs to do leader election, the PingTime field is updated to signal to the LeaseCandidate that they should update the RenewTime. Old LeaseCandidate objects are also garbage collected if it has been hours since the last renew. The PingTime field is updated regularly to prevent garbage collection for still active LeaseCandidates.",
+							Description: "renewTime is the time that the LeaseCandidate was last updated. Any time a Lease needs to do leader election, the PingTime field is updated to signal to the LeaseCandidate that they should update the RenewTime. Old LeaseCandidate objects are also garbage collected if it has been hours since the last renew. The PingTime field is updated regularly to prevent garbage collection for still active LeaseCandidates.",
 							Ref:         ref(metav1.MicroTime{}.OpenAPIModelName()),
 						},
 					},
 					"binaryVersion": {
 						SchemaProps: spec.SchemaProps{
-							Description: "BinaryVersion is the binary version. It must be in a semver format without leading `v`. This field is required.",
+							Description: "binaryVersion is the binary version. It must be in a semver format without leading `v`. This field is required.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -18906,14 +18906,14 @@ func schema_k8sio_api_coordination_v1alpha2_LeaseCandidateSpec(ref common.Refere
 					},
 					"emulationVersion": {
 						SchemaProps: spec.SchemaProps{
-							Description: "EmulationVersion is the emulation version. It must be in a semver format without leading `v`. EmulationVersion must be less than or equal to BinaryVersion. This field is required when strategy is \"OldestEmulationVersion\"",
+							Description: "emulationVersion is the emulation version. It must be in a semver format without leading `v`. EmulationVersion must be less than or equal to BinaryVersion. This field is required when strategy is \"OldestEmulationVersion\"",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"strategy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Strategy is the strategy that coordinated leader election will use for picking the leader. If multiple candidates for the same Lease return different strategies, the strategy provided by the candidate with the latest BinaryVersion will be used. If there is still conflict, this is a user error and coordinated leader election will not operate the Lease until resolved.",
+							Description: "strategy is the strategy that coordinated leader election will use for picking the leader. If multiple candidates for the same Lease return different strategies, the strategy provided by the candidate with the latest BinaryVersion will be used. If there is still conflict, this is a user error and coordinated leader election will not operate the Lease until resolved.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -18950,7 +18950,7 @@ func schema_k8sio_api_coordination_v1beta1_Lease(ref common.ReferenceCallback) c
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Description: "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
 							Default:     map[string]interface{}{},
 							Ref:         ref(metav1.ObjectMeta{}.OpenAPIModelName()),
 						},
@@ -18993,7 +18993,7 @@ func schema_k8sio_api_coordination_v1beta1_LeaseCandidate(ref common.ReferenceCa
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Description: "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
 							Default:     map[string]interface{}{},
 							Ref:         ref(metav1.ObjectMeta{}.OpenAPIModelName()),
 						},
@@ -19073,7 +19073,7 @@ func schema_k8sio_api_coordination_v1beta1_LeaseCandidateSpec(ref common.Referen
 				Properties: map[string]spec.Schema{
 					"leaseName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "LeaseName is the name of the lease for which this candidate is contending. The limits on this field are the same as on Lease.name. Multiple lease candidates may reference the same Lease.name. This field is immutable.",
+							Description: "leaseName is the name of the lease for which this candidate is contending. The limits on this field are the same as on Lease.name. Multiple lease candidates may reference the same Lease.name. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -19081,19 +19081,19 @@ func schema_k8sio_api_coordination_v1beta1_LeaseCandidateSpec(ref common.Referen
 					},
 					"pingTime": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PingTime is the last time that the server has requested the LeaseCandidate to renew. It is only done during leader election to check if any LeaseCandidates have become ineligible. When PingTime is updated, the LeaseCandidate will respond by updating RenewTime.",
+							Description: "pingTime is the last time that the server has requested the LeaseCandidate to renew. It is only done during leader election to check if any LeaseCandidates have become ineligible. When PingTime is updated, the LeaseCandidate will respond by updating RenewTime.",
 							Ref:         ref(metav1.MicroTime{}.OpenAPIModelName()),
 						},
 					},
 					"renewTime": {
 						SchemaProps: spec.SchemaProps{
-							Description: "RenewTime is the time that the LeaseCandidate was last updated. Any time a Lease needs to do leader election, the PingTime field is updated to signal to the LeaseCandidate that they should update the RenewTime. Old LeaseCandidate objects are also garbage collected if it has been hours since the last renew. The PingTime field is updated regularly to prevent garbage collection for still active LeaseCandidates.",
+							Description: "renewTime is the time that the LeaseCandidate was last updated. Any time a Lease needs to do leader election, the PingTime field is updated to signal to the LeaseCandidate that they should update the RenewTime. Old LeaseCandidate objects are also garbage collected if it has been hours since the last renew. The PingTime field is updated regularly to prevent garbage collection for still active LeaseCandidates.",
 							Ref:         ref(metav1.MicroTime{}.OpenAPIModelName()),
 						},
 					},
 					"binaryVersion": {
 						SchemaProps: spec.SchemaProps{
-							Description: "BinaryVersion is the binary version. It must be in a semver format without leading `v`. This field is required.",
+							Description: "binaryVersion is the binary version. It must be in a semver format without leading `v`. This field is required.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -19101,14 +19101,14 @@ func schema_k8sio_api_coordination_v1beta1_LeaseCandidateSpec(ref common.Referen
 					},
 					"emulationVersion": {
 						SchemaProps: spec.SchemaProps{
-							Description: "EmulationVersion is the emulation version. It must be in a semver format without leading `v`. EmulationVersion must be less than or equal to BinaryVersion. This field is required when strategy is \"OldestEmulationVersion\"",
+							Description: "emulationVersion is the emulation version. It must be in a semver format without leading `v`. EmulationVersion must be less than or equal to BinaryVersion. This field is required when strategy is \"OldestEmulationVersion\"",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"strategy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Strategy is the strategy that coordinated leader election will use for picking the leader. If multiple candidates for the same Lease return different strategies, the strategy provided by the candidate with the latest BinaryVersion will be used. If there is still conflict, this is a user error and coordinated leader election will not operate the Lease until resolved.",
+							Description: "strategy is the strategy that coordinated leader election will use for picking the leader. If multiple candidates for the same Lease return different strategies, the strategy provided by the candidate with the latest BinaryVersion will be used. If there is still conflict, this is a user error and coordinated leader election will not operate the Lease until resolved.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -19214,14 +19214,14 @@ func schema_k8sio_api_coordination_v1beta1_LeaseSpec(ref common.ReferenceCallbac
 					},
 					"strategy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Strategy indicates the strategy for picking the leader for coordinated leader election (Alpha) Using this field requires the CoordinatedLeaderElection feature gate to be enabled.",
+							Description: "strategy indicates the strategy for picking the leader for coordinated leader election (Alpha) Using this field requires the CoordinatedLeaderElection feature gate to be enabled.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"preferredHolder": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PreferredHolder signals to a lease holder that the lease has a more optimal holder and should be given up.",
+							Description: "preferredHolder signals to a lease holder that the lease has a more optimal holder and should be given up.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/staging/src/k8s.io/api/coordination/v1/generated.proto
+++ b/staging/src/k8s.io/api/coordination/v1/generated.proto
@@ -30,6 +30,7 @@ option go_package = "k8s.io/api/coordination/v1";
 
 // Lease defines a lease concept.
 message Lease {
+  // metadata is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
@@ -79,14 +80,14 @@ message LeaseSpec {
   // +optional
   optional int32 leaseTransitions = 5;
 
-  // Strategy indicates the strategy for picking the leader for coordinated leader election.
+  // strategy indicates the strategy for picking the leader for coordinated leader election.
   // If the field is not specified, there is no active coordination for this lease.
   // (Alpha) Using this field requires the CoordinatedLeaderElection feature gate to be enabled.
   // +featureGate=CoordinatedLeaderElection
   // +optional
   optional string strategy = 6;
 
-  // PreferredHolder signals to a lease holder that the lease has a
+  // preferredHolder signals to a lease holder that the lease has a
   // more optimal holder and should be given up.
   // This field can only be set if Strategy is also set.
   // +featureGate=CoordinatedLeaderElection

--- a/staging/src/k8s.io/api/coordination/v1/types.go
+++ b/staging/src/k8s.io/api/coordination/v1/types.go
@@ -39,6 +39,7 @@ const (
 // Lease defines a lease concept.
 type Lease struct {
 	metav1.TypeMeta `json:""`
+	// metadata is the standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
@@ -72,13 +73,13 @@ type LeaseSpec struct {
 	// holders.
 	// +optional
 	LeaseTransitions *int32 `json:"leaseTransitions,omitempty" protobuf:"varint,5,opt,name=leaseTransitions"`
-	// Strategy indicates the strategy for picking the leader for coordinated leader election.
+	// strategy indicates the strategy for picking the leader for coordinated leader election.
 	// If the field is not specified, there is no active coordination for this lease.
 	// (Alpha) Using this field requires the CoordinatedLeaderElection feature gate to be enabled.
 	// +featureGate=CoordinatedLeaderElection
 	// +optional
 	Strategy *CoordinatedLeaseStrategy `json:"strategy,omitempty" protobuf:"bytes,6,opt,name=strategy"`
-	// PreferredHolder signals to a lease holder that the lease has a
+	// preferredHolder signals to a lease holder that the lease has a
 	// more optimal holder and should be given up.
 	// This field can only be set if Strategy is also set.
 	// +featureGate=CoordinatedLeaderElection

--- a/staging/src/k8s.io/api/coordination/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/coordination/v1/types_swagger_doc_generated.go
@@ -29,7 +29,7 @@ package v1
 // AUTO-GENERATED FUNCTIONS START HERE. DO NOT EDIT.
 var map_Lease = map[string]string{
 	"":         "Lease defines a lease concept.",
-	"metadata": "More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+	"metadata": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
 	"spec":     "spec contains the specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
 }
 
@@ -54,8 +54,8 @@ var map_LeaseSpec = map[string]string{
 	"acquireTime":          "acquireTime is a time when the current lease was acquired.",
 	"renewTime":            "renewTime is a time when the current holder of a lease has last updated the lease.",
 	"leaseTransitions":     "leaseTransitions is the number of transitions of a lease between holders.",
-	"strategy":             "Strategy indicates the strategy for picking the leader for coordinated leader election. If the field is not specified, there is no active coordination for this lease. (Alpha) Using this field requires the CoordinatedLeaderElection feature gate to be enabled.",
-	"preferredHolder":      "PreferredHolder signals to a lease holder that the lease has a more optimal holder and should be given up. This field can only be set if Strategy is also set.",
+	"strategy":             "strategy indicates the strategy for picking the leader for coordinated leader election. If the field is not specified, there is no active coordination for this lease. (Alpha) Using this field requires the CoordinatedLeaderElection feature gate to be enabled.",
+	"preferredHolder":      "preferredHolder signals to a lease holder that the lease has a more optimal holder and should be given up. This field can only be set if Strategy is also set.",
 }
 
 func (LeaseSpec) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/coordination/v1alpha2/generated.proto
+++ b/staging/src/k8s.io/api/coordination/v1alpha2/generated.proto
@@ -32,6 +32,7 @@ option go_package = "k8s.io/api/coordination/v1alpha2";
 // LeaseCandidate defines a candidate for a Lease object.
 // Candidates are created such that coordinated leader election will pick the best leader from the list of candidates.
 message LeaseCandidate {
+  // metadata is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
@@ -55,19 +56,19 @@ message LeaseCandidateList {
 
 // LeaseCandidateSpec is a specification of a Lease.
 message LeaseCandidateSpec {
-  // LeaseName is the name of the lease for which this candidate is contending.
+  // leaseName is the name of the lease for which this candidate is contending.
   // This field is immutable.
   // +required
   optional string leaseName = 1;
 
-  // PingTime is the last time that the server has requested the LeaseCandidate
+  // pingTime is the last time that the server has requested the LeaseCandidate
   // to renew. It is only done during leader election to check if any
   // LeaseCandidates have become ineligible. When PingTime is updated, the
   // LeaseCandidate will respond by updating RenewTime.
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime pingTime = 2;
 
-  // RenewTime is the time that the LeaseCandidate was last updated.
+  // renewTime is the time that the LeaseCandidate was last updated.
   // Any time a Lease needs to do leader election, the PingTime field
   // is updated to signal to the LeaseCandidate that they should update
   // the RenewTime.
@@ -77,18 +78,18 @@ message LeaseCandidateSpec {
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime renewTime = 3;
 
-  // BinaryVersion is the binary version. It must be in a semver format without leading `v`.
+  // binaryVersion is the binary version. It must be in a semver format without leading `v`.
   // This field is required.
   // +required
   optional string binaryVersion = 4;
 
-  // EmulationVersion is the emulation version. It must be in a semver format without leading `v`.
+  // emulationVersion is the emulation version. It must be in a semver format without leading `v`.
   // EmulationVersion must be less than or equal to BinaryVersion.
   // This field is required when strategy is "OldestEmulationVersion"
   // +optional
   optional string emulationVersion = 5;
 
-  // Strategy is the strategy that coordinated leader election will use for picking the leader.
+  // strategy is the strategy that coordinated leader election will use for picking the leader.
   // If multiple candidates for the same Lease return different strategies, the strategy provided
   // by the candidate with the latest BinaryVersion will be used. If there is still conflict,
   // this is a user error and coordinated leader election will not operate the Lease until resolved.

--- a/staging/src/k8s.io/api/coordination/v1alpha2/types.go
+++ b/staging/src/k8s.io/api/coordination/v1alpha2/types.go
@@ -29,6 +29,7 @@ import (
 // Candidates are created such that coordinated leader election will pick the best leader from the list of candidates.
 type LeaseCandidate struct {
 	metav1.TypeMeta `json:""`
+	// metadata is the standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
@@ -41,17 +42,17 @@ type LeaseCandidate struct {
 
 // LeaseCandidateSpec is a specification of a Lease.
 type LeaseCandidateSpec struct {
-	// LeaseName is the name of the lease for which this candidate is contending.
+	// leaseName is the name of the lease for which this candidate is contending.
 	// This field is immutable.
 	// +required
 	LeaseName string `json:"leaseName" protobuf:"bytes,1,name=leaseName"`
-	// PingTime is the last time that the server has requested the LeaseCandidate
+	// pingTime is the last time that the server has requested the LeaseCandidate
 	// to renew. It is only done during leader election to check if any
 	// LeaseCandidates have become ineligible. When PingTime is updated, the
 	// LeaseCandidate will respond by updating RenewTime.
 	// +optional
 	PingTime *metav1.MicroTime `json:"pingTime,omitempty" protobuf:"bytes,2,opt,name=pingTime"`
-	// RenewTime is the time that the LeaseCandidate was last updated.
+	// renewTime is the time that the LeaseCandidate was last updated.
 	// Any time a Lease needs to do leader election, the PingTime field
 	// is updated to signal to the LeaseCandidate that they should update
 	// the RenewTime.
@@ -60,16 +61,16 @@ type LeaseCandidateSpec struct {
 	// garbage collection for still active LeaseCandidates.
 	// +optional
 	RenewTime *metav1.MicroTime `json:"renewTime,omitempty" protobuf:"bytes,3,opt,name=renewTime"`
-	// BinaryVersion is the binary version. It must be in a semver format without leading `v`.
+	// binaryVersion is the binary version. It must be in a semver format without leading `v`.
 	// This field is required.
 	// +required
 	BinaryVersion string `json:"binaryVersion" protobuf:"bytes,4,name=binaryVersion"`
-	// EmulationVersion is the emulation version. It must be in a semver format without leading `v`.
+	// emulationVersion is the emulation version. It must be in a semver format without leading `v`.
 	// EmulationVersion must be less than or equal to BinaryVersion.
 	// This field is required when strategy is "OldestEmulationVersion"
 	// +optional
 	EmulationVersion string `json:"emulationVersion,omitempty" protobuf:"bytes,5,opt,name=emulationVersion"`
-	// Strategy is the strategy that coordinated leader election will use for picking the leader.
+	// strategy is the strategy that coordinated leader election will use for picking the leader.
 	// If multiple candidates for the same Lease return different strategies, the strategy provided
 	// by the candidate with the latest BinaryVersion will be used. If there is still conflict,
 	// this is a user error and coordinated leader election will not operate the Lease until resolved.

--- a/staging/src/k8s.io/api/coordination/v1alpha2/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/coordination/v1alpha2/types_swagger_doc_generated.go
@@ -29,7 +29,7 @@ package v1alpha2
 // AUTO-GENERATED FUNCTIONS START HERE. DO NOT EDIT.
 var map_LeaseCandidate = map[string]string{
 	"":         "LeaseCandidate defines a candidate for a Lease object. Candidates are created such that coordinated leader election will pick the best leader from the list of candidates.",
-	"metadata": "More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+	"metadata": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
 	"spec":     "spec contains the specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
 }
 
@@ -49,12 +49,12 @@ func (LeaseCandidateList) SwaggerDoc() map[string]string {
 
 var map_LeaseCandidateSpec = map[string]string{
 	"":                 "LeaseCandidateSpec is a specification of a Lease.",
-	"leaseName":        "LeaseName is the name of the lease for which this candidate is contending. This field is immutable.",
-	"pingTime":         "PingTime is the last time that the server has requested the LeaseCandidate to renew. It is only done during leader election to check if any LeaseCandidates have become ineligible. When PingTime is updated, the LeaseCandidate will respond by updating RenewTime.",
-	"renewTime":        "RenewTime is the time that the LeaseCandidate was last updated. Any time a Lease needs to do leader election, the PingTime field is updated to signal to the LeaseCandidate that they should update the RenewTime. Old LeaseCandidate objects are also garbage collected if it has been hours since the last renew. The PingTime field is updated regularly to prevent garbage collection for still active LeaseCandidates.",
-	"binaryVersion":    "BinaryVersion is the binary version. It must be in a semver format without leading `v`. This field is required.",
-	"emulationVersion": "EmulationVersion is the emulation version. It must be in a semver format without leading `v`. EmulationVersion must be less than or equal to BinaryVersion. This field is required when strategy is \"OldestEmulationVersion\"",
-	"strategy":         "Strategy is the strategy that coordinated leader election will use for picking the leader. If multiple candidates for the same Lease return different strategies, the strategy provided by the candidate with the latest BinaryVersion will be used. If there is still conflict, this is a user error and coordinated leader election will not operate the Lease until resolved.",
+	"leaseName":        "leaseName is the name of the lease for which this candidate is contending. This field is immutable.",
+	"pingTime":         "pingTime is the last time that the server has requested the LeaseCandidate to renew. It is only done during leader election to check if any LeaseCandidates have become ineligible. When PingTime is updated, the LeaseCandidate will respond by updating RenewTime.",
+	"renewTime":        "renewTime is the time that the LeaseCandidate was last updated. Any time a Lease needs to do leader election, the PingTime field is updated to signal to the LeaseCandidate that they should update the RenewTime. Old LeaseCandidate objects are also garbage collected if it has been hours since the last renew. The PingTime field is updated regularly to prevent garbage collection for still active LeaseCandidates.",
+	"binaryVersion":    "binaryVersion is the binary version. It must be in a semver format without leading `v`. This field is required.",
+	"emulationVersion": "emulationVersion is the emulation version. It must be in a semver format without leading `v`. EmulationVersion must be less than or equal to BinaryVersion. This field is required when strategy is \"OldestEmulationVersion\"",
+	"strategy":         "strategy is the strategy that coordinated leader election will use for picking the leader. If multiple candidates for the same Lease return different strategies, the strategy provided by the candidate with the latest BinaryVersion will be used. If there is still conflict, this is a user error and coordinated leader election will not operate the Lease until resolved.",
 }
 
 func (LeaseCandidateSpec) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/coordination/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/coordination/v1beta1/generated.proto
@@ -31,6 +31,7 @@ option go_package = "k8s.io/api/coordination/v1beta1";
 
 // Lease defines a lease concept.
 message Lease {
+  // metadata is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
@@ -44,6 +45,7 @@ message Lease {
 // LeaseCandidate defines a candidate for a Lease object.
 // Candidates are created such that coordinated leader election will pick the best leader from the list of candidates.
 message LeaseCandidate {
+  // metadata is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
@@ -67,21 +69,21 @@ message LeaseCandidateList {
 
 // LeaseCandidateSpec is a specification of a Lease.
 message LeaseCandidateSpec {
-  // LeaseName is the name of the lease for which this candidate is contending.
+  // leaseName is the name of the lease for which this candidate is contending.
   // The limits on this field are the same as on Lease.name. Multiple lease candidates
   // may reference the same Lease.name.
   // This field is immutable.
   // +required
   optional string leaseName = 1;
 
-  // PingTime is the last time that the server has requested the LeaseCandidate
+  // pingTime is the last time that the server has requested the LeaseCandidate
   // to renew. It is only done during leader election to check if any
   // LeaseCandidates have become ineligible. When PingTime is updated, the
   // LeaseCandidate will respond by updating RenewTime.
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime pingTime = 2;
 
-  // RenewTime is the time that the LeaseCandidate was last updated.
+  // renewTime is the time that the LeaseCandidate was last updated.
   // Any time a Lease needs to do leader election, the PingTime field
   // is updated to signal to the LeaseCandidate that they should update
   // the RenewTime.
@@ -91,18 +93,18 @@ message LeaseCandidateSpec {
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime renewTime = 3;
 
-  // BinaryVersion is the binary version. It must be in a semver format without leading `v`.
+  // binaryVersion is the binary version. It must be in a semver format without leading `v`.
   // This field is required.
   // +required
   optional string binaryVersion = 4;
 
-  // EmulationVersion is the emulation version. It must be in a semver format without leading `v`.
+  // emulationVersion is the emulation version. It must be in a semver format without leading `v`.
   // EmulationVersion must be less than or equal to BinaryVersion.
   // This field is required when strategy is "OldestEmulationVersion"
   // +optional
   optional string emulationVersion = 5;
 
-  // Strategy is the strategy that coordinated leader election will use for picking the leader.
+  // strategy is the strategy that coordinated leader election will use for picking the leader.
   // If multiple candidates for the same Lease return different strategies, the strategy provided
   // by the candidate with the latest BinaryVersion will be used. If there is still conflict,
   // this is a user error and coordinated leader election will not operate the Lease until resolved.
@@ -149,13 +151,13 @@ message LeaseSpec {
   // +optional
   optional int32 leaseTransitions = 5;
 
-  // Strategy indicates the strategy for picking the leader for coordinated leader election
+  // strategy indicates the strategy for picking the leader for coordinated leader election
   // (Alpha) Using this field requires the CoordinatedLeaderElection feature gate to be enabled.
   // +featureGate=CoordinatedLeaderElection
   // +optional
   optional string strategy = 6;
 
-  // PreferredHolder signals to a lease holder that the lease has a
+  // preferredHolder signals to a lease holder that the lease has a
   // more optimal holder and should be given up.
   // +featureGate=CoordinatedLeaderElection
   // +optional

--- a/staging/src/k8s.io/api/coordination/v1beta1/types.go
+++ b/staging/src/k8s.io/api/coordination/v1beta1/types.go
@@ -30,6 +30,7 @@ import (
 // Lease defines a lease concept.
 type Lease struct {
 	metav1.TypeMeta `json:""`
+	// metadata is the standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
@@ -63,12 +64,12 @@ type LeaseSpec struct {
 	// holders.
 	// +optional
 	LeaseTransitions *int32 `json:"leaseTransitions,omitempty" protobuf:"varint,5,opt,name=leaseTransitions"`
-	// Strategy indicates the strategy for picking the leader for coordinated leader election
+	// strategy indicates the strategy for picking the leader for coordinated leader election
 	// (Alpha) Using this field requires the CoordinatedLeaderElection feature gate to be enabled.
 	// +featureGate=CoordinatedLeaderElection
 	// +optional
 	Strategy *v1.CoordinatedLeaseStrategy `json:"strategy,omitempty" protobuf:"bytes,6,opt,name=strategy"`
-	// PreferredHolder signals to a lease holder that the lease has a
+	// preferredHolder signals to a lease holder that the lease has a
 	// more optimal holder and should be given up.
 	// +featureGate=CoordinatedLeaderElection
 	// +optional
@@ -100,6 +101,7 @@ type LeaseList struct {
 // Candidates are created such that coordinated leader election will pick the best leader from the list of candidates.
 type LeaseCandidate struct {
 	metav1.TypeMeta `json:""`
+	// metadata is the standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
@@ -112,19 +114,19 @@ type LeaseCandidate struct {
 
 // LeaseCandidateSpec is a specification of a Lease.
 type LeaseCandidateSpec struct {
-	// LeaseName is the name of the lease for which this candidate is contending.
+	// leaseName is the name of the lease for which this candidate is contending.
 	// The limits on this field are the same as on Lease.name. Multiple lease candidates
 	// may reference the same Lease.name.
 	// This field is immutable.
 	// +required
 	LeaseName string `json:"leaseName" protobuf:"bytes,1,name=leaseName"`
-	// PingTime is the last time that the server has requested the LeaseCandidate
+	// pingTime is the last time that the server has requested the LeaseCandidate
 	// to renew. It is only done during leader election to check if any
 	// LeaseCandidates have become ineligible. When PingTime is updated, the
 	// LeaseCandidate will respond by updating RenewTime.
 	// +optional
 	PingTime *metav1.MicroTime `json:"pingTime,omitempty" protobuf:"bytes,2,opt,name=pingTime"`
-	// RenewTime is the time that the LeaseCandidate was last updated.
+	// renewTime is the time that the LeaseCandidate was last updated.
 	// Any time a Lease needs to do leader election, the PingTime field
 	// is updated to signal to the LeaseCandidate that they should update
 	// the RenewTime.
@@ -133,16 +135,16 @@ type LeaseCandidateSpec struct {
 	// garbage collection for still active LeaseCandidates.
 	// +optional
 	RenewTime *metav1.MicroTime `json:"renewTime,omitempty" protobuf:"bytes,3,opt,name=renewTime"`
-	// BinaryVersion is the binary version. It must be in a semver format without leading `v`.
+	// binaryVersion is the binary version. It must be in a semver format without leading `v`.
 	// This field is required.
 	// +required
 	BinaryVersion string `json:"binaryVersion" protobuf:"bytes,4,name=binaryVersion"`
-	// EmulationVersion is the emulation version. It must be in a semver format without leading `v`.
+	// emulationVersion is the emulation version. It must be in a semver format without leading `v`.
 	// EmulationVersion must be less than or equal to BinaryVersion.
 	// This field is required when strategy is "OldestEmulationVersion"
 	// +optional
 	EmulationVersion string `json:"emulationVersion,omitempty" protobuf:"bytes,5,opt,name=emulationVersion"`
-	// Strategy is the strategy that coordinated leader election will use for picking the leader.
+	// strategy is the strategy that coordinated leader election will use for picking the leader.
 	// If multiple candidates for the same Lease return different strategies, the strategy provided
 	// by the candidate with the latest BinaryVersion will be used. If there is still conflict,
 	// this is a user error and coordinated leader election will not operate the Lease until resolved.

--- a/staging/src/k8s.io/api/coordination/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/coordination/v1beta1/types_swagger_doc_generated.go
@@ -29,7 +29,7 @@ package v1beta1
 // AUTO-GENERATED FUNCTIONS START HERE. DO NOT EDIT.
 var map_Lease = map[string]string{
 	"":         "Lease defines a lease concept.",
-	"metadata": "More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+	"metadata": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
 	"spec":     "spec contains the specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
 }
 
@@ -39,7 +39,7 @@ func (Lease) SwaggerDoc() map[string]string {
 
 var map_LeaseCandidate = map[string]string{
 	"":         "LeaseCandidate defines a candidate for a Lease object. Candidates are created such that coordinated leader election will pick the best leader from the list of candidates.",
-	"metadata": "More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+	"metadata": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
 	"spec":     "spec contains the specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
 }
 
@@ -59,12 +59,12 @@ func (LeaseCandidateList) SwaggerDoc() map[string]string {
 
 var map_LeaseCandidateSpec = map[string]string{
 	"":                 "LeaseCandidateSpec is a specification of a Lease.",
-	"leaseName":        "LeaseName is the name of the lease for which this candidate is contending. The limits on this field are the same as on Lease.name. Multiple lease candidates may reference the same Lease.name. This field is immutable.",
-	"pingTime":         "PingTime is the last time that the server has requested the LeaseCandidate to renew. It is only done during leader election to check if any LeaseCandidates have become ineligible. When PingTime is updated, the LeaseCandidate will respond by updating RenewTime.",
-	"renewTime":        "RenewTime is the time that the LeaseCandidate was last updated. Any time a Lease needs to do leader election, the PingTime field is updated to signal to the LeaseCandidate that they should update the RenewTime. Old LeaseCandidate objects are also garbage collected if it has been hours since the last renew. The PingTime field is updated regularly to prevent garbage collection for still active LeaseCandidates.",
-	"binaryVersion":    "BinaryVersion is the binary version. It must be in a semver format without leading `v`. This field is required.",
-	"emulationVersion": "EmulationVersion is the emulation version. It must be in a semver format without leading `v`. EmulationVersion must be less than or equal to BinaryVersion. This field is required when strategy is \"OldestEmulationVersion\"",
-	"strategy":         "Strategy is the strategy that coordinated leader election will use for picking the leader. If multiple candidates for the same Lease return different strategies, the strategy provided by the candidate with the latest BinaryVersion will be used. If there is still conflict, this is a user error and coordinated leader election will not operate the Lease until resolved.",
+	"leaseName":        "leaseName is the name of the lease for which this candidate is contending. The limits on this field are the same as on Lease.name. Multiple lease candidates may reference the same Lease.name. This field is immutable.",
+	"pingTime":         "pingTime is the last time that the server has requested the LeaseCandidate to renew. It is only done during leader election to check if any LeaseCandidates have become ineligible. When PingTime is updated, the LeaseCandidate will respond by updating RenewTime.",
+	"renewTime":        "renewTime is the time that the LeaseCandidate was last updated. Any time a Lease needs to do leader election, the PingTime field is updated to signal to the LeaseCandidate that they should update the RenewTime. Old LeaseCandidate objects are also garbage collected if it has been hours since the last renew. The PingTime field is updated regularly to prevent garbage collection for still active LeaseCandidates.",
+	"binaryVersion":    "binaryVersion is the binary version. It must be in a semver format without leading `v`. This field is required.",
+	"emulationVersion": "emulationVersion is the emulation version. It must be in a semver format without leading `v`. EmulationVersion must be less than or equal to BinaryVersion. This field is required when strategy is \"OldestEmulationVersion\"",
+	"strategy":         "strategy is the strategy that coordinated leader election will use for picking the leader. If multiple candidates for the same Lease return different strategies, the strategy provided by the candidate with the latest BinaryVersion will be used. If there is still conflict, this is a user error and coordinated leader election will not operate the Lease until resolved.",
 }
 
 func (LeaseCandidateSpec) SwaggerDoc() map[string]string {
@@ -88,8 +88,8 @@ var map_LeaseSpec = map[string]string{
 	"acquireTime":          "acquireTime is a time when the current lease was acquired.",
 	"renewTime":            "renewTime is a time when the current holder of a lease has last updated the lease.",
 	"leaseTransitions":     "leaseTransitions is the number of transitions of a lease between holders.",
-	"strategy":             "Strategy indicates the strategy for picking the leader for coordinated leader election (Alpha) Using this field requires the CoordinatedLeaderElection feature gate to be enabled.",
-	"preferredHolder":      "PreferredHolder signals to a lease holder that the lease has a more optimal holder and should be given up.",
+	"strategy":             "strategy indicates the strategy for picking the leader for coordinated leader election (Alpha) Using this field requires the CoordinatedLeaderElection feature gate to be enabled.",
+	"preferredHolder":      "preferredHolder signals to a lease holder that the lease has a more optimal holder and should be given up.",
 }
 
 func (LeaseSpec) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1/lease.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1/lease.go
@@ -33,6 +33,7 @@ import (
 // Lease defines a lease concept.
 type LeaseApplyConfiguration struct {
 	metav1.TypeMetaApplyConfiguration `json:""`
+	// metadata is the standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	*metav1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
 	// spec contains the specification of the Lease.

--- a/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1/leasespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1/leasespec.go
@@ -44,11 +44,11 @@ type LeaseSpecApplyConfiguration struct {
 	// leaseTransitions is the number of transitions of a lease between
 	// holders.
 	LeaseTransitions *int32 `json:"leaseTransitions,omitempty"`
-	// Strategy indicates the strategy for picking the leader for coordinated leader election.
+	// strategy indicates the strategy for picking the leader for coordinated leader election.
 	// If the field is not specified, there is no active coordination for this lease.
 	// (Alpha) Using this field requires the CoordinatedLeaderElection feature gate to be enabled.
 	Strategy *coordinationv1.CoordinatedLeaseStrategy `json:"strategy,omitempty"`
-	// PreferredHolder signals to a lease holder that the lease has a
+	// preferredHolder signals to a lease holder that the lease has a
 	// more optimal holder and should be given up.
 	// This field can only be set if Strategy is also set.
 	PreferredHolder *string `json:"preferredHolder,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1alpha2/leasecandidate.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1alpha2/leasecandidate.go
@@ -34,6 +34,7 @@ import (
 // Candidates are created such that coordinated leader election will pick the best leader from the list of candidates.
 type LeaseCandidateApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration `json:""`
+	// metadata is the standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
 	// spec contains the specification of the Lease.

--- a/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1alpha2/leasecandidatespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1alpha2/leasecandidatespec.go
@@ -28,15 +28,15 @@ import (
 //
 // LeaseCandidateSpec is a specification of a Lease.
 type LeaseCandidateSpecApplyConfiguration struct {
-	// LeaseName is the name of the lease for which this candidate is contending.
+	// leaseName is the name of the lease for which this candidate is contending.
 	// This field is immutable.
 	LeaseName *string `json:"leaseName,omitempty"`
-	// PingTime is the last time that the server has requested the LeaseCandidate
+	// pingTime is the last time that the server has requested the LeaseCandidate
 	// to renew. It is only done during leader election to check if any
 	// LeaseCandidates have become ineligible. When PingTime is updated, the
 	// LeaseCandidate will respond by updating RenewTime.
 	PingTime *v1.MicroTime `json:"pingTime,omitempty"`
-	// RenewTime is the time that the LeaseCandidate was last updated.
+	// renewTime is the time that the LeaseCandidate was last updated.
 	// Any time a Lease needs to do leader election, the PingTime field
 	// is updated to signal to the LeaseCandidate that they should update
 	// the RenewTime.
@@ -44,14 +44,14 @@ type LeaseCandidateSpecApplyConfiguration struct {
 	// since the last renew. The PingTime field is updated regularly to prevent
 	// garbage collection for still active LeaseCandidates.
 	RenewTime *v1.MicroTime `json:"renewTime,omitempty"`
-	// BinaryVersion is the binary version. It must be in a semver format without leading `v`.
+	// binaryVersion is the binary version. It must be in a semver format without leading `v`.
 	// This field is required.
 	BinaryVersion *string `json:"binaryVersion,omitempty"`
-	// EmulationVersion is the emulation version. It must be in a semver format without leading `v`.
+	// emulationVersion is the emulation version. It must be in a semver format without leading `v`.
 	// EmulationVersion must be less than or equal to BinaryVersion.
 	// This field is required when strategy is "OldestEmulationVersion"
 	EmulationVersion *string `json:"emulationVersion,omitempty"`
-	// Strategy is the strategy that coordinated leader election will use for picking the leader.
+	// strategy is the strategy that coordinated leader election will use for picking the leader.
 	// If multiple candidates for the same Lease return different strategies, the strategy provided
 	// by the candidate with the latest BinaryVersion will be used. If there is still conflict,
 	// this is a user error and coordinated leader election will not operate the Lease until resolved.

--- a/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1beta1/lease.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1beta1/lease.go
@@ -33,6 +33,7 @@ import (
 // Lease defines a lease concept.
 type LeaseApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration `json:""`
+	// metadata is the standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
 	// spec contains the specification of the Lease.

--- a/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1beta1/leasecandidate.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1beta1/leasecandidate.go
@@ -34,6 +34,7 @@ import (
 // Candidates are created such that coordinated leader election will pick the best leader from the list of candidates.
 type LeaseCandidateApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration `json:""`
+	// metadata is the standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
 	// spec contains the specification of the Lease.

--- a/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1beta1/leasecandidatespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1beta1/leasecandidatespec.go
@@ -28,17 +28,17 @@ import (
 //
 // LeaseCandidateSpec is a specification of a Lease.
 type LeaseCandidateSpecApplyConfiguration struct {
-	// LeaseName is the name of the lease for which this candidate is contending.
+	// leaseName is the name of the lease for which this candidate is contending.
 	// The limits on this field are the same as on Lease.name. Multiple lease candidates
 	// may reference the same Lease.name.
 	// This field is immutable.
 	LeaseName *string `json:"leaseName,omitempty"`
-	// PingTime is the last time that the server has requested the LeaseCandidate
+	// pingTime is the last time that the server has requested the LeaseCandidate
 	// to renew. It is only done during leader election to check if any
 	// LeaseCandidates have become ineligible. When PingTime is updated, the
 	// LeaseCandidate will respond by updating RenewTime.
 	PingTime *v1.MicroTime `json:"pingTime,omitempty"`
-	// RenewTime is the time that the LeaseCandidate was last updated.
+	// renewTime is the time that the LeaseCandidate was last updated.
 	// Any time a Lease needs to do leader election, the PingTime field
 	// is updated to signal to the LeaseCandidate that they should update
 	// the RenewTime.
@@ -46,14 +46,14 @@ type LeaseCandidateSpecApplyConfiguration struct {
 	// since the last renew. The PingTime field is updated regularly to prevent
 	// garbage collection for still active LeaseCandidates.
 	RenewTime *v1.MicroTime `json:"renewTime,omitempty"`
-	// BinaryVersion is the binary version. It must be in a semver format without leading `v`.
+	// binaryVersion is the binary version. It must be in a semver format without leading `v`.
 	// This field is required.
 	BinaryVersion *string `json:"binaryVersion,omitempty"`
-	// EmulationVersion is the emulation version. It must be in a semver format without leading `v`.
+	// emulationVersion is the emulation version. It must be in a semver format without leading `v`.
 	// EmulationVersion must be less than or equal to BinaryVersion.
 	// This field is required when strategy is "OldestEmulationVersion"
 	EmulationVersion *string `json:"emulationVersion,omitempty"`
-	// Strategy is the strategy that coordinated leader election will use for picking the leader.
+	// strategy is the strategy that coordinated leader election will use for picking the leader.
 	// If multiple candidates for the same Lease return different strategies, the strategy provided
 	// by the candidate with the latest BinaryVersion will be used. If there is still conflict,
 	// this is a user error and coordinated leader election will not operate the Lease until resolved.

--- a/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1beta1/leasespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1beta1/leasespec.go
@@ -44,10 +44,10 @@ type LeaseSpecApplyConfiguration struct {
 	// leaseTransitions is the number of transitions of a lease between
 	// holders.
 	LeaseTransitions *int32 `json:"leaseTransitions,omitempty"`
-	// Strategy indicates the strategy for picking the leader for coordinated leader election
+	// strategy indicates the strategy for picking the leader for coordinated leader election
 	// (Alpha) Using this field requires the CoordinatedLeaderElection feature gate to be enabled.
 	Strategy *coordinationv1.CoordinatedLeaseStrategy `json:"strategy,omitempty"`
-	// PreferredHolder signals to a lease holder that the lease has a
+	// preferredHolder signals to a lease holder that the lease has a
 	// more optimal holder and should be given up.
 	PreferredHolder *string `json:"preferredHolder,omitempty"`
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Enables the `commentstart` api-linter rule for the `coordination` API group. The PR fixes 20 pre-existing godoc commentstart violations in:
- `staging/src/k8s.io/api/coordination/v1/types.go`
- `staging/src/k8s.io/api/coordination/v1alpha2/types.go`
- `staging/src/k8s.io/api/coordination/v1beta1/types.go`

Specifically, it updates field comments to start with their serialized field name (e.g. `strategy`, `preferredHolder`, `leaseName`, `pingTime`, `renewTime`, `binaryVersion`, `emulationVersion`), prepends `metadata` to the ObjectMeta comments, and removes the `coordination` package from the list of exempted paths in `hack/kube-api-linter/exceptions.yaml`. 

Finally, all swagger docs, protobufs, openapi files, and applyconfigurations have been regenerated.

#### Which issue(s) this PR is related to:
None.

#### Special notes for your reviewer:
None.

#### Does this PR introduce a user-facing change?
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
None.
