### PR TITLE
scheduler: fix data race in handleSchedulingFailure

### DIFF
--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -1192,6 +1192,7 @@ func getAttemptsLabel(p *framework.QueuedPodInfo) string {
 // handleSchedulingFailure records an event for the pod that indicates the
 // pod has failed to schedule. Also, update the pod condition and nominated node name if set.
 func (sched *Scheduler) handleSchedulingFailure(ctx context.Context, podFwk framework.Framework, podInfo *framework.QueuedPodInfo, status *fwk.Status, nominatingInfo *fwk.NominatingInfo, start time.Time) {
+	podInfo = podInfo.DeepCopy()
 	calledDone := false
 	defer func() {
 		if !calledDone {


### PR DESCRIPTION
Fixes kubernetes/kubernetes#140541

### Description
This PR resolves a data race condition in the scheduler's `handleSchedulingFailure` function. The race occurred because the scheduler concurrently reads/writes the podInfo object while `handleSchedulingFailure` is processing. By performing a `DeepCopy` of the `podInfo` struct at the beginning of the function, we guarantee safe concurrent access and prevent data races.

### Verification
Verified that the scheduler tests compile and pass successfully.

```release-note
Fixed a concurrent map read/write data race condition in `handleSchedulingFailure` during scheduling failure handling.
```