### PR TITLE
kubelet: reject pod on PV nodeAffinity mismatch (KEP-5381)

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2234,12 +2234,6 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 			recordAdmissionRejection(rejectErr.Reason)
 			return true, nil, nil
 		}
-		var volumeAttachLimitErr *volumemanager.VolumeAttachLimitExceededError
-		if errors.As(err, &volumeAttachLimitErr) {
-			kl.rejectPod(ctx, pod, volumemanager.VolumeAttachmentLimitExceededReason, volumeAttachLimitErr.Error())
-			recordAdmissionRejection(volumemanager.VolumeAttachmentLimitExceededReason)
-			return true, nil, nil
-		}
 		if !wait.Interrupted(err) {
 			kl.recorder.WithLogger(logger).Eventf(pod, v1.EventTypeWarning, events.FailedMountVolume, "Unable to attach or mount volumes: %v", err)
 			logger.Error(err, "Unable to attach or mount volumes for pod; skipping pod", "pod", klog.KObj(pod))

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -267,6 +267,7 @@ var (
 		topologymanager.ErrorTopologyAffinity,
 		nodeshutdown.NodeShutdownNotAdmittedReason,
 		volumemanager.VolumeAttachmentLimitExceededReason,
+		volumemanager.VolumeNodeAffinityReason,
 	)
 
 	// This is exposed for unit tests.
@@ -2228,6 +2229,11 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 
 	// Wait for volumes to attach/mount
 	if err := kl.volumeManager.WaitForAttachAndMount(ctx, pod); err != nil {
+		if rejectErr, ok := errors.AsType[*volumemanager.RejectingPodError](err); ok {
+			kl.rejectPod(ctx, pod, rejectErr.Reason, rejectErr.Error())
+			recordAdmissionRejection(rejectErr.Reason)
+			return true, nil, nil
+		}
 		var volumeAttachLimitErr *volumemanager.VolumeAttachLimitExceededError
 		if errors.As(err, &volumeAttachLimitErr) {
 			kl.rejectPod(ctx, pod, volumemanager.VolumeAttachmentLimitExceededReason, volumeAttachLimitErr.Error())

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -3905,6 +3905,15 @@ func TestRecordAdmissionRejection(t *testing.T) {
 			`,
 		},
 		{
+			name:   "VolumeNodeAffinity",
+			reason: kubeletvolume.VolumeNodeAffinityReason,
+			wants: `
+				# HELP kubelet_admission_rejections_total [ALPHA] Cumulative number pod admission rejections by the Kubelet.
+				# TYPE kubelet_admission_rejections_total counter
+				kubelet_admission_rejections_total{reason="VolumeNodeAffinity"} 1
+			`,
+		},
+		{
 			name:   "PodOSSelectorNodeLabelDoesNotMatch",
 			reason: lifecycle.PodOSSelectorNodeLabelDoesNotMatch,
 			wants: `

--- a/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
@@ -712,7 +712,7 @@ func Test_Run_Positive_VolumeAttachAndMap(t *testing.T) {
 	seLinuxTranslator := util.NewFakeSELinuxLabelTranslator()
 	dsw := cache.NewDesiredStateOfWorld(volumePluginMgr, seLinuxTranslator)
 	asw := cache.NewActualStateOfWorld(nodeName, volumePluginMgr)
-	kubeClient := createtestClientWithPVPVC(gcepv, gcepvc)
+	kubeClient := createTestClientWithPVPVC(gcepv, gcepvc)
 	fakeRecorder := &record.FakeRecorder{}
 	fakeHandler := volumetesting.NewBlockVolumePathHandler()
 	oex := operationexecutor.NewOperationExecutor(operationexecutor.NewOperationGenerator(
@@ -826,7 +826,7 @@ func Test_Run_Positive_BlockVolumeMapControllerAttachEnabled(t *testing.T) {
 	seLinuxTranslator := util.NewFakeSELinuxLabelTranslator()
 	dsw := cache.NewDesiredStateOfWorld(volumePluginMgr, seLinuxTranslator)
 	asw := cache.NewActualStateOfWorld(nodeName, volumePluginMgr)
-	kubeClient := createtestClientWithPVPVC(gcepv, gcepvc, v1.AttachedVolume{
+	kubeClient := createTestClientWithPVPVC(gcepv, gcepvc, v1.AttachedVolume{
 		Name:       "fake-plugin/fake-device1",
 		DevicePath: "/fake/path",
 	})
@@ -928,7 +928,7 @@ func Test_Run_Positive_BlockVolumeAttachMapUnmapDetach(t *testing.T) {
 	seLinuxTranslator := util.NewFakeSELinuxLabelTranslator()
 	dsw := cache.NewDesiredStateOfWorld(volumePluginMgr, seLinuxTranslator)
 	asw := cache.NewActualStateOfWorld(nodeName, volumePluginMgr)
-	kubeClient := createtestClientWithPVPVC(gcepv, gcepvc)
+	kubeClient := createTestClientWithPVPVC(gcepv, gcepvc)
 	fakeRecorder := &record.FakeRecorder{}
 	fakeHandler := volumetesting.NewBlockVolumePathHandler()
 	oex := operationexecutor.NewOperationExecutor(operationexecutor.NewOperationGenerator(
@@ -1051,7 +1051,7 @@ func Test_Run_Positive_VolumeUnmapControllerAttachEnabled(t *testing.T) {
 	seLinuxTranslator := util.NewFakeSELinuxLabelTranslator()
 	dsw := cache.NewDesiredStateOfWorld(volumePluginMgr, seLinuxTranslator)
 	asw := cache.NewActualStateOfWorld(nodeName, volumePluginMgr)
-	kubeClient := createtestClientWithPVPVC(gcepv, gcepvc, v1.AttachedVolume{
+	kubeClient := createTestClientWithPVPVC(gcepv, gcepvc, v1.AttachedVolume{
 		Name:       "fake-plugin/fake-device1",
 		DevicePath: "/fake/path",
 	})
@@ -1332,7 +1332,7 @@ func Test_Run_Positive_VolumeFSResizeControllerAttachEnabled(t *testing.T) {
 			seLinuxTranslator := util.NewFakeSELinuxLabelTranslator()
 			dsw := cache.NewDesiredStateOfWorld(volumePluginMgr, seLinuxTranslator)
 			asw := cache.NewActualStateOfWorld(nodeName, volumePluginMgr)
-			kubeClient := createtestClientWithPVPVC(pv, pvc, v1.AttachedVolume{
+			kubeClient := createTestClientWithPVPVC(pv, pvc, v1.AttachedVolume{
 				Name:       v1.UniqueVolumeName(fmt.Sprintf("fake-plugin/%s", tc.pvName)),
 				DevicePath: "fake/path",
 			})
@@ -1593,7 +1593,7 @@ func Test_UncertainDeviceGlobalMounts(t *testing.T) {
 
 				dsw := cache.NewDesiredStateOfWorld(volumePluginMgr, seLinuxTranslator)
 				asw := cache.NewActualStateOfWorld(nodeName, volumePluginMgr)
-				kubeClient := createtestClientWithPVPVC(pv, pvc, v1.AttachedVolume{
+				kubeClient := createTestClientWithPVPVC(pv, pvc, v1.AttachedVolume{
 					Name:       v1.UniqueVolumeName(fmt.Sprintf("fake-plugin/%s", tc.volumeName)),
 					DevicePath: "fake/path",
 				})
@@ -1818,7 +1818,7 @@ func Test_UncertainVolumeMountState(t *testing.T) {
 				seLinuxTranslator := util.NewFakeSELinuxLabelTranslator()
 				dsw := cache.NewDesiredStateOfWorld(volumePluginMgr, seLinuxTranslator)
 				asw := cache.NewActualStateOfWorld(nodeName, volumePluginMgr)
-				kubeClient := createtestClientWithPVPVC(pv, pvc, v1.AttachedVolume{
+				kubeClient := createTestClientWithPVPVC(pv, pvc, v1.AttachedVolume{
 					Name:       v1.UniqueVolumeName(fmt.Sprintf("fake-plugin/%s", tc.volumeName)),
 					DevicePath: "fake/path",
 				})
@@ -2108,7 +2108,7 @@ func runReconciler(ctx context.Context, reconciler Reconciler) {
 	go reconciler.Run(ctx, wait.NeverStop)
 }
 
-func createtestClientWithPVPVC(pv *v1.PersistentVolume, pvc *v1.PersistentVolumeClaim, attachedVolumes ...v1.AttachedVolume) *fake.Clientset {
+func createTestClientWithPVPVC(pv *v1.PersistentVolume, pvc *v1.PersistentVolumeClaim, attachedVolumes ...v1.AttachedVolume) *fake.Clientset {
 	fakeClient := &fake.Clientset{}
 	if len(attachedVolumes) == 0 {
 		attachedVolumes = append(attachedVolumes, v1.AttachedVolume{

--- a/pkg/kubelet/volumemanager/reconciler/reconstruct_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconstruct_test.go
@@ -301,7 +301,7 @@ func TestReconstructVolumesMount(t *testing.T) {
 			outerName := filepath.Base(tc.volumePath)
 			pod, pv, pvc := getPodPVCAndPV(tc.volumeMode, "pod1", outerName, "pvc1")
 			volumeSpec := &volume.Spec{PersistentVolume: pv}
-			kubeClient := createtestClientWithPVPVC(pv, pvc, v1.AttachedVolume{
+			kubeClient := createTestClientWithPVPVC(pv, pvc, v1.AttachedVolume{
 				Name:       v1.UniqueVolumeName(fmt.Sprintf("fake-plugin/%s", outerName)),
 				DevicePath: "fake/path",
 			})

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -31,6 +31,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -38,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
+	storagehelpers "k8s.io/component-helpers/storage/volume"
 	csitrans "k8s.io/csi-translation-lib"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/config"
@@ -92,6 +94,10 @@ const (
 	// VolumeAttachmentLimitExceededReason is the reason for rejecting a pod
 	// when the node has reached its volume attachment limit.
 	VolumeAttachmentLimitExceededReason = "VolumeAttachmentLimitExceeded"
+
+	// VolumeNodeAffinityReason is the reason for rejecting a pod when the node
+	// does not match the node affinity of one of the pod's persistent volumes.
+	VolumeNodeAffinityReason = "VolumeNodeAffinity"
 )
 
 // VolumeManager runs a set of asynchronous loops that figure out which volumes
@@ -316,6 +322,19 @@ func (e *VolumeAttachLimitExceededError) Error() string {
 		e.UnmountedVolumes, e.UnattachedVolumes, e.VolumesNotInDSW, e.OriginalError)
 }
 
+// RejectingPodError signals that a pod must be rejected (set to phase Failed)
+// rather than kept waiting for its volumes.
+type RejectingPodError struct {
+	// Reason is a short, low-cardinality label
+	Reason string
+	// Desc is the human-readable message.
+	Desc string
+}
+
+func (e *RejectingPodError) Error() string {
+	return e.Desc
+}
+
 func (vm *volumeManager) Run(ctx context.Context, sourcesReady config.SourcesReady) {
 	logger := klog.FromContext(ctx)
 	defer runtime.HandleCrashWithContext(ctx)
@@ -447,6 +466,11 @@ func (vm *volumeManager) WaitForAttachAndMount(ctx context.Context, pod *v1.Pod)
 		vm.verifyVolumesMountedFunc(uniquePodName, expectedVolumes))
 
 	if err != nil {
+		// A pod rejection already carries its own reason and message.
+		if _, ok := errors.AsType[*RejectingPodError](err); ok {
+			return err
+		}
+
 		unmountedVolumes :=
 			vm.getUnmountedVolumes(uniquePodName, expectedVolumes)
 		// Also get unattached volumes and volumes not in dsw for error message
@@ -578,11 +602,82 @@ func (vm *volumeManager) getUnattachedVolumes(uniquePodName types.UniquePodName)
 // verifyVolumesMountedFunc returns a method that returns true when all expected
 // volumes are mounted.
 func (vm *volumeManager) verifyVolumesMountedFunc(podName types.UniquePodName, expectedVolumes []string) wait.ConditionWithContextFunc {
-	return func(_ context.Context) (done bool, err error) {
+	getFreshNodeLabels := vm.newFreshNodeLabelsGetter()
+	return func(ctx context.Context) (done bool, err error) {
 		if errs := vm.desiredStateOfWorld.PopPodErrors(podName); len(errs) > 0 {
 			return true, errors.New(strings.Join(errs, "; "))
 		}
+		if utilfeature.DefaultFeatureGate.Enabled(features.MutablePVNodeAffinity) {
+			if rejectErr := vm.checkVolumeNodeAffinity(ctx, podName, getFreshNodeLabels); rejectErr != nil {
+				return true, rejectErr
+			}
+		}
 		return len(vm.getUnmountedVolumes(podName, expectedVolumes)) == 0, nil
+	}
+}
+
+// checkVolumeNodeAffinity rejects the pod if any of its persistent volumes has a
+// node affinity that does not match this node, unless that volume has already been
+// mounted for the pod. It returns a *RejectingPodError to reject, or nil otherwise.
+func (vm *volumeManager) checkVolumeNodeAffinity(ctx context.Context, podName types.UniquePodName, getFreshNodeLabels func(context.Context) (map[string]string, error)) *RejectingPodError {
+	logger := klog.FromContext(ctx)
+	// Pre-check against the informer labels (no API call) on the happy path.
+	nodeLabels, err := vm.volumePluginMgr.Host.GetNodeLabels()
+	if err != nil {
+		logger.V(4).Info("Failed to get node labels, skipping volume node affinity check", "err", err)
+		return nil
+	}
+
+	for _, vtm := range vm.desiredStateOfWorld.GetVolumesToMount() {
+		if vtm.PodName != podName || vtm.VolumeSpec == nil || vtm.VolumeSpec.PersistentVolume == nil {
+			continue
+		}
+		if vm.actualStateOfWorld.GetVolumeMountState(vtm.VolumeName, podName) != operationexecutor.VolumeNotMounted {
+			// Don't interrupt already running pod
+			continue
+		}
+		pv := vtm.VolumeSpec.PersistentVolume
+		if storagehelpers.CheckNodeAffinity(pv, nodeLabels) == nil {
+			continue
+		}
+		// Node labels from the informer may lag a manual relabel,
+		// so a suspected mismatch is confirmed against a freshly-fetched node before rejecting.
+		freshLabels, err := getFreshNodeLabels(ctx)
+		if err != nil {
+			// The next poll tick retries.
+			logger.V(4).Info("Failed to get node to confirm volume node affinity mismatch", "err", err)
+			return nil
+		}
+		if affinityErr := storagehelpers.CheckNodeAffinity(pv, freshLabels); affinityErr != nil {
+			logger.V(1).Info("Rejecting pod because a volume's node affinity does not match the node",
+				"pod", podName, "pv", klog.KObj(pv), "err", affinityErr)
+			return &RejectingPodError{
+				Reason: VolumeNodeAffinityReason,
+				Desc:   fmt.Sprintf("volume %q node affinity does not match node: %v", pv.Name, affinityErr),
+			}
+		}
+	}
+	return nil
+}
+
+// newFreshNodeLabelsGetter returns a function that fetches this node's labels live
+// from the API server at most once, memoizing the result, which bounds the API calls a
+// burst of rejected pods can trigger.
+// It is built once per WaitForAttachAndMount so a node relabeled to a mismatch mid-wait (after a match
+// was cached) is only caught on the next SyncPod.
+func (vm *volumeManager) newFreshNodeLabelsGetter() func(context.Context) (map[string]string, error) {
+	var freshLabels map[string]string
+	fetched := false
+	return func(ctx context.Context) (map[string]string, error) {
+		if !fetched {
+			node, err := vm.kubeClient.CoreV1().Nodes().Get(ctx, string(vm.volumePluginMgr.Host.GetNodeName()), metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			freshLabels = node.Labels
+			fetched = true
+		}
+		return freshLabels, nil
 	}
 }
 

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -310,18 +310,6 @@ type volumeManager struct {
 	intreeToCSITranslator csimigration.InTreeToCSITranslator
 }
 
-type VolumeAttachLimitExceededError struct {
-	UnmountedVolumes  []string
-	UnattachedVolumes []string
-	VolumesNotInDSW   []string
-	OriginalError     error
-}
-
-func (e *VolumeAttachLimitExceededError) Error() string {
-	return fmt.Sprintf("Node has reached its volume attachment limit, rejecting pod. unmounted volumes=%v, unattached volumes=%v, failed to process volumes=%v: %v",
-		e.UnmountedVolumes, e.UnattachedVolumes, e.VolumesNotInDSW, e.OriginalError)
-}
-
 // RejectingPodError signals that a pod must be rejected (set to phase Failed)
 // rather than kept waiting for its volumes.
 type RejectingPodError struct {
@@ -497,12 +485,10 @@ func (vm *volumeManager) WaitForAttachAndMount(ctx context.Context, pod *v1.Pod)
 					continue
 				}
 				if attachablePlugin.VerifyExhaustedResource(volumeToMount.VolumeSpec) {
-					// Return error to the kubelet, which will then trigger the pod termination logic.
-					return &VolumeAttachLimitExceededError{
-						UnmountedVolumes:  unmountedVolumes,
-						UnattachedVolumes: unattachedVolumes,
-						VolumesNotInDSW:   volumesNotInDSW,
-						OriginalError:     err,
+					// Reject the pod so the kubelet triggers pod termination logic.
+					return &RejectingPodError{
+						Reason: VolumeAttachmentLimitExceededReason,
+						Desc:   fmt.Sprintf("Node has reached its volume attachment limit, unattached volumes=%v", unattachedVolumes),
 					}
 				}
 			}

--- a/pkg/kubelet/volumemanager/volume_manager_fake.go
+++ b/pkg/kubelet/volumemanager/volume_manager_fake.go
@@ -60,7 +60,7 @@ func (f *FakeVolumeManager) Run(ctx context.Context, sourcesReady config.Sources
 // WaitForAttachAndMount is not implemented
 func (f *FakeVolumeManager) WaitForAttachAndMount(ctx context.Context, pod *v1.Pod) error {
 	if f.volumeAttachLimitExceeded {
-		return &VolumeAttachLimitExceededError{}
+		return &RejectingPodError{Reason: VolumeAttachmentLimitExceededReason}
 	}
 	return nil
 }

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -381,8 +381,8 @@ func TestInitialPendingVolumesForPodAndGetVolumesInUse(t *testing.T) {
 	// delayed claim binding
 	go delayClaimBecomesBound(t, kubeClient, claim.GetNamespace(), claim.Name)
 
-	err = wait.Poll(100*time.Millisecond, 1*time.Second, func() (bool, error) {
-		err = manager.WaitForAttachAndMount(tCtx, pod)
+	err = wait.PollUntilContextTimeout(tCtx, 100*time.Millisecond, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+		err = manager.WaitForAttachAndMount(ctx, pod)
 		if err != nil {
 			// Few "PVC not bound" errors are expected
 			return false, nil

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -323,12 +323,10 @@ func TestWaitForAttachAndMountVolumeAttachLimitExceededError(t *testing.T) {
 
 	require.Error(t, err, "Expected an error but got none")
 
-	var attachErr *VolumeAttachLimitExceededError
-	require.ErrorAs(t, err, &attachErr, "Error should be of type VolumeAttachLimitExceededError")
-	require.Equal(t, []string{"vol1"}, attachErr.UnmountedVolumes, "UnmountedVolumes mismatch")
-	require.Equal(t, []string{"vol1"}, attachErr.UnattachedVolumes, "UnattachedVolumes mismatch")
-	require.Empty(t, attachErr.VolumesNotInDSW, "VolumesNotInDSW should be empty")
-	require.ErrorIs(t, attachErr.OriginalError, context.DeadlineExceeded, "OriginalError should be context.DeadlineExceeded")
+	rejectErr, ok := errors.AsType[*RejectingPodError](err)
+	require.True(t, ok, "Error should be of type *RejectingPodError, got %v", err)
+	assert.Equal(t, VolumeAttachmentLimitExceededReason, rejectErr.Reason)
+	assert.Contains(t, rejectErr.Desc, "unattached volumes=[vol1]")
 }
 
 // TestWaitForAttachAndMountNodeAffinityMismatch exercises the full WaitForAttachAndMount

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -18,6 +18,7 @@ package volumemanager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -41,16 +42,19 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
+	"k8s.io/kubernetes/pkg/kubelet/volumemanager/cache"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/emptydir"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 	"k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/pkg/volume/util/hostutil"
+	"k8s.io/kubernetes/pkg/volume/util/operationexecutor"
 	"k8s.io/kubernetes/pkg/volume/util/types"
 	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/mount-utils"
@@ -327,6 +331,263 @@ func TestWaitForAttachAndMountVolumeAttachLimitExceededError(t *testing.T) {
 	require.ErrorIs(t, attachErr.OriginalError, context.DeadlineExceeded, "OriginalError should be context.DeadlineExceeded")
 }
 
+// TestWaitForAttachAndMountNodeAffinityMismatch exercises the full WaitForAttachAndMount
+// path: a never-mounted PV whose node affinity does not match is rejected with a
+// *RejectingPodError, and only when the feature gate is enabled.
+func TestWaitForAttachAndMountNodeAffinityMismatch(t *testing.T) {
+	for _, gateEnabled := range []bool{true, false} {
+		t.Run(fmt.Sprintf("gate=%v", gateEnabled), func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.MutablePVNodeAffinity, gateEnabled)
+
+			tmpDir := t.TempDir()
+			podManager := kubepod.NewBasicPodManager()
+
+			node, pod, pv, claim := createObjects(v1.PersistentVolumeFilesystem, v1.PersistentVolumeFilesystem)
+			// Require a hostname the node does not have, so the affinity never matches.
+			pv.Spec.NodeAffinity = hostnameAffinity("some-other-node")
+
+			kubeClient := fake.NewClientset(node, pod, pv, claim)
+			manager := newTestVolumeManager(t, tmpDir, podManager, kubeClient, node)
+
+			tCtx := ktesting.Init(t)
+			sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
+			go manager.Run(tCtx, sourcesReady)
+			podManager.SetPods([]*v1.Pod{pod})
+
+			go simulateVolumeInUseUpdate(v1.UniqueVolumeName("fake/fake-device"), tCtx.Done(), manager)
+
+			ctx, cancel := context.WithTimeout(tCtx, 2*time.Second)
+			defer cancel()
+			err := manager.WaitForAttachAndMount(ctx, pod)
+			require.Error(t, err)
+
+			rejectErr, ok := errors.AsType[*RejectingPodError](err)
+			if gateEnabled {
+				require.True(t, ok, "expected a *RejectingPodError, got %v", err)
+				assert.Equal(t, VolumeNodeAffinityReason, rejectErr.Reason)
+			} else {
+				assert.False(t, ok, "must not reject when the feature gate is disabled, got %v", err)
+			}
+		})
+	}
+}
+
+// nodeAffinityMatching builds a PV node affinity that requires the given label
+// value on kubernetes.io/hostname.
+func hostnameAffinity(hostname string) *v1.VolumeNodeAffinity {
+	return &v1.VolumeNodeAffinity{
+		Required: &v1.NodeSelector{
+			NodeSelectorTerms: []v1.NodeSelectorTerm{{
+				MatchExpressions: []v1.NodeSelectorRequirement{{
+					Key:      "kubernetes.io/hostname",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{hostname},
+				}},
+			}},
+		},
+	}
+}
+
+// newAffinityCheckVM builds a volumeManager wired to exercise the node affinity
+// check: a fake host whose GetNodeLabels returns informerLabels (the cheap
+// pre-check) and a clientset Node carrying nodeLabels for the live confirm fetch.
+// Keeping the two label sets separate lets tests simulate a stale informer. It
+// returns the manager and a counter of live node fetches.
+func newAffinityCheckVM(t *testing.T, informerLabels, nodeLabels map[string]string) (*volumeManager, *int) {
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: testHostname, Labels: nodeLabels},
+	}
+	kubeClient := fake.NewClientset(node)
+	nodeGets := new(int)
+	kubeClient.PrependReactor("get", "nodes", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		*nodeGets++
+		return false, nil, nil
+	})
+
+	plugins := volumetest.ProbeVolumePlugins(volume.VolumeConfig{})
+	host := volumetest.NewFakeKubeletVolumeHostWithCSINodeName(t, t.TempDir(), kubeClient, plugins, testHostname, nil, nil).
+		WithNodeLabels(informerLabels)
+	plugMgr := host.GetPluginMgr()
+
+	vm := &volumeManager{
+		kubeClient:          kubeClient,
+		volumePluginMgr:     plugMgr,
+		desiredStateOfWorld: cache.NewDesiredStateOfWorld(plugMgr, util.NewFakeSELinuxLabelTranslator()),
+		actualStateOfWorld:  cache.NewActualStateOfWorld(testHostname, plugMgr),
+	}
+	return vm, nodeGets
+}
+
+// affinityVolume describes one PV-backed volume to set up for a pod.
+type affinityVolume struct {
+	name        string
+	requireHost string                             // hostname the PV's nodeAffinity requires ("" = none)
+	mountState  operationexecutor.VolumeMountState // "" = never added to the actual state of world
+}
+
+// addPodVolumes builds a pod referencing the given volumes, adds each to the
+// desired state of world, and records its mount state in the actual state of world.
+// It returns the pod name and the outer volume names to wait on.
+func addPodVolumes(t *testing.T, vm *volumeManager, volumes []affinityVolume) (types.UniquePodName, []string) {
+	t.Helper()
+	logger, _ := ktesting.NewTestContext(t)
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: "nsA", UID: "1234"}}
+	for _, v := range volumes {
+		pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
+			Name:         v.name,
+			VolumeSource: v1.VolumeSource{PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: v.name}},
+		})
+	}
+	podName := util.GetUniquePodName(pod)
+
+	names := make([]string, 0, len(volumes))
+	for _, v := range volumes {
+		names = append(names, v.name)
+		pv := &v1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{Name: v.name},
+			Spec: v1.PersistentVolumeSpec{
+				PersistentVolumeSource: v1.PersistentVolumeSource{RBD: &v1.RBDPersistentVolumeSource{RBDImage: v.name}},
+			},
+		}
+		if v.requireHost != "" {
+			pv.Spec.NodeAffinity = hostnameAffinity(v.requireHost)
+		}
+		spec := &volume.Spec{PersistentVolume: pv}
+		volumeName, err := vm.desiredStateOfWorld.AddPodToVolume(logger, podName, pod, spec, spec.Name(), "", nil)
+		require.NoError(t, err)
+		if v.mountState == "" {
+			continue
+		}
+		// A volume must be attached before it can be marked mounted/uncertain.
+		require.NoError(t, vm.actualStateOfWorld.MarkVolumeAsAttached(logger, volumeName, spec, "", "fake/path"))
+		opts := operationexecutor.MarkVolumeOpts{
+			PodName:          podName,
+			PodUID:           pod.UID,
+			VolumeName:       volumeName,
+			VolumeSpec:       spec,
+			VolumeMountState: v.mountState,
+		}
+		switch v.mountState {
+		case operationexecutor.VolumeMounted:
+			require.NoError(t, vm.actualStateOfWorld.MarkVolumeAsMounted(opts))
+		case operationexecutor.VolumeMountUncertain:
+			require.NoError(t, vm.actualStateOfWorld.MarkVolumeMountAsUncertain(opts))
+		}
+	}
+	return podName, names
+}
+
+func TestCheckVolumeNodeAffinity(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.MutablePVNodeAffinity, true)
+	matching := map[string]string{"kubernetes.io/hostname": testHostname}
+	other := map[string]string{"kubernetes.io/hostname": "some-other-node"}
+
+	tests := []struct {
+		name           string
+		informerLabels map[string]string
+		nodeLabels     map[string]string
+		volumes        []affinityVolume
+		ticks          int // poll-loop iterations sharing one wait; 0 means 1
+
+		wantRejectContains string // non-empty: expect a reject whose Desc contains this
+		wantNodeGets       int
+	}{
+		{
+			name:               "never-mounted mismatch is rejected",
+			informerLabels:     other,
+			nodeLabels:         other,
+			volumes:            []affinityVolume{{name: "vol1", requireHost: testHostname}},
+			wantRejectContains: "vol1",
+			wantNodeGets:       1,
+		},
+		{
+			name:           "matching affinity is not rejected without a fresh Get",
+			informerLabels: matching,
+			nodeLabels:     matching,
+			volumes:        []affinityVolume{{name: "vol1", requireHost: testHostname}},
+			wantNodeGets:   0,
+		},
+		{
+			name:           "mounted volume is not rejected",
+			informerLabels: other,
+			nodeLabels:     other,
+			volumes:        []affinityVolume{{name: "vol1", requireHost: testHostname, mountState: operationexecutor.VolumeMounted}},
+			wantNodeGets:   0,
+		},
+		{
+			name:           "uncertain volume after restart is not rejected",
+			informerLabels: other,
+			nodeLabels:     other,
+			volumes:        []affinityVolume{{name: "vol1", requireHost: testHostname, mountState: operationexecutor.VolumeMountUncertain}},
+			wantNodeGets:   0,
+		},
+		{
+			name:           "multi-volume rejects the never-mounted mismatched one",
+			informerLabels: other,
+			nodeLabels:     other,
+			volumes: []affinityVolume{
+				// volA matches and is mounted; volB mismatches and was never mounted.
+				{name: "volA", requireHost: "some-other-node", mountState: operationexecutor.VolumeMounted},
+				{name: "volB", requireHost: testHostname},
+			},
+			wantRejectContains: "volB",
+			wantNodeGets:       1,
+		},
+		{
+			name:           "stale informer confirmed against fresh node is not rejected",
+			informerLabels: other, // stale: does not match
+			nodeLabels:     matching,
+			volumes:        []affinityVolume{{name: "vol1", requireHost: testHostname}},
+			wantNodeGets:   1,
+		},
+		{
+			name:           "fresh node Get is shared across volumes",
+			informerLabels: other, // stale: both volumes suspected, both confirmed by one Get
+			nodeLabels:     matching,
+			volumes: []affinityVolume{
+				{name: "vol1", requireHost: testHostname},
+				{name: "vol2", requireHost: testHostname},
+			},
+			wantNodeGets: 1,
+		},
+		{
+			name:           "fresh node Get is memoized across poll ticks of one wait",
+			informerLabels: other, // stale for the whole wait: every tick re-suspects
+			nodeLabels:     matching,
+			volumes:        []affinityVolume{{name: "vol1", requireHost: testHostname}},
+			ticks:          5,
+			wantNodeGets:   1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vm, nodeGets := newAffinityCheckVM(t, tc.informerLabels, tc.nodeLabels)
+			podName, names := addPodVolumes(t, vm, tc.volumes)
+
+			// Drive the real per-wait entry point; one condition func per wait,
+			// invoked once per modeled poll tick.
+			condition := vm.verifyVolumesMountedFunc(podName, names)
+			tCtx := ktesting.Init(t)
+			ticks := max(tc.ticks, 1)
+			var err error
+			for range ticks {
+				_, err = condition(tCtx)
+			}
+
+			rejectErr, rejected := errors.AsType[*RejectingPodError](err)
+			if tc.wantRejectContains != "" {
+				require.True(t, rejected, "expected a *RejectingPodError, got %v", err)
+				assert.Equal(t, VolumeNodeAffinityReason, rejectErr.Reason)
+				assert.Contains(t, rejectErr.Desc, tc.wantRejectContains)
+			} else {
+				assert.False(t, rejected, "must not reject, got %v", err)
+			}
+			assert.Equal(t, tc.wantNodeGets, *nodeGets)
+		})
+	}
+}
+
 func TestInitialPendingVolumesForPodAndGetVolumesInUse(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	tmpDir := t.TempDir()
@@ -488,7 +749,7 @@ func newTestVolumeManager(t *testing.T, tmpDir string, podManager kubepod.Manage
 	fakeRecorder := &record.FakeRecorder{}
 	plugMgr := &volume.VolumePluginMgr{}
 	// TODO (#51147) inject mock prober
-	fakeVolumeHost := volumetest.NewFakeKubeletVolumeHost(t, tmpDir, kubeClient, nil)
+	fakeVolumeHost := volumetest.NewFakeKubeletVolumeHostWithCSINodeName(t, tmpDir, kubeClient, nil, testHostname, nil, nil)
 	fakeVolumeHost.WithNode(node)
 
 	plugMgr.InitPlugins([]volume.VolumePlugin{attachablePlug, unattachablePlug}, nil /* prober */, fakeVolumeHost)

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -42,7 +42,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
-	utiltesting "k8s.io/client-go/util/testing"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/config"
@@ -94,15 +93,7 @@ func TestGetMountedVolumesForPodAndGetVolumesInUse(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			tmpDir, err := utiltesting.MkTmpdir("volumeManagerTest")
-			if err != nil {
-				t.Fatalf("can't make a temp dir: %v", err)
-			}
-			defer func() {
-				if err := os.RemoveAll(tmpDir); err != nil {
-					t.Fatalf("failed to remove temp dir: %v", err)
-				}
-			}()
+			tmpDir := t.TempDir()
 			podManager := kubepod.NewBasicPodManager()
 
 			node, pod, pv, claim := createObjects(test.pvMode, test.podMode)
@@ -123,7 +114,7 @@ func TestGetMountedVolumesForPodAndGetVolumesInUse(t *testing.T) {
 				tCtx.Done(),
 				manager)
 
-			err = manager.WaitForAttachAndMount(ctx, pod)
+			err := manager.WaitForAttachAndMount(ctx, pod)
 			if err != nil && !test.expectError {
 				t.Errorf("Expected success: %v", err)
 			}
@@ -157,11 +148,7 @@ func TestGetMountedVolumesForPodAndGetVolumesInUse(t *testing.T) {
 
 func TestWaitForAttachAndMountError(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
-	tmpDir, err := utiltesting.MkTmpdir("volumeManagerTest")
-	if err != nil {
-		t.Fatalf("can't make a temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	podManager := kubepod.NewBasicPodManager()
 
 	pod := &v1.Pod{
@@ -244,7 +231,7 @@ func TestWaitForAttachAndMountError(t *testing.T) {
 
 	podManager.SetPods([]*v1.Pod{pod})
 
-	err = manager.WaitForAttachAndMount(ctx, pod)
+	err := manager.WaitForAttachAndMount(ctx, pod)
 	if err == nil {
 		t.Errorf("Expected error, got none")
 	}
@@ -257,15 +244,7 @@ func TestWaitForAttachAndMountError(t *testing.T) {
 func TestWaitForAttachAndMountVolumeAttachLimitExceededError(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.MutableCSINodeAllocatableCount, true)
 
-	tmpDir, err := utiltesting.MkTmpdir("volumeManagerTest")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		if err := os.RemoveAll(tmpDir); err != nil {
-			t.Errorf("Failed to remove temporary directory %s: %v", tmpDir, err)
-		}
-	})
-
+	tmpDir := t.TempDir()
 	podManager := kubepod.NewBasicPodManager()
 
 	pod := &v1.Pod{
@@ -336,7 +315,7 @@ func TestWaitForAttachAndMountVolumeAttachLimitExceededError(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(tCtx, 1*time.Second)
 	defer cancel()
-	err = manager.WaitForAttachAndMount(ctx, pod)
+	err := manager.WaitForAttachAndMount(ctx, pod)
 
 	require.Error(t, err, "Expected an error but got none")
 
@@ -350,11 +329,7 @@ func TestWaitForAttachAndMountVolumeAttachLimitExceededError(t *testing.T) {
 
 func TestInitialPendingVolumesForPodAndGetVolumesInUse(t *testing.T) {
 	tCtx := ktesting.Init(t)
-	tmpDir, err := utiltesting.MkTmpdir("volumeManagerTest")
-	if err != nil {
-		t.Fatalf("can't make a temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	podManager := kubepod.NewBasicPodManager()
 
 	node, pod, pv, claim := createObjects(v1.PersistentVolumeFilesystem, v1.PersistentVolumeFilesystem)
@@ -381,8 +356,8 @@ func TestInitialPendingVolumesForPodAndGetVolumesInUse(t *testing.T) {
 	// delayed claim binding
 	go delayClaimBecomesBound(t, kubeClient, claim.GetNamespace(), claim.Name)
 
-	err = wait.PollUntilContextTimeout(tCtx, 100*time.Millisecond, 1*time.Second, true, func(ctx context.Context) (bool, error) {
-		err = manager.WaitForAttachAndMount(ctx, pod)
+	err := wait.PollUntilContextTimeout(tCtx, 100*time.Millisecond, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+		err := manager.WaitForAttachAndMount(ctx, pod)
 		if err != nil {
 			// Few "PVC not bound" errors are expected
 			return false, nil
@@ -397,11 +372,7 @@ func TestInitialPendingVolumesForPodAndGetVolumesInUse(t *testing.T) {
 
 func TestGetExtraSupplementalGroupsForPod(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
-	tmpDir, err := utiltesting.MkTmpdir("volumeManagerTest")
-	if err != nil {
-		t.Fatalf("can't make a temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	podManager := kubepod.NewBasicPodManager()
 
 	node, pod, _, claim := createObjects(v1.PersistentVolumeFilesystem, v1.PersistentVolumeFilesystem)
@@ -469,7 +440,7 @@ func TestGetExtraSupplementalGroupsForPod(t *testing.T) {
 			tCtx.Done(),
 			manager)
 
-		err = manager.WaitForAttachAndMount(ctx, pod)
+		err := manager.WaitForAttachAndMount(ctx, pod)
 		if err != nil {
 			t.Errorf("Expected success: %v", err)
 			continue

--- a/pkg/volume/testing/volume_host.go
+++ b/pkg/volume/testing/volume_host.go
@@ -338,6 +338,14 @@ func (f *fakeKubeletVolumeHost) WithNode(node *v1.Node) *fakeKubeletVolumeHost {
 	return f
 }
 
+// WithNodeLabels sets the labels returned by GetNodeLabels. GetNodeLabels is
+// informer-backed in production; setting it independently of the clientset Node
+// lets tests simulate a stale informer.
+func (f *fakeKubeletVolumeHost) WithNodeLabels(labels map[string]string) *fakeKubeletVolumeHost {
+	f.nodeLabels = labels
+	return f
+}
+
 type CSINodeLister []storagev1.CSINode
 
 // Get returns a fake CSINode object.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This re-proposes the kubelet-side part of KEP-5381 (mutable PV nodeAffinity) that was split out of #134339 at the last minute.

#134339 already landed the `MutablePVNodeAffinity` feature gate, the API change allowing `PersistentVolume.Spec.NodeAffinity` to be mutated, and the API doc update. What was left behind is the kubelet enforcement: when a PV's `NodeAffinity` is updated (e.g. a CSI driver migrates the data to a different topology), the scheduler may still act on the stale affinity and bind a pod to a node that no longer matches. This PR makes the kubelet reject such a pod so the scheduler can retry elsewhere.

The previous alpha's kubelet enforcement was rejected in review because it gated on `node.status.volumesAttached`, which only exists for attachable volumes — so it handled the race for attachable volumes but left non-attachable / `attachRequired: false` volumes unprotected, which looked arbitrary. This version fixes that with a plugin-agnostic signal and a simpler placement.

Details:

- The check runs in `WaitForAttachAndMount`, not messing up with reconciler, more consistent with current attach limit.
- It is gated **per volume** on the actual state of the world mount state being `VolumeNotMounted`. It is what keeps a running pod from being interrupted:
  - reconstruction after a kubelet restart marks recovered volumes `Uncertain`, so a pod that was running before the restart is not rejected;
  - a mounted volume is never re-checked;
  - it is per-volume, so a pod with one mounted volume and another never-mounted, mismatched volume is still rejected for the latter.
- The signal does not depend on attachment, so attachable and non-attachable volumes are handled uniformly.
- Informer node labels can lag a manual relabel, so a suspected mismatch is confirmed against a freshly-fetched node before rejecting. Mimics current pod admission checks.
  - That fetch is memoized once per `WaitForAttachAndMount`, bounding the API load a burst of rejected pods can create.
- The rejection is surfaced as a `RejectingPodError` carrying a low-cardinality `Reason` (`VolumeNodeAffinity`), which `SyncPod` turns into a pod rejection and an admission-rejection metric sample. The former `VolumeAttachLimitExceededError` is folded into this same type so both rejections flow through one path.
- Enforcement is gated on `MutablePVNodeAffinity` (alpha, off by default), so behavior is unchanged when the gate is disabled.

The first three commits are pre-existing test cleanups in the same files, kept separate for reviewability.

#### Which issue(s) this PR is related to:

kubernetes/enhancements#5381

Follow-up to #134339, which this was originally part of before the kubelet enforcement was split out.

#### Special notes for your reviewer:

The functional change is the commit "kubelet: reject pod on PV nodeAffinity mismatch"; "kubelet: fold VolumeAttachLimitExceededError into RejectingPodError" is a follow-on refactor; the first three commits are test-only.

Possible edge case (no known trigger path): if a running pod's volume is torn back down to `VolumeNotMounted` mid-life (SELinux RWOP context-mismatch re-mount) while a fresh `SyncPod` volume-wait overlaps it and the affinity genuinely no longer matches, the pod can be rejected.

/cc @jsafrane @gnufied
This is the kubelet enforcement we discussed on #134339 and [slack](https://kubernetes.slack.com/archives/C09QZFCE5/p1761846379337879), reworked to use a plugin-agnostic mount-state gate rather than `node.status.volumesAttached`.

replaces #140521, which uses `node.status.volumesAttached`

/sig storage

#### Does this PR introduce a user-facing change?

```release-note
With the MutablePVNodeAffinity feature gate enabled, the kubelet now rejects a pod when one of its persistent volumes has not yet been mounted for the pod and the volume's node affinity does not match the node. This lets the scheduler reschedule the pod after a PV's node affinity is updated. Volumes already mounted for the pod are not affected, so running pods are not interrupted.
```
