### PR TITLE
DRA consumable capacity: fix DistinctAttribute for requests with multiple devices

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -6234,6 +6234,92 @@ func TestAllocator(t *testing.T,
 				deviceRequestAllocationResult(req2SubReq0, driverA, pool1, device1).withConsumedCapacity(&fixedShareID, nil),
 			)},
 		},
+		"distinct-constraint-single-request-multiple-devices-attribute-not-set": {
+			features: Features{
+				ConsumableCapacity: true,
+			},
+			claimsToAllocate: objects(
+				claimWithRequests(claim0,
+					[]resourceapi.DeviceConstraint{{DistinctAttribute: &intAttribute}},
+					request(req0, classA, 3),
+				),
+			),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
+					device(device1, nil, nil),
+					device(device2, nil, nil),
+					device(device3, nil, nil),
+				),
+			),
+			node:          node(node1, region1),
+			expectResults: []any{},
+		},
+		"distinct-constraint-single-request-not-enough-distinct-values": {
+			features: Features{
+				ConsumableCapacity: true,
+			},
+			claimsToAllocate: objects(
+				claimWithRequests(claim0,
+					[]resourceapi.DeviceConstraint{{DistinctAttribute: &intAttribute}},
+					request(req0, classA, 3),
+				),
+			),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
+					device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"numa": {IntValue: new(int64(1))},
+					}),
+					device(device2, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"numa": {IntValue: new(int64(2))},
+					}),
+					device(device3, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"numa": {IntValue: new(int64(2))},
+					}),
+					device(device4, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"numa": {IntValue: new(int64(2))},
+					}),
+				),
+			),
+			node:          node(node1, region1),
+			expectResults: []any{},
+		},
+		"distinct-constraint-single-request-multiple-devices-attribute-set": {
+			features: Features{
+				ConsumableCapacity: true,
+			},
+			claimsToAllocate: objects(
+				claimWithRequests(claim0,
+					[]resourceapi.DeviceConstraint{{DistinctAttribute: &intAttribute}},
+					request(req0, classA, 3),
+				),
+			),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
+					device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"numa": {IntValue: new(int64(1))},
+					}),
+					device(device2, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"numa": {IntValue: new(int64(2))},
+					}),
+					device(device3, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"numa": {IntValue: new(int64(1))},
+					}),
+					device(device4, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"numa": {IntValue: new(int64(3))},
+					}),
+				),
+			),
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool1, device1, false),
+				deviceAllocationResult(req0, driverA, pool1, device2, false),
+				deviceAllocationResult(req0, driverA, pool1, device4, false),
+			)},
+		},
 		"distinct-constraint-one-multi-allocatable-device-with-distinct-constraint": {
 			features: Features{
 				ConsumableCapacity: true,

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -308,7 +308,6 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 					requestNames:  sets.New(constraint.Requests...),
 					attributeName: distinctAttribute,
 					features:      a.features,
-					attributes:    make(map[string]resourceapi.DeviceAttribute),
 				}
 				constraints[i] = m
 			default:

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/constraint.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/constraint.go
@@ -38,8 +38,7 @@ type distinctAttributeConstraint struct {
 	attributeName resourceapi.FullyQualifiedName
 	features      Features
 
-	attributes map[string]resourceapi.DeviceAttribute
-	numDevices int
+	attributes []*resourceapi.DeviceAttribute
 }
 
 func (m *distinctAttributeConstraint) add(requestName, subRequestName string, device *draapi.Device, deviceID DeviceID) bool {
@@ -55,21 +54,12 @@ func (m *distinctAttributeConstraint) add(requestName, subRequestName string, de
 		return false
 	}
 
-	if m.numDevices == 0 {
-		// The first device can always get picked.
-		m.attributes[requestName] = *attribute
-		m.numDevices = 1
-		m.logger.V(7).Info("First attribute added")
-		return true
-	}
-
 	if !m.matchesAttribute(*attribute) {
 		m.logger.V(7).Info("Constraint not satisfied, has some duplicated attributes")
 		return false
 	}
-	m.attributes[requestName] = *attribute
-	m.numDevices++
-	m.logger.V(7).Info("Constraint satisfied by device", "device", deviceID, "numDevices", m.numDevices)
+	m.attributes = append(m.attributes, attribute)
+	m.logger.V(7).Info("Constraint satisfied by device", "device", deviceID, "numDevices", len(m.attributes))
 	return true
 
 }
@@ -79,9 +69,9 @@ func (m *distinctAttributeConstraint) remove(requestName, subRequestName string,
 		// Device not affected by constraint.
 		return
 	}
-	delete(m.attributes, requestName)
-	m.numDevices--
-	m.logger.V(7).Info("Device removed from constraint set", "device", deviceID, "numDevices", m.numDevices)
+
+	m.attributes = m.attributes[:len(m.attributes)-1]
+	m.logger.V(7).Info("Device removed from constraint set", "device", deviceID, "numDevices", len(m.attributes))
 }
 
 func (m *distinctAttributeConstraint) matches(requestName, subRequestName string) bool {
@@ -106,7 +96,7 @@ func (m *distinctAttributeConstraint) matchesAttribute(attribute resourceapi.Dev
 
 		// Check that the new device is disjoint from each existing device
 		for _, attr := range m.attributes {
-			existingSet := attributeAsSet(&attr)
+			existingSet := attributeAsSet(attr)
 			if existingSet == nil {
 				continue
 			}

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
@@ -305,7 +305,6 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 					logger:        logger,
 					requestNames:  sets.New(constraint.Requests...),
 					attributeName: distinctAttribute,
-					attributes:    make(map[string]resourceapi.DeviceAttribute),
 				}
 				constraints[i] = m
 			default:

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/constraint.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/constraint.go
@@ -37,8 +37,7 @@ type distinctAttributeConstraint struct {
 	requestNames  sets.Set[string]
 	attributeName resourceapi.FullyQualifiedName
 
-	attributes map[string]resourceapi.DeviceAttribute
-	numDevices int
+	attributes []*resourceapi.DeviceAttribute
 }
 
 func (m *distinctAttributeConstraint) add(requestName, subRequestName string, device *draapi.Device, deviceID DeviceID) bool {
@@ -54,21 +53,13 @@ func (m *distinctAttributeConstraint) add(requestName, subRequestName string, de
 		return false
 	}
 
-	if m.numDevices == 0 {
-		// The first device can always get picked.
-		m.attributes[requestName] = *attribute
-		m.numDevices = 1
-		m.logger.V(7).Info("First attribute added")
-		return true
-	}
-
 	if !m.matchesAttribute(*attribute) {
 		m.logger.V(7).Info("Constraint not satisfied, has some duplicated attributes")
 		return false
 	}
-	m.attributes[requestName] = *attribute
-	m.numDevices++
-	m.logger.V(7).Info("Constraint satisfied by device", "device", deviceID, "numDevices", m.numDevices)
+
+	m.attributes = append(m.attributes, attribute)
+	m.logger.V(7).Info("Constraint satisfied by device", "device", deviceID, "numDevices", len(m.attributes))
 	return true
 
 }
@@ -78,9 +69,9 @@ func (m *distinctAttributeConstraint) remove(requestName, subRequestName string,
 		// Device not affected by constraint.
 		return
 	}
-	delete(m.attributes, requestName)
-	m.numDevices--
-	m.logger.V(7).Info("Device removed from constraint set", "device", deviceID, "numDevices", m.numDevices)
+
+	m.attributes = m.attributes[:len(m.attributes)-1]
+	m.logger.V(7).Info("Device removed from constraint set", "device", deviceID, "numDevices", len(m.attributes))
 }
 
 func (m *distinctAttributeConstraint) matches(requestName, subRequestName string) bool {


### PR DESCRIPTION
…tiple devices

Add one of the following kinds:
/kind bug

#### What this PR does / why we need it:
The description what the PR does is mentioned in the linked issue.

#### Which issue(s) this PR is related to:
Fixes #140438 

#### Does this PR introduce a user-facing change?

```release-note
DRA consumable capacity: when a request allocated multiple devices, the DistinctAttribute constraint was not checked properly for each device.
```
