### PR TITLE
Fix NodeRestriction audience authz fallback on volume lookup error

### DIFF
--- a/plugin/pkg/admission/noderestriction/admission.go
+++ b/plugin/pkg/admission/noderestriction/admission.go
@@ -723,14 +723,17 @@ func (p *Plugin) validateNodeServiceAccountAudience(ctx context.Context, tr *aut
 		return fmt.Errorf("node may only request 0 or 1 audiences")
 	}
 
-	foundAudiencesInPodSpec, err := p.podReferencesAudience(ctx, pod, requestedAudience)
-	if err != nil {
-		return fmt.Errorf("error validating audience %q: %w", requestedAudience, err)
-	}
-	if foundAudiencesInPodSpec {
+	foundAudiencesInPodSpec, podRefErr := p.podReferencesAudience(ctx, pod, requestedAudience)
+	if podRefErr == nil && foundAudiencesInPodSpec {
 		return nil
 	}
 
+	// The pod spec does not reference the requested audience, or we could not
+	// determine whether it does because resolving the pod's volume sources failed
+	// (for example a referenced PVC, PV, or CSIDriver was not found). Either way,
+	// fall back to the authorizer so that an explicit grant of the
+	// request-serviceaccounts-token-audience verb still acts as an escape hatch,
+	// including on the error path.
 	attrs := buildAuthorizerAttributes(
 		a,
 		"request-serviceaccounts-token-audience",
@@ -738,14 +741,21 @@ func (p *Plugin) validateNodeServiceAccountAudience(ctx context.Context, tr *aut
 		a.GetName(), // This API operation is on the service account, so this is the SA name.
 	)
 
-	authorized, _, err := p.authz.Authorize(ctx, attrs)
+	authorized, _, authzErr := p.authz.Authorize(ctx, attrs)
 	// an authorizer like RBAC could encounter evaluation errors and still allow the request, so authorizer decision is checked before error here.
 	// following the same pattern as withAuthorization (ref: https://github.com/kubernetes/kubernetes/blob/2b025e645975d6d51bf38c008f972c632cf49657/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization.go#L71-L91)
 	if authorized == authorizer.DecisionAllow {
 		return nil
 	}
-	if err != nil {
-		return fmt.Errorf("error authorizing %s to request tokens for audience %q: %w", a.GetUserInfo().GetName(), requestedAudience, err)
+
+	// The authorizer did not allow the request. Surface the most actionable error:
+	// a failure to resolve the pod's audiences points at a real misconfiguration,
+	// so prefer it over the generic authorization errors.
+	if podRefErr != nil {
+		return fmt.Errorf("error validating audience %q: %w", requestedAudience, podRefErr)
+	}
+	if authzErr != nil {
+		return fmt.Errorf("error authorizing %s to request tokens for audience %q: %w", a.GetUserInfo().GetName(), requestedAudience, authzErr)
 	}
 
 	return fmt.Errorf("%s is not authorized to request tokens for audience %q", a.GetUserInfo().GetName(), requestedAudience)

--- a/plugin/pkg/admission/noderestriction/admission_test.go
+++ b/plugin/pkg/admission/noderestriction/admission_test.go
@@ -1502,7 +1502,7 @@ func Test_nodePlugin_Admit(t *testing.T) {
 			}.build(),
 		},
 		{
-			name:            "forbid create of token when audience in pod --> csi --> driver --> tokenrequest with audience and ServiceAccountNodeAudienceRestriction is enabled, csidriver not found",
+			name:            "forbid create of token when audience in pod --> csi --> driver --> tokenrequest with audience and ServiceAccountNodeAudienceRestriction is enabled, csidriver not found, authorizer denies",
 			podsGetter:      existingPods,
 			csiDriverGetter: noexistingCSIDriverLister,
 			features:        feature.DefaultFeatureGate,
@@ -1512,6 +1512,31 @@ func Test_nodePlugin_Admit(t *testing.T) {
 			},
 			attributes: admission.NewAttributesRecord(makeTokenRequest(coremypodWithCSI.Name, v1mypodWithCSI.UID, []string{"foo"}), nil, tokenrequestKind, coremypod.Namespace, "mysa", svcacctResource, "token", admission.Create, &metav1.CreateOptions{}, false, mynode),
 			err:        `error validating audience "foo": csidriver.storage.k8s.io "com.example.csi.mydriver" not found`,
+			authz: saAuthorizerBuilder{
+				t:                  t,
+				serviceAccountName: "mysa",
+				namespace:          coremypod.Namespace,
+				requestAudience:    "foo",
+				decision:           authorizer.DecisionDeny,
+			}.build(),
+		},
+		{
+			name:            "allow create of token when audience in pod --> csi --> driver --> tokenrequest with audience and ServiceAccountNodeAudienceRestriction is enabled, csidriver not found, authorizer allows",
+			podsGetter:      existingPods,
+			csiDriverGetter: noexistingCSIDriverLister,
+			features:        feature.DefaultFeatureGate,
+			setupFunc: func(t *testing.T) {
+				t.Helper()
+				featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.ServiceAccountNodeAudienceRestriction, true)
+			},
+			attributes: admission.NewAttributesRecord(makeTokenRequest(coremypodWithCSI.Name, v1mypodWithCSI.UID, []string{"foo"}), nil, tokenrequestKind, coremypod.Namespace, "mysa", svcacctResource, "token", admission.Create, &metav1.CreateOptions{}, false, mynode),
+			authz: saAuthorizerBuilder{
+				t:                  t,
+				serviceAccountName: "mysa",
+				namespace:          coremypod.Namespace,
+				requestAudience:    "foo",
+				decision:           authorizer.DecisionAllow,
+			}.build(),
 		},
 		{
 			name:            "allow create of token when audience in pod --> pvc --> pv --> csi --> driver --> tokenrequest with audience and ServiceAccountNodeAudienceRestriction is enabled",
@@ -1548,7 +1573,7 @@ func Test_nodePlugin_Admit(t *testing.T) {
 			}.build(),
 		},
 		{
-			name:            "forbid create of token when audience in pod --> pvc --> pv --> csi --> driver --> tokenrequest with audience and ServiceAccountNodeAudienceRestriction is enabled, pvc not found",
+			name:            "forbid create of token when audience in pod --> pvc --> pv --> csi --> driver --> tokenrequest with audience and ServiceAccountNodeAudienceRestriction is enabled, pvc not found, authorizer denies",
 			podsGetter:      existingPods,
 			csiDriverGetter: csiDriverLister,
 			pvcGetter:       noexistingPVCLister,
@@ -1560,9 +1585,36 @@ func Test_nodePlugin_Admit(t *testing.T) {
 			},
 			attributes: admission.NewAttributesRecord(makeTokenRequest(coremypodWithPVCRefCSI.Name, v1mypodWithPVCRefCSI.UID, []string{"foo"}), nil, tokenrequestKind, coremypod.Namespace, "mysa", svcacctResource, "token", admission.Create, &metav1.CreateOptions{}, false, mynode),
 			err:        `error validating audience "foo": persistentvolumeclaim "pvclaim" not found`,
+			authz: saAuthorizerBuilder{
+				t:                  t,
+				serviceAccountName: "mysa",
+				namespace:          coremypod.Namespace,
+				requestAudience:    "foo",
+				decision:           authorizer.DecisionDeny,
+			}.build(),
 		},
 		{
-			name:            "forbid create of token when audience in pod --> pvc --> pv --> csi --> driver --> tokenrequest with audience and ServiceAccountNodeAudienceRestriction is enabled, pv not found",
+			name:            "allow create of token when audience in pod --> pvc --> pv --> csi --> driver --> tokenrequest with audience and ServiceAccountNodeAudienceRestriction is enabled, pvc not found, authorizer allows",
+			podsGetter:      existingPods,
+			csiDriverGetter: csiDriverLister,
+			pvcGetter:       noexistingPVCLister,
+			pvGetter:        pvLister,
+			features:        feature.DefaultFeatureGate,
+			setupFunc: func(t *testing.T) {
+				t.Helper()
+				featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.ServiceAccountNodeAudienceRestriction, true)
+			},
+			attributes: admission.NewAttributesRecord(makeTokenRequest(coremypodWithPVCRefCSI.Name, v1mypodWithPVCRefCSI.UID, []string{"foo"}), nil, tokenrequestKind, coremypod.Namespace, "mysa", svcacctResource, "token", admission.Create, &metav1.CreateOptions{}, false, mynode),
+			authz: saAuthorizerBuilder{
+				t:                  t,
+				serviceAccountName: "mysa",
+				namespace:          coremypod.Namespace,
+				requestAudience:    "foo",
+				decision:           authorizer.DecisionAllow,
+			}.build(),
+		},
+		{
+			name:            "forbid create of token when audience in pod --> pvc --> pv --> csi --> driver --> tokenrequest with audience and ServiceAccountNodeAudienceRestriction is enabled, pv not found, authorizer denies",
 			podsGetter:      existingPods,
 			csiDriverGetter: csiDriverLister,
 			pvcGetter:       pvcLister,
@@ -1574,6 +1626,33 @@ func Test_nodePlugin_Admit(t *testing.T) {
 			},
 			attributes: admission.NewAttributesRecord(makeTokenRequest(coremypodWithPVCRefCSI.Name, v1mypodWithPVCRefCSI.UID, []string{"foo"}), nil, tokenrequestKind, coremypod.Namespace, "mysa", svcacctResource, "token", admission.Create, &metav1.CreateOptions{}, false, mynode),
 			err:        `error validating audience "foo": persistentvolume "pvname" not found`,
+			authz: saAuthorizerBuilder{
+				t:                  t,
+				serviceAccountName: "mysa",
+				namespace:          coremypod.Namespace,
+				requestAudience:    "foo",
+				decision:           authorizer.DecisionDeny,
+			}.build(),
+		},
+		{
+			name:            "allow create of token when audience in pod --> pvc --> pv --> csi --> driver --> tokenrequest with audience and ServiceAccountNodeAudienceRestriction is enabled, pv not found, authorizer allows",
+			podsGetter:      existingPods,
+			csiDriverGetter: csiDriverLister,
+			pvcGetter:       pvcLister,
+			pvGetter:        noexistingPVLister,
+			features:        feature.DefaultFeatureGate,
+			setupFunc: func(t *testing.T) {
+				t.Helper()
+				featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.ServiceAccountNodeAudienceRestriction, true)
+			},
+			attributes: admission.NewAttributesRecord(makeTokenRequest(coremypodWithPVCRefCSI.Name, v1mypodWithPVCRefCSI.UID, []string{"foo"}), nil, tokenrequestKind, coremypod.Namespace, "mysa", svcacctResource, "token", admission.Create, &metav1.CreateOptions{}, false, mynode),
+			authz: saAuthorizerBuilder{
+				t:                  t,
+				serviceAccountName: "mysa",
+				namespace:          coremypod.Namespace,
+				requestAudience:    "foo",
+				decision:           authorizer.DecisionAllow,
+			}.build(),
 		},
 		{
 			name:            "allow create of token when audience in pod --> ephemeral --> pvc --> pv --> csi --> driver --> tokenrequest with audience and ServiceAccountNodeAudienceRestriction is enabled",

--- a/test/integration/auth/node_test.go
+++ b/test/integration/auth/node_test.go
@@ -963,6 +963,42 @@ func TestNodeRestrictionServiceAccountAudience(t *testing.T) {
 		deletePod(t, superuserClient, "pod1")
 	})
 
+	t.Run("pod --> csi --> driver --> tokenrequest with audience allowed via authz bypass even when CSI driver not found", func(t *testing.T) {
+		cr := &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{Name: "audience-access-for-node1"},
+			Rules: []rbacv1.PolicyRule{{
+				APIGroups:     []string{""},
+				Resources:     []string{"csidrivernotfound-bypass-audience"},
+				Verbs:         []string{"request-serviceaccounts-token-audience"},
+				ResourceNames: []string{},
+			}},
+		}
+		crb := &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "audience-access-for-node1"},
+			Subjects:   []rbacv1.Subject{{Kind: "User", Name: "system:node:node1"}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "audience-access-for-node1"},
+		}
+
+		csiDriverVolumeSource := &corev1.CSIVolumeSource{Driver: "com.example.csi.mydriver"}
+		pod := createPod(t, superuserClient, []corev1.Volume{{Name: "foo", VolumeSource: corev1.VolumeSource{CSI: csiDriverVolumeSource}}})
+
+		// Without the authz grant, the missing CSI driver makes the request fail
+		// with the underlying lookup error.
+		expectedForbiddenMessage(t, createTokenRequest(node1Client, pod.UID, tokenRequestWithAudiences("csidrivernotfound-bypass-audience")), `error validating audience "csidrivernotfound-bypass-audience": csidriver.storage.k8s.io "com.example.csi.mydriver" not found`)
+
+		createRBACClusterRole(t, cr, superuserClient)
+		createRBACClusterRoleBinding(t, crb, superuserClient)
+
+		// The authz bypass must still take effect on the error path.
+		expectAllowed(t, createTokenRequest(node1Client, pod.UID, tokenRequestWithAudiences("csidrivernotfound-bypass-audience")))
+
+		deleteRBACClusterRole(t, cr, superuserClient)
+		deleteRBACClusterRoleBinding(t, crb, superuserClient)
+		// After the delete use a expectedForbiddenMessage to wait for the RBAC authorizer to catch up.
+		expectedForbiddenMessage(t, createTokenRequest(node1Client, pod.UID, tokenRequestWithAudiences("csidrivernotfound-bypass-audience")), `error validating audience "csidrivernotfound-bypass-audience": csidriver.storage.k8s.io "com.example.csi.mydriver" not found`)
+		deletePod(t, superuserClient, "pod1")
+	})
+
 	t.Run("pod --> csi --> driver --> tokenrequest with audience works", func(t *testing.T) {
 		createCSIDriver(t, superuserClient, "csidriver-audience", "com.example.csi.mydriver")
 		csiDriverVolumeSource := &corev1.CSIVolumeSource{Driver: "com.example.csi.mydriver"}


### PR DESCRIPTION
#### What this PR does / why we need it

When `ServiceAccountNodeAudienceRestriction` is enabled, NodeRestriction allows a
node to request a token audience if the pod references it OR the node holds the
`request-serviceaccounts-token-audience` authz grant. Previously, if resolving the
pod's CSI volume sources errored (CSIDriver/PVC/PV not found), the plugin returned
early and never consulted the authorizer, so the bypass didn't work on that path.

This falls back to the authorizer even when the volume lookup errors. Deny-by-default
is preserved: the only new allow path is gated on `authorizer.DecisionAllow`; on
denial the lookup error is surfaced first.

#### Which issue(s) this PR fixes

Fixes #140159

#### Does this PR introduce a user-facing change?

```release-note
Fixed the NodeRestriction admission plugin so the request-serviceaccounts-token-audience authorization check is still consulted when resolving a pod's CSI volume sources fails (e.g. a referenced CSIDriver, PVC, or PV is not found). This restores the authorizer bypass on the error path when the ServiceAccountNodeAudienceRestriction feature is enabled.
```

/kind bug
/sig auth
/priority important-soon
/milestone v1.37
/triage accepted