### PR TITLE
Use NNN from pod group preemption for all pods from pod group

### DIFF
--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -557,10 +557,6 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 			continue
 		}
 		if podResult.status.IsSuccess() {
-			nominatingInfo := &fwk.NominatingInfo{
-				NominatingMode:    fwk.ModeOverride,
-				NominatedNodeName: podResult.scheduleResult.SuggestedHost,
-			}
 			switch {
 			case podGroupResult.status.IsSuccess():
 				// Disable pod group scheduling in cycle state before binding.
@@ -578,7 +574,7 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 			case podGroupResult.status.IsRejected():
 				if podGroupResult.waitingOnPreemption {
 					// Pod has to come back to the scheduling queue as unschedulable, waiting for preemption to complete.
-					sched.FailureHandler(ctx, schedFwk, pInfo, podGroupResult.status, nominatingInfo, podSchedulingStart)
+					sched.FailureHandler(ctx, schedFwk, pInfo, podGroupResult.status, podResult.scheduleResult.nominatingInfo, podSchedulingStart)
 				} else {
 					// Pod group is unschedulable, so the pod has to be marked as unschedulable.
 					// Its rejection status is set to the pod group's status message.

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -1293,7 +1293,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 		existingPodGroup        *schedulingv1alpha3.PodGroup
 		algorithmResult         podGroupAlgorithmResult
 		expectBound             sets.Set[string]
-		expectPreempting        sets.Set[string]
+		expectPreempting        map[string]string
 		expectFailed            sets.Set[string]
 		expectCondition         *metav1.Condition
 		expectPodsInActiveQueue sets.Set[string]
@@ -1395,7 +1395,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 					requiresPreemption: true,
 				}},
 			},
-			expectPreempting: sets.New("p1", "p2", "p3"),
+			expectPreempting: map[string]string{"p1": "node1", "p2": "node1", "p3": "node1"},
 			expectCondition: &metav1.Condition{
 				Type:    schedulingapi.PodGroupInitiallyScheduled,
 				Status:  metav1.ConditionFalse,
@@ -1416,14 +1416,14 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 					status:             fwk.NewStatus(fwk.Unschedulable),
 					requiresPreemption: true,
 				}, {
-					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
+					scheduleResult: ScheduleResult{SuggestedHost: "node1", nominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride}},
 					status:         nil,
 				}, {
-					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
+					scheduleResult: ScheduleResult{SuggestedHost: "node1", nominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride}},
 					status:         nil,
 				}},
 			},
-			expectPreempting: sets.New("p1", "p2", "p3"),
+			expectPreempting: map[string]string{"p1": "node1", "p2": "node1", "p3": "node1"},
 			expectCondition: &metav1.Condition{
 				Type:    schedulingapi.PodGroupInitiallyScheduled,
 				Status:  metav1.ConditionFalse,
@@ -1447,11 +1447,11 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 					scheduleResult: ScheduleResult{SuggestedHost: "", nominatingInfo: clearNominatedNode},
 					status:         fwk.NewStatus(fwk.Unschedulable),
 				}, {
-					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
+					scheduleResult: ScheduleResult{SuggestedHost: "node1", nominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride}},
 					status:         nil,
 				}},
 			},
-			expectPreempting: sets.New("p1", "p3"),
+			expectPreempting: map[string]string{"p1": "node1", "p3": "node1"},
 			expectFailed:     sets.New("p2"),
 			expectCondition: &metav1.Condition{
 				Type:    schedulingapi.PodGroupInitiallyScheduled,
@@ -1684,6 +1684,36 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			},
 		},
 		{
+			// If:
+			// - PodGroup failed scheduling
+			// - some pods were successfully evaluated
+			// - pod group preemption successfully found placement
+			// The scheduler should use the nominating info from preemption instead of suggested host from evaluation.
+			name: "PodGroup waiting on preemption uses nominating info instead of suggested host for successfully evaluated pods",
+			algorithmResult: podGroupAlgorithmResult{
+				status:              fwk.NewStatus(fwk.Unschedulable, "waiting on preemption"),
+				waitingOnPreemption: true,
+				podResults: []algorithmResult{{
+					scheduleResult: ScheduleResult{SuggestedHost: "node1", nominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node2", NominatingMode: fwk.ModeOverride}},
+					status:         nil,
+				}, {
+					scheduleResult: ScheduleResult{SuggestedHost: "", nominatingInfo: clearNominatedNode},
+					status:         fwk.NewStatus(fwk.Unschedulable),
+				}, {
+					scheduleResult: ScheduleResult{SuggestedHost: "", nominatingInfo: clearNominatedNode},
+					status:         fwk.NewStatus(fwk.Unschedulable),
+				}},
+			},
+			expectPreempting: map[string]string{"p1": "node2"},
+			expectFailed:     sets.New("p2", "p3"),
+			expectCondition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupInitiallyScheduled,
+				Status:  metav1.ConditionFalse,
+				Reason:  schedulingapi.PodGroupReasonUnschedulable,
+				Message: "waiting on preemption",
+			},
+		},
+		{
 			name: "Different number of pods in result and queue, should fail all queue pods",
 			algorithmResult: podGroupAlgorithmResult{
 				status: fwk.NewStatus(fwk.Error),
@@ -1708,7 +1738,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 
 			var lock sync.Mutex
 			boundPods := sets.New[string]()
-			preemptingPods := sets.New[string]()
+			preemptingPods := make(map[string]string)
 			failedPods := sets.New[string]()
 
 			pg := testPodGroup
@@ -1770,7 +1800,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 				FailureHandler: func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *fwk.NominatingInfo, start time.Time) {
 					lock.Lock()
 					if ni != nil && ni.NominatedNodeName != "" {
-						preemptingPods.Insert(p.Pod.Name)
+						preemptingPods[p.Pod.Name] = ni.NominatedNodeName
 					} else {
 						failedPods.Insert(p.Pod.Name)
 					}
@@ -1818,8 +1848,8 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			if !tt.expectBound.Equal(boundPods) {
 				t.Errorf("Expected bound pods: %v, but got: %v", tt.expectBound, boundPods)
 			}
-			if !tt.expectPreempting.Equal(preemptingPods) {
-				t.Errorf("Expected preempting pods: %v, but got: %v", tt.expectPreempting, preemptingPods)
+			if diff := cmp.Diff(tt.expectPreempting, preemptingPods, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Unexpected preempting pods (-want, +got):\n%s", diff)
 			}
 			if !tt.expectFailed.Equal(failedPods) {
 				t.Errorf("Expected failed pods: %v, but got: %v", tt.expectFailed, failedPods)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Right now, when a Pod evaluated successfully during the pod group cycle, but the PodGroup still failed, we set NNN from the suggested host instead of from the pod group preemption. 

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fixed a case where Pods from PodGroup that evaluated successfully during the pod group cycle that eventually failed would have NNN set from this evaluation instead of from Pod Group preemption.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
