### PR TITLE
kubectl: complete debug targets correctly

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -251,7 +251,7 @@ func NewKubectlCommand(o KubectlOptions) *cobra.Command {
 	getCmd := get.NewCmdGet("kubectl", f, o.IOStreams)
 	getCmd.ValidArgsFunction = utilcomp.ResourceTypeAndNameCompletionFunc(f)
 	debugCmd := debug.NewCmdDebug(f, o.IOStreams)
-	debugCmd.ValidArgsFunction = utilcomp.ResourceTypeAndNameCompletionFunc(f)
+	debugCmd.ValidArgsFunction = utilcomp.DebugResourceNameCompletionFunc(f)
 
 	groups := templates.CommandGroups{
 		{

--- a/staging/src/k8s.io/kubectl/pkg/util/completion/completion.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/completion/completion.go
@@ -95,6 +95,41 @@ func PodResourceNameCompletionFunc(f cmdutil.Factory) func(*cobra.Command, []str
 	}
 }
 
+// DebugResourceNameCompletionFunc returns a completion function for the resource targeted by
+// kubectl debug. Bare names are completed as pods, and pods and nodes are offered for the
+// <type>/<name> form.
+func DebugResourceNameCompletionFunc(f cmdutil.Factory) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		directive := cobra.ShellCompDirectiveNoFileComp
+		if len(args) > 0 {
+			return nil, directive
+		}
+
+		resourceType, namePrefix, hasSlash := strings.Cut(toComplete, "/")
+		if hasSlash {
+			nameComps := CompGetResource(f, resourceType, namePrefix)
+			comps := make([]string, 0, len(nameComps))
+			for _, name := range nameComps {
+				comps = append(comps, fmt.Sprintf("%s/%s", resourceType, name))
+			}
+			return comps, directive
+		}
+
+		comps := CompGetResource(f, "pods", toComplete)
+		hasPodComps := len(comps) > 0
+		for _, resource := range []string{"nodes", "pods"} {
+			if strings.HasPrefix(resource, toComplete) {
+				comps = append(comps, resource+"/")
+			}
+		}
+
+		if !hasPodComps {
+			directive |= cobra.ShellCompDirectiveNoSpace
+		}
+		return comps, directive
+	}
+}
+
 // ResourceAndPortCompletionFunc Returns a completion function that completes, as a first argument:
 // 1- resources that match the toComplete prefix
 // 2- the ports of the specific resource. i.e: container ports for pod resources and port for services

--- a/staging/src/k8s.io/kubectl/pkg/util/completion/completion_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/completion/completion_test.go
@@ -330,6 +330,69 @@ func TestPodResourceNameCompletionFuncJointFormTooManyArgs(t *testing.T) {
 	checkCompletion(t, comps, []string{}, directive, cobra.ShellCompDirectiveNoFileComp)
 }
 
+func TestDebugResourceNameCompletionFunc(t *testing.T) {
+	testCases := []struct {
+		name              string
+		obj               runtime.Object
+		args              []string
+		toComplete        string
+		expectedComps     []string
+		expectedDirective cobra.ShellCompDirective
+	}{
+		{
+			name:              "pod names",
+			obj:               &corev1.PodList{Items: []corev1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: "bar"}}, {ObjectMeta: metav1.ObjectMeta{Name: "foo"}}}},
+			toComplete:        "b",
+			expectedComps:     []string{"bar"},
+			expectedDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:              "resource types",
+			obj:               &corev1.PodList{},
+			toComplete:        "",
+			expectedComps:     []string{"nodes/", "pods/"},
+			expectedDirective: cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace,
+		},
+		{
+			name:              "pod type and name",
+			obj:               &corev1.PodList{Items: []corev1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: "bar"}}, {ObjectMeta: metav1.ObjectMeta{Name: "foo"}}}},
+			toComplete:        "pods/b",
+			expectedComps:     []string{"pods/bar"},
+			expectedDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:              "node type and name",
+			obj:               &corev1.NodeList{Items: []corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "bar"}}, {ObjectMeta: metav1.ObjectMeta{Name: "foo"}}}},
+			toComplete:        "nodes/f",
+			expectedComps:     []string{"nodes/foo"},
+			expectedDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:              "singular resource type",
+			obj:               &corev1.NodeList{Items: []corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "bar"}}}},
+			toComplete:        "node/b",
+			expectedComps:     []string{"node/bar"},
+			expectedDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:              "target already provided",
+			obj:               &corev1.PodList{},
+			args:              []string{"bar"},
+			expectedDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tf, cmd := prepareCompletionTest()
+			addResourceToFactory(tf, tc.obj)
+
+			comps, directive := DebugResourceNameCompletionFunc(tf)(cmd, tc.args, tc.toComplete)
+			checkCompletion(t, comps, tc.expectedComps, directive, tc.expectedDirective)
+		})
+	}
+}
+
 func TestResourceAndContainerNameCompletionFunc(t *testing.T) {
 	barPod := getTestPod()
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig cli

#### What this PR does / why we need it:

kubectl debug currently uses the general resource type-and-name completer. As a result, completion starts by suggesting resource types and can produce a separate type and name even though debug expects a single target argument.

This change adds a debug-specific completer that:

- suggests pod names directly for bare targets
- offers pods/ and nodes/ for explicit resource targets
- completes names after the slash while preserving singular resource forms
- stops suggesting additional targets after one has already been supplied

The focused tests cover bare pod names, pod and node resource forms, singular resource types, shell directives, and the single-target constraint.

#### Which issue(s) this PR is related to:

Fixes kubernetes/kubectl#1861

#### Special notes for your reviewer:

The full mirror command go test ./... was started and passed the affected packages, including pkg/cmd, pkg/cmd/debug, pkg/cmd/completion, and pkg/util/completion. It was interrupted after 141 seconds in an unrelated existing pkg/cmd/diff test because the macOS system diff process does not terminate when comparing /dev/zero with itself.

Focused canonical staging checks pass:

- GOWORK=off go test ./pkg/util/completion ./pkg/cmd
- GOWORK=off go vet ./pkg/util/completion ./pkg/cmd

#### Does this PR introduce a user-facing change?

```release-note
kubectl debug shell completion now suggests pod names directly and preserves pod and node type/name completion.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```