### PR TITLE
Fix: make volume binding delay deterministic

### DIFF
--- a/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"sync"
 	"testing"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
@@ -1981,7 +1983,9 @@ func TestBindPodVolumes(t *testing.T) {
 			initPVs:  []*v1.PersistentVolume{pvNode1a},
 			initPVCs: []*v1.PersistentVolumeClaim{unboundPVC},
 			delayFunc: func(t *testing.T, ctx context.Context, testEnv *testEnv, pod *v1.Pod, pvs []*v1.PersistentVolume, pvcs []*v1.PersistentVolumeClaim) {
-				testEnv.client.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+				if err := testEnv.internalPodInformer.Informer().GetIndexer().Delete(pod); err != nil {
+					t.Errorf("failed to delete pod %q: %v", pod.Name, err)
+				}
 			},
 			shouldFail: true,
 		},
@@ -2078,9 +2082,22 @@ func TestBindPodVolumes(t *testing.T) {
 		}
 
 		if scenario.delayFunc != nil {
+			apiUpdateDone := make(chan struct{})
+			var apiUpdateDoneOnce sync.Once
+			testEnv.client.(*fake.Clientset).PrependReactor("update", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				handled, ret, err := testEnv.reactor.React(ctx, action)
+				if err == nil && (action.Matches("update", "persistentvolumes") || action.Matches("update", "persistentvolumeclaims")) {
+					apiUpdateDoneOnce.Do(func() { close(apiUpdateDone) })
+				}
+				return handled, ret, err
+			})
+
 			go func(scenario scenarioType) {
-				time.Sleep(5 * time.Second)
-				// Sleep a while to run after bindAPIUpdate in BindPodVolumes
+				select {
+				case <-apiUpdateDone:
+				case <-ctx.Done():
+					return
+				}
 				logger.V(5).Info("Running delay function")
 				scenario.delayFunc(t, ctx, testEnv, pod, scenario.initPVs, scenario.initPVCs)
 			}(scenario)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
 /kind flake

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Makes `TestBindPodVolumes` deterministic by replacing a fixed `time.Sleep(5 * time.Second)` delay with synchronization on the fake API update performed by `BindPodVolumes`.

  The previous test relied on wall-clock timing: it slept for 5 seconds, then simulated PV controller updates, while `BindPodVolumes` polled informer-backed caches with a 10 second
  timeout. Under `-race` and CI load, the fake watch/informer path could fail to observe the PVC update before the deadline, causing flakes.

  This also updates the pod deletion scenario to remove the pod from the pod informer cache directly, matching what `checkBindings` actually reads.

#### Which issue(s) this PR is related to:
N/A
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

Observed in `ci-kubernetes-unit`:
  https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-unit/2077184771565293568

  Tested with:

  ```bash
  go test -race ./pkg/scheduler/framework/plugins/volumebinding -run '^TestBindPodVolumes$' -count=20 -v
  go test -race ./pkg/scheduler/framework/plugins/volumebinding -run '^TestBindPodVolumes$' -count=1
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
