### PR TITLE
Remove deprecated wait.NewExponentialBackoffManager from csi_attacher

### DIFF
--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -483,16 +484,20 @@ func (c *csiAttacher) waitForVolumeDetachmentWithLister(volumeHandle, attachID s
 }
 
 func (c *csiAttacher) waitForVolumeAttachDetachStatusWithLister(spec *volume.Spec, volumeHandle, attachID string, timeout time.Duration, verifyStatus func() (bool, error), operation string) error {
-	var (
-		initBackoff = 500 * time.Millisecond
+	clock := &clock.RealClock{}
+	backoff := wait.Backoff{
+		Duration: 500 * time.Millisecond,
+		Factor:   1.05,
+		Jitter:   0.1,
+		// Steps is set to MaxInt32 to mirror the behavior of the removed
+		// wait.NewExponentialBackoffManager, which never exhausted its steps so the
+		// backoff kept increasing up to Cap and then held there.
+		Steps: math.MaxInt32,
 		// This is approximately the duration between consecutive ticks after two minutes (CSI timeout).
-		maxBackoff    = 7 * time.Second
-		resetDuration = time.Minute
-		backoffFactor = 1.05
-		jitter        = 0.1
-		clock         = &clock.RealClock{}
-	)
-	backoffMgr := wait.NewExponentialBackoffManager(initBackoff, maxBackoff, resetDuration, backoffFactor, jitter, clock)
+		Cap: 7 * time.Second,
+	}
+	timer := backoff.DelayWithReset(clock, time.Minute).Timer(clock)
+	defer timer.Stop()
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -505,9 +510,8 @@ func (c *csiAttacher) waitForVolumeAttachDetachStatusWithLister(spec *volume.Spe
 	}
 
 	for {
-		t := backoffMgr.Backoff()
 		select {
-		case <-t.C():
+		case <-timer.C():
 			successful, err := verifyStatus()
 			if err != nil {
 				return err
@@ -515,8 +519,8 @@ func (c *csiAttacher) waitForVolumeAttachDetachStatusWithLister(spec *volume.Spe
 			if successful {
 				return nil
 			}
+			timer.Next()
 		case <-ctx.Done():
-			t.Stop()
 			klog.Error(log("%s timeout after %v [volume=%v; attachment.ID=%v]", operation, timeout, volumeHandle, attachID))
 			return fmt.Errorf("timed out waiting for external-attacher of %v CSI driver to %v volume %v", csiDriverName, strings.ToLower(operation), volumeHandle)
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig storage

#### What this PR does / why we need it:

`pkg/volume/csi/csi_attacher.go` held the last remaining use of the deprecated `wait.NewExponentialBackoffManager`. This PR migrates it to `wait.Backoff{...}.DelayWithReset(clock, resetDuration).Timer(clock)`, following the same pattern already merged in #136824 and #137066, and completes the removal effort tracked in #136823.

Behavior is preserved. Because this call site uses a small `Factor` (1.05), `Steps` is set to `math.MaxInt32` — exactly what the removed `NewExponentialBackoffManager` used internally — so the backoff keeps growing up to `Cap` (7s) and then holds there, and the per-minute reset is retained via `DelayWithReset`.

#### Which issue(s) this PR is related to:

Fixes #137068

#### Special notes for your reviewer:

- No functional change; only the deprecated backoff helper is replaced.
- The wait loop now creates a single `wait.Timer` and advances it with `Next()` after each check, with `defer timer.Stop()` for cleanup.
- Verified locally: `go build`, `go vet`, `gofmt`, and `go test ./pkg/volume/csi/` all pass.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
