### PR TITLE
fix: replace stopped dynamic informers

### DIFF
--- a/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer.go
@@ -77,9 +77,10 @@ func (f *dynamicSharedInformerFactory) ForResource(gvr schema.GroupVersionResour
 
 	key := gvr
 	informer, exists := f.informers[key]
-	if exists {
+	if exists && !informer.Informer().IsStopped() {
 		return informer
 	}
+	delete(f.startedInformers, key)
 
 	informer = NewFilteredDynamicInformer(f.client, gvr, f.namespace, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 	f.informers[key] = informer

--- a/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
@@ -387,6 +388,51 @@ func TestDynamicSharedInformerFactory(t *testing.T) {
 				t.Errorf("tested informer haven't received an object, waited %v", timeout)
 			}
 		})
+	}
+}
+
+func TestDynamicSharedInformerFactoryReplacesStoppedInformer(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	fakeClient := fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "DeploymentList"},
+	)
+	factory := dynamicinformer.NewDynamicSharedInformerFactory(fakeClient, 0)
+
+	first := factory.ForResource(gvr)
+	if duplicate := factory.ForResource(gvr); duplicate != first {
+		t.Fatal("ForResource returned a new informer before the cached informer stopped")
+	}
+
+	firstCtx, stopFirst := context.WithTimeout(t.Context(), 5*time.Second)
+	factory.Start(firstCtx.Done())
+	if synced := factory.WaitForCacheSync(firstCtx.Done()); !synced[gvr] {
+		stopFirst()
+		t.Fatalf("first informer for %s did not sync", gvr)
+	}
+	stopFirst()
+	if err := wait.PollUntilContextTimeout(t.Context(), time.Millisecond, 5*time.Second, true, func(context.Context) (bool, error) {
+		return first.Informer().IsStopped(), nil
+	}); err != nil {
+		t.Fatalf("timed out waiting for first informer to stop: %v", err)
+	}
+
+	replacement := factory.ForResource(gvr)
+	if replacement == first {
+		t.Fatal("ForResource returned the stopped informer")
+	}
+	if duplicate := factory.ForResource(gvr); duplicate != replacement {
+		t.Fatal("ForResource did not cache the replacement informer")
+	}
+
+	replacementCtx, stopReplacement := context.WithTimeout(t.Context(), 5*time.Second)
+	factory.Start(replacementCtx.Done())
+	defer func() {
+		stopReplacement()
+		factory.Shutdown()
+	}()
+	if synced := factory.WaitForCacheSync(replacementCtx.Done()); !synced[gvr] {
+		t.Fatalf("replacement informer for %s did not sync", gvr)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig api-machinery

#### What this PR does / why we need it:

`DynamicSharedInformerFactory.ForResource` now replaces a cached informer after that informer has stopped. It also clears the factory's started-state entry so a later `Start` call runs and synchronizes the replacement.

Active informers remain cached and are returned unchanged.

#### Which issue(s) this PR is related to:

Fixes #138800

#### Special notes for your reviewer:

The regression test covers the complete factory lifecycle: cache reuse while active, replacement after stop, reuse of the replacement, and restart/cache synchronization through the factory.

#### Testing

- `go test ./...` in the published client-go module
- `go test -race ./dynamic/dynamicinformer -run '^TestDynamicSharedInformerFactoryReplacesStoppedInformer$' -count=10`
- `GOWORK=off go test ./dynamic/dynamicinformer` in the Kubernetes staging module
- `GOWORK=off go test -race ./dynamic/dynamicinformer -run '^TestDynamicSharedInformerFactoryReplacesStoppedInformer$' -count=3`

#### Does this PR introduce a user-facing change?

```release-note
Dynamic shared informer factories now return a fresh informer from ForResource after the previously cached informer has stopped.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
