### PR TITLE
Fix flaky TestCoSchedulingWithPermitPlugin

### DIFF
--- a/test/integration/scheduler/plugins/plugins_test.go
+++ b/test/integration/scheduler/plugins/plugins_test.go
@@ -2236,6 +2236,15 @@ func TestCoSchedulingWithPermitPlugin(t *testing.T) {
 			if err != nil {
 				t.Errorf("Error while creating the first pod: %v", err)
 			}
+			// Wait for podA to enter the waiting state.
+			err = wait.PollUntilContextTimeout(testCtx.Ctx, 10*time.Millisecond, 30*time.Second, false, func(ctx context.Context) (bool, error) {
+				w := false
+				permitPlugin.fh.IterateOverWaitingPods(func(wp fwk.WaitingPod) { w = true })
+				return w, nil
+			})
+			if err != nil {
+				t.Errorf("Error while waiting for the first pod to wait: %v", err)
+			}
 			podB, err := testutils.CreatePausePod(testCtx.ClientSet,
 				testutils.InitPausePod(&testutils.PausePodConfig{Name: "pod-b", Namespace: testCtx.NS.Name}))
 			if err != nil {
@@ -2249,10 +2258,11 @@ func TestCoSchedulingWithPermitPlugin(t *testing.T) {
 				if err = testutils.WaitForPodUnschedulable(testCtx.Ctx, testCtx.ClientSet, podB); err != nil {
 					t.Errorf("Didn't expect the second pod to be scheduled. error: %v", err)
 				}
-				if !((permitPlugin.waitingPod == podA.Name && permitPlugin.rejectingPod == podB.Name) ||
-					(permitPlugin.waitingPod == podB.Name && permitPlugin.rejectingPod == podA.Name)) {
-					t.Errorf("Expect one pod to wait and another pod to reject instead %s waited and %s rejected.",
-						permitPlugin.waitingPod, permitPlugin.rejectingPod)
+				// Create copy for safely reading the fields.
+				pp := permitPlugin.deepCopy()
+				if pp.waitingPod != podA.Name || pp.rejectingPod != podB.Name {
+					t.Errorf("Expect podA to wait and podB to reject instead %s waited and %s rejected.",
+						pp.waitingPod, pp.rejectingPod)
 				}
 			} else {
 				if err = testutils.WaitForPodToSchedule(testCtx.Ctx, testCtx.ClientSet, podA); err != nil {
@@ -2261,10 +2271,11 @@ func TestCoSchedulingWithPermitPlugin(t *testing.T) {
 				if err = testutils.WaitForPodToSchedule(testCtx.Ctx, testCtx.ClientSet, podB); err != nil {
 					t.Errorf("Expected the second pod to be scheduled. error: %v", err)
 				}
-				if !((permitPlugin.waitingPod == podA.Name && permitPlugin.allowingPod == podB.Name) ||
-					(permitPlugin.waitingPod == podB.Name && permitPlugin.allowingPod == podA.Name)) {
-					t.Errorf("Expect one pod to wait and another pod to allow instead %s waited and %s allowed.",
-						permitPlugin.waitingPod, permitPlugin.allowingPod)
+				// Create copy for safely reading the fields.
+				pp := permitPlugin.deepCopy()
+				if pp.waitingPod != podA.Name || pp.allowingPod != podB.Name {
+					t.Errorf("Expect podA to wait and podB to allow instead %s waited and %s allowed.",
+						pp.waitingPod, pp.allowingPod)
 				}
 			}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix race condition in TestCoSchedulingWithPermitPlugin/having_wait_reject_true_and_wait_allow_false. There were two issues:

1. Call for PermitPlugin.Permit() is returning ```Wait``` status in https://github.com/kubernetes/kubernetes/blob/ba3578f278d8bd6138ecd580fe735b46f6c00fa0/pkg/scheduler/framework/runtime/framework.go#L2016-L2071 and pod is added to waitingPods in https://github.com/kubernetes/kubernetes/blob/ba3578f278d8bd6138ecd580fe735b46f6c00fa0/pkg/scheduler/schedule_one.go#L211-L213 So when Pod A returns ```Wait``` status from ```Permit()```, ```AddWaitingPod()``` must run in the scheduler thread to register Pod A into the framework's waitingPods map. If Pod B enters ```Permit()``` and calls ```IterateOverWaitingPods()``` before the scheduler thread executes ```AddWaitingPod(Pod A)```, IterateOverWaitingPods() iterates over an empty map and misses Pod A.
1. Test was directly calling fields of PermitPlugin, for example ```permitPlugin.waitingPod```, so test could read data when PermitPlugin was modifying it
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #140598

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
