### PR TITLE
build: also package Windows release artifacts as .zip

### DIFF
--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -114,6 +114,11 @@ function kube::release::package_client_tarballs() {
 
       local package_name="${RELEASE_TARS}/kubernetes-client-${platform_tag}.tar.gz"
       kube::release::create_tarball "${package_name}" "${release_stage}/.."
+
+      # Orgs commonly block .exe downloads, so also offer Windows clients as a .zip.
+      if [[ "${platform%/*}" = 'windows' ]]; then
+        kube::release::create_zip "${package_name%.tar.gz}.zip" "${release_stage}/.."
+      fi
     ) &
   done
 
@@ -168,6 +173,10 @@ function kube::release::package_node_tarballs() {
 
     local package_name="${RELEASE_TARS}/kubernetes-node-${platform_tag}.tar.gz"
     kube::release::create_tarball "${package_name}" "${release_stage}/.."
+
+    if [[ "${platform%/*}" = 'windows' ]]; then
+      kube::release::create_zip "${package_name%.tar.gz}.zip" "${release_stage}/.."
+    fi
   done
 }
 
@@ -248,6 +257,10 @@ function kube::release::package_server_tarballs() {
     local package_name
     package_name="${RELEASE_TARS}/kubernetes-server-${platform_tag}.tar.gz"
     kube::release::create_tarball "${package_name}" "${release_stage}/.."
+
+    if [[ "${platform%/*}" = 'windows' ]]; then
+      kube::release::create_zip "${package_name%.tar.gz}.zip" "${release_stage}/.."
+    fi
   done
 }
 
@@ -560,4 +573,22 @@ function kube::release::create_tarball() {
   local stagingdir=$2
 
   "${TAR}" czf "${tarfile}" -C "${stagingdir}" kubernetes --owner=0 --group=0
+}
+
+# Build a release zip.  $1 is the output zip name.  $2 is the base directory
+# of the files to be packaged.  This assumes that ${2}/kubernetes is what is
+# being packaged.  Used for Windows artifacts, since some organizations block
+# downloads of .exe files that aren't wrapped in a .zip.
+function kube::release::create_zip() {
+  if ! command -v zip &>/dev/null; then
+    kube::log::error "zip not found; unable to create ${1}"
+    return 1
+  fi
+
+  local zipfile=$1
+  local stagingdir=$2
+
+  # -X drops extra file attributes (uid/gid, timestamps beyond mtime) to keep
+  # the zip reproducible, mirroring --owner=0 --group=0 above for the tarball.
+  (cd "${stagingdir}" && zip -Xrq "${zipfile}" kubernetes)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Many organizations block downloads of `.exe` files that aren't wrapped in a `.zip`, so Windows binaries shipped only as `.tar.gz` are hard to fetch in those environments. This PR adds a `create_zip` helper alongside the existing `create_tarball` one, and calls it from `package_client_tarballs`, `package_node_tarballs`, and `package_server_tarballs` whenever the target platform is windows, reusing the same staged release directory that's already tarred so nothing is re-staged.

#### Which issue(s) this PR is related to:

Fixes kubernetes/kubernetes#124435

#### Special notes for your reviewer:

The zip is built from the same staging directory used for the tarball, so no additional staging work or duplication of release contents is introduced.

#### Does this PR introduce a user-facing change?

```release-note
Windows release artifacts (client, node, and server tarballs) are now also packaged as `.zip` archives in addition to `.tar.gz`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
