### PR TITLE
storagemigration: enable commentstart kube-api-linter rule

### DIFF
--- a/api/openapi-spec/v3/apis__storagemigration.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__storagemigration.k8s.io__v1_openapi.json
@@ -19,7 +19,7 @@
               }
             ],
             "default": {},
-            "description": "Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+            "description": "metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
           },
           "spec": {
             "allOf": [
@@ -28,7 +28,7 @@
               }
             ],
             "default": {},
-            "description": "Specification of the migration."
+            "description": "spec is the specification of the migration."
           },
           "status": {
             "allOf": [
@@ -37,7 +37,7 @@
               }
             ],
             "default": {},
-            "description": "Status of the migration."
+            "description": "status is the status of the migration."
           }
         },
         "type": "object",
@@ -99,7 +99,7 @@
               }
             ],
             "default": {},
-            "description": "The resource that is being migrated. The migrator sends requests to the endpoint serving the resource. Immutable."
+            "description": "resource is the resource that is being migrated. The migrator sends requests to the endpoint serving the resource. Immutable."
           }
         },
         "required": [
@@ -111,7 +111,7 @@
         "description": "Status of the storage version migration.",
         "properties": {
           "conditions": {
-            "description": "The latest available observations of the migration's current state.",
+            "description": "conditions is the latest available observations of the migration's current state.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
             },
@@ -124,7 +124,7 @@
             "x-kubernetes-patch-strategy": "merge"
           },
           "resourceVersion": {
-            "description": "ResourceVersion to compare with the GC cache for performing the migration. This is the current resource version of given group, version and resource when kube-controller-manager first observes this StorageVersionMigration resource.",
+            "description": "resourceVersion to compare with the GC cache for performing the migration. This is the current resource version of given group, version and resource when kube-controller-manager first observes this StorageVersionMigration resource.",
             "type": "string"
           }
         },

--- a/api/openapi-spec/v3/apis__storagemigration.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__storagemigration.k8s.io__v1beta1_openapi.json
@@ -19,7 +19,7 @@
               }
             ],
             "default": {},
-            "description": "Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+            "description": "metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
           },
           "spec": {
             "allOf": [
@@ -28,7 +28,7 @@
               }
             ],
             "default": {},
-            "description": "Specification of the migration."
+            "description": "spec is the specification of the migration."
           },
           "status": {
             "allOf": [
@@ -37,7 +37,7 @@
               }
             ],
             "default": {},
-            "description": "Status of the migration."
+            "description": "status is the status of the migration."
           }
         },
         "type": "object",
@@ -99,7 +99,7 @@
               }
             ],
             "default": {},
-            "description": "The resource that is being migrated. The migrator sends requests to the endpoint serving the resource. Immutable."
+            "description": "resource is the resource that is being migrated. The migrator sends requests to the endpoint serving the resource. Immutable."
           }
         },
         "required": [
@@ -111,7 +111,7 @@
         "description": "Status of the storage version migration.",
         "properties": {
           "conditions": {
-            "description": "The latest available observations of the migration's current state.",
+            "description": "conditions is the latest available observations of the migration's current state.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
             },
@@ -124,7 +124,7 @@
             "x-kubernetes-patch-strategy": "merge"
           },
           "resourceVersion": {
-            "description": "ResourceVersion to compare with the GC cache for performing the migration. This is the current resource version of given group, version and resource when kube-controller-manager first observes this StorageVersionMigration resource.",
+            "description": "resourceVersion to compare with the GC cache for performing the migration. This is the current resource version of given group, version and resource when kube-controller-manager first observes this StorageVersionMigration resource.",
             "type": "string"
           }
         },

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -147,7 +147,7 @@ linters:
       # Commentstart - Ignore commentstart issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "godoc for field .* should start with '.* ...'"
-        path: "staging/src/k8s.io/api/(apps|batch|certificates|core|extensions|flowcontrol|resource|storagemigration)"
+        path: "staging/src/k8s.io/api/(apps|batch|certificates|core|extensions|flowcontrol|resource)"
       
       # notimestamp: Legacy 'Timestamp' fields retained for backward compatibility
       - text: 'notimestamp: naming convention "notimestamp": field TokenRequestStatus.ExpirationTimestamp: prefer use of the term ''time'' over ''timestamp'''

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -162,7 +162,7 @@ linters:
       # Commentstart - Ignore commentstart issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "godoc for field .* should start with '.* ...'"
-        path: "staging/src/k8s.io/api/(apps|batch|certificates|core|extensions|flowcontrol|resource|storagemigration)"
+        path: "staging/src/k8s.io/api/(apps|batch|certificates|core|extensions|flowcontrol|resource)"
       
       # notimestamp: Legacy 'Timestamp' fields retained for backward compatibility
       - text: 'notimestamp: naming convention "notimestamp": field TokenRequestStatus.ExpirationTimestamp: prefer use of the term ''time'' over ''timestamp'''

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -23,7 +23,7 @@
 # Commentstart - Ignore commentstart issues for existing API group
 # TODO: For each existing API group, we aim to remove it over time.
 - text: "godoc for field .* should start with '.* ...'"
-  path: "staging/src/k8s.io/api/(apps|batch|certificates|core|extensions|flowcontrol|resource|storagemigration)"
+  path: "staging/src/k8s.io/api/(apps|batch|certificates|core|extensions|flowcontrol|resource)"
 
 # notimestamp: Legacy 'Timestamp' fields retained for backward compatibility
 - text: 'notimestamp: naming convention "notimestamp": field TokenRequestStatus.ExpirationTimestamp: prefer use of the term ''time'' over ''timestamp'''

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -62508,21 +62508,21 @@ func schema_k8sio_api_storagemigration_v1_StorageVersionMigration(ref common.Ref
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Description: "metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
 							Default:     map[string]interface{}{},
 							Ref:         ref(metav1.ObjectMeta{}.OpenAPIModelName()),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Specification of the migration.",
+							Description: "spec is the specification of the migration.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(storagemigrationv1.StorageVersionMigrationSpec{}.OpenAPIModelName()),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Status of the migration.",
+							Description: "status is the status of the migration.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(storagemigrationv1.StorageVersionMigrationStatus{}.OpenAPIModelName()),
 						},
@@ -62594,7 +62594,7 @@ func schema_k8sio_api_storagemigration_v1_StorageVersionMigrationSpec(ref common
 				Properties: map[string]spec.Schema{
 					"resource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The resource that is being migrated. The migrator sends requests to the endpoint serving the resource. Immutable.",
+							Description: "resource is the resource that is being migrated. The migrator sends requests to the endpoint serving the resource. Immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(metav1.GroupResource{}.OpenAPIModelName()),
 						},
@@ -62627,7 +62627,7 @@ func schema_k8sio_api_storagemigration_v1_StorageVersionMigrationStatus(ref comm
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "The latest available observations of the migration's current state.",
+							Description: "conditions is the latest available observations of the migration's current state.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -62640,7 +62640,7 @@ func schema_k8sio_api_storagemigration_v1_StorageVersionMigrationStatus(ref comm
 					},
 					"resourceVersion": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ResourceVersion to compare with the GC cache for performing the migration. This is the current resource version of given group, version and resource when kube-controller-manager first observes this StorageVersionMigration resource.",
+							Description: "resourceVersion to compare with the GC cache for performing the migration. This is the current resource version of given group, version and resource when kube-controller-manager first observes this StorageVersionMigration resource.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -62676,21 +62676,21 @@ func schema_k8sio_api_storagemigration_v1beta1_StorageVersionMigration(ref commo
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Description: "metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
 							Default:     map[string]interface{}{},
 							Ref:         ref(metav1.ObjectMeta{}.OpenAPIModelName()),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Specification of the migration.",
+							Description: "spec is the specification of the migration.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(storagemigrationv1beta1.StorageVersionMigrationSpec{}.OpenAPIModelName()),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Status of the migration.",
+							Description: "status is the status of the migration.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(storagemigrationv1beta1.StorageVersionMigrationStatus{}.OpenAPIModelName()),
 						},
@@ -62762,7 +62762,7 @@ func schema_k8sio_api_storagemigration_v1beta1_StorageVersionMigrationSpec(ref c
 				Properties: map[string]spec.Schema{
 					"resource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The resource that is being migrated. The migrator sends requests to the endpoint serving the resource. Immutable.",
+							Description: "resource is the resource that is being migrated. The migrator sends requests to the endpoint serving the resource. Immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(metav1.GroupResource{}.OpenAPIModelName()),
 						},
@@ -62795,7 +62795,7 @@ func schema_k8sio_api_storagemigration_v1beta1_StorageVersionMigrationStatus(ref
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "The latest available observations of the migration's current state.",
+							Description: "conditions is the latest available observations of the migration's current state.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -62808,7 +62808,7 @@ func schema_k8sio_api_storagemigration_v1beta1_StorageVersionMigrationStatus(ref
 					},
 					"resourceVersion": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ResourceVersion to compare with the GC cache for performing the migration. This is the current resource version of given group, version and resource when kube-controller-manager first observes this StorageVersionMigration resource.",
+							Description: "resourceVersion to compare with the GC cache for performing the migration. This is the current resource version of given group, version and resource when kube-controller-manager first observes this StorageVersionMigration resource.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/staging/src/k8s.io/api/storagemigration/v1/generated.proto
+++ b/staging/src/k8s.io/api/storagemigration/v1/generated.proto
@@ -32,16 +32,16 @@ option go_package = "k8s.io/api/storagemigration/v1";
 // storage version.
 // +k8s:supportsSubresource="/status"
 message StorageVersionMigration {
-  // Standard object metadata.
+  // metadata is the standard object metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // Specification of the migration.
+  // spec is the specification of the migration.
   // +optional
   optional StorageVersionMigrationSpec spec = 2;
 
-  // Status of the migration.
+  // status is the status of the migration.
   // +optional
   optional StorageVersionMigrationStatus status = 3;
 }
@@ -59,7 +59,7 @@ message StorageVersionMigrationList {
 
 // Spec of the storage version migration.
 message StorageVersionMigrationSpec {
-  // The resource that is being migrated. The migrator sends requests to
+  // resource is the resource that is being migrated. The migrator sends requests to
   // the endpoint serving the resource.
   // Immutable.
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupResource resource = 1;
@@ -67,7 +67,7 @@ message StorageVersionMigrationSpec {
 
 // Status of the storage version migration.
 message StorageVersionMigrationStatus {
-  // The latest available observations of the migration's current state.
+  // conditions is the latest available observations of the migration's current state.
   // +patchMergeKey=type
   // +patchStrategy=merge
   // +listType=map
@@ -78,7 +78,7 @@ message StorageVersionMigrationStatus {
   // +k8s:alpha(since: "1.37")=+k8s:listMapKey=type
   repeated .k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 1;
 
-  // ResourceVersion to compare with the GC cache for performing the migration.
+  // resourceVersion to compare with the GC cache for performing the migration.
   // This is the current resource version of given group, version and resource when
   // kube-controller-manager first observes this StorageVersionMigration resource.
   optional string resourceVersion = 2;

--- a/staging/src/k8s.io/api/storagemigration/v1/types.go
+++ b/staging/src/k8s.io/api/storagemigration/v1/types.go
@@ -30,21 +30,21 @@ import (
 // +k8s:supportsSubresource="/status"
 type StorageVersionMigration struct {
 	metav1.TypeMeta `json:""`
-	// Standard object metadata.
+	// metadata is the standard object metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-	// Specification of the migration.
+	// spec is the specification of the migration.
 	// +optional
 	Spec StorageVersionMigrationSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
-	// Status of the migration.
+	// status is the status of the migration.
 	// +optional
 	Status StorageVersionMigrationStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
 // Spec of the storage version migration.
 type StorageVersionMigrationSpec struct {
-	// The resource that is being migrated. The migrator sends requests to
+	// resource is the resource that is being migrated. The migrator sends requests to
 	// the endpoint serving the resource.
 	// Immutable.
 	Resource metav1.GroupResource `json:"resource" protobuf:"bytes,1,opt,name=resource"`
@@ -63,7 +63,7 @@ const (
 
 // Status of the storage version migration.
 type StorageVersionMigrationStatus struct {
-	// The latest available observations of the migration's current state.
+	// conditions is the latest available observations of the migration's current state.
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	// +listType=map
@@ -73,7 +73,7 @@ type StorageVersionMigrationStatus struct {
 	// +k8s:alpha(since: "1.37")=+k8s:listType=map
 	// +k8s:alpha(since: "1.37")=+k8s:listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
-	// ResourceVersion to compare with the GC cache for performing the migration.
+	// resourceVersion to compare with the GC cache for performing the migration.
 	// This is the current resource version of given group, version and resource when
 	// kube-controller-manager first observes this StorageVersionMigration resource.
 	ResourceVersion string `json:"resourceVersion,omitempty" protobuf:"bytes,2,opt,name=resourceVersion"`

--- a/staging/src/k8s.io/api/storagemigration/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/storagemigration/v1/types_swagger_doc_generated.go
@@ -29,9 +29,9 @@ package v1
 // AUTO-GENERATED FUNCTIONS START HERE. DO NOT EDIT.
 var map_StorageVersionMigration = map[string]string{
 	"":         "StorageVersionMigration represents a migration of stored data to the latest storage version.",
-	"metadata": "Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
-	"spec":     "Specification of the migration.",
-	"status":   "Status of the migration.",
+	"metadata": "metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+	"spec":     "spec is the specification of the migration.",
+	"status":   "status is the status of the migration.",
 }
 
 func (StorageVersionMigration) SwaggerDoc() map[string]string {
@@ -50,7 +50,7 @@ func (StorageVersionMigrationList) SwaggerDoc() map[string]string {
 
 var map_StorageVersionMigrationSpec = map[string]string{
 	"":         "Spec of the storage version migration.",
-	"resource": "The resource that is being migrated. The migrator sends requests to the endpoint serving the resource. Immutable.",
+	"resource": "resource is the resource that is being migrated. The migrator sends requests to the endpoint serving the resource. Immutable.",
 }
 
 func (StorageVersionMigrationSpec) SwaggerDoc() map[string]string {
@@ -59,8 +59,8 @@ func (StorageVersionMigrationSpec) SwaggerDoc() map[string]string {
 
 var map_StorageVersionMigrationStatus = map[string]string{
 	"":                "Status of the storage version migration.",
-	"conditions":      "The latest available observations of the migration's current state.",
-	"resourceVersion": "ResourceVersion to compare with the GC cache for performing the migration. This is the current resource version of given group, version and resource when kube-controller-manager first observes this StorageVersionMigration resource.",
+	"conditions":      "conditions is the latest available observations of the migration's current state.",
+	"resourceVersion": "resourceVersion to compare with the GC cache for performing the migration. This is the current resource version of given group, version and resource when kube-controller-manager first observes this StorageVersionMigration resource.",
 }
 
 func (StorageVersionMigrationStatus) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/storagemigration/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/storagemigration/v1beta1/generated.proto
@@ -32,16 +32,16 @@ option go_package = "k8s.io/api/storagemigration/v1beta1";
 // storage version.
 // +k8s:supportsSubresource="/status"
 message StorageVersionMigration {
-  // Standard object metadata.
+  // metadata is the standard object metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // Specification of the migration.
+  // spec is the specification of the migration.
   // +optional
   optional StorageVersionMigrationSpec spec = 2;
 
-  // Status of the migration.
+  // status is the status of the migration.
   // +optional
   optional StorageVersionMigrationStatus status = 3;
 }
@@ -59,7 +59,7 @@ message StorageVersionMigrationList {
 
 // Spec of the storage version migration.
 message StorageVersionMigrationSpec {
-  // The resource that is being migrated. The migrator sends requests to
+  // resource is the resource that is being migrated. The migrator sends requests to
   // the endpoint serving the resource.
   // Immutable.
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupResource resource = 1;
@@ -67,7 +67,7 @@ message StorageVersionMigrationSpec {
 
 // Status of the storage version migration.
 message StorageVersionMigrationStatus {
-  // The latest available observations of the migration's current state.
+  // conditions is the latest available observations of the migration's current state.
   // +patchMergeKey=type
   // +patchStrategy=merge
   // +listType=map
@@ -78,7 +78,7 @@ message StorageVersionMigrationStatus {
   // +k8s:alpha(since: "1.37")=+k8s:listMapKey=type
   repeated .k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 1;
 
-  // ResourceVersion to compare with the GC cache for performing the migration.
+  // resourceVersion to compare with the GC cache for performing the migration.
   // This is the current resource version of given group, version and resource when
   // kube-controller-manager first observes this StorageVersionMigration resource.
   optional string resourceVersion = 2;

--- a/staging/src/k8s.io/api/storagemigration/v1beta1/types.go
+++ b/staging/src/k8s.io/api/storagemigration/v1beta1/types.go
@@ -32,21 +32,21 @@ import (
 // +k8s:supportsSubresource="/status"
 type StorageVersionMigration struct {
 	metav1.TypeMeta `json:""`
-	// Standard object metadata.
+	// metadata is the standard object metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-	// Specification of the migration.
+	// spec is the specification of the migration.
 	// +optional
 	Spec StorageVersionMigrationSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
-	// Status of the migration.
+	// status is the status of the migration.
 	// +optional
 	Status StorageVersionMigrationStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
 // Spec of the storage version migration.
 type StorageVersionMigrationSpec struct {
-	// The resource that is being migrated. The migrator sends requests to
+	// resource is the resource that is being migrated. The migrator sends requests to
 	// the endpoint serving the resource.
 	// Immutable.
 	Resource metav1.GroupResource `json:"resource" protobuf:"bytes,1,opt,name=resource"`
@@ -65,7 +65,7 @@ const (
 
 // Status of the storage version migration.
 type StorageVersionMigrationStatus struct {
-	// The latest available observations of the migration's current state.
+	// conditions is the latest available observations of the migration's current state.
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	// +listType=map
@@ -75,7 +75,7 @@ type StorageVersionMigrationStatus struct {
 	// +k8s:alpha(since: "1.37")=+k8s:listType=map
 	// +k8s:alpha(since: "1.37")=+k8s:listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
-	// ResourceVersion to compare with the GC cache for performing the migration.
+	// resourceVersion to compare with the GC cache for performing the migration.
 	// This is the current resource version of given group, version and resource when
 	// kube-controller-manager first observes this StorageVersionMigration resource.
 	ResourceVersion string `json:"resourceVersion,omitempty" protobuf:"bytes,2,opt,name=resourceVersion"`

--- a/staging/src/k8s.io/api/storagemigration/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/storagemigration/v1beta1/types_swagger_doc_generated.go
@@ -29,9 +29,9 @@ package v1beta1
 // AUTO-GENERATED FUNCTIONS START HERE. DO NOT EDIT.
 var map_StorageVersionMigration = map[string]string{
 	"":         "StorageVersionMigration represents a migration of stored data to the latest storage version.",
-	"metadata": "Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
-	"spec":     "Specification of the migration.",
-	"status":   "Status of the migration.",
+	"metadata": "metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+	"spec":     "spec is the specification of the migration.",
+	"status":   "status is the status of the migration.",
 }
 
 func (StorageVersionMigration) SwaggerDoc() map[string]string {
@@ -50,7 +50,7 @@ func (StorageVersionMigrationList) SwaggerDoc() map[string]string {
 
 var map_StorageVersionMigrationSpec = map[string]string{
 	"":         "Spec of the storage version migration.",
-	"resource": "The resource that is being migrated. The migrator sends requests to the endpoint serving the resource. Immutable.",
+	"resource": "resource is the resource that is being migrated. The migrator sends requests to the endpoint serving the resource. Immutable.",
 }
 
 func (StorageVersionMigrationSpec) SwaggerDoc() map[string]string {
@@ -59,8 +59,8 @@ func (StorageVersionMigrationSpec) SwaggerDoc() map[string]string {
 
 var map_StorageVersionMigrationStatus = map[string]string{
 	"":                "Status of the storage version migration.",
-	"conditions":      "The latest available observations of the migration's current state.",
-	"resourceVersion": "ResourceVersion to compare with the GC cache for performing the migration. This is the current resource version of given group, version and resource when kube-controller-manager first observes this StorageVersionMigration resource.",
+	"conditions":      "conditions is the latest available observations of the migration's current state.",
+	"resourceVersion": "resourceVersion to compare with the GC cache for performing the migration. This is the current resource version of given group, version and resource when kube-controller-manager first observes this StorageVersionMigration resource.",
 }
 
 func (StorageVersionMigrationStatus) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1/storageversionmigration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1/storageversionmigration.go
@@ -34,12 +34,12 @@ import (
 // storage version.
 type StorageVersionMigrationApplyConfiguration struct {
 	metav1.TypeMetaApplyConfiguration `json:""`
-	// Standard object metadata.
+	// metadata is the standard object metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	*metav1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	// Specification of the migration.
+	// spec is the specification of the migration.
 	Spec *StorageVersionMigrationSpecApplyConfiguration `json:"spec,omitempty"`
-	// Status of the migration.
+	// status is the status of the migration.
 	Status *StorageVersionMigrationStatusApplyConfiguration `json:"status,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1/storageversionmigrationspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1/storageversionmigrationspec.go
@@ -27,7 +27,7 @@ import (
 //
 // Spec of the storage version migration.
 type StorageVersionMigrationSpecApplyConfiguration struct {
-	// The resource that is being migrated. The migrator sends requests to
+	// resource is the resource that is being migrated. The migrator sends requests to
 	// the endpoint serving the resource.
 	// Immutable.
 	Resource *metav1.GroupResourceApplyConfiguration `json:"resource,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1/storageversionmigrationstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1/storageversionmigrationstatus.go
@@ -27,9 +27,9 @@ import (
 //
 // Status of the storage version migration.
 type StorageVersionMigrationStatusApplyConfiguration struct {
-	// The latest available observations of the migration's current state.
+	// conditions is the latest available observations of the migration's current state.
 	Conditions []metav1.ConditionApplyConfiguration `json:"conditions,omitempty"`
-	// ResourceVersion to compare with the GC cache for performing the migration.
+	// resourceVersion to compare with the GC cache for performing the migration.
 	// This is the current resource version of given group, version and resource when
 	// kube-controller-manager first observes this StorageVersionMigration resource.
 	ResourceVersion *string `json:"resourceVersion,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1beta1/storageversionmigration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1beta1/storageversionmigration.go
@@ -34,12 +34,12 @@ import (
 // storage version.
 type StorageVersionMigrationApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration `json:""`
-	// Standard object metadata.
+	// metadata is the standard object metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	// Specification of the migration.
+	// spec is the specification of the migration.
 	Spec *StorageVersionMigrationSpecApplyConfiguration `json:"spec,omitempty"`
-	// Status of the migration.
+	// status is the status of the migration.
 	Status *StorageVersionMigrationStatusApplyConfiguration `json:"status,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1beta1/storageversionmigrationspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1beta1/storageversionmigrationspec.go
@@ -27,7 +27,7 @@ import (
 //
 // Spec of the storage version migration.
 type StorageVersionMigrationSpecApplyConfiguration struct {
-	// The resource that is being migrated. The migrator sends requests to
+	// resource is the resource that is being migrated. The migrator sends requests to
 	// the endpoint serving the resource.
 	// Immutable.
 	Resource *v1.GroupResourceApplyConfiguration `json:"resource,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1beta1/storageversionmigrationstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1beta1/storageversionmigrationstatus.go
@@ -27,9 +27,9 @@ import (
 //
 // Status of the storage version migration.
 type StorageVersionMigrationStatusApplyConfiguration struct {
-	// The latest available observations of the migration's current state.
+	// conditions is the latest available observations of the migration's current state.
 	Conditions []v1.ConditionApplyConfiguration `json:"conditions,omitempty"`
-	// ResourceVersion to compare with the GC cache for performing the migration.
+	// resourceVersion to compare with the GC cache for performing the migration.
 	// This is the current resource version of given group, version and resource when
 	// kube-controller-manager first observes this StorageVersionMigration resource.
 	ResourceVersion *string `json:"resourceVersion,omitempty"`


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Enables the `commentstart` api-linter rule for the `storagemigration` API group. The PR fixes 12 pre-existing godoc commentstart violations in:
- `staging/src/k8s.io/api/storagemigration/v1/types.go`
- `staging/src/k8s.io/api/storagemigration/v1beta1/types.go`

Specifically, it updates field comments to start with their serialized field name (e.g. `metadata`, `spec`, `status`, `resource`, `conditions`, `resourceVersion`) and removes the `storagemigration` package from the list of exempted paths in `hack/kube-api-linter/exceptions.yaml`. 

Finally, all swagger docs, protobufs, openapi files, and applyconfigurations have been regenerated.

#### Which issue(s) this PR is related to:
None.

#### Special notes for your reviewer:
None.

#### Does this PR introduce a user-facing change?
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
None.
