### PR TITLE
scheduler: update requeue-assumed-PodGroup test

### DIFF
--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -521,17 +521,28 @@ func TestScheduleOnePodGroup_FinishesAttemptWhenAllPoppedPodsAreAssumed(t *testi
 			}
 
 			cache := internalcache.New(ctx, nil, true, false)
+			queue := internalqueue.NewTestQueue(ctx, schedFwk.QueueSortFunc())
+
 			cache.AddPodGroup(podGroup)
+			queue.AddPodGroup(logger, podGroup)
+
+			// 1. p1 is added to the queue, its PodGroup is popped, and its scheduling cycle succeeds.
+			// The pod gets assumed in the cache and proceeds to binding.
 			cache.AddPodGroupMember(p1)
+
+			// 2. An assumed pod can only re-enter the queue due to a subtle race condition:
+			// an update event arrives, the event handler sees `isAssumed=false` and calls `queue.Update()`.
+			// Right before `Update()` acquires the lock, the main scheduling loop assumes the pod
+			// and calls `Done()`, removing it from `inFlightPods`. The `Update()` logic then falls
+			// through and adds the now-assumed pod back to the queue.
 			assumedP1 := p1.DeepCopy()
 			assumedP1.Spec.NodeName = "node1"
 			if err := cache.AssumePod(logger, assumedP1); err != nil {
 				t.Fatalf("Failed to assume pod: %v", err)
 			}
+			queue.Update(ctx, p1, p1)
 
-			queue := internalqueue.NewTestQueue(ctx, schedFwk.QueueSortFunc())
-			queue.AddPodGroup(logger, podGroup)
-			queue.Add(ctx, p1)
+			// 3. During the next cycle, the PodGroup is popped again and contains only the assumed pod.
 			entity, err := queue.Pop(logger)
 			if err != nil {
 				t.Fatalf("Failed to pop pod group: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

/wg workload-aware-scheduling

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR addresses [feedback](https://github.com/kubernetes/kubernetes/pull/140478#pullrequestreview-4703468341) from #140478 to better illustrate the scenario exercised by the new test added by that PR. 

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
