### PR TITLE
fix: initialize clusterip allocator metrics on EnableMetrics

### DIFF
--- a/pkg/registry/core/service/ipallocator/bitmap.go
+++ b/pkg/registry/core/service/ipallocator/bitmap.go
@@ -341,6 +341,9 @@ func (r *Range) Destroy() {
 func (r *Range) EnableMetrics() {
 	registerMetrics()
 	r.metrics = &metricsRecorder{}
+	label := r.CIDR()
+	r.metrics.setAllocated(label.String(), r.Used())
+	r.metrics.setAvailable(label.String(), r.Free())
 }
 
 // calculateIPOffset calculates the integer offset of ip from base such that

--- a/pkg/registry/core/service/ipallocator/bitmap_test.go
+++ b/pkg/registry/core/service/ipallocator/bitmap_test.go
@@ -451,14 +451,14 @@ func TestClusterIPMetrics(t *testing.T) {
 
 	// Check initial state
 	em := testMetrics{
-		free:      0,
+		free:      254,
 		used:      0,
 		allocated: 0,
 		errors:    0,
 	}
 	expectMetrics(t, cidrIPv4, em)
 	em = testMetrics{
-		free:      0,
+		free:      65535,
 		used:      0,
 		allocated: 0,
 		errors:    0,
@@ -554,7 +554,7 @@ func TestClusterIPAllocatedMetrics(t *testing.T) {
 	a.EnableMetrics()
 
 	em := testMetrics{
-		free:      0,
+		free:      126,
 		used:      0,
 		allocated: 0,
 		errors:    0,
@@ -620,7 +620,7 @@ func TestMetricsDisabled(t *testing.T) {
 
 	// Check initial state
 	em := testMetrics{
-		free:      0,
+		free:      254,
 		used:      0,
 		allocated: 0,
 		errors:    0,

--- a/pkg/registry/core/service/ipallocator/cidrallocator_test.go
+++ b/pkg/registry/core/service/ipallocator/cidrallocator_test.go
@@ -821,7 +821,7 @@ func TestCIDRAllocatorClusterIPAllocatedMetrics(t *testing.T) {
 
 	// Check initial metrics for first CIDR
 	em1 := testMetrics{
-		free:      0,
+		free:      2,
 		used:      0,
 		allocated: 0,
 		errors:    0,
@@ -880,7 +880,7 @@ func TestCIDRAllocatorClusterIPAllocatedMetrics(t *testing.T) {
 
 	// Check initial metrics for second CIDR
 	em2 := testMetrics{
-		free:      0,
+		free:      6,
 		used:      0,
 		allocated: 0,
 		errors:    0,

--- a/pkg/registry/core/service/ipallocator/ipallocator.go
+++ b/pkg/registry/core/service/ipallocator/ipallocator.go
@@ -488,6 +488,8 @@ func (a *Allocator) DryRun() Interface {
 func (a *Allocator) EnableMetrics() {
 	registerMetrics()
 	a.metrics = &metricsRecorder{}
+	a.metrics.setAllocated(a.metricLabel, a.Used())
+	a.metrics.setAvailable(a.metricLabel, a.Free())
 }
 
 // dryRunRange is a shim to satisfy Interface without persisting state.

--- a/pkg/registry/core/service/ipallocator/ipallocator_test.go
+++ b/pkg/registry/core/service/ipallocator/ipallocator_test.go
@@ -430,14 +430,14 @@ func TestIPAllocatorClusterIPMetrics(t *testing.T) {
 
 	// Check initial state
 	em := testMetrics{
-		free:      0,
+		free:      254,
 		used:      0,
 		allocated: 0,
 		errors:    0,
 	}
 	expectMetrics(t, cidrIPv4, em)
 	em = testMetrics{
-		free:      0,
+		free:      65535, // IPv6 clusterIP range is capped to 2^16 and considers the broadcast address as valid
 		used:      0,
 		allocated: 0,
 		errors:    0,
@@ -521,6 +521,35 @@ func TestIPAllocatorClusterIPMetrics(t *testing.T) {
 	expectMetrics(t, cidrIPv6, em)
 }
 
+func TestIPAllocatorEnableMetricsInitializesGauges(t *testing.T) {
+	clearMetrics()
+	cidr := "10.1.0.0/16"
+	_, clusterCIDR, err := netutils.ParseCIDRSloppy(cidr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, err := newTestAllocator(clusterCIDR)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.EnableMetrics()
+
+	if _, err := testutil.GetGaugeMetricValue(clusterIPAvailable.WithLabelValues(cidr)); err != nil {
+		t.Fatalf("available_ips gauge missing for %s before any allocation: %v", cidr, err)
+	}
+	if _, err := testutil.GetGaugeMetricValue(clusterIPAllocated.WithLabelValues(cidr)); err != nil {
+		t.Fatalf("allocated_ips gauge missing for %s before any allocation: %v", cidr, err)
+	}
+
+	em := testMetrics{
+		free:      65534,
+		used:      0,
+		allocated: 0,
+		errors:    0,
+	}
+	expectMetrics(t, cidr, em)
+}
+
 func TestIPAllocatorClusterIPAllocatedMetrics(t *testing.T) {
 	clearMetrics()
 	// create IPv4 allocator
@@ -533,7 +562,7 @@ func TestIPAllocatorClusterIPAllocatedMetrics(t *testing.T) {
 	a.EnableMetrics()
 
 	em := testMetrics{
-		free:      0,
+		free:      126,
 		used:      0,
 		allocated: 0,
 		errors:    0,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`EnableMetrics()` on the IPAddress-based and bitmap ClusterIP allocators registered the metrics recorder but did not publish `available_ips` or `allocated_ips` gauge values. After a kube-apiserver restart, extension ServiceCIDR allocators had no `kube_apiserver_clusterip_allocator_available_ips` series until the next allocate or release.

This PR initializes both gauges from the current allocator state when metrics are enabled.

#### Which issue(s) this PR is related to:

Fixes #140613

#### Special notes for your reviewer:

None.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a gap where `kube_apiserver_clusterip_allocator_available_ips` was not exported for ServiceCIDR allocators on freshly started kube-apiserver instances until the next ClusterIP allocation or release.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```