### PR TITLE
Fix CEL map-list merge of duplicate new keys

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
@@ -1385,6 +1385,11 @@ func TestListAdd(t *testing.T) {
 			expression: "(x.mapList + [{'key1': 'k1v9', 'key2': 'k2v9', 'value': 9}])[2].value == 9",
 		}, skipSchemaless: true},
 		{testCase: testCase{
+			name:       "map list + literal list merges duplicate new keys",
+			expression: "size(x.mapList + [{'key1': 'k1v9', 'key2': 'k2v9', 'value': 9}, {'key1': 'k1v9', 'key2': 'k2v9', 'value': 10}]) == 3 && (x.mapList + [{'key1': 'k1v9', 'key2': 'k2v9', 'value': 9}, {'key1': 'k1v9', 'key2': 'k2v9', 'value': 10}])[2].value == 10",
+		}, // skipUnstructured: unstructuredMapList.Add cannot compute merge keys for CEL literal elements.
+			skipSchemaless: true, skipUnstructured: true},
+		{testCase: testCase{
 			name:       "chained map list merge",
 			expression: "(x.mapList + y.mapList + [{'key1': 'k1v3', 'key2': 'k2v3', 'value': 33}])[2].value == 33",
 		}, skipSchemaless: true},

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
@@ -1352,6 +1352,11 @@ func TestListAdd(t *testing.T) {
 		}, // skipUnstructured: unstructuredMapList.Add cannot compute merge keys for CEL literal elements.
 			skipSchemaless: true, skipUnstructured: true},
 		{testCase: testCase{
+			name:       "map list + literal list merges duplicate new keys",
+			expression: "size(x.mapList + [{'key1': 'k1v9', 'key2': 'k2v9', 'value': 9}, {'key1': 'k1v9', 'key2': 'k2v9', 'value': 10}]) == 3 && (x.mapList + [{'key1': 'k1v9', 'key2': 'k2v9', 'value': 9}, {'key1': 'k1v9', 'key2': 'k2v9', 'value': 10}])[2].value == 10",
+		}, // skipUnstructured: unstructuredMapList.Add cannot compute merge keys for CEL literal elements.
+			skipSchemaless: true, skipUnstructured: true},
+		{testCase: testCase{
 			name:       "chained map list merge",
 			expression: "(x.mapList + y.mapList + [{'key1': 'k1v3', 'key2': 'k2v3', 'value': 33}])[2].value == 33",
 		}, // skipUnstructured: unstructuredMapList.Add cannot compute merge keys for CEL literal elements.

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
@@ -529,6 +529,7 @@ func addToMapList(elements []ref.Val, other traits.Lister, escapedKeyProps []str
 			elements[overwritePosition] = v
 		} else {
 			elements = append(elements, v)
+			keyToIdx[k] = len(elements) - 1
 		}
 	}
 	return &refValMapList{

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
@@ -531,6 +531,7 @@ func addToMapList(elements []ref.Val, other traits.Lister, escapedKeyProps []str
 			elements[overwritePosition] = v
 		} else {
 			elements = append(elements, v)
+			keyToIdx[k] = len(elements) - 1
 		}
 	}
 	return &refValMapList{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

Updates the map-list key index whenever concatenation appends a new key from the right operand. If that operand contains the same new key again, the later element now overwrites the earlier one in place instead of creating a duplicate.

This preserves the merge-by-key semantics added for schema-aware CEL concatenation results in #140292.

Adds a regression case covering duplicate new keys in a literal right operand.

#### Which issue(s) this PR is related to:

Fixes #140591

#### Special notes for your reviewer:

Tested with:

```console
GOWORK=off go test ./pkg/cel/common -count=1
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
