### PR TITLE
validation: ratchet empty NodeSelectorTerm validation in pod node affinity

### DIFF
--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -432,6 +432,7 @@ func GetValidationOptionsFromPodSpecAndMeta(podSpec, oldPodSpec *api.PodSpec, po
 		AllowRestartAllContainers:                               utilfeature.DefaultFeatureGate.Enabled(features.RestartAllContainersOnContainerExits),
 		AllowImageVolumeWithDigest:                              utilfeature.DefaultFeatureGate.Enabled(features.ImageVolumeWithDigest),
 		AllowExistingRestartContainerForNonSidecarInitContainer: hasRestartContainerForNonSidecarInitContainer(oldPodSpec),
+		AllowEmptyNodeSelectorTerm:                              !utilfeature.DefaultFeatureGate.Enabled(features.ValidateEmptyNodeSelectorTerm),
 	}
 
 	// If old spec uses relaxed validation or enabled the RelaxedEnvironmentVariableValidation feature gate,
@@ -449,6 +450,9 @@ func GetValidationOptionsFromPodSpecAndMeta(podSpec, oldPodSpec *api.PodSpec, po
 
 		opts.AllowInvalidLabelValueInSelector = hasInvalidLabelValueInAffinitySelector(oldPodSpec)
 		opts.AllowInvalidLabelValueInRequiredNodeAffinity = hasInvalidLabelValueInRequiredNodeAffinity(oldPodSpec)
+		if hasEmptyNodeSelectorTerm(oldPodSpec) {
+			opts.AllowEmptyNodeSelectorTerm = true
+		}
 		// if old spec has invalid labelSelector in topologySpreadConstraint, we must allow it
 		opts.AllowInvalidTopologySpreadConstraintLabelSelector = hasInvalidTopologySpreadConstraintLabelSelector(oldPodSpec)
 		if opts.AllowMatchLabelKeysInPodTopologySpread {
@@ -1501,6 +1505,26 @@ func hasInvalidLabelValueInRequiredNodeAffinity(spec *api.PodSpec) bool {
 		return false
 	}
 	return helper.HasInvalidLabelValueInNodeSelectorTerms(spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms)
+}
+
+func hasEmptyNodeSelectorTerm(spec *api.PodSpec) bool {
+	if spec == nil || spec.Affinity == nil || spec.Affinity.NodeAffinity == nil {
+		return false
+	}
+	na := spec.Affinity.NodeAffinity
+	if na.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+		for _, term := range na.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
+			if len(term.MatchExpressions) == 0 && len(term.MatchFields) == 0 {
+				return true
+			}
+		}
+	}
+	for _, term := range na.PreferredDuringSchedulingIgnoredDuringExecution {
+		if len(term.Preference.MatchExpressions) == 0 && len(term.Preference.MatchFields) == 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // KEP: https://kep.k8s.io/4639

--- a/pkg/api/pod/util_test.go
+++ b/pkg/api/pod/util_test.go
@@ -4408,6 +4408,74 @@ func TestValidateInvalidLabelValueInNodeSelectorOption(t *testing.T) {
 	}
 }
 
+func TestValidateEmptyNodeSelectorTermOption(t *testing.T) {
+	testCases := []struct {
+		name       string
+		oldPodSpec *api.PodSpec
+		wantOption bool
+	}{
+		{
+			name:       "Create",
+			wantOption: false,
+		},
+		{
+			name: "UpdateEmptyNodeSelectorTermRequired",
+			oldPodSpec: &api.PodSpec{
+				Affinity: &api.Affinity{
+					NodeAffinity: &api.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &api.NodeSelector{
+							NodeSelectorTerms: []api.NodeSelectorTerm{{}},
+						},
+					},
+				},
+			},
+			wantOption: true,
+		},
+		{
+			name: "UpdateEmptyNodeSelectorTermPreferred",
+			oldPodSpec: &api.PodSpec{
+				Affinity: &api.Affinity{
+					NodeAffinity: &api.NodeAffinity{
+						PreferredDuringSchedulingIgnoredDuringExecution: []api.PreferredSchedulingTerm{{
+							Weight:     10,
+							Preference: api.NodeSelectorTerm{},
+						}},
+					},
+				},
+			},
+			wantOption: true,
+		},
+		{
+			name: "UpdateValidNodeSelectorTerm",
+			oldPodSpec: &api.PodSpec{
+				Affinity: &api.Affinity{
+					NodeAffinity: &api.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &api.NodeSelector{
+							NodeSelectorTerms: []api.NodeSelectorTerm{{
+								MatchExpressions: []api.NodeSelectorRequirement{{
+									Key:      "foo",
+									Operator: api.NodeSelectorOpIn,
+									Values:   []string{"bar"},
+								}},
+							}},
+						},
+					},
+				},
+			},
+			wantOption: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotOptions := GetValidationOptionsFromPodSpecAndMeta(&api.PodSpec{}, tc.oldPodSpec, nil, nil)
+			if tc.wantOption != gotOptions.AllowEmptyNodeSelectorTerm {
+				t.Errorf("Got AllowEmptyNodeSelectorTerm=%t, want %t", gotOptions.AllowEmptyNodeSelectorTerm, tc.wantOption)
+			}
+		})
+	}
+}
+
 func TestHasAPIReferences(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -4502,6 +4502,8 @@ type PodValidationOptions struct {
 	AllowRestartAllContainers bool
 	// Allows container statuses to contain image volume digest
 	AllowImageVolumeWithDigest bool
+	// Allow empty NodeSelectorTerms for backward compatibility
+	AllowEmptyNodeSelectorTerm bool
 	// Allow empty image volume reference for backward compatibility
 	AllowEmptyImageVolumeReference bool
 }
@@ -5046,7 +5048,16 @@ func ValidateNodeFieldSelectorRequirement(req core.NodeSelectorRequirement, fldP
 
 // ValidateNodeSelectorTerm tests that the specified node selector term has valid data
 func ValidateNodeSelectorTerm(term core.NodeSelectorTerm, allowInvalidLabelValueInRequiredNodeAffinity bool, fldPath *field.Path) field.ErrorList {
+	return ValidateNodeSelectorTermWithRatcheting(term, allowInvalidLabelValueInRequiredNodeAffinity, true, fldPath)
+}
+
+func ValidateNodeSelectorTermWithRatcheting(term core.NodeSelectorTerm, allowInvalidLabelValueInRequiredNodeAffinity bool, allowEmptyNodeSelectorTerm bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
+
+	if !allowEmptyNodeSelectorTerm && len(term.MatchExpressions) == 0 && len(term.MatchFields) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath, "must have at least one matchExpressions or matchFields"))
+		return allErrs
+	}
 
 	for j, req := range term.MatchExpressions {
 		allErrs = append(allErrs, ValidateNodeSelectorRequirement(req, allowInvalidLabelValueInRequiredNodeAffinity, fldPath.Child("matchExpressions").Index(j))...)
@@ -5061,6 +5072,10 @@ func ValidateNodeSelectorTerm(term core.NodeSelectorTerm, allowInvalidLabelValue
 
 // ValidateNodeSelector tests that the specified nodeSelector fields has valid data
 func ValidateNodeSelector(nodeSelector *core.NodeSelector, allowInvalidLabelValueInRequiredNodeAffinity bool, fldPath *field.Path) field.ErrorList {
+	return ValidateNodeSelectorWithRatcheting(nodeSelector, allowInvalidLabelValueInRequiredNodeAffinity, true, fldPath)
+}
+
+func ValidateNodeSelectorWithRatcheting(nodeSelector *core.NodeSelector, allowInvalidLabelValueInRequiredNodeAffinity bool, allowEmptyNodeSelectorTerm bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	termFldPath := fldPath.Child("nodeSelectorTerms")
@@ -5069,7 +5084,7 @@ func ValidateNodeSelector(nodeSelector *core.NodeSelector, allowInvalidLabelValu
 	}
 
 	for i, term := range nodeSelector.NodeSelectorTerms {
-		allErrs = append(allErrs, ValidateNodeSelectorTerm(term, allowInvalidLabelValueInRequiredNodeAffinity, termFldPath.Index(i))...)
+		allErrs = append(allErrs, ValidateNodeSelectorTermWithRatcheting(term, allowInvalidLabelValueInRequiredNodeAffinity, allowEmptyNodeSelectorTerm, termFldPath.Index(i))...)
 	}
 
 	return allErrs
@@ -5163,6 +5178,10 @@ func validatePreferAvoidPodsEntry(avoidPodEntry core.PreferAvoidPodsEntry, fldPa
 
 // ValidatePreferredSchedulingTerms tests that the specified SoftNodeAffinity fields has valid data
 func ValidatePreferredSchedulingTerms(terms []core.PreferredSchedulingTerm, fldPath *field.Path) field.ErrorList {
+	return ValidatePreferredSchedulingTermsWithRatcheting(terms, true, fldPath)
+}
+
+func ValidatePreferredSchedulingTermsWithRatcheting(terms []core.PreferredSchedulingTerm, allowEmptyNodeSelectorTerm bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	for i, term := range terms {
@@ -5172,7 +5191,7 @@ func ValidatePreferredSchedulingTerms(terms []core.PreferredSchedulingTerm, fldP
 
 		// we always allow invalid label-value for preferred affinity
 		// as they can success when cluster has only one node
-		allErrs = append(allErrs, ValidateNodeSelectorTerm(term.Preference, true, fldPath.Index(i).Child("preference"))...)
+		allErrs = append(allErrs, ValidateNodeSelectorTermWithRatcheting(term.Preference, true, allowEmptyNodeSelectorTerm, fldPath.Index(i).Child("preference"))...)
 	}
 	return allErrs
 }
@@ -5242,10 +5261,10 @@ func validateNodeAffinity(na *core.NodeAffinity, opts PodValidationOptions, fldP
 	//	allErrs = append(allErrs, ValidateNodeSelector(na.RequiredDuringSchedulingRequiredDuringExecution, fldPath.Child("requiredDuringSchedulingRequiredDuringExecution"))...)
 	// }
 	if na.RequiredDuringSchedulingIgnoredDuringExecution != nil {
-		allErrs = append(allErrs, ValidateNodeSelector(na.RequiredDuringSchedulingIgnoredDuringExecution, opts.AllowInvalidLabelValueInRequiredNodeAffinity, fldPath.Child("requiredDuringSchedulingIgnoredDuringExecution"))...)
+		allErrs = append(allErrs, ValidateNodeSelectorWithRatcheting(na.RequiredDuringSchedulingIgnoredDuringExecution, opts.AllowInvalidLabelValueInRequiredNodeAffinity, opts.AllowEmptyNodeSelectorTerm, fldPath.Child("requiredDuringSchedulingIgnoredDuringExecution"))...)
 	}
 	if len(na.PreferredDuringSchedulingIgnoredDuringExecution) > 0 {
-		allErrs = append(allErrs, ValidatePreferredSchedulingTerms(na.PreferredDuringSchedulingIgnoredDuringExecution, fldPath.Child("preferredDuringSchedulingIgnoredDuringExecution"))...)
+		allErrs = append(allErrs, ValidatePreferredSchedulingTermsWithRatcheting(na.PreferredDuringSchedulingIgnoredDuringExecution, opts.AllowEmptyNodeSelectorTerm, fldPath.Child("preferredDuringSchedulingIgnoredDuringExecution"))...)
 	}
 	return allErrs
 }

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -10778,39 +10778,7 @@ func TestValidatePod(t *testing.T) {
 					},
 				}),
 		),
-		"serialized node affinity requirements, II": *podtest.MakePod("123",
-			podtest.SetAffinity(
-				// TODO: Uncomment and move this block and move inside NodeAffinity once
-				// RequiredDuringSchedulingRequiredDuringExecution is implemented
-				//		RequiredDuringSchedulingRequiredDuringExecution: &core.NodeSelector{
-				//			NodeSelectorTerms: []core.NodeSelectorTerm{
-				//				{
-				//					MatchExpressions: []core.NodeSelectorRequirement{
-				//						{
-				//							Key: "key1",
-				//							Operator: core.NodeSelectorOpExists
-				//						},
-				//					},
-				//				},
-				//			},
-				//		},
-				&core.Affinity{
-					NodeAffinity: &core.NodeAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
-							NodeSelectorTerms: []core.NodeSelectorTerm{{
-								MatchExpressions: []core.NodeSelectorRequirement{},
-							}},
-						},
-						PreferredDuringSchedulingIgnoredDuringExecution: []core.PreferredSchedulingTerm{{
-							Weight: 10,
-							Preference: core.NodeSelectorTerm{
-								MatchExpressions: []core.NodeSelectorRequirement{},
-							},
-						}},
-					},
-				},
-			),
-		),
+
 		"serialized pod affinity in affinity requirements in annotations": *podtest.MakePod("123",
 			podtest.SetAffinity(
 				// TODO: Uncomment and move this block into Annotations map once
@@ -11627,6 +11595,31 @@ func TestValidatePod(t *testing.T) {
 						RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
 							NodeSelectorTerms: []core.NodeSelectorTerm{},
 						},
+					},
+				}),
+			),
+		},
+		"invalid NodeSelectorTerm in required node affinity, matchExpressions and matchFields must have at least one element": {
+			expectedError: "spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0]: Required value: must have at least one matchExpressions or matchFields",
+			spec: *podtest.MakePod("123",
+				podtest.SetAffinity(&core.Affinity{
+					NodeAffinity: &core.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
+							NodeSelectorTerms: []core.NodeSelectorTerm{{}},
+						},
+					},
+				}),
+			),
+		},
+		"invalid NodeSelectorTerm in preferred node affinity, matchExpressions and matchFields must have at least one element": {
+			expectedError: "spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference: Required value: must have at least one matchExpressions or matchFields",
+			spec: *podtest.MakePod("123",
+				podtest.SetAffinity(&core.Affinity{
+					NodeAffinity: &core.NodeAffinity{
+						PreferredDuringSchedulingIgnoredDuringExecution: []core.PreferredSchedulingTerm{{
+							Weight:     10,
+							Preference: core.NodeSelectorTerm{},
+						}},
 					},
 				}),
 			),
@@ -14734,6 +14727,61 @@ func TestValidatePodUpdate(t *testing.T) {
 			),
 			err:  "pod updates may not change fields other than",
 			test: "updated restartPolicyRules",
+		},
+		{
+			test: "empty NodeSelectorTerm in node affinity allowed if old pod had it",
+			old: *podtest.MakePod("foo",
+				podtest.SetAffinity(&core.Affinity{
+					NodeAffinity: &core.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
+							NodeSelectorTerms: []core.NodeSelectorTerm{{}},
+						},
+					},
+				}),
+			),
+			new: *podtest.MakePod("foo",
+				podtest.SetAffinity(&core.Affinity{
+					NodeAffinity: &core.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
+							NodeSelectorTerms: []core.NodeSelectorTerm{{}},
+						},
+					},
+				}),
+			),
+			err:  "",
+			opts: PodValidationOptions{AllowEmptyNodeSelectorTerm: true},
+		},
+		{
+			test: "empty NodeSelectorTerm in node affinity rejected if old pod did not have it",
+			old: *podtest.MakePod("foo",
+				podtest.SetAffinity(&core.Affinity{
+					NodeAffinity: &core.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
+							NodeSelectorTerms: []core.NodeSelectorTerm{
+								{
+									MatchExpressions: []core.NodeSelectorRequirement{
+										{
+											Key:      "foo",
+											Operator: core.NodeSelectorOpIn,
+											Values:   []string{"bar"},
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+			),
+			new: *podtest.MakePod("foo",
+				podtest.SetAffinity(&core.Affinity{
+					NodeAffinity: &core.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
+							NodeSelectorTerms: []core.NodeSelectorTerm{{}},
+						},
+					},
+				}),
+			),
+			err: "must have at least one matchExpressions or matchFields",
 		},
 	}
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1060,6 +1060,11 @@ const (
 	// Requires stricter validation of IP addresses and CIDR values in API objects.
 	StrictIPCIDRValidation featuregate.Feature = "StrictIPCIDRValidation"
 
+	// owner: @Astraw99
+	//
+	// Add validation for empty NodeSelectorTerms
+	ValidateEmptyNodeSelectorTerm featuregate.Feature = "ValidateEmptyNodeSelectorTerm"
+
 	// owner: @everpeace
 	// kep: https://kep.k8s.io/3619
 	//
@@ -1959,6 +1964,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.36"), Default: true, PreRelease: featuregate.Beta},
 	},
 
+	ValidateEmptyNodeSelectorTerm: {
+		{Version: version.MustParse("1.36"), Default: true, PreRelease: featuregate.Beta},
+	},
+
 	SupplementalGroupsPolicy: {
 		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.Beta},
@@ -2576,6 +2585,8 @@ var defaultKubernetesFeatureGateDependencies = map[featuregate.Feature][]feature
 	StorageVersionMigrator: {},
 
 	StrictIPCIDRValidation: {},
+
+	ValidateEmptyNodeSelectorTerm: {},
 
 	SupplementalGroupsPolicy: {},
 


### PR DESCRIPTION
Fixes kubernetes/kubernetes#126325

### Description
This PR implements validation ratcheting for empty `NodeSelectorTerm`s in Pod node affinity behind a new feature gate `ValidateEmptyNodeSelectorTerm`.
Empty node selector terms (e.g. `nodeSelectorTerms: [{}]`) in `spec.affinity.nodeAffinity` are currently accepted but cause pods to remain in a `Pending` state or fail scheduling.

To preserve backward compatibility, this change implements the following behavior:
- Introduces the `ValidateEmptyNodeSelectorTerm` feature gate.
- Creates a new `AllowEmptyNodeSelectorTerm` option in `PodValidationOptions`.
- Under the `ValidateEmptyNodeSelectorTerm` feature gate, empty terms are strictly rejected during Pod creation.
- During Pod updates, empty terms are only allowed if they already existed in the old pod spec (validation ratcheting).

### Verification
Verified that:
- Core Pod validation unit tests in `pkg/apis/core/validation/` compile and pass.
- Pod utilities options tests in `pkg/api/pod/` compile and pass.
- Unit tests cover the creation behavior (rejection) and update behavior (ratcheting allowance when existing, rejection when new).

```release-note
Implemented validation ratcheting for empty `NodeSelectorTerm`s in Pod node affinity behind the new `ValidateEmptyNodeSelectorTerm` feature gate.
```