### PR TITLE
Add warning to CRDs for use of non-scalar items in sets

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apiserver/pkg/cel/environment"
@@ -138,6 +139,8 @@ func (strategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []stri
 		warnings = append(warnings, fmt.Sprintf("unrecognized format %q", format))
 	}
 
+	warnings = append(warnings, getNonScalarListTypeSetWarnings(&newCRD.Spec)...)
+
 	return warnings
 }
 
@@ -193,6 +196,14 @@ func (strategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) [
 		warnings = append(warnings, fmt.Sprintf("unrecognized format %q", format))
 	}
 
+	seen := sets.New[string]()
+	seen.Insert(getNonScalarListTypeSetWarnings(&oldCRD.Spec)...)
+	for _, w := range getNonScalarListTypeSetWarnings(&newCRD.Spec) {
+		if !seen.Has(w) {
+			warnings = append(warnings, w)
+		}
+	}
+
 	return warnings
 }
 
@@ -213,6 +224,31 @@ func getUnrecognizedFormatsInCRD(spec *apiextensions.CustomResourceDefinitionSpe
 	}
 
 	return unrecognizedFormats
+}
+
+// getNonScalarListTypeSetWarnings returns warning messages for schema fields
+// declaring x-kubernetes-list-type: set with non-scalar items anywhere in the
+// CRD's schemas. The output is sorted to ensure warnings are displayed in a stable order.
+func getNonScalarListTypeSetWarnings(spec *apiextensions.CustomResourceDefinitionSpec) []string {
+	seen := sets.New[string]()
+	check := func(s *apiextensions.JSONSchemaProps) bool {
+		if s.XListType != nil && *s.XListType == "set" && s.Items != nil && s.Items.Schema != nil {
+			switch s.Items.Schema.Type {
+			case "object", "array":
+				seen.Insert(fmt.Sprintf("x-kubernetes-list-type: set for items of type %q is not supported by server-side apply or CEL validation rules", s.Items.Schema.Type))
+			}
+		}
+		return false // continue traversing
+	}
+	if spec.Validation != nil && spec.Validation.OpenAPIV3Schema != nil {
+		validation.SchemaHas(spec.Validation.OpenAPIV3Schema, check)
+	}
+	for _, v := range spec.Versions {
+		if v.Schema != nil && v.Schema.OpenAPIV3Schema != nil {
+			validation.SchemaHas(v.Schema.OpenAPIV3Schema, check)
+		}
+	}
+	return sets.List(seen)
 }
 
 // getUnrecognizedFormatsInSchema recursively traverses the schema and collects unrecognized formats.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy_test.go
@@ -18,6 +18,7 @@ package customresourcedefinition
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"testing"
 
@@ -49,6 +50,35 @@ func mkCRD(tweaks ...func(*apiextensions.CustomResourceDefinitionSpec)) *apiexte
 	}
 
 	return crd
+}
+
+// withListTypeSetItems appends a version whose openAPIV3Schema has one
+// top-level property (fieldName) of type array with x-kubernetes-list-type: set
+// and items of the given itemType. Reused across create/update warning tests.
+func withListTypeSetItems(itemType, fieldName string) func(*apiextensions.CustomResourceDefinitionSpec) {
+	return func(spec *apiextensions.CustomResourceDefinitionSpec) {
+		setType := "set"
+		version := apiextensions.CustomResourceDefinitionVersion{
+			Name:    fmt.Sprintf("v%d", len(spec.Versions)+1),
+			Served:  true,
+			Storage: len(spec.Versions) == 0,
+			Schema: &apiextensions.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+					Type: "object",
+					Properties: map[string]apiextensions.JSONSchemaProps{
+						fieldName: {
+							Type:      "array",
+							XListType: &setType,
+							Items: &apiextensions.JSONSchemaPropsOrArray{
+								Schema: &apiextensions.JSONSchemaProps{Type: itemType},
+							},
+						},
+					},
+				},
+			},
+		}
+		spec.Versions = append(spec.Versions, version)
+	}
 }
 
 func TestValidateAPIApproval(t *testing.T) {
@@ -1561,6 +1591,88 @@ func TestWarningsOnCreate(t *testing.T) {
 				})
 			}),
 		},
+		"listType=set on object items": {
+			wantWarningMessages: []string{
+				`x-kubernetes-list-type: set for items of type "object" is not supported by server-side apply or CEL validation rules`,
+			},
+			crd: mkCRD(withListTypeSetItems("object", "endpoints")),
+		},
+		"listType=set on array items": {
+			wantWarningMessages: []string{
+				`x-kubernetes-list-type: set for items of type "array" is not supported by server-side apply or CEL validation rules`,
+			},
+			crd: mkCRD(withListTypeSetItems("array", "cidrGroups")),
+		},
+		"listType=set on both object and array items reports each type": {
+			wantWarningMessages: []string{
+				`x-kubernetes-list-type: set for items of type "array" is not supported by server-side apply or CEL validation rules`,
+				`x-kubernetes-list-type: set for items of type "object" is not supported by server-side apply or CEL validation rules`,
+			},
+			crd: mkCRD(withListTypeSetItems("object", "endpoints"), withListTypeSetItems("array", "cidrGroups")),
+		},
+		"listType=set on scalar items is not flagged": {
+			wantWarningMessages: []string{},
+			crd:                 mkCRD(withListTypeSetItems("string", "verbs")),
+		},
+		"listType=set nested under items and properties is detected": {
+			wantWarningMessages: []string{
+				`x-kubernetes-list-type: set for items of type "object" is not supported by server-side apply or CEL validation rules`,
+			},
+			crd: mkCRD(func(spec *apiextensions.CustomResourceDefinitionSpec) {
+				setType := "set"
+				spec.Versions = append(spec.Versions, apiextensions.CustomResourceDefinitionVersion{
+					Name:    "v1",
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensions.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]apiextensions.JSONSchemaProps{
+								"outer": {
+									Type: "array",
+									Items: &apiextensions.JSONSchemaPropsOrArray{
+										Schema: &apiextensions.JSONSchemaProps{
+											Type: "object",
+											Properties: map[string]apiextensions.JSONSchemaProps{
+												"inner": {
+													Type:      "array",
+													XListType: &setType,
+													Items: &apiextensions.JSONSchemaPropsOrArray{
+														Schema: &apiextensions.JSONSchemaProps{Type: "object"},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				})
+			}),
+		},
+		"listType=set in top-level validation schema": {
+			wantWarningMessages: []string{
+				`x-kubernetes-list-type: set for items of type "object" is not supported by server-side apply or CEL validation rules`,
+			},
+			crd: mkCRD(func(spec *apiextensions.CustomResourceDefinitionSpec) {
+				setType := "set"
+				spec.Validation = &apiextensions.CustomResourceValidation{
+					OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+						Type: "object",
+						Properties: map[string]apiextensions.JSONSchemaProps{
+							"endpoints": {
+								Type:      "array",
+								XListType: &setType,
+								Items: &apiextensions.JSONSchemaPropsOrArray{
+									Schema: &apiextensions.JSONSchemaProps{Type: "object"},
+								},
+							},
+						},
+					},
+				}
+			}),
+		},
 	}
 
 	for name, tc := range testcases {
@@ -1756,6 +1868,18 @@ func TestWarningsOnUpdate(t *testing.T) {
 					},
 				})
 			}),
+		},
+		"pre-existing listType=set on object items does not warn on update": {
+			wantWarningMessages: []string{},
+			oldCRD:              mkCRD(withListTypeSetItems("object", "endpoints")),
+			newCRD:              mkCRD(withListTypeSetItems("object", "endpoints")),
+		},
+		"newly introduced listType=set on array items warns": {
+			wantWarningMessages: []string{
+				`x-kubernetes-list-type: set for items of type "array" is not supported by server-side apply or CEL validation rules`,
+			},
+			oldCRD: mkCRD(withListTypeSetItems("object", "endpoints")),
+			newCRD: mkCRD(withListTypeSetItems("object", "endpoints"), withListTypeSetItems("array", "cidrGroups")),
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

As described in https://github.com/kubernetes/kubernetes/issues/114613, SSA does not support sets of non-scalar items.

In https://github.com/kubernetes/kubernetes/pull/140293#pullrequestreview-4705355233 we decided not to support non-scalar items in CEL either.

This adds a warning to CRD authors about these limitations.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

