### PR TITLE
DRA: restrict CEL includes function to device attributes

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/cel/compile.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/cel/compile.go
@@ -29,6 +29,8 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/checker"
+	celast "github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/common/operators"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
@@ -179,10 +181,20 @@ func (c compiler) CompileCELExpression(expression string, options Options) Compi
 		return resultError(fmt.Sprintf("must evaluate to %v or the unknown type, not %v", expectedReturnType.String(), ast.OutputType().String()), apiservercel.ErrorTypeInvalid)
 	}
 
-	_, err = cel.AstToCheckedExpr(ast)
+	checkedExpr, err := cel.AstToCheckedExpr(ast)
 	if err != nil {
 		// should be impossible since env.Compile returned no issues
 		return resultError("unexpected compilation error: "+err.Error(), apiservercel.ErrorTypeInternal)
+	}
+
+	celAST, err := celast.ToAST(checkedExpr)
+	if err != nil {
+		// should be impossible since env.Compile returned no issues
+		return resultError("unexpected compilation error: "+err.Error(), apiservercel.ErrorTypeInternal)
+	}
+
+	if err := checkIncludes(celAST.Expr(), nil); err != nil {
+		return resultError(err.Error(), apiservercel.ErrorTypeInvalid)
 	}
 	prog, err := env.Program(ast,
 		// The Kubernetes CEL base environment sets the VAP limit as runtime cost limit.
@@ -648,5 +660,122 @@ func (s *sizeEstimator) EstimateSize(element checker.AstNode) (res *checker.Size
 }
 
 func (s *sizeEstimator) EstimateCallCost(function, overloadID string, target *checker.AstNode, args []checker.AstNode) *checker.CallEstimate {
+	return nil
+}
+
+func isDeviceAttributesPath(e celast.Expr, bound map[string]celast.Expr) bool {
+	switch e.Kind() {
+	case celast.IdentKind:
+		name := e.AsIdent()
+		if initExpr, found := bound[name]; found {
+			return isDeviceAttributesPath(initExpr, bound)
+		}
+	case celast.SelectKind:
+		sel := e.AsSelect()
+		if isDeviceAttributesRoot(sel.Operand()) {
+			return true
+		}
+		return isDeviceAttributesPath(sel.Operand(), bound)
+	case celast.CallKind:
+		call := e.AsCall()
+		if call.FunctionName() == operators.Index && len(call.Args()) > 0 {
+			if isDeviceAttributesRoot(call.Args()[0]) {
+				return true
+			}
+			return isDeviceAttributesPath(call.Args()[0], bound)
+		}
+	}
+	return false
+}
+
+func isDeviceAttributesRoot(e celast.Expr) bool {
+	if e.Kind() != celast.SelectKind {
+		return false
+	}
+	sel := e.AsSelect()
+	if sel.FieldName() != attributesVar {
+		return false
+	}
+	operand := sel.Operand()
+	return operand.Kind() == celast.IdentKind && operand.AsIdent() == deviceVar
+}
+
+func checkIncludes(e celast.Expr, bound map[string]celast.Expr) error {
+	switch e.Kind() {
+	case celast.CallKind:
+		call := e.AsCall()
+		if call.FunctionName() == "includes" {
+			var target celast.Expr
+			if call.Target() != nil {
+				target = call.Target()
+			} else if len(call.Args()) > 0 {
+				target = call.Args()[0]
+			}
+			if target == nil || !isDeviceAttributesPath(target, bound) {
+				return fmt.Errorf("includes function can only be applied to device attributes")
+			}
+		}
+		if call.Target() != nil {
+			if err := checkIncludes(call.Target(), bound); err != nil {
+				return err
+			}
+		}
+		for _, arg := range call.Args() {
+			if err := checkIncludes(arg, bound); err != nil {
+				return err
+			}
+		}
+
+	case celast.SelectKind:
+		sel := e.AsSelect()
+		return checkIncludes(sel.Operand(), bound)
+
+	case celast.ComprehensionKind:
+		comp := e.AsComprehension()
+		if err := checkIncludes(comp.IterRange(), bound); err != nil {
+			return err
+		}
+		if err := checkIncludes(comp.AccuInit(), bound); err != nil {
+			return err
+		}
+		nestedBound := make(map[string]celast.Expr, len(bound)+2)
+		for k, v := range bound {
+			nestedBound[k] = v
+		}
+		nestedBound[comp.IterVar()] = comp.IterRange()
+		nestedBound[comp.AccuVar()] = comp.AccuInit()
+		if err := checkIncludes(comp.LoopStep(), nestedBound); err != nil {
+			return err
+		}
+		if err := checkIncludes(comp.Result(), nestedBound); err != nil {
+			return err
+		}
+
+	case celast.ListKind:
+		for _, el := range e.AsList().Elements() {
+			if err := checkIncludes(el, bound); err != nil {
+				return err
+			}
+		}
+
+	case celast.MapKind:
+		for _, entry := range e.AsMap().Entries() {
+			mapEntry := entry.AsMapEntry()
+			if err := checkIncludes(mapEntry.Key(), bound); err != nil {
+				return err
+			}
+			if err := checkIncludes(mapEntry.Value(), bound); err != nil {
+				return err
+			}
+		}
+
+	case celast.StructKind:
+		for _, entry := range e.AsStruct().Fields() {
+			structField := entry.AsStructField()
+			if err := checkIncludes(structField.Value(), bound); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/cel/compile_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/cel/compile_test.go
@@ -415,6 +415,64 @@ var testcases = map[string]struct {
 		expectMatch: false,
 		expectCost:  4 + 64, /* cost of "includes" on dynamic type */
 	},
+	"includes-function-on-list-literal-rejected": {
+		features:           &Features{EnableListTypeAttributes: true},
+		expression:         `[1, 2, 3].includes(1)`,
+		driver:             "dra.example.com",
+		expectCompileError: "includes function can only be applied to device attributes",
+	},
+	"includes-function-on-scalar-rejected": {
+		features:           &Features{EnableListTypeAttributes: true},
+		expression:         `1.includes(1)`,
+		driver:             "dra.example.com",
+		expectCompileError: "includes function can only be applied to device attributes",
+	},
+	"includes-function-on-other-variable-rejected": {
+		features:           &Features{EnableListTypeAttributes: true},
+		expression:         `device.driver.includes("foo")`,
+		driver:             "dra.example.com",
+		expectCompileError: "includes function can only be applied to device attributes",
+	},
+	"includes-function-on-capacity-rejected": {
+		features:           &Features{EnableListTypeAttributes: true},
+		expression:         `device.capacity["dra.example.com"].name.includes("foo")`,
+		capacity:           map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{"name": {Value: resource.MustParse("1Mi")}},
+		driver:             "dra.example.com",
+		expectCompileError: "includes function can only be applied to device attributes",
+	},
+	"includes-function-on-bound-variable-success": {
+		features:    &Features{EnableListTypeAttributes: true},
+		expression:  `cel.bind(dra, device.attributes["dra.example.com"], dra.name.includes("fish"))`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValues: []string{"fish", "bird"}}},
+		driver:      "dra.example.com",
+		expectMatch: true,
+		expectCost:  79,
+	},
+	"includes-function-on-bound-variable-rejected": {
+		features:           &Features{EnableListTypeAttributes: true},
+		expression:         `cel.bind(lst, [1, 2, 3], lst.includes(1))`,
+		driver:             "dra.example.com",
+		expectCompileError: "includes function can only be applied to device attributes",
+	},
+	// Nested cel.bind: inner variable bound to a field of the outer bound variable.
+	// The checker must trace through both binding levels to confirm the attribute path.
+	"includes-function-on-nested-bound-variable-success": {
+		features:    &Features{EnableListTypeAttributes: true},
+		expression:  `cel.bind(dra, device.attributes["dra.example.com"], cel.bind(attr, dra.name, attr.includes("fish")))`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValues: []string{"fish", "bird"}}},
+		driver:      "dra.example.com",
+		expectMatch: true,
+		expectCost:  90,
+	},
+
+	// Inner cel.bind shadows an outer attribute-bound variable with a list literal;
+	// the check must respect inner scope and correctly reject.
+	"includes-function-on-shadowed-bound-variable-rejected": {
+		features:           &Features{EnableListTypeAttributes: true},
+		expression:         `cel.bind(dra, device.attributes["dra.example.com"], cel.bind(dra, [1, 2, 3], dra.includes(1)))`,
+		driver:             "dra.example.com",
+		expectCompileError: "includes function can only be applied to device attributes",
+	},
 	"in-operator-on-list": {
 		// This case is for documenting purpose to present the difference of call cost estimation
 		// between "in" operator and "includes" function.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Exposing the `.includes` function on the `DynType` receiver allows it to compile successfully on arbitrary receivers(such as list literals, scalars). This PR introduces a compile-time-checked AST validation check in `CompileCELExpression` to ensure `.includes` is strictly applied only to device attribute targets.

Key changes - 
- `checkIncludes(e, bound)` - recursive AST visitor that walks the entire expression tree. For each includes call it verifies the receiver resolves to `device.attributes` path. Handles all AST node kinds.
- `isDeviceAttributesPath(e, bound)` - resolves an expression back to `device.attributes`.
- `isDeviceAttributesRoot(e)` - checks if an expression is exactly `device.attributes`.
- conprehension scope tracking - Both `IterVar` and `AccuVar` are tracked in a `bound` map so that patterns like `cel.bind(dra, device.attributes[...] , dra.name.includes(...))` correctly resolve the binding target back to `device.attributes`.


#### Which issue(s) this PR is related to:

Fixes #137901

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
DRA: CEL `includes` function is now restricted to device attributes. 
```