### PR TITLE
DRA: avoid divide-by-zero validating a validRange.step above MaxInt64

### DIFF
--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -1194,11 +1194,18 @@ func validateRequestPolicyRange(defaultValue apiresource.Quantity, maxCapacity a
 
 func validateRequestPolicyRangeStep(value, min, step apiresource.Quantity, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
-	stepVal := step.Value()
-	minVal := min.Value()
-	val := value.Value()
-	added := (val - minVal)
-	if added%stepVal != 0 {
+	// A positive step (the caller checks Sign() > 0) can still exceed
+	// math.MaxInt64, in which case Value() truncates it: a multiple of 2^64
+	// truncates to 0. Handle that with an exact comparison so the int64 modulo
+	// never divides by zero. Such a step evenly divides only when value equals
+	// min (reachable with zero steps); any smaller difference is not a multiple.
+	var notMultiple bool
+	if stepVal := step.Value(); stepVal == 0 {
+		notMultiple = value.Cmp(min) != 0
+	} else {
+		notMultiple = (value.Value()-min.Value())%stepVal != 0
+	}
+	if notMultiple {
 		allErrs = append(allErrs, field.Invalid(fldPath, value.String(), fmt.Sprintf("value is not a multiple of a given step (%s) from (%s)", step.String(), min.String())))
 	}
 	return allErrs

--- a/pkg/apis/resource/validation/validation_device_capacity_test.go
+++ b/pkg/apis/resource/validation/validation_device_capacity_test.go
@@ -181,3 +181,25 @@ func TestValidateDeviceCapacity(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateRequestPolicyRangeStepLargeStep covers a positive validRange.step
+// that exceeds math.MaxInt64 (a multiple of 2^64), whose Value() truncates to 0.
+// The int64 modulo used to divide by zero and panic, bypassing the Sign() guard
+// from #139698. It must report a plain validation error instead.
+func TestValidateRequestPolicyRangeStepLargeStep(t *testing.T) {
+	step := apiresource.MustParse("18446744073709551616") // 2^64
+	if step.Sign() <= 0 || step.Value() != 0 {
+		t.Fatalf("precondition: 2^64 should have Sign()>0 and Value()==0, got Sign()=%d Value()=%d", step.Sign(), step.Value())
+	}
+	min := apiresource.MustParse("1")
+	stepPath := field.NewPath("step")
+
+	// value != min cannot be reached by such a step: expect one error, no panic.
+	if errs := validateRequestPolicyRangeStep(apiresource.MustParse("2"), min, step, stepPath); len(errs) != 1 {
+		t.Errorf("value != min with a 2^64 step: want 1 error, got %v", errs)
+	}
+	// value == min is valid (reachable with zero steps): expect no error, no panic.
+	if errs := validateRequestPolicyRangeStep(min, min, step, stepPath); len(errs) != 0 {
+		t.Errorf("value == min with a 2^64 step: want no error, got %v", errs)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node

#### What this PR does / why we need it:

`validateRequestPolicyRangeStep` divided by `step.Value()`, which truncates a positive step larger than `math.MaxInt64` (a multiple of 2^64) to zero, so a ResourceSlice with such a `capacity.requestPolicy.validRange.step` panicked with `integer divide by zero` during validation. That bypassed the `Sign()` guard added in #139698, which is exact while `Value()` is not.

When the step does not fit in int64, this compares `value` and `min` exactly instead: such a step evenly divides only when `value` equals `min`, so any other value is not a multiple. The sibling capacity check just above it already uses exact `Cmp`, so this keeps the same approach and needs no new imports.

The added regression test panics without the fix.

#### Which issue(s) this PR fixes:

Fixes #140472

#### Does this PR introduce a user-facing change?

```release-note
Fixed a panic (integer divide by zero) when validating a ResourceSlice whose capacity requestPolicy validRange.step is larger than int64 (a multiple of 2^64).
```
