### PR TITLE
scheduler: requeue pods on PVC deletion

### DIFF
--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
@@ -112,7 +112,7 @@ func (pl *VolumeBinding) EventsToRegister(_ context.Context) ([]fwk.ClusterEvent
 		{Event: fwk.ClusterEvent{Resource: fwk.StorageClass, ActionType: fwk.Add | fwk.Update}, QueueingHintFn: pl.isSchedulableAfterStorageClassChange},
 
 		// We bind PVCs with PVs, so any changes may make the pods schedulable.
-		{Event: fwk.ClusterEvent{Resource: fwk.PersistentVolumeClaim, ActionType: fwk.Add | fwk.Update}, QueueingHintFn: pl.isSchedulableAfterPersistentVolumeClaimChange},
+		{Event: fwk.ClusterEvent{Resource: fwk.PersistentVolumeClaim, ActionType: fwk.Add | fwk.Update | fwk.Delete}, QueueingHintFn: pl.isSchedulableAfterPersistentVolumeClaimChange},
 		{Event: fwk.ClusterEvent{Resource: fwk.PersistentVolume, ActionType: fwk.Add | fwk.Update}},
 
 		// Pods may fail to find available PVs because the node labels do not
@@ -158,19 +158,27 @@ func (pl *VolumeBinding) isSchedulableAfterCSINodeChange(logger klog.Logger, pod
 }
 
 func (pl *VolumeBinding) isSchedulableAfterPersistentVolumeClaimChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
-	_, newPVC, err := util.As[*v1.PersistentVolumeClaim](oldObj, newObj)
+	oldPVC, newPVC, err := util.As[*v1.PersistentVolumeClaim](oldObj, newObj)
 	if err != nil {
 		return fwk.Queue, err
+	}
+
+	pvc := newPVC
+	if pvc == nil {
+		pvc = oldPVC
+	}
+	if pvc == nil {
+		return fwk.Queue, fmt.Errorf("both old and new PVC are nil")
 	}
 
 	logger = klog.LoggerWithValues(
 		logger,
 		"Pod", klog.KObj(pod),
-		"PersistentVolumeClaim", klog.KObj(newPVC),
+		"PersistentVolumeClaim", klog.KObj(pvc),
 	)
 
-	if pod.Namespace != newPVC.Namespace {
-		logger.V(5).Info("PersistentVolumeClaim was created or updated, but it doesn't make this pod schedulable because the PVC belongs to a different namespace")
+	if pod.Namespace != pvc.Namespace {
+		logger.V(5).Info("PersistentVolumeClaim was created, updated or deleted, but it doesn't make this pod schedulable because the PVC belongs to a different namespace")
 		return fwk.QueueSkip, nil
 	}
 
@@ -185,15 +193,15 @@ func (pl *VolumeBinding) isSchedulableAfterPersistentVolumeClaimChange(logger kl
 			continue
 		}
 
-		if pvcName == newPVC.Name {
+		if pvcName == pvc.Name {
 			// Return Queue because, in this case,
-			// all PVC creations and almost all PVC updates could make the Pod schedulable.
-			logger.V(5).Info("PersistentVolumeClaim the pod requires was created or updated, potentially making the target Pod schedulable")
+			// all PVC creations, deletions, and almost all PVC updates could make the Pod schedulable.
+			logger.V(5).Info("PersistentVolumeClaim the pod requires was created, updated or deleted, potentially making the target Pod schedulable")
 			return fwk.Queue, nil
 		}
 	}
 
-	logger.V(5).Info("PersistentVolumeClaim was created or updated, but it doesn't make this pod schedulable")
+	logger.V(5).Info("PersistentVolumeClaim was created, updated or deleted, but it doesn't make this pod schedulable")
 	return fwk.QueueSkip, nil
 }
 

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
@@ -1554,6 +1554,27 @@ func TestIsSchedulableAfterPersistentVolumeClaimChange(t *testing.T) {
 			expect:  fwk.Queue,
 		},
 		{
+			name: "pod has the pvc that is being deleted",
+			pod: makePod("pod-a").
+				withPVCVolume("pvc-a", "").
+				withPVCVolume("pvc-b", "").
+				Pod,
+			oldPVC:  makePVC("pvc-b", "").PersistentVolumeClaim,
+			newPVC:  nil,
+			wantErr: false,
+			expect:  fwk.Queue,
+		},
+		{
+			name: "pod does not have the pvc that is being deleted",
+			pod: makePod("pod-a").
+				withPVCVolume("pvc-a", "").
+				Pod,
+			oldPVC:  makePVC("pvc-b", "").PersistentVolumeClaim,
+			newPVC:  nil,
+			wantErr: false,
+			expect:  fwk.QueueSkip,
+		},
+		{
 			name:    "type conversion error",
 			oldPVC:  new(struct{}),
 			newPVC:  new(struct{}),


### PR DESCRIPTION
### Description
This PR enables requeueing of unschedulable pods when a PersistentVolumeClaim (PVC) is deleted.
Currently, the `VolumeBinding` plugin registers only `Add | Update` events for PVCs, meaning that pods waiting on a PVC won't be requeued when the PVC is deleted.
This PR:
1. Registers `Delete` events for PVCs.
2. Updates `isSchedulableAfterPersistentVolumeClaimChange` to fallback to the `oldObj` when `newObj` is `nil` (representing a deletion), preventing a nil-pointer dereference.

### Verification
Added unit test cases to verify that `isSchedulableAfterPersistentVolumeClaimChange` returns `fwk.Queue` on PVC deletion events when the PVC name matches the pod's volume claims, and that all scheduler volume binding tests pass successfully.

```release-note
Added PersistentVolumeClaim deletion event handling in scheduler `VolumeBinding` plugin to correctly requeue pods waiting on the deleted PVC.
```