### PR TITLE
DNM: Demo: possible split for 129719

### DIFF
--- a/pkg/kubelet/allocation/allocation_manager.go
+++ b/pkg/kubelet/allocation/allocation_manager.go
@@ -18,11 +18,6 @@ package allocation
 
 import (
 	"context"
-	"path/filepath"
-	"slices"
-	"sync"
-	"time"
-
 	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,6 +36,10 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/pkg/kubelet/status"
+	"path/filepath"
+	"slices"
+	"sync"
+	"time"
 )
 
 // podStatusManagerStateFile is the file name where status manager stores its state
@@ -595,7 +594,11 @@ func (m *manager) canAdmitPod(ctx context.Context, allocatedPods []*v1.Pod, pod 
 	for _, podAdmitHandler := range m.admitHandlers {
 		if result := podAdmitHandler.Admit(ctx, attrs); !result.Admit {
 			logger.Info("Pod admission denied", "podUID", attrs.Pod.UID, "pod", klog.KObj(attrs.Pod), "reason", result.Reason, "message", result.Message, "operation", operation)
-			return false, result.Reason, result.Message
+			if result.Reason == "prohibitedCPUAllocationError" {
+				return false, v1.PodReasonInfeasible, result.Message
+			} else {
+				return false, result.Reason, result.Message
+			}
 		}
 	}
 

--- a/pkg/kubelet/cm/cpumanager/cpu_assignment.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment.go
@@ -94,6 +94,11 @@ type numaOrSocketsFirstFuncs interface {
 	sortAvailableNUMANodes() []int
 	sortAvailableSockets() []int
 	sortAvailableCores() []int
+	takeFullFirstLevelForResize()
+	takeFullSecondLevelForResize()
+	sortAvailableNUMANodesForResize() []int
+	sortAvailableSocketsForResize() []int
+	sortAvailableCoresForResize() []int
 }
 
 type numaFirst struct{ acc *cpuAccumulator }
@@ -203,8 +208,186 @@ func (s *socketsFirst) sortAvailableCores() []int {
 	return result
 }
 
+// Sort the UncoreCaches within the NUMA nodes.
+func (a *cpuAccumulator) sortAvailableUncoreCachesForResize() []int {
+	var result []int
+	for _, numa := range a.sortAvailableNUMANodesForResize() {
+		allocatedUncoreCachesSet := a.resultDetails.UncoreInNUMANodes(numa)
+		availableUncoreCachesSet := a.details.UncoreInNUMANodes(numa)
+
+		// Sort UncoreCaches that have allocated CPUs
+		allocatedUncoreCaches := allocatedUncoreCachesSet.Intersection(availableUncoreCachesSet).UnsortedList()
+		a.sort(allocatedUncoreCaches, a.details.CPUsInUncoreCaches)
+		result = append(result, allocatedUncoreCaches...)
+
+		// Sort other available UncoreCaches
+		availableUncoreCaches := availableUncoreCachesSet.Difference(allocatedUncoreCachesSet).UnsortedList()
+		a.sort(availableUncoreCaches, a.details.CPUsInUncoreCaches)
+		result = append(result, availableUncoreCaches...)
+	}
+	return result
+}
+
+// If NUMA nodes are higher in the memory hierarchy than sockets, then we take
+// from the set of NUMA Nodes as the first level for resize.
+func (n *numaFirst) takeFullFirstLevelForResize() {
+	n.acc.takeFullNUMANodesForResize()
+}
+
+// If NUMA nodes are higher in the memory hierarchy than sockets, then we take
+// from the set of sockets as the second level for resize.
+func (n *numaFirst) takeFullSecondLevelForResize() {
+	n.acc.takeFullSocketsForResize()
+}
+
+// If NUMA nodes are higher in the memory hierarchy than sockets, then return the available NUMA nodes
+// which have allocated CPUs to Container.
+func (n *numaFirst) sortAvailableNUMANodesForResize() []int {
+	var result []int
+
+	allocatedNumaNodesSet := n.acc.resultDetails.NUMANodes()
+	availableNumaNodesSet := n.acc.details.NUMANodes()
+
+	// Sort Numa nodes which have allocated CPUs
+	allocatedNumas := allocatedNumaNodesSet.Intersection(availableNumaNodesSet).UnsortedList()
+	n.acc.sort(allocatedNumas, n.acc.details.CPUsInNUMANodes)
+	result = append(result, allocatedNumas...)
+
+	// Sort other Numa nodes
+	availableNumas := availableNumaNodesSet.Difference(allocatedNumaNodesSet).UnsortedList()
+	n.acc.sort(availableNumas, n.acc.details.CPUsInNUMANodes)
+	result = append(result, availableNumas...)
+	return result
+}
+
+// If NUMA nodes are higher in the memory hierarchy than sockets,
+// Firstly, pull the socket which are allocated CPUs to the Container
+// Secondly, pull the other sockets which are not allocated CPUs to the Container, but contains in the NUMA node which are allocated CPUs to the Container
+func (n *numaFirst) sortAvailableSocketsForResize() []int {
+	var result []int
+
+	for _, numa := range n.sortAvailableNUMANodesForResize() {
+		allocatedSocketsSet := n.acc.resultDetails.SocketsInNUMANodes(numa)
+		availableSocketsSet := n.acc.details.SocketsInNUMANodes(numa)
+
+		// Sort sockets that have allocated CPUs
+		allocatedSockets := allocatedSocketsSet.Intersection(availableSocketsSet).UnsortedList()
+		n.acc.sort(allocatedSockets, n.acc.details.CPUsInSockets)
+		result = append(result, allocatedSockets...)
+
+		// Sort other available sockets
+		availableSockets := availableSocketsSet.Difference(allocatedSocketsSet).UnsortedList()
+		n.acc.sort(availableSockets, n.acc.details.CPUsInSockets)
+		result = append(result, availableSockets...)
+	}
+	return result
+}
+
+// If NUMA nodes are higher in the memory hierarchy than sockets,
+// Firstly, pull the cores which are allocated CPUs to the Container
+// Secondly, pull the other cores which are not allocated CPUs to the Container, but contains in the NUMA node which are allocated CPUs to the Container
+func (n *numaFirst) sortAvailableCoresForResize() []int {
+	var result []int
+
+	for _, socket := range n.acc.sortAvailableSocketsForResize() {
+		allocatedCoresSet := n.acc.resultDetails.CoresInSockets(socket)
+		availableCoresSet := n.acc.details.CoresInSockets(socket)
+
+		// Sort cores that have allocated CPUs
+		allocatedCores := allocatedCoresSet.Intersection(availableCoresSet).UnsortedList()
+		n.acc.sort(allocatedCores, n.acc.details.CPUsInCores)
+		result = append(result, allocatedCores...)
+
+		// Sort other available cores
+		availableCores := availableCoresSet.Difference(allocatedCoresSet).UnsortedList()
+		n.acc.sort(availableCores, n.acc.details.CPUsInCores)
+		result = append(result, availableCores...)
+	}
+	return result
+}
+
+// If sockets are higher in the memory hierarchy than NUMA nodes, then we take
+// from the set of NUMA Nodes as the first level for resize.
+func (s *socketsFirst) takeFullFirstLevelForResize() {
+	s.acc.takeFullSocketsForResize()
+}
+
+// If sockets are higher in the memory hierarchy than NUMA nodes, then we take
+// from the set of sockets as the second level for resize.
+func (s *socketsFirst) takeFullSecondLevelForResize() {
+	s.acc.takeFullNUMANodesForResize()
+}
+
+// If sockets are higher in the memory hierarchy than NUMA nodes,
+// Firstly, pull the NUMA nodes which are allocated CPUs to the Container
+// Secondly, pull the other NUMA nodes which are not allocated CPUs to the Container, but contains in the sockets which are allocated CPUs to the Container
+func (s *socketsFirst) sortAvailableNUMANodesForResize() []int {
+	var result []int
+
+	for _, socket := range s.sortAvailableSocketsForResize() {
+		allocatedNumaNodesSet := s.acc.resultDetails.NUMANodesInSockets(socket)
+		availableNumaNodesSet := s.acc.details.NUMANodesInSockets(socket)
+
+		// Sort Numa nodes which have allocated CPUs
+		allocatedNumas := allocatedNumaNodesSet.Intersection(availableNumaNodesSet).UnsortedList()
+		s.acc.sort(allocatedNumas, s.acc.details.CPUsInNUMANodes)
+		result = append(result, allocatedNumas...)
+
+		// Sort other Numa nodes
+		availableNumas := availableNumaNodesSet.Difference(allocatedNumaNodesSet).UnsortedList()
+		s.acc.sort(availableNumas, s.acc.details.CPUsInNUMANodes)
+		result = append(result, availableNumas...)
+	}
+	return result
+}
+
+// If sockets are higher in the memory hierarchy than NUMA nodes, then return the available sockets
+// which have allocated CPUs to Container.
+func (s *socketsFirst) sortAvailableSocketsForResize() []int {
+	var result []int
+
+	allocatedSocketsSet := s.acc.resultDetails.Sockets()
+	availableSocketsSet := s.acc.details.Sockets()
+
+	// Sort Sockets which have allocated CPUs
+	allocatedSockets := allocatedSocketsSet.Intersection(availableSocketsSet).UnsortedList()
+	s.acc.sort(allocatedSockets, s.acc.details.CPUsInSockets)
+	result = append(result, allocatedSockets...)
+
+	// Sort other Sockets
+	availableSockets := availableSocketsSet.Difference(allocatedSocketsSet).UnsortedList()
+	s.acc.sort(availableSockets, s.acc.details.CPUsInSockets)
+	result = append(result, availableSockets...)
+
+	return result
+}
+
+// If sockets are higher in the memory hierarchy than NUMA nodes,
+// Firstly, pull the cores which are allocated CPUs to the Container
+// Secondly, pull the other cores which are not allocated CPUs to the Container, but contains in the socket which are allocated CPUs to the Container
+func (s *socketsFirst) sortAvailableCoresForResize() []int {
+	var result []int
+
+	for _, numa := range s.acc.sortAvailableNUMANodesForResize() {
+		allocatedCoresSet := s.acc.resultDetails.CoresInNUMANodes(numa)
+		availableCoresSet := s.acc.details.CoresInNUMANodes(numa)
+
+		// Sort cores that have allocated CPUs
+		allocatedCores := allocatedCoresSet.Intersection(availableCoresSet).UnsortedList()
+		s.acc.sort(allocatedCores, s.acc.details.CPUsInCores)
+		result = append(result, allocatedCores...)
+
+		// Sort other available cores
+		availableCores := availableCoresSet.Difference(allocatedCoresSet).UnsortedList()
+		s.acc.sort(availableCores, s.acc.details.CPUsInCores)
+		result = append(result, availableCores...)
+	}
+	return result
+}
+
 type availableCPUSorter interface {
 	sort() []int
+	sortForResize() []int
 }
 
 type sortCPUsPacked struct{ acc *cpuAccumulator }
@@ -219,6 +402,14 @@ func (s sortCPUsPacked) sort() []int {
 
 func (s sortCPUsSpread) sort() []int {
 	return s.acc.sortAvailableCPUsSpread()
+}
+
+func (s sortCPUsPacked) sortForResize() []int {
+	return s.acc.sortAvailableCPUsPackedForResize()
+}
+
+func (s sortCPUsSpread) sortForResize() []int {
+	return s.acc.sortAvailableCPUsSpreadForResize()
 }
 
 // CPUSortingStrategy describes the CPU sorting solution within the socket scope.
@@ -288,6 +479,9 @@ type cpuAccumulator struct {
 	// cardinality equal to the total number of CPUs to accumulate.
 	result cpuset.CPUSet
 
+	// `resultDetails` is the set of allocated CPUs in `result`
+	resultDetails topology.CPUDetails
+
 	numaOrSocketsFirst numaOrSocketsFirstFuncs
 
 	// availableCPUSorter is used to control the cpu sorting result.
@@ -304,6 +498,64 @@ func newCPUAccumulator(logger klog.Logger, topo *topology.CPUTopology, available
 		details:       topo.CPUDetails.KeepOnly(availableCPUs),
 		numCPUsNeeded: numCPUs,
 		result:        cpuset.New(),
+	}
+
+	if topo.NumSockets >= topo.NumNUMANodes {
+		acc.numaOrSocketsFirst = &numaFirst{acc}
+	} else {
+		acc.numaOrSocketsFirst = &socketsFirst{acc}
+	}
+
+	if cpuSortingStrategy == CPUSortingStrategyPacked {
+		acc.availableCPUSorter = &sortCPUsPacked{acc}
+	} else {
+		acc.availableCPUSorter = &sortCPUsSpread{acc}
+	}
+
+	return acc
+}
+
+func newCPUAccumulatorForResize(logger klog.Logger, topo *topology.CPUTopology, availableCPUs cpuset.CPUSet, numCPUs int, cpuSortingStrategy CPUSortingStrategy, reusableCPUsForResize *cpuset.CPUSet, mustKeepCPUsForResize *cpuset.CPUSet) *cpuAccumulator {
+	acc := &cpuAccumulator{
+		logger:        logger,
+		topo:          topo,
+		details:       topo.CPUDetails.KeepOnly(availableCPUs),
+		numCPUsNeeded: numCPUs,
+		result:        cpuset.New(),
+		resultDetails: topo.CPUDetails.KeepOnly(cpuset.New()),
+	}
+
+	if reusableCPUsForResize != nil {
+		if !reusableCPUsForResize.IsEmpty() {
+			// Increase of CPU resources ( scale up )
+			// Take existing from allocated
+			// CPUs
+			if numCPUs > reusableCPUsForResize.Size() {
+				// scale up ...
+				acc.take(reusableCPUsForResize.Clone())
+			}
+
+			// Decrease of CPU resources ( scale down )
+			// Take delta from allocated CPUs, if mustKeepCPUsForResize
+			// is not nil, use explicetely those. If it is nil
+			// take delta starting from lowest CoreId of CPUs ( TODO esotsal, perhaps not needed).
+			if numCPUs < reusableCPUsForResize.Size() {
+				if mustKeepCPUsForResize != nil {
+					// If explicetely CPUs to keep
+					// during scale down is given ( this requires
+					// addition in container[].resources ... which
+					// could be possible to patch ? Esotsal Note This means
+					// modifying API code
+					acc.take(mustKeepCPUsForResize.Clone())
+				}
+			}
+
+			if numCPUs == reusableCPUsForResize.Size() {
+				// nothing to do return as is
+				acc.take(reusableCPUsForResize.Clone())
+				return acc
+			}
+		}
 	}
 
 	if topo.NumSockets >= topo.NumNUMANodes {
@@ -392,6 +644,26 @@ func (a *cpuAccumulator) freeCores() []int {
 // Returns free CPU IDs as a slice sorted by sortAvailableCPUsPacked().
 func (a *cpuAccumulator) freeCPUs() []int {
 	return a.availableCPUSorter.sort()
+}
+
+// Return true if this numa only allocated CPUs for this Container
+func (a *cpuAccumulator) isFullNUMANodeForResize(numaID int) bool {
+	return a.resultDetails.CPUsInNUMANodes(numaID).Size()+a.details.CPUsInNUMANodes(numaID).Size() == a.topo.CPUDetails.CPUsInNUMANodes(numaID).Size()
+}
+
+// Return true if this Socket only allocated CPUs for this Container
+func (a *cpuAccumulator) isFullSocketForResize(socketID int) bool {
+	return a.resultDetails.CPUsInSockets(socketID).Size()+a.details.CPUsInSockets(socketID).Size() == a.topo.CPUsPerSocket()
+}
+
+// return true if this Core only allocated CPUs for this Container
+func (a *cpuAccumulator) isFullCoreForResize(coreID int) bool {
+	return a.resultDetails.CPUsInCores(coreID).Size()+a.details.CPUsInCores(coreID).Size() == a.topo.CPUsPerCore()
+}
+
+// return true if this UncoreCache only allocated CPUs for this Container
+func (a *cpuAccumulator) isFullUncoreCacheForResize(uncoreID int) bool {
+	return a.resultDetails.CPUsInUncoreCaches(uncoreID).Size()+a.details.CPUsInUncoreCaches(uncoreID).Size() == a.topo.CPUDetails.CPUsInUncoreCaches(uncoreID).Size()
 }
 
 // Sorts the provided list of NUMA nodes/sockets/cores/cpus referenced in 'ids'
@@ -523,8 +795,108 @@ func (a *cpuAccumulator) sortAvailableCPUsSpread() []int {
 	return result
 }
 
+// Sort all NUMA nodes with at least one free CPU.
+//
+// If NUMA nodes are higher than sockets in the memory hierarchy, they are sorted by ascending number
+// of free CPUs that they contain. "higher than sockets in the memory hierarchy" means that NUMA nodes
+// contain a bigger number of CPUs (free and busy) than sockets, or equivalently that each NUMA node
+// contains more than one socket.
+//
+// If instead NUMA nodes are lower in the memory hierarchy than sockets, they are sorted as follows.
+// First part, sort the NUMA nodes which contains the CPUs allocated to Container. and these NUMA nodes
+// are sorted by number of free CPUs that they contain.
+// Second part, sort the NUMA nodes contained in the sockets which contains the CPUs allocated to Container,
+// but exclude the NUMA nodes in first part. these NUMA nodes sorted by the rule as below
+//
+//	First, they are sorted by number of free CPUs in the sockets that contain them. Then, for each
+//	socket they are sorted by number of free CPUs that they contain. The order is always ascending.
+func (a *cpuAccumulator) sortAvailableNUMANodesForResize() []int {
+	return a.numaOrSocketsFirst.sortAvailableNUMANodesForResize()
+}
+
+// Sort all sockets with at least one free CPU.
+//
+// If sockets are higher than NUMA nodes in the memory hierarchy, they are sorted by ascending number
+// of free CPUs that they contain. "higher than NUMA nodes in the memory hierarchy" means that
+// sockets contain a bigger number of CPUs (free and busy) than NUMA nodes, or equivalently that each
+// socket contains more than one NUMA node.
+//
+// If instead sockets are lower in the memory hierarchy than NUMA nodes, they are sorted as follows.
+// First part, sort the sockets which contains the CPUs allocated to Container. and these sockets
+// are sorted by number of free CPUs that they contain.
+// Second part, sort the sockets contained in the NUMA nodes which contains the CPUs allocated to Container,
+// but exclude the sockets in first part. these sockets sorted by the rule as below
+//
+//	First, they are sorted by number of free CPUs in the NUMA nodes that contain them. Then, for each
+//	NUMA node they are sorted by number of free CPUs that they contain. The order is always ascending.
+func (a *cpuAccumulator) sortAvailableSocketsForResize() []int {
+	return a.numaOrSocketsFirst.sortAvailableSocketsForResize()
+}
+
+// Sort all cores with at least one free CPU.
+//
+// If sockets are higher in the memory hierarchy than NUMA nodes, meaning that sockets contain a
+// bigger number of CPUs (free and busy) than NUMA nodes, or equivalently that each socket contains
+// more than one NUMA node, the cores are sorted as follows.
+// First part, sort the cores which contains the CPUs allocated to Container. and these cores
+// are sorted by number of free CPUs that they contain.
+// Second part, sort the cores contained in the NUMA nodes which contains the CPUs allocated to Container,
+// but exclude the cores in first part. these cores sorted by the rule as below
+// First, they are sorted by number of
+// free CPUs that their sockets contain. Then, for each socket, the cores in it are sorted by number
+// of free CPUs that their NUMA nodes contain. Then, for each NUMA node, the cores in it are sorted
+// by number of free CPUs that they contain. The order is always ascending.
+
+// If instead NUMA nodes are higher in the memory hierarchy than sockets, the sorting happens in the
+// same way as described in the previous paragraph.
+func (a *cpuAccumulator) sortAvailableCoresForResize() []int {
+	return a.numaOrSocketsFirst.sortAvailableCoresForResize()
+}
+
+// Sort all free CPUs.
+//
+// If sockets are higher in the memory hierarchy than NUMA nodes, meaning that sockets contain a
+// bigger number of CPUs (free and busy) than NUMA nodes, or equivalently that each socket contains
+// more than one NUMA node, the CPUs are sorted as follows.
+// First part, sort the cores which contains the CPUs allocated to Container. and these cores
+// are sorted by number of free CPUs that they contain. for each core, the CPUs in it are
+// sorted by numerical ID.
+// Second part, sort the cores contained in the NUMA nodes which contains the CPUs allocated to Container,
+// but exclude the cores in first part. these cores sorted by the rule as below
+// First, they are sorted by number of
+// free CPUs that their sockets contain. Then, for each socket, the CPUs in it are sorted by number
+// of free CPUs that their NUMA nodes contain. Then, for each NUMA node, the CPUs in it are sorted
+// by number of free CPUs that their cores contain. Finally, for each core, the CPUs in it are
+// sorted by numerical ID. The order is always ascending.
+//
+// If instead NUMA nodes are higher in the memory hierarchy than sockets, the sorting happens in the
+// same way as described in the previous paragraph.
+func (a *cpuAccumulator) sortAvailableCPUsPackedForResize() []int {
+	var result []int
+	for _, core := range a.sortAvailableCoresForResize() {
+		cpus := a.details.CPUsInCores(core).UnsortedList()
+		sort.Ints(cpus)
+		result = append(result, cpus...)
+	}
+	return result
+}
+
+// Sort all available CPUs:
+// - First by core using sortAvailableSocketsForResize().
+// - Then within each socket, sort cpus directly using the sort() algorithm defined above.
+func (a *cpuAccumulator) sortAvailableCPUsSpreadForResize() []int {
+	var result []int
+	for _, socket := range a.sortAvailableSocketsForResize() {
+		cpus := a.details.CPUsInSockets(socket).UnsortedList()
+		sort.Ints(cpus)
+		result = append(result, cpus...)
+	}
+	return result
+}
+
 func (a *cpuAccumulator) take(cpus cpuset.CPUSet) {
 	a.result = a.result.Union(cpus)
+	a.resultDetails = a.topo.CPUDetails.KeepOnly(a.result)
 	a.details = a.details.KeepOnly(a.details.CPUs().Difference(a.result))
 	a.numCPUsNeeded -= cpus.Size()
 }
@@ -639,6 +1011,84 @@ func (a *cpuAccumulator) takeFullCores() {
 func (a *cpuAccumulator) takeRemainingCPUs() {
 	for _, cpu := range a.availableCPUSorter.sort() {
 		a.logger.V(4).Info("takeRemainingCPUs: claiming CPU", "cpu", cpu)
+		a.take(cpuset.New(cpu))
+		if a.isSatisfied() {
+			return
+		}
+	}
+}
+
+func (a *cpuAccumulator) takeFullUncoreForResize() {
+	for _, uncore := range a.sortAvailableUncoreCachesForResize() {
+		if a.isFullUncoreCacheForResize(uncore) {
+			cpusInUncore := a.details.CPUsInUncoreCaches(uncore)
+			if !a.needsAtLeast(cpusInUncore.Size()) {
+				continue
+			}
+			a.logger.V(4).Info("takeFullUncoreForResize: claiming uncore", "uncore", uncore)
+			a.take(cpusInUncore)
+		}
+	}
+}
+
+func (a *cpuAccumulator) takeUncoreCacheForResize() {
+	// take full UncoreCache if the CPUs needed is greater than free UncoreCache size
+	a.takeFullUncoreForResize()
+	if a.isSatisfied() {
+		return
+	}
+
+	// take partial UncoreCache if the CPUs needed is less than free UncoreCache size
+	for _, uncore := range a.sortAvailableUncoreCachesForResize() {
+		a.takePartialUncore(uncore)
+		if a.isSatisfied() {
+			return
+		}
+	}
+}
+
+func (a *cpuAccumulator) takeFullNUMANodesForResize() {
+	for _, numa := range a.sortAvailableNUMANodesForResize() {
+		if a.isFullNUMANodeForResize(numa) {
+			cpusInNUMANode := a.details.CPUsInNUMANodes(numa)
+			if !a.needsAtLeast(cpusInNUMANode.Size()) {
+				continue
+			}
+			a.logger.V(4).Info("takeFullNUMANodesForResize: claiming NUMA node", "numa", numa, "cpusInNUMANode", cpusInNUMANode)
+			a.take(cpusInNUMANode)
+		}
+	}
+}
+
+func (a *cpuAccumulator) takeFullSocketsForResize() {
+	for _, socket := range a.sortAvailableSocketsForResize() {
+		if a.isFullSocketForResize(socket) {
+			cpusInSocket := a.details.CPUsInSockets(socket)
+			if !a.needsAtLeast(cpusInSocket.Size()) {
+				continue
+			}
+			a.logger.V(4).Info("takeFullSocketsForResize: claiming Socket", "socket", socket, "cpusInSocket", cpusInSocket)
+			a.take(cpusInSocket)
+		}
+	}
+}
+
+func (a *cpuAccumulator) takeFullCoresForResize() {
+	for _, core := range a.sortAvailableCoresForResize() {
+		if a.isFullCoreForResize(core) {
+			cpusInCore := a.details.CPUsInCores(core)
+			if !a.needsAtLeast(cpusInCore.Size()) {
+				continue
+			}
+			a.logger.V(4).Info("takeFullCoresForResize: claiming Core", "core", core, "cpusInCore", cpusInCore)
+			a.take(cpusInCore)
+		}
+	}
+}
+
+func (a *cpuAccumulator) takeRemainingCPUsForResize() {
+	for _, cpu := range a.availableCPUSorter.sortForResize() {
+		a.logger.V(4).Info("takeRemainingCPUsForResize: claiming CPU", "cpu", cpu)
 		a.take(cpuset.New(cpu))
 		if a.isSatisfied() {
 			return
@@ -1151,4 +1601,322 @@ func takeByTopologyNUMADistributed(logger klog.Logger, topo *topology.CPUTopolog
 	// If we never found a combination of NUMA nodes that we could properly
 	// distribute CPUs across, fall back to the packing algorithm.
 	return takeByTopologyNUMAPacked(logger, topo, availableCPUs, numCPUs, cpuSortingStrategy, false)
+}
+
+func takeByTopologyNUMADistributedForResize(logger klog.Logger, topo *topology.CPUTopology, availableCPUs cpuset.CPUSet, numCPUs int, cpuGroupSize int, cpuSortingStrategy CPUSortingStrategy, reusableCPUsForResize *cpuset.CPUSet, mustKeepCPUsForResize *cpuset.CPUSet) (cpuset.CPUSet, error) {
+	// If the number of CPUs requested cannot be handed out in chunks of
+	// 'cpuGroupSize', then we just call out the packing algorithm since we
+	// can't distribute CPUs in this chunk size.
+	// PreferAlignByUncoreCache feature not implemented here yet and set to false.
+	// Support for PreferAlignByUncoreCache to be done at beta release.
+	if (numCPUs % cpuGroupSize) != 0 {
+		return takeByTopologyNUMAPackedForResize(logger, topo, availableCPUs, numCPUs, cpuSortingStrategy, false, reusableCPUsForResize, mustKeepCPUsForResize)
+	}
+
+	// If the number of CPUs requested to be retained is not a subset
+	// of reusableCPUs, then we fail early
+	if reusableCPUsForResize != nil && mustKeepCPUsForResize != nil {
+		if !mustKeepCPUsForResize.Clone().IsSubsetOf(reusableCPUsForResize.Clone()) {
+			return cpuset.New(), fmt.Errorf("requested CPUs to be retained %s are not a subset of reusable CPUs %s", mustKeepCPUsForResize.String(), reusableCPUsForResize.String())
+		}
+	}
+
+	// Otherwise build an accumulator to start allocating CPUs from.
+	acc := newCPUAccumulatorForResize(logger, topo, availableCPUs, numCPUs, cpuSortingStrategy, reusableCPUsForResize, mustKeepCPUsForResize)
+	if acc.isSatisfied() {
+		return acc.result, nil
+	}
+	if acc.isFailed() {
+		return cpuset.New(), fmt.Errorf("not enough cpus available to satisfy request: requested=%d, available=%d", numCPUs, availableCPUs.Size())
+	}
+
+	// Get the list of NUMA nodes represented by the set of CPUs in 'availableCPUs'.
+	numas := acc.sortAvailableNUMANodesForResize()
+
+	// Calculate the minimum and maximum possible number of NUMA nodes that
+	// could satisfy this request. This is used to optimize how many iterations
+	// of the loop we need to go through below.
+	minNUMAs, maxNUMAs := acc.rangeNUMANodesNeededToSatisfy(cpuGroupSize)
+	minNUMAs = max(minNUMAs, acc.resultDetails.NUMANodes().Size())
+
+	// Try combinations of 1,2,3,... NUMA nodes until we find a combination
+	// where we can evenly distribute CPUs across them. To optimize things, we
+	// don't always start at 1 and end at len(numas). Instead, we use the
+	// values of 'minNUMAs' and 'maxNUMAs' calculated above.
+	for k := minNUMAs; k <= maxNUMAs; k++ {
+		// Iterate through the various n-choose-k NUMA node combinations,
+		// looking for the combination of NUMA nodes that can best have CPUs
+		// distributed across them.
+		var bestBalance = math.MaxFloat64
+		var bestRemainder []int = nil
+		var bestCombo []int = nil
+		acc.iterateCombinations(numas, k, func(combo []int) LoopControl {
+			// If we've already found a combo with a balance of 0 in a
+			// different iteration, then don't bother checking any others.
+			if bestBalance == 0 {
+				return Break
+			}
+
+			// Check if the 'allocatedNumas' CPU set is a subset of the 'comboSet'
+			comboSet := cpuset.New(combo...)
+			if !acc.resultDetails.NUMANodes().IsSubsetOf(comboSet) {
+				return Continue
+			}
+
+			// Check that this combination of NUMA nodes has enough CPUs to
+			// satisfy the allocation overall.
+			cpus := acc.details.CPUsInNUMANodes(combo...)
+			if (cpus.Size() + acc.result.Size()) < numCPUs {
+				return Continue
+			}
+
+			// Check that CPUs can be handed out in groups of size
+			// 'cpuGroupSize' across the NUMA nodes in this combo.
+			numCPUGroups := 0
+			for _, numa := range combo {
+				numCPUGroups += ((acc.details.CPUsInNUMANodes(numa).Size() + acc.resultDetails.CPUsInNUMANodes(numa).Size()) / cpuGroupSize)
+			}
+			if (numCPUGroups * cpuGroupSize) < numCPUs {
+				return Continue
+			}
+
+			// Check that each NUMA node in this combination can allocate an
+			// even distribution of CPUs in groups of size 'cpuGroupSize',
+			// modulo some remainder.
+			distribution := (numCPUs / len(combo) / cpuGroupSize) * cpuGroupSize
+			for _, numa := range combo {
+				cpus := acc.details.CPUsInNUMANodes(numa)
+				allocateCpus := acc.resultDetails.CPUsInNUMANodes(numa)
+				if (cpus.Size() + allocateCpus.Size()) < distribution {
+					return Continue
+				}
+				if allocateCpus.Size() > distribution {
+					return Continue
+				}
+			}
+
+			// Calculate how many CPUs will be available on each NUMA node in
+			// the system after allocating an even distribution of CPU groups
+			// of size 'cpuGroupSize' from each NUMA node in 'combo'. This will
+			// be used in the "balance score" calculation to help decide if
+			// this combo should ultimately be chosen.
+			availableAfterAllocation := make(mapIntInt, len(numas))
+			for _, numa := range numas {
+				availableAfterAllocation[numa] = acc.details.CPUsInNUMANodes(numa).Size()
+			}
+			for _, numa := range combo {
+				availableAfterAllocation[numa] -= (distribution - acc.resultDetails.CPUsInNUMANodes(numa).Size())
+			}
+
+			// Check if there are any remaining CPUs to distribute across the
+			// NUMA nodes once CPUs have been evenly distributed in groups of
+			// size 'cpuGroupSize'.
+			remainder := numCPUs - (distribution * len(combo))
+
+			// Get a list of NUMA nodes to consider pulling the remainder CPUs
+			// from. This list excludes NUMA nodes that don't have at least
+			// 'cpuGroupSize' CPUs available after being allocated
+			// 'distribution' number of CPUs.
+			var remainderCombo []int
+			for _, numa := range combo {
+				if availableAfterAllocation[numa] >= cpuGroupSize {
+					remainderCombo = append(remainderCombo, numa)
+				}
+			}
+
+			// Declare a set of local variables to help track the "balance
+			// scores" calculated when using different subsets of
+			// 'remainderCombo' to allocate remainder CPUs from.
+			var bestLocalBalance = math.MaxFloat64
+			var bestLocalRemainder []int = nil
+
+			// If there aren't any remainder CPUs to allocate, then calculate
+			// the "balance score" of this combo as the standard deviation of
+			// the values contained in 'availableAfterAllocation'.
+			if remainder == 0 {
+				bestLocalBalance = standardDeviation(availableAfterAllocation.Values())
+				bestLocalRemainder = nil
+			}
+
+			// Otherwise, find the best "balance score" when allocating the
+			// remainder CPUs across different subsets of NUMA nodes in 'remainderCombo'.
+			// These remainder CPUs are handed out in groups of size 'cpuGroupSize'.
+			// We start from k=len(remainderCombo) and walk down to k=1 so that
+			// we continue to distribute CPUs as much as possible across
+			// multiple NUMA nodes.
+			for k := len(remainderCombo); remainder > 0 && k >= 1; k-- {
+				acc.iterateCombinations(remainderCombo, k, func(subset []int) LoopControl {
+					// Make a local copy of 'remainder'.
+					remainder := remainder
+
+					// Make a local copy of 'availableAfterAllocation'.
+					availableAfterAllocation := availableAfterAllocation.Clone()
+
+					// If this subset is not capable of allocating all
+					// remainder CPUs, continue to the next one.
+					if sum(availableAfterAllocation.Values(subset...)) < remainder {
+						return Continue
+					}
+
+					// For all NUMA nodes in 'subset', walk through them,
+					// removing 'cpuGroupSize' number of CPUs from each
+					// until all remainder CPUs have been accounted for.
+					for remainder > 0 {
+						for _, numa := range subset {
+							if remainder == 0 {
+								break
+							}
+							if availableAfterAllocation[numa] < cpuGroupSize {
+								continue
+							}
+							availableAfterAllocation[numa] -= cpuGroupSize
+							remainder -= cpuGroupSize
+						}
+					}
+
+					// Calculate the "balance score" as the standard deviation
+					// of the number of CPUs available on all NUMA nodes in the
+					// system after the remainder CPUs have been allocated
+					// across 'subset' in groups of size 'cpuGroupSize'.
+					balance := standardDeviation(availableAfterAllocation.Values())
+					if balance < bestLocalBalance {
+						bestLocalBalance = balance
+						bestLocalRemainder = subset
+					}
+
+					return Continue
+				})
+			}
+
+			// If the best "balance score" for this combo is less than the
+			// lowest "balance score" of all previous combos, then update this
+			// combo (and remainder set) to be the best one found so far.
+			if bestLocalBalance < bestBalance {
+				bestBalance = bestLocalBalance
+				bestRemainder = bestLocalRemainder
+				bestCombo = combo
+			}
+
+			return Continue
+		})
+
+		// If we made it through all of the iterations above without finding a
+		// combination of NUMA nodes that can properly balance CPU allocations,
+		// then move on to the next larger set of NUMA node combinations.
+		if bestCombo == nil {
+			continue
+		}
+
+		// Otherwise, start allocating CPUs from the NUMA node combination
+		// chosen. First allocate an even distribution of CPUs in groups of
+		// size 'cpuGroupSize' from 'bestCombo'.
+		distribution := (numCPUs / len(bestCombo) / cpuGroupSize) * cpuGroupSize
+		for _, numa := range bestCombo {
+			allocatedCPUs := acc.resultDetails.CPUsInNUMANodes(numa)
+			cpus, _ := takeByTopologyNUMAPackedForResize(logger, acc.topo, acc.details.CPUsInNUMANodes(numa), distribution, cpuSortingStrategy, false, &allocatedCPUs, nil)
+			acc.take(cpus.Difference(allocatedCPUs))
+		}
+
+		// Then allocate any remaining CPUs in groups of size 'cpuGroupSize'
+		// from each NUMA node in the remainder set.
+		remainder := numCPUs - (distribution * len(bestCombo))
+		for remainder > 0 {
+			for _, numa := range bestRemainder {
+				if remainder == 0 {
+					break
+				}
+				if acc.details.CPUsInNUMANodes(numa).Size() < cpuGroupSize {
+					continue
+				}
+				allocatedCPUs := acc.resultDetails.CPUsInNUMANodes(numa)
+				needCPUsInNuma := allocatedCPUs.Size() + cpuGroupSize
+				cpus, _ := takeByTopologyNUMAPackedForResize(logger, acc.topo, acc.details.CPUsInNUMANodes(numa), needCPUsInNuma, cpuSortingStrategy, false, &allocatedCPUs, nil)
+				acc.take(cpus.Difference(allocatedCPUs))
+				remainder -= cpuGroupSize
+			}
+		}
+
+		// If we haven't allocated all of our CPUs at this point, then something
+		// went wrong in our accounting and we should error out.
+		if acc.numCPUsNeeded > 0 {
+			return cpuset.New(), fmt.Errorf("accounting error, not enough CPUs allocated, remaining: %v", acc.numCPUsNeeded)
+		}
+
+		// Likewise, if we have allocated too many CPUs at this point, then something
+		// went wrong in our accounting and we should error out.
+		if acc.numCPUsNeeded < 0 {
+			return cpuset.New(), fmt.Errorf("accounting error, too many CPUs allocated, remaining: %v", acc.numCPUsNeeded)
+		}
+
+		// Otherwise, return the result
+		return acc.result, nil
+	}
+
+	// If we never found a combination of NUMA nodes that we could properly
+	// distribute CPUs across, fall back to the packing algorithm.
+	return takeByTopologyNUMAPackedForResize(logger, topo, availableCPUs, numCPUs, cpuSortingStrategy, false, reusableCPUsForResize, mustKeepCPUsForResize)
+}
+
+func takeByTopologyNUMAPackedForResize(logger klog.Logger, topo *topology.CPUTopology, availableCPUs cpuset.CPUSet, numCPUs int, cpuSortingStrategy CPUSortingStrategy, preferAlignByUncoreCache bool, reusableCPUsForResize *cpuset.CPUSet, mustKeepCPUsForResize *cpuset.CPUSet) (cpuset.CPUSet, error) {
+
+	// If the number of CPUs requested to be retained is not a subset
+	// of reusableCPUs, then we fail early
+	if reusableCPUsForResize != nil && mustKeepCPUsForResize != nil {
+		if !mustKeepCPUsForResize.Clone().IsSubsetOf(reusableCPUsForResize.Clone()) {
+			return cpuset.New(), fmt.Errorf("requested CPUs to be retained %s are not a subset of reusable CPUs %s", mustKeepCPUsForResize.String(), reusableCPUsForResize.String())
+		}
+	}
+
+	acc := newCPUAccumulatorForResize(logger, topo, availableCPUs, numCPUs, cpuSortingStrategy, reusableCPUsForResize, mustKeepCPUsForResize)
+	if acc.isSatisfied() {
+		return acc.result, nil
+	}
+	if acc.isFailed() {
+		return cpuset.New(), fmt.Errorf("not enough cpus available to satisfy request: requested=%d, available=%d", numCPUs, availableCPUs.Size())
+	}
+
+	// Algorithm: topology-aware best-fit
+	// 1. Acquire whole NUMA nodes and sockets, if available and the container
+	//    requires at least a NUMA node or socket's-worth of CPUs. If NUMA
+	//    Nodes map to 1 or more sockets, pull from NUMA nodes first.
+	//    Otherwise pull from sockets first.
+	acc.numaOrSocketsFirst.takeFullFirstLevelForResize()
+	if acc.isSatisfied() {
+		return acc.result, nil
+	}
+
+	acc.numaOrSocketsFirst.takeFullSecondLevelForResize()
+	if acc.isSatisfied() {
+		return acc.result, nil
+	}
+
+	// 2. If PreferAlignByUncoreCache is enabled, acquire whole UncoreCaches
+	//    if available and the container requires at least a UncoreCache's-worth
+	//    of CPUs. Otherwise, acquire CPUs from the least amount of UncoreCaches.
+	if preferAlignByUncoreCache {
+		acc.takeUncoreCacheForResize()
+		if acc.isSatisfied() {
+			return acc.result, nil
+		}
+	}
+
+	// 3. Acquire whole cores, if available and the container requires at least
+	//    a core's-worth of CPUs.
+	//    If `CPUSortingStrategySpread` is specified, skip taking the whole core.
+	if cpuSortingStrategy != CPUSortingStrategySpread {
+		acc.takeFullCoresForResize()
+		if acc.isSatisfied() {
+			return acc.result, nil
+		}
+	}
+
+	// 4. Acquire single threads, preferring to fill partially-allocated cores
+	//    on the same sockets as the whole cores we have already taken in this
+	//    allocation.
+	acc.takeRemainingCPUsForResize()
+	if acc.isSatisfied() {
+		return acc.result, nil
+	}
+
+	return cpuset.New(), fmt.Errorf("failed to allocate cpus")
 }

--- a/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
@@ -1080,6 +1080,495 @@ func TestTakeByTopologyNUMADistributed(t *testing.T) {
 	}
 }
 
+type takeByTopologyTestCaseForResize struct {
+	description   string
+	topo          *topology.CPUTopology
+	opts          StaticPolicyOptions
+	availableCPUs cpuset.CPUSet
+	reusableCPUs  cpuset.CPUSet
+	numCPUs       int
+	expErr        string
+	expResult     cpuset.CPUSet
+}
+
+func commonTakeByTopologyTestCasesForResize(t *testing.T) []takeByTopologyTestCaseForResize {
+	return []takeByTopologyTestCaseForResize{
+		{
+			"Allocated 1 CPUs, and take 1 cpus from single socket with HT",
+			topoSingleSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "1-7"),
+			cpuset.New(0),
+			1,
+			"",
+			cpuset.New(0),
+		},
+		{
+			"Allocated 1 CPU, and take 2 cpu from single socket with HT",
+			topoSingleSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "1-7"),
+			cpuset.New(0),
+			2,
+			"",
+			cpuset.New(0, 4),
+		},
+		{
+			"Allocated 1 CPU, and take 2 cpu from single socket with HT, some cpus are taken, no sibling CPU of allocated CPU",
+			topoSingleSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "1,3,5,6,7"),
+			cpuset.New(0),
+			2,
+			"",
+			cpuset.New(0, 6),
+		},
+		{
+			"Allocated 1 CPU, and take 3 cpu from single socket with HT, some cpus are taken, no sibling CPU of allocated CPU",
+			topoSingleSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "1,3,5,6,7"),
+			cpuset.New(0),
+			3,
+			"",
+			cpuset.New(0, 1, 5),
+		},
+		{
+			"Allocated 1 CPU, and take all cpu from single socket with HT",
+			topoSingleSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "1-7"),
+			cpuset.New(0),
+			8,
+			"",
+			mustParseCPUSet(t, "0-7"),
+		},
+		{
+			"Allocated 1 CPU, take a core from dual socket with HT",
+			topoDualSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "0-10"),
+			cpuset.New(11),
+			2,
+			"",
+			cpuset.New(5, 11),
+		},
+		{
+			"Allocated 1 CPU, take a socket of cpus from dual socket with HT",
+			topoDualSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "0-10"),
+			cpuset.New(11),
+			6,
+			"",
+			cpuset.New(1, 3, 5, 7, 9, 11),
+		},
+		{
+			"Allocated 1 CPU, take a socket of cpus and 1 core of CPU from dual socket with HT",
+			topoDualSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "0-10"),
+			cpuset.New(11),
+			8,
+			"",
+			cpuset.New(0, 1, 3, 5, 6, 7, 9, 11),
+		},
+		{
+			"Allocated 1 CPU, take a socket of cpus from dual socket with multi-numa-per-socket with HT",
+			topoDualSocketMultiNumaPerSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "0-38,40-79"),
+			cpuset.New(39),
+			40,
+			"",
+			mustParseCPUSet(t, "20-39,60-79"),
+		},
+		{
+			"Allocated 1 CPU, take a NUMA node of cpus from dual socket with multi-numa-per-socket with HT",
+			topoDualSocketMultiNumaPerSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "0-38,40-79"),
+			cpuset.New(39),
+			20,
+			"",
+			mustParseCPUSet(t, "30-39,70-79"),
+		},
+		{
+			"Allocated 2 CPUs, take a socket and a NUMA node of cpus from dual socket with multi-numa-per-socket with HT",
+			topoDualSocketMultiNumaPerSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "0-38,40-58,60-79"),
+			cpuset.New(39, 59),
+			60,
+			"",
+			mustParseCPUSet(t, "0-19,30-59,70-79"),
+		},
+		{
+			"Allocated 1 CPU, take NUMA nodes of cpus from dual socket with multi-numa-per-socket with HT, the NUMA node with allocated CPUs already taken some CPUs",
+			topoDualSocketMultiNumaPerSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "0-38,40-69"),
+			cpuset.New(39),
+			40,
+			"",
+			mustParseCPUSet(t, "0-8,20-30,39-48,60-69"),
+		},
+		{
+			"Take NUMA nodes of cpus from dual socket with multi-numa-per-socket with HT, the NUMA node with allocated CPUs already taken more CPUs",
+			topoDualSocketMultiNumaPerSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "9,30-38,49"),
+			cpuset.New(),
+			1,
+			"",
+			mustParseCPUSet(t, "9"),
+		},
+		{
+			"Allocated 1 CPU, take NUMA nodes of cpus and 1 CPU from dual socket with multi-numa-per-socket with HT, the NUMA node with allocated CPUs already taken some CPUs",
+			topoDualSocketMultiNumaPerSocketHT,
+			StaticPolicyOptions{},
+			mustParseCPUSet(t, "0-38,40-69"),
+			cpuset.New(39),
+			41,
+			"",
+			mustParseCPUSet(t, "0-19,39-59"),
+		},
+		{
+			"Allocated 1 CPUs, take a socket of cpus from single socket with HT, 3 cpus",
+			topoSingleSocketHT,
+			StaticPolicyOptions{DistributeCPUsAcrossCores: true},
+			mustParseCPUSet(t, "0-6"),
+			cpuset.New(7),
+			3,
+			"",
+			mustParseCPUSet(t, "0,1,7"),
+		},
+		{
+			"Allocated 1 CPUs, take a socket of cpus from dual socket with HT, 3 cpus",
+			topoDualSocketHT,
+			StaticPolicyOptions{DistributeCPUsAcrossCores: true},
+			mustParseCPUSet(t, "0-10"),
+			cpuset.New(11),
+			3,
+			"",
+			mustParseCPUSet(t, "1,3,11"),
+		},
+		{
+			"Allocated 1 CPUs, take a socket of cpus from dual socket with HT, 6 cpus",
+			topoDualSocketHT,
+			StaticPolicyOptions{DistributeCPUsAcrossCores: true},
+			mustParseCPUSet(t, "0-10"),
+			cpuset.New(11),
+			6,
+			"",
+			mustParseCPUSet(t, "1,3,5,7,9,11"),
+		},
+		{
+			"Allocated 1 CPUs, take a socket of cpus from dual socket with HT, 8 cpus",
+			topoDualSocketHT,
+			StaticPolicyOptions{DistributeCPUsAcrossCores: true},
+			mustParseCPUSet(t, "0-10"),
+			cpuset.New(11),
+			8,
+			"",
+			mustParseCPUSet(t, "0,1,2,3,5,7,9,11"),
+		},
+		{
+			"Allocated 1 CPUs, take a socket of cpus from dual socket without HT, 2 cpus",
+			topoDualSocketNoHT,
+			StaticPolicyOptions{DistributeCPUsAcrossCores: true},
+			mustParseCPUSet(t, "0-6"),
+			cpuset.New(7),
+			2,
+			"",
+			mustParseCPUSet(t, "4,7"),
+		},
+		{
+			"Allocated 1 CPUs, take a socket of cpus from dual socket with multi numa per socket and HT, 8 cpus",
+			topoDualSocketMultiNumaPerSocketHT,
+			StaticPolicyOptions{DistributeCPUsAcrossCores: true},
+			mustParseCPUSet(t, "0-38,40-79"),
+			cpuset.New(39),
+			8,
+			"",
+			mustParseCPUSet(t, "20-26,39"),
+		},
+		{
+			"Allocated 1 CPU, take NUMA nodes of cpus from dual socket with multi-numa-per-socket with HT, the NUMA node with allocated CPUs already taken some CPUs",
+			topoDualSocketMultiNumaPerSocketHT,
+			StaticPolicyOptions{DistributeCPUsAcrossCores: true},
+			mustParseCPUSet(t, "0-38,40-69"),
+			cpuset.New(39),
+			40,
+			"",
+			mustParseCPUSet(t, "0-9,20-39,60-69"),
+		},
+		{
+			"Allocated 1 CPUs, take a socket of cpus from quad socket four way with HT, 12 cpus",
+			topoQuadSocketFourWayHT,
+			StaticPolicyOptions{DistributeCPUsAcrossCores: true},
+			mustParseCPUSet(t, "0-59,61-287"),
+			cpuset.New(60),
+			8,
+			"",
+			mustParseCPUSet(t, "3,4,11,12,15,16,23,60"),
+		},
+		{
+			"Allocated 2 CPUs, take cpus from best available UncoreCache group of multi uncore cache single socket - SMT disabled",
+			topoUncoreSingleSocketNoSMT,
+			StaticPolicyOptions{PreferAlignByUncoreCacheOption: true},
+			mustParseCPUSet(t, "2-3,10-11,4-7,12-15"),
+			cpuset.New(8, 9),
+			8,
+			"",
+			cpuset.New(4, 5, 6, 7, 8, 9, 10, 11),
+		},
+		{
+			"Allocated 2 CPUs, take cpus from the allocated cores in partial UncoreCache - SMT enabled",
+			topoUncoreSingleSocketSMT,
+			StaticPolicyOptions{PreferAlignByUncoreCacheOption: true},
+			mustParseCPUSet(t, "0-3,7-15"),
+			cpuset.New(4, 5, 6),
+			8,
+			"",
+			cpuset.New(4, 5, 6, 7, 12, 13, 14, 15),
+		},
+	}
+}
+
+func TestTakeByTopologyNUMAPackedForResize(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	testCases := commonTakeByTopologyTestCasesForResize(t)
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			strategy := CPUSortingStrategyPacked
+			if tc.opts.DistributeCPUsAcrossCores {
+				strategy = CPUSortingStrategySpread
+			}
+
+			result, err := takeByTopologyNUMAPackedForResize(logger, tc.topo, tc.availableCPUs, tc.numCPUs, strategy, tc.opts.PreferAlignByUncoreCacheOption, &tc.reusableCPUs, nil)
+
+			if tc.expErr != "" && err != nil && err.Error() != tc.expErr {
+				t.Errorf("expected error to be [%v] but it was [%v]", tc.expErr, err)
+			}
+			if !result.Equals(tc.expResult) {
+				t.Errorf("expected result [%s] to equal [%s]", result, tc.expResult)
+			}
+		})
+	}
+}
+
+type takeByTopologyExtendedTestCaseForResize struct {
+	description   string
+	topo          *topology.CPUTopology
+	availableCPUs cpuset.CPUSet
+	reusableCPUs  cpuset.CPUSet
+	numCPUs       int
+	cpuGroupSize  int
+	expErr        string
+	expResult     cpuset.CPUSet
+}
+
+func commonTakeByTopologyExtendedTestCasesForResize(t *testing.T) []takeByTopologyExtendedTestCaseForResize {
+	return []takeByTopologyExtendedTestCaseForResize{
+		{
+			"Allocated 1 CPUs, allocate 4 full cores with 2 distributed across each NUMA node",
+			topoDualSocketHT,
+			mustParseCPUSet(t, "0-10"),
+			cpuset.New(11),
+			8,
+			1,
+			"",
+			mustParseCPUSet(t, "0,6,2,8,1,7,5,11"),
+		},
+		{
+			"Allocated 8 CPUs, allocate 32 full cores with 8 distributed across each NUMA node",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "0-35,40-75"),
+			mustParseCPUSet(t, "36-39,76-79"),
+			64,
+			1,
+			"",
+			mustParseCPUSet(t, "0-7,10-17,20-27,30-33,36-39,40-47,50-57,60-67,70-73,76-79"),
+		},
+		{
+			"Allocated 2 CPUs, allocate 8 full cores with 2 distributed across each NUMA node",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "2,10-12,20-22,30-32,40-41,50-51,60-61,70-71"),
+			mustParseCPUSet(t, "0,1"),
+			16,
+			1,
+			"",
+			mustParseCPUSet(t, "0-1,10-11,20-21,30-31,40-41,50-51,60-61,70-71"),
+		},
+		{
+			"Allocated 1 CPUs, take 1 cpu from dual socket with HT - core from Socket 0",
+			topoDualSocketHT,
+			mustParseCPUSet(t, "0-10"),
+			mustParseCPUSet(t, "11"),
+			1,
+			1,
+			"",
+			mustParseCPUSet(t, "11"),
+		},
+		{
+			"Allocated 1 CPUs, take 2 cpu from dual socket with HT - core from Socket 0",
+			topoDualSocketHT,
+			mustParseCPUSet(t, "0-10"),
+			mustParseCPUSet(t, "11"),
+			2,
+			1,
+			"",
+			mustParseCPUSet(t, "5,11"),
+		},
+		{
+			"Allocated 2 CPUs, allocate 31 full cores with 15 CPUs distributed across each NUMA node and 1 CPU spilling over to each of NUMA 0, 1",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "2-79"),
+			mustParseCPUSet(t, "0,1"),
+			62,
+			1,
+			"",
+			mustParseCPUSet(t, "0-7,10-17,20-27,30-37,40-47,50-57,60-66,70-76"),
+		},
+		{
+			"Allocated 2 CPUs, allocate 31 full cores with 14 CPUs distributed across each NUMA node and 2 CPUs spilling over to each of NUMA 0, 1, 2 (cpuGroupSize 2)",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "2-79"),
+			mustParseCPUSet(t, "0,1"),
+			62,
+			2,
+			"",
+			mustParseCPUSet(t, "0-7,10-17,20-27,30-36,40-47,50-57,60-67,70-76"),
+		},
+		{
+			"Allocated 2 CPUs, allocate 31 full cores with 15 CPUs distributed across each NUMA node and 1 CPU spilling over to each of NUMA 2, 3 (to keep balance)",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "2-8,10-18,20-39,40-48,50-58,60-79"),
+			mustParseCPUSet(t, "0,1"),
+			62,
+			1,
+			"",
+			mustParseCPUSet(t, "0-7,10-17,20-27,30-37,40-46,50-56,60-67,70-77"),
+		},
+		{
+			"Allocated 2 CPUs, allocate 31 full cores with 14 CPUs distributed across each NUMA node and 2 CPUs spilling over to each of NUMA 0, 2, 3 (to keep balance with cpuGroupSize 2)",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "2-8,10-18,20-39,40-48,50-58,60-79"),
+			mustParseCPUSet(t, "0,1"),
+			62,
+			2,
+			"",
+			mustParseCPUSet(t, "0-7,10-16,20-27,30-37,40-47,50-56,60-67,70-77"),
+		},
+		{
+			"Allocated 4 CPUs, ensure bestRemainder chosen with NUMA nodes that have enough CPUs to satisfy the request",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "10-13,20-23,30-36,40-43,50-53,60-63,70-76"),
+			mustParseCPUSet(t, "0-3"),
+			34,
+			1,
+			"",
+			mustParseCPUSet(t, "0-3,10-13,20-23,30-34,40-43,50-53,60-63,70-74"),
+		},
+		{
+			"Allocated 4 CPUs, ensure previous failure encountered on live machine has been fixed (1/1)",
+			topoDualSocketMultiNumaPerSocketHTLarge,
+			mustParseCPUSet(t, "0,128,30,31,158,159,47,171-175,62,63,190,191,75-79,203-207,94,96,222,223,101-111,229-239,126,127,254,255"),
+			mustParseCPUSet(t, "43-46"),
+			28,
+			1,
+			"",
+			mustParseCPUSet(t, "43-47,75-79,96,101-105,171-174,203-206,229-232"),
+		},
+		{
+			"Allocated 14 CPUs, allocate 24 full cores with 8 distributed across the first 3 NUMA nodes",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "8-39,48-79"),
+			mustParseCPUSet(t, "0-7,40-47"),
+			48,
+			1,
+			"",
+			mustParseCPUSet(t, "0-7,10-17,20-27,40-47,50-57,60-67"),
+		},
+		{
+			"Allocated 20 CPUs, allocated CPUs in numa0 is bigger than distribute CPUs, allocated CPUs by takeByTopologyNUMAPacked",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "10-39,50-79"),
+			mustParseCPUSet(t, "0-9,40-49"),
+			48,
+			1,
+			"",
+			mustParseCPUSet(t, "0-23,40-63"),
+		},
+		{
+			"Allocated 12 CPUs, allocate 24 full cores with 8 distributed across the first 3 NUMA nodes (taking all but 2 from the first NUMA node)",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "8-29,32-39,48-69,72-79"),
+			mustParseCPUSet(t, "1-7,41-47"),
+			48,
+			1,
+			"",
+			mustParseCPUSet(t, "1-8,10-17,20-27,41-48,50-57,60-67"),
+		},
+		{
+			"Allocated 10 CPUs, allocate 24 full cores with 8 distributed across the first 3 NUMA nodes (even though all 8 could be allocated from the first NUMA node)",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "2-29,31-39,42-69,71-79"),
+			mustParseCPUSet(t, "2-7,42-47"),
+			48,
+			1,
+			"",
+			mustParseCPUSet(t, "2-9,10-17,20-27,42-49,50-57,60-67"),
+		},
+		{
+			"Allocated 2 CPUs, allocate 13 full cores distributed across the 2 NUMA nodes",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "0-29,31-69,71-79"),
+			mustParseCPUSet(t, "30,70"),
+			26,
+			1,
+			"",
+			mustParseCPUSet(t, "20-26,30-36,60-65,70-75"),
+		},
+		{
+			"Allocated 2 CPUs, allocate 13 full cores distributed across the 2 NUMA nodes (cpuGroupSize 2)",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "0-29,31-69,71-79"),
+			mustParseCPUSet(t, "30,70"),
+			26,
+			2,
+			"",
+			mustParseCPUSet(t, "20-25,30-36,60-65,70-76"),
+		},
+	}
+}
+
+func TestTakeByTopologyNUMADistributedForResize(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	testCases := commonTakeByTopologyExtendedTestCasesForResize(t)
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+
+			result, err := takeByTopologyNUMADistributedForResize(logger, tc.topo, tc.availableCPUs, tc.numCPUs, tc.cpuGroupSize, CPUSortingStrategyPacked, &tc.reusableCPUs, nil)
+			if err != nil {
+				if tc.expErr == "" {
+					t.Errorf("unexpected error [%v]", err)
+				}
+				if tc.expErr != "" && err.Error() != tc.expErr {
+					t.Errorf("expected error to be [%v] but it was [%v]", tc.expErr, err)
+				}
+				return
+			}
+			if !result.Equals(tc.expResult) {
+				t.Errorf("expected result [%s] to equal [%s]", result, tc.expResult)
+			}
+		})
+	}
+}
+
 func mustParseCPUSet(t *testing.T, s string) cpuset.CPUSet {
 	cpus, err := cpuset.Parse(s)
 	if err != nil {

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -1649,11 +1649,12 @@ func TestCPUManagerGetAllocatableCPUs(t *testing.T) {
 	}
 }
 
-func TestCPUManagerAddResize(t *testing.T) {
+func TestCPUManagerAddWithInPlacePodVerticalScalingExclusiveCPUs(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsCPUAndMemoryAffinity, true)
 	}
 
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingExclusiveCPUs, true)
 	logger, tCtx := ktesting.NewTestContext(t)
 
 	testPolicy, _ := NewStaticPolicy(
@@ -1673,90 +1674,31 @@ func TestCPUManagerAddResize(t *testing.T) {
 		cpuset.New(),
 		topologymanager.NewFakeManager(logger),
 		nil)
-
-	type testStep struct {
-		description      string
-		operation        lifecycle.Operation
-		expDefaultCPUSet cpuset.CPUSet
-		expAllocateErr   error
-		expContainerErr  error
-	}
-
 	testCases := []struct {
-		description string
-		updateErr   error
-		policy      Policy
-		testSteps   []testStep
+		description        string
+		updateErr          error
+		policy             Policy
+		expCPUSet          cpuset.CPUSet
+		expAllocateErr     error
+		expAddContainerErr error
 	}{
 		{
-			description: "CPU Manager first add then resize",
-			updateErr:   nil,
-			policy:      testPolicy,
-			testSteps: []testStep{
-				{
-					description:      "first add operation - no error",
-					operation:        lifecycle.AddOperation,
-					expDefaultCPUSet: cpuset.New(3, 4),
-					expAllocateErr:   nil,
-					expContainerErr:  nil,
-				},
-				{
-					description:      "then resize operation - no error - skip resize",
-					operation:        lifecycle.ResizeOperation,
-					expDefaultCPUSet: cpuset.New(3, 4),
-					expAllocateErr:   nil,
-					expContainerErr:  nil,
-				},
-			},
+			description:        "cpu manager add - no error",
+			updateErr:          nil,
+			policy:             testPolicy,
+			expCPUSet:          cpuset.New(3, 4),
+			expAllocateErr:     nil,
+			expAddContainerErr: nil,
 		},
 		{
-			description: "CPU Manager attempt to resize",
+			description: "cpu manager add - policy add container error",
 			updateErr:   nil,
-			policy:      testPolicy,
-			testSteps: []testStep{
-				{
-					description:      "no error - skip allocation",
-					operation:        lifecycle.ResizeOperation,
-					expDefaultCPUSet: cpuset.New(1, 2, 3, 4),
-					expAllocateErr:   nil,
-					expContainerErr:  nil,
-				},
+			policy: &mockPolicy{
+				err: fmt.Errorf("fake reg error"),
 			},
-		},
-		{
-			description: "CPU Manager attempt to use empty operation",
-			updateErr:   nil,
-			policy:      testPolicy,
-			testSteps: []testStep{
-				{
-					description:      "no error - skip allocation",
-					operation:        "",
-					expDefaultCPUSet: cpuset.New(1, 2, 3, 4),
-					expAllocateErr:   nil,
-					expContainerErr:  nil,
-				},
-			},
-		},
-		{
-			description: "CPU Manager first resize then add",
-			updateErr:   nil,
-			policy:      testPolicy,
-			testSteps: []testStep{
-				{
-					description:      "first resize operation - no error - skip resize",
-					operation:        lifecycle.ResizeOperation,
-					expDefaultCPUSet: cpuset.New(1, 2, 3, 4),
-					expAllocateErr:   nil,
-					expContainerErr:  nil,
-				},
-				{
-					description:      "then add operation - no error",
-					operation:        lifecycle.AddOperation,
-					expDefaultCPUSet: cpuset.New(3, 4),
-					expAllocateErr:   nil,
-					expContainerErr:  nil,
-				},
-			},
+			expCPUSet:          cpuset.New(1, 2, 3, 4),
+			expAllocateErr:     fmt.Errorf("fake reg error"),
+			expAddContainerErr: nil,
 		},
 	}
 
@@ -1765,6 +1707,7 @@ func TestCPUManagerAddResize(t *testing.T) {
 			policy: testCase.policy,
 			state: &mockState{
 				assignments:   state.ContainerCPUAssignments{},
+				baselines:     state.ContainerCPUBaselines{},
 				defaultCPUSet: cpuset.New(1, 2, 3, 4),
 			},
 			lastUpdateState: state.NewMemoryState(logger),
@@ -1780,23 +1723,22 @@ func TestCPUManagerAddResize(t *testing.T) {
 		container := &pod.Spec.Containers[0]
 		mgr.activePods = func() []*v1.Pod { return []*v1.Pod{pod} }
 
-		for _, testStep := range testCase.testSteps {
-			err := mgr.Allocate(tCtx, pod, container, testStep.operation)
-			if !reflect.DeepEqual(err, testStep.expAllocateErr) {
-				t.Errorf("CPU Manager Allocate(%v) error (%v). expected error: %v but got: %v",
-					testStep.operation, testStep.description, testStep.expAllocateErr, err)
-			}
+		err := mgr.Allocate(tCtx, pod, container, lifecycle.AddOperation)
+		if !reflect.DeepEqual(err, testCase.expAllocateErr) {
+			t.Errorf("CPU Manager Allocate() error (%v). expected error: %v but got: %v",
+				testCase.description, testCase.expAllocateErr, err)
+		}
 
-			mgr.AddContainer(logger, pod, container, "fakeID")
-			_, _, err = mgr.containerMap.GetContainerRef("fakeID")
-			if !reflect.DeepEqual(err, testStep.expContainerErr) {
-				t.Errorf("CPU Manager AddContainer(%v) error (%v). expected error: %v but got: %v",
-					testStep.operation, testStep.description, testStep.expContainerErr, err)
-			}
-			if !testStep.expDefaultCPUSet.Equals(mgr.state.GetDefaultCPUSet()) {
-				t.Errorf("CPU Manager AddContainer(%v) error (%v). expected default cpuset: %v but got: %v",
-					testStep.operation, testStep.description, testStep.expDefaultCPUSet, mgr.state.GetDefaultCPUSet())
-			}
+		mgr.AddContainer(logger, pod, container, "fakeID")
+		_, _, err = mgr.containerMap.GetContainerRef("fakeID")
+		if !reflect.DeepEqual(err, testCase.expAddContainerErr) {
+			t.Errorf("CPU Manager AddContainer() error (%v). expected error: %v but got: %v",
+				testCase.description, testCase.expAddContainerErr, err)
+		}
+		if !testCase.expCPUSet.Equals(mgr.state.GetDefaultCPUSet()) {
+			t.Errorf("CPU Manager AddContainer() error (%v). expected cpuset: %v but got: %v",
+				testCase.description, testCase.expCPUSet, mgr.state.GetDefaultCPUSet())
 		}
 	}
 }
+

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -1742,3 +1742,1288 @@ func TestCPUManagerAddWithInPlacePodVerticalScalingExclusiveCPUs(t *testing.T) {
 	}
 }
 
+func TestCPUManagerAddWithInitContainersWithInPlacePodVerticalScalingExclusiveCPUs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsCPUAndMemoryAffinity, true)
+	}
+
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingExclusiveCPUs, true)
+	testCases := []struct {
+		description      string
+		topo             *topology.CPUTopology
+		numReservedCPUs  int
+		initContainerIDs []string
+		containerIDs     []string
+		stAssignments    state.ContainerCPUAssignments
+		stBaselines      state.ContainerCPUBaselines
+		stDefaultCPUSet  cpuset.CPUSet
+		pod              *v1.Pod
+		expInitCSets     []cpuset.CPUSet
+		expCSets         []cpuset.CPUSet
+	}{
+		{
+			description:      "No Guaranteed Init CPUs",
+			topo:             topoSingleSocketHT,
+			numReservedCPUs:  0,
+			stAssignments:    state.ContainerCPUAssignments{},
+			stBaselines:      state.ContainerCPUBaselines{},
+			stDefaultCPUSet:  cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			initContainerIDs: []string{"initFakeID"},
+			containerIDs:     []string{"appFakeID"},
+			pod: makeMultiContainerPod(
+				[]struct{ request, limit string }{{"100m", "100m"}},
+				[]struct{ request, limit string }{{"4000m", "4000m"}}),
+			expInitCSets: []cpuset.CPUSet{
+				cpuset.New()},
+			expCSets: []cpuset.CPUSet{
+				cpuset.New(0, 4, 1, 5)},
+		},
+		{
+			description:      "Equal Number of Guaranteed CPUs",
+			topo:             topoSingleSocketHT,
+			numReservedCPUs:  0,
+			stAssignments:    state.ContainerCPUAssignments{},
+			stBaselines:      state.ContainerCPUBaselines{},
+			stDefaultCPUSet:  cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			initContainerIDs: []string{"initFakeID"},
+			containerIDs:     []string{"appFakeID"},
+			pod: makeMultiContainerPod(
+				[]struct{ request, limit string }{{"4000m", "4000m"}},
+				[]struct{ request, limit string }{{"4000m", "4000m"}}),
+			expInitCSets: []cpuset.CPUSet{
+				cpuset.New(0, 4, 1, 5)},
+			expCSets: []cpuset.CPUSet{
+				cpuset.New(0, 4, 1, 5)},
+		},
+		{
+			description:      "More Init Container Guaranteed CPUs",
+			topo:             topoSingleSocketHT,
+			numReservedCPUs:  0,
+			stAssignments:    state.ContainerCPUAssignments{},
+			stBaselines:      state.ContainerCPUBaselines{},
+			stDefaultCPUSet:  cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			initContainerIDs: []string{"initFakeID"},
+			containerIDs:     []string{"appFakeID"},
+			pod: makeMultiContainerPod(
+				[]struct{ request, limit string }{{"6000m", "6000m"}},
+				[]struct{ request, limit string }{{"4000m", "4000m"}}),
+			expInitCSets: []cpuset.CPUSet{
+				cpuset.New(0, 4, 1, 5, 2, 6)},
+			expCSets: []cpuset.CPUSet{
+				cpuset.New(0, 4, 1, 5)},
+		},
+		{
+			description:      "Less Init Container Guaranteed CPUs",
+			topo:             topoSingleSocketHT,
+			numReservedCPUs:  0,
+			stAssignments:    state.ContainerCPUAssignments{},
+			stBaselines:      state.ContainerCPUBaselines{},
+			stDefaultCPUSet:  cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			initContainerIDs: []string{"initFakeID"},
+			containerIDs:     []string{"appFakeID"},
+			pod: makeMultiContainerPod(
+				[]struct{ request, limit string }{{"2000m", "2000m"}},
+				[]struct{ request, limit string }{{"4000m", "4000m"}}),
+			expInitCSets: []cpuset.CPUSet{
+				cpuset.New(0, 4)},
+			expCSets: []cpuset.CPUSet{
+				cpuset.New(0, 4, 1, 5)},
+		},
+		{
+			description:      "Multi Init Container Equal CPUs",
+			topo:             topoSingleSocketHT,
+			numReservedCPUs:  0,
+			stAssignments:    state.ContainerCPUAssignments{},
+			stBaselines:      state.ContainerCPUBaselines{},
+			stDefaultCPUSet:  cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			initContainerIDs: []string{"initFakeID-1", "initFakeID-2"},
+			containerIDs:     []string{"appFakeID"},
+			pod: makeMultiContainerPod(
+				[]struct{ request, limit string }{
+					{"2000m", "2000m"},
+					{"2000m", "2000m"}},
+				[]struct{ request, limit string }{
+					{"2000m", "2000m"}}),
+			expInitCSets: []cpuset.CPUSet{
+				cpuset.New(0, 4),
+				cpuset.New(0, 4)},
+			expCSets: []cpuset.CPUSet{
+				cpuset.New(0, 4)},
+		},
+		{
+			description:      "Multi Init Container Less CPUs",
+			topo:             topoSingleSocketHT,
+			numReservedCPUs:  0,
+			stAssignments:    state.ContainerCPUAssignments{},
+			stBaselines:      state.ContainerCPUBaselines{},
+			stDefaultCPUSet:  cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			initContainerIDs: []string{"initFakeID-1", "initFakeID-2"},
+			containerIDs:     []string{"appFakeID"},
+			pod: makeMultiContainerPod(
+				[]struct{ request, limit string }{
+					{"4000m", "4000m"},
+					{"4000m", "4000m"}},
+				[]struct{ request, limit string }{
+					{"2000m", "2000m"}}),
+			expInitCSets: []cpuset.CPUSet{
+				cpuset.New(0, 4, 1, 5),
+				cpuset.New(0, 4, 1, 5)},
+			expCSets: []cpuset.CPUSet{
+				cpuset.New(0, 4)},
+		},
+		{
+			description:      "Multi Init Container More CPUs",
+			topo:             topoSingleSocketHT,
+			numReservedCPUs:  0,
+			stAssignments:    state.ContainerCPUAssignments{},
+			stBaselines:      state.ContainerCPUBaselines{},
+			stDefaultCPUSet:  cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			initContainerIDs: []string{"initFakeID-1", "initFakeID-2"},
+			containerIDs:     []string{"appFakeID"},
+			pod: makeMultiContainerPod(
+				[]struct{ request, limit string }{
+					{"2000m", "2000m"},
+					{"2000m", "2000m"}},
+				[]struct{ request, limit string }{
+					{"4000m", "4000m"}}),
+			expInitCSets: []cpuset.CPUSet{
+				cpuset.New(0, 4),
+				cpuset.New(0, 4)},
+			expCSets: []cpuset.CPUSet{
+				cpuset.New(0, 4, 1, 5)},
+		},
+		{
+			description:      "Multi Init Container Increasing CPUs",
+			topo:             topoSingleSocketHT,
+			numReservedCPUs:  0,
+			stAssignments:    state.ContainerCPUAssignments{},
+			stBaselines:      state.ContainerCPUBaselines{},
+			stDefaultCPUSet:  cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			initContainerIDs: []string{"initFakeID-1", "initFakeID-2"},
+			containerIDs:     []string{"appFakeID"},
+			pod: makeMultiContainerPod(
+				[]struct{ request, limit string }{
+					{"2000m", "2000m"},
+					{"4000m", "4000m"}},
+				[]struct{ request, limit string }{
+					{"6000m", "6000m"}}),
+			expInitCSets: []cpuset.CPUSet{
+				cpuset.New(0, 4),
+				cpuset.New(0, 4, 1, 5)},
+			expCSets: []cpuset.CPUSet{
+				cpuset.New(0, 4, 1, 5, 2, 6)},
+		},
+		{
+			description:      "Multi Init, Multi App Container Split CPUs",
+			topo:             topoSingleSocketHT,
+			numReservedCPUs:  0,
+			stAssignments:    state.ContainerCPUAssignments{},
+			stBaselines:      state.ContainerCPUBaselines{},
+			stDefaultCPUSet:  cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			initContainerIDs: []string{"initFakeID-1", "initFakeID-2"},
+			containerIDs:     []string{"appFakeID-1", "appFakeID-2"},
+			pod: makeMultiContainerPod(
+				[]struct{ request, limit string }{
+					{"2000m", "2000m"},
+					{"4000m", "4000m"}},
+				[]struct{ request, limit string }{
+					{"2000m", "2000m"},
+					{"2000m", "2000m"}}),
+			expInitCSets: []cpuset.CPUSet{
+				cpuset.New(0, 4),
+				cpuset.New(0, 4, 1, 5)},
+			expCSets: []cpuset.CPUSet{
+				cpuset.New(0, 4),
+				cpuset.New(1, 5)},
+		},
+	}
+
+	for _, testCase := range testCases {
+		logger, tCtx := ktesting.NewTestContext(t)
+		policy, _ := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(logger), nil)
+
+		mockState := &mockState{
+			assignments:   testCase.stAssignments,
+			baselines:     testCase.stBaselines,
+			defaultCPUSet: testCase.stDefaultCPUSet,
+		}
+
+		mgr := &manager{
+			policy:            policy,
+			state:             mockState,
+			lastUpdateState:   state.NewMemoryState(logger),
+			containerRuntime:  mockRuntimeService{},
+			containerMap:      containermap.NewContainerMap(),
+			podStatusProvider: mockPodStatusProvider{},
+			sourcesReady:      &sourcesReadyStub{},
+			activePods: func() []*v1.Pod {
+				return []*v1.Pod{testCase.pod}
+			},
+		}
+
+		containers := append(testCase.pod.Spec.InitContainers, testCase.pod.Spec.Containers...) //nolint:gocritic
+
+		containerIDs := append(testCase.initContainerIDs, testCase.containerIDs...) //nolint:gocritic
+
+		expCSets := append(testCase.expInitCSets, testCase.expCSets...) //nolint:gocritic
+
+		cumCSet := cpuset.New()
+		cumBaselineCSet := cpuset.New()
+
+		for i := range containers {
+			err := mgr.Allocate(tCtx, testCase.pod, &containers[i], lifecycle.AddOperation)
+			if err != nil {
+				t.Errorf("StaticPolicy Allocate() error (%v). unexpected error for container id: %v: %v",
+					testCase.description, containerIDs[i], err)
+			}
+
+			mgr.AddContainer(logger, testCase.pod, &containers[i], containerIDs[i])
+			_, _, err = mgr.containerMap.GetContainerRef(containerIDs[i])
+			if err != nil {
+				t.Errorf("StaticPolicy AddContainer() error (%v). unexpected error for container id: %v: %v",
+					testCase.description, containerIDs[i], err)
+			}
+
+			cset, found := mockState.assignments[string(testCase.pod.UID)][containers[i].Name]
+			if !expCSets[i].IsEmpty() && !found {
+				t.Errorf("StaticPolicy AddContainer() error (%v). expected container %v to be present in assignments %v",
+					testCase.description, containers[i].Name, mockState.assignments)
+			}
+
+			baseline, found := mockState.baselines[string(testCase.pod.UID)][containers[i].Name]
+			if !expCSets[i].IsEmpty() && !found {
+				t.Errorf("StaticPolicy AddContainer() error (%v). expected container %v to be present in baselines %v",
+					testCase.description, containers[i].Name, mockState.baselines)
+			}
+
+			if found && !baseline.Baseline.Equals(expCSets[i]) {
+				t.Errorf("StaticPolicy AddContainer() error (%v). expected cpuset %v for container %v but got %v",
+					testCase.description, expCSets[i], containers[i].Name, baseline.Baseline)
+			}
+
+			cumCSet = cumCSet.Union(cset)
+			cumBaselineCSet = cumCSet.Union(baseline.Baseline)
+		}
+
+		if !testCase.stDefaultCPUSet.Difference(cumCSet).Equals(mockState.defaultCPUSet) {
+			t.Errorf("StaticPolicy error (%v). expected final state for defaultCPUSet %v but got %v",
+				testCase.description, testCase.stDefaultCPUSet.Difference(cumCSet), mockState.defaultCPUSet)
+		}
+
+		if !testCase.stDefaultCPUSet.Difference(cumBaselineCSet).Equals(mockState.defaultCPUSet) {
+			t.Errorf("StaticPolicy error (%v). expected final state for defaultCPUSet %v but got %v",
+				testCase.description, testCase.stDefaultCPUSet.Difference(cumBaselineCSet), mockState.defaultCPUSet)
+		}
+
+	}
+}
+
+func TestCPUManagerGenerateWithInPlacePodVerticalScalingExclusiveCPUs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsCPUAndMemoryAffinity, true)
+	}
+
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingExclusiveCPUs, true)
+	testCases := []struct {
+		description                string
+		cpuPolicyName              string
+		nodeAllocatableReservation v1.ResourceList
+		isTopologyBroken           bool
+		expectedPolicy             string
+		expectedError              error
+	}{
+		{
+			description:                "set none policy",
+			cpuPolicyName:              "none",
+			nodeAllocatableReservation: nil,
+			expectedPolicy:             "none",
+		},
+		{
+			description:                "invalid policy name",
+			cpuPolicyName:              "invalid",
+			nodeAllocatableReservation: nil,
+			expectedError:              fmt.Errorf("unknown policy: \"invalid\""),
+		},
+		{
+			description:                "static policy",
+			cpuPolicyName:              "static",
+			nodeAllocatableReservation: v1.ResourceList{v1.ResourceCPU: *resource.NewQuantity(3, resource.DecimalSI)},
+			expectedPolicy:             "static",
+		},
+		{
+			description:                "static policy - broken topology",
+			cpuPolicyName:              "static",
+			nodeAllocatableReservation: v1.ResourceList{},
+			isTopologyBroken:           true,
+			expectedError:              fmt.Errorf("could not detect number of cpus"),
+		},
+		{
+			description:                "static policy - broken reservation",
+			cpuPolicyName:              "static",
+			nodeAllocatableReservation: v1.ResourceList{},
+			expectedError:              fmt.Errorf("unable to determine reserved CPU resources for static policy"),
+		},
+		{
+			description:                "static policy - no CPU resources",
+			cpuPolicyName:              "static",
+			nodeAllocatableReservation: v1.ResourceList{v1.ResourceCPU: *resource.NewQuantity(0, resource.DecimalSI)},
+			expectedError:              fmt.Errorf("the static policy requires systemreserved.cpu + kubereserved.cpu to be greater than zero"),
+		},
+	}
+
+	mockedMachineInfo := cadvisorapi.MachineInfo{
+		NumCores: 4,
+		Topology: []cadvisorapi.Node{
+			{
+				Cores: []cadvisorapi.Core{
+					{
+						Id:           0,
+						Threads:      []int{0},
+						UncoreCaches: []cadvisorapi.Cache{{Id: 1}},
+					},
+					{
+						Id:           1,
+						Threads:      []int{1},
+						UncoreCaches: []cadvisorapi.Cache{{Id: 1}},
+					},
+					{
+						Id:           2,
+						Threads:      []int{2},
+						UncoreCaches: []cadvisorapi.Cache{{Id: 1}},
+					},
+					{
+						Id:           3,
+						Threads:      []int{3},
+						UncoreCaches: []cadvisorapi.Cache{{Id: 1}},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			machineInfo := &mockedMachineInfo
+			if testCase.isTopologyBroken {
+				machineInfo = &cadvisorapi.MachineInfo{}
+			}
+			sDir, err := os.MkdirTemp("", "cpu_manager_test")
+			if err != nil {
+				t.Errorf("cannot create state file: %s", err.Error())
+			}
+			t.Cleanup(func() {
+				require.NoErrorf(t, os.RemoveAll(sDir), "unable to remove dir %s", sDir)
+			})
+
+			logger, _ := ktesting.NewTestContext(t)
+			mgr, err := NewManager(logger, testCase.cpuPolicyName, nil, 5*time.Second, machineInfo, cpuset.New(), testCase.nodeAllocatableReservation, sDir, topologymanager.NewFakeManager(logger))
+			if testCase.expectedError != nil {
+				if !strings.Contains(err.Error(), testCase.expectedError.Error()) {
+					t.Errorf("Unexpected error message. Have: %s wants %s", err.Error(), testCase.expectedError.Error())
+				}
+			} else {
+				rawMgr := mgr.(*manager)
+				if rawMgr.policy.Name() != testCase.expectedPolicy {
+					t.Errorf("Unexpected policy name. Have: %q wants %q", rawMgr.policy.Name(), testCase.expectedPolicy)
+				}
+				if rawMgr.topology == nil {
+					t.Errorf("Expected topology to be non-nil for policy '%v'. Have: %v", rawMgr.policy.Name(), rawMgr.topology)
+				}
+			}
+		})
+
+	}
+}
+
+func TestCPUManagerRemoveWithInPlacePodVerticalScalingExclusiveCPUs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsCPUAndMemoryAffinity, true)
+	}
+
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingExclusiveCPUs, true)
+	containerID := "fakeID"
+	containerMap := containermap.NewContainerMap()
+
+	logger, _ := ktesting.NewTestContext(t)
+	mgr := &manager{
+		policy: &mockPolicy{
+			err: nil,
+		},
+		state: &mockState{
+			baselines:     state.ContainerCPUBaselines{},
+			defaultCPUSet: cpuset.New(),
+		},
+		lastUpdateState:   state.NewMemoryState(logger),
+		containerRuntime:  mockRuntimeService{},
+		containerMap:      containerMap,
+		activePods:        func() []*v1.Pod { return nil },
+		podStatusProvider: mockPodStatusProvider{},
+	}
+
+	containerMap.Add("", "", containerID)
+	err := mgr.RemoveContainer(logger, containerID)
+	if err != nil {
+		t.Errorf("CPU Manager RemoveContainer() error. expected error to be nil but got: %v", err)
+	}
+
+	mgr = &manager{
+		policy: &mockPolicy{
+			err: fmt.Errorf("fake error"),
+		},
+		state:             state.NewMemoryState(logger),
+		containerRuntime:  mockRuntimeService{},
+		containerMap:      containerMap,
+		activePods:        func() []*v1.Pod { return nil },
+		podStatusProvider: mockPodStatusProvider{},
+	}
+
+	containerMap.Add("", "", containerID)
+	err = mgr.RemoveContainer(logger, containerID)
+	if !reflect.DeepEqual(err, fmt.Errorf("fake error")) {
+		t.Errorf("CPU Manager RemoveContainer() error. expected error: fake error but got: %v", err)
+	}
+}
+
+func TestReconcileStateWithInPlacePodVerticalScalingExclusiveCPUs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsCPUAndMemoryAffinity, true)
+	}
+
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingExclusiveCPUs, true)
+	logger, _ := ktesting.NewTestContext(t)
+
+	testPolicy, _ := NewStaticPolicy(
+		logger,
+		&topology.CPUTopology{
+			NumCPUs:    8,
+			NumSockets: 2,
+			NumCores:   4,
+			CPUDetails: map[int]topology.CPUInfo{
+				0: {CoreID: 0, SocketID: 0},
+				1: {CoreID: 1, SocketID: 0},
+				2: {CoreID: 2, SocketID: 0},
+				3: {CoreID: 3, SocketID: 0},
+				4: {CoreID: 0, SocketID: 1},
+				5: {CoreID: 1, SocketID: 1},
+				6: {CoreID: 2, SocketID: 1},
+				7: {CoreID: 3, SocketID: 1},
+			},
+		},
+		0,
+		cpuset.New(),
+		topologymanager.NewFakeManager(logger),
+		nil)
+
+	testCases := []struct {
+		description                  string
+		policy                       Policy
+		activePods                   []*v1.Pod
+		pspPS                        v1.PodStatus
+		pspFound                     bool
+		updateErr                    error
+		stAssignments                state.ContainerCPUAssignments
+		stBaselines                  state.ContainerCPUBaselines
+		stDefaultCPUSet              cpuset.CPUSet
+		lastUpdateStBaselines        state.ContainerCPUBaselines
+		lastUpdateStDefaultCPUSet    cpuset.CPUSet
+		expectStAssignments          state.ContainerCPUAssignments
+		expectStBaselines            state.ContainerCPUBaselines
+		expectStDefaultCPUSet        cpuset.CPUSet
+		expectSucceededContainerName string
+		expectFailedContainerName    string
+	}{
+		{
+			description: "cpu manager reconcile - no error",
+			policy:      testPolicy,
+			activePods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "fakePodName",
+						UID:  "fakePodUID",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "fakeContainerName",
+							},
+						},
+					},
+				},
+			},
+			pspPS: v1.PodStatus{
+				ContainerStatuses: []v1.ContainerStatus{
+					{
+						Name:        "fakeContainerName",
+						ContainerID: "docker://fakeContainerID",
+						State: v1.ContainerState{
+							Running: &v1.ContainerStateRunning{},
+						},
+					},
+				},
+			},
+			pspFound:  true,
+			updateErr: nil,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.New(1, 2),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePodUID": map[string]state.ContainerCPUBaseline{
+					"fakeContainerName": {Baseline: cpuset.New(1, 2)},
+				},
+			},
+			stDefaultCPUSet:           cpuset.New(3, 4, 5, 6, 7),
+			lastUpdateStBaselines:     state.ContainerCPUBaselines{},
+			lastUpdateStDefaultCPUSet: cpuset.New(),
+			expectStAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.New(1, 2),
+				},
+			},
+			expectStBaselines: state.ContainerCPUBaselines{
+				"fakePodUID": map[string]state.ContainerCPUBaseline{
+					"fakeContainerName": {Baseline: cpuset.New(1, 2)},
+				},
+			},
+			expectStDefaultCPUSet:        cpuset.New(3, 4, 5, 6, 7),
+			expectSucceededContainerName: "fakeContainerName",
+			expectFailedContainerName:    "",
+		},
+		{
+			description: "cpu manager reconcile init container - no error",
+			policy:      testPolicy,
+			activePods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "fakePodName",
+						UID:  "fakePodUID",
+					},
+					Spec: v1.PodSpec{
+						InitContainers: []v1.Container{
+							{
+								Name: "fakeContainerName",
+							},
+						},
+					},
+				},
+			},
+			pspPS: v1.PodStatus{
+				InitContainerStatuses: []v1.ContainerStatus{
+					{
+						Name:        "fakeContainerName",
+						ContainerID: "docker://fakeContainerID",
+						State: v1.ContainerState{
+							Running: &v1.ContainerStateRunning{},
+						},
+					},
+				},
+			},
+			pspFound:  true,
+			updateErr: nil,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.New(1, 2),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePodUID": map[string]state.ContainerCPUBaseline{
+					"fakeContainerName": {Baseline: cpuset.New(1, 2)},
+				},
+			},
+			stDefaultCPUSet:           cpuset.New(3, 4, 5, 6, 7),
+			lastUpdateStBaselines:     state.ContainerCPUBaselines{},
+			lastUpdateStDefaultCPUSet: cpuset.New(),
+			expectStAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.New(1, 2),
+				},
+			},
+			expectStBaselines: state.ContainerCPUBaselines{
+				"fakePodUID": map[string]state.ContainerCPUBaseline{
+					"fakeContainerName": {Baseline: cpuset.New(1, 2)},
+				},
+			},
+			expectStDefaultCPUSet:        cpuset.New(3, 4, 5, 6, 7),
+			expectSucceededContainerName: "fakeContainerName",
+			expectFailedContainerName:    "",
+		},
+		{
+			description: "cpu manager reconcile - pod status not found",
+			policy:      testPolicy,
+			activePods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "fakePodName",
+						UID:  "fakePodUID",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "fakeContainerName",
+							},
+						},
+					},
+				},
+			},
+			pspPS:                        v1.PodStatus{},
+			pspFound:                     false,
+			updateErr:                    nil,
+			stAssignments:                state.ContainerCPUAssignments{},
+			stBaselines:                  state.ContainerCPUBaselines{},
+			stDefaultCPUSet:              cpuset.New(),
+			lastUpdateStBaselines:        state.ContainerCPUBaselines{},
+			lastUpdateStDefaultCPUSet:    cpuset.New(),
+			expectStAssignments:          state.ContainerCPUAssignments{},
+			expectStBaselines:            state.ContainerCPUBaselines{},
+			expectStDefaultCPUSet:        cpuset.New(),
+			expectSucceededContainerName: "",
+			expectFailedContainerName:    "",
+		},
+		{
+			description: "cpu manager reconcile - container state not found",
+			policy:      testPolicy,
+			activePods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "fakePodName",
+						UID:  "fakePodUID",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "fakeContainerName",
+							},
+						},
+					},
+				},
+			},
+			pspPS: v1.PodStatus{
+				ContainerStatuses: []v1.ContainerStatus{
+					{
+						Name:        "fakeContainerName1",
+						ContainerID: "docker://fakeContainerID",
+					},
+				},
+			},
+			pspFound:                     true,
+			updateErr:                    nil,
+			stAssignments:                state.ContainerCPUAssignments{},
+			stBaselines:                  state.ContainerCPUBaselines{},
+			stDefaultCPUSet:              cpuset.New(),
+			lastUpdateStBaselines:        state.ContainerCPUBaselines{},
+			lastUpdateStDefaultCPUSet:    cpuset.New(),
+			expectStAssignments:          state.ContainerCPUAssignments{},
+			expectStBaselines:            state.ContainerCPUBaselines{},
+			expectStDefaultCPUSet:        cpuset.New(),
+			expectSucceededContainerName: "",
+			expectFailedContainerName:    "fakeContainerName",
+		},
+		{
+			description: "cpu manager reconclie - cpuset is empty",
+			policy:      testPolicy,
+			activePods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "fakePodName",
+						UID:  "fakePodUID",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "fakeContainerName",
+							},
+						},
+					},
+				},
+			},
+			pspPS: v1.PodStatus{
+				ContainerStatuses: []v1.ContainerStatus{
+					{
+						Name:        "fakeContainerName",
+						ContainerID: "docker://fakeContainerID",
+						State: v1.ContainerState{
+							Running: &v1.ContainerStateRunning{},
+						},
+					},
+				},
+			},
+			pspFound:  true,
+			updateErr: nil,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.New(),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePodUID": map[string]state.ContainerCPUBaseline{
+					"fakeContainerName": {Baseline: cpuset.New()},
+				},
+			},
+			stDefaultCPUSet:           cpuset.New(1, 2, 3, 4, 5, 6, 7),
+			lastUpdateStBaselines:     state.ContainerCPUBaselines{},
+			lastUpdateStDefaultCPUSet: cpuset.New(),
+			expectStAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.New(),
+				},
+			},
+			expectStBaselines: state.ContainerCPUBaselines{
+				"fakePodUID": map[string]state.ContainerCPUBaseline{
+					"fakeContainerName": {Baseline: cpuset.New()},
+				},
+			},
+			expectStDefaultCPUSet:        cpuset.New(1, 2, 3, 4, 5, 6, 7),
+			expectSucceededContainerName: "",
+			expectFailedContainerName:    "fakeContainerName",
+		},
+		{
+			description: "cpu manager reconclie - container update error",
+			policy:      testPolicy,
+			activePods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "fakePodName",
+						UID:  "fakePodUID",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "fakeContainerName",
+							},
+						},
+					},
+				},
+			},
+			pspPS: v1.PodStatus{
+				ContainerStatuses: []v1.ContainerStatus{
+					{
+						Name:        "fakeContainerName",
+						ContainerID: "docker://fakeContainerID",
+						State: v1.ContainerState{
+							Running: &v1.ContainerStateRunning{},
+						},
+					},
+				},
+			},
+			pspFound:  true,
+			updateErr: fmt.Errorf("fake container update error"),
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.New(1, 2),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePodUID": map[string]state.ContainerCPUBaseline{
+					"fakeContainerName": {Baseline: cpuset.New(1, 2)},
+				},
+			},
+			stDefaultCPUSet:           cpuset.New(3, 4, 5, 6, 7),
+			lastUpdateStBaselines:     state.ContainerCPUBaselines{},
+			lastUpdateStDefaultCPUSet: cpuset.New(),
+			expectStAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.New(1, 2),
+				},
+			},
+			expectStBaselines: state.ContainerCPUBaselines{
+				"fakePodUID": map[string]state.ContainerCPUBaseline{
+					"fakeContainerName": {Baseline: cpuset.New(1, 2)},
+				},
+			},
+			expectStDefaultCPUSet:        cpuset.New(3, 4, 5, 6, 7),
+			expectSucceededContainerName: "",
+			expectFailedContainerName:    "fakeContainerName",
+		},
+		{
+			description: "cpu manager reconcile - state has inactive container",
+			policy:      testPolicy,
+			activePods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "fakePodName",
+						UID:  "fakePodUID",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "fakeContainerName",
+							},
+						},
+					},
+				},
+			},
+			pspPS: v1.PodStatus{
+				ContainerStatuses: []v1.ContainerStatus{
+					{
+						Name:        "fakeContainerName",
+						ContainerID: "docker://fakeContainerID",
+						State: v1.ContainerState{
+							Running: &v1.ContainerStateRunning{},
+						},
+					},
+				},
+			},
+			pspFound:  true,
+			updateErr: nil,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.New(1, 2),
+				},
+				"secondfakePodUID": map[string]cpuset.CPUSet{
+					"secondfakeContainerName": cpuset.New(3, 4),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePodUID": map[string]state.ContainerCPUBaseline{
+					"fakeContainerName": {Baseline: cpuset.New(1, 2)},
+				},
+				"secondfakePodUID": map[string]state.ContainerCPUBaseline{
+					"secondfakeContainerName": {Baseline: cpuset.New(3, 4)},
+				},
+			},
+			stDefaultCPUSet:           cpuset.New(5, 6, 7),
+			lastUpdateStBaselines:     state.ContainerCPUBaselines{},
+			lastUpdateStDefaultCPUSet: cpuset.New(),
+			expectStAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.New(1, 2),
+				},
+			},
+			expectStBaselines: state.ContainerCPUBaselines{
+				"fakePodUID": map[string]state.ContainerCPUBaseline{
+					"fakeContainerName": {Baseline: cpuset.New(1, 2)},
+				},
+			},
+			expectStDefaultCPUSet:        cpuset.New(3, 4, 5, 6, 7),
+			expectSucceededContainerName: "fakeContainerName",
+			expectFailedContainerName:    "",
+		},
+		{
+			description: "cpu manager reconcile - last update state is current",
+			policy:      testPolicy,
+			activePods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "fakePodName",
+						UID:  "fakePodUID",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "fakeContainerName",
+							},
+						},
+					},
+				},
+			},
+			pspPS: v1.PodStatus{
+				ContainerStatuses: []v1.ContainerStatus{
+					{
+						Name:        "fakeContainerName",
+						ContainerID: "docker://fakeContainerID",
+						State: v1.ContainerState{
+							Running: &v1.ContainerStateRunning{},
+						},
+					},
+				},
+			},
+			pspFound:  true,
+			updateErr: nil,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.New(1, 2),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePodUID": map[string]state.ContainerCPUBaseline{
+					"fakeContainerName": {Baseline: cpuset.New(1, 2)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(5, 6, 7),
+			lastUpdateStBaselines: state.ContainerCPUBaselines{
+				"fakePodUID": map[string]state.ContainerCPUBaseline{
+					"fakeContainerName": {Baseline: cpuset.New(1, 2)},
+				},
+			},
+			lastUpdateStDefaultCPUSet: cpuset.New(5, 6, 7),
+			expectStAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.New(1, 2),
+				},
+			},
+			expectStBaselines: state.ContainerCPUBaselines{
+				"fakePodUID": map[string]state.ContainerCPUBaseline{
+					"fakeContainerName": {Baseline: cpuset.New(1, 2)},
+				},
+			},
+			expectStDefaultCPUSet:        cpuset.New(5, 6, 7),
+			expectSucceededContainerName: "fakeContainerName",
+			expectFailedContainerName:    "",
+		},
+		{
+			description: "cpu manager reconcile - last update state is not current",
+			policy:      testPolicy,
+			activePods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "fakePodName",
+						UID:  "fakePodUID",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "fakeContainerName",
+							},
+						},
+					},
+				},
+			},
+			pspPS: v1.PodStatus{
+				ContainerStatuses: []v1.ContainerStatus{
+					{
+						Name:        "fakeContainerName",
+						ContainerID: "docker://fakeContainerID",
+						State: v1.ContainerState{
+							Running: &v1.ContainerStateRunning{},
+						},
+					},
+				},
+			},
+			pspFound:  true,
+			updateErr: nil,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.New(1, 2),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePodUID": map[string]state.ContainerCPUBaseline{
+					"fakeContainerName": {Baseline: cpuset.New(1, 2)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(3, 4, 5, 6, 7),
+			expectStAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.New(1, 2),
+				},
+			},
+			lastUpdateStBaselines: state.ContainerCPUBaselines{
+				"fakePodUID": map[string]state.ContainerCPUBaseline{
+					"fakeContainerName": {Baseline: cpuset.New(3, 4)},
+				},
+			},
+			lastUpdateStDefaultCPUSet: cpuset.New(1, 2, 5, 6, 7),
+			expectStBaselines: state.ContainerCPUBaselines{
+				"fakePodUID": map[string]state.ContainerCPUBaseline{
+					"fakeContainerName": {Baseline: cpuset.New(1, 2)},
+				},
+			},
+			expectStDefaultCPUSet:        cpuset.New(3, 4, 5, 6, 7),
+			expectSucceededContainerName: "fakeContainerName",
+			expectFailedContainerName:    "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		logger, _ := ktesting.NewTestContext(t)
+		mgr := &manager{
+			policy: testCase.policy,
+			state: &mockState{
+				assignments:   testCase.stAssignments,
+				baselines:     testCase.stBaselines,
+				defaultCPUSet: testCase.stDefaultCPUSet,
+			},
+			lastUpdateState: state.NewMemoryState(logger),
+			containerRuntime: mockRuntimeService{
+				err: testCase.updateErr,
+			},
+			containerMap: containermap.NewContainerMap(),
+			activePods: func() []*v1.Pod {
+				return testCase.activePods
+			},
+			podStatusProvider: mockPodStatusProvider{
+				podStatus: testCase.pspPS,
+				found:     testCase.pspFound,
+			},
+		}
+		mgr.sourcesReady = &sourcesReadyStub{}
+		success, failure := mgr.reconcileState(context.Background())
+
+		if !reflect.DeepEqual(testCase.expectStAssignments, mgr.state.GetCPUAssignments()) {
+			t.Errorf("%v", testCase.description)
+			t.Errorf("Expected state container cpu assignments: %v, actual: %v", testCase.expectStAssignments, mgr.state.GetCPUAssignments())
+
+		}
+
+		if !reflect.DeepEqual(testCase.expectStBaselines, mgr.state.GetCPUBaselines()) {
+			t.Errorf("%v", testCase.description)
+			t.Errorf("Expected state container cpu baselines: %v, actual: %v", testCase.expectStBaselines, mgr.state.GetCPUBaselines())
+
+		}
+
+		if !reflect.DeepEqual(testCase.expectStDefaultCPUSet, mgr.state.GetDefaultCPUSet()) {
+			t.Errorf("%v", testCase.description)
+			t.Errorf("Expected state default cpuset: %v, actual: %v", testCase.expectStDefaultCPUSet, mgr.state.GetDefaultCPUSet())
+
+		}
+
+		if testCase.expectSucceededContainerName != "" {
+			// Search succeeded reconciled containers for the supplied name.
+			foundSucceededContainer := false
+			for _, reconciled := range success {
+				if reconciled.containerName == testCase.expectSucceededContainerName {
+					foundSucceededContainer = true
+					break
+				}
+			}
+			if !foundSucceededContainer {
+				t.Errorf("%v", testCase.description)
+				t.Errorf("Expected reconciliation success for container: %s", testCase.expectSucceededContainerName)
+			}
+		}
+
+		if testCase.expectFailedContainerName != "" {
+			// Search failed reconciled containers for the supplied name.
+			foundFailedContainer := false
+			for _, reconciled := range failure {
+				if reconciled.containerName == testCase.expectFailedContainerName {
+					foundFailedContainer = true
+					break
+				}
+			}
+			if !foundFailedContainer {
+				t.Errorf("%v", testCase.description)
+				t.Errorf("Expected reconciliation failure for container: %s", testCase.expectFailedContainerName)
+			}
+		}
+	}
+}
+
+// above test cases are without kubelet --reserved-cpus cmd option
+// the following tests are with --reserved-cpus configured
+func TestCPUManagerAddWithResvListWithInPlacePodVerticalScalingExclusiveCPUs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsCPUAndMemoryAffinity, true)
+	}
+
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingExclusiveCPUs, true)
+	logger, tCtx := ktesting.NewTestContext(t)
+	testPolicy, _ := NewStaticPolicy(
+		logger,
+		&topology.CPUTopology{
+			NumCPUs:    4,
+			NumSockets: 1,
+			NumCores:   4,
+			CPUDetails: map[int]topology.CPUInfo{
+				0: {CoreID: 0, SocketID: 0},
+				1: {CoreID: 1, SocketID: 0},
+				2: {CoreID: 2, SocketID: 0},
+				3: {CoreID: 3, SocketID: 0},
+			},
+		},
+		1,
+		cpuset.New(0),
+		topologymanager.NewFakeManager(logger),
+		nil)
+	testCases := []struct {
+		description        string
+		updateErr          error
+		policy             Policy
+		expCPUSet          cpuset.CPUSet
+		expAllocateErr     error
+		expAddContainerErr error
+	}{
+		{
+			description:        "cpu manager add - no error",
+			updateErr:          nil,
+			policy:             testPolicy,
+			expCPUSet:          cpuset.New(0, 3),
+			expAllocateErr:     nil,
+			expAddContainerErr: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		mgr := &manager{
+			policy: testCase.policy,
+			state: &mockState{
+				assignments:   state.ContainerCPUAssignments{},
+				baselines:     state.ContainerCPUBaselines{},
+				defaultCPUSet: cpuset.New(0, 1, 2, 3),
+			},
+			lastUpdateState: state.NewMemoryState(logger),
+			containerRuntime: mockRuntimeService{
+				err: testCase.updateErr,
+			},
+			containerMap:      containermap.NewContainerMap(),
+			podStatusProvider: mockPodStatusProvider{},
+			sourcesReady:      &sourcesReadyStub{},
+		}
+
+		pod := makePod("fakePod", "fakeContainer", "2", "2")
+		container := &pod.Spec.Containers[0]
+		mgr.activePods = func() []*v1.Pod { return []*v1.Pod{pod} }
+
+		err := mgr.Allocate(tCtx, pod, container, lifecycle.AddOperation)
+		if !reflect.DeepEqual(err, testCase.expAllocateErr) {
+			t.Errorf("CPU Manager Allocate() error (%v). expected error: %v but got: %v",
+				testCase.description, testCase.expAllocateErr, err)
+		}
+
+		mgr.AddContainer(logger, pod, container, "fakeID")
+		_, _, err = mgr.containerMap.GetContainerRef("fakeID")
+		if !reflect.DeepEqual(err, testCase.expAddContainerErr) {
+			t.Errorf("CPU Manager AddContainer() error (%v). expected error: %v but got: %v",
+				testCase.description, testCase.expAddContainerErr, err)
+		}
+		if !testCase.expCPUSet.Equals(mgr.state.GetDefaultCPUSet()) {
+			t.Errorf("CPU Manager AddContainer() error (%v). expected cpuset: %v but got: %v",
+				testCase.description, testCase.expCPUSet, mgr.state.GetDefaultCPUSet())
+		}
+	}
+}
+
+func TestCPUManagerHandlePolicyOptionsWithInPlacePodVerticalScalingExclusiveCPUs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsCPUAndMemoryAffinity, true)
+	}
+
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingExclusiveCPUs, true)
+	testCases := []struct {
+		description      string
+		cpuPolicyName    string
+		cpuPolicyOptions map[string]string
+		expectedError    error
+	}{
+		{
+			description:   "options to none policy",
+			cpuPolicyName: "none",
+			cpuPolicyOptions: map[string]string{
+				FullPCPUsOnlyOption: "true",
+			},
+			expectedError: fmt.Errorf("received unsupported options"),
+		},
+	}
+
+	// any correct realistic topology is fine. We pick a simple one.
+	mockedMachineInfo := cadvisorapi.MachineInfo{
+		NumCores: 4,
+		Topology: []cadvisorapi.Node{
+			{
+				Cores: []cadvisorapi.Core{
+					{
+						Id:      0,
+						Threads: []int{0},
+					},
+					{
+						Id:      1,
+						Threads: []int{1},
+					},
+					{
+						Id:      2,
+						Threads: []int{2},
+					},
+					{
+						Id:      3,
+						Threads: []int{3},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			machineInfo := &mockedMachineInfo
+			nodeAllocatableReservation := v1.ResourceList{}
+			sDir, err := os.MkdirTemp("", "cpu_manager_test")
+			if err != nil {
+				t.Errorf("cannot create state file: %s", err.Error())
+			}
+			t.Cleanup(func() {
+				require.NoErrorf(t, os.RemoveAll(sDir), "unable to remove dir %s", sDir)
+			})
+			logger, _ := ktesting.NewTestContext(t)
+			_, err = NewManager(logger, testCase.cpuPolicyName, testCase.cpuPolicyOptions, 5*time.Second, machineInfo, cpuset.New(), nodeAllocatableReservation, sDir, topologymanager.NewFakeManager(logger))
+			if err == nil {
+				t.Errorf("Expected error, but NewManager succeeded")
+			}
+			if !strings.Contains(err.Error(), testCase.expectedError.Error()) {
+				t.Errorf("Unexpected error message. Have: %s wants %s", err.Error(), testCase.expectedError.Error())
+			}
+		})
+
+	}
+}
+
+func TestCPUManagerGetAllocatableCPUsWithInPlacePodVerticalScalingExclusiveCPUs(t *testing.T) {
+	logger, tCtx := ktesting.NewTestContext(t)
+	if runtime.GOOS == "windows" {
+		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsCPUAndMemoryAffinity, true)
+	}
+
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingExclusiveCPUs, true)
+	nonePolicy, _ := NewNonePolicy(nil)
+	staticPolicy, _ := NewStaticPolicy(
+		logger,
+		&topology.CPUTopology{
+			NumCPUs:    4,
+			NumSockets: 1,
+			NumCores:   4,
+			CPUDetails: map[int]topology.CPUInfo{
+				0: {CoreID: 0, SocketID: 0},
+				1: {CoreID: 1, SocketID: 0},
+				2: {CoreID: 2, SocketID: 0},
+				3: {CoreID: 3, SocketID: 0},
+			},
+		},
+		1,
+		cpuset.New(0),
+		topologymanager.NewFakeManager(logger),
+		nil)
+
+	testCases := []struct {
+		description        string
+		policy             Policy
+		expAllocatableCPUs cpuset.CPUSet
+	}{
+		{
+			description:        "None Policy",
+			policy:             nonePolicy,
+			expAllocatableCPUs: cpuset.New(),
+		},
+		{
+			description:        "Static Policy",
+			policy:             staticPolicy,
+			expAllocatableCPUs: cpuset.New(1, 2, 3),
+		},
+	}
+	for _, testCase := range testCases {
+		mgr := &manager{
+			policy:     testCase.policy,
+			activePods: func() []*v1.Pod { return nil },
+			state: &mockState{
+				assignments:   state.ContainerCPUAssignments{},
+				baselines:     state.ContainerCPUBaselines{},
+				defaultCPUSet: cpuset.New(0, 1, 2, 3),
+			},
+			lastUpdateState:   state.NewMemoryState(logger),
+			containerMap:      containermap.NewContainerMap(),
+			podStatusProvider: mockPodStatusProvider{},
+			sourcesReady:      &sourcesReadyStub{},
+		}
+		mgr.sourcesReady = &sourcesReadyStub{}
+		mgr.allocatableCPUs = testCase.policy.GetAllocatableCPUs(mgr.state)
+
+		pod := makePod("fakePod", "fakeContainer", "2", "2")
+		container := &pod.Spec.Containers[0]
+
+		_ = mgr.Allocate(tCtx, pod, container, lifecycle.AddOperation)
+
+		if !mgr.GetAllocatableCPUs().Equals(testCase.expAllocatableCPUs) {
+			t.Errorf("Policy GetAllocatableCPUs() error (%v). expected cpuset %v for container %v but got %v",
+				testCase.description, testCase.expAllocatableCPUs, "fakeContainer", mgr.GetAllocatableCPUs())
+		}
+	}
+}

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -47,6 +47,14 @@ const (
 	PolicyStatic policyName = "static"
 	// ErrorSMTAlignment represents the type of an SMTAlignmentError
 	ErrorSMTAlignment = "SMTAlignmentError"
+	// ErrorInconsistentCPUAllocation represents the type of an inconsistentCPUAllocationError
+	ErrorInconsistentCPUAllocation = "inconsistentCPUAllocationError"
+	// ErrorProhibitedCPUAllocation represents the type of an prohibitedCPUAllocationError
+	ErrorProhibitedCPUAllocation = "prohibitedCPUAllocationError"
+	// ErrorGetBaselineCPUSetError represents the type of an getBaselineCPUSetError
+	ErrorGetBaselineCPUSet = "getBaselineCPUSetError"
+	// ErrorResizeAllocateCPUs represents the type of a ResizeAllocateCPUsError
+	ErrorResizeAllocateCPUs = "ResizeAllocateCPUsError"
 )
 
 // SMTAlignmentError represents an error due to SMT alignment
@@ -67,6 +75,90 @@ func (e SMTAlignmentError) Error() string {
 // Type returns human-readable type of this error. Used in the admission control to populate Admission Failure reason.
 func (e SMTAlignmentError) Type() string {
 	return ErrorSMTAlignment
+}
+
+// prohibitedCPUAllocationError represents an error due to an
+// attempt to reduce container exclusively allocated
+// pool below container exclusively original pool
+// allocated when container was created.
+type prohibitedCPUAllocationError struct {
+	RequestedCPUs  string
+	AllocatedCPUs  string
+	BaselineCPUs   int
+	GuaranteedCPUs int
+}
+
+func (e prohibitedCPUAllocationError) Error() string {
+	return fmt.Sprintf("prohibitedCPUAllocation Error: Skip resize, Not allowed to reduce container exclusively allocated pool below original, (requested CPUs = %s, allocated CPUs = %s, baseline CPUs = %d, guaranteed CPUs = %d)", e.RequestedCPUs, e.AllocatedCPUs, e.BaselineCPUs, e.GuaranteedCPUs)
+}
+
+// Type returns human-readable type of this error.
+// Used in the HandlePodResourcesResize to populate Failure reason
+func (e prohibitedCPUAllocationError) Type() string {
+	return ErrorProhibitedCPUAllocation
+}
+
+// inconsistentCPUAllocationError represents an error due to an
+// attempt to either move a container from exclusively allocated
+// pool to shared pool or move a container from shared pool to
+// exclusively allocated pool.
+type inconsistentCPUAllocationError struct {
+	RequestedCPUs    string
+	AllocatedCPUs    string
+	Shared2Exclusive bool
+}
+
+func (e inconsistentCPUAllocationError) Error() string {
+	if e.RequestedCPUs == e.AllocatedCPUs {
+		return fmt.Sprintf("inconsistentCPUAllocation Error: Skip resize, nothing to be done, (requested CPUs = %s equal to allocated CPUs = %s)", e.RequestedCPUs, e.AllocatedCPUs)
+	}
+	if e.Shared2Exclusive {
+		return fmt.Sprintf("inconsistentCPUAllocation Error: Not allowed to move a container from shared pool to exclusively allocated pool, (requested CPUs = %s, allocated CPUs = %s)", e.RequestedCPUs, e.AllocatedCPUs)
+	} else {
+		return fmt.Sprintf("inconsistentCPUAllocation Error: Not allowed to move a container from exclusively allocated pool to shared pool, not allowed (requested CPUs = %s, allocated CPUs = %s)", e.RequestedCPUs, e.AllocatedCPUs)
+	}
+}
+
+// Type returns human-readable type of this error.
+// Used in the HandlePodResourcesResize to populate Failure reason
+func (e inconsistentCPUAllocationError) Type() string {
+	return ErrorInconsistentCPUAllocation
+}
+
+// getBaselineCPUSetError represents an error due to a
+// failed attempt to GetBaselineCPUSet from state
+type getBaselineCPUSetError struct {
+	PodUID        string
+	ContainerName string
+}
+
+func (e getBaselineCPUSetError) Error() string {
+	return fmt.Sprintf("getBaselineCPUSet Error: Skip resize, unable to get PromisedCPUSet, nothing to be done, (podUID = %s, containerName %s)", e.PodUID, e.ContainerName)
+}
+
+// Type returns human-readable type of this error.
+// Used in the HandlePodResourcesResize to populate Failure reason
+func (e getBaselineCPUSetError) Type() string {
+	return ErrorGetBaselineCPUSet
+}
+
+// ResizeAllocateCPUsError represents an error during
+// an attempt to allocate a container's CPU exclusive pool
+// resize.
+type ResizeAllocateCPUsError struct {
+	PodUID        string
+	ContainerName string
+	TopologyError string
+}
+
+func (e ResizeAllocateCPUsError) Error() string {
+	return fmt.Sprintf("ResizeAllocateCPUs Error: Skip resize, unable to resize container exclusively allocated pool, (podUID = %s, containerName = %s, topologyError = %s)", e.PodUID, e.ContainerName, e.TopologyError)
+}
+
+// Type returns human-readable type of this error.
+// Used in the HandlePodResourcesResize to populate Failure reason
+func (e ResizeAllocateCPUsError) Type() string {
+	return ErrorResizeAllocateCPUs
 }
 
 // staticPolicy is a CPU manager policy that does not change CPU
@@ -204,7 +296,14 @@ func (p *staticPolicy) Start(logger klog.Logger, s state.State) error {
 }
 
 func (p *staticPolicy) validateState(logger klog.Logger, s state.State) error {
-	tmpAssignments := s.GetCPUAssignments()
+	var tmpAssignments state.ContainerCPUAssignments
+	var tmpBaselines state.ContainerCPUBaselines
+
+	tmpAssignments = s.GetCPUAssignments()
+	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingExclusiveCPUs) {
+		tmpBaselines = s.GetCPUBaselines()
+	}
+
 	tmpDefaultCPUset := s.GetDefaultCPUSet()
 
 	allCPUs := p.topology.CPUDetails.CPUs()
@@ -215,7 +314,12 @@ func (p *staticPolicy) validateState(logger klog.Logger, s state.State) error {
 	// Default cpuset cannot be empty when assignments exist
 	if tmpDefaultCPUset.IsEmpty() {
 		if len(tmpAssignments) != 0 {
-			return fmt.Errorf("default cpuset cannot be empty")
+			return fmt.Errorf("default cpuset cannot be empty when assignments exist")
+		}
+		if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingExclusiveCPUs) {
+			if len(tmpBaselines) != 0 {
+				return fmt.Errorf("default cpuset cannot be empty when originals exist and assignments don't exist")
+			}
 		}
 		// state is empty initialize
 		s.SetDefaultCPUSet(allCPUs)
@@ -571,6 +675,8 @@ func (p *staticPolicy) Allocate(logger klog.Logger, s state.State, pod *v1.Pod, 
 	switch operation {
 	case lifecycle.AddOperation:
 		return p.allocateForAdd(logger, s, pod, container)
+	case lifecycle.ResizeOperation:
+		return p.allocateForResize(logger, s, pod, container)
 	default:
 		logger.V(2).Info("CPU Manager container-level resource allocation skipped, operation not supported by the static CPU manager policy")
 		return nil
@@ -633,11 +739,151 @@ func (p *staticPolicy) allocateForAdd(logger klog.Logger, s state.State, pod *v1
 		return err
 	}
 
+	// Allocation for first time successful, create the current state
+	// If InPlacePodVerticalScalingExclusiveCPUs is enabled, SetCPUSet sets also Baselines
 	s.SetCPUSet(string(pod.UID), container.Name, cpuAllocation.CPUs)
 	p.updateCPUsToReuse(pod, container, cpuAllocation.CPUs)
 	p.updateMetricsOnAllocate(logger, s, cpuAllocation)
 	metrics.ResourceManagerAllocationsTotal.WithLabelValues(metrics.ResourceManagerCPU, metrics.ResourceManagerNode).Inc()
 	metrics.ResourceManagerContainerAssignments.WithLabelValues(metrics.ResourceManagerCPU, metrics.ResourceManagerExclusiveNode).Inc()
+
+	logger.V(4).Info("Allocated exclusive CPUs", "cpuset", cpuAllocation.CPUs.String())
+	return nil
+}
+
+func (p *staticPolicy) allocateForResize(logger klog.Logger, s state.State, pod *v1.Pod, container *v1.Container) (rerr error) {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingExclusiveCPUs) || !utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
+		logger.V(2).Info("CPU Manager container-level resource allocation skipped, operation not supported by the static CPU manager policy, InPlacePodVerticalScaling and/or InPlacePodVerticalScalingExclusiveCPUs are not enabled")
+		return nil
+	}
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResourceManagers) || utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources) && resourcehelper.IsPodLevelResourcesSet(pod) {
+		logger.V(2).Info("CPU Manager container-level resource allocation skipped, pod is using pod-level resources which are not supported for resize operations with static CPU manager policy")
+		return nil
+	}
+
+	numCPUs := p.guaranteedCPUs(logger, pod, container)
+	if numCPUs == 0 {
+		// container belongs in the shared pool (nothing to do; use default cpuset)
+		return nil
+	}
+
+	// During a pod resize, handle corner cases
+	err := p.isFeasibleResize(logger, s, pod, container)
+	if err != nil {
+		logger.Error(err, "Static policy: Unfeasible to resize allocated CPUs,", "pod", klog.KObj(pod), "containerName", container.Name, "numCPUs", numCPUs)
+		return err
+	}
+
+	// container belongs in an exclusively allocated pool
+	metrics.CPUManagerPinningRequestsTotal.Inc()
+	defer func() {
+		if rerr != nil {
+			metrics.CPUManagerPinningErrorsTotal.Inc()
+			if p.options.FullPhysicalCPUsOnly {
+				metrics.ContainerAlignedComputeResourcesFailure.WithLabelValues(metrics.AlignScopeContainer, metrics.AlignedPhysicalCPU).Inc()
+			}
+			return
+		}
+		// TODO: move in updateMetricsOnAllocate
+		if p.options.FullPhysicalCPUsOnly {
+			// increment only if we know we allocate aligned resources
+			metrics.ContainerAlignedComputeResources.WithLabelValues(metrics.AlignScopeContainer, metrics.AlignedPhysicalCPU).Inc()
+		}
+	}()
+
+	if p.options.FullPhysicalCPUsOnly {
+		if (numCPUs % p.cpuGroupSize) != 0 {
+			// Since CPU Manager has been enabled requesting strict SMT alignment, it means a guaranteed pod can only be admitted
+			// if the CPU requested is a multiple of the number of virtual cpus per physical cores.
+			// In case CPU request is not a multiple of the number of virtual cpus per physical cores the Pod will be put
+			// in Failed state, with SMTAlignmentError as reason. Since the allocation happens in terms of physical cores
+			// and the scheduler is responsible for ensuring that the workload goes to a node that has enough CPUs,
+			// the pod would be placed on a node where there are enough physical cores available to be allocated.
+			// Just like the behaviour in case of static policy, takeByTopology will try to first allocate CPUs from the same socket
+			// and only in case the request cannot be sattisfied on a single socket, CPU allocation is done for a workload to occupy all
+			// CPUs on a physical core. Allocation of individual threads would never have to occur.
+			return SMTAlignmentError{
+				RequestedCPUs:        numCPUs,
+				CpusPerCore:          p.cpuGroupSize,
+				CausedByPhysicalCPUs: false,
+			}
+		}
+
+		availablePhysicalCPUs := s.GetDefaultCPUSet().Difference(p.reservedPhysicalCPUs).Size()
+
+		if cs, found := podutil.GetContainerStatus(pod.Status.ContainerStatuses, container.Name); found {
+			cpuAllocatedQuantity := cs.AllocatedResources[v1.ResourceCPU]
+			availablePhysicalCPUs += int(cpuAllocatedQuantity.Value())
+		}
+		// It's legal to reserve CPUs which are not core siblings. In this case the CPU allocator can descend to single cores
+		// when picking CPUs. This will void the guarantee of FullPhysicalCPUsOnly. To prevent this, we need to additionally consider
+		// all the core siblings of the reserved CPUs as unavailable when computing the free CPUs, before to start the actual allocation.
+		// This way, by construction all possible CPUs allocation whose number is multiple of the SMT level are now correct again.
+		if numCPUs > availablePhysicalCPUs {
+			return SMTAlignmentError{
+				RequestedCPUs:         numCPUs,
+				CpusPerCore:           p.cpuGroupSize,
+				AvailablePhysicalCPUs: availablePhysicalCPUs,
+				CausedByPhysicalCPUs:  true,
+			}
+		}
+	}
+	if cpusInUseByPodContainer, ok := s.GetCPUSet(string(pod.UID), container.Name); ok {
+		logger.Info("Static policy: container already present in state, attempting InPlacePodVerticalScaling", "pod", klog.KObj(pod), "containerName", container.Name)
+		// Call Topology Manager to get the aligned socket affinity across all hint providers.
+		hint := p.affinity.GetAffinity(logger, string(pod.UID), container.Name)
+		logger.Info("Topology Affinity", "pod", klog.KObj(pod), "containerName", container.Name, "affinity", hint)
+		// Attempt new allocation ( reusing allocated CPUs ) according to the NUMA affinity contained in the hint
+		// Since NUMA affinity container in the hint is unmutable already allocated CPUs pass the criteria
+		mustKeepCPUsForResize, ok := s.GetBaselineCPUSet(string(pod.UID), container.Name)
+		if !ok {
+			err := getBaselineCPUSetError{
+				PodUID:        string(pod.UID),
+				ContainerName: container.Name,
+			}
+			return err
+		}
+		// Allocate CPUs according to the NUMA affinity contained in the hint.
+		newallocatedcpuset, witherr := p.allocateCPUsForResize(logger, s, numCPUs, hint.NUMANodeAffinity, p.cpusToReuse[string(pod.UID)], &cpusInUseByPodContainer, &mustKeepCPUsForResize)
+		if witherr != nil {
+			err := ResizeAllocateCPUsError{
+				PodUID:        string(pod.UID),
+				ContainerName: container.Name,
+				TopologyError: witherr.Error(),
+			}
+			return err
+		}
+
+		// Allocation resize successful, update the current state
+		s.SetCPUSet(string(pod.UID), container.Name, newallocatedcpuset.CPUs)
+		p.updateCPUsToReuse(pod, container, newallocatedcpuset.CPUs)
+		p.updateMetricsOnAllocate(logger, s, newallocatedcpuset)
+		logger.Info("Allocated exclusive CPUs after InPlacePodVerticalScaling attempt", "pod", klog.KObj(pod), "containerName", container.Name, "cpuset", newallocatedcpuset.CPUs.String())
+		// Updated state to the checkpoint file will be stored during
+		// the reconcile loop. TODO is this a problem? I don't believe
+		// because if kubelet will be terminated now, anyhow it will be
+		// needed the state to be cleaned up, an error will appear requiring
+		// the node to be drained. I think we are safe. All computations are
+		// using state_mem and not the checkpoint.
+		return nil
+	}
+
+	// Call Topology Manager to get the aligned socket affinity across all hint providers.
+	hint := p.affinity.GetAffinity(logger, string(pod.UID), container.Name)
+	logger.Info("Topology Affinity", "affinity", hint)
+
+	// Allocate CPUs according to the NUMA affinity contained in the hint.
+	cpuAllocation, err := p.allocateCPUsForResize(logger, s, numCPUs, hint.NUMANodeAffinity, p.cpusToReuse[string(pod.UID)], nil, nil)
+	if err != nil {
+		logger.Error(err, "Unable to allocate CPUs", "numCPUs", numCPUs)
+		return err
+	}
+
+	// Allocation resize successful, update the current state
+	s.SetCPUSet(string(pod.UID), container.Name, cpuAllocation.CPUs)
+	p.updateCPUsToReuse(pod, container, cpuAllocation.CPUs)
+	p.updateMetricsOnAllocate(logger, s, cpuAllocation)
 
 	logger.V(4).Info("Allocated exclusive CPUs", "cpuset", cpuAllocation.CPUs.String())
 	return nil
@@ -693,6 +939,80 @@ func (p *staticPolicy) RemoveContainer(logger klog.Logger, s state.State, podUID
 	return nil
 }
 
+func (p *staticPolicy) allocateCPUsForResize(logger klog.Logger, s state.State, numCPUs int, numaAffinity bitmask.BitMask, reusableCPUs cpuset.CPUSet, reusableCPUsForResize *cpuset.CPUSet, mustKeepCPUsForResize *cpuset.CPUSet) (topology.Allocation, error) {
+	logger.Info("AllocateCPUs", "numCPUs", numCPUs, "socket", numaAffinity)
+	allocatableCPUs := cpuset.New()
+
+	if mustKeepCPUsForResize != nil {
+		if numCPUs >= mustKeepCPUsForResize.Size() {
+			allocatableCPUs = mustKeepCPUsForResize.Clone()
+		}
+		if numCPUs < mustKeepCPUsForResize.Size() {
+			return topology.EmptyAllocation(), fmt.Errorf("requested number of CPUs ( %d ) are less than number of retained CPUs ( %d )", numCPUs, mustKeepCPUsForResize.Size())
+		}
+	}
+
+	if reusableCPUsForResize != nil {
+		if numCPUs >= reusableCPUsForResize.Size() {
+			allocatableCPUs = allocatableCPUs.Union(p.GetAvailableCPUs(s).Union(reusableCPUsForResize.Clone()))
+		} else if numCPUs < reusableCPUsForResize.Size() {
+			allocatableCPUs = reusableCPUsForResize.Clone()
+		}
+	} else {
+		allocatableCPUs = allocatableCPUs.Union(p.GetAvailableCPUs(s).Union(reusableCPUs))
+	}
+
+	// If there are aligned CPUs in numaAffinity, attempt to take those first.
+	result := topology.EmptyAllocation()
+	if numaAffinity != nil {
+		alignedCPUs := p.getAlignedCPUs(numaAffinity, allocatableCPUs)
+
+		numAlignedToAlloc := alignedCPUs.Size()
+		if min(numCPUs, numAlignedToAlloc) == numCPUs {
+			numAlignedToAlloc = numCPUs
+		}
+
+		allocatedCPUs, err := p.takeByTopologyForResize(logger, alignedCPUs, numAlignedToAlloc, reusableCPUsForResize, mustKeepCPUsForResize)
+		if err != nil {
+			return topology.EmptyAllocation(), err
+		}
+
+		result.CPUs = result.CPUs.Union(allocatedCPUs)
+	}
+
+	if numCPUs > result.CPUs.Size() {
+		// Get any remaining CPUs from what's leftover after attempting to grab aligned ones.
+		remainingCPUs, err := p.takeByTopologyForResize(logger, allocatableCPUs.Difference(result.CPUs), numCPUs-result.CPUs.Size(), reusableCPUsForResize, mustKeepCPUsForResize)
+		if err != nil {
+			return topology.EmptyAllocation(), err
+		}
+		result.CPUs = result.CPUs.Union(remainingCPUs)
+	}
+
+	if mustKeepCPUsForResize != nil {
+		if !mustKeepCPUsForResize.IsSubsetOf(result.CPUs) {
+			return topology.EmptyAllocation(), fmt.Errorf("requested CPUs to be retained %s are not a subset of resulted CPUs %s", mustKeepCPUsForResize.String(), result.CPUs.String())
+		}
+	}
+	result.Aligned = p.topology.CheckAlignment(result.CPUs)
+
+	// Remove allocated CPUs from the shared CPUSet.
+	if reusableCPUsForResize != nil {
+		if reusableCPUsForResize.Size() < result.CPUs.Size() {
+			// Scale up or creation has been performed
+			s.SetDefaultCPUSet(s.GetDefaultCPUSet().Difference(result.CPUs))
+		} else if reusableCPUsForResize.Size() > result.CPUs.Size() {
+			// Scale down has been performed
+			s.SetDefaultCPUSet(s.GetDefaultCPUSet().Union(reusableCPUsForResize.Difference(result.CPUs)))
+		}
+	} else {
+		s.SetDefaultCPUSet(s.GetDefaultCPUSet().Difference(result.CPUs))
+	}
+
+	logger.Info("AllocateCPUs", "result", result.String())
+	return result, nil
+}
+
 func (p *staticPolicy) allocateCPUs(logger klog.Logger, s state.State, numCPUs int, numaAffinity bitmask.BitMask, reusableCPUs cpuset.CPUSet) (topology.Allocation, error) {
 	logger.Info("AllocateCPUs", "numCPUs", numCPUs, "socket", numaAffinity)
 
@@ -733,6 +1053,10 @@ func (p *staticPolicy) allocateCPUs(logger klog.Logger, s state.State, numCPUs i
 
 func isIntegralCPUAmount(cpuQuantity resource.Quantity) bool {
 	return cpuQuantity.Value()*1000 == cpuQuantity.MilliValue()
+}
+
+func inExclusiveCPUPool(cpuQuantity resource.Quantity) bool {
+	return cpuQuantity.MilliValue() > 0 && isIntegralCPUAmount(cpuQuantity)
 }
 
 func (p *staticPolicy) guaranteedCPUs(logger klog.Logger, pod *v1.Pod, container *v1.Container) int {
@@ -837,6 +1161,8 @@ func (p *staticPolicy) GetTopologyHints(logger klog.Logger, s state.State, pod *
 	switch operation {
 	case lifecycle.AddOperation:
 		return p.getTopologyHintsForAdd(logger, s, pod, container)
+	case lifecycle.ResizeOperation:
+		return p.getTopologyHintsForResize(logger, s, pod, container)
 	default:
 		logger.V(2).Info("CPU Manager container-level hint generation skipped, operation not supported by the static CPU manager policy")
 		return nil
@@ -859,7 +1185,7 @@ func (p *staticPolicy) getTopologyHintsForAdd(logger klog.Logger, s state.State,
 	// If the pod has pod-level resources but the feature gate is disabled,
 	// log it and return nil hints to admit the pod without alignment.
 	if (!utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResourceManagers) || !utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources)) && resourcehelper.IsPodLevelResourcesSet(pod) {
-		logger.V(3).Info("CPU Manager hint generation skipped, pod is using pod-level resources but the PodLevelResourceManagers feature gate is not enabled")
+		logger.V(2).Info("CPU Manager hint generation skipped, pod is using pod-level resources but the PodLevelResourceManagers feature gate is not enabled")
 		return nil
 	}
 
@@ -903,6 +1229,8 @@ func (p *staticPolicy) GetPodTopologyHints(logger klog.Logger, s state.State, po
 	switch operation {
 	case lifecycle.AddOperation:
 		return p.getPodTopologyHintsForAdd(logger, s, pod)
+	case lifecycle.ResizeOperation:
+		return p.getPodTopologyHintsForResize(logger, s, pod)
 	default:
 		logger.V(2).Info("CPU Manager pod hint generation skipped, operation not supported by the static CPU manager policy")
 		return nil
@@ -926,7 +1254,7 @@ func (p *staticPolicy) getPodTopologyHintsForAdd(logger klog.Logger, s state.Sta
 	// If the pod has pod-level resources but the feature gate is disabled,
 	// log it and return nil hints to admit the pod without alignment.
 	if (!utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResourceManagers) || !utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources)) && resourcehelper.IsPodLevelResourcesSet(pod) {
-		logger.V(3).Info("CPU Manager pod hint generation skipped, pod is using pod-level resources but the PodLevelResourceManagers feature gate is not enabled", "podUID", pod.UID)
+		logger.V(2).Info("CPU Manager pod hint generation skipped, pod is using pod-level resources but the PodLevelResourceManagers feature gate is not enabled", "podUID", pod.UID)
 		return nil
 	}
 
@@ -990,6 +1318,78 @@ func (p *staticPolicy) getPodTopologyHintsForAdd(logger klog.Logger, s state.Sta
 	return map[string][]topologymanager.TopologyHint{
 		string(v1.ResourceCPU): cpuHints,
 	}
+}
+
+func (p *staticPolicy) getPodTopologyHintsForResize(logger klog.Logger, s state.State, pod *v1.Pod) map[string][]topologymanager.TopologyHint {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingExclusiveCPUs) || !utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
+		logger.V(2).Info("CPU Manager pod hint generation skipped, operation not supported by the static CPU manager policy, InPlacePodVerticalScaling and/or InPlacePodVerticalScalingExclusiveCPUs are not enabled")
+		return nil
+	}
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResourceManagers) || utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources) && resourcehelper.IsPodLevelResourcesSet(pod) {
+		logger.V(2).Info("CPU Manager hint generation skipped, pod is using pod-level resources which are not supported for resize operations with static CPU manager policy")
+		return nil
+	}
+
+	// Get a count of how many guaranteed CPUs have been requested by Pod.
+	requested := p.podGuaranteedCPUs(logger, pod)
+
+	// Number of required CPUs is not an integer or a pod is not part of the Guaranteed QoS class.
+	// It will be treated by the TopologyManager as having no preference and cause it to ignore this
+	// resource when considering pod alignment.
+	// In terms of hints, this is equal to: TopologyHints[NUMANodeAffinity: nil, Preferred: true].
+	if requested == 0 {
+		return nil
+	}
+
+
+	assignedCPUs := cpuset.New()
+	for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
+		logger_ := klog.LoggerWithValues(logger, "containerName", container.Name)
+
+		requestedByContainer := p.guaranteedCPUs(logger, pod, &container)
+		// Short circuit to regenerate the same hints if there are already
+		// guaranteed CPUs allocated to the Container. This might happen after a
+		// kubelet restart, for example.
+		if allocated, exists := s.GetCPUSet(string(pod.UID), container.Name); exists {
+			if allocated.Size() != requestedByContainer {
+				logger_.Info("CPUs already allocated to container with different number than request", "allocatedSize", requested, "requestedByContainer", requestedByContainer, "allocatedSize", allocated.Size())
+				// An empty list of hints will be treated as a preference that cannot be satisfied.
+				// In definition of hints this is equal to: TopologyHint[NUMANodeAffinity: nil, Preferred: false].
+				// For all but the best-effort policy, the Topology Manager will throw a pod-admission error.
+				return map[string][]topologymanager.TopologyHint{
+					string(v1.ResourceCPU): {},
+				}
+			}
+			// A set of CPUs already assigned to containers in this pod
+			assignedCPUs = assignedCPUs.Union(allocated)
+		}
+	}
+	if assignedCPUs.Size() == requested {
+		logger.Info("Regenerating TopologyHints for CPUs already allocated")
+		return map[string][]topologymanager.TopologyHint{
+			string(v1.ResourceCPU): p.generateCPUTopologyHints(assignedCPUs, cpuset.New(), requested),
+		}
+	}
+
+	// Get a list of available CPUs.
+	available := p.GetAvailableCPUs(s)
+
+	// Get a list of reusable CPUs (e.g. CPUs reused from initContainers).
+	// It should be an empty CPUSet for a newly created pod.
+	reusable := p.cpusToReuse[string(pod.UID)]
+
+	// Ensure any CPUs already assigned to containers in this pod are included as part of the hint generation.
+	reusable = reusable.Union(assignedCPUs)
+
+	// Generate hints.
+	cpuHints := p.generateCPUTopologyHints(available, reusable, requested)
+	logger.Info("TopologyHints generated", "cpuHints", cpuHints)
+
+	return map[string][]topologymanager.TopologyHint{
+		string(v1.ResourceCPU): cpuHints,
+	}
+
 }
 
 // generateCPUTopologyHints generates a set of TopologyHints given the set of
@@ -1105,6 +1505,8 @@ func (p *staticPolicy) initializeMetrics(logger klog.Logger, s state.State) {
 	totalAssignedCPUs := getTotalAssignedExclusiveCPUs(s)
 	metrics.CPUManagerExclusiveCPUsAllocationCount.Set(float64(totalAssignedCPUs.Size()))
 	updateAllocationPerNUMAMetric(logger, p.topology, totalAssignedCPUs)
+	// TODO fix the hard coded nodeID
+	metrics.CPUManagerAllocationPerNUMA.WithLabelValues("1").Add(0)
 }
 
 func (p *staticPolicy) updateMetricsOnAllocate(logger klog.Logger, s state.State, cpuAlloc topology.Allocation) {
@@ -1154,4 +1556,232 @@ func updateAllocationPerNUMAMetric(logger klog.Logger, topo *topology.CPUTopolog
 	for numaNode, count := range numaCount {
 		metrics.CPUManagerAllocationPerNUMA.WithLabelValues(strconv.Itoa(numaNode)).Set(float64(count))
 	}
+}
+
+func (p *staticPolicy) isFeasibleResize(logger klog.Logger, s state.State, pod *v1.Pod, container *v1.Container) error {
+
+	if v1qos.GetPodQOS(pod) != v1.PodQOSGuaranteed {
+		return nil
+	}
+	cpuQuantity := container.Resources.Requests[v1.ResourceCPU]
+	cs, ok := podutil.GetContainerStatus(pod.Status.ContainerStatuses, container.Name)
+	if !ok {
+		return nil
+	}
+	// Policy static specific resize feasibility checks, to decide if it is capable of performing the resize
+	allocatedCPUQuantity := cs.AllocatedResources[v1.ResourceCPU]
+	allocatedExclusive := inExclusiveCPUPool(allocatedCPUQuantity)
+	requestedExclusive := inExclusiveCPUPool(cpuQuantity)
+
+	// Case 1: Illegal transition from Exclusive to Shared
+	if allocatedExclusive && !requestedExclusive {
+		return inconsistentCPUAllocationError{
+			RequestedCPUs:    cpuQuantity.String(),
+			AllocatedCPUs:    allocatedCPUQuantity.String(),
+			Shared2Exclusive: false,
+		}
+	}
+
+	// Case 2: Illegal transition from Shared to Exclusive
+	if !allocatedExclusive && requestedExclusive {
+		return inconsistentCPUAllocationError{
+			RequestedCPUs:    cpuQuantity.String(),
+			AllocatedCPUs:    allocatedCPUQuantity.String(),
+			Shared2Exclusive: true,
+		}
+	}
+
+	// Case 3: Resize within Exclusive pool
+	if allocatedExclusive && requestedExclusive {
+		// Todo this is a good place to add a check with cpu manage
+		// state reading original / resized and check if allocated is
+		// up to date, this will be useful for troubleshooting  and
+		// fine tune errors
+		mustKeepCPUsPromised, ok := s.GetBaselineCPUSet(string(pod.UID), container.Name)
+		if !ok {
+			return getBaselineCPUSetError{
+				PodUID:        string(pod.UID),
+				ContainerName: container.Name,
+			}
+		}
+		numCPUs := p.guaranteedCPUs(logger, pod, container)
+		originalCPUsQuantity := mustKeepCPUsPromised.Size()
+		if originalCPUsQuantity <= numCPUs {
+			return nil
+		}
+		return prohibitedCPUAllocationError{
+			RequestedCPUs:  cpuQuantity.String(),
+			AllocatedCPUs:  allocatedCPUQuantity.String(),
+			BaselineCPUs:   originalCPUsQuantity,
+			GuaranteedCPUs: numCPUs,
+		}
+	}
+
+	return nil
+}
+
+// generateCPUTopologyHintsForResize generates a set of TopologyHints given the set of
+// available CPUs and the number of CPUs being requested.
+//
+// It follows the convention of marking all hints that have the same number of
+// bits set as the narrowest matching NUMANodeAffinity with 'Preferred: true', and
+// marking all others with 'Preferred: false'.
+func (p *staticPolicy) generateCPUTopologyHintsForResize(availableCPUs cpuset.CPUSet, reusableCPUs cpuset.CPUSet, request int) []topologymanager.TopologyHint {
+	// Initialize minAffinitySize to include all NUMA Nodes.
+	minAffinitySize := p.topology.CPUDetails.NUMANodes().Size()
+
+	// Iterate through all combinations of numa nodes bitmask and build hints from them.
+	hints := []topologymanager.TopologyHint{}
+	bitmask.IterateBitMasks(p.topology.CPUDetails.NUMANodes().List(), func(mask bitmask.BitMask) {
+		// First, update minAffinitySize for the current request size.
+		cpusInMask := p.topology.CPUDetails.CPUsInNUMANodes(mask.GetBits()...).Size()
+		if cpusInMask >= request && mask.Count() < minAffinitySize {
+			minAffinitySize = mask.Count()
+		}
+
+		// Then check to see if we have enough CPUs available on the current
+		// numa node bitmask to satisfy the CPU request.
+		numMatching := 0
+		for _, c := range reusableCPUs.List() {
+			// Disregard this mask if its NUMANode isn't part of it.
+			if !mask.IsSet(p.topology.CPUDetails[c].NUMANodeID) {
+				return
+			}
+			numMatching++
+		}
+
+		// Finally, check to see if enough available CPUs remain on the current
+		// NUMA node combination to satisfy the CPU request.
+		for _, c := range availableCPUs.List() {
+			if mask.IsSet(p.topology.CPUDetails[c].NUMANodeID) {
+				numMatching++
+			}
+		}
+
+		// If they don't, then move onto the next combination.
+		if numMatching < request {
+			return
+		}
+
+		// Otherwise, create a new hint from the numa node bitmask and add it to the
+		// list of hints.  We set all hint preferences to 'false' on the first
+		// pass through.
+		hints = append(hints, topologymanager.TopologyHint{
+			NUMANodeAffinity: mask,
+			Preferred:        false,
+		})
+	})
+
+	// Loop back through all hints and update the 'Preferred' field based on
+	// counting the number of bits sets in the affinity mask and comparing it
+	// to the minAffinitySize. Only those with an equal number of bits set (and
+	// with a minimal set of numa nodes) will be considered preferred.
+	for i := range hints {
+		if p.options.AlignBySocket && p.isHintSocketAligned(hints[i], minAffinitySize) {
+			hints[i].Preferred = true
+			continue
+		}
+		if hints[i].NUMANodeAffinity.Count() == minAffinitySize {
+			hints[i].Preferred = true
+		}
+	}
+
+	return hints
+}
+
+func (p *staticPolicy) takeByTopologyForResize(logger klog.Logger, availableCPUs cpuset.CPUSet, numCPUs int, reusableCPUsForResize *cpuset.CPUSet, mustKeepCPUsForResize *cpuset.CPUSet) (cpuset.CPUSet, error) {
+
+	// Protect against CPU leaks by failing early
+	if mustKeepCPUsForResize != nil {
+		if !mustKeepCPUsForResize.IsSubsetOf(availableCPUs) {
+			return cpuset.New(), fmt.Errorf("requested CPUs to be retained %s are not a subset of available CPUs %s", mustKeepCPUsForResize.String(), availableCPUs.String())
+		}
+	}
+	if reusableCPUsForResize != nil {
+		if !reusableCPUsForResize.IsSubsetOf(availableCPUs) {
+			return cpuset.New(), fmt.Errorf("reusable CPUs %s are not a subset of available CPUs %s", reusableCPUsForResize.String(), availableCPUs.String())
+		}
+	}
+
+	cpuSortingStrategy := CPUSortingStrategyPacked
+	if p.options.DistributeCPUsAcrossCores {
+		cpuSortingStrategy = CPUSortingStrategySpread
+	}
+
+	if p.options.DistributeCPUsAcrossNUMA {
+		cpuGroupSize := 1
+		if p.options.FullPhysicalCPUsOnly {
+			cpuGroupSize = p.cpuGroupSize
+		}
+		return takeByTopologyNUMADistributedForResize(logger, p.topology, availableCPUs, numCPUs, cpuGroupSize, cpuSortingStrategy, reusableCPUsForResize, mustKeepCPUsForResize)
+	}
+
+	return takeByTopologyNUMAPackedForResize(logger, p.topology, availableCPUs, numCPUs, cpuSortingStrategy, p.options.PreferAlignByUncoreCacheOption, reusableCPUsForResize, mustKeepCPUsForResize)
+}
+
+func (p *staticPolicy) getTopologyHintsForResize(logger klog.Logger, s state.State, pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingExclusiveCPUs) || !utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
+		logger.V(2).Info("CPU Manager hint generation skipped, operation not supported by the static CPU manager policy, InPlacePodVerticalScaling and/or InPlacePodVerticalScalingExclusiveCPUs are not enabled")
+		return nil
+	}
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResourceManagers) || utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources) && resourcehelper.IsPodLevelResourcesSet(pod) {
+		logger.V(2).Info("CPU Manager hint generation skipped, pod is using pod-level resources which are not supported for resize operations by the static CPU manager policy")
+		return nil
+	}
+
+	// Get a count of how many guaranteed CPUs have been requested.
+	requested := p.guaranteedCPUs(logger, pod, container)
+
+	// Number of required CPUs is not an integer or a container is not part of the Guaranteed QoS class.
+	// It will be treated by the TopologyManager as having no preference and cause it to ignore this
+	// resource when considering pod alignment.
+	// In terms of hints, this is equal to: TopologyHints[NUMANodeAffinity: nil, Preferred: true].
+	if requested == 0 {
+		return nil
+	}
+
+
+	reusable := cpuset.New()
+
+	// Short circuit to regenerate the same hints if there are already
+	// guaranteed CPUs allocated to the Container. This might happen after a
+	// kubelet restart, for example.
+	if allocated, exists := s.GetCPUSet(string(pod.UID), container.Name); exists {
+		if allocated.Size() != requested {
+			if allocated.Size() < requested {
+				reusable = reusable.Union(allocated)
+			} else {
+				// Generate hints.
+				mustKeepCPUsForResize, _ := s.GetBaselineCPUSet(string(pod.UID), container.Name)
+				cpuHints := p.generateCPUTopologyHintsForResize(allocated, mustKeepCPUsForResize, requested)
+				logger.Info("TopologyHints generated", "pod", klog.KObj(pod), "containerName", container.Name, "cpuHints", cpuHints)
+
+				return map[string][]topologymanager.TopologyHint{
+					string(v1.ResourceCPU): cpuHints,
+				}
+			}
+		} else {
+			logger.Info("Regenerating TopologyHints for CPUs already allocated", "pod", klog.KObj(pod), "containerName", container.Name)
+			return map[string][]topologymanager.TopologyHint{
+				string(v1.ResourceCPU): p.generateCPUTopologyHintsForResize(allocated, cpuset.New(), requested),
+			}
+		}
+	}
+
+	// Get a list of available CPUs.
+	available := p.GetAvailableCPUs(s)
+
+	// Get a list of reusable CPUs (e.g. CPUs reused from initContainers).
+	// It should be an empty CPUSet for a newly created pod.
+	reusable = reusable.Union(p.cpusToReuse[string(pod.UID)])
+
+	// Generate hints.
+	cpuHints := p.generateCPUTopologyHintsForResize(available, reusable, requested)
+	logger.Info("TopologyHints generated", "cpuHints", cpuHints)
+
+	return map[string][]topologymanager.TopologyHint{
+		string(v1.ResourceCPU): cpuHints,
+	}
+
 }

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -3215,6 +3215,785 @@ func TestStaticPolicyStartAlognsideInPlacePodVerticalScalingExclusiveCPUs(t *tes
 	}
 }
 
+func TestStaticPolicyAddWithInPlacePodVerticalScalingExclusiveCPUs(t *testing.T) {
+	var largeTopoCPUids []int
+	var largeTopoSock0CPUids []int
+	var largeTopoSock1CPUids []int
+	largeTopo := *topoQuadSocketFourWayHT
+	for cpuid, val := range largeTopo.CPUDetails {
+		largeTopoCPUids = append(largeTopoCPUids, cpuid)
+		switch val.SocketID {
+		case 0:
+			largeTopoSock0CPUids = append(largeTopoSock0CPUids, cpuid)
+		case 1:
+			largeTopoSock1CPUids = append(largeTopoSock1CPUids, cpuid)
+		}
+	}
+	largeTopoCPUSet := cpuset.New(largeTopoCPUids...)
+	largeTopoSock0CPUSet := cpuset.New(largeTopoSock0CPUids...)
+	largeTopoSock1CPUSet := cpuset.New(largeTopoSock1CPUids...)
+
+	// these are the cases which must behave the same regardless the policy options.
+	// So we will permutate the options to ensure this holds true.
+
+	optionsInsensitiveTestCases := []staticPolicyResizeTest{
+		{
+			description:     "GuPodMultipleCores, SingleSocketHT, ExpectAllocOneCore",
+			topo:            topoSingleSocketHT,
+			numReservedCPUs: 1,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer100": cpuset.New(2, 3, 6, 7),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"fakeContainer100": {Baseline: cpuset.New(2, 3, 6, 7)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(0, 1, 4, 5),
+			pod:             makePod("fakePod", "fakeContainer3", "2000m", "2000m"),
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         cpuset.New(1, 5),
+		},
+		{
+			description:     "GuPodMultipleCores, DualSocketHT, ExpectAllocOneSocket",
+			topo:            topoDualSocketHT,
+			numReservedCPUs: 1,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer100": cpuset.New(2),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"fakeContainer100": {Baseline: cpuset.New(2)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(0, 1, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			pod:             makePod("fakePod", "fakeContainer3", "6000m", "6000m"),
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         cpuset.New(1, 3, 5, 7, 9, 11),
+		},
+		{
+			description:     "GuPodMultipleCores, DualSocketHT, ExpectAllocThreeCores",
+			topo:            topoDualSocketHT,
+			numReservedCPUs: 1,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer100": cpuset.New(1, 5),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"fakeContainer100": {Baseline: cpuset.New(1, 5)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(0, 2, 3, 4, 6, 7, 8, 9, 10, 11),
+			pod:             makePod("fakePod", "fakeContainer3", "6000m", "6000m"),
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         cpuset.New(2, 3, 4, 8, 9, 10),
+		},
+		{
+			description:     "GuPodMultipleCores, DualSocketNoHT, ExpectAllocOneSocket",
+			topo:            topoDualSocketNoHT,
+			numReservedCPUs: 1,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer100": cpuset.New(),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"fakeContainer100": {Baseline: cpuset.New()},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(0, 1, 3, 4, 5, 6, 7),
+			pod:             makePod("fakePod", "fakeContainer1", "4000m", "4000m"),
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         cpuset.New(4, 5, 6, 7),
+		},
+		{
+			description:     "GuPodMultipleCores, DualSocketNoHT, ExpectAllocFourCores",
+			topo:            topoDualSocketNoHT,
+			numReservedCPUs: 1,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer100": cpuset.New(4, 5),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"fakeContainer100": {Baseline: cpuset.New(4, 5)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(0, 1, 3, 6, 7),
+			pod:             makePod("fakePod", "fakeContainer1", "4000m", "4000m"),
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         cpuset.New(1, 3, 6, 7),
+		},
+		{
+			description:     "GuPodMultipleCores, DualSocketHT, ExpectAllocOneSocketOneCore",
+			topo:            topoDualSocketHT,
+			numReservedCPUs: 1,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer100": cpuset.New(2),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"fakeContainer100": {Baseline: cpuset.New(2)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(0, 1, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			pod:             makePod("fakePod", "fakeContainer3", "8000m", "8000m"),
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         cpuset.New(1, 3, 4, 5, 7, 9, 10, 11),
+		},
+		{
+			description:     "NonGuPod, SingleSocketHT, NoAlloc",
+			topo:            topoSingleSocketHT,
+			numReservedCPUs: 1,
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			pod:             makePod("fakePod", "fakeContainer1", "1000m", "2000m"),
+			expErr:          nil,
+			expCPUAlloc:     false,
+			expCSet:         cpuset.New(),
+		},
+		{
+			description:     "GuPodNonIntegerCore, SingleSocketHT, NoAlloc",
+			topo:            topoSingleSocketHT,
+			numReservedCPUs: 1,
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			pod:             makePod("fakePod", "fakeContainer4", "977m", "977m"),
+			expErr:          nil,
+			expCPUAlloc:     false,
+			expCSet:         cpuset.New(),
+		},
+		{
+			// All the CPUs from Socket 0 are available. Some CPUs from each
+			// Socket have been already assigned.
+			// Expect all CPUs from Socket 0.
+			description: "GuPodMultipleCores, topoQuadSocketFourWayHT, ExpectAllocSock0",
+			topo:        topoQuadSocketFourWayHT,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer100": cpuset.New(3, 11, 4, 5, 6, 7),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"fakeContainer100": {Baseline: cpuset.New(3, 11, 4, 5, 6, 7)},
+				},
+			},
+			stDefaultCPUSet: largeTopoCPUSet.Difference(cpuset.New(3, 11, 4, 5, 6, 7)),
+			pod:             makePod("fakePod", "fakeContainer5", "72000m", "72000m"),
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         largeTopoSock0CPUSet,
+		},
+		{
+			// Only 2 full cores from three Sockets and some partial cores are available.
+			// Expect CPUs from the 2 full cores available from the three Sockets.
+			description: "GuPodMultipleCores, topoQuadSocketFourWayHT, ExpectAllocAllFullCoresFromThreeSockets",
+			topo:        topoQuadSocketFourWayHT,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer100": largeTopoCPUSet.Difference(cpuset.New(1, 25, 13, 38, 2, 9, 11, 35, 23, 48, 12, 51,
+						53, 173, 113, 233, 54, 61)),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"fakeContainer100": {Baseline: largeTopoCPUSet.Difference(cpuset.New(1, 25, 13, 38, 2, 9, 11, 35, 23, 48, 12, 51,
+						53, 173, 113, 233, 54, 61))},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(1, 25, 13, 38, 2, 9, 11, 35, 23, 48, 12, 51, 53, 173, 113, 233, 54, 61),
+			pod:             makePod("fakePod", "fakeCcontainer5", "12000m", "12000m"),
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         cpuset.New(1, 25, 13, 38, 11, 35, 23, 48, 53, 173, 113, 233),
+		},
+		{
+			// All CPUs from Socket 1, 1 full core and some partial cores are available.
+			// Expect all CPUs from Socket 1 and the hyper-threads from the full core.
+			description: "GuPodMultipleCores, topoQuadSocketFourWayHT, ExpectAllocAllSock1+FullCore",
+			topo:        topoQuadSocketFourWayHT,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer100": largeTopoCPUSet.Difference(largeTopoSock1CPUSet.Union(cpuset.New(10, 34, 22, 47, 53,
+						173, 61, 181, 108, 228, 115, 235))),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"fakeContainer100": {Baseline: largeTopoCPUSet.Difference(largeTopoSock1CPUSet.Union(cpuset.New(10, 34, 22, 47, 53,
+						173, 61, 181, 108, 228, 115, 235)))},
+				},
+			},
+			stDefaultCPUSet: largeTopoSock1CPUSet.Union(cpuset.New(10, 34, 22, 47, 53, 173, 61, 181, 108, 228,
+				115, 235)),
+			pod:         makePod("fakePod", "fakeContainer5", "76000m", "76000m"),
+			expErr:      nil,
+			expCPUAlloc: true,
+			expCSet:     largeTopoSock1CPUSet.Union(cpuset.New(10, 34, 22, 47)),
+		},
+	}
+
+	// testcases for the default behaviour of the policy.
+	defaultOptionsTestCases := []staticPolicyResizeTest{
+		{
+			description:     "GuPodSingleCore, SingleSocketHT, ExpectAllocOneCPU",
+			topo:            topoSingleSocketHT,
+			numReservedCPUs: 1,
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			pod:             makePod("fakePod", "fakeContainer2", "1000m", "1000m"),
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         cpuset.New(4), // expect sibling of partial core
+		},
+		{
+			// Only partial cores are available in the entire system.
+			// Expect allocation of all the CPUs from the partial cores.
+			description: "GuPodMultipleCores, topoQuadSocketFourWayHT, ExpectAllocCPUs",
+			topo:        topoQuadSocketFourWayHT,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer100": largeTopoCPUSet.Difference(cpuset.New(10, 11, 53, 37, 55, 67, 52)),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"fakeContainer100": {Baseline: largeTopoCPUSet.Difference(cpuset.New(10, 11, 53, 37, 55, 67, 52))},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(10, 11, 53, 67, 52),
+			pod:             makePod("fakePod", "fakeContainer5", "5000m", "5000m"),
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         cpuset.New(10, 11, 53, 67, 52),
+		},
+		{
+			description:     "GuPodSingleCore, SingleSocketHT, ExpectError",
+			topo:            topoSingleSocketHT,
+			numReservedCPUs: 1,
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			pod:             makePod("fakePod", "fakeContainer2", "8000m", "8000m"),
+			expErr:          fmt.Errorf("not enough cpus available to satisfy request: requested=8, available=7"),
+			expCPUAlloc:     false,
+			expCSet:         cpuset.New(),
+		},
+		{
+			description:     "GuPodMultipleCores, SingleSocketHT, ExpectSameAllocation",
+			topo:            topoSingleSocketHT,
+			numReservedCPUs: 1,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer3": cpuset.New(1, 2, 5, 6),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"fakeContainer3": {Baseline: cpuset.New(1, 2, 5, 6)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(0, 3, 4, 7),
+			pod:             makePod("fakePod", "fakeContainer3", "4000m", "4000m"),
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         cpuset.New(1, 2, 5, 6),
+		},
+		{
+			description:     "GuPodMultipleCores, DualSocketHT, NoAllocExpectError",
+			topo:            topoDualSocketHT,
+			numReservedCPUs: 1,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer100": cpuset.New(1, 2, 3),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"fakeContainer100": {Baseline: cpuset.New(1, 2, 3)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(0, 4, 5, 6, 7, 8, 9, 10, 11),
+			pod:             makePod("fakePod", "fakeContainer5", "10000m", "10000m"),
+			expErr:          fmt.Errorf("not enough cpus available to satisfy request: requested=10, available=8"),
+			expCPUAlloc:     false,
+			expCSet:         cpuset.New(),
+		},
+		{
+			description:     "GuPodMultipleCores, SingleSocketHT, NoAllocExpectError",
+			topo:            topoSingleSocketHT,
+			numReservedCPUs: 1,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer100": cpuset.New(1, 2, 3, 4, 5, 6),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"fakeContainer100": {Baseline: cpuset.New(1, 2, 3, 4, 5, 6)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(0, 7),
+			pod:             makePod("fakePod", "fakeContainer5", "2000m", "2000m"),
+			expErr:          fmt.Errorf("not enough cpus available to satisfy request: requested=2, available=1"),
+			expCPUAlloc:     false,
+			expCSet:         cpuset.New(),
+		},
+		{
+			// Only 7 CPUs are available.
+			// Pod requests 76 cores.
+			// Error is expected since available CPUs are less than the request.
+			description: "GuPodMultipleCores, topoQuadSocketFourWayHT, NoAlloc",
+			topo:        topoQuadSocketFourWayHT,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer100": largeTopoCPUSet.Difference(cpuset.New(10, 11, 53, 37, 55, 67, 52)),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"fakeContainer100": {Baseline: largeTopoCPUSet.Difference(cpuset.New(10, 11, 53, 37, 55, 67, 52))},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(10, 11, 53, 37, 55, 67, 52),
+			pod:             makePod("fakePod", "fakeContainer5", "76000m", "76000m"),
+			expErr:          fmt.Errorf("not enough cpus available to satisfy request: requested=76, available=7"),
+			expCPUAlloc:     false,
+			expCSet:         cpuset.New(),
+		},
+	}
+
+	// testcases for the FullPCPUsOnlyOption
+	smtalignOptionTestCases := []staticPolicyResizeTest{
+		{
+			description: "GuPodSingleCore, SingleSocketHT, ExpectAllocOneCPU",
+			topo:        topoSingleSocketHT,
+			options: map[string]string{
+				FullPCPUsOnlyOption: "true",
+			},
+			numReservedCPUs: 1,
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			pod:             makePod("fakePod", "fakeContainer2", "1000m", "1000m"),
+			expErr:          SMTAlignmentError{RequestedCPUs: 1, CpusPerCore: 2},
+			expCPUAlloc:     false,
+			expCSet:         cpuset.New(), // reject allocation of sibling of partial core
+		},
+		{
+			// test SMT-level != 2 - which is the default on x86_64
+			description: "GuPodMultipleCores, topoQuadSocketFourWayHT, ExpectAllocOneCPUs",
+			topo:        topoQuadSocketFourWayHT,
+			options: map[string]string{
+				FullPCPUsOnlyOption: "true",
+			},
+			numReservedCPUs: 8,
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: largeTopoCPUSet,
+			pod:             makePod("fakePod", "fakeContainer15", "15000m", "15000m"),
+			expErr:          SMTAlignmentError{RequestedCPUs: 15, CpusPerCore: 4},
+			expCPUAlloc:     false,
+			expCSet:         cpuset.New(),
+		},
+		{
+			description: "GuPodManyCores, topoDualSocketHT, ExpectDoNotAllocPartialCPU",
+			topo:        topoDualSocketHT,
+			options: map[string]string{
+				FullPCPUsOnlyOption: "true",
+			},
+			numReservedCPUs: 2,
+			reservedCPUs:    newCPUSetPtr(1, 6),
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(0, 2, 3, 4, 5, 7, 8, 9, 10, 11),
+			pod:             makePod("fakePod", "fakeContainerBug113537_1", "10000m", "10000m"),
+			expErr:          SMTAlignmentError{RequestedCPUs: 10, CpusPerCore: 2, AvailablePhysicalCPUs: 8, CausedByPhysicalCPUs: true},
+			expCPUAlloc:     false,
+			expCSet:         cpuset.New(),
+		},
+		{
+			description: "GuPodManyCores, topoDualSocketHT, AutoReserve, ExpectAllocAllCPUs",
+			topo:        topoDualSocketHT,
+			options: map[string]string{
+				FullPCPUsOnlyOption: "true",
+			},
+			numReservedCPUs: 2,
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(1, 2, 3, 4, 5, 7, 8, 9, 10, 11),
+			pod:             makePod("fakePod", "fakeContainerBug113537_2", "10000m", "10000m"),
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         cpuset.New(1, 2, 3, 4, 5, 7, 8, 9, 10, 11),
+		},
+		{
+			description: "GuPodManyCores, topoDualSocketHT, ExpectAllocAllCPUs",
+			topo:        topoDualSocketHT,
+			options: map[string]string{
+				FullPCPUsOnlyOption: "true",
+			},
+			numReservedCPUs: 2,
+			reservedCPUs:    newCPUSetPtr(0, 6),
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(1, 2, 3, 4, 5, 7, 8, 9, 10, 11),
+			pod:             makePod("fakePod", "fakeContainerBug113537_2", "10000m", "10000m"),
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         cpuset.New(1, 2, 3, 4, 5, 7, 8, 9, 10, 11),
+		},
+		{
+			// The purpose of this test is to verify that SMTAlignment consider
+			// pre-allocated CPUs assigned to the container.
+			// for example, in case of kubelet restart.
+			description: "GuPodManyCores, DualSocketHT, ExpectReAllocCPUs",
+			topo:        topoDualSocketHT,
+			options: map[string]string{
+				FullPCPUsOnlyOption: "true",
+			},
+			numReservedCPUs: 4,
+			reservedCPUs:    newCPUSetPtr(0, 1, 6, 7),
+			pod:             makePod("fakePod", "fakeContainer", "2", "2"),
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer3": cpuset.New(5, 11),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"fakeContainer3": {Baseline: cpuset.New(5, 11)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(0, 1, 5, 6, 7, 11),
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         cpuset.New(5, 11),
+		},
+		{
+			// The purpose of this test is to verify that SMTAlignment consider
+			// pre-allocated CPUs assigned to the container.
+			// for example, in case of kubelet restart.
+			description: "GuPodManyCores, DualSocketHT, ExpectReAllocCPUs",
+			topo:        topoDualSocketHT,
+			options: map[string]string{
+				FullPCPUsOnlyOption: "true",
+			},
+			numReservedCPUs: 4,
+			reservedCPUs:    newCPUSetPtr(0, 1, 6, 7),
+			pod:             makePod("fakePod", "fakeContainer", "6", "6"),
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer3": cpuset.New(2, 3, 4, 8, 9, 10),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"fakeContainer3": {Baseline: cpuset.New(2, 3, 4, 8, 9, 10)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(0, 1, 5, 6, 7, 11),
+			expErr:          SMTAlignmentError{RequestedCPUs: 6, CpusPerCore: 2, AvailablePhysicalCPUs: 2, CausedByPhysicalCPUs: true},
+			expCPUAlloc:     false,
+		},
+		{
+			description: "GuPodManyCores, DualSocketHT, NotEnoughAvailable, NoAlloc",
+			topo:        topoDualSocketHT,
+			options: map[string]string{
+				FullPCPUsOnlyOption: "true",
+			},
+			numReservedCPUs: 4,
+			reservedCPUs:    newCPUSetPtr(0, 1, 6, 7),
+			pod:             makePod("fakePod", "fakeContainer", "10", "10"),
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			expErr:          SMTAlignmentError{RequestedCPUs: 10, CpusPerCore: 2, AvailablePhysicalCPUs: 8, CausedByPhysicalCPUs: true},
+			expCPUAlloc:     false,
+		},
+	}
+
+	// testcases for podResize
+	podResizeTestCases := []staticPolicyResizeTest{
+		{
+			description:     "podResize GuPodMultipleCores, SingleSocketHT, ExpectSameAllocation",
+			topo:            topoSingleSocketHT,
+			numReservedCPUs: 1,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer3": cpuset.New(1, 2, 5, 6),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"fakeContainer3": {Baseline: cpuset.New(1, 2, 5, 6)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(0, 3, 4, 7),
+			pod:             makePod("fakePod", "fakeContainer3", "4000m", "4000m"),
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         cpuset.New(1, 2, 5, 6),
+		},
+		{
+			description: "podResize GuPodSingleCore, SingleSocketHT, ExpectAllocOneCPU",
+			topo:        topoSingleSocketHT,
+			options: map[string]string{
+				FullPCPUsOnlyOption: "true",
+			},
+			numReservedCPUs: 1,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer3": cpuset.New(1, 5),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"fakeContainer3": {Baseline: cpuset.New(1, 5)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(0, 2, 3, 4, 6, 7),
+			pod:             makePod("fakePod", "fakeContainer3", "4000m", "4000m"),
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         cpuset.New(1, 5),
+		},
+		{
+			description: "podResize GuPodSingleCore, SingleSocketHT, ExpectAllocOneCPU",
+			topo:        topoSingleSocketHT,
+			options: map[string]string{
+				FullPCPUsOnlyOption: "true",
+			},
+			numReservedCPUs: 1,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer3": cpuset.New(1, 5),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"fakeContainer3": {Baseline: cpuset.New(1, 5)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(0, 2, 3, 4, 6, 7),
+			pod:             makePod("fakePod", "fakeContainer3", "2000m", "2000m"),
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         cpuset.New(1, 5),
+		},
+		{
+			description: "podResize",
+			topo:        topoSingleSocketHT,
+			options: map[string]string{
+				FullPCPUsOnlyOption: "true",
+			},
+			numReservedCPUs: 1,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer3": cpuset.New(1, 5),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"fakeContainer3": {Baseline: cpuset.New(1, 5)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(0, 2, 3, 4, 6, 7),
+			pod:             makePod("fakePod", "fakeContainer3", "100m", "100m"),
+			//expErr:          inconsistentCPUAllocationError{RequestedCPUs: "0", AllocatedCPUs: "2"},
+			expErr:      nil,
+			expCPUAlloc: true,
+			expCSet:     cpuset.New(1, 5),
+		},
+		{
+			description: "podResize",
+			topo:        topoSingleSocketHT,
+			options: map[string]string{
+				FullPCPUsOnlyOption: "false",
+			},
+			numReservedCPUs: 1,
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			pod:             makePod("fakePod", "fakeContainer3", "1000m", "1000m"),
+			//expErr:          inconsistentCPUAllocationError{RequestedCPUs: "0", AllocatedCPUs: "2"},
+			expErr:      nil,
+			expCPUAlloc: true,
+			expCSet:     cpuset.New(4),
+		},
+		{
+			description: "podResize",
+			topo:        topoSingleSocketHT,
+			options: map[string]string{
+				FullPCPUsOnlyOption: "true",
+			},
+			numReservedCPUs: 1,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer3": cpuset.New(1, 5),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"fakeContainer3": {Baseline: cpuset.New(1, 5)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(0, 2, 3, 4, 6, 7),
+			pod:             makePod("fakePod", "fakeContainer3", "100m", "100m"),
+			//expErr:          inconsistentCPUAllocationError{RequestedCPUs: "0", AllocatedCPUs: "2"},
+			expErr:      nil,
+			expCPUAlloc: true,
+			expCSet:     cpuset.New(1, 5),
+		},
+	}
+
+	newNUMAAffinity := func(bits ...int) bitmask.BitMask {
+		affinity, _ := bitmask.NewBitMask(bits...)
+		return affinity
+	}
+	alignBySocketOptionTestCases := []staticPolicyResizeTest{
+		{
+			description: "Align by socket: true, cpu's within same socket of numa in hint are part of allocation",
+			topo:        topoDualSocketMultiNumaPerSocketHT,
+			options: map[string]string{
+				AlignBySocketOption: "true",
+			},
+			numReservedCPUs: 1,
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(2, 11, 21, 22),
+			pod:             makePod("fakePod", "fakeContainer2", "2000m", "2000m"),
+			topologyHint:    &topologymanager.TopologyHint{NUMANodeAffinity: newNUMAAffinity(0, 2), Preferred: true},
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         cpuset.New(2, 11),
+		},
+		{
+			description: "Align by socket: false, cpu's are taken strictly from NUMA nodes in hint",
+			topo:        topoDualSocketMultiNumaPerSocketHT,
+			options: map[string]string{
+				AlignBySocketOption: "false",
+			},
+			numReservedCPUs: 1,
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(2, 11, 21, 22),
+			pod:             makePod("fakePod", "fakeContainer2", "2000m", "2000m"),
+			topologyHint:    &topologymanager.TopologyHint{NUMANodeAffinity: newNUMAAffinity(0, 2), Preferred: true},
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         cpuset.New(2, 21),
+		},
+	}
+
+	for _, testCase := range optionsInsensitiveTestCases {
+		for _, options := range []map[string]string{
+			nil,
+			{
+				FullPCPUsOnlyOption: "true",
+			},
+		} {
+			tCase := testCase.PseudoClone()
+			tCase.description = fmt.Sprintf("options=%v %s", options, testCase.description)
+			tCase.options = options
+			runStaticPolicyTestCaseWithInPlacePodVerticalScalingExclusiveCPUs(t, tCase)
+		}
+	}
+
+	for _, testCase := range defaultOptionsTestCases {
+		runStaticPolicyTestCaseWithInPlacePodVerticalScalingExclusiveCPUs(t, testCase)
+	}
+	for _, testCase := range smtalignOptionTestCases {
+		runStaticPolicyTestCaseWithInPlacePodVerticalScalingExclusiveCPUs(t, testCase)
+	}
+	for _, testCase := range alignBySocketOptionTestCases {
+		runStaticPolicyTestCaseWithInPlacePodVerticalScalingExclusiveCPUs(t, testCase)
+	}
+	for _, testCase := range podResizeTestCases {
+		runStaticPolicyTestCaseWithInPlacePodVerticalScalingExclusiveCPUs(t, testCase)
+	}
+}
+
+func runStaticPolicyTestCaseWithInPlacePodVerticalScalingExclusiveCPUs(t *testing.T, testCase staticPolicyResizeTest) {
+	logger, _ := ktesting.NewTestContext(t)
+	tm := topologymanager.NewFakeManager(logger)
+	if testCase.topologyHint != nil {
+		tm = topologymanager.NewFakeManagerWithHint(logger, testCase.topologyHint)
+	}
+	cpus := cpuset.New()
+	if testCase.reservedCPUs != nil {
+		cpus = testCase.reservedCPUs.Clone()
+	}
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.InPlacePodVerticalScaling, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.InPlacePodVerticalScalingExclusiveCPUs, true)
+	// Below will be used only for alignBySocketOptionTestCases ( adding here not to duplicate function )
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.CPUManagerPolicyAlphaOptions, true)
+
+	policy, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, cpus, tm, testCase.options)
+	if err != nil {
+		t.Fatalf("NewStaticPolicy() failed (%v) : %v", testCase.description, err)
+	}
+
+	st := &mockState{
+		assignments:   testCase.stAssignments,
+		baselines:     testCase.stBaselines,
+		defaultCPUSet: testCase.stDefaultCPUSet,
+	}
+
+	container := &testCase.pod.Spec.Containers[0]
+	err = policy.Allocate(logger, st, testCase.pod, container, lifecycle.AddOperation)
+	if !reflect.DeepEqual(err, testCase.expErr) {
+		t.Errorf("StaticPolicy Allocate() error (%v). expected add error: %q but got: %q",
+			testCase.description, testCase.expErr, err)
+	}
+
+	if testCase.expCPUAlloc {
+		original, found := st.baselines[string(testCase.pod.UID)][container.Name]
+		if !found {
+			t.Errorf("StaticPolicy Allocate() error (%v). expected container %v to be present in assignments %v",
+				testCase.description, container.Name, st.baselines)
+		}
+
+		if !original.Baseline.Equals(testCase.expCSet) {
+			t.Errorf("StaticPolicy Allocate() error (%v). expected cpuset %s but got %s",
+				testCase.description, testCase.expCSet, original.Baseline)
+		}
+
+		if !original.Baseline.Intersection(st.defaultCPUSet).IsEmpty() {
+			t.Errorf("StaticPolicy Allocate() error (%v). expected cpuset %s to be disoint from the shared cpuset %s",
+				testCase.description, original.Baseline, st.defaultCPUSet)
+		}
+	}
+
+	if !testCase.expCPUAlloc {
+		_, found := st.baselines[string(testCase.pod.UID)][container.Name]
+		if found {
+			t.Errorf("StaticPolicy Allocate() error (%v). Did not expect container %v to be present in assignments %v",
+				testCase.description, container.Name, st.assignments)
+		}
+	}
+}
+
 func TestStaticPolicyPodResizeCPUsSingleContainerPod(t *testing.T) {
 	testCases := []struct {
 		staticPolicyResizeTest
@@ -3519,3 +4298,971 @@ func TestStaticPolicyPodResizeCPUsSingleContainerPod(t *testing.T) {
 	}
 }
 
+func TestStaticPolicyPodResizeCPUsMultiContainerPod(t *testing.T) {
+	testCases := []struct {
+		staticPolicyResizeTest
+		containerName2         string
+		expAllocErr            error
+		expCSetAfterAlloc      cpuset.CPUSet
+		expCSetAfterResize     cpuset.CPUSet
+		expCSetAfterResizeSize int
+		expCSetAfterRemove     cpuset.CPUSet
+	}{
+		{
+			staticPolicyResizeTest: staticPolicyResizeTest{
+				description: "SingleSocketHT, PodResize, Containers in exclusively allocated pool, Increase appContainer-0 allocated CPUs",
+				topo:        topoSingleSocketHT,
+				pod: makeMultiContainerPodWithOptions(
+					nil,
+					[]*containerOptions{
+						{request: "2000m", limit: "2000m", restartPolicy: v1.ContainerRestartPolicy("Never")},  // 0, 4
+						{request: "2000m", limit: "2000m", restartPolicy: v1.ContainerRestartPolicy("Never")}}, // 1, 5
+				),
+				qosClass:        v1.PodQOSGuaranteed,
+				podAllocated:    "2000m",
+				resizeLimit:     "4000m",
+				resizeRequest:   "4000m",
+				containerName:   "appContainer-0",
+				stAssignments:   state.ContainerCPUAssignments{},
+				stBaselines:     state.ContainerCPUBaselines{},
+				stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			},
+			containerName2:     "appContainer-1",
+			expCSetAfterAlloc:  cpuset.New(2, 3, 6, 7),
+			expCSetAfterResize: cpuset.New(3, 7),
+			expCSetAfterRemove: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+		},
+		{
+			staticPolicyResizeTest: staticPolicyResizeTest{
+				description: "SingleSocketHT, PodResize, Containers in exclusively allocated pool, Keep same allocated CPUs",
+				topo:        topoSingleSocketHT,
+				pod: makeMultiContainerPodWithOptions(
+					nil,
+					[]*containerOptions{
+						{request: "2000m", limit: "2000m", restartPolicy: v1.ContainerRestartPolicy("Never")},  // 0, 4
+						{request: "2000m", limit: "2000m", restartPolicy: v1.ContainerRestartPolicy("Never")}}, // 1, 5
+				),
+				qosClass:        v1.PodQOSGuaranteed,
+				podAllocated:    "2000m",
+				resizeLimit:     "2000m",
+				resizeRequest:   "2000m",
+				containerName:   "appContainer-0",
+				stAssignments:   state.ContainerCPUAssignments{},
+				stBaselines:     state.ContainerCPUBaselines{},
+				stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			},
+			containerName2:     "appContainer-1",
+			expAllocErr:        inconsistentCPUAllocationError{RequestedCPUs: "2", AllocatedCPUs: "2", Shared2Exclusive: false},
+			expCSetAfterAlloc:  cpuset.New(2, 3, 6, 7),
+			expCSetAfterResize: cpuset.New(2, 3, 6, 7),
+			expCSetAfterRemove: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+		},
+		{
+			staticPolicyResizeTest: staticPolicyResizeTest{
+				description: "SingleSocketHT, PodResize, Containers in exclusively allocated pool, Decrease appContainer-0 allocated CPUs",
+				topo:        topoSingleSocketHT,
+				pod: makeMultiContainerPodWithOptions(
+					nil,
+					[]*containerOptions{
+						{request: "4000m", limit: "4000m", restartPolicy: v1.ContainerRestartPolicy("Never")},  // appContainer-0 CPUs 0, 4, 1, 5
+						{request: "4000m", limit: "4000m", restartPolicy: v1.ContainerRestartPolicy("Never")}}, // appContainer-1 CPUS 2, 6, 3, 7
+				),
+				qosClass:        v1.PodQOSGuaranteed,
+				podAllocated:    "4000m",
+				resizeLimit:     "2000m",
+				resizeRequest:   "2000m",
+				containerName:   "appContainer-0",
+				stAssignments:   state.ContainerCPUAssignments{},
+				stBaselines:     state.ContainerCPUBaselines{},
+				stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			},
+			expAllocErr:        prohibitedCPUAllocationError{RequestedCPUs: "2", AllocatedCPUs: "4", BaselineCPUs: 4, GuaranteedCPUs: 2},
+			containerName2:     "appContainer-1",
+			expCSetAfterAlloc:  cpuset.New(),
+			expCSetAfterResize: cpuset.New(),
+			expCSetAfterRemove: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+		},
+		{
+			staticPolicyResizeTest: staticPolicyResizeTest{
+				description: "SingleSocketHT, PodResize, Containers in shared pool with more than one core, Attempt to move to exclusively allocated pool",
+				topo:        topoSingleSocketHT,
+				pod: makeMultiContainerPodWithOptions(
+					nil,
+					[]*containerOptions{
+						{request: "2100m", limit: "2100m", restartPolicy: v1.ContainerRestartPolicy("Never")},  // 0-7
+						{request: "2100m", limit: "2100m", restartPolicy: v1.ContainerRestartPolicy("Never")}}, // 0-7
+				),
+				qosClass:        v1.PodQOSGuaranteed,
+				podAllocated:    "2100m",
+				resizeLimit:     "2000m",
+				resizeRequest:   "2000m",
+				containerName:   "appContainer-0",
+				stAssignments:   state.ContainerCPUAssignments{},
+				stBaselines:     state.ContainerCPUBaselines{},
+				stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			},
+			containerName2:     "appContainer-1",
+			expAllocErr:        inconsistentCPUAllocationError{RequestedCPUs: "2", AllocatedCPUs: "2100m", Shared2Exclusive: true},
+			expCSetAfterAlloc:  cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			expCSetAfterResize: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			expCSetAfterRemove: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+		},
+		{
+			staticPolicyResizeTest: staticPolicyResizeTest{
+				description: "SingleSocketHT, PodResize, appContainer-0 in shared pool, Increase CPU and keep appContainer-0 in shared pool",
+				topo:        topoSingleSocketHT,
+				pod: makeMultiContainerPodWithOptions(
+					nil,
+					[]*containerOptions{
+						{request: "100m", limit: "100m", restartPolicy: v1.ContainerRestartPolicy("Never")},    // 2-3, 6-7
+						{request: "4000m", limit: "4000m", restartPolicy: v1.ContainerRestartPolicy("Never")}}, // 0-1, 4-5
+				),
+				qosClass:        v1.PodQOSGuaranteed,
+				podAllocated:    "100m",
+				resizeLimit:     "200m",
+				resizeRequest:   "200m",
+				containerName:   "appContainer-0",
+				stAssignments:   state.ContainerCPUAssignments{},
+				stBaselines:     state.ContainerCPUBaselines{},
+				stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			},
+			containerName2:     "appContainer-1",
+			expCSetAfterAlloc:  cpuset.New(2, 3, 6, 7),
+			expCSetAfterResize: cpuset.New(2, 3, 6, 7),
+			expCSetAfterRemove: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+		},
+		{
+			staticPolicyResizeTest: staticPolicyResizeTest{
+				description: "SingleSocketHT, PodResize, appContainer-0 in shared pool with more than one core, Increase CPU and keep appContainer-0 in shared pool",
+				topo:        topoSingleSocketHT,
+				pod: makeMultiContainerPodWithOptions(
+					nil,
+					[]*containerOptions{
+						{request: "1100m", limit: "1100m", restartPolicy: v1.ContainerRestartPolicy("Never")},  // 0-7
+						{request: "4000m", limit: "4000m", restartPolicy: v1.ContainerRestartPolicy("Never")}}, // 0-1, 4-5
+				),
+				qosClass:        v1.PodQOSGuaranteed,
+				podAllocated:    "1100m",
+				resizeLimit:     "1200m",
+				resizeRequest:   "1200m",
+				containerName:   "appContainer-0",
+				stAssignments:   state.ContainerCPUAssignments{},
+				stBaselines:     state.ContainerCPUBaselines{},
+				stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			},
+			containerName2:     "appContainer-1",
+			expCSetAfterAlloc:  cpuset.New(2, 3, 6, 7),
+			expCSetAfterResize: cpuset.New(2, 3, 6, 7),
+			expCSetAfterRemove: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+		},
+		{
+			staticPolicyResizeTest: staticPolicyResizeTest{
+				description: "SingleSocketHT, PodResize, appContainer-0 in shared pool, appContainer-1 in exclusive pool, Decrease CPU and keep in shared pool",
+				topo:        topoSingleSocketHT,
+				pod: makeMultiContainerPodWithOptions(
+					nil,
+					[]*containerOptions{
+						{request: "200m", limit: "200m", restartPolicy: v1.ContainerRestartPolicy("Never")},    // 0-7
+						{request: "4000m", limit: "4000m", restartPolicy: v1.ContainerRestartPolicy("Never")}}, // 0-1, 4-5
+				),
+				qosClass:        v1.PodQOSGuaranteed,
+				podAllocated:    "200m",
+				resizeLimit:     "100m",
+				resizeRequest:   "100m",
+				containerName:   "appContainer-0",
+				stAssignments:   state.ContainerCPUAssignments{},
+				stBaselines:     state.ContainerCPUBaselines{},
+				stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			},
+			containerName2:     "appContainer-1",
+			expCSetAfterAlloc:  cpuset.New(2, 3, 6, 7),
+			expCSetAfterResize: cpuset.New(2, 3, 6, 7),
+			expCSetAfterRemove: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+		},
+		{
+			staticPolicyResizeTest: staticPolicyResizeTest{
+				description: "SingleSocketHT, PodResize, appContainer-0 in exclusively allocated pool, Move to shared pool",
+				topo:        topoSingleSocketHT,
+				pod: makeMultiContainerPodWithOptions(
+					nil,
+					[]*containerOptions{
+						{request: "2000m", limit: "2000m", restartPolicy: v1.ContainerRestartPolicy("Never")}, // 0-1, 4-5
+						{request: "200m", limit: "200m", restartPolicy: v1.ContainerRestartPolicy("Never")}},  // 0-7
+				),
+				qosClass:        v1.PodQOSGuaranteed,
+				podAllocated:    "2000m",
+				resizeLimit:     "1500m",
+				resizeRequest:   "1500m",
+				containerName:   "appContainer-0",
+				stAssignments:   state.ContainerCPUAssignments{},
+				stBaselines:     state.ContainerCPUBaselines{},
+				stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			},
+			containerName2:     "appContainer-1",
+			expAllocErr:        inconsistentCPUAllocationError{RequestedCPUs: "1500m", AllocatedCPUs: "2", Shared2Exclusive: false},
+			expCSetAfterAlloc:  cpuset.New(1, 2, 3, 5, 6, 7),
+			expCSetAfterResize: cpuset.New(1, 2, 3, 5, 6, 7),
+			expCSetAfterRemove: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+		},
+	}
+
+	for _, testCase := range testCases {
+		logger, _ := ktesting.NewTestContext(t)
+		t.Run(testCase.description, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.InPlacePodVerticalScalingExclusiveCPUs, true)
+			policy, _ := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(logger), nil)
+
+			st := &mockState{
+				assignments:   testCase.stAssignments,
+				baselines:     testCase.stBaselines,
+				defaultCPUSet: testCase.stDefaultCPUSet,
+			}
+			pod := testCase.pod
+			pod.Status.QOSClass = testCase.qosClass
+
+			// allocate
+			for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
+				err := policy.Allocate(logger, st, pod, &container, lifecycle.AddOperation)
+				if err != nil {
+					t.Errorf("StaticPolicy Allocate() error (%v). expected no error but got %v",
+						testCase.description, err)
+				}
+			}
+			if !reflect.DeepEqual(st.defaultCPUSet, testCase.expCSetAfterAlloc) {
+				t.Errorf("StaticPolicy Allocate() error (%v) before pod resize. expected default cpuset %v but got %v",
+					testCase.description, testCase.expCSetAfterAlloc, st.defaultCPUSet)
+			}
+
+			// resize
+			pod.Status.ContainerStatuses = []v1.ContainerStatus{
+				{
+					Name: testCase.containerName,
+					AllocatedResources: v1.ResourceList{
+						v1.ResourceCPU: resource.MustParse(testCase.podAllocated),
+					},
+				},
+			}
+			pod.Spec.Containers[0].Resources = v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceName(v1.ResourceCPU): resource.MustParse(testCase.resizeLimit),
+				},
+				Requests: v1.ResourceList{
+					v1.ResourceName(v1.ResourceCPU): resource.MustParse(testCase.resizeRequest),
+				},
+			}
+			podResized := pod
+			for _, container := range append(podResized.Spec.InitContainers, podResized.Spec.Containers...) {
+				err := policy.Allocate(logger, st, podResized, &container, lifecycle.ResizeOperation)
+				if err != nil {
+					if !reflect.DeepEqual(err, testCase.expAllocErr) {
+						t.Errorf("StaticPolicy Allocate() error (%v), expected error: %v but got: %v",
+							testCase.description, testCase.expAllocErr, err)
+					}
+				}
+			}
+
+			if testCase.expCSetAfterResizeSize > 0 {
+				// expCSetAfterResizeSize is used when testing scale down because allocated CPUs are not deterministic,
+				// since size of defaultCPUSet is deterministic and also interesection  with expected allocation
+				// should not be nill. < ====== TODO esotsal
+				if !reflect.DeepEqual(st.defaultCPUSet.Size(), testCase.expCSetAfterResizeSize) {
+					t.Errorf("StaticPolicy Allocate() error (%v) after pod resize. expected default cpuset size equal to %v but got %v",
+						testCase.description, testCase.expCSetAfterResizeSize, st.defaultCPUSet.Size())
+				}
+			} else {
+				if !reflect.DeepEqual(st.defaultCPUSet, testCase.expCSetAfterResize) {
+					t.Errorf("StaticPolicy Allocate() error (%v) after pod resize. expected default cpuset %v but got %v",
+						testCase.description, testCase.expCSetAfterResize, st.defaultCPUSet)
+				}
+			}
+
+			// remove
+			err := policy.RemoveContainer(logger, st, string(pod.UID), testCase.containerName)
+			if err != nil {
+				t.Errorf("StaticPolicy RemoveContainer() error (%v) after pod resize. expected no error but got %v",
+					testCase.description, err)
+			}
+			err = policy.RemoveContainer(logger, st, string(pod.UID), testCase.containerName2)
+			if err != nil {
+				t.Errorf("StaticPolicy RemoveContainer() error (%v) after pod resize. expected no error but got %v",
+					testCase.description, err)
+			}
+
+			if !reflect.DeepEqual(st.defaultCPUSet, testCase.expCSetAfterRemove) {
+				t.Errorf("StaticPolicy RemoveContainer() error (%v) after pod resize. expected default cpuset %v but got %v",
+					testCase.description, testCase.expCSetAfterRemove, st.defaultCPUSet)
+			}
+			if _, found := st.assignments[string(pod.UID)][testCase.containerName]; found {
+				t.Errorf("StaticPolicy RemoveContainer() error (%v) after pod resize. expected (pod %v, container %v) not be in assignments %v",
+					testCase.description, testCase.podUID, testCase.containerName, st.assignments)
+			}
+		})
+	}
+}
+func TestStaticPolicyRemoveAlognsideInPlacePodVerticalScalingExclusiveCPUs(t *testing.T) {
+
+	testCases := []staticPolicyTest{
+		{
+			description:   "SingleSocketHT, DeAllocOneContainer",
+			topo:          topoSingleSocketHT,
+			podUID:        "fakePod",
+			containerName: "fakeContainer1",
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer1": cpuset.New(1, 2, 3),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"fakeContainer1": {Baseline: cpuset.New(1, 2, 3)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(4, 5, 6, 7),
+			expCSet:         cpuset.New(1, 2, 3, 4, 5, 6, 7),
+		},
+		{
+			description:   "SingleSocketHT, DeAllocOneContainer, BeginEmpty",
+			topo:          topoSingleSocketHT,
+			podUID:        "fakePod",
+			containerName: "fakeContainer1",
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer1": cpuset.New(1, 2, 3),
+					"fakeContainer2": cpuset.New(4, 5, 6, 7),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"fakeContainer1": {Baseline: cpuset.New(1, 2, 3)},
+					"fakeContainer2": {Baseline: cpuset.New(4, 5, 6, 7)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(),
+			expCSet:         cpuset.New(1, 2, 3),
+		},
+		{
+			description:   "SingleSocketHT, DeAllocTwoContainer",
+			topo:          topoSingleSocketHT,
+			podUID:        "fakePod",
+			containerName: "fakeContainer1",
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer1": cpuset.New(1, 3, 5),
+					"fakeContainer2": cpuset.New(2, 4),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"fakeContainer1": {Baseline: cpuset.New(1, 3, 5)},
+					"fakeContainer2": {Baseline: cpuset.New(2, 4)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(6, 7),
+			expCSet:         cpuset.New(1, 3, 5, 6, 7),
+		},
+		{
+			description:   "SingleSocketHT, NoDeAlloc",
+			topo:          topoSingleSocketHT,
+			podUID:        "fakePod",
+			containerName: "fakeContainer2",
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer1": cpuset.New(1, 3, 5),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"fakeContainer1": {Baseline: cpuset.New(1, 3, 5)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(2, 4, 6, 7),
+			expCSet:         cpuset.New(2, 4, 6, 7),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.InPlacePodVerticalScalingExclusiveCPUs, true)
+			logger, _ := ktesting.NewTestContext(t)
+			policy, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(logger), nil)
+			if err != nil {
+				t.Fatalf("NewStaticPolicy() failed: %v", err)
+			}
+
+			st := &mockState{
+				assignments:   testCase.stAssignments,
+				baselines:     testCase.stBaselines,
+				defaultCPUSet: testCase.stDefaultCPUSet,
+			}
+
+			_ = policy.RemoveContainer(logger, st, testCase.podUID, testCase.containerName)
+
+			if !st.defaultCPUSet.Equals(testCase.expCSet) {
+				t.Errorf("StaticPolicy RemoveContainer() error (%v). expected default cpuset %s but got %s",
+					testCase.description, testCase.expCSet, st.defaultCPUSet)
+			}
+
+			if _, found := st.assignments[testCase.podUID][testCase.containerName]; found {
+				t.Errorf("StaticPolicy RemoveContainer() error (%v). expected (pod %v, container %v) not be in assignments %v",
+					testCase.description, testCase.podUID, testCase.containerName, st.assignments)
+			}
+
+			if _, found := st.baselines[testCase.podUID][testCase.containerName]; found {
+				t.Errorf("StaticPolicy RemoveContainer() error (%v). expected (pod %v, container %v) not be in baselines %v",
+					testCase.description, testCase.podUID, testCase.containerName, st.baselines)
+			}
+
+		})
+	}
+}
+
+func TestTopologyAwareAllocateCPUsAlongsideInPlacePodVerticalScalingExclusiveCPUs(t *testing.T) {
+	testCases := []struct {
+		description     string
+		topo            *topology.CPUTopology
+		stAssignments   state.ContainerCPUAssignments
+		stBaselines     state.ContainerCPUBaselines
+		stDefaultCPUSet cpuset.CPUSet
+		numRequested    int
+		socketMask      bitmask.BitMask
+		expCSet         cpuset.CPUSet
+	}{
+		{
+			description:     "Request 2 CPUs, No BitMask",
+			topo:            topoDualSocketHT,
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			numRequested:    2,
+			socketMask:      nil,
+			expCSet:         cpuset.New(0, 6),
+		},
+		{
+			description:     "Request 2 CPUs, BitMask on Socket 0",
+			topo:            topoDualSocketHT,
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			numRequested:    2,
+			socketMask: func() bitmask.BitMask {
+				mask, _ := bitmask.NewBitMask(0)
+				return mask
+			}(),
+			expCSet: cpuset.New(0, 6),
+		},
+		{
+			description:     "Request 2 CPUs, BitMask on Socket 1",
+			topo:            topoDualSocketHT,
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			numRequested:    2,
+			socketMask: func() bitmask.BitMask {
+				mask, _ := bitmask.NewBitMask(1)
+				return mask
+			}(),
+			expCSet: cpuset.New(1, 7),
+		},
+		{
+			description:     "Request 8 CPUs, BitMask on Socket 0",
+			topo:            topoDualSocketHT,
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			numRequested:    8,
+			socketMask: func() bitmask.BitMask {
+				mask, _ := bitmask.NewBitMask(0)
+				return mask
+			}(),
+			expCSet: cpuset.New(0, 6, 2, 8, 4, 10, 1, 7),
+		},
+		{
+			description:     "Request 8 CPUs, BitMask on Socket 1",
+			topo:            topoDualSocketHT,
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			numRequested:    8,
+			socketMask: func() bitmask.BitMask {
+				mask, _ := bitmask.NewBitMask(1)
+				return mask
+			}(),
+			expCSet: cpuset.New(1, 7, 3, 9, 5, 11, 0, 6),
+		},
+	}
+	for _, tc := range testCases {
+		logger, _ := ktesting.NewTestContext(t)
+		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.InPlacePodVerticalScaling, true)
+		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.InPlacePodVerticalScalingExclusiveCPUs, true)
+		p, err := NewStaticPolicy(logger, tc.topo, 0, cpuset.New(), topologymanager.NewFakeManager(logger), nil)
+		if err != nil {
+			t.Fatalf("NewStaticPolicy() failed: %v", err)
+		}
+		policy := p.(*staticPolicy)
+		st := &mockState{
+			assignments:   tc.stAssignments,
+			baselines:     tc.stBaselines,
+			defaultCPUSet: tc.stDefaultCPUSet,
+		}
+		err = policy.Start(logger, st)
+		if err != nil {
+			t.Errorf("StaticPolicy Start() error (%v)", err)
+			continue
+		}
+
+		cpuAlloc, err := policy.allocateCPUs(logger, st, tc.numRequested, tc.socketMask, cpuset.New())
+		if err != nil {
+			t.Errorf("StaticPolicy allocateCPUs() error (%v). expected CPUSet %v not error %v",
+				tc.description, tc.expCSet, err)
+			continue
+		}
+
+		if !tc.expCSet.Equals(cpuAlloc.CPUs) {
+			t.Errorf("StaticPolicy allocateCPUs() error (%v). expected CPUSet %v but got %v",
+				tc.description, tc.expCSet, cpuAlloc.CPUs)
+		}
+	}
+}
+
+// above test cases are without kubelet --reserved-cpus cmd option
+// the following tests are with --reserved-cpus configured
+// with InPlacePodVerticalScalingExclusiveCPUs enabled
+type staticPolicyTestWithResvListWithInPlacePodVerticalScalingExclusiveCPUs struct {
+	description     string
+	topo            *topology.CPUTopology
+	numReservedCPUs int
+	reserved        cpuset.CPUSet
+	stAssignments   state.ContainerCPUAssignments
+	stBaselines     state.ContainerCPUBaselines
+	stDefaultCPUSet cpuset.CPUSet
+	pod             *v1.Pod
+	expErr          error
+	expCPUAlloc     bool
+	expCSet         cpuset.CPUSet
+}
+
+func TestStaticPolicyAddWithResvListAlongsideInPlacePodVerticalScalingExclusiveCPUs(t *testing.T) {
+
+	testCases := []staticPolicyTestWithResvListWithInPlacePodVerticalScalingExclusiveCPUs{
+		{
+			description:     "GuPodSingleCore, SingleSocketHT, ExpectError",
+			topo:            topoSingleSocketHT,
+			numReservedCPUs: 1,
+			reserved:        cpuset.New(0),
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			pod:             makePod("fakePod", "fakeContainer2", "8000m", "8000m"),
+			expErr:          fmt.Errorf("not enough cpus available to satisfy request: requested=8, available=7"),
+			expCPUAlloc:     false,
+			expCSet:         cpuset.New(),
+		},
+		{
+			description:     "GuPodSingleCore, SingleSocketHT, ExpectAllocOneCPU",
+			topo:            topoSingleSocketHT,
+			numReservedCPUs: 2,
+			reserved:        cpuset.New(0, 1),
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			pod:             makePod("fakePod", "fakeContainer2", "1000m", "1000m"),
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         cpuset.New(4), // expect sibling of partial core
+		},
+		{
+			description:     "GuPodMultipleCores, SingleSocketHT, ExpectAllocOneCore",
+			topo:            topoSingleSocketHT,
+			numReservedCPUs: 2,
+			reserved:        cpuset.New(0, 1),
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"fakeContainer100": cpuset.New(2, 3, 6, 7),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"fakeContainer100": {Baseline: cpuset.New(2, 3, 6, 7)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(0, 1, 4, 5),
+			pod:             makePod("fakePod", "fakeContainer3", "2000m", "2000m"),
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         cpuset.New(4, 5),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.InPlacePodVerticalScalingExclusiveCPUs, true)
+			logger, _ := ktesting.NewTestContext(t)
+			policy, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, testCase.reserved, topologymanager.NewFakeManager(logger), nil)
+			if err != nil {
+				t.Fatalf("NewStaticPolicy() failed: %v", err)
+			}
+
+			st := &mockState{
+				assignments:   testCase.stAssignments,
+				baselines:     testCase.stBaselines,
+				defaultCPUSet: testCase.stDefaultCPUSet,
+			}
+
+			container := &testCase.pod.Spec.Containers[0]
+			err = policy.Allocate(logger, st, testCase.pod, container, lifecycle.AddOperation)
+			if !reflect.DeepEqual(err, testCase.expErr) {
+				t.Errorf("StaticPolicy Allocate() error (%v). expected add error: %v but got: %v",
+					testCase.description, testCase.expErr, err)
+			}
+
+			if testCase.expCPUAlloc {
+				original, found := st.baselines[string(testCase.pod.UID)][container.Name]
+				if !found {
+					t.Errorf("StaticPolicy Allocate() error (%v). expected container %v to be present in assignments %v",
+						testCase.description, container.Name, st.baselines)
+				}
+
+				if !original.Baseline.Equals(testCase.expCSet) {
+					t.Errorf("StaticPolicy Allocate() error (%v). expected cpuset %s but got %s",
+						testCase.description, testCase.expCSet, original.Baseline)
+				}
+
+				if !original.Baseline.Intersection(st.defaultCPUSet).IsEmpty() {
+					t.Errorf("StaticPolicy Allocate() error (%v). expected cpuset %s to be disoint from the shared cpuset %s",
+						testCase.description, original.Baseline, st.defaultCPUSet)
+				}
+			}
+
+			if !testCase.expCPUAlloc {
+				_, found := st.baselines[string(testCase.pod.UID)][container.Name]
+				if found {
+					t.Errorf("StaticPolicy Allocate() error (%v). Did not expect container %v to be present in assignments %v",
+						testCase.description, container.Name, st.baselines)
+				}
+			}
+		})
+	}
+}
+
+func TestStaticPolicyAllocatePodWithInPlacePodVerticalScalingExclusiveCPUs(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+
+	testCases := []staticPolicyAllocatePodTest{
+		{
+			description:     "should successfully allocate CPUs for a guaranteed pod with pod-level resources",
+			topo:            topoDualSocketHT,
+			numReservedCPUs: 1,
+			reservedCPUs:    cpuset.New(0),
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			pod:             makePodWithPodLevelResources("pod1", "2", "2", "container1", "1", "1"),
+			topologyHint:    topologymanager.TopologyHint{NUMANodeAffinity: newNUMAAffinity(0), Preferred: true},
+			expErr:          nil,
+			expPodBaselines: state.ContainerCPUBaselines{
+				"pod1": map[string]state.ContainerCPUBaseline{
+					"container1": {Baseline: cpuset.New(2)},
+				},
+			},
+			expDefaultCPUSet:                cpuset.New(0, 1, 3, 4, 5, 6, 7, 9, 10, 11),
+			podLevelResourcesEnabled:        true,
+			podLevelResourceManagersEnabled: true,
+			requiredMetrics: requiredMetrics{
+				expTotalAllocs:              1,
+				expExclusiveAssignments:     1,
+				expPodSharedPoolAssignments: 0,
+			},
+		},
+		{
+			description:     "scope: pod, should allocate exclusive CPUs to a guaranteed pod with pod-level resources and guaranteed container, PodLevelResourceManagers enabled",
+			topo:            topoDualSocketHT,
+			numReservedCPUs: 1,
+			reservedCPUs:    cpuset.New(0),
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			pod:             makePodWithPodLevelResources("gu-pod-level-resources", "2", "2", "gu-container", "1", "1"),
+			topologyHint:    topologymanager.TopologyHint{NUMANodeAffinity: newNUMAAffinity(0), Preferred: true},
+			expErr:          nil,
+			expPodBaselines: state.ContainerCPUBaselines{
+				"gu-pod-level-resources": map[string]state.ContainerCPUBaseline{
+					"gu-container": {Baseline: cpuset.New(2)},
+				},
+			},
+			expDefaultCPUSet:                cpuset.New(0, 1, 3, 4, 5, 6, 7, 9, 10, 11),
+			podLevelResourcesEnabled:        true,
+			podLevelResourceManagersEnabled: true,
+			requiredMetrics: requiredMetrics{
+				expTotalAllocs:              1,
+				expExclusiveAssignments:     1,
+				expPodSharedPoolAssignments: 0,
+			},
+		},
+		{
+			description:     "scope: pod, should allocate exclusive CPUs to a guaranteed pod with pod-level resources and non-guaranteed container, PodLevelResourceManagers enabled",
+			topo:            topoDualSocketHT,
+			numReservedCPUs: 1,
+			reservedCPUs:    cpuset.New(0),
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			pod: makePodWithContainersAndPodLevelResources("gu-pod-level-resources", "1", "1", []containerSpec{}, []containerSpec{
+				{name: "ngu-container"},
+			}),
+			topologyHint: topologymanager.TopologyHint{NUMANodeAffinity: newNUMAAffinity(0), Preferred: true},
+			expErr:       nil,
+			expPodBaselines: state.ContainerCPUBaselines{
+				"gu-pod-level-resources": map[string]state.ContainerCPUBaseline{
+					"ngu-container": {Baseline: cpuset.New(6)},
+				},
+			},
+			expDefaultCPUSet:                cpuset.New(0, 1, 2, 3, 4, 5, 7, 8, 9, 10, 11),
+			podLevelResourcesEnabled:        true,
+			podLevelResourceManagersEnabled: true,
+			requiredMetrics: requiredMetrics{
+				expTotalAllocs:              1,
+				expExclusiveAssignments:     0,
+				expPodSharedPoolAssignments: 1,
+			},
+		},
+		{
+			description:     "scope: pod, should allocate exclusive CPUs to a guaranteed pod with pod-level resources and mix of guaranteed and non-guaranteed containers, PodLevelResourceManagers enabled",
+			topo:            topoDualSocketHT,
+			numReservedCPUs: 1,
+			reservedCPUs:    cpuset.New(0),
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			pod: makePodWithContainersAndPodLevelResources("gu-pod-level-mix-ctn", "3", "3", []containerSpec{}, []containerSpec{
+				{name: "gu-container-1", request: "1", limit: "1"},
+				{name: "gu-container-2", request: "1", limit: "1"},
+				{name: "ngu-container"},
+			}),
+			topologyHint: topologymanager.TopologyHint{NUMANodeAffinity: newNUMAAffinity(0), Preferred: true},
+			expErr:       nil,
+			expPodBaselines: state.ContainerCPUBaselines{
+				"gu-pod-level-mix-ctn": {
+					"gu-container-1": {Baseline: cpuset.New(6)},
+					"gu-container-2": {Baseline: cpuset.New(2)},
+					"ngu-container":  {Baseline: cpuset.New(8)},
+				},
+			},
+			expDefaultCPUSet:                cpuset.New(0, 1, 3, 4, 5, 7, 9, 10, 11),
+			podLevelResourcesEnabled:        true,
+			podLevelResourceManagersEnabled: true,
+			requiredMetrics: requiredMetrics{
+				expTotalAllocs:              3,
+				expExclusiveAssignments:     2,
+				expPodSharedPoolAssignments: 1,
+			},
+		},
+		{
+			description:     "scope: pod, should allocate exclusive CPUs to a guaranteed pod with pod-level resources and mix of guaranteed standard and init containers, PodLevelResourceManagers enabled",
+			topo:            topoDualSocketHT,
+			numReservedCPUs: 1,
+			reservedCPUs:    cpuset.New(0),
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			pod: makePodWithContainersAndPodLevelResources("gu-pod-level-gu-init-ctn", "2", "2", []containerSpec{
+				{name: "gu-init-container-1", request: "1", limit: "1"},
+				{name: "gu-init-container-2", request: "1", limit: "1"},
+			}, []containerSpec{
+				{name: "gu-container-1", request: "1", limit: "1"},
+				{name: "gu-container-2", request: "1", limit: "1"},
+			}),
+			topologyHint: topologymanager.TopologyHint{NUMANodeAffinity: newNUMAAffinity(0), Preferred: true},
+			expErr:       nil,
+			expPodBaselines: state.ContainerCPUBaselines{
+				"gu-pod-level-gu-init-ctn": {
+					"gu-init-container-1": {Baseline: cpuset.New(2)},
+					"gu-init-container-2": {Baseline: cpuset.New(2)},
+					"gu-container-1":      {Baseline: cpuset.New(2)},
+					"gu-container-2":      {Baseline: cpuset.New(8)},
+				},
+			},
+			expDefaultCPUSet:                cpuset.New(0, 1, 3, 4, 5, 6, 7, 9, 10, 11),
+			podLevelResourcesEnabled:        true,
+			podLevelResourceManagersEnabled: true,
+			requiredMetrics: requiredMetrics{
+				expTotalAllocs:              4,
+				expExclusiveAssignments:     4,
+				expPodSharedPoolAssignments: 0,
+			},
+		},
+		{
+			description:     "scope: pod, should allocate exclusive CPUs to a guaranteed pod with pod-level resources and mix of guaranteed standard and guaranteed restartable and non-guaranteed standard init containers, PodLevelResourceManagers enabled",
+			topo:            topoDualSocketHT,
+			numReservedCPUs: 1,
+			reservedCPUs:    cpuset.New(0),
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			pod: makePodWithContainersAndPodLevelResources("gu-pod-level-gu-init-ctn", "3", "3", []containerSpec{
+				{name: "ngu-init-container-1"},
+				{name: "gu-init-restartable-2", request: "1", limit: "1", restartPolicy: &containerRestartPolicyAlways},
+				{name: "ngu-init-container-3"},
+			}, []containerSpec{
+				{name: "gu-container-1", request: "1", limit: "1"},
+				{name: "ngu-container-2"},
+			}),
+			topologyHint: topologymanager.TopologyHint{NUMANodeAffinity: newNUMAAffinity(0), Preferred: true},
+			expErr:       nil,
+			expPodBaselines: state.ContainerCPUBaselines{
+				"gu-pod-level-gu-init-ctn": {
+					"ngu-init-container-1":  {Baseline: cpuset.New(2, 6, 8)},
+					"gu-init-restartable-2": {Baseline: cpuset.New(6)},
+					"ngu-init-container-3":  {Baseline: cpuset.New(2, 8)},
+					"gu-container-1":        {Baseline: cpuset.New(2)},
+					"ngu-container-2":       {Baseline: cpuset.New(8)},
+				},
+			},
+			expDefaultCPUSet:                cpuset.New(0, 1, 3, 4, 5, 7, 9, 10, 11),
+			podLevelResourcesEnabled:        true,
+			podLevelResourceManagersEnabled: true,
+			requiredMetrics: requiredMetrics{
+				expTotalAllocs:              5,
+				expExclusiveAssignments:     2,
+				expPodSharedPoolAssignments: 3,
+			},
+		},
+		{
+			description:     "scope: pod, should allocate exclusive CPUs to a guaranteed pod with pod-level resources and mix of guaranteed standard and non-guaranteed restartable init containers, PodLevelResourceManagers enabled",
+			topo:            topoDualSocketHT,
+			numReservedCPUs: 1,
+			reservedCPUs:    cpuset.New(0),
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			pod: makePodWithContainersAndPodLevelResources("gu-pod-level-gu-init-ctn", "3", "3", []containerSpec{
+				{name: "ngu-init-container-1"},
+				{name: "ngu-init-restartable-2", restartPolicy: &containerRestartPolicyAlways},
+				{name: "ngu-init-container-3"},
+			}, []containerSpec{
+				{name: "gu-container-1", request: "1", limit: "1"},
+				{name: "ngu-container-2"},
+			}),
+			topologyHint: topologymanager.TopologyHint{NUMANodeAffinity: newNUMAAffinity(0), Preferred: true},
+			expErr:       nil,
+			expPodBaselines: state.ContainerCPUBaselines{
+				"gu-pod-level-gu-init-ctn": {
+					"ngu-init-container-1":   {Baseline: cpuset.New(2, 6, 8)},
+					"ngu-init-restartable-2": {Baseline: cpuset.New(2, 8)},
+					"ngu-init-container-3":   {Baseline: cpuset.New(2, 6, 8)},
+					"gu-container-1":         {Baseline: cpuset.New(6)},
+					"ngu-container-2":        {Baseline: cpuset.New(2, 8)},
+				},
+			},
+			expDefaultCPUSet:                cpuset.New(0, 1, 3, 4, 5, 7, 9, 10, 11),
+			podLevelResourcesEnabled:        true,
+			podLevelResourceManagersEnabled: true,
+			requiredMetrics: requiredMetrics{
+				expTotalAllocs:              5,
+				expExclusiveAssignments:     1,
+				expPodSharedPoolAssignments: 4,
+			},
+		},
+		{
+			description:     "scope: pod, should reject a pod that would result in an empty pod shared pool",
+			topo:            topoDualSocketHT,
+			numReservedCPUs: 1,
+			reservedCPUs:    cpuset.New(0),
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			pod: makePodWithContainersAndPodLevelResources("gu-pod-level-empty-pod-shared-pool", "2", "2", []containerSpec{}, []containerSpec{
+				{name: "gu-container-1", request: "1", limit: "1"},
+				{name: "gu-container-2", request: "1", limit: "1"},
+				{name: "ngu-container"},
+			}),
+			topologyHint:                    topologymanager.TopologyHint{NUMANodeAffinity: newNUMAAffinity(0), Preferred: true},
+			expErr:                          admission.NewEmptyPodSharedPoolError(fmt.Errorf("pod rejected, sum of exclusive container cpu requests equals pod budget, leaving no cpus for shared containers")),
+			expPodBaselines:                 state.ContainerCPUBaselines{},
+			expDefaultCPUSet:                cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			podLevelResourcesEnabled:        true,
+			podLevelResourceManagersEnabled: true,
+			requiredMetrics: requiredMetrics{
+				expTotalErrors: 1,
+			},
+		},
+		{
+			description:     "scope: pod, should not allocate exclusive CPUs to a non-guaranteed pod with pod-level resources and guaranteed containers, PodLevelResourceManagers enabled",
+			topo:            topoDualSocketHT,
+			numReservedCPUs: 1,
+			reservedCPUs:    cpuset.New(0),
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			pod: makePodWithContainersAndPodLevelResources("ngu-pod-level-empty-pod-shared-pool", "2", "1", []containerSpec{}, []containerSpec{
+				{name: "gu-container-1", request: "1", limit: "1"},
+			}),
+			topologyHint:                    topologymanager.TopologyHint{NUMANodeAffinity: newNUMAAffinity(0), Preferred: true},
+			expErr:                          nil,
+			expPodBaselines:                 state.ContainerCPUBaselines{},
+			expDefaultCPUSet:                cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			podLevelResourcesEnabled:        true,
+			podLevelResourceManagersEnabled: true,
+			requiredMetrics: requiredMetrics{
+				expTotalErrors: 0,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.PodLevelResources, testCase.podLevelResourcesEnabled)
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.PodLevelResourceManagers, testCase.podLevelResourceManagersEnabled)
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.InPlacePodVerticalScalingExclusiveCPUs, true)
+
+			metrics.Register()
+			metrics.ResourceManagerAllocationsTotal.Reset()
+			metrics.ResourceManagerAllocationErrorsTotal.Reset()
+			metrics.ResourceManagerContainerAssignments.Reset()
+
+			policy, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, testCase.reservedCPUs, topologymanager.NewFakeManager(logger), testCase.options)
+			if err != nil {
+				t.Fatalf("NewStaticPolicy() failed: %v", err)
+			}
+
+			st := &mockState{
+				assignments:   testCase.stAssignments,
+				baselines:     testCase.stBaselines,
+				defaultCPUSet: testCase.stDefaultCPUSet,
+			}
+
+			err = policy.AllocatePod(logger, st, testCase.pod, lifecycle.AddOperation)
+			if testCase.expErr != nil {
+				require.Error(t, err)
+
+				errors, err := testutil.GetCounterMetricValue(metrics.ResourceManagerAllocationErrorsTotal.WithLabelValues(metrics.ResourceManagerCPU, metrics.ResourceManagerPod))
+				require.NoError(t, err)
+				require.InDelta(t, float64(testCase.requiredMetrics.expTotalErrors), errors, 0.001, "expected allocation errors to be incremented")
+
+				return
+			}
+			require.NoError(t, err)
+
+			if !reflect.DeepEqual(st.GetCPUBaselines(), testCase.expPodBaselines) {
+				t.Errorf("StaticPolicy AllocatePod() error (%v). expected allocations: %v but got: %v",
+					testCase.description, testCase.expPodBaselines, st.GetCPUBaselines())
+			}
+
+			if !st.GetDefaultCPUSet().Equals(testCase.expDefaultCPUSet) {
+				t.Errorf("StaticPolicy AllocatePod() error (%v). expected default cpuset: %v but got: %v",
+					testCase.description, testCase.expDefaultCPUSet, st.GetDefaultCPUSet())
+			}
+
+			allocations, err := testutil.GetCounterMetricValue(metrics.ResourceManagerAllocationsTotal.WithLabelValues(metrics.ResourceManagerCPU, metrics.ResourceManagerPod))
+			require.NoError(t, err)
+			require.InDelta(t, float64(testCase.requiredMetrics.expTotalAllocs), allocations, 0.001, "unexpected number of allocations")
+
+			exclusiveAssignments, err := testutil.GetCounterMetricValue(metrics.ResourceManagerContainerAssignments.WithLabelValues(metrics.ResourceManagerCPU, metrics.ResourceManagerExclusivePod))
+			require.NoError(t, err)
+			require.InDelta(t, float64(testCase.requiredMetrics.expExclusiveAssignments), exclusiveAssignments, 0.001, "unexpected number of assignments")
+
+			podSharedPoolAssignments, err := testutil.GetCounterMetricValue(metrics.ResourceManagerContainerAssignments.WithLabelValues(metrics.ResourceManagerCPU, metrics.ResourceManagerSharedPod))
+			require.NoError(t, err)
+			require.InDelta(t, float64(testCase.requiredMetrics.expPodSharedPoolAssignments), podSharedPoolAssignments, 0.001, "unexpected number of assignments")
+		})
+	}
+}

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -67,6 +67,7 @@ type staticPolicyTest struct {
 	options         map[string]string
 	containerName   string
 	stAssignments   state.ContainerCPUAssignments
+	stBaselines     state.ContainerCPUBaselines
 	stDefaultCPUSet cpuset.CPUSet
 	pod             *v1.Pod
 	topologyHint    *topologymanager.TopologyHint
@@ -86,6 +87,7 @@ func (spt staticPolicyTest) PseudoClone() staticPolicyTest {
 		options:         spt.options, // accessed in read-only
 		containerName:   spt.containerName,
 		stAssignments:   spt.stAssignments.Clone(),
+		stBaselines:     spt.stBaselines.Clone(),
 		stDefaultCPUSet: spt.stDefaultCPUSet.Clone(),
 		pod:             spt.pod, // accessed in read-only
 		expErr:          spt.expErr,
@@ -2173,11 +2175,13 @@ type staticPolicyAllocatePodTest struct {
 	reservedCPUs                    cpuset.CPUSet
 	options                         map[string]string
 	stAssignments                   state.ContainerCPUAssignments
+	stBaselines                     state.ContainerCPUBaselines
 	stDefaultCPUSet                 cpuset.CPUSet
 	pod                             *v1.Pod
 	topologyHint                    topologymanager.TopologyHint
 	expErr                          error
 	expPodAssignments               state.ContainerCPUAssignments
+	expPodBaselines                 state.ContainerCPUBaselines
 	expDefaultCPUSet                cpuset.CPUSet
 	podLevelResourcesEnabled        bool
 	podLevelResourceManagersEnabled bool
@@ -3003,131 +3007,515 @@ func TestStaticPolicyLifecycleAllocatePod(t *testing.T) {
 	}
 }
 
-func TestStaticPolicyLifecycleGetTopologyHints(t *testing.T) {
+// The following lifecycle tests verify that InPlacePodVerticalScalingExclusiveCPUs
+// alongside static CPU manager policy processes resize operations as per KEP
+// All following tests require InPlacePodVerticalScalingExclusiveCPUs enabled
+type staticPolicyResizeTest struct {
+	description     string
+	topo            *topology.CPUTopology
+	numReservedCPUs int
+	reservedCPUs    *cpuset.CPUSet
+	podUID          string
+	options         map[string]string
+	containerName   string
+	stAssignments   state.ContainerCPUAssignments
+	stBaselines     state.ContainerCPUBaselines
+	stDefaultCPUSet cpuset.CPUSet
+	pod             *v1.Pod
+	qosClass        v1.PodQOSClass
+	podAllocated    string
+	resizeLimit     string
+	resizeRequest   string
+	topologyHint    *topologymanager.TopologyHint
+	expErr          error
+	expCPUAlloc     bool
+	expCSet         cpuset.CPUSet
+}
+
+// this is not a real Clone() - hence Pseudo- - because we don't clone some
+// objects which are accessed read-only
+func (spt staticPolicyResizeTest) PseudoClone() staticPolicyResizeTest {
+	return staticPolicyResizeTest{
+		description:     spt.description,
+		topo:            spt.topo, // accessed in read-only
+		numReservedCPUs: spt.numReservedCPUs,
+		podUID:          spt.podUID,
+		options:         spt.options, // accessed in read-only
+		containerName:   spt.containerName,
+		stAssignments:   spt.stAssignments.Clone(),
+		stBaselines:     spt.stBaselines.Clone(),
+		stDefaultCPUSet: spt.stDefaultCPUSet.Clone(),
+		pod:             spt.pod, // accessed in read-only
+		qosClass:        spt.qosClass,
+		podAllocated:    spt.podAllocated,
+		resizeLimit:     spt.resizeLimit,
+		resizeRequest:   spt.resizeRequest,
+		topologyHint:    spt.topologyHint, // accessed in read-only
+		expErr:          spt.expErr,
+		expCPUAlloc:     spt.expCPUAlloc,
+		expCSet:         spt.expCSet.Clone(),
+	}
+}
+
+func TestStaticPolicyStartAlognsideInPlacePodVerticalScalingExclusiveCPUs(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.CPUManagerPolicyAlphaOptions, true)
+	testCases := []staticPolicyResizeTest{
+		{
+			description: "non-corrupted state",
+			topo:        topoDualSocketHT,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"0": cpuset.New(0),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"0": {Baseline: cpuset.New(0)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			expCSet:         cpuset.New(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+		},
+		{
+			description:     "empty cpuset",
+			topo:            topoDualSocketHT,
+			numReservedCPUs: 1,
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(),
+			expCSet:         cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+		},
+		{
+			description:     "reserved cores 0 & 6 are not present in available cpuset",
+			topo:            topoDualSocketHT,
+			numReservedCPUs: 2,
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(0, 1),
+			expErr:          fmt.Errorf("not all reserved cpus: \"0,6\" are present in defaultCpuSet: \"0-1\""),
+		},
+		{
+			description:     "some of reserved cores are present in available cpuset (StrictCPUReservationOption)",
+			topo:            topoDualSocketHT,
+			numReservedCPUs: 2,
+			options:         map[string]string{StrictCPUReservationOption: "true"},
+			stAssignments:   state.ContainerCPUAssignments{},
+			stBaselines:     state.ContainerCPUBaselines{},
+			stDefaultCPUSet: cpuset.New(0, 1),
+			expErr:          fmt.Errorf("some of strictly reserved cpus: \"0\" are present in defaultCpuSet: \"0-1\""),
+		},
+		{
+			description: "assigned core 2 is still present in available cpuset",
+			topo:        topoDualSocketHT,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"0": cpuset.New(0, 1, 2),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"0": {Baseline: cpuset.New(0, 1, 2)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			expErr:          fmt.Errorf("pod: fakePod, container: 0 cpuset: \"0-2\" overlaps with default cpuset \"2-11\""),
+		},
+		{
+			description: "assigned core 2 is still present in available cpuset (StrictCPUReservationOption)",
+			topo:        topoDualSocketHT,
+			options:     map[string]string{StrictCPUReservationOption: "true"},
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"0": cpuset.New(0, 1, 2),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"0": {Baseline: cpuset.New(0, 1, 2)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			expErr:          fmt.Errorf("pod: fakePod, container: 0 cpuset: \"0-2\" overlaps with default cpuset \"2-11\""),
+		},
+		{
+			description: "core 12 is not present in topology but is in state cpuset",
+			topo:        topoDualSocketHT,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"0": cpuset.New(0, 1, 2),
+					"1": cpuset.New(3, 4),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"0": {Baseline: cpuset.New(0, 1, 2)},
+					"1": {Baseline: cpuset.New(3, 4)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(5, 6, 7, 8, 9, 10, 11, 12),
+			expErr:          fmt.Errorf("current set of available CPUs \"0-11\" doesn't match with CPUs in state \"0-12\""),
+		},
+		{
+			description: "core 11 is present in topology but is not in state cpuset",
+			topo:        topoDualSocketHT,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePod": map[string]cpuset.CPUSet{
+					"0": cpuset.New(0, 1, 2),
+					"1": cpuset.New(3, 4),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePod": map[string]state.ContainerCPUBaseline{
+					"0": {Baseline: cpuset.New(0, 1, 2)},
+					"1": {Baseline: cpuset.New(3, 4)},
+				},
+			},
+			stDefaultCPUSet: cpuset.New(5, 6, 7, 8, 9, 10),
+			expErr:          fmt.Errorf("current set of available CPUs \"0-11\" doesn't match with CPUs in state \"0-10\""),
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.CPUManagerPolicyAlphaOptions, true)
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.InPlacePodVerticalScaling, true)
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.InPlacePodVerticalScalingExclusiveCPUs, true)
+			p, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(logger), testCase.options)
+			if err != nil {
+				t.Fatalf("NewStaticPolicy() failed: %v", err)
+			}
+			policy := p.(*staticPolicy)
+			st := &mockState{
+				assignments:   testCase.stAssignments,
+				baselines:     testCase.stBaselines,
+				defaultCPUSet: testCase.stDefaultCPUSet,
+			}
+			err = policy.Start(logger, st)
+			if !reflect.DeepEqual(err, testCase.expErr) {
+				t.Errorf("StaticPolicy Start() error (%v). expected error: %v but got: %v",
+					testCase.description, testCase.expErr, err)
+			}
+			if err != nil {
+				return
+			}
+
+			if !testCase.stDefaultCPUSet.IsEmpty() {
+				for cpuid := 1; cpuid < policy.topology.NumCPUs; cpuid++ {
+					if !st.defaultCPUSet.Contains(cpuid) {
+						t.Errorf("StaticPolicy Start() error. expected cpuid %d to be present in defaultCPUSet", cpuid)
+					}
+				}
+			}
+			if !st.GetDefaultCPUSet().Equals(testCase.expCSet) {
+				t.Errorf("State CPUSet is different than expected. Have %q wants: %q", st.GetDefaultCPUSet(),
+					testCase.expCSet)
+			}
+
+		})
+	}
+}
+
+func TestStaticPolicyPodResizeCPUsSingleContainerPod(t *testing.T) {
 	testCases := []struct {
-		description string
-		operation   lifecycle.Operation
-		skipped     bool
+		staticPolicyResizeTest
+		expAllocErr            error
+		expCSetAfterAlloc      cpuset.CPUSet
+		expCSetAfterResize     cpuset.CPUSet
+		expCSetAfterResizeSize int
+		expCSetAfterRemove     cpuset.CPUSet
 	}{
 		{
-			description: "CPUManager static policy processes AddOperation",
-			operation:   lifecycle.AddOperation,
-			skipped:     false,
+			staticPolicyResizeTest: staticPolicyResizeTest{
+				description: "SingleSocketHT, PodResize, Container in exclusively allocated pool, Increase allocated CPUs",
+				topo:        topoSingleSocketHT,
+				pod: makeMultiContainerPodWithOptions(
+					nil,
+					[]*containerOptions{
+						{request: "2000m", limit: "2000m", restartPolicy: v1.ContainerRestartPolicy("Never")}}, // 0, 4
+				),
+				qosClass:        v1.PodQOSGuaranteed,
+				podAllocated:    "2000m",
+				resizeLimit:     "4000m",
+				resizeRequest:   "4000m",
+				containerName:   "appContainer-0",
+				stAssignments:   state.ContainerCPUAssignments{},
+				stBaselines:     state.ContainerCPUBaselines{},
+				stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			},
+			expCSetAfterAlloc:  cpuset.New(1, 2, 3, 5, 6, 7),
+			expCSetAfterResize: cpuset.New(2, 3, 6, 7),
+			expCSetAfterRemove: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
 		},
 		{
-			description: "CPUManager static policy skips ResizeOperation",
-			operation:   lifecycle.ResizeOperation,
-			skipped:     true,
+			staticPolicyResizeTest: staticPolicyResizeTest{
+				description: "SingleSocketHT, PodResize, Container in exclusively allocated pool, Keep same allocated CPUs",
+				topo:        topoSingleSocketHT,
+				pod: makeMultiContainerPodWithOptions(
+					nil,
+					[]*containerOptions{
+						{request: "2000m", limit: "2000m", restartPolicy: v1.ContainerRestartPolicy("Never")}}, // 0, 4
+				),
+				qosClass:        v1.PodQOSGuaranteed,
+				podAllocated:    "2000m",
+				resizeLimit:     "2000m",
+				resizeRequest:   "2000m",
+				containerName:   "appContainer-0",
+				stAssignments:   state.ContainerCPUAssignments{},
+				stBaselines:     state.ContainerCPUBaselines{},
+				stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			},
+			expAllocErr:        inconsistentCPUAllocationError{RequestedCPUs: "2", AllocatedCPUs: "2", Shared2Exclusive: false},
+			expCSetAfterAlloc:  cpuset.New(1, 2, 3, 5, 6, 7),
+			expCSetAfterResize: cpuset.New(1, 2, 3, 5, 6, 7),
+			expCSetAfterRemove: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
 		},
 		{
-			description: "CPUManager static policy skips empty operation",
-			operation:   "",
-			skipped:     true,
+			staticPolicyResizeTest: staticPolicyResizeTest{
+				description: "SingleSocketHT, PodResize, Container in exclusively allocated pool, Decrease allocated CPUs",
+				topo:        topoSingleSocketHT,
+				pod: makeMultiContainerPodWithOptions(
+					nil,
+					[]*containerOptions{
+						{request: "4000m", limit: "4000m", restartPolicy: v1.ContainerRestartPolicy("Never")}}, // 0-1, 4-5
+				),
+				qosClass:        v1.PodQOSGuaranteed,
+				podAllocated:    "4000m",
+				resizeLimit:     "2000m",
+				resizeRequest:   "2000m",
+				containerName:   "appContainer-0",
+				stAssignments:   state.ContainerCPUAssignments{},
+				stBaselines:     state.ContainerCPUBaselines{},
+				stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			},
+			expAllocErr:            prohibitedCPUAllocationError{RequestedCPUs: "2", AllocatedCPUs: "4", BaselineCPUs: 4, GuaranteedCPUs: 2},
+			expCSetAfterAlloc:      cpuset.New(2, 3, 6, 7),
+			expCSetAfterResizeSize: 4,
+			expCSetAfterRemove:     cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+		},
+		{
+			staticPolicyResizeTest: staticPolicyResizeTest{
+				description: "SingleSocketHT, PodResize, Container in shared pool with more than one core, Attempt to move to exclusively allocated pool",
+				topo:        topoSingleSocketHT,
+				pod: makeMultiContainerPodWithOptions(
+					nil,
+					[]*containerOptions{
+						{request: "2100m", limit: "2100m", restartPolicy: v1.ContainerRestartPolicy("Never")}}, // 0-7
+				),
+				qosClass:        v1.PodQOSGuaranteed,
+				podAllocated:    "2100m",
+				resizeLimit:     "2000m",
+				resizeRequest:   "2000m",
+				containerName:   "appContainer-0",
+				stAssignments:   state.ContainerCPUAssignments{},
+				stBaselines:     state.ContainerCPUBaselines{},
+				stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			},
+			expAllocErr:        inconsistentCPUAllocationError{RequestedCPUs: "2", AllocatedCPUs: "2100m", Shared2Exclusive: true},
+			expCSetAfterAlloc:  cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			expCSetAfterResize: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			expCSetAfterRemove: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+		},
+		{
+			staticPolicyResizeTest: staticPolicyResizeTest{
+				description: "SingleSocketHT, PodResize, Container in shared pool, Increase CPU and keep in shared pool",
+				topo:        topoSingleSocketHT,
+				pod: makeMultiContainerPodWithOptions(
+					nil,
+					[]*containerOptions{
+						{request: "100m", limit: "100m", restartPolicy: v1.ContainerRestartPolicy("Never")}}, // 0-7
+				),
+				qosClass:        v1.PodQOSGuaranteed,
+				podAllocated:    "100m",
+				resizeLimit:     "200m",
+				resizeRequest:   "200m",
+				containerName:   "appContainer-0",
+				stAssignments:   state.ContainerCPUAssignments{},
+				stBaselines:     state.ContainerCPUBaselines{},
+				stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			},
+			expCSetAfterAlloc:  cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			expCSetAfterResize: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			expCSetAfterRemove: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+		},
+		{
+			staticPolicyResizeTest: staticPolicyResizeTest{
+				description: "SingleSocketHT, PodResize, Container in shared pool, Increase CPU and keep in shared pool",
+				topo:        topoSingleSocketHT,
+				pod: makeMultiContainerPodWithOptions(
+					nil,
+					[]*containerOptions{
+						{request: "1100m", limit: "1100m", restartPolicy: v1.ContainerRestartPolicy("Never")}}, // 0-7
+				),
+				qosClass:        v1.PodQOSGuaranteed,
+				podAllocated:    "1100m",
+				resizeLimit:     "1200m",
+				resizeRequest:   "1200m",
+				containerName:   "appContainer-0",
+				stAssignments:   state.ContainerCPUAssignments{},
+				stBaselines:     state.ContainerCPUBaselines{},
+				stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			},
+			expCSetAfterAlloc:  cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			expCSetAfterResize: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			expCSetAfterRemove: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+		},
+		{
+			staticPolicyResizeTest: staticPolicyResizeTest{
+				description: "SingleSocketHT, PodResize, Container in shared pool with less than one core, Decrease CPU and keep in shared pool",
+				topo:        topoSingleSocketHT,
+				pod: makeMultiContainerPodWithOptions(
+					nil,
+					[]*containerOptions{
+						{request: "200m", limit: "200m", restartPolicy: v1.ContainerRestartPolicy("Never")}}, // 0-7
+				),
+				qosClass:        v1.PodQOSGuaranteed,
+				podAllocated:    "200m",
+				resizeLimit:     "100m",
+				resizeRequest:   "100m",
+				containerName:   "appContainer-0",
+				stAssignments:   state.ContainerCPUAssignments{},
+				stBaselines:     state.ContainerCPUBaselines{},
+				stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			},
+			expCSetAfterAlloc:  cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			expCSetAfterResize: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			expCSetAfterRemove: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+		},
+		{
+			staticPolicyResizeTest: staticPolicyResizeTest{
+				description: "SingleSocketHT, PodResize, Container in shared pool with more than one core, Decrease CPU and keep in shared pool",
+				topo:        topoSingleSocketHT,
+				pod: makeMultiContainerPodWithOptions(
+					nil,
+					[]*containerOptions{
+						{request: "1200m", limit: "1200m", restartPolicy: v1.ContainerRestartPolicy("Never")}}, // 0-7
+				),
+				qosClass:        v1.PodQOSGuaranteed,
+				podAllocated:    "1200m",
+				resizeLimit:     "1100m",
+				resizeRequest:   "1100m",
+				containerName:   "appContainer-0",
+				stAssignments:   state.ContainerCPUAssignments{},
+				stBaselines:     state.ContainerCPUBaselines{},
+				stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			},
+			expCSetAfterAlloc:  cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			expCSetAfterResize: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			expCSetAfterRemove: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+		},
+		{
+			staticPolicyResizeTest: staticPolicyResizeTest{
+				description: "SingleSocketHT, PodResize, Container in exclusively allocated pool, Move to shared pool",
+				topo:        topoSingleSocketHT,
+				pod: makeMultiContainerPodWithOptions(
+					nil,
+					[]*containerOptions{
+						{request: "2000m", limit: "2000m", restartPolicy: v1.ContainerRestartPolicy("Never")}}, // 0-1, 4-5
+				),
+				qosClass:        v1.PodQOSGuaranteed,
+				podAllocated:    "2000m",
+				resizeLimit:     "1500m",
+				resizeRequest:   "1500m",
+				containerName:   "appContainer-0",
+				stAssignments:   state.ContainerCPUAssignments{},
+				stBaselines:     state.ContainerCPUBaselines{},
+				stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			},
+			expAllocErr:        inconsistentCPUAllocationError{RequestedCPUs: "1500m", AllocatedCPUs: "2", Shared2Exclusive: false},
+			expCSetAfterAlloc:  cpuset.New(1, 2, 3, 5, 6, 7),
+			expCSetAfterResize: cpuset.New(1, 2, 3, 5, 6, 7),
+			expCSetAfterRemove: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
 		},
 	}
 
 	for _, testCase := range testCases {
+		logger, _ := ktesting.NewTestContext(t)
 		t.Run(testCase.description, func(t *testing.T) {
-			ktesting.SetDefaultVerbosity(2)
-			tCtx := ktesting.Init(t, initoption.BufferLogs(true))
-			logger := tCtx.Logger()
-
-			policy, err := NewStaticPolicy(logger, topoSingleSocketHT, 0, cpuset.New(), topologymanager.NewFakeManager(logger), nil)
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.InPlacePodVerticalScalingExclusiveCPUs, true)
+			policy, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(logger), nil)
 			if err != nil {
 				t.Fatalf("NewStaticPolicy() failed: %v", err)
 			}
 
 			st := &mockState{
-				assignments:   state.ContainerCPUAssignments{},
-				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+				assignments:   testCase.stAssignments,
+				baselines:     testCase.stBaselines,
+				defaultCPUSet: testCase.stDefaultCPUSet,
 			}
-			pod := makeMultiContainerPod(nil, []struct{ request, limit string }{{"1", "2"}})
-			container := pod.Spec.Containers[0]
+			pod := testCase.pod
+			pod.Status.QOSClass = testCase.qosClass
 
-			hints := policy.GetTopologyHints(logger, st, pod, &container, testCase.operation)
-			if hints != nil {
-				t.Errorf("Unexpected hints: %v", hints)
+			// allocate
+			for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
+				err := policy.Allocate(logger, st, pod, &container, lifecycle.AddOperation)
+				if err != nil {
+					t.Errorf("StaticPolicy Allocate() error (%v). expected no error but got %v",
+						testCase.description, err)
+				}
+			}
+			if !reflect.DeepEqual(st.defaultCPUSet, testCase.expCSetAfterAlloc) {
+				t.Errorf("StaticPolicy Allocate() error (%v) before pod resize. expected default cpuset %v but got %v",
+					testCase.description, testCase.expCSetAfterAlloc, st.defaultCPUSet)
 			}
 
-			underlier, ok := logger.GetSink().(ktesting.Underlier)
-			if !ok {
-				t.Fatalf("Should have had a ktesting LogSink, got %T", logger.GetSink())
+			// resize
+			pod.Status.ContainerStatuses = []v1.ContainerStatus{
+				{
+					Name: testCase.containerName,
+					AllocatedResources: v1.ResourceList{
+						v1.ResourceCPU: resource.MustParse(testCase.podAllocated),
+					},
+				},
 			}
-			logs := underlier.GetBuffer().String()
-			expectedLog := "CPU Manager container-level hint generation skipped, operation not supported by the static CPU manager policy"
-			if testCase.skipped {
-				if !strings.Contains(logs, expectedLog) {
-					t.Errorf("Expected log '%s' not found in logs: %s", expectedLog, logs)
+			pod.Spec.Containers[0].Resources = v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceName(v1.ResourceCPU): resource.MustParse(testCase.resizeLimit),
+				},
+				Requests: v1.ResourceList{
+					v1.ResourceName(v1.ResourceCPU): resource.MustParse(testCase.resizeRequest),
+				},
+			}
+			podResized := pod
+			for _, container := range append(podResized.Spec.InitContainers, podResized.Spec.Containers...) {
+				err := policy.Allocate(logger, st, podResized, &container, lifecycle.ResizeOperation)
+				if err != nil {
+					if !reflect.DeepEqual(err, testCase.expAllocErr) {
+						t.Errorf("StaticPolicy Allocate() error (%v), expected error: %v but got: %v",
+							testCase.description, testCase.expAllocErr, err)
+					}
+				}
+			}
+			if testCase.expCSetAfterResizeSize > 0 {
+				// expCSetAfterResizeSize is used when testing scale down because allocated CPUs are not deterministic,
+				// since size of defaultCPUSet is deterministic and also interesection  with expected allocation
+				// should not be nill. < ====== TODO esotsal
+				if !reflect.DeepEqual(st.defaultCPUSet.Size(), testCase.expCSetAfterResizeSize) {
+					t.Errorf("StaticPolicy Allocate() error (%v) after pod resize. expected default cpuset size equal to %v but got %v",
+						testCase.description, testCase.expCSetAfterResizeSize, st.defaultCPUSet.Size())
 				}
 			} else {
-				if strings.Contains(logs, expectedLog) {
-					t.Errorf("Unexpected log '%s' found in logs: %s", expectedLog, logs)
+				if !reflect.DeepEqual(st.defaultCPUSet, testCase.expCSetAfterResize) {
+					t.Errorf("StaticPolicy Allocate() error (%v) after pod resize. expected default cpuset %v but got %v",
+						testCase.description, testCase.expCSetAfterResize, st.defaultCPUSet)
 				}
 			}
-		})
-	}
-}
 
-func TestStaticPolicyLifecycleGetPodTopologyHints(t *testing.T) {
-	testCases := []struct {
-		description string
-		operation   lifecycle.Operation
-		skipped     bool
-	}{
-		{
-			description: "CPUManager static policy processes AddOperation",
-			operation:   lifecycle.AddOperation,
-			skipped:     false,
-		},
-		{
-			description: "CPUManager static policy skips ResizeOperation",
-			operation:   lifecycle.ResizeOperation,
-			skipped:     true,
-		},
-		{
-			description: "CPUManager static policy skips empty operation",
-			operation:   "",
-			skipped:     true,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.description, func(t *testing.T) {
-			ktesting.SetDefaultVerbosity(2)
-			tCtx := ktesting.Init(t, initoption.BufferLogs(true))
-			logger := tCtx.Logger()
-
-			policy, err := NewStaticPolicy(logger, topoSingleSocketHT, 0, cpuset.New(), topologymanager.NewFakeManager(logger), nil)
+			// remove
+			err = policy.RemoveContainer(logger, st, string(pod.UID), testCase.containerName)
 			if err != nil {
-				t.Fatalf("NewStaticPolicy() failed: %v", err)
+				t.Errorf("StaticPolicy RemoveContainer() error (%v) after pod resize. expected no error but got %v",
+					testCase.description, err)
 			}
 
-			st := &mockState{
-				assignments:   state.ContainerCPUAssignments{},
-				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			if !reflect.DeepEqual(st.defaultCPUSet, testCase.expCSetAfterRemove) {
+				t.Errorf("StaticPolicy RemoveContainer() error (%v) after pod resize. expected default cpuset %v but got %v",
+					testCase.description, testCase.expCSetAfterRemove, st.defaultCPUSet)
 			}
-			pod := makeMultiContainerPod(nil, []struct{ request, limit string }{{"1", "2"}})
-
-			hints := policy.GetPodTopologyHints(logger, st, pod, testCase.operation)
-			if hints != nil {
-				t.Errorf("Unexpected hints: %v", hints)
-			}
-
-			underlier, ok := logger.GetSink().(ktesting.Underlier)
-			if !ok {
-				t.Fatalf("Should have had a ktesting LogSink, got %T", logger.GetSink())
-			}
-			logs := underlier.GetBuffer().String()
-			expectedLog := "CPU Manager pod hint generation skipped, operation not supported by the static CPU manager policy"
-			if testCase.skipped {
-				if !strings.Contains(logs, expectedLog) {
-					t.Errorf("Expected log '%s' not found in logs: %s", expectedLog, logs)
-				}
-			} else {
-				if strings.Contains(logs, expectedLog) {
-					t.Errorf("Unexpected log '%s' found in logs: %s", expectedLog, logs)
-				}
+			if _, found := st.assignments[string(pod.UID)][testCase.containerName]; found {
+				t.Errorf("StaticPolicy RemoveContainer() error (%v) after pod resize. expected (pod %v, container %v) not be in assignments %v",
+					testCase.description, testCase.podUID, testCase.containerName, st.assignments)
 			}
 		})
 	}
 }
+

--- a/pkg/kubelet/cm/cpumanager/state/state.go
+++ b/pkg/kubelet/cm/cpumanager/state/state.go
@@ -110,7 +110,6 @@ func (a PodCPUAssignments) Clone() PodCPUAssignments {
 	return clone
 }
 
-// ContainerCPUAllocation tracks the current allocation state
 // ContainerCPUBaselines tracks the allocation state at admission time.
 // If in-place vertical scaling is enabled, the allocation state at admission
 // time is required to proper resource accounting; otherwise the field is

--- a/pkg/kubelet/cm/cpumanager/topology_hints_test.go
+++ b/pkg/kubelet/cm/cpumanager/topology_hints_test.go
@@ -37,14 +37,16 @@ import (
 )
 
 type testCase struct {
-	name                            string
-	pod                             v1.Pod
-	container                       v1.Container
-	assignments                     state.ContainerCPUAssignments
-	defaultCPUSet                   cpuset.CPUSet
-	expectedHints                   []topologymanager.TopologyHint
-	podLevelResourcesEnabled        bool
-	podLevelResourceManagersEnabled bool
+	name                                          string
+	pod                                           v1.Pod
+	container                                     v1.Container
+	assignments                                   state.ContainerCPUAssignments
+	baselines                                     state.ContainerCPUBaselines
+	defaultCPUSet                                 cpuset.CPUSet
+	expectedHints                                 []topologymanager.TopologyHint
+	podLevelResourcesEnabled                      bool
+	podLevelResourceManagersEnabled               bool
+	inPlacePodVerticalScalingExclusiveCPUsEnabled bool
 }
 
 func returnMachineInfo() cadvisorapi.MachineInfo {
@@ -242,6 +244,9 @@ func TestGetTopologyHints(t *testing.T) {
 		if tc.podLevelResourceManagersEnabled {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResourceManagers, tc.podLevelResourceManagersEnabled)
 		}
+		if tc.inPlacePodVerticalScalingExclusiveCPUsEnabled {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingExclusiveCPUs, tc.inPlacePodVerticalScalingExclusiveCPUsEnabled)
+		}
 
 		topology, _ := topology.Discover(logger, &machineInfo)
 
@@ -256,34 +261,65 @@ func TestGetTopologyHints(t *testing.T) {
 			}
 			activePods = append(activePods, &pod)
 		}
+		if tc.inPlacePodVerticalScalingExclusiveCPUsEnabled == false {
+			m := manager{
+				policy: &staticPolicy{
+					topology: topology,
+				},
+				state: &mockState{
+					assignments:   tc.assignments,
+					defaultCPUSet: tc.defaultCPUSet,
+				},
+				topology:          topology,
+				activePods:        func() []*v1.Pod { return activePods },
+				podStatusProvider: mockPodStatusProvider{},
+				sourcesReady:      &sourcesReadyStub{},
+			}
+			hints := m.GetTopologyHints(logger, &tc.pod, &tc.container, lifecycle.AddOperation)[string(v1.ResourceCPU)]
+			if len(tc.expectedHints) == 0 && len(hints) == 0 {
+				continue
+			}
+			sort.SliceStable(hints, func(i, j int) bool {
+				return hints[i].LessThan(hints[j])
+			})
+			sort.SliceStable(tc.expectedHints, func(i, j int) bool {
+				return tc.expectedHints[i].LessThan(tc.expectedHints[j])
+			})
+			if !reflect.DeepEqual(tc.expectedHints, hints) {
+				t.Errorf("Test case %q: Expected in result to be %v , got %v", tc.name, tc.expectedHints, hints)
+			}
 
-		m := manager{
-			policy: &staticPolicy{
-				topology: topology,
-			},
-			state: &mockState{
-				assignments:   tc.assignments,
-				defaultCPUSet: tc.defaultCPUSet,
-			},
-			topology:          topology,
-			activePods:        func() []*v1.Pod { return activePods },
-			podStatusProvider: mockPodStatusProvider{},
-			sourcesReady:      &sourcesReadyStub{},
+		} else {
+			m := manager{
+				policy: &staticPolicy{
+					topology: topology,
+				},
+				state: &mockState{
+					assignments:   tc.assignments,
+					baselines:     tc.baselines,
+					defaultCPUSet: tc.defaultCPUSet,
+				},
+				topology:          topology,
+				activePods:        func() []*v1.Pod { return activePods },
+				podStatusProvider: mockPodStatusProvider{},
+				sourcesReady:      &sourcesReadyStub{},
+			}
+			hints := m.GetTopologyHints(logger, &tc.pod, &tc.container, lifecycle.AddOperation)[string(v1.ResourceCPU)]
+			if len(tc.expectedHints) == 0 && len(hints) == 0 {
+				continue
+			}
+			sort.SliceStable(hints, func(i, j int) bool {
+				return hints[i].LessThan(hints[j])
+			})
+			sort.SliceStable(tc.expectedHints, func(i, j int) bool {
+				return tc.expectedHints[i].LessThan(tc.expectedHints[j])
+			})
+			if !reflect.DeepEqual(tc.expectedHints, hints) {
+				t.Errorf("Test case %q: Expected in result to be %v , got %v", tc.name, tc.expectedHints, hints)
+			}
+
 		}
 
-		hints := m.GetTopologyHints(logger, &tc.pod, &tc.container, lifecycle.AddOperation)[string(v1.ResourceCPU)]
-		if len(tc.expectedHints) == 0 && len(hints) == 0 {
-			continue
-		}
-		sort.SliceStable(hints, func(i, j int) bool {
-			return hints[i].LessThan(hints[j])
-		})
-		sort.SliceStable(tc.expectedHints, func(i, j int) bool {
-			return tc.expectedHints[i].LessThan(tc.expectedHints[j])
-		})
-		if !reflect.DeepEqual(tc.expectedHints, hints) {
-			t.Errorf("Test case %q: Expected in result to be %v , got %v", tc.name, tc.expectedHints, hints)
-		}
 	}
 }
 
@@ -298,6 +334,9 @@ func TestGetPodTopologyHints(t *testing.T) {
 		if tc.podLevelResourceManagersEnabled {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResourceManagers, tc.podLevelResourceManagersEnabled)
 		}
+		if tc.inPlacePodVerticalScalingExclusiveCPUsEnabled {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingExclusiveCPUs, tc.inPlacePodVerticalScalingExclusiveCPUsEnabled)
+		}
 
 		topology, _ := topology.Discover(logger, &machineInfo)
 
@@ -313,34 +352,66 @@ func TestGetPodTopologyHints(t *testing.T) {
 			activePods = append(activePods, &pod)
 		}
 
-		m := manager{
-			policy: &staticPolicy{
-				topology: topology,
-			},
-			state: &mockState{
-				assignments:   tc.assignments,
-				defaultCPUSet: tc.defaultCPUSet,
-			},
-			topology:          topology,
-			activePods:        func() []*v1.Pod { return activePods },
-			podStatusProvider: mockPodStatusProvider{},
-			sourcesReady:      &sourcesReadyStub{},
-		}
+		if tc.inPlacePodVerticalScalingExclusiveCPUsEnabled == false {
+			m := manager{
+				policy: &staticPolicy{
+					topology: topology,
+				},
+				state: &mockState{
+					assignments:   tc.assignments,
+					defaultCPUSet: tc.defaultCPUSet,
+				},
+				topology:          topology,
+				activePods:        func() []*v1.Pod { return activePods },
+				podStatusProvider: mockPodStatusProvider{},
+				sourcesReady:      &sourcesReadyStub{},
+			}
 
-		podHints := m.GetPodTopologyHints(logger, &tc.pod, lifecycle.AddOperation)[string(v1.ResourceCPU)]
-		if len(tc.expectedHints) == 0 && len(podHints) == 0 {
-			continue
-		}
-		sort.SliceStable(podHints, func(i, j int) bool {
-			return podHints[i].LessThan(podHints[j])
-		})
-		sort.SliceStable(tc.expectedHints, func(i, j int) bool {
-			return tc.expectedHints[i].LessThan(tc.expectedHints[j])
-		})
-		if !reflect.DeepEqual(tc.expectedHints, podHints) {
-			t.Errorf("Test case %q: Expected in result to be %v , got %v", tc.name, tc.expectedHints, podHints)
+			podHints := m.GetPodTopologyHints(logger, &tc.pod, lifecycle.AddOperation)[string(v1.ResourceCPU)]
+			if len(tc.expectedHints) == 0 && len(podHints) == 0 {
+				continue
+			}
+			sort.SliceStable(podHints, func(i, j int) bool {
+				return podHints[i].LessThan(podHints[j])
+			})
+			sort.SliceStable(tc.expectedHints, func(i, j int) bool {
+				return tc.expectedHints[i].LessThan(tc.expectedHints[j])
+			})
+			if !reflect.DeepEqual(tc.expectedHints, podHints) {
+				t.Errorf("Test case %q: Expected in result to be %v , got %v", tc.name, tc.expectedHints, podHints)
+			}
+		} else {
+			m := manager{
+				policy: &staticPolicy{
+					topology: topology,
+				},
+				state: &mockState{
+					assignments:   tc.assignments,
+					baselines:     tc.baselines,
+					defaultCPUSet: tc.defaultCPUSet,
+				},
+				topology:          topology,
+				activePods:        func() []*v1.Pod { return activePods },
+				podStatusProvider: mockPodStatusProvider{},
+				sourcesReady:      &sourcesReadyStub{},
+			}
+
+			podHints := m.GetPodTopologyHints(logger, &tc.pod, lifecycle.AddOperation)[string(v1.ResourceCPU)]
+			if len(tc.expectedHints) == 0 && len(podHints) == 0 {
+				continue
+			}
+			sort.SliceStable(podHints, func(i, j int) bool {
+				return podHints[i].LessThan(podHints[j])
+			})
+			sort.SliceStable(tc.expectedHints, func(i, j int) bool {
+				return tc.expectedHints[i].LessThan(tc.expectedHints[j])
+			})
+			if !reflect.DeepEqual(tc.expectedHints, podHints) {
+				t.Errorf("Test case %q: Expected in result to be %v , got %v", tc.name, tc.expectedHints, podHints)
+			}
 		}
 	}
+
 }
 
 func TestGetPodTopologyHintsWithPolicyOptions(t *testing.T) {
@@ -778,7 +849,7 @@ func returnTestCases() []testCase {
 			},
 		},
 		{
-			name:      "Regenerate Single-Node NUMA Hints if already allocated 1/2",
+			name:      "Regenerate Single-Node NUMA Hints if already allocated 2/2",
 			pod:       *testPod1,
 			container: *testContainer1,
 			assignments: state.ContainerCPUAssignments{
@@ -826,6 +897,9 @@ func returnTestCases() []testCase {
 			},
 			defaultCPUSet: cpuset.New(),
 			expectedHints: []topologymanager.TopologyHint{},
+			inPlacePodVerticalScalingExclusiveCPUsEnabled: true,
+			podLevelResourcesEnabled:                      false,
+			podLevelResourceManagersEnabled:               false,
 		},
 		{
 			name:      "Requested more than already allocated",
@@ -836,8 +910,11 @@ func returnTestCases() []testCase {
 					testContainer4.Name: cpuset.New(0, 6, 3, 9),
 				},
 			},
-			defaultCPUSet: cpuset.New(),
-			expectedHints: []topologymanager.TopologyHint{},
+			defaultCPUSet:                                 cpuset.New(),
+			expectedHints:                                 []topologymanager.TopologyHint{},
+			podLevelResourcesEnabled:                      false,
+			podLevelResourceManagersEnabled:               false,
+			inPlacePodVerticalScalingExclusiveCPUsEnabled: true,
 		},
 		{
 			name:                            "Pod has pod level resources but PodLevelResourceManagersEnabled is disabled, no hint generation",
@@ -847,6 +924,7 @@ func returnTestCases() []testCase {
 			expectedHints:                   nil,
 			podLevelResourcesEnabled:        true,
 			podLevelResourceManagersEnabled: false,
+			inPlacePodVerticalScalingExclusiveCPUsEnabled: false,
 		},
 		{
 			name:          "Pod has pod level resources and PodLevelResourceManagersEnabled is enabled, hint generation",
@@ -863,8 +941,9 @@ func returnTestCases() []testCase {
 					Preferred:        false,
 				},
 			},
-			podLevelResourcesEnabled:        true,
-			podLevelResourceManagersEnabled: true,
+			podLevelResourcesEnabled:                      true,
+			podLevelResourceManagersEnabled:               true,
+			inPlacePodVerticalScalingExclusiveCPUsEnabled: false,
 		},
 		{
 			name:                            "Burstable pod with pod level resources should not generate hints",
@@ -874,6 +953,124 @@ func returnTestCases() []testCase {
 			expectedHints:                   nil,
 			podLevelResourcesEnabled:        true,
 			podLevelResourceManagersEnabled: true,
+			inPlacePodVerticalScalingExclusiveCPUsEnabled: false,
+		},
+		{
+			name:      "Regenerate Single-Node NUMA Hints if already allocated 1/2, with InPlacePodVerticalScalingExclusiveCPUs enabled",
+			pod:       *testPod1,
+			container: *testContainer1,
+			assignments: state.ContainerCPUAssignments{
+				string(testPod1.UID): map[string]cpuset.CPUSet{
+					testContainer1.Name: cpuset.New(0, 6),
+				},
+			},
+			baselines: state.ContainerCPUBaselines{
+				string(testPod1.UID): map[string]state.ContainerCPUBaseline{
+					testContainer1.Name: {Baseline: cpuset.New(0, 6)},
+				},
+			},
+			defaultCPUSet: cpuset.New(),
+			expectedHints: []topologymanager.TopologyHint{
+				{
+					NUMANodeAffinity: firstSocketMask,
+					Preferred:        true,
+				},
+				{
+					NUMANodeAffinity: crossSocketMask,
+					Preferred:        false,
+				},
+			},
+			inPlacePodVerticalScalingExclusiveCPUsEnabled: true,
+		},
+		{
+			name:      "Regenerate Single-Node NUMA Hints if already allocated 2/2, with InPlacePodVerticalScalingExclusiveCPUs enabled",
+			pod:       *testPod1,
+			container: *testContainer1,
+			assignments: state.ContainerCPUAssignments{
+				string(testPod1.UID): map[string]cpuset.CPUSet{
+					testContainer1.Name: cpuset.New(3, 9),
+				},
+			},
+			baselines: state.ContainerCPUBaselines{
+				string(testPod1.UID): map[string]state.ContainerCPUBaseline{
+					testContainer1.Name: {Baseline: cpuset.New(3, 9)},
+				},
+			},
+			defaultCPUSet: cpuset.New(),
+			expectedHints: []topologymanager.TopologyHint{
+				{
+					NUMANodeAffinity: secondSocketMask,
+					Preferred:        true,
+				},
+				{
+					NUMANodeAffinity: crossSocketMask,
+					Preferred:        false,
+				},
+			},
+			inPlacePodVerticalScalingExclusiveCPUsEnabled: true,
+		},
+		{
+			name:      "Regenerate Cross-NUMA Hints if already allocated, with InPlacePodVerticalScalingExclusiveCPUs",
+			pod:       *testPod4,
+			container: *testContainer4,
+			assignments: state.ContainerCPUAssignments{
+				string(testPod4.UID): map[string]cpuset.CPUSet{
+					testContainer4.Name: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
+				},
+			},
+			baselines: state.ContainerCPUBaselines{
+				string(testPod4.UID): map[string]state.ContainerCPUBaseline{
+					testContainer4.Name: {Baseline: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)},
+				},
+			},
+			defaultCPUSet: cpuset.New(),
+			expectedHints: []topologymanager.TopologyHint{
+				{
+					NUMANodeAffinity: crossSocketMask,
+					Preferred:        true,
+				},
+			},
+			inPlacePodVerticalScalingExclusiveCPUsEnabled: true,
+		},
+		{
+			name:      "Requested less than already allocated, with InPlacePodVerticalScalingExclusiveCPUs",
+			pod:       *testPod1,
+			container: *testContainer1,
+			assignments: state.ContainerCPUAssignments{
+				string(testPod1.UID): map[string]cpuset.CPUSet{
+					testContainer1.Name: cpuset.New(0, 6, 3, 9),
+				},
+			},
+			baselines: state.ContainerCPUBaselines{
+				string(testPod1.UID): map[string]state.ContainerCPUBaseline{
+					testContainer1.Name: {Baseline: cpuset.New(0, 6, 3, 9)},
+				},
+			},
+			defaultCPUSet:                                 cpuset.New(),
+			expectedHints:                                 []topologymanager.TopologyHint{},
+			podLevelResourcesEnabled:                      true,
+			podLevelResourceManagersEnabled:               true,
+			inPlacePodVerticalScalingExclusiveCPUsEnabled: true,
+		},
+		{
+			name:      "Requested more than already allocated, with InPlacePodVerticalScalingExclusiveCPUs",
+			pod:       *testPod4,
+			container: *testContainer4,
+			assignments: state.ContainerCPUAssignments{
+				string(testPod4.UID): map[string]cpuset.CPUSet{
+					testContainer4.Name: cpuset.New(0, 6, 3, 9),
+				},
+			},
+			baselines: state.ContainerCPUBaselines{
+				string(testPod4.UID): map[string]state.ContainerCPUBaseline{
+					testContainer4.Name: {Baseline: cpuset.New(0, 6, 3, 9)},
+				},
+			},
+			defaultCPUSet:                                 cpuset.New(),
+			expectedHints:                                 []topologymanager.TopologyHint{},
+			podLevelResourcesEnabled:                      true,
+			podLevelResourceManagersEnabled:               true,
+			inPlacePodVerticalScalingExclusiveCPUsEnabled: true,
 		},
 	}
 }

--- a/pkg/kubelet/cm/topologymanager/scope_container.go
+++ b/pkg/kubelet/cm/topologymanager/scope_container.go
@@ -64,6 +64,9 @@ func (s *containerScope) Admit(ctx context.Context, pod *v1.Pod, operation lifec
 			if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResourceManagers) && resourcehelper.IsPodLevelResourcesSet(pod) {
 				return admission.GetPodAdmitResult(NewPodLevelTopologyAffinityError("pod with pod-level resources failed admission with a container-level topology manager"))
 			}
+			if operation == lifecycle.ResizeOperation {
+				return lifecycle.PodAdmitResult{Admit: false, Reason: v1.PodReasonInfeasible, Message: "Resources cannot be resized with Topology locality"}
+			}
 			return admission.GetPodAdmitResult(&TopologyAffinityError{})
 		}
 		logger.Info("Topology Affinity", "bestHint", bestHint, "pod", klog.KObj(pod), "containerName", container.Name, "operation", operation)

--- a/pkg/kubelet/cm/topologymanager/scope_pod.go
+++ b/pkg/kubelet/cm/topologymanager/scope_pod.go
@@ -64,6 +64,14 @@ func (s *podScope) admitUsingContainerResources(ctx context.Context, pod *v1.Pod
 
 	bestHint, admit := s.checkAffinity(logger, pod, operation)
 	if !admit {
+		if IsAlignmentGuaranteed(s.policy) {
+			// increment only if we know we allocate aligned resources.
+			metrics.ContainerAlignedComputeResourcesFailure.WithLabelValues(metrics.AlignScopePod, metrics.AlignedNUMANode).Inc()
+		}
+		metrics.TopologyManagerAdmissionErrorsTotal.Inc()
+		if operation == lifecycle.ResizeOperation {
+			return lifecycle.PodAdmitResult{Admit: false, Reason: v1.PodReasonInfeasible, Message: "Resources cannot be resized with Topology locality"}
+		}
 		return admission.GetPodAdmitResult(NewTopologyAffinityError())
 	}
 

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2454,7 +2454,25 @@ func (kl *Kubelet) convertToAPIContainerStatuses(ctx context.Context, pod *v1.Po
 					resources.Limits[v1.ResourceCPU] = cStatus.Resources.CPULimit.DeepCopy()
 				}
 			} else {
-				preserveOldResourcesValue(v1.ResourceCPU, oldStatus.Resources.Limits, resources.Limits)
+				// To support InPlacePodVerticalScaling of container with exclusive CPUs, CPULimit need to
+				// be in sync with CPURequests, otherwise the resize operation fails.
+				// for that case, and for those containers we update CPULimit equal to CPURequests,
+				// when CPURequest changes, to stay in sync.
+				hasCPURequest := cStatus.Resources != nil &&
+					cStatus.Resources.CPULimit == nil &&
+					cStatus.Resources.CPURequest != nil &&
+					kl.containerManager.ContainerHasExclusiveCPUs(logger, pod, allocatedContainer)
+
+				didCPURequestChange := false
+				if oldStatus.Resources != nil && oldStatus.Resources.Requests != nil && cStatus.Resources != nil && cStatus.Resources.CPURequest != nil {
+					oldCPURequest := oldStatus.Resources.Requests[v1.ResourceCPU]
+					didCPURequestChange = !oldCPURequest.Equal(*cStatus.Resources.CPURequest)
+				}
+				if hasCPURequest && didCPURequestChange {
+					resources.Limits[v1.ResourceCPU] = cStatus.Resources.CPURequest.DeepCopy()
+				} else {
+					preserveOldResourcesValue(v1.ResourceCPU, oldStatus.Resources.Limits, resources.Limits)
+				}
 			}
 			if cStatus.Resources != nil && cStatus.Resources.MemoryLimit != nil {
 				resources.Limits[v1.ResourceMemory] = cStatus.Resources.MemoryLimit.DeepCopy()

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
@@ -402,6 +402,7 @@ func TestCalculateLinuxResources(t *testing.T) {
 		expected             *runtimeapi.LinuxContainerResources
 		cgroupVersion        CgroupVersion
 		singleProcessOOMKill bool
+		hasExclusiveCPUs     bool
 	}{
 		{
 			name:   "Request128MBLimit256MB",
@@ -523,11 +524,27 @@ func TestCalculateLinuxResources(t *testing.T) {
 			},
 			cgroupVersion: cgroupV2,
 		},
+		{
+			name:   "RequestExclusiveCPU",
+			cpuReq: generateResourceQuantity("2"),
+			cpuLim: generateResourceQuantity("2"),
+			memLim: generateResourceQuantity("0"),
+			expected: &runtimeapi.LinuxContainerResources{
+				CpuPeriod:          100000,
+				CpuQuota:           -1,
+				CpuShares:          2048,
+				MemoryLimitInBytes: 0,
+				Unified:            map[string]string{"memory.oom.group": "1"},
+			},
+			cgroupVersion:    cgroupV2,
+			hasExclusiveCPUs: true,
+		},
 	}
 	for _, test := range tests {
 		setCgroupVersionDuringTest(test.cgroupVersion)
 		m.singleProcessOOMKill = ptr.To(test.singleProcessOOMKill)
-		linuxContainerResources := m.calculateLinuxResources(test.cpuReq, test.cpuLim, test.memLim, false)
+		disableCPUQuota := utilfeature.DefaultFeatureGate.Enabled(features.DisableCPUQuotaWithExclusiveCPUs) && test.hasExclusiveCPUs
+		linuxContainerResources := m.calculateLinuxResources(test.cpuReq, test.cpuLim, test.memLim, disableCPUQuota)
 		assert.Equal(t, test.expected, linuxContainerResources)
 	}
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux.go
@@ -59,7 +59,7 @@ func (m *kubeGenericRuntimeManager) calculateSandboxResources(ctx context.Contex
 		cpuRequest = req.Cpu()
 	}
 
-	// If pod has exclusive cpu the sandbox will not have cfs quote enforced
+	// If pod has exclusive cpu the sandbox will not have cfs quota enforced
 	disableCPUQuota := utilfeature.DefaultFeatureGate.Enabled(features.DisableCPUQuotaWithExclusiveCPUs) && m.containerManager.PodHasExclusiveCPUs(logger, pod)
 
 	logger.V(5).Info("Enforcing CFS quota", "pod", klog.KObj(pod), "unlimited", disableCPUQuota)

--- a/test/e2e/common/node/framework/cgroups/cgroups.go
+++ b/test/e2e/common/node/framework/cgroups/cgroups.go
@@ -231,13 +231,24 @@ func verifyContainerCPUWeight(ctx context.Context, f *framework.Framework, pod *
 	return err
 }
 
-func VerifyContainerCPULimit(ctx context.Context, f *framework.Framework, pod *v1.Pod, containerName string, expectedResources *v1.ResourceRequirements, podOnCgroupv2 bool) error {
+func VerifyContainerCPULimit(ctx context.Context, f *framework.Framework, pod *v1.Pod, containerName string, expectedResources *v1.ResourceRequirements, podOnCgroupv2 bool, disableCPUQuota bool) error {
 	cpuLimCgPath := getCgroupCPULimitPath(cgroupFsPath, podOnCgroupv2)
 	cpuLim := expectedResources.Limits.Cpu()
 	if cpuLim.IsZero() && pod.Spec.Resources != nil {
 		cpuLim = pod.Spec.Resources.Limits.Cpu()
 	}
 	expectedCPULimits := getCPULimitCgroupExpectations(cpuLim, podOnCgroupv2)
+
+	// When disableCPUQuota is true, the CFS quota is set to unlimited.
+	// Set expectedCPULimits to unlimited quota value.
+	if disableCPUQuota {
+		if podOnCgroupv2 {
+			expectedCPULimits = []string{fmt.Sprintf("max %d", kubecm.QuotaPeriod)}
+		} else {
+			expectedCPULimits = []string{"-1"}
+		}
+	}
+
 	if err := VerifyCgroupValue(ctx, f, pod, containerName, cpuLimCgPath, expectedCPULimits...); err != nil {
 		return fmt.Errorf("failed to verify cpu limit cgroup value: %w", err)
 	}
@@ -260,10 +271,10 @@ func VerifyContainerMemoryLimit(ctx context.Context, f *framework.Framework, pod
 	return nil
 }
 
-func VerifyContainerCgroupValues(ctx context.Context, f *framework.Framework, pod *v1.Pod, tc *v1.Container, podOnCgroupv2 bool) error {
+func VerifyContainerCgroupValues(ctx context.Context, f *framework.Framework, pod *v1.Pod, tc *v1.Container, podOnCgroupv2 bool, disableCPUQuota bool) error {
 	var errs []error
 	errs = append(errs, VerifyContainerMemoryLimit(ctx, f, pod, tc.Name, &tc.Resources, podOnCgroupv2))
-	errs = append(errs, VerifyContainerCPULimit(ctx, f, pod, tc.Name, &tc.Resources, podOnCgroupv2))
+	errs = append(errs, VerifyContainerCPULimit(ctx, f, pod, tc.Name, &tc.Resources, podOnCgroupv2, disableCPUQuota))
 	errs = append(errs, verifyContainerCPUWeight(ctx, f, pod, tc.Name, &tc.Resources, podOnCgroupv2))
 	return utilerrors.NewAggregate(errs)
 }

--- a/test/e2e/common/node/framework/podresize/resize.go
+++ b/test/e2e/common/node/framework/podresize/resize.go
@@ -29,8 +29,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	helpers "k8s.io/component-helpers/resource"
 	"k8s.io/kubectl/pkg/util/podutils"
+	"k8s.io/kubernetes/pkg/features"
 	kubeqos "k8s.io/kubernetes/pkg/kubelet/qos"
 	"k8s.io/kubernetes/test/e2e/common/node/framework/cgroups"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -45,13 +47,14 @@ const (
 )
 
 type ResizableContainerInfo struct {
-	Name          string
-	Resources     *cgroups.ContainerResources
-	CPUPolicy     *v1.ResourceResizeRestartPolicy
-	MemPolicy     *v1.ResourceResizeRestartPolicy
-	RestartCount  int32
-	RestartPolicy v1.ContainerRestartPolicy
-	InitCtr       bool
+	Name             string
+	Resources        *cgroups.ContainerResources
+	CPUPolicy        *v1.ResourceResizeRestartPolicy
+	MemPolicy        *v1.ResourceResizeRestartPolicy
+	RestartCount     int32
+	RestartPolicy    v1.ContainerRestartPolicy
+	InitCtr          bool
+	HasExclusiveCPUs bool
 }
 
 func getTestResizePolicy(tcInfo ResizableContainerInfo) (resizePol []v1.ContainerResizePolicy) {
@@ -300,7 +303,8 @@ func VerifyPodContainersCgroupValues(ctx context.Context, f *framework.Framework
 	var errs []error
 	for _, ci := range tcInfo {
 		tc := makeResizableContainer(ci)
-		errs = append(errs, cgroups.VerifyContainerCgroupValues(ctx, f, pod, &tc, onCgroupv2))
+		disableCPUQuota := utilfeature.DefaultFeatureGate.Enabled(features.DisableCPUQuotaWithExclusiveCPUs) && ci.HasExclusiveCPUs
+		errs = append(errs, cgroups.VerifyContainerCgroupValues(ctx, f, pod, &tc, onCgroupv2, disableCPUQuota))
 	}
 	return utilerrors.NewAggregate(errs)
 }

--- a/test/e2e/common/node/framework/podresize/resize.go
+++ b/test/e2e/common/node/framework/podresize/resize.go
@@ -511,3 +511,36 @@ func formatErrors(err error) error {
 	}
 	return fmt.Errorf("[\n%s\n]", strings.Join(errStrings, ",\n"))
 }
+
+func ExpectPodResizePending(ctx context.Context, f *framework.Framework, resizePendingPod *v1.Pod, expectedContainers []ResizableContainerInfo) {
+	ginkgo.GinkgoHelper()
+
+	// Verify Pod Containers Cgroup Values
+	var errs []error
+	if cgroupErrs := VerifyPodContainersCgroupValues(ctx, f, resizePendingPod, expectedContainers); cgroupErrs != nil {
+		errs = append(errs, fmt.Errorf("container cgroup values don't match expected: %w", formatErrors(cgroupErrs)))
+	}
+	if resourceErrs := VerifyPodStatusResources(resizePendingPod, expectedContainers); resourceErrs != nil {
+		errs = append(errs, fmt.Errorf("container status resources don't match expected: %w", formatErrors(resourceErrs)))
+	}
+	if restartErrs := verifyPodRestarts(ctx, f, resizePendingPod, expectedContainers); restartErrs != nil {
+		errs = append(errs, fmt.Errorf("container restart counts don't match expected: %w", formatErrors(restartErrs)))
+	}
+
+	// Verify PodResizePending condition are empty.
+	podResizePendingFound := false
+	for _, condition := range resizePendingPod.Status.Conditions {
+		if condition.Type == v1.PodResizePending {
+			podResizePendingFound = true
+		}
+	}
+	if !podResizePendingFound {
+		errs = append(errs, fmt.Errorf("resize condition type %s not found in pod status", v1.PodResizePending))
+	}
+
+	if len(errs) > 0 {
+		resizePendingPod.ManagedFields = nil // Suppress managed fields in error output.
+		framework.ExpectNoError(formatErrors(utilerrors.NewAggregate(errs)),
+			"Verifying pod resources resize state. Pod: %s", framework.PrettyPrintJSON(resizePendingPod))
+	}
+}

--- a/test/e2e/common/node/pod_level_resources.go
+++ b/test/e2e/common/node/pod_level_resources.go
@@ -27,6 +27,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/test/e2e/common/node/framework/cgroups"
 	"k8s.io/kubernetes/test/e2e/feature"
@@ -169,6 +170,7 @@ func podLevelResourcesTests(f *framework.Framework) {
 		// Still, the pod-level limits field itself will not have default values set.
 		// To cover this pattern, we allow overriding the values when comparing against the PodSpec.
 		expectedPodLevelResourcesOverride *cgroups.ContainerResources
+		hasExclusiveCPUs                  map[string]bool
 	}
 
 	tests := []testCase{
@@ -182,6 +184,7 @@ func podLevelResourcesTests(f *framework.Framework) {
 				qos:               v1.PodQOSGuaranteed,
 				totalPodResources: &cgroups.ContainerResources{CPUReq: "120m", CPULim: "120m", MemReq: "120Mi", MemLim: "120Mi"},
 			},
+			hasExclusiveCPUs: map[string]bool{"c1": false, "c2": false},
 		},
 		{
 			name:         "Guaranteed QoS pod, no container resources",
@@ -191,6 +194,7 @@ func podLevelResourcesTests(f *framework.Framework) {
 				qos:               v1.PodQOSGuaranteed,
 				totalPodResources: &cgroups.ContainerResources{CPUReq: "100m", CPULim: "100m", MemReq: "100Mi", MemLim: "100Mi"},
 			},
+			hasExclusiveCPUs: map[string]bool{"c1": false, "c2": false},
 		},
 		{
 			name:         "Guaranteed QoS pod with other container resources",
@@ -203,6 +207,7 @@ func podLevelResourcesTests(f *framework.Framework) {
 				qos:               v1.PodQOSGuaranteed,
 				totalPodResources: &cgroups.ContainerResources{CPUReq: "100m", CPULim: "100m", MemReq: "100Mi", MemLim: "100Mi"},
 			},
+			hasExclusiveCPUs: map[string]bool{"c1": false, "c2": false},
 		},
 		{
 			name:         "Guaranteed QoS pod, 1 container with resources",
@@ -215,6 +220,7 @@ func podLevelResourcesTests(f *framework.Framework) {
 				qos:               v1.PodQOSGuaranteed,
 				totalPodResources: &cgroups.ContainerResources{CPUReq: "100m", CPULim: "100m", MemReq: "100Mi", MemLim: "100Mi"},
 			},
+			hasExclusiveCPUs: map[string]bool{"c1": false, "c2": false},
 		},
 		{
 			name:         "Guaranteed QoS pod, pod resources limits, no container resources",
@@ -227,6 +233,7 @@ func podLevelResourcesTests(f *framework.Framework) {
 				qos:               v1.PodQOSGuaranteed,
 				totalPodResources: &cgroups.ContainerResources{CPUReq: "100m", CPULim: "100m", MemReq: "100Mi", MemLim: "100Mi"},
 			},
+			hasExclusiveCPUs: map[string]bool{"c1": false, "c2": false},
 		},
 		{
 			name:         "Burstable QoS pod, pod resources limits, container resources limits",
@@ -239,6 +246,7 @@ func podLevelResourcesTests(f *framework.Framework) {
 				qos:               v1.PodQOSBurstable,
 				totalPodResources: &cgroups.ContainerResources{CPUReq: "80m", CPULim: "100m", MemReq: "80Mi", MemLim: "100Mi"},
 			},
+			hasExclusiveCPUs: map[string]bool{"c1": false, "c2": false},
 		},
 		{
 			name:         "Burstable QoS pod, pod resources limits, container resources requests",
@@ -251,6 +259,7 @@ func podLevelResourcesTests(f *framework.Framework) {
 				qos:               v1.PodQOSBurstable,
 				totalPodResources: &cgroups.ContainerResources{CPUReq: "80m", CPULim: "100m", MemReq: "80Mi", MemLim: "100Mi"},
 			},
+			hasExclusiveCPUs: map[string]bool{"c1": false, "c2": false},
 		},
 		{
 			name:         "Burstable QoS pod, pod resources requests, no container resources",
@@ -260,6 +269,7 @@ func podLevelResourcesTests(f *framework.Framework) {
 				qos:               v1.PodQOSBurstable,
 				totalPodResources: &cgroups.ContainerResources{CPUReq: "100m", MemReq: "100Mi"},
 			},
+			hasExclusiveCPUs: map[string]bool{"c1": false, "c2": false},
 		},
 		{
 			name:         "Burstable QoS pod, pod resources requests, container resources requests",
@@ -272,6 +282,7 @@ func podLevelResourcesTests(f *framework.Framework) {
 				qos:               v1.PodQOSBurstable,
 				totalPodResources: &cgroups.ContainerResources{CPUReq: "100m", MemReq: "100Mi"},
 			},
+			hasExclusiveCPUs: map[string]bool{"c1": false, "c2": false},
 		},
 		{
 			name:         "Burstable QoS pod, pod resources requests, container resources requests and partial limits",
@@ -284,6 +295,7 @@ func podLevelResourcesTests(f *framework.Framework) {
 				qos:               v1.PodQOSBurstable,
 				totalPodResources: &cgroups.ContainerResources{CPUReq: "100m", MemReq: "100Mi"},
 			},
+			hasExclusiveCPUs: map[string]bool{"c1": false, "c2": false},
 		},
 		{
 			name:         "Burstable QoS pod, pod resources requests, container resources limits",
@@ -297,6 +309,7 @@ func podLevelResourcesTests(f *framework.Framework) {
 				totalPodResources: &cgroups.ContainerResources{CPUReq: "100m", CPULim: "100m", MemReq: "100Mi", MemLim: "100Mi"},
 			},
 			expectedPodLevelResourcesOverride: &cgroups.ContainerResources{CPUReq: "100m", MemReq: "100Mi"},
+			hasExclusiveCPUs:                  map[string]bool{"c1": false, "c2": false},
 		},
 		{
 			name:         "Burstable QoS pod, pod resources requests, partial container resources limits",
@@ -312,6 +325,7 @@ func podLevelResourcesTests(f *framework.Framework) {
 				totalPodResources: &cgroups.ContainerResources{CPUReq: "100m", MemReq: "100Mi"},
 			},
 			expectedPodLevelResourcesOverride: &cgroups.ContainerResources{CPUReq: "100m", MemReq: "100Mi"},
+			hasExclusiveCPUs:                  map[string]bool{"c1": false, "c2": false},
 		},
 		{
 			name:         "Burstable QoS pod, pod resources requests, container resources requests and limits",
@@ -330,6 +344,7 @@ func podLevelResourcesTests(f *framework.Framework) {
 				totalPodResources: &cgroups.ContainerResources{CPUReq: "100m", CPULim: "60m", MemReq: "100Mi", MemLim: "60Mi"},
 			},
 			expectedPodLevelResourcesOverride: &cgroups.ContainerResources{CPUReq: "100m", MemReq: "100Mi"},
+			hasExclusiveCPUs:                  map[string]bool{"c1": false, "c2": false},
 		},
 		{
 			name:         "Burstable QoS pod, no container resources",
@@ -342,6 +357,7 @@ func podLevelResourcesTests(f *framework.Framework) {
 				qos:               v1.PodQOSBurstable,
 				totalPodResources: &cgroups.ContainerResources{CPUReq: "50m", CPULim: "100m", MemReq: "50Mi", MemLim: "100Mi"},
 			},
+			hasExclusiveCPUs: map[string]bool{"c1": false, "c2": false},
 		},
 		{
 			name:         "Burstable QoS pod with yet some other container resources",
@@ -354,6 +370,7 @@ func podLevelResourcesTests(f *framework.Framework) {
 				qos:               v1.PodQOSBurstable,
 				totalPodResources: &cgroups.ContainerResources{CPUReq: "50m", CPULim: "100m", MemReq: "50Mi", MemLim: "100Mi"},
 			},
+			hasExclusiveCPUs: map[string]bool{"c1": false, "c2": false},
 		},
 		{
 			name:         "Burstable QoS pod, 1 container with resources",
@@ -366,6 +383,7 @@ func podLevelResourcesTests(f *framework.Framework) {
 				qos:               v1.PodQOSBurstable,
 				totalPodResources: &cgroups.ContainerResources{CPUReq: "50m", CPULim: "100m", MemReq: "50Mi", MemLim: "100Mi"},
 			},
+			hasExclusiveCPUs: map[string]bool{"c1": false, "c2": false},
 		},
 		{
 			name:         "Burstable QoS pod, pod resources requests and limits, container resources limits",
@@ -378,6 +396,7 @@ func podLevelResourcesTests(f *framework.Framework) {
 				qos:               v1.PodQOSBurstable,
 				totalPodResources: &cgroups.ContainerResources{CPUReq: "50m", CPULim: "100m", MemReq: "50Mi", MemLim: "100Mi"},
 			},
+			hasExclusiveCPUs: map[string]bool{"c1": false, "c2": false},
 		},
 		{
 			name:         "Burstable QoS pod, pod resources requests and limits, container resources requests",
@@ -390,6 +409,7 @@ func podLevelResourcesTests(f *framework.Framework) {
 				qos:               v1.PodQOSBurstable,
 				totalPodResources: &cgroups.ContainerResources{CPUReq: "50m", CPULim: "100m", MemReq: "50Mi", MemLim: "100Mi"},
 			},
+			hasExclusiveCPUs: map[string]bool{"c1": false, "c2": false},
 		},
 		{
 			name:         "Burstable QoS pod, partial requests in pod level resources, 1 container with guaranteed resources",
@@ -402,6 +422,7 @@ func podLevelResourcesTests(f *framework.Framework) {
 				qos:               v1.PodQOSBurstable,
 				totalPodResources: &cgroups.ContainerResources{CPUReq: "100m", CPULim: "200m", MemReq: "200Mi", MemLim: "200Mi"},
 			},
+			hasExclusiveCPUs: map[string]bool{"c1": false, "c2": false},
 		},
 		{
 			name: "BestEffort QoS no pod resources, no container resources",
@@ -413,6 +434,33 @@ func podLevelResourcesTests(f *framework.Framework) {
 				qos:               v1.PodQOSBestEffort,
 				totalPodResources: &cgroups.ContainerResources{CPUReq: "", CPULim: "", MemReq: "", MemLim: ""},
 			},
+			hasExclusiveCPUs: map[string]bool{"c1": false, "c2": false},
+		},
+		{
+			name:         "Guaranteed QoS pod with one container with exclusive CPUs other container resources",
+			podResources: &cgroups.ContainerResources{CPUReq: "2050m", CPULim: "2050m", MemReq: "100Mi", MemLim: "100Mi"},
+			containers: []containerInfo{
+				{Name: "c1", Resources: &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "50Mi", MemLim: "100Mi"}},
+				{Name: "c2", Resources: &cgroups.ContainerResources{CPUReq: "50m", CPULim: "100m", MemReq: "50Mi", MemLim: "100Mi"}},
+			},
+			expected: expectedPodConfig{
+				qos:               v1.PodQOSGuaranteed,
+				totalPodResources: &cgroups.ContainerResources{CPUReq: "2050m", CPULim: "2050m", MemReq: "100Mi", MemLim: "100Mi"},
+			},
+			hasExclusiveCPUs: map[string]bool{"c1": true, "c2": false},
+		},
+		{
+			name:         "Guaranteed QoS pod, 1 container with resources and exclusive CPUs",
+			podResources: &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "100Mi", MemLim: "100Mi"},
+			containers: []containerInfo{
+				{Name: "c1", Resources: &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "50Mi", MemLim: "100Mi"}},
+				{Name: "c2"},
+			},
+			expected: expectedPodConfig{
+				qos:               v1.PodQOSGuaranteed,
+				totalPodResources: &cgroups.ContainerResources{CPUReq: "2", CPULim: "2", MemReq: "100Mi", MemLim: "100Mi"},
+			},
+			hasExclusiveCPUs: map[string]bool{"c1": true, "c2": false},
 		},
 	}
 
@@ -440,7 +488,7 @@ func podLevelResourcesTests(f *framework.Framework) {
 			framework.ExpectNoError(err, "failed to verify pod's cgroup values: %v", err)
 
 			ginkgo.By("verifying containers cgroup limits are same as pod container's cgroup limits")
-			err = verifyContainersCgroupLimits(ctx, f, pod)
+			err = verifyContainersCgroupLimits(ctx, f, pod, tc.hasExclusiveCPUs)
 			framework.ExpectNoError(err, "failed to verify containers cgroup values: %v", err)
 
 			ginkgo.By("deleting pods")
@@ -450,7 +498,7 @@ func podLevelResourcesTests(f *framework.Framework) {
 	}
 }
 
-func verifyContainersCgroupLimits(ctx context.Context, f *framework.Framework, pod *v1.Pod) error {
+func verifyContainersCgroupLimits(ctx context.Context, f *framework.Framework, pod *v1.Pod, hasExclusiveCPUs map[string]bool) error {
 	var errs []error
 	for _, container := range pod.Spec.Containers {
 		if pod.Spec.Resources != nil && pod.Spec.Resources.Limits.Memory() != nil &&
@@ -463,7 +511,8 @@ func verifyContainersCgroupLimits(ctx context.Context, f *framework.Framework, p
 
 		if pod.Spec.Resources != nil && pod.Spec.Resources.Limits.Cpu() != nil &&
 			container.Resources.Limits.Cpu() == nil {
-			err := cgroups.VerifyContainerCPULimit(ctx, f, pod, container.Name, &container.Resources, true)
+			disableCPUQuota := utilfeature.DefaultFeatureGate.Enabled(features.DisableCPUQuotaWithExclusiveCPUs) && hasExclusiveCPUs[container.Name]
+			err := cgroups.VerifyContainerCPULimit(ctx, f, pod, container.Name, &container.Resources, true, disableCPUQuota)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("failed to verify cpu limit cgroup value: %w", err))
 			}

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/test/e2e/common/node/framework/cgroups"
 	"k8s.io/kubernetes/test/e2e/common/node/framework/podresize"
@@ -749,14 +750,20 @@ func doPodResizeInitContainerResizeTest(f *framework.Framework) {
 		testPod = e2epod.MustMixinRestrictedPodSecurity(testPod)
 		podClient := e2epod.NewPodClient(f)
 		newPod := podClient.Create(ctx, testPod)
-		verifyInitContainerResources(ctx, f, newPod, originalContainers, originalInitCtr)
+
+		// TODO improve test coverage to test HasExclusiveCPUs set to true
+		disableCPUQuota := utilfeature.DefaultFeatureGate.Enabled(features.DisableCPUQuotaWithExclusiveCPUs) &&
+			originalContainers[0].HasExclusiveCPUs
+		verifyInitContainerResources(ctx, f, newPod, originalContainers, originalInitCtr, disableCPUQuota)
 
 		ginkgo.By("patching and verifying pod for resize")
 		patch := podresize.MakeResizePatch(originalContainers, resizedContainers, nil, nil)
 		patchedPod, pErr := f.ClientSet.CoreV1().Pods(newPod.Namespace).Patch(ctx, newPod.Name,
 			types.StrategicMergePatchType, patch, metav1.PatchOptions{}, "resize")
 		framework.ExpectNoError(pErr, "failed to patch pod for resize")
-		verifyInitContainerResources(ctx, f, patchedPod, resizedContainers, resizedInitCtr)
+		disableCPUQuota = utilfeature.DefaultFeatureGate.Enabled(features.DisableCPUQuotaWithExclusiveCPUs) &&
+			resizedContainers[1].HasExclusiveCPUs
+		verifyInitContainerResources(ctx, f, patchedPod, resizedContainers, resizedInitCtr, disableCPUQuota)
 
 		// Resize has been actuated, test the reverse operation.
 		ginkgo.By("patching and verifying pod to revert to original resources")
@@ -764,7 +771,9 @@ func doPodResizeInitContainerResizeTest(f *framework.Framework) {
 		patchedPod, pErr = f.ClientSet.CoreV1().Pods(newPod.Namespace).Patch(ctx, newPod.Name,
 			types.StrategicMergePatchType, patch, metav1.PatchOptions{}, "resize")
 		framework.ExpectNoError(pErr, "failed to patch pod for resize")
-		verifyInitContainerResources(ctx, f, patchedPod, originalContainers, originalInitCtr)
+		disableCPUQuota = utilfeature.DefaultFeatureGate.Enabled(features.DisableCPUQuotaWithExclusiveCPUs) &&
+			originalContainers[0].HasExclusiveCPUs
+		verifyInitContainerResources(ctx, f, patchedPod, originalContainers, originalInitCtr, disableCPUQuota)
 
 		ginkgo.By("deleting pod")
 		podClient.DeleteSync(ctx, newPod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
@@ -1088,7 +1097,7 @@ func createRollbackContainers(originalContainers, expectedContainers []podresize
 	return rollbackContainers
 }
 
-func verifyInitContainerResources(ctx context.Context, f *framework.Framework, pod *v1.Pod, expectedContainers []podresize.ResizableContainerInfo, expectedInitCtr v1.Container) {
+func verifyInitContainerResources(ctx context.Context, f *framework.Framework, pod *v1.Pod, expectedContainers []podresize.ResizableContainerInfo, expectedInitCtr v1.Container, disableCPUQuota bool) {
 	ginkgo.GinkgoHelper()
 
 	podresize.VerifyPodResizePolicy(pod, expectedContainers)
@@ -1109,7 +1118,7 @@ func verifyInitContainerResources(ctx context.Context, f *framework.Framework, p
 				}, nil
 			}
 			onCgroupv2 := cgroups.IsPodOnCgroupv2Node(f, pod.Name, pod.Spec.InitContainers[0].Name)
-			if err := cgroups.VerifyContainerCgroupValues(ctx, f, pod, &expectedInitCtr, onCgroupv2); err != nil {
+			if err := cgroups.VerifyContainerCgroupValues(ctx, f, pod, &expectedInitCtr, onCgroupv2, disableCPUQuota); err != nil {
 				return func() string {
 					return fmt.Sprintf("cgroup values for init container don't match expected: %v", err)
 				}, nil

--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -209,6 +209,11 @@ var (
 	// InPlacePodVerticalScaling is used for testing in-place pod vertical scaling (https://kep.k8s.io/1287).
 	InPlacePodVerticalScaling = framework.WithFeature(framework.ValidFeatures.Add("InPlacePodVerticalScaling"))
 
+	// Owner: sig-node
+	// Marks a test for InPlacePodVerticalScalingExclusiveCPUs feature that requires
+	// InPlacePodVerticalScalingExclusiveCPUs feature gate to be enabled.
+	InPlacePodVerticalScalingExclusiveCPUs = framework.WithFeature(framework.ValidFeatures.Add("InPlacePodVerticalScalingExclusiveCPUs"))
+
 	// Owner: sig-network
 	// Marks tests that require a conforming implementation of
 	// Ingress.networking.k8s.io to be present.

--- a/test/e2e_node/cpu_manager_test.go
+++ b/test/e2e_node/cpu_manager_test.go
@@ -35,14 +35,18 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	helpers "k8s.io/component-helpers/resource"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
+	"k8s.io/kubernetes/test/e2e/common/node/framework/cgroups"
+	"k8s.io/kubernetes/test/e2e/common/node/framework/podresize"
 	admissionapi "k8s.io/pod-security-admission/api"
 	"k8s.io/utils/cpuset"
 
@@ -3388,7 +3392,3680 @@ var _ = SIGDescribe("CPU Manager Pod Level Resources", ginkgo.Ordered, ginkgo.Co
 	})
 })
 
+var _ = SIGDescribe("CPU Manager with InPlacePodVerticalScalingExclusiveCPUs disabled",
+	ginkgo.Ordered,
+	ginkgo.ContinueOnFailure,
+	framework.WithSerial(),
+	feature.CPUManager,
+	feature.InPlacePodVerticalScaling,
+	feature.InPlacePodVerticalScalingExclusiveCPUs,
+	framework.WithFeatureGate(features.InPlacePodVerticalScaling),
+	framework.WithFeatureGate(features.InPlacePodVerticalScalingExclusiveCPUs),
+	func() {
+
+		type containerCPUInfo struct {
+			Name     string
+			cpuCount int
+		}
+
+		f := framework.NewDefaultFramework("cpu-manager-pod-resize-test")
+		f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+		// original kubeletconfig before the context start, to be restored
+		var oldCfg *kubeletconfig.KubeletConfiguration
+		var reservedCPUs cpuset.CPUSet
+		var onlineCPUs cpuset.CPUSet
+		var smtLevel int
+		var uncoreGroupSize int
+		// tracks all the pods created by a It() block. Best would be a namespace per It block
+		// TODO: move to a namespace per It block?
+		var podMap map[string]*v1.Pod
+
+		// closure just and only to not carry around awkwardly `f` and `onlineCPUs` only for logging purposes
+		var skipIfAllocatableCPUsLessThan func(node *v1.Node, cpuReq int)
+
+		ginkgo.BeforeAll(func(ctx context.Context) {
+			var err error
+			oldCfg, err = getCurrentKubeletConfig(ctx)
+			framework.ExpectNoError(err)
+
+			onlineCPUs, err = getOnlineCPUs() // this should not change at all, at least during this suite lifetime
+			framework.ExpectNoError(err)
+			framework.Logf("Online CPUs: %s", onlineCPUs)
+
+			smtLevel = smtLevelFromSysFS() // this should not change at all, at least during this suite lifetime
+			framework.Logf("SMT level: %d", smtLevel)
+
+			uncoreGroupSize = getUncoreCPUGroupSize()
+			framework.Logf("Uncore Group Size: %d", uncoreGroupSize)
+
+			e2enodeCgroupV2Enabled = IsCgroup2UnifiedMode()
+			framework.Logf("cgroup V2 enabled: %v", e2enodeCgroupV2Enabled)
+
+			e2enodeCgroupDriver = oldCfg.CgroupDriver
+			framework.Logf("cgroup driver: %s", e2enodeCgroupDriver)
+
+			runtime, _, err := getCRIClient(ctx)
+			framework.ExpectNoError(err, "Failed to get CRI client")
+
+			version, err := runtime.Version(context.Background(), "")
+			framework.ExpectNoError(err, "Failed to get runtime version")
+
+			e2enodeRuntimeName = version.GetRuntimeName()
+			framework.Logf("runtime: %s", e2enodeRuntimeName)
+		})
+
+		ginkgo.AfterAll(func(ctx context.Context) {
+			updateKubeletConfig(ctx, f, oldCfg, true)
+		})
+
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			// note intentionally NOT set reservedCPUs -  this must be initialized on a test-by-test basis
+			podMap = make(map[string]*v1.Pod)
+		})
+
+		ginkgo.JustBeforeEach(func(ctx context.Context) {
+			// note intentionally NOT set reservedCPUs -  this must be initialized on a test-by-test basis
+
+			// use a closure to minimize the arguments, to make the usage more straightforward
+			skipIfAllocatableCPUsLessThan = func(node *v1.Node, val int) {
+				ginkgo.GinkgoHelper()
+				cpuReq := int64(val + reservedCPUs.Size()) // reserved CPUs are not usable, need to account them
+				// the framework is initialized using an injected BeforeEach node, so the
+				// earliest we can do is to initialize the other objects here
+				nodeCPUDetails := cpuDetailsFromNode(node)
+
+				msg := fmt.Sprintf("%v full CPUs (detected=%v requested=%v reserved=%v online=%v smt=%v)", cpuReq, nodeCPUDetails.Allocatable, val, reservedCPUs.Size(), onlineCPUs.Size(), smtLevel)
+				ginkgo.By("Checking if allocatable: " + msg)
+				if nodeCPUDetails.Allocatable < cpuReq {
+					e2eskipper.Skipf("Skipping CPU Manager test: not allocatable %s", msg)
+				}
+			}
+		})
+
+		ginkgo.AfterEach(func(ctx context.Context) {
+			deletePodsAsync(ctx, f, podMap)
+		})
+
+		ginkgo.When("resizing a Guaranteed QoS single container pod with integer CPU requests", ginkgo.Label("guaranteed single container pod with integer CPU requests resize", "exclusive-cpus"), func() {
+			ginkgo.BeforeEach(func(ctx context.Context) {
+				reservedCPUs = cpuset.New(0)
+			})
+			ginkgo.DescribeTable("",
+				func(ctx context.Context,
+					originalContainers []podresize.ResizableContainerInfo,
+					originalCpuInfo []containerCPUInfo,
+					desiredContainers []podresize.ResizableContainerInfo,
+					expectedContainers []podresize.ResizableContainerInfo,
+					expectedCpuInfo []containerCPUInfo,
+					wantError string,
+				) {
+					skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), expectedCpuInfo[0].cpuCount)
+
+					updateKubeletConfigIfNeeded(ctx, f, configureCPUManagerInKubelet(oldCfg, &cpuManagerKubeletArguments{
+						policyName:         string(cpumanager.PolicyStatic),
+						reservedSystemCPUs: reservedCPUs, // Not really needed for the tests but helps to make a more precise check
+						enableInPlacePodVerticalScalingExclusiveCPUs: false,
+					}))
+
+					tStamp := strconv.Itoa(time.Now().Nanosecond())
+					testPod1 := podresize.MakePodWithResizableContainers(f.Namespace.Name, "testpod1", tStamp, originalContainers, nil)
+					testPod1 = e2epod.MustMixinRestrictedPodSecurity(testPod1)
+
+					ginkgo.By("creating pod")
+					podClient := e2epod.NewPodClient(f)
+					testPod1 = podClient.CreateSync(ctx, testPod1)
+					podMap[string(testPod1.UID)] = testPod1
+
+					ginkgo.By("verifying original pod resources, allocations and policy are as expected")
+					podresize.VerifyPodResources(testPod1, originalContainers, nil)
+
+					ginkgo.By("verifying original pod cpusets are as expected")
+					gomega.Expect(testPod1).To(HaveContainerCPUsCount("gu-container-1", originalCpuInfo[0].cpuCount))
+
+					ginkgo.By("patching pod for resize")
+					patchString := podresize.MakeResizePatch(originalContainers, desiredContainers, nil, nil)
+
+					if wantError == "" {
+						patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+							testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+						framework.ExpectNoError(pErr, "failed to patch pod for resize")
+
+						expected := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, expectedContainers)
+						ginkgo.By("verifying pod resources are as expected post patch, pre-actuation")
+						podresize.VerifyPodResources(patchedPod, expected, nil)
+
+						ginkgo.By("waiting for resize to be actuated")
+						resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expected)
+						podresize.ExpectPodResized(ctx, f, resizedPod, expected)
+
+						ginkgo.By("verifying pod resources after resize")
+						podresize.VerifyPodResources(resizedPod, expectedContainers, nil)
+
+						ginkgo.By("verifying pod cpusets after resize")
+						gomega.Expect(testPod1).To(HaveContainerCPUsCount("gu-container-1", expectedCpuInfo[0].cpuCount))
+					} else {
+						patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+							testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+						framework.ExpectNoError(pErr, "failed to patch pod for resize")
+
+						ginkgo.By("verifying testing pod resources are as expected post patch, pre-actuation")
+						expectedPreActuation := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, desiredContainers)
+						podresize.VerifyPodResources(patchedPod, expectedPreActuation, nil)
+
+						resizePendingPod, err := framework.GetObject(podClient.Get, patchedPod.Name, metav1.GetOptions{})(ctx)
+						framework.ExpectNoError(err, "failed to get resize pending pod")
+
+						ginkgo.By("waiting for testing pod resize to be infeasible")
+						WaitForPodResizeInfeasible(ctx, f, resizePendingPod)
+
+					}
+				},
+				ginkgo.Entry("neither should increase the CPU request/limit nor decrease the memory request/limit, within available capacity",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "400Mi", MemLim: "400Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					[]containerCPUInfo{
+						{
+							Name:     "gu-container-1",
+							cpuCount: 2,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "400Mi", MemLim: "400Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					[]containerCPUInfo{
+						{
+							Name:     "gu-container-1",
+							cpuCount: 2,
+						},
+					},
+					"Resize is infeasible for Guaranteed Pods alongside CPU Manager",
+				),
+				ginkgo.Entry("neither should increase the CPU request/limit nor increase the memory request/limit, within available capacity",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					[]containerCPUInfo{
+						{
+							Name:     "gu-container-1",
+							cpuCount: 2,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "400Mi", MemLim: "400Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					[]containerCPUInfo{
+						{
+							Name:     "gu-container-1",
+							cpuCount: 2,
+						},
+					},
+					"Resize is infeasible for Guaranteed Pods alongside CPU Manager",
+				),
+				ginkgo.Entry("should not increase the exclusively CPUs, within available capacity",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "300Mi", MemLim: "300Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					[]containerCPUInfo{
+						{
+							Name:     "gu-container-1",
+							cpuCount: 2,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "3000m", CPULim: "3000m", MemReq: "300Mi", MemLim: "300Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "300Mi", MemLim: "300Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					[]containerCPUInfo{
+						{
+							Name:     "gu-container-1",
+							cpuCount: 2,
+						},
+					},
+					"Resize is infeasible for Guaranteed Pods alongside CPU Manager",
+				),
+				ginkgo.Entry("should not decrease the allocated exclusively CPUs below original cpuset",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "300Mi", MemLim: "300Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					[]containerCPUInfo{
+						{
+							Name:     "gu-container-1",
+							cpuCount: 2,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "1000m", CPULim: "1000m", MemReq: "300Mi", MemLim: "300Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "300Mi", MemLim: "300Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					[]containerCPUInfo{
+						{
+							Name:     "gu-container-1",
+							cpuCount: 2,
+						},
+					},
+					"Resize is infeasible for Guaranteed Pods alongside CPU Manager",
+				),
+			)
+		})
+	},
+)
+
+var _ = SIGDescribe("CPU Manager with InPlacePodVerticalScalingExclusiveCPUs enabled",
+	ginkgo.Ordered,
+	ginkgo.ContinueOnFailure,
+	framework.WithSerial(),
+	feature.CPUManager,
+	feature.InPlacePodVerticalScaling,
+	feature.InPlacePodVerticalScalingExclusiveCPUs,
+	framework.WithFeatureGate(features.InPlacePodVerticalScaling),
+	framework.WithFeatureGate(features.InPlacePodVerticalScalingExclusiveCPUs),
+	func() {
+
+		type containerCPUInfo struct {
+			Name     string
+			cpuCount int
+		}
+
+		f := framework.NewDefaultFramework("cpu-manager-pod-resize-test")
+		f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+		// original kubeletconfig before the context start, to be restored
+		var oldCfg *kubeletconfig.KubeletConfiguration
+		var reservedCPUs cpuset.CPUSet
+		var onlineCPUs cpuset.CPUSet
+		var smtLevel int
+		var uncoreGroupSize int
+		// tracks all the pods created by a It() block. Best would be a namespace per It block
+		// TODO: move to a namespace per It block?
+		var podMap map[string]*v1.Pod
+
+		// closure just and only to not carry around awkwardly `f` and `onlineCPUs` only for logging purposes
+		var skipIfAllocatableCPUsLessThan func(node *v1.Node, cpuReq int)
+
+		ginkgo.BeforeAll(func(ctx context.Context) {
+			var err error
+			oldCfg, err = getCurrentKubeletConfig(ctx)
+			framework.ExpectNoError(err)
+
+			onlineCPUs, err = getOnlineCPUs() // this should not change at all, at least during this suite lifetime
+			framework.ExpectNoError(err)
+			framework.Logf("Online CPUs: %s", onlineCPUs)
+
+			smtLevel = smtLevelFromSysFS() // this should not change at all, at least during this suite lifetime
+			framework.Logf("SMT level: %d", smtLevel)
+
+			uncoreGroupSize = getUncoreCPUGroupSize()
+			framework.Logf("Uncore Group Size: %d", uncoreGroupSize)
+
+			e2enodeCgroupV2Enabled = IsCgroup2UnifiedMode()
+			framework.Logf("cgroup V2 enabled: %v", e2enodeCgroupV2Enabled)
+
+			e2enodeCgroupDriver = oldCfg.CgroupDriver
+			framework.Logf("cgroup driver: %s", e2enodeCgroupDriver)
+
+			runtime, _, err := getCRIClient(ctx)
+			framework.ExpectNoError(err, "Failed to get CRI client")
+
+			version, err := runtime.Version(context.Background(), "")
+			framework.ExpectNoError(err, "Failed to get runtime version")
+
+			e2enodeRuntimeName = version.GetRuntimeName()
+			framework.Logf("runtime: %s", e2enodeRuntimeName)
+		})
+
+		ginkgo.AfterAll(func(ctx context.Context) {
+			updateKubeletConfig(ctx, f, oldCfg, true)
+		})
+
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			// note intentionally NOT set reservedCPUs -  this must be initialized on a test-by-test basis
+			podMap = make(map[string]*v1.Pod)
+		})
+
+		ginkgo.JustBeforeEach(func(ctx context.Context) {
+			// note intentionally NOT set reservedCPUs -  this must be initialized on a test-by-test basis
+
+			// use a closure to minimize the arguments, to make the usage more straightforward
+			skipIfAllocatableCPUsLessThan = func(node *v1.Node, val int) {
+				ginkgo.GinkgoHelper()
+				cpuReq := int64(val + reservedCPUs.Size()) // reserved CPUs are not usable, need to account them
+				// the framework is initialized using an injected BeforeEach node, so the
+				// earliest we can do is to initialize the other objects here
+				nodeCPUDetails := cpuDetailsFromNode(node)
+
+				msg := fmt.Sprintf("%v full CPUs (detected=%v requested=%v reserved=%v online=%v smt=%v)", cpuReq, nodeCPUDetails.Allocatable, val, reservedCPUs.Size(), onlineCPUs.Size(), smtLevel)
+				ginkgo.By("Checking if allocatable: " + msg)
+				if nodeCPUDetails.Allocatable < cpuReq {
+					e2eskipper.Skipf("Skipping CPU Manager test: not allocatable %s", msg)
+				}
+			}
+		})
+
+		ginkgo.AfterEach(func(ctx context.Context) {
+			deletePodsAsync(ctx, f, podMap)
+		})
+
+		ginkgo.When("resizing a Burstable single container Pod", ginkgo.Label("burstable single container pod resize", "exclusive-cpus"), func() {
+			ginkgo.BeforeEach(func(ctx context.Context) {
+				reservedCPUs = cpuset.New(0)
+			})
+			ginkgo.DescribeTable("",
+				func(ctx context.Context,
+					originalContainers []podresize.ResizableContainerInfo,
+					desiredContainers []podresize.ResizableContainerInfo,
+					expectedContainers []podresize.ResizableContainerInfo,
+					wantError string,
+				) {
+					updateKubeletConfigIfNeeded(ctx, f, configureCPUManagerInKubelet(oldCfg, &cpuManagerKubeletArguments{
+						policyName:         string(cpumanager.PolicyStatic),
+						reservedSystemCPUs: reservedCPUs, // Not really needed for the tests but helps to make a more precise check
+						enableInPlacePodVerticalScalingExclusiveCPUs: true,
+					}))
+
+					tStamp := strconv.Itoa(time.Now().Nanosecond())
+					testPod1 := podresize.MakePodWithResizableContainers(f.Namespace.Name, "testpod1", tStamp, originalContainers, nil)
+					testPod1 = e2epod.MustMixinRestrictedPodSecurity(testPod1)
+
+					ginkgo.By("creating pod")
+					podClient := e2epod.NewPodClient(f)
+					testPod1 = podClient.CreateSync(ctx, testPod1)
+					podMap[string(testPod1.UID)] = testPod1
+
+					ginkgo.By("verifying original pod resources, allocations and policy are as expected")
+					podresize.VerifyPodResources(testPod1, originalContainers, nil)
+
+					ginkgo.By("verifying original pod cpusets are as expected")
+					gomega.Expect(testPod1).To(HaveContainerCPUsCount("non-gu-container-1", onlineCPUs.Size()))
+
+					ginkgo.By("patching pod for resize")
+					patchString := podresize.MakeResizePatch(originalContainers, desiredContainers, nil, nil)
+
+					if wantError == "" {
+						patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+							testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+						framework.ExpectNoError(pErr, "failed to patch pod for resize")
+
+						expected := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, expectedContainers)
+						ginkgo.By("verifying pod resources are as expected post patch, pre-actuation")
+						podresize.VerifyPodResources(patchedPod, expected, nil)
+
+						ginkgo.By("waiting for resize to be actuated")
+						resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expected)
+						podresize.ExpectPodResized(ctx, f, resizedPod, expected)
+
+						ginkgo.By("verifying pod resources after resize")
+						podresize.VerifyPodResources(resizedPod, expected, nil)
+
+						ginkgo.By("verifying pod cpusets after resize")
+						gomega.Expect(testPod1).To(HaveContainerCPUsCount("non-gu-container-1", onlineCPUs.Size()))
+					} else {
+						patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+							testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+						framework.ExpectNoError(pErr, "failed to patch pod for resize")
+
+						ginkgo.By("verifying testing pod resources are as expected post patch, pre-actuation")
+						expectedPreActuation := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, desiredContainers)
+						podresize.VerifyPodResources(patchedPod, expectedPreActuation, nil)
+
+						resizePendingPod, err := framework.GetObject(podClient.Get, patchedPod.Name, metav1.GetOptions{})(ctx)
+						framework.ExpectNoError(err, "failed to get resize pending pod")
+
+						ginkgo.By("waiting for testing pod resize to be actuated")
+						expectedPostActuation := podresize.UpdateExpectedContainerRestarts(ctx, resizePendingPod, expectedContainers)
+						actuatedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expectedPostActuation)
+
+						ginkgo.By("waiting for testing pod resize status to be pending")
+						WaitForPodResizePending(ctx, f, actuatedPod)
+
+						actuatedPod, err = framework.GetObject(podClient.Get, actuatedPod.Name, metav1.GetOptions{})(ctx)
+						framework.ExpectNoError(err, "failed to get actuated pod")
+
+						expectedPostActuation = podresize.UpdateExpectedContainerRestarts(ctx, actuatedPod, expectedContainers)
+						ginkgo.By("verifying testing pod condition type as expected post patch, post-actuation")
+						podresize.ExpectPodResizePending(ctx, f, actuatedPod, expectedPostActuation)
+
+						ginkgo.By("ensuring the testing pod is failed for the expected reason")
+						gomega.Expect(actuatedPod).To(HaveStatusConditionsMatchingRegex(wantError))
+
+						// we cannot nor we should predict which CPUs the container gets
+						ginkgo.By("verifying pod cpusets after resize")
+						gomega.Expect(testPod1).To(HaveContainerCPUsCount("non-gu-container-1", onlineCPUs.Size()))
+					}
+				},
+				ginkgo.Entry("should increase the CPU request/limit & the memory request/limit, within available capacity",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "non-gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "300m", MemReq: "200Mi", MemLim: "300Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "non-gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "400m", CPULim: "2000m", MemReq: "200Mi", MemLim: "400Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "non-gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "400m", CPULim: "2000m", MemReq: "200Mi", MemLim: "400Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					"",
+				),
+				ginkgo.Entry("should decrease the CPU request/limit and the memory request/limit, within available capacity",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "non-gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "500m", CPULim: "3000m", MemReq: "200Mi", MemLim: "400Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "non-gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "500m", CPULim: "1000m", MemReq: "200Mi", MemLim: "300Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "non-gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "500m", CPULim: "1000m", MemReq: "200Mi", MemLim: "300Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					"",
+				),
+			)
+		})
+
+		ginkgo.When("resizing a Guaranteed single container Pod without integer CPU requests", ginkgo.Label("guaranteed single container pod resize"), func() {
+			ginkgo.BeforeEach(func(ctx context.Context) {
+				reservedCPUs = cpuset.New(0)
+			})
+			ginkgo.DescribeTable("",
+				func(ctx context.Context,
+					originalContainers []podresize.ResizableContainerInfo,
+					desiredContainers []podresize.ResizableContainerInfo,
+					expectedContainers []podresize.ResizableContainerInfo,
+					wantError string,
+				) {
+					updateKubeletConfigIfNeeded(ctx, f, configureCPUManagerInKubelet(oldCfg, &cpuManagerKubeletArguments{
+						policyName:         string(cpumanager.PolicyStatic),
+						reservedSystemCPUs: reservedCPUs, // Not really needed for the tests but helps to make a more precise check
+						enableInPlacePodVerticalScalingExclusiveCPUs: true,
+					}))
+
+					tStamp := strconv.Itoa(time.Now().Nanosecond())
+					testPod1 := podresize.MakePodWithResizableContainers(f.Namespace.Name, "testpod1", tStamp, originalContainers, nil)
+					testPod1 = e2epod.MustMixinRestrictedPodSecurity(testPod1)
+
+					ginkgo.By("creating pod")
+					podClient := e2epod.NewPodClient(f)
+					testPod1 = podClient.CreateSync(ctx, testPod1)
+					podMap[string(testPod1.UID)] = testPod1
+
+					ginkgo.By("verifying original pod resources, allocations and policy are as expected")
+					podresize.VerifyPodResources(testPod1, originalContainers, nil)
+
+					ginkgo.By("verifying original pod cpusets are as expected")
+					gomega.Expect(testPod1).To(HaveContainerCPUsCount("gu-container-1", onlineCPUs.Size()))
+
+					ginkgo.By("patching pod for resize")
+					patchString := podresize.MakeResizePatch(originalContainers, desiredContainers, nil, nil)
+
+					if wantError == "" {
+						patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+							testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+						framework.ExpectNoError(pErr, "failed to patch pod for resize")
+
+						expected := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, expectedContainers)
+						ginkgo.By("verifying pod resources are as expected post patch, pre-actuation")
+						podresize.VerifyPodResources(patchedPod, expected, nil)
+
+						ginkgo.By("waiting for resize to be actuated")
+						resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expected)
+						podresize.ExpectPodResized(ctx, f, resizedPod, expected)
+
+						ginkgo.By("verifying pod resources after resize")
+						podresize.VerifyPodResources(resizedPod, expected, nil)
+
+						ginkgo.By("verifying pod cpusets after resize")
+						gomega.Expect(testPod1).To(HaveContainerCPUsCount("gu-container-1", onlineCPUs.Size()))
+					} else {
+						patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+							testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+						framework.ExpectNoError(pErr, "failed to patch pod for resize")
+
+						ginkgo.By("verifying testing pod resources are as expected post patch, pre-actuation")
+						expectedPreActuation := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, desiredContainers)
+						podresize.VerifyPodResources(patchedPod, expectedPreActuation, nil)
+
+						resizePendingPod, err := framework.GetObject(podClient.Get, patchedPod.Name, metav1.GetOptions{})(ctx)
+						framework.ExpectNoError(err, "failed to get resize pending pod")
+
+						ginkgo.By("waiting for testing pod resize to be actuated")
+						expectedPostActuation := podresize.UpdateExpectedContainerRestarts(ctx, resizePendingPod, expectedContainers)
+						actuatedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expectedPostActuation)
+
+						ginkgo.By("waiting for testing pod resize status to be pending")
+						WaitForPodResizePending(ctx, f, actuatedPod)
+
+						actuatedPod, err = framework.GetObject(podClient.Get, actuatedPod.Name, metav1.GetOptions{})(ctx)
+						framework.ExpectNoError(err, "failed to get actuated pod")
+
+						expectedPostActuation = podresize.UpdateExpectedContainerRestarts(ctx, actuatedPod, expectedContainers)
+						ginkgo.By("verifying testing pod condition type as expected post patch, post-actuation")
+						podresize.ExpectPodResizePending(ctx, f, actuatedPod, expectedPostActuation)
+
+						ginkgo.By("ensuring the testing pod is failed for the expected reason")
+						gomega.Expect(actuatedPod).To(HaveStatusConditionsMatchingRegex(wantError))
+
+						// we cannot nor we should predict which CPUs the container gets
+						ginkgo.By("verifying pod cpusets after resize")
+						gomega.Expect(testPod1).To(HaveContainerCPUsCount("gu-container-1", onlineCPUs.Size()))
+					}
+				},
+				ginkgo.Entry("should increase CPU & memory request/limit, within available capacity",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "100m", MemReq: "200Mi", MemLim: "200Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "200m", MemReq: "400Mi", MemLim: "400Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "200m", MemReq: "400Mi", MemLim: "400Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					"",
+				),
+				ginkgo.Entry("should decrease CPU & memory request/limit",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "300m", CPULim: "300m", MemReq: "500Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "100m", MemReq: "250Mi", MemLim: "250Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "100m", MemReq: "250Mi", MemLim: "250Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					"",
+				),
+				ginkgo.Entry("should decrease CPU request/limit, increase memory request/limit",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "100m", MemReq: "200Mi", MemLim: "200Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "50m", CPULim: "50m", MemReq: "300Mi", MemLim: "300Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "50m", CPULim: "50m", MemReq: "300Mi", MemLim: "300Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					"",
+				),
+			)
+		})
+
+		ginkgo.When("resizing a Burstable single container Pod", ginkgo.Label("burstable single container pod resize"), func() {
+			ginkgo.BeforeEach(func(ctx context.Context) {
+				reservedCPUs = cpuset.New(0)
+			})
+			ginkgo.DescribeTable("",
+				func(ctx context.Context,
+					originalContainers []podresize.ResizableContainerInfo,
+					desiredContainers []podresize.ResizableContainerInfo,
+					expectedContainers []podresize.ResizableContainerInfo,
+					wantError string,
+				) {
+					updateKubeletConfigIfNeeded(ctx, f, configureCPUManagerInKubelet(oldCfg, &cpuManagerKubeletArguments{
+						policyName:         string(cpumanager.PolicyStatic),
+						reservedSystemCPUs: reservedCPUs, // Not really needed for the tests but helps to make a more precise check
+						enableInPlacePodVerticalScalingExclusiveCPUs: true,
+					}))
+
+					tStamp := strconv.Itoa(time.Now().Nanosecond())
+					testPod1 := podresize.MakePodWithResizableContainers(f.Namespace.Name, "testpod1", tStamp, originalContainers, nil)
+					testPod1 = e2epod.MustMixinRestrictedPodSecurity(testPod1)
+
+					ginkgo.By("creating pod")
+					podClient := e2epod.NewPodClient(f)
+					testPod1 = podClient.CreateSync(ctx, testPod1)
+					podMap[string(testPod1.UID)] = testPod1
+
+					ginkgo.By("verifying original pod resources, allocations and policy are as expected")
+					podresize.VerifyPodResources(testPod1, originalContainers, nil)
+
+					ginkgo.By("verifying original pod cpusets are as expected")
+					gomega.Expect(testPod1).To(HaveContainerCPUsCount("bu-container-1", onlineCPUs.Size()))
+
+					ginkgo.By("patching pod for resize")
+					patchString := podresize.MakeResizePatch(originalContainers, desiredContainers, nil, nil)
+
+					if wantError == "" {
+						patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+							testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+						framework.ExpectNoError(pErr, "failed to patch pod for resize")
+
+						expected := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, expectedContainers)
+						ginkgo.By("verifying pod resources are as expected post patch, pre-actuation")
+						podresize.VerifyPodResources(patchedPod, expected, nil)
+
+						ginkgo.By("waiting for resize to be actuated")
+						resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expected)
+						podresize.ExpectPodResized(ctx, f, resizedPod, expected)
+
+						ginkgo.By("verifying pod resources after resize")
+						podresize.VerifyPodResources(resizedPod, expected, nil)
+
+						ginkgo.By("verifying pod cpusets after resize")
+						gomega.Expect(testPod1).To(HaveContainerCPUsCount("bu-container-1", onlineCPUs.Size()))
+					} else {
+						patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+							testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+						framework.ExpectNoError(pErr, "failed to patch pod for resize")
+
+						ginkgo.By("verifying testing pod resources are as expected post patch, pre-actuation")
+						expectedPreActuation := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, desiredContainers)
+						podresize.VerifyPodResources(patchedPod, expectedPreActuation, nil)
+
+						resizePendingPod, err := framework.GetObject(podClient.Get, patchedPod.Name, metav1.GetOptions{})(ctx)
+						framework.ExpectNoError(err, "failed to get resize pending pod")
+
+						ginkgo.By("waiting for testing pod resize to be actuated")
+						expectedPostActuation := podresize.UpdateExpectedContainerRestarts(ctx, resizePendingPod, expectedContainers)
+						actuatedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expectedPostActuation)
+
+						ginkgo.By("waiting for testing pod resize status to be pending")
+						WaitForPodResizePending(ctx, f, actuatedPod)
+
+						actuatedPod, err = framework.GetObject(podClient.Get, actuatedPod.Name, metav1.GetOptions{})(ctx)
+						framework.ExpectNoError(err, "failed to get actuated pod")
+
+						expectedPostActuation = podresize.UpdateExpectedContainerRestarts(ctx, actuatedPod, expectedContainers)
+						ginkgo.By("verifying testing pod condition type as expected post patch, post-actuation")
+						podresize.ExpectPodResizePending(ctx, f, actuatedPod, expectedPostActuation)
+
+						ginkgo.By("ensuring the testing pod is failed for the expected reason")
+						gomega.Expect(actuatedPod).To(HaveStatusConditionsMatchingRegex(wantError))
+
+						// we cannot nor we should predict which CPUs the container gets
+						ginkgo.By("verifying pod cpusets after resize")
+						gomega.Expect(testPod1).To(HaveContainerCPUsCount("bu-container-1", onlineCPUs.Size()))
+					}
+				},
+				ginkgo.Entry("should decrease the memory request only",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "400m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "400m", MemReq: "200Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "400m", MemReq: "200Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					"",
+				),
+				ginkgo.Entry("should decrease the memory limit only",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "400m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "400m", MemReq: "250Mi", MemLim: "400Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "400m", MemReq: "250Mi", MemLim: "400Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					"",
+				),
+				ginkgo.Entry("should increase the memory request only",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "400m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "400m", MemReq: "300Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "400m", MemReq: "300Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					"",
+				),
+				ginkgo.Entry("should increase the memory limit only",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "400m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "400m", MemReq: "250Mi", MemLim: "600Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "400m", MemReq: "250Mi", MemLim: "600Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					"",
+				),
+				ginkgo.Entry("should decrease the CPU request only",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "400m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "400m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "400m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					"",
+				),
+				ginkgo.Entry("should decrease the CPU limit only",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "400m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "300m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "300m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					"",
+				),
+				ginkgo.Entry("should increase the CPU request only",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "200m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "150m", CPULim: "200m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "150m", CPULim: "200m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					"",
+				),
+				ginkgo.Entry("should increase the CPU limit only",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "400m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "500m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "500m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					"",
+				),
+				ginkgo.Entry("should decrease the CPU request/limit",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "400m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "200m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "200m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					"",
+				),
+				ginkgo.Entry("should increase the CPU request/limit",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "200m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "400m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "400m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					"",
+				),
+				ginkgo.Entry("should decrease the CPU request and increase the CPU limit",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "400m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "500m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "500m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					"",
+				),
+				ginkgo.Entry("should increase the CPU request and the decrease CPU limit",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "400m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "300m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "300m", MemReq: "250Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					"",
+				),
+				ginkgo.Entry("should decrease the memory request/limit",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "200m", MemReq: "200Mi", MemLim: "400Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "200m", MemReq: "100Mi", MemLim: "300Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "200m", MemReq: "100Mi", MemLim: "300Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					"",
+				),
+				ginkgo.Entry("should increase the memory request/limit",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "200m", MemReq: "200Mi", MemLim: "400Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "200m", MemReq: "300Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "200m", MemReq: "300Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					"",
+				),
+				ginkgo.Entry("should decrease the memory request and increase the memory limit",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "200m", MemReq: "200Mi", MemLim: "400Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "200m", MemReq: "100Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "200m", MemReq: "100Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					"",
+				),
+				ginkgo.Entry("should increase the memory request and decrease the memory limit",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "200m", MemReq: "200Mi", MemLim: "400Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "200m", MemReq: "300Mi", MemLim: "300Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "200m", MemReq: "300Mi", MemLim: "300Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					"",
+				),
+				ginkgo.Entry("should decrease the CPU request and increase the memory limit",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "400m", MemReq: "200Mi", MemLim: "400Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "400m", MemReq: "200Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "400m", MemReq: "200Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					"",
+				),
+				ginkgo.Entry("should increase the CPU request and decrease the memory limit",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "400m", MemReq: "200Mi", MemLim: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "400m", MemReq: "200Mi", MemLim: "400Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "400m", MemReq: "200Mi", MemLim: "400Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					"",
+				),
+				ginkgo.Entry("should decrease the memory request and increase the CPU limit",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "200m", MemReq: "200Mi", MemLim: "400Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "300m", MemReq: "100Mi", MemLim: "400Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "100m", CPULim: "300m", MemReq: "100Mi", MemLim: "400Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					"",
+				),
+				ginkgo.Entry("should increase the memory request and decrease the CPU limit",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "400m", MemReq: "200Mi", MemLim: "400Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "300m", MemReq: "300Mi", MemLim: "400Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", CPULim: "300m", MemReq: "300Mi", MemLim: "400Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					"",
+				),
+				ginkgo.Entry("should decrease the memory request",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", MemReq: "500Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", MemReq: "400Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "bu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "200m", MemReq: "400Mi"},
+							HasExclusiveCPUs: false,
+						},
+					},
+					"",
+				),
+			)
+		})
+
+		ginkgo.When("resizing a Guaranteed Pod with a single container and integer CPU requests", ginkgo.Label("single container guaranteed pod with integer CPU requests resize", "exclusive-cpus"), func() {
+			ginkgo.BeforeEach(func(ctx context.Context) {
+				reservedCPUs = cpuset.New(0)
+			})
+			ginkgo.DescribeTable("",
+				func(ctx context.Context,
+					originalContainers []podresize.ResizableContainerInfo,
+					originalCpuInfo []containerCPUInfo,
+					desiredContainers []podresize.ResizableContainerInfo,
+					expectedContainers []podresize.ResizableContainerInfo,
+					expectedCpuInfo []containerCPUInfo,
+					wantError string,
+				) {
+					skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), expectedCpuInfo[0].cpuCount)
+
+					updateKubeletConfigIfNeeded(ctx, f, configureCPUManagerInKubelet(oldCfg, &cpuManagerKubeletArguments{
+						policyName:         string(cpumanager.PolicyStatic),
+						reservedSystemCPUs: reservedCPUs, // Not really needed for the tests but helps to make a more precise check
+						enableInPlacePodVerticalScalingExclusiveCPUs: true,
+					}))
+
+					podClient := e2epod.NewPodClient(f)
+					nodes, err := e2enode.GetReadySchedulableNodes(ctx, f.ClientSet)
+					framework.ExpectNoError(err, "failed to get running nodes")
+					gomega.Expect(nodes.Items).ShouldNot(gomega.BeEmpty())
+					framework.Logf("Found %d schedulable nodes", len(nodes.Items))
+
+					ginkgo.By("Find node CPU resources available for allocation!")
+					node := nodes.Items[0]
+					nodeAllocatableCPU, nodeAvailableCPU, err := e2enode.GetNodeAllocatableAndAvailableQuantities(ctx, f.ClientSet, &node, v1.ResourceCPU)
+					framework.ExpectNoError(err, "failed to get CPU resources available for allocation")
+					framework.Logf("Node '%s': NodeAllocatable MilliCPUs = %dm. MilliCPUs currently available to allocate = %dm.",
+						node.Name, nodeAllocatableCPU.MilliValue(), nodeAvailableCPU.MilliValue())
+
+					tStamp := strconv.Itoa(time.Now().Nanosecond())
+					testPod1 := podresize.MakePodWithResizableContainers(f.Namespace.Name, "testpod1", tStamp, originalContainers, nil)
+					testPod1 = e2epod.MustMixinRestrictedPodSecurity(testPod1)
+					e2epod.SetNodeAffinity(&testPod1.Spec, node.Name)
+
+					ginkgo.By("creating pod")
+					testPod1 = e2epod.NewPodClient(f).CreateSync(ctx, testPod1)
+					podMap[string(testPod1.UID)] = testPod1
+
+					ginkgo.By("verifying original pod resources, allocations and policy are as expected")
+					podresize.VerifyPodResources(testPod1, originalContainers, nil)
+
+					ginkgo.By("verifying original pod cpusets are as expected")
+					gomega.Expect(testPod1).To(HaveContainerCPUsCount("gu-container-1", originalCpuInfo[0].cpuCount))
+
+					nodeAllocatableCPUAfterPodCreate, nodeAvailableCPUAfterPodCreate, err := e2enode.GetNodeAllocatableAndAvailableQuantities(ctx, f.ClientSet, &node, v1.ResourceCPU)
+					framework.ExpectNoError(err, "failed to get CPU resources available for allocation")
+					framework.Logf("Node '%s': NodeAllocatable MilliCPUs = %dm. MilliCPUs currently available to allocate = %dm.",
+						node.Name, nodeAllocatableCPUAfterPodCreate.MilliValue(), nodeAvailableCPUAfterPodCreate.MilliValue())
+
+					ginkgo.By("patching pod for resize")
+					patchString := podresize.MakeResizePatch(originalContainers, desiredContainers, nil, nil)
+
+					if wantError == "" {
+						patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+							testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+						framework.ExpectNoError(pErr, "failed to patch pod for resize")
+
+						expected := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, expectedContainers)
+						ginkgo.By("verifying pod resources are as expected post patch, pre-actuation")
+						podresize.VerifyPodResources(patchedPod, expected, nil)
+
+						ginkgo.By("waiting for resize to be actuated")
+						resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expected)
+						podresize.ExpectPodResized(ctx, f, resizedPod, expected)
+
+						ginkgo.By("verifying pod resources after resize")
+						podresize.VerifyPodResources(resizedPod, expected, nil)
+
+						// we cannot nor we should predict which CPUs the container gets
+						ginkgo.By("verifying pod cpusets after resize")
+						gomega.Expect(testPod1).To(HaveContainerCPUsCount("gu-container-1", expectedCpuInfo[0].cpuCount))
+
+						nodeAllocatableCPUAfterPodResize, nodeAvailableCPUAfterPodResize, err := e2enode.GetNodeAllocatableAndAvailableQuantities(ctx, f.ClientSet, &node, v1.ResourceCPU)
+						framework.ExpectNoError(err, "failed to get CPU resources available for allocation")
+						framework.Logf("Node '%s': NodeAllocatable MilliCPUs = %dm. MilliCPUs currently available to allocate = %dm.",
+							node.Name, nodeAllocatableCPUAfterPodResize.MilliValue(), nodeAvailableCPUAfterPodResize.MilliValue())
+
+					} else {
+						patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+							testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+						framework.ExpectNoError(pErr, "failed to patch pod for resize")
+
+						ginkgo.By("verifying testing pod resources are as expected post patch, pre-actuation")
+						expectedPreActuation := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, desiredContainers)
+						podresize.VerifyPodResources(patchedPod, expectedPreActuation, nil)
+
+						resizePendingPod, err := framework.GetObject(podClient.Get, patchedPod.Name, metav1.GetOptions{})(ctx)
+						framework.ExpectNoError(err, "failed to get resize pending pod")
+
+						ginkgo.By("waiting for testing pod resize to be infeasible")
+						WaitForPodResizeInfeasible(ctx, f, resizePendingPod)
+
+					}
+				},
+				ginkgo.Entry("should increase the CPU request/limit, decrease memory request/limit, within available capacity",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "400Mi", MemLim: "400Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					[]containerCPUInfo{
+						{
+							Name:     "gu-container-1",
+							cpuCount: 2,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					[]containerCPUInfo{
+						{
+							Name:     "gu-container-1",
+							cpuCount: 4,
+						},
+					},
+					"",
+				),
+				ginkgo.Entry("should increase the CPU request/limit, increase memory request/limit, within available capacity",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					[]containerCPUInfo{
+						{
+							Name:     "gu-container-1",
+							cpuCount: 2,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "400Mi", MemLim: "400Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "400Mi", MemLim: "400Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					[]containerCPUInfo{
+						{
+							Name:     "gu-container-1",
+							cpuCount: 4,
+						},
+					},
+					"",
+				),
+				ginkgo.Entry("should increase exclusively CPUs, within available capacity",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "300Mi", MemLim: "300Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					[]containerCPUInfo{
+						{
+							Name:     "gu-container-1",
+							cpuCount: 2,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "3000m", CPULim: "3000m", MemReq: "300Mi", MemLim: "300Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "3000m", CPULim: "3000m", MemReq: "300Mi", MemLim: "300Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					[]containerCPUInfo{
+						{
+							Name:     "gu-container-1",
+							cpuCount: 3,
+						},
+					},
+					"",
+				),
+				ginkgo.Entry("should not decrease allocated exclusively CPUs, below original cpuset",
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "300Mi", MemLim: "300Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					[]containerCPUInfo{
+						{
+							Name:     "gu-container-1",
+							cpuCount: 2,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "1000m", CPULim: "1000m", MemReq: "300Mi", MemLim: "300Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "300Mi", MemLim: "300Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					[]containerCPUInfo{
+						{
+							Name:     "gu-container-1",
+							cpuCount: 2,
+						},
+					},
+					"prohibitedCPUAllocation.*",
+				),
+			)
+		})
+
+		ginkgo.When("topologyManagerPolicy is set to none, resizing a Guaranteed multiple containers Pod with integer CPU requests", ginkgo.Label("guaranteed multiple container pod with integer CPU requests resize", "exclusive-cpus"), func() {
+			ginkgo.BeforeEach(func(ctx context.Context) {
+				reservedCPUs = cpuset.New(0)
+			})
+			ginkgo.DescribeTable("",
+				func(ctx context.Context,
+					originalContainers []podresize.ResizableContainerInfo,
+					originalCpuInfo []containerCPUInfo,
+					desiredContainersFirstPatch []podresize.ResizableContainerInfo,
+					expectedContainersFirstPatch []podresize.ResizableContainerInfo,
+					expectedCpuInfoFirstPatch []containerCPUInfo,
+					wantErrorFirstPatch string,
+					desiredContainersSecondPatch []podresize.ResizableContainerInfo,
+					expectedContainersSecondPatch []podresize.ResizableContainerInfo,
+					expectedCpuInfoSecondPatch []containerCPUInfo,
+					wantErrorSecondPatch string,
+				) {
+
+					expectedCPUCount := 0
+					for ctx := range expectedCpuInfoFirstPatch {
+						expectedCPUCount += expectedCpuInfoFirstPatch[ctx].cpuCount
+					}
+					skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), expectedCPUCount)
+
+					expectedCPUCount = 0
+					for ctx := range expectedCpuInfoSecondPatch {
+						expectedCPUCount += expectedCpuInfoSecondPatch[ctx].cpuCount
+					}
+					skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), expectedCPUCount)
+
+					updateKubeletConfigIfNeeded(ctx, f, configureCPUManagerInKubelet(oldCfg, &cpuManagerKubeletArguments{
+						policyName:         string(cpumanager.PolicyStatic),
+						reservedSystemCPUs: reservedCPUs, // Not really needed for the tests but helps to make a more precise check
+						enableInPlacePodVerticalScalingExclusiveCPUs: true,
+						topologyManagerPolicy:                        "none",
+						topologyManagerScope:                         "container",
+						topologyManagerPolicyOptions: map[string]string{
+							"max-allowable-numa-nodes":  "8",
+							"prefer-closest-numa-nodes": "true",
+						},
+					}))
+
+					tStamp := strconv.Itoa(time.Now().Nanosecond())
+					testPod1 := podresize.MakePodWithResizableContainers(f.Namespace.Name, "testpod1", tStamp, originalContainers, nil)
+					testPod1 = e2epod.MustMixinRestrictedPodSecurity(testPod1)
+
+					ginkgo.By("creating pod with multiple containers")
+					podClient := e2epod.NewPodClient(f)
+					testPod1 = podClient.CreateSync(ctx, testPod1)
+					podMap[string(testPod1.UID)] = testPod1
+
+					ginkgo.By("verifying original pod resources, allocations are as expected")
+					podresize.VerifyPodResources(testPod1, originalContainers, nil)
+
+					ginkgo.By("verifying original pod cpusets are as expected")
+					for cdx := range originalCpuInfo {
+						gomega.Expect(testPod1).To(HaveContainerCPUsCount(originalCpuInfo[cdx].Name, originalCpuInfo[cdx].cpuCount))
+					}
+
+					ginkgo.By("patching pod for resize")
+					patchString := podresize.MakeResizePatch(originalContainers, desiredContainersFirstPatch, nil, nil)
+
+					if wantErrorFirstPatch == "" {
+						patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+							testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+						framework.ExpectNoError(pErr, "failed to patch pod for resize")
+
+						expected := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, expectedContainersFirstPatch)
+						ginkgo.By("verifying pod resources are as expected post patch, pre-actuation")
+						podresize.VerifyPodResources(patchedPod, expected, nil)
+
+						ginkgo.By("waiting for resize to be actuated")
+						resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expected)
+						podresize.ExpectPodResized(ctx, f, resizedPod, expected)
+
+						ginkgo.By("verifying pod resources after resize")
+						podresize.VerifyPodResources(resizedPod, expected, nil)
+
+						ginkgo.By("verifying pod cpusets after resize")
+						for cdx := range originalCpuInfo {
+							gomega.Expect(testPod1).To(HaveContainerCPUsCount(expectedCpuInfoFirstPatch[cdx].Name, expectedCpuInfoFirstPatch[cdx].cpuCount))
+						}
+
+						ginkgo.By("patching again pod for resize")
+						secondPatchString := podresize.MakeResizePatch(expected, desiredContainersSecondPatch, nil, nil)
+
+						if wantErrorSecondPatch == "" {
+
+							patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+								testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(secondPatchString), metav1.PatchOptions{}, "resize")
+							framework.ExpectNoError(pErr, "failed to patch again pod for resize")
+
+							expected = podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, expectedContainersSecondPatch)
+							ginkgo.By("verifying pod resources are as expected post second patch, pre-actuation")
+							podresize.VerifyPodResources(patchedPod, expected, nil)
+
+							ginkgo.By("waiting for second patch resize to be actuated")
+							resizedPod = podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expected)
+							podresize.ExpectPodResized(ctx, f, resizedPod, expected)
+
+							ginkgo.By("verifying pod resources after second resize")
+							podresize.VerifyPodResources(resizedPod, expected, nil)
+
+							ginkgo.By("verifying pod cpusets after second resize")
+							for cdx := range expectedCpuInfoSecondPatch {
+								gomega.Expect(testPod1).To(HaveContainerCPUsCount(expectedCpuInfoSecondPatch[cdx].Name, expectedCpuInfoSecondPatch[cdx].cpuCount))
+							}
+						} else {
+							patchedPod, pErr = f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+								testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(secondPatchString), metav1.PatchOptions{}, "resize")
+							framework.ExpectNoError(pErr, "failed to patch again pod for resize")
+
+							ginkgo.By("verifying testing pod resources are as expected post second patch, pre-actuation")
+							expectedPreActuation := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, desiredContainersSecondPatch)
+							podresize.VerifyPodResources(patchedPod, expectedPreActuation, nil)
+
+							resizePendingPod, err := framework.GetObject(podClient.Get, patchedPod.Name, metav1.GetOptions{})(ctx)
+							framework.ExpectNoError(err, "failed to get resize pending pod for second patch")
+
+							ginkgo.By("waiting for testing pod resize to be actuated for second patch")
+							expectedPostActuation := podresize.UpdateExpectedContainerRestarts(ctx, resizePendingPod, expectedContainersSecondPatch)
+							actuatedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expectedPostActuation)
+
+							ginkgo.By("waiting for testing pod resize status to be pending for second patch")
+							WaitForPodResizePending(ctx, f, actuatedPod)
+
+							actuatedPod, err = framework.GetObject(podClient.Get, actuatedPod.Name, metav1.GetOptions{})(ctx)
+							framework.ExpectNoError(err, "failed to get actuated pod for second patch")
+
+							expectedPostActuation = podresize.UpdateExpectedContainerRestarts(ctx, actuatedPod, expectedContainersSecondPatch)
+							ginkgo.By("verifying testing pod condition type as expected post patch, post-actuation for second patch")
+							podresize.ExpectPodResizePending(ctx, f, actuatedPod, expectedPostActuation)
+
+							ginkgo.By("ensuring the testing pod is failed for the expected reason for second patch")
+							gomega.Expect(actuatedPod).To(HaveStatusConditionsMatchingRegex(wantErrorSecondPatch))
+
+							for cdx := range expectedCpuInfoSecondPatch {
+								gomega.Expect(testPod1).To(HaveContainerCPUsCount(expectedCpuInfoSecondPatch[cdx].Name, expectedCpuInfoSecondPatch[cdx].cpuCount))
+							}
+						}
+					} else {
+						patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+							testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+						framework.ExpectNoError(pErr, "failed to patch pod for resize")
+
+						ginkgo.By("verifying testing pod resources are as expected post patch, pre-actuation")
+						expectedPreActuation := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, desiredContainersFirstPatch)
+						podresize.VerifyPodResources(patchedPod, expectedPreActuation, nil)
+
+						resizePendingPod, err := framework.GetObject(podClient.Get, patchedPod.Name, metav1.GetOptions{})(ctx)
+						framework.ExpectNoError(err, "failed to get resize pending pod")
+
+						ginkgo.By("waiting for testing pod resize to be actuated")
+						expectedPostActuation := podresize.UpdateExpectedContainerRestarts(ctx, resizePendingPod, expectedContainersFirstPatch)
+						actuatedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expectedPostActuation)
+
+						ginkgo.By("waiting for testing pod resize status to be pending")
+						WaitForPodResizePending(ctx, f, actuatedPod)
+
+						actuatedPod, err = framework.GetObject(podClient.Get, actuatedPod.Name, metav1.GetOptions{})(ctx)
+						framework.ExpectNoError(err, "failed to get actuated pod")
+
+						expectedPostActuation = podresize.UpdateExpectedContainerRestarts(ctx, actuatedPod, expectedContainersFirstPatch)
+						ginkgo.By("verifying testing pod condition type as expected post patch, post-actuation")
+						podresize.ExpectPodResizePending(ctx, f, actuatedPod, expectedPostActuation)
+
+						ginkgo.By("ensuring the testing pod is failed for the expected reason")
+						gomega.Expect(actuatedPod).To(HaveStatusConditionsMatchingRegex(wantErrorFirstPatch))
+
+						// we cannot nor we should predict which CPUs the container gets
+						ginkgo.By("verifying pod cpusets after resize")
+						gomega.Expect(actuatedPod).To(HaveContainerCPUsCount("gu-container-1", expectedCpuInfoFirstPatch[0].cpuCount))
+					}
+				},
+				ginkgo.Entry("should first increase CPU (gu-container-1) request and limit, afterwards decrease CPU (gu-container-1) request and limit within available capacity",
+					// Initial
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					// Expected cpuCount before first patch
+					[]containerCPUInfo{
+						{
+							Name:     "gu-container-1",
+							cpuCount: 2,
+						},
+					},
+					// Desired first patch
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					// Expected after first patch
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					// Expected cpuCount after first patch
+					[]containerCPUInfo{
+						{
+							Name:     "gu-container-1",
+							cpuCount: 4,
+						},
+					},
+					// Want error after first patch
+					"",
+					// Desired second patch
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					// Expected after second patch
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					// Expected cpuCount after second patch
+					[]containerCPUInfo{
+						{
+							Name:     "gu-container-1",
+							cpuCount: 2,
+						},
+					},
+					"",
+				),
+			)
+		})
+
+		ginkgo.When("topologyManagerPolicOption is set to best-effort, resizing a Guaranteed multiple containers Pod with integer CPU request", ginkgo.Label("guaranteed pod with integer CPU requests resize", "exclusive-cpus"), func() {
+			ginkgo.BeforeEach(func(ctx context.Context) {
+				reservedCPUs = cpuset.New(0)
+			})
+			ginkgo.DescribeTable("",
+				func(ctx context.Context,
+					originalContainers []podresize.ResizableContainerInfo,
+					originalCpuInfo []containerCPUInfo,
+					desiredContainersFirstPatch []podresize.ResizableContainerInfo,
+					expectedContainersFirstPatch []podresize.ResizableContainerInfo,
+					expectedCpuInfoFirstPatch []containerCPUInfo,
+					wantErrorFirstPatch string,
+					desiredContainersSecondPatch []podresize.ResizableContainerInfo,
+					expectedContainersSecondPatch []podresize.ResizableContainerInfo,
+					expectedCpuInfoSecondPatch []containerCPUInfo,
+					wantErrorSecondPatch string,
+				) {
+
+					expectedCPUCount := 0
+					for ctx := range expectedCpuInfoFirstPatch {
+						expectedCPUCount += expectedCpuInfoFirstPatch[ctx].cpuCount
+					}
+					skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), expectedCPUCount)
+
+					expectedCPUCount = 0
+					for ctx := range expectedCpuInfoSecondPatch {
+						expectedCPUCount += expectedCpuInfoSecondPatch[ctx].cpuCount
+					}
+					skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), expectedCPUCount)
+
+					updateKubeletConfigIfNeeded(ctx, f, configureCPUManagerInKubelet(oldCfg, &cpuManagerKubeletArguments{
+						policyName:         string(cpumanager.PolicyStatic),
+						reservedSystemCPUs: reservedCPUs, // Not really needed for the tests but helps to make a more precise check
+						enableInPlacePodVerticalScalingExclusiveCPUs: true,
+						topologyManagerPolicy:                        "best-effort",
+						topologyManagerScope:                         "container",
+						topologyManagerPolicyOptions: map[string]string{
+							"max-allowable-numa-nodes":  "8",
+							"prefer-closest-numa-nodes": "true",
+						},
+					}))
+
+					tStamp := strconv.Itoa(time.Now().Nanosecond())
+					testPod1 := podresize.MakePodWithResizableContainers(f.Namespace.Name, "testpod1", tStamp, originalContainers, nil)
+					testPod1 = e2epod.MustMixinRestrictedPodSecurity(testPod1)
+
+					ginkgo.By("creating pod with multiple containers")
+					podClient := e2epod.NewPodClient(f)
+					testPod1 = podClient.CreateSync(ctx, testPod1)
+					podMap[string(testPod1.UID)] = testPod1
+
+					ginkgo.By("verifying original pod resources, allocations are as expected")
+					podresize.VerifyPodResources(testPod1, originalContainers, nil)
+
+					ginkgo.By("verifying original pod cpusets are as expected")
+					for cdx := range originalCpuInfo {
+						gomega.Expect(testPod1).To(HaveContainerCPUsCount(originalCpuInfo[cdx].Name, originalCpuInfo[cdx].cpuCount))
+					}
+
+					ginkgo.By("patching pod for resize")
+					patchString := podresize.MakeResizePatch(originalContainers, desiredContainersFirstPatch, nil, nil)
+
+					if wantErrorFirstPatch == "" {
+						patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+							testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+						framework.ExpectNoError(pErr, "failed to patch pod for resize")
+
+						expected := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, expectedContainersFirstPatch)
+						ginkgo.By("verifying pod resources are as expected post patch, pre-actuation")
+						podresize.VerifyPodResources(patchedPod, expected, nil)
+
+						ginkgo.By("waiting for resize to be actuated")
+						resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expected)
+						podresize.ExpectPodResized(ctx, f, resizedPod, expected)
+
+						ginkgo.By("verifying pod resources after resize")
+						podresize.VerifyPodResources(resizedPod, expected, nil)
+
+						ginkgo.By("verifying pod cpusets after resize")
+						for cdx := range originalCpuInfo {
+							gomega.Expect(testPod1).To(HaveContainerCPUsCount(expectedCpuInfoFirstPatch[cdx].Name, expectedCpuInfoFirstPatch[cdx].cpuCount))
+						}
+
+						ginkgo.By("patching again pod for resize")
+						secondPatchString := podresize.MakeResizePatch(expected, desiredContainersSecondPatch, nil, nil)
+
+						if wantErrorSecondPatch == "" {
+
+							patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+								testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(secondPatchString), metav1.PatchOptions{}, "resize")
+							framework.ExpectNoError(pErr, "failed to patch again pod for resize")
+
+							expected = podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, expectedContainersSecondPatch)
+							ginkgo.By("verifying pod resources are as expected post second patch, pre-actuation")
+							podresize.VerifyPodResources(patchedPod, expected, nil)
+
+							ginkgo.By("waiting for second patch resize to be actuated")
+							resizedPod = podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expected)
+							podresize.ExpectPodResized(ctx, f, resizedPod, expected)
+
+							ginkgo.By("verifying pod resources after second resize")
+							podresize.VerifyPodResources(resizedPod, expected, nil)
+
+							ginkgo.By("verifying pod cpusets after second resize")
+							for cdx := range expectedCpuInfoSecondPatch {
+								gomega.Expect(testPod1).To(HaveContainerCPUsCount(expectedCpuInfoSecondPatch[cdx].Name, expectedCpuInfoSecondPatch[cdx].cpuCount))
+							}
+						} else {
+							patchedPod, pErr = f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+								testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(secondPatchString), metav1.PatchOptions{}, "resize")
+							framework.ExpectNoError(pErr, "failed to patch again pod for resize")
+
+							ginkgo.By("verifying testing pod resources are as expected post second patch, pre-actuation")
+							expectedPreActuation := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, desiredContainersSecondPatch)
+							podresize.VerifyPodResources(patchedPod, expectedPreActuation, nil)
+
+							resizePendingPod, err := framework.GetObject(podClient.Get, patchedPod.Name, metav1.GetOptions{})(ctx)
+							framework.ExpectNoError(err, "failed to get resize pending pod for second patch")
+
+							ginkgo.By("waiting for testing pod resize to be actuated for second patch")
+							expectedPostActuation := podresize.UpdateExpectedContainerRestarts(ctx, resizePendingPod, expectedContainersSecondPatch)
+							actuatedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expectedPostActuation)
+
+							ginkgo.By("waiting for testing pod resize status to be pending for second patch")
+							WaitForPodResizePending(ctx, f, actuatedPod)
+
+							actuatedPod, err = framework.GetObject(podClient.Get, actuatedPod.Name, metav1.GetOptions{})(ctx)
+							framework.ExpectNoError(err, "failed to get actuated pod for second patch")
+
+							expectedPostActuation = podresize.UpdateExpectedContainerRestarts(ctx, actuatedPod, expectedContainersSecondPatch)
+							ginkgo.By("verifying testing pod condition type as expected post patch, post-actuation for second patch")
+							podresize.ExpectPodResizePending(ctx, f, actuatedPod, expectedPostActuation)
+
+							ginkgo.By("ensuring the testing pod is failed for the expected reason for second patch")
+							gomega.Expect(actuatedPod).To(HaveStatusConditionsMatchingRegex(wantErrorSecondPatch))
+
+							for cdx := range expectedCpuInfoSecondPatch {
+								gomega.Expect(testPod1).To(HaveContainerCPUsCount(expectedCpuInfoSecondPatch[cdx].Name, expectedCpuInfoSecondPatch[cdx].cpuCount))
+							}
+						}
+					} else {
+						patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+							testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+						framework.ExpectNoError(pErr, "failed to patch pod for resize")
+
+						ginkgo.By("verifying testing pod resources are as expected post patch, pre-actuation")
+						expectedPreActuation := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, desiredContainersFirstPatch)
+						podresize.VerifyPodResources(patchedPod, expectedPreActuation, nil)
+
+						resizePendingPod, err := framework.GetObject(podClient.Get, patchedPod.Name, metav1.GetOptions{})(ctx)
+						framework.ExpectNoError(err, "failed to get resize pending pod")
+
+						ginkgo.By("waiting for testing pod resize to be actuated")
+						expectedPostActuation := podresize.UpdateExpectedContainerRestarts(ctx, resizePendingPod, expectedContainersFirstPatch)
+						actuatedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expectedPostActuation)
+
+						ginkgo.By("waiting for testing pod resize status to be pending")
+						WaitForPodResizePending(ctx, f, actuatedPod)
+
+						actuatedPod, err = framework.GetObject(podClient.Get, actuatedPod.Name, metav1.GetOptions{})(ctx)
+						framework.ExpectNoError(err, "failed to get actuated pod")
+
+						expectedPostActuation = podresize.UpdateExpectedContainerRestarts(ctx, actuatedPod, expectedContainersFirstPatch)
+						ginkgo.By("verifying testing pod condition type as expected post patch, post-actuation")
+						podresize.ExpectPodResizePending(ctx, f, actuatedPod, expectedPostActuation)
+
+						ginkgo.By("ensuring the testing pod is failed for the expected reason")
+						gomega.Expect(actuatedPod).To(HaveStatusConditionsMatchingRegex(wantErrorFirstPatch))
+
+						// we cannot nor we should predict which CPUs the container gets
+						ginkgo.By("verifying pod cpusets after resize")
+						gomega.Expect(actuatedPod).To(HaveContainerCPUsCount("gu-container-1", expectedCpuInfoFirstPatch[0].cpuCount))
+					}
+				},
+				ginkgo.Entry("should first increase (gu-container-1) CPU request/limit, afterwards decrease (gu-container-1) CPU request/limit, within available capacity",
+					// Initial
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					// Expected cpuCount before first patch
+					[]containerCPUInfo{
+						{
+							Name:     "gu-container-1",
+							cpuCount: 2,
+						},
+					},
+					// Desired first patch
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					// Expected after first patch
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					// Expected cpuCount after first patch
+					[]containerCPUInfo{
+						{
+							Name:     "gu-container-1",
+							cpuCount: 4,
+						},
+					},
+					// Want error after first patch
+					"",
+					// Desired second patch
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					// Expected after second patch
+					[]podresize.ResizableContainerInfo{
+						{
+							Name:             "gu-container-1",
+							Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+							HasExclusiveCPUs: true,
+						},
+					},
+					// Expected cpuCount after second patch
+					[]containerCPUInfo{
+						{
+							Name:     "gu-container-1",
+							cpuCount: 2,
+						},
+					},
+					"",
+				),
+			)
+		})
+
+		ginkgo.When("topologyManagerPolicy option is set to restricted, resizing a Guaranteed multiple containers Pod, with integer CPU request", ginkgo.Label("guaranteed multiple containers pod with integer CPU requests resize", "exclusive-cpus"), func() {
+			ginkgo.BeforeEach(func(ctx context.Context) {
+				if smtLevel < 1 {
+					e2eskipper.Skipf("Skipping CPU Manager %q tests since SMT disabled", cpumanager.FullPCPUsOnlyOption)
+				}
+				reservedCPUs = cpuset.New(0)
+			})
+			if smtLevel >= minSMTLevel {
+				ginkgo.DescribeTable("",
+					func(ctx context.Context,
+						originalContainers []podresize.ResizableContainerInfo,
+						originalCpuInfo []containerCPUInfo,
+						desiredContainersFirstPatch []podresize.ResizableContainerInfo,
+						expectedContainersFirstPatch []podresize.ResizableContainerInfo,
+						expectedCpuInfoFirstPatch []containerCPUInfo,
+						wantErrorFirstPatch string,
+						desiredContainersSecondPatch []podresize.ResizableContainerInfo,
+						expectedContainersSecondPatch []podresize.ResizableContainerInfo,
+						expectedCpuInfoSecondPatch []containerCPUInfo,
+						wantErrorSecondPatch string,
+					) {
+
+						expectedCPUCount := 0
+						for ctx := range expectedCpuInfoFirstPatch {
+							expectedCPUCount += expectedCpuInfoFirstPatch[ctx].cpuCount
+						}
+						skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), expectedCPUCount)
+
+						expectedCPUCount = 0
+						for ctx := range expectedCpuInfoSecondPatch {
+							expectedCPUCount += expectedCpuInfoSecondPatch[ctx].cpuCount
+						}
+						skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), expectedCPUCount)
+
+						updateKubeletConfigIfNeeded(ctx, f, configureCPUManagerInKubelet(oldCfg, &cpuManagerKubeletArguments{
+							policyName:         string(cpumanager.PolicyStatic),
+							reservedSystemCPUs: reservedCPUs, // Not really needed for the tests but helps to make a more precise check
+							enableInPlacePodVerticalScalingExclusiveCPUs: true,
+							topologyManagerPolicy:                        "restricted",
+							topologyManagerScope:                         "container",
+							topologyManagerPolicyOptions: map[string]string{
+								"max-allowable-numa-nodes":  "8",
+								"prefer-closest-numa-nodes": "true",
+							},
+						}))
+
+						tStamp := strconv.Itoa(time.Now().Nanosecond())
+						testPod1 := podresize.MakePodWithResizableContainers(f.Namespace.Name, "testpod1", tStamp, originalContainers, nil)
+						testPod1 = e2epod.MustMixinRestrictedPodSecurity(testPod1)
+
+						ginkgo.By("creating pod with multiple containers")
+						podClient := e2epod.NewPodClient(f)
+						testPod1 = podClient.CreateSync(ctx, testPod1)
+
+						ginkgo.By("verifying original pod resources, allocations are as expected")
+						podresize.VerifyPodResources(testPod1, originalContainers, nil)
+
+						ginkgo.By("verifying original pod cpusets are as expected")
+						for cdx := range originalCpuInfo {
+							gomega.Expect(testPod1).To(HaveContainerCPUsCount(originalCpuInfo[cdx].Name, originalCpuInfo[cdx].cpuCount))
+						}
+
+						ginkgo.By("patching pod for resize")
+						patchString := podresize.MakeResizePatch(originalContainers, desiredContainersFirstPatch, nil, nil)
+
+						if wantErrorFirstPatch == "" {
+							patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+								testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+							framework.ExpectNoError(pErr, "failed to patch pod for resize")
+
+							expected := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, expectedContainersFirstPatch)
+							ginkgo.By("verifying pod resources are as expected post patch, pre-actuation")
+							podresize.VerifyPodResources(patchedPod, expected, nil)
+
+							ginkgo.By("waiting for resize to be actuated")
+							resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expected)
+							podresize.ExpectPodResized(ctx, f, resizedPod, expected)
+
+							ginkgo.By("verifying pod resources after resize")
+							podresize.VerifyPodResources(resizedPod, expected, nil)
+
+							ginkgo.By("verifying pod cpusets after resize")
+							for cdx := range originalCpuInfo {
+								gomega.Expect(testPod1).To(HaveContainerCPUsCount(expectedCpuInfoFirstPatch[cdx].Name, expectedCpuInfoFirstPatch[cdx].cpuCount))
+							}
+
+							ginkgo.By("patching again pod for resize")
+							secondPatchString := podresize.MakeResizePatch(expected, desiredContainersSecondPatch, nil, nil)
+
+							if wantErrorSecondPatch == "" {
+
+								patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+									testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(secondPatchString), metav1.PatchOptions{}, "resize")
+								framework.ExpectNoError(pErr, "failed to patch again pod for resize")
+
+								expected = podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, expectedContainersSecondPatch)
+								ginkgo.By("verifying pod resources are as expected post second patch, pre-actuation")
+								podresize.VerifyPodResources(patchedPod, expected, nil)
+
+								ginkgo.By("waiting for second patch resize to be actuated")
+								resizedPod = podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expected)
+								podresize.ExpectPodResized(ctx, f, resizedPod, expected)
+
+								ginkgo.By("verifying pod resources after second resize")
+								podresize.VerifyPodResources(resizedPod, expected, nil)
+
+								ginkgo.By("verifying pod cpusets after second resize")
+								for cdx := range expectedCpuInfoSecondPatch {
+									gomega.Expect(testPod1).To(HaveContainerCPUsCount(expectedCpuInfoSecondPatch[cdx].Name, expectedCpuInfoSecondPatch[cdx].cpuCount))
+								}
+							} else {
+								patchedPod, pErr = f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+									testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(secondPatchString), metav1.PatchOptions{}, "resize")
+								framework.ExpectNoError(pErr, "failed to patch again pod for resize")
+
+								ginkgo.By("verifying testing pod resources are as expected post second patch, pre-actuation")
+								expectedPreActuation := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, desiredContainersSecondPatch)
+								podresize.VerifyPodResources(patchedPod, expectedPreActuation, nil)
+
+								resizePendingPod, err := framework.GetObject(podClient.Get, patchedPod.Name, metav1.GetOptions{})(ctx)
+								framework.ExpectNoError(err, "failed to get resize pending pod for second patch")
+
+								ginkgo.By("waiting for testing pod resize to be actuated for second patch")
+								expectedPostActuation := podresize.UpdateExpectedContainerRestarts(ctx, resizePendingPod, expectedContainersSecondPatch)
+								actuatedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expectedPostActuation)
+
+								ginkgo.By("waiting for testing pod resize status to be pending for second patch")
+								WaitForPodResizePending(ctx, f, actuatedPod)
+
+								actuatedPod, err = framework.GetObject(podClient.Get, actuatedPod.Name, metav1.GetOptions{})(ctx)
+								framework.ExpectNoError(err, "failed to get actuated pod for second patch")
+
+								expectedPostActuation = podresize.UpdateExpectedContainerRestarts(ctx, actuatedPod, expectedContainersSecondPatch)
+								ginkgo.By("verifying testing pod condition type as expected post patch, post-actuation for second patch")
+								podresize.ExpectPodResizePending(ctx, f, actuatedPod, expectedPostActuation)
+
+								ginkgo.By("ensuring the testing pod is failed for the expected reason for second patch")
+								gomega.Expect(actuatedPod).To(HaveStatusConditionsMatchingRegex(wantErrorSecondPatch))
+
+								for cdx := range expectedCpuInfoSecondPatch {
+									gomega.Expect(testPod1).To(HaveContainerCPUsCount(expectedCpuInfoSecondPatch[cdx].Name, expectedCpuInfoSecondPatch[cdx].cpuCount))
+								}
+							}
+						} else {
+							patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+								testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+							framework.ExpectNoError(pErr, "failed to patch pod for resize")
+
+							ginkgo.By("verifying testing pod resources are as expected post patch, pre-actuation")
+							expectedPreActuation := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, desiredContainersFirstPatch)
+							podresize.VerifyPodResources(patchedPod, expectedPreActuation, nil)
+
+							resizePendingPod, err := framework.GetObject(podClient.Get, patchedPod.Name, metav1.GetOptions{})(ctx)
+							framework.ExpectNoError(err, "failed to get resize pending pod")
+
+							ginkgo.By("waiting for testing pod resize to be actuated")
+							expectedPostActuation := podresize.UpdateExpectedContainerRestarts(ctx, resizePendingPod, expectedContainersFirstPatch)
+							actuatedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expectedPostActuation)
+
+							ginkgo.By("waiting for testing pod resize status to be pending")
+							WaitForPodResizePending(ctx, f, actuatedPod)
+
+							actuatedPod, err = framework.GetObject(podClient.Get, actuatedPod.Name, metav1.GetOptions{})(ctx)
+							framework.ExpectNoError(err, "failed to get actuated pod")
+
+							expectedPostActuation = podresize.UpdateExpectedContainerRestarts(ctx, actuatedPod, expectedContainersFirstPatch)
+							ginkgo.By("verifying testing pod condition type as expected post patch, post-actuation")
+							podresize.ExpectPodResizePending(ctx, f, actuatedPod, expectedPostActuation)
+
+							ginkgo.By("ensuring the testing pod is failed for the expected reason")
+							gomega.Expect(actuatedPod).To(HaveStatusConditionsMatchingRegex(wantErrorFirstPatch))
+
+							// we cannot nor we should predict which CPUs the container gets
+							ginkgo.By("verifying pod cpusets after resize")
+							gomega.Expect(actuatedPod).To(HaveContainerCPUsCount("gu-container-1", expectedCpuInfoFirstPatch[0].cpuCount))
+						}
+					},
+					ginkgo.Entry("should first increase (gu-container-1) CPU request/limit, afterwards decrease (gu-container-1) CPU request/limit, within available capacity",
+						// Initial
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount before first patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 2,
+							},
+						},
+						// Desired first patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "10000m", CPULim: "10000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected after first patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "10000m", CPULim: "10000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount after first patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 10,
+							},
+						},
+						// Want error after first patch
+						"",
+						// Desired second patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected after second patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount after second patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 2,
+							},
+						},
+						"",
+					),
+				)
+			}
+			if smtLevel == 1 {
+				ginkgo.DescribeTable("",
+					func(ctx context.Context,
+						originalContainers []podresize.ResizableContainerInfo,
+						originalCpuInfo []containerCPUInfo,
+						desiredContainersFirstPatch []podresize.ResizableContainerInfo,
+						expectedContainersFirstPatch []podresize.ResizableContainerInfo,
+						expectedCpuInfoFirstPatch []containerCPUInfo,
+						wantErrorFirstPatch string,
+						desiredContainersSecondPatch []podresize.ResizableContainerInfo,
+						expectedContainersSecondPatch []podresize.ResizableContainerInfo,
+						expectedCpuInfoSecondPatch []containerCPUInfo,
+						wantErrorSecondPatch string,
+					) {
+
+						expectedCPUCount := 0
+						for ctx := range expectedCpuInfoFirstPatch {
+							expectedCPUCount += expectedCpuInfoFirstPatch[ctx].cpuCount
+						}
+						skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), expectedCPUCount)
+
+						expectedCPUCount = 0
+						for ctx := range expectedCpuInfoSecondPatch {
+							expectedCPUCount += expectedCpuInfoSecondPatch[ctx].cpuCount
+						}
+						skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), expectedCPUCount)
+
+						updateKubeletConfigIfNeeded(ctx, f, configureCPUManagerInKubelet(oldCfg, &cpuManagerKubeletArguments{
+							policyName:         string(cpumanager.PolicyStatic),
+							reservedSystemCPUs: reservedCPUs, // Not really needed for the tests but helps to make a more precise check
+							enableInPlacePodVerticalScalingExclusiveCPUs: true,
+							topologyManagerPolicy:                        "restricted",
+							topologyManagerScope:                         "container",
+							topologyManagerPolicyOptions: map[string]string{
+								"max-allowable-numa-nodes":  "8",
+								"prefer-closest-numa-nodes": "true",
+							},
+						}))
+
+						tStamp := strconv.Itoa(time.Now().Nanosecond())
+						testPod1 := podresize.MakePodWithResizableContainers(f.Namespace.Name, "testpod1", tStamp, originalContainers, nil)
+						testPod1 = e2epod.MustMixinRestrictedPodSecurity(testPod1)
+
+						ginkgo.By("creating pod with multiple containers")
+						podClient := e2epod.NewPodClient(f)
+						testPod1 = podClient.CreateSync(ctx, testPod1)
+						podMap[string(testPod1.UID)] = testPod1
+
+						ginkgo.By("verifying original pod resources, allocations are as expected")
+						podresize.VerifyPodResources(testPod1, originalContainers, nil)
+
+						ginkgo.By("verifying original pod cpusets are as expected")
+						for cdx := range originalCpuInfo {
+							gomega.Expect(testPod1).To(HaveContainerCPUsCount(originalCpuInfo[cdx].Name, originalCpuInfo[cdx].cpuCount))
+						}
+
+						ginkgo.By("patching pod for resize")
+						patchString := podresize.MakeResizePatch(originalContainers, desiredContainersFirstPatch, nil, nil)
+
+						if wantErrorFirstPatch == "" {
+							patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+								testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+							framework.ExpectNoError(pErr, "failed to patch pod for resize")
+
+							expected := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, expectedContainersFirstPatch)
+							ginkgo.By("verifying pod resources are as expected post patch, pre-actuation")
+							podresize.VerifyPodResources(patchedPod, expected, nil)
+
+							ginkgo.By("waiting for resize to be actuated")
+							resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expected)
+							podresize.ExpectPodResized(ctx, f, resizedPod, expected)
+
+							ginkgo.By("verifying pod resources after resize")
+							podresize.VerifyPodResources(resizedPod, expected, nil)
+
+							ginkgo.By("verifying pod cpusets after resize")
+							for cdx := range originalCpuInfo {
+								gomega.Expect(testPod1).To(HaveContainerCPUsCount(expectedCpuInfoFirstPatch[cdx].Name, expectedCpuInfoFirstPatch[cdx].cpuCount))
+							}
+
+							ginkgo.By("patching again pod for resize")
+							secondPatchString := podresize.MakeResizePatch(expected, desiredContainersSecondPatch, nil, nil)
+
+							if wantErrorSecondPatch == "" {
+
+								patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+									testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(secondPatchString), metav1.PatchOptions{}, "resize")
+								framework.ExpectNoError(pErr, "failed to patch again pod for resize")
+
+								expected = podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, expectedContainersSecondPatch)
+								ginkgo.By("verifying pod resources are as expected post second patch, pre-actuation")
+								podresize.VerifyPodResources(patchedPod, expected, nil)
+
+								ginkgo.By("waiting for second patch resize to be actuated")
+								resizedPod = podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expected)
+								podresize.ExpectPodResized(ctx, f, resizedPod, expected)
+
+								ginkgo.By("verifying pod resources after second resize")
+								podresize.VerifyPodResources(resizedPod, expected, nil)
+
+								ginkgo.By("verifying pod cpusets after second resize")
+								for cdx := range expectedCpuInfoSecondPatch {
+									gomega.Expect(testPod1).To(HaveContainerCPUsCount(expectedCpuInfoSecondPatch[cdx].Name, expectedCpuInfoSecondPatch[cdx].cpuCount))
+								}
+							} else {
+								patchedPod, pErr = f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+									testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(secondPatchString), metav1.PatchOptions{}, "resize")
+								framework.ExpectNoError(pErr, "failed to patch again pod for resize")
+
+								ginkgo.By("verifying testing pod resources are as expected post second patch, pre-actuation")
+								expectedPreActuation := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, desiredContainersSecondPatch)
+								podresize.VerifyPodResources(patchedPod, expectedPreActuation, nil)
+
+								resizePendingPod, err := framework.GetObject(podClient.Get, patchedPod.Name, metav1.GetOptions{})(ctx)
+								framework.ExpectNoError(err, "failed to get resize pending pod for second patch")
+
+								ginkgo.By("waiting for testing pod resize to be actuated for second patch")
+								expectedPostActuation := podresize.UpdateExpectedContainerRestarts(ctx, resizePendingPod, expectedContainersSecondPatch)
+								actuatedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expectedPostActuation)
+
+								ginkgo.By("waiting for testing pod resize status to be pending for second patch")
+								WaitForPodResizePending(ctx, f, actuatedPod)
+
+								actuatedPod, err = framework.GetObject(podClient.Get, actuatedPod.Name, metav1.GetOptions{})(ctx)
+								framework.ExpectNoError(err, "failed to get actuated pod for second patch")
+
+								expectedPostActuation = podresize.UpdateExpectedContainerRestarts(ctx, actuatedPod, expectedContainersSecondPatch)
+								ginkgo.By("verifying testing pod condition type as expected post patch, post-actuation for second patch")
+								podresize.ExpectPodResizePending(ctx, f, actuatedPod, expectedPostActuation)
+
+								ginkgo.By("ensuring the testing pod is failed for the expected reason for second patch")
+								gomega.Expect(actuatedPod).To(HaveStatusConditionsMatchingRegex(wantErrorSecondPatch))
+
+								for cdx := range expectedCpuInfoSecondPatch {
+									gomega.Expect(testPod1).To(HaveContainerCPUsCount(expectedCpuInfoSecondPatch[cdx].Name, expectedCpuInfoSecondPatch[cdx].cpuCount))
+								}
+							}
+						} else {
+							patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+								testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+							framework.ExpectNoError(pErr, "failed to patch pod for resize")
+
+							ginkgo.By("verifying testing pod resources are as expected post patch, pre-actuation")
+							expectedPreActuation := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, desiredContainersFirstPatch)
+							podresize.VerifyPodResources(patchedPod, expectedPreActuation, nil)
+
+							resizePendingPod, err := framework.GetObject(podClient.Get, patchedPod.Name, metav1.GetOptions{})(ctx)
+							framework.ExpectNoError(err, "failed to get resize pending pod")
+
+							ginkgo.By("waiting for testing pod resize to be actuated")
+							expectedPostActuation := podresize.UpdateExpectedContainerRestarts(ctx, resizePendingPod, expectedContainersFirstPatch)
+							actuatedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expectedPostActuation)
+
+							ginkgo.By("waiting for testing pod resize status to be pending")
+							WaitForPodResizePending(ctx, f, actuatedPod)
+
+							actuatedPod, err = framework.GetObject(podClient.Get, actuatedPod.Name, metav1.GetOptions{})(ctx)
+							framework.ExpectNoError(err, "failed to get actuated pod")
+
+							expectedPostActuation = podresize.UpdateExpectedContainerRestarts(ctx, actuatedPod, expectedContainersFirstPatch)
+							ginkgo.By("verifying testing pod condition type as expected post patch, post-actuation")
+							podresize.ExpectPodResizePending(ctx, f, actuatedPod, expectedPostActuation)
+
+							ginkgo.By("ensuring the testing pod is failed for the expected reason")
+							gomega.Expect(actuatedPod).To(HaveStatusConditionsMatchingRegex(wantErrorFirstPatch))
+
+							// we cannot nor we should predict which CPUs the container gets
+							ginkgo.By("verifying pod cpusets after resize")
+							gomega.Expect(actuatedPod).To(HaveContainerCPUsCount("gu-container-1", expectedCpuInfoFirstPatch[0].cpuCount))
+						}
+					},
+					ginkgo.Entry("should first increase (gu-container-1) CPU request/limit, afterwards fail to decrease (gu-container-1) CPU request/limit, within available capacity because of TopologyAffinityError",
+						// Initial
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount before first patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 2,
+							},
+						},
+						// Desired first patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "10000m", CPULim: "10000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected after first patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "10000m", CPULim: "10000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount after first patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 10,
+							},
+						},
+						// Want error after first patch
+						"",
+						// Desired second patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected after second patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "10000m", CPULim: "10000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount after second patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 10,
+							},
+						},
+						// Want error after first patch
+						"Infeasible.*",
+					),
+				)
+			}
+		})
+
+		ginkgo.When("topology manager policy option is set to single-numa-node, resizing a Guaranteed multiple container pod, with integer CPU request", ginkgo.Label("guaranteed multiple containers pod with integer CPU requests resize", "exclusive-cpus"), func() {
+			ginkgo.BeforeEach(func(ctx context.Context) {
+				if smtLevel < 1 {
+					e2eskipper.Skipf("Skipping CPU Manager %q tests since SMT disabled", cpumanager.FullPCPUsOnlyOption)
+				}
+				reservedCPUs = cpuset.New(0)
+			})
+			if smtLevel >= minSMTLevel {
+				ginkgo.DescribeTable("",
+					func(ctx context.Context,
+						originalContainers []podresize.ResizableContainerInfo,
+						originalCpuInfo []containerCPUInfo,
+						desiredContainersFirstPatch []podresize.ResizableContainerInfo,
+						expectedContainersFirstPatch []podresize.ResizableContainerInfo,
+						expectedCpuInfoFirstPatch []containerCPUInfo,
+						wantErrorFirstPatch string,
+						desiredContainersSecondPatch []podresize.ResizableContainerInfo,
+						expectedContainersSecondPatch []podresize.ResizableContainerInfo,
+						expectedCpuInfoSecondPatch []containerCPUInfo,
+						wantErrorSecondPatch string,
+					) {
+
+						expectedCPUCount := 0
+						for ctx := range expectedCpuInfoFirstPatch {
+							expectedCPUCount += expectedCpuInfoFirstPatch[ctx].cpuCount
+						}
+						skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), expectedCPUCount)
+
+						expectedCPUCount = 0
+						for ctx := range expectedCpuInfoSecondPatch {
+							expectedCPUCount += expectedCpuInfoSecondPatch[ctx].cpuCount
+						}
+						skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), expectedCPUCount)
+
+						updateKubeletConfigIfNeeded(ctx, f, configureCPUManagerInKubelet(oldCfg, &cpuManagerKubeletArguments{
+							policyName:         string(cpumanager.PolicyStatic),
+							reservedSystemCPUs: reservedCPUs, // Not really needed for the tests but helps to make a more precise check
+							enableInPlacePodVerticalScalingExclusiveCPUs: true,
+							topologyManagerPolicy:                        "single-numa-node",
+							topologyManagerScope:                         "container",
+							topologyManagerPolicyOptions: map[string]string{
+								"max-allowable-numa-nodes":  "8",
+								"prefer-closest-numa-nodes": "true",
+							},
+						}))
+
+						tStamp := strconv.Itoa(time.Now().Nanosecond())
+						testPod1 := podresize.MakePodWithResizableContainers(f.Namespace.Name, "testpod1", tStamp, originalContainers, nil)
+						testPod1 = e2epod.MustMixinRestrictedPodSecurity(testPod1)
+
+						ginkgo.By("creating pod with multiple containers")
+						podClient := e2epod.NewPodClient(f)
+						testPod1 = podClient.CreateSync(ctx, testPod1)
+						podMap[string(testPod1.UID)] = testPod1
+
+						ginkgo.By("verifying original pod resources, allocations are as expected")
+						podresize.VerifyPodResources(testPod1, originalContainers, nil)
+
+						ginkgo.By("verifying original pod cpusets are as expected")
+						for cdx := range originalCpuInfo {
+							gomega.Expect(testPod1).To(HaveContainerCPUsCount(originalCpuInfo[cdx].Name, originalCpuInfo[cdx].cpuCount))
+						}
+
+						ginkgo.By("patching pod for resize")
+						patchString := podresize.MakeResizePatch(originalContainers, desiredContainersFirstPatch, nil, nil)
+
+						if wantErrorFirstPatch == "" {
+							patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+								testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+							framework.ExpectNoError(pErr, "failed to patch pod for resize")
+
+							expected := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, expectedContainersFirstPatch)
+							ginkgo.By("verifying pod resources are as expected post patch, pre-actuation")
+							podresize.VerifyPodResources(patchedPod, expected, nil)
+
+							ginkgo.By("waiting for resize to be actuated")
+							resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expected)
+							podresize.ExpectPodResized(ctx, f, resizedPod, expected)
+
+							ginkgo.By("verifying pod resources after resize")
+							podresize.VerifyPodResources(resizedPod, expected, nil)
+
+							ginkgo.By("verifying pod cpusets after resize")
+							for cdx := range originalCpuInfo {
+								gomega.Expect(testPod1).To(HaveContainerCPUsCount(expectedCpuInfoFirstPatch[cdx].Name, expectedCpuInfoFirstPatch[cdx].cpuCount))
+							}
+
+							ginkgo.By("patching again pod for resize")
+							secondPatchString := podresize.MakeResizePatch(expected, desiredContainersSecondPatch, nil, nil)
+
+							if wantErrorSecondPatch == "" {
+
+								patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+									testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(secondPatchString), metav1.PatchOptions{}, "resize")
+								framework.ExpectNoError(pErr, "failed to patch again pod for resize")
+
+								expected = podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, expectedContainersSecondPatch)
+								ginkgo.By("verifying pod resources are as expected post second patch, pre-actuation")
+								podresize.VerifyPodResources(patchedPod, expected, nil)
+
+								ginkgo.By("waiting for second patch resize to be actuated")
+								resizedPod = podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expected)
+								podresize.ExpectPodResized(ctx, f, resizedPod, expected)
+
+								ginkgo.By("verifying pod resources after second resize")
+								podresize.VerifyPodResources(resizedPod, expected, nil)
+
+								ginkgo.By("verifying pod cpusets after second resize")
+								for cdx := range expectedCpuInfoSecondPatch {
+									gomega.Expect(testPod1).To(HaveContainerCPUsCount(expectedCpuInfoSecondPatch[cdx].Name, expectedCpuInfoSecondPatch[cdx].cpuCount))
+								}
+							} else {
+								patchedPod, pErr = f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+									testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(secondPatchString), metav1.PatchOptions{}, "resize")
+								framework.ExpectNoError(pErr, "failed to patch again pod for resize")
+
+								ginkgo.By("verifying testing pod resources are as expected post second patch, pre-actuation")
+								expectedPreActuation := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, desiredContainersSecondPatch)
+								podresize.VerifyPodResources(patchedPod, expectedPreActuation, nil)
+
+								resizePendingPod, err := framework.GetObject(podClient.Get, patchedPod.Name, metav1.GetOptions{})(ctx)
+								framework.ExpectNoError(err, "failed to get resize pending pod for second patch")
+
+								ginkgo.By("waiting for testing pod resize to be actuated for second patch")
+								expectedPostActuation := podresize.UpdateExpectedContainerRestarts(ctx, resizePendingPod, expectedContainersSecondPatch)
+								actuatedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expectedPostActuation)
+
+								ginkgo.By("waiting for testing pod resize status to be pending for second patch")
+								WaitForPodResizePending(ctx, f, actuatedPod)
+
+								actuatedPod, err = framework.GetObject(podClient.Get, actuatedPod.Name, metav1.GetOptions{})(ctx)
+								framework.ExpectNoError(err, "failed to get actuated pod for second patch")
+
+								expectedPostActuation = podresize.UpdateExpectedContainerRestarts(ctx, actuatedPod, expectedContainersSecondPatch)
+								ginkgo.By("verifying testing pod condition type as expected post patch, post-actuation for second patch")
+								podresize.ExpectPodResizePending(ctx, f, actuatedPod, expectedPostActuation)
+
+								ginkgo.By("ensuring the testing pod is failed for the expected reason for second patch")
+								gomega.Expect(actuatedPod).To(HaveStatusConditionsMatchingRegex(wantErrorSecondPatch))
+
+								for cdx := range expectedCpuInfoSecondPatch {
+									gomega.Expect(testPod1).To(HaveContainerCPUsCount(expectedCpuInfoSecondPatch[cdx].Name, expectedCpuInfoSecondPatch[cdx].cpuCount))
+								}
+							}
+						} else {
+							patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+								testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+							framework.ExpectNoError(pErr, "failed to patch pod for resize")
+
+							ginkgo.By("verifying testing pod resources are as expected post patch, pre-actuation")
+							expectedPreActuation := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, desiredContainersFirstPatch)
+							podresize.VerifyPodResources(patchedPod, expectedPreActuation, nil)
+
+							resizePendingPod, err := framework.GetObject(podClient.Get, patchedPod.Name, metav1.GetOptions{})(ctx)
+							framework.ExpectNoError(err, "failed to get resize pending pod")
+
+							ginkgo.By("waiting for testing pod resize to be actuated")
+							expectedPostActuation := podresize.UpdateExpectedContainerRestarts(ctx, resizePendingPod, expectedContainersFirstPatch)
+							actuatedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expectedPostActuation)
+
+							ginkgo.By("waiting for testing pod resize status to be pending")
+							WaitForPodResizePending(ctx, f, actuatedPod)
+
+							actuatedPod, err = framework.GetObject(podClient.Get, actuatedPod.Name, metav1.GetOptions{})(ctx)
+							framework.ExpectNoError(err, "failed to get actuated pod")
+
+							expectedPostActuation = podresize.UpdateExpectedContainerRestarts(ctx, actuatedPod, expectedContainersFirstPatch)
+							ginkgo.By("verifying testing pod condition type as expected post patch, post-actuation")
+							podresize.ExpectPodResizePending(ctx, f, actuatedPod, expectedPostActuation)
+
+							ginkgo.By("ensuring the testing pod is failed for the expected reason")
+							gomega.Expect(actuatedPod).To(HaveStatusConditionsMatchingRegex(wantErrorFirstPatch))
+
+							// we cannot nor we should predict which CPUs the container gets
+							ginkgo.By("verifying pod cpusets after resize")
+							gomega.Expect(actuatedPod).To(HaveContainerCPUsCount("gu-container-1", expectedCpuInfoFirstPatch[0].cpuCount))
+						}
+					},
+					ginkgo.Entry("should first increase (gu-container-1) CPU request/limit and afterwards decrease (gu-container-1) CPU request/limit, within available capacity",
+						// Initial
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount before first patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 2,
+							},
+						},
+						// Desired first patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected after first patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount after first patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 4,
+							},
+						},
+						// Want error after first patch
+						"",
+						// Desired second patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected after second patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount after second patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 2,
+							},
+						},
+						// Want error after first patch
+						"",
+					),
+					ginkgo.Entry("should first increase (gu-container-1) CPU request/limit, afterwards restore (gu-container-1) CPU request/limit and increase (gu-container-2) CPU request/limit, within available capacity",
+						// Initial
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount before first patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 2,
+							},
+							{
+								Name:     "gu-container-2",
+								cpuCount: 2,
+							},
+						},
+						// Desired first patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected after first patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount after first patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 4,
+							},
+							{
+								Name:     "gu-container-2",
+								cpuCount: 2,
+							},
+						},
+						// Want error after first patch
+						"",
+						// Desired second patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected after second patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount after second patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 2,
+							},
+							{
+								Name:     "gu-container-2",
+								cpuCount: 4,
+							},
+						},
+						"",
+					),
+					ginkgo.Entry("should first increase (gu-container-1) CPU request/limit, afterwards fail to reduce (gu-container-1) CPU request/limit, below original and increase (gu-container-2) CPU request/limit, within available capacity",
+						// Initial
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "3000m", CPULim: "3000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount before first patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 3,
+							},
+							{
+								Name:     "gu-container-2",
+								cpuCount: 2,
+							},
+						},
+						// Desired first patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected after first patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount after first patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 4,
+							},
+							{
+								Name:     "gu-container-2",
+								cpuCount: 2,
+							},
+						},
+						// Want error after first patch
+						"",
+						// Desired second patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected after second patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount after second patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 4,
+							},
+							{
+								Name:     "gu-container-2",
+								cpuCount: 2,
+							},
+						},
+						"prohibitedCPUAllocation.*",
+					),
+					ginkgo.Entry("should first increase (gu-container-1) CPU request/limit, afterwards fail to restore (gu-container-1) CPU request/limit and to increase (gu-container-2) CPU request/limit above available capacity",
+						// Initial
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount before first patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 2,
+							},
+							{
+								Name:     "gu-container-2",
+								cpuCount: 2,
+							},
+						},
+						// Desired first patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected after first patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount after first patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 4,
+							},
+							{
+								Name:     "gu-container-2",
+								cpuCount: 2,
+							},
+						},
+						// Want error after first patch
+						"",
+						// Desired second patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "40000m", CPULim: "40000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected after second patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount after second patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 4,
+							},
+							{
+								Name:     "gu-container-2",
+								cpuCount: 2,
+							},
+						},
+						"Infeasible.*Node.*didn't.*have.*enough.*capacity.*",
+					),
+				)
+			}
+			if smtLevel == 1 {
+				ginkgo.DescribeTable("",
+					func(ctx context.Context,
+						originalContainers []podresize.ResizableContainerInfo,
+						originalCpuInfo []containerCPUInfo,
+						desiredContainersFirstPatch []podresize.ResizableContainerInfo,
+						expectedContainersFirstPatch []podresize.ResizableContainerInfo,
+						expectedCpuInfoFirstPatch []containerCPUInfo,
+						wantErrorFirstPatch string,
+						desiredContainersSecondPatch []podresize.ResizableContainerInfo,
+						expectedContainersSecondPatch []podresize.ResizableContainerInfo,
+						expectedCpuInfoSecondPatch []containerCPUInfo,
+						wantErrorSecondPatch string,
+					) {
+
+						expectedCPUCount := 0
+						for ctx := range expectedCpuInfoFirstPatch {
+							expectedCPUCount += expectedCpuInfoFirstPatch[ctx].cpuCount
+						}
+						skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), expectedCPUCount)
+
+						expectedCPUCount = 0
+						for ctx := range expectedCpuInfoSecondPatch {
+							expectedCPUCount += expectedCpuInfoSecondPatch[ctx].cpuCount
+						}
+						skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), expectedCPUCount)
+
+						updateKubeletConfigIfNeeded(ctx, f, configureCPUManagerInKubelet(oldCfg, &cpuManagerKubeletArguments{
+							policyName:         string(cpumanager.PolicyStatic),
+							reservedSystemCPUs: reservedCPUs, // Not really needed for the tests but helps to make a more precise check
+							enableInPlacePodVerticalScalingExclusiveCPUs: true,
+							topologyManagerPolicy:                        "single-numa-node",
+							topologyManagerScope:                         "container",
+							topologyManagerPolicyOptions: map[string]string{
+								"max-allowable-numa-nodes":  "8",
+								"prefer-closest-numa-nodes": "true",
+							},
+						}))
+
+						tStamp := strconv.Itoa(time.Now().Nanosecond())
+						testPod1 := podresize.MakePodWithResizableContainers(f.Namespace.Name, "testpod1", tStamp, originalContainers, nil)
+						testPod1 = e2epod.MustMixinRestrictedPodSecurity(testPod1)
+
+						ginkgo.By("creating pod with multiple containers")
+						podClient := e2epod.NewPodClient(f)
+						testPod1 = podClient.CreateSync(ctx, testPod1)
+						podMap[string(testPod1.UID)] = testPod1
+
+						ginkgo.By("verifying original pod resources, allocations are as expected")
+						podresize.VerifyPodResources(testPod1, originalContainers, nil)
+
+						ginkgo.By("verifying original pod cpusets are as expected")
+						for cdx := range originalCpuInfo {
+							gomega.Expect(testPod1).To(HaveContainerCPUsCount(originalCpuInfo[cdx].Name, originalCpuInfo[cdx].cpuCount))
+						}
+
+						ginkgo.By("patching pod for resize")
+						patchString := podresize.MakeResizePatch(originalContainers, desiredContainersFirstPatch, nil, nil)
+
+						if wantErrorFirstPatch == "" {
+							patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+								testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+							framework.ExpectNoError(pErr, "failed to patch pod for resize")
+
+							expected := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, expectedContainersFirstPatch)
+							ginkgo.By("verifying pod resources are as expected post patch, pre-actuation")
+							podresize.VerifyPodResources(patchedPod, expected, nil)
+
+							ginkgo.By("waiting for resize to be actuated")
+							resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expected)
+							podresize.ExpectPodResized(ctx, f, resizedPod, expected)
+
+							ginkgo.By("verifying pod resources after resize")
+							podresize.VerifyPodResources(resizedPod, expected, nil)
+
+							ginkgo.By("verifying pod cpusets after resize")
+							for cdx := range originalCpuInfo {
+								gomega.Expect(testPod1).To(HaveContainerCPUsCount(expectedCpuInfoFirstPatch[cdx].Name, expectedCpuInfoFirstPatch[cdx].cpuCount))
+							}
+
+							ginkgo.By("patching again pod for resize")
+							secondPatchString := podresize.MakeResizePatch(expected, desiredContainersSecondPatch, nil, nil)
+
+							if wantErrorSecondPatch == "" {
+
+								patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+									testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(secondPatchString), metav1.PatchOptions{}, "resize")
+								framework.ExpectNoError(pErr, "failed to patch again pod for resize")
+
+								expected = podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, expectedContainersSecondPatch)
+								ginkgo.By("verifying pod resources are as expected post second patch, pre-actuation")
+								podresize.VerifyPodResources(patchedPod, expected, nil)
+
+								ginkgo.By("waiting for second patch resize to be actuated")
+								resizedPod = podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expected)
+								podresize.ExpectPodResized(ctx, f, resizedPod, expected)
+
+								ginkgo.By("verifying pod resources after second resize")
+								podresize.VerifyPodResources(resizedPod, expected, nil)
+
+								ginkgo.By("verifying pod cpusets after second resize")
+								for cdx := range expectedCpuInfoSecondPatch {
+									gomega.Expect(testPod1).To(HaveContainerCPUsCount(expectedCpuInfoSecondPatch[cdx].Name, expectedCpuInfoSecondPatch[cdx].cpuCount))
+								}
+							} else {
+								patchedPod, pErr = f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+									testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(secondPatchString), metav1.PatchOptions{}, "resize")
+								framework.ExpectNoError(pErr, "failed to patch again pod for resize")
+
+								ginkgo.By("verifying testing pod resources are as expected post second patch, pre-actuation")
+								expectedPreActuation := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, desiredContainersSecondPatch)
+								podresize.VerifyPodResources(patchedPod, expectedPreActuation, nil)
+
+								resizePendingPod, err := framework.GetObject(podClient.Get, patchedPod.Name, metav1.GetOptions{})(ctx)
+								framework.ExpectNoError(err, "failed to get resize pending pod for second patch")
+
+								ginkgo.By("waiting for testing pod resize to be actuated for second patch")
+								expectedPostActuation := podresize.UpdateExpectedContainerRestarts(ctx, resizePendingPod, expectedContainersSecondPatch)
+								actuatedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expectedPostActuation)
+
+								ginkgo.By("waiting for testing pod resize status to be pending for second patch")
+								WaitForPodResizePending(ctx, f, actuatedPod)
+
+								actuatedPod, err = framework.GetObject(podClient.Get, actuatedPod.Name, metav1.GetOptions{})(ctx)
+								framework.ExpectNoError(err, "failed to get actuated pod for second patch")
+
+								expectedPostActuation = podresize.UpdateExpectedContainerRestarts(ctx, actuatedPod, expectedContainersSecondPatch)
+								ginkgo.By("verifying testing pod condition type as expected post patch, post-actuation for second patch")
+								podresize.ExpectPodResizePending(ctx, f, actuatedPod, expectedPostActuation)
+
+								ginkgo.By("ensuring the testing pod is failed for the expected reason for second patch")
+								gomega.Expect(actuatedPod).To(HaveStatusConditionsMatchingRegex(wantErrorSecondPatch))
+
+								for cdx := range expectedCpuInfoSecondPatch {
+									gomega.Expect(testPod1).To(HaveContainerCPUsCount(expectedCpuInfoSecondPatch[cdx].Name, expectedCpuInfoSecondPatch[cdx].cpuCount))
+								}
+							}
+						} else {
+							patchedPod, pErr := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+								testPod1.Name, apimachinerytypes.StrategicMergePatchType, []byte(patchString), metav1.PatchOptions{}, "resize")
+							framework.ExpectNoError(pErr, "failed to patch pod for resize")
+
+							ginkgo.By("verifying testing pod resources are as expected post patch, pre-actuation")
+							expectedPreActuation := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, desiredContainersFirstPatch)
+							podresize.VerifyPodResources(patchedPod, expectedPreActuation, nil)
+
+							resizePendingPod, err := framework.GetObject(podClient.Get, patchedPod.Name, metav1.GetOptions{})(ctx)
+							framework.ExpectNoError(err, "failed to get resize pending pod")
+
+							ginkgo.By("waiting for testing pod resize to be actuated")
+							expectedPostActuation := podresize.UpdateExpectedContainerRestarts(ctx, resizePendingPod, expectedContainersFirstPatch)
+							actuatedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expectedPostActuation)
+
+							ginkgo.By("waiting for testing pod resize status to be pending")
+							WaitForPodResizePending(ctx, f, actuatedPod)
+
+							actuatedPod, err = framework.GetObject(podClient.Get, actuatedPod.Name, metav1.GetOptions{})(ctx)
+							framework.ExpectNoError(err, "failed to get actuated pod")
+
+							expectedPostActuation = podresize.UpdateExpectedContainerRestarts(ctx, actuatedPod, expectedContainersFirstPatch)
+							ginkgo.By("verifying testing pod condition type as expected post patch, post-actuation")
+							podresize.ExpectPodResizePending(ctx, f, actuatedPod, expectedPostActuation)
+
+							ginkgo.By("ensuring the testing pod is failed for the expected reason")
+							gomega.Expect(actuatedPod).To(HaveStatusConditionsMatchingRegex(wantErrorFirstPatch))
+
+							// we cannot nor we should predict which CPUs the container gets
+							ginkgo.By("verifying pod cpusets after resize")
+							gomega.Expect(actuatedPod).To(HaveContainerCPUsCount("gu-container-1", expectedCpuInfoFirstPatch[0].cpuCount))
+						}
+					},
+					ginkgo.Entry("should first increase (gu-container-1) CPU request/limit and afterwards decrease (gu-container-1) CPU request/limit, within available capacity",
+						// Initial
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount before first patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 2,
+							},
+						},
+						// Desired first patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected after first patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount after first patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 4,
+							},
+						},
+						// Want error after first patch
+						"",
+						// Desired second patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected after second patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount after second patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 2,
+							},
+						},
+						// Want error after first patch
+						"",
+					),
+					ginkgo.Entry("should first increase (gu-container-1) CPU request/limit, afterwards restore (gu-container-1) CPU request/limit and increase (gu-container-2) CPU request/limit, within available capacity",
+						// Initial
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount before first patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 2,
+							},
+							{
+								Name:     "gu-container-2",
+								cpuCount: 2,
+							},
+						},
+						// Desired first patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected after first patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount after first patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 4,
+							},
+							{
+								Name:     "gu-container-2",
+								cpuCount: 2,
+							},
+						},
+						// Want error after first patch
+						"",
+						// Desired second patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected after second patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount after second patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 2,
+							},
+							{
+								Name:     "gu-container-2",
+								cpuCount: 4,
+							},
+						},
+						"",
+					),
+					ginkgo.Entry("should first increase (gu-container-1) CPU request/limit, afterwards fail to reduce (gu-container-1) CPU request/limit, below original and increase (gu-container-2) CPU request/limit, within available capacity",
+						// Initial
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "3000m", CPULim: "3000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount before first patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 3,
+							},
+							{
+								Name:     "gu-container-2",
+								cpuCount: 2,
+							},
+						},
+						// Desired first patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected after first patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount after first patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 4,
+							},
+							{
+								Name:     "gu-container-2",
+								cpuCount: 2,
+							},
+						},
+						// Want error after first patch
+						"",
+						// Desired second patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected after second patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount after second patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 4,
+							},
+							{
+								Name:     "gu-container-2",
+								cpuCount: 2,
+							},
+						},
+						"prohibitedCPUAllocation.*",
+					),
+					ginkgo.Entry("should first increase (gu-container-1) CPU request/limit, afterwards fail to restore (gu-container-1) CPU request/limit and to increase (gu-container-2) CPU request/limit above available capacity",
+						// Initial
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount before first patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 2,
+							},
+							{
+								Name:     "gu-container-2",
+								cpuCount: 2,
+							},
+						},
+						// Desired first patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected after first patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount after first patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 4,
+							},
+							{
+								Name:     "gu-container-2",
+								cpuCount: 2,
+							},
+						},
+						// Want error after first patch
+						"",
+						// Desired second patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "40000m", CPULim: "40000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected after second patch
+						[]podresize.ResizableContainerInfo{
+							{
+								Name:             "gu-container-1",
+								Resources:        &cgroups.ContainerResources{CPUReq: "4000m", CPULim: "4000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+							{
+								Name:             "gu-container-2",
+								Resources:        &cgroups.ContainerResources{CPUReq: "2000m", CPULim: "2000m", MemReq: "200Mi", MemLim: "200Mi"},
+								HasExclusiveCPUs: true,
+							},
+						},
+						// Expected cpuCount after second patch
+						[]containerCPUInfo{
+							{
+								Name:     "gu-container-1",
+								cpuCount: 4,
+							},
+							{
+								Name:     "gu-container-2",
+								cpuCount: 2,
+							},
+						},
+						"Infeasible.*Node.*didn't.*have.*enough.*capacity.*",
+					),
+				)
+			}
+		})
+	},
+)
+
 // Matching helpers
+func WaitForPodResizePending(ctx context.Context, f *framework.Framework, testPod *v1.Pod) {
+	framework.ExpectNoError(e2epod.WaitForPodCondition(ctx, f.ClientSet, testPod.Namespace, testPod.Name, "display pod resize status as pending", f.Timeouts.PodStart, func(pod *v1.Pod) (bool, error) {
+		for _, condition := range pod.Status.Conditions {
+
+			if condition.Type == v1.PodResizePending {
+				return true, nil
+			}
+		}
+		return false, nil
+	}))
+}
+
+func WaitForPodResizeDeferred(ctx context.Context, f *framework.Framework, testPod *v1.Pod) {
+	framework.ExpectNoError(e2epod.WaitForPodCondition(ctx, f.ClientSet, testPod.Namespace, testPod.Name, "display pod resize status as deferred", f.Timeouts.PodStart, func(pod *v1.Pod) (bool, error) {
+		return helpers.IsPodResizeDeferred(pod), nil
+	}))
+}
+
+func WaitForPodResizeInfeasible(ctx context.Context, f *framework.Framework, testPod *v1.Pod) {
+	framework.ExpectNoError(e2epod.WaitForPodCondition(ctx, f.ClientSet, testPod.Namespace, testPod.Name, "display pod resize status as infeasible", f.Timeouts.PodStart, func(pod *v1.Pod) (bool, error) {
+		return helpers.IsPodResizeInfeasible(pod), nil
+	}))
+}
+
+func HaveStatusConditionsMatchingRegex(expr string) types.GomegaMatcher {
+	return gcustom.MakeMatcher(func(actual *v1.Pod) (bool, error) {
+		re, err := regexp.Compile(expr)
+		if err != nil {
+			return false, err
+		}
+		for _, condition := range actual.Status.Conditions {
+			if re.MatchString(fmt.Sprintf("%v", condition)) {
+				return true, nil
+			}
+		}
+		return false, nil
+	}).WithTemplate("Pod {{.Actual.Namespace}}/{{.Actual.Name}} UID {{.Actual.UID}} conditions {{.Actual.Status.Conditions}} does not match regexp {{.Data}}", expr)
+}
 
 func HaveStatusReasonMatchingRegex(expr string) types.GomegaMatcher {
 	return gcustom.MakeMatcher(func(actual *v1.Pod) (bool, error) {
@@ -4274,15 +7951,17 @@ func makeCPUManagerInitContainersPod(podName string, ctnAttributes []ctnAttribut
 }
 
 type cpuManagerKubeletArguments struct {
-	policyName                     string
-	topologyManagerPolicy          string
-	topologyManagerScope           string
-	enableCPUManagerOptions        bool
-	enablePodLevelResources        bool
-	customCPUCFSQuotaPeriod        time.Duration
-	enablePodLevelResourceManagers bool
-	reservedSystemCPUs             cpuset.CPUSet
-	options                        map[string]string
+	policyName                                   string
+	topologyManagerPolicy                        string
+	topologyManagerScope                         string
+	enableCPUManagerOptions                      bool
+	enablePodLevelResources                      bool
+	customCPUCFSQuotaPeriod                      time.Duration
+	enablePodLevelResourceManagers               bool
+	reservedSystemCPUs                           cpuset.CPUSet
+	options                                      map[string]string
+	enableInPlacePodVerticalScalingExclusiveCPUs bool
+	topologyManagerPolicyOptions                 map[string]string
 }
 
 func configureCPUManagerInKubelet(oldCfg *kubeletconfig.KubeletConfiguration, kubeletArguments *cpuManagerKubeletArguments) *kubeletconfig.KubeletConfiguration {
@@ -4299,6 +7978,7 @@ func configureCPUManagerInKubelet(oldCfg *kubeletconfig.KubeletConfiguration, ku
 		newCfg.FeatureGates["InPlacePodLevelResourcesVerticalScaling"] = kubeletArguments.enablePodLevelResources
 	}
 	newCfg.FeatureGates["PodLevelResourceManagers"] = kubeletArguments.enablePodLevelResourceManagers
+	newCfg.FeatureGates["InPlacePodVerticalScalingExclusiveCPUs"] = kubeletArguments.enableInPlacePodVerticalScalingExclusiveCPUs
 
 	if kubeletArguments.customCPUCFSQuotaPeriod != 0 {
 		newCfg.FeatureGates["CustomCPUCFSQuotaPeriod"] = true
@@ -4311,6 +7991,10 @@ func configureCPUManagerInKubelet(oldCfg *kubeletconfig.KubeletConfiguration, ku
 	newCfg.TopologyManagerPolicy = kubeletArguments.topologyManagerPolicy
 	newCfg.TopologyManagerScope = kubeletArguments.topologyManagerScope
 	newCfg.CPUManagerReconcilePeriod = metav1.Duration{Duration: 1 * time.Second}
+
+	if kubeletArguments.topologyManagerPolicyOptions != nil {
+		newCfg.TopologyManagerPolicyOptions = kubeletArguments.topologyManagerPolicyOptions
+	}
 
 	if kubeletArguments.options != nil {
 		newCfg.CPUManagerPolicyOptions = kubeletArguments.options

--- a/test/e2e_node/util_machineinfo_unsupported.go
+++ b/test/e2e_node/util_machineinfo_unsupported.go
@@ -57,3 +57,7 @@ func getNumaNodeCPUs() (map[int]cpuset.CPUSet, error) {
 func getCPUSocketID(cpuID int) (int, error) {
 	return -1, errors.New("not implemented")
 }
+
+func getSMTLevel() int {
+	return 1
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When pods with exlusive cpus are resized, this commit ensures the new allocated cpu quota limit will be set equal to request, when DisableCPUQuotaWithExclusiveCPUs is enabled ( enabled by default ). This commit is part of the preparation commits for InPlacePodVerticalScalingExclusiveCPUs feature.

Why we need this PR ?

Please check https://github.com/kubernetes/kubernetes/pull/129719#issuecomment-4777937514 , https://github.com/kubernetes/kubernetes/pull/129719#issuecomment-4778833474 , https://github.com/kubernetes/kubernetes/pull/129719#issuecomment-4777732973 and https://github.com/kubernetes/kubernetes/pull/129719#issuecomment-4842655251

#### Which issue(s) this PR is related to:

KEP https://github.com/kubernetes/enhancements/issues/5554

#### Special notes for your reviewer:
This is a AI-assisted DEMO for the split proposed in https://github.com/kubernetes/kubernetes/pull/129719#issuecomment-4981067970 . I took a random snapshot (the latest available when I did the split) and implemented the suggestion.

The commit messages were entirely auto-generated by the LLM. I was focusing on the commit shape, so review of the commit messages was cursory and minimal. Another reason why we **must never merge this PR** -  the commit message should be carrying the author intent, not anyone else's.

**THIS PR MUST NOT BE MERGED** but hopefully can help to reshape the final PR

Another reason why this PR must not be merged is that 
**auditing the commit to ensure the LLM didn't introduced subtle bugs in the rebase, or did subtle changes to authorship/metadata is a task rivalling in magnitude with reshaping the original PR, but much more error-prone**.

#### Does this PR introduce a user-facing change?
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
N/A