### PR TITLE
apimachinery: document +listType=map / +listMapKey=uid limitation on OwnerReferences

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
@@ -95,6 +95,23 @@ func validateOwnerReference(ownerReference metav1.OwnerReference, fldPath *field
 }
 
 // ValidateOwnerReferences validates that a set of owner references are correctly defined.
+//
+// Note on +listType=map / +listMapKey=uid: ObjectMeta.OwnerReferences carries
+// those markers, which in theory means each entry must be uniquely keyed by
+// its uid field. In practice two things prevent us from enforcing that as a
+// hard validation error today:
+//
+//  1. The OwnerReference struct itself is annotated +structType=atomic, which
+//     is semantically incompatible with acting as an SSA map-key element.
+//     Enforcing map-key uniqueness requires the list element to be a struct
+//     type, not an atomic one.
+//
+//  2. Kubernetes does not currently reject objects with duplicate UIDs in
+//     ownerReferences; adding such a check retroactively would break existing
+//     persisted objects that violate the constraint.
+//
+// Until both of these issues are resolved, uid-uniqueness in ownerReferences
+// remains documented but unenforced. See https://github.com/kubernetes/kubernetes/issues/140503.
 func ValidateOwnerReferences(ownerReferences []metav1.OwnerReference, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	firstControllerName := ""

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -268,6 +268,14 @@ type ObjectMeta struct {
 	// +listType=map
 	// +listMapKey=uid
 	// +k8s:alpha(since:"1.37")=+k8s:optional
+	//
+	// Note: although +listType=map / +listMapKey=uid are declared here (and
+	// respected by server-side apply for merge semantics), uid-uniqueness is
+	// NOT currently enforced as a hard validation error.  The OwnerReference
+	// struct carries +structType=atomic, which conflicts with its role as an
+	// SSA map-key element; resolving this without breaking existing objects
+	// requires a careful migration.  See
+	// https://github.com/kubernetes/kubernetes/issues/140503 for tracking.
 	OwnerReferences []OwnerReference `json:"ownerReferences,omitempty" patchStrategy:"merge" patchMergeKey:"uid" protobuf:"bytes,13,rep,name=ownerReferences"`
 
 	// Must be empty before the object is deleted from the registry. Each entry


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it:**

`ObjectMeta.OwnerReferences` in `types.go` carries the following markers:

```
// +listType=map
// +listMapKey=uid
```

These markers are used by server-side apply for three-way merge semantics and
imply that entries in the list should be uniquely keyed by their `uid` field.
However, no handwritten or declarative validation currently enforces this
uid-uniqueness constraint, and there was no documentation explaining why.

This PR resolves **action item 3** from issue #140503:

> "if they should remain unenforced, add appropriate comments/documentation
> explaining this limitation."

**Root cause of the gap (why enforcement is deferred):**

Two structural problems block enforcement today:

1. `OwnerReference` carries `+structType=atomic`. Server-side apply treats
   atomic structs as opaque blobs; they cannot serve as SSA map-key elements.
   Enforcing uid-uniqueness on an atomic-struct list requires first resolving
   this type annotation conflict.

2. Kubernetes does not currently reject objects that have duplicate UIDs in
   `ownerReferences`. Adding such a validation check retroactively would be a
   breaking change for existing objects in production clusters.

**Changes:**

- `staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go`: added an
  explanatory comment on the `OwnerReferences` field documenting the known gap
  and linking the tracking issue.
- `staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go`: expanded
  the godoc on `ValidateOwnerReferences` with a numbered rationale and a
  reference to the tracking issue.

No behaviour is changed. No generated files are modified.

**Which issue(s) this PR fixes:**

Fixes #140503

**Special notes for your reviewer:**

This is the safe, non-breaking resolution of the issue. A follow-up PR can
tackle actual uid-uniqueness enforcement once the `+structType=atomic` conflict
on `OwnerReference` is addressed and a migration plan is agreed upon.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```
