### PR TITLE
Fix PodLevelResourcesFixKubeletQOSClass gate coupling in CPU/memory tests

### DIFF
--- a/test/e2e_node/cpu_manager_test.go
+++ b/test/e2e_node/cpu_manager_test.go
@@ -4294,9 +4294,10 @@ func configureCPUManagerInKubelet(oldCfg *kubeletconfig.KubeletConfiguration, ku
 	newCfg.FeatureGates["CPUManagerPolicyBetaOptions"] = kubeletArguments.enableCPUManagerOptions
 	newCfg.FeatureGates["CPUManagerPolicyAlphaOptions"] = kubeletArguments.enableCPUManagerOptions
 	newCfg.FeatureGates["PodLevelResources"] = kubeletArguments.enablePodLevelResources
-	// InPlacePodLevelResourcesVerticalScaling is only supported when PodLevelResources is enabled
+	// InPlacePodLevelResourcesVerticalScaling and PodLevelResourcesFixKubeletQOSClass are only supported when PodLevelResources is enabled
 	if !kubeletArguments.enablePodLevelResources {
 		newCfg.FeatureGates["InPlacePodLevelResourcesVerticalScaling"] = kubeletArguments.enablePodLevelResources
+		newCfg.FeatureGates["PodLevelResourcesFixKubeletQOSClass"] = kubeletArguments.enablePodLevelResources
 	}
 	newCfg.FeatureGates["PodLevelResourceManagers"] = kubeletArguments.enablePodLevelResourceManagers
 

--- a/test/e2e_node/memory_manager_test.go
+++ b/test/e2e_node/memory_manager_test.go
@@ -807,9 +807,10 @@ func configureMemoryManagerInKubelet(oldCfg *kubeletconfig.KubeletConfiguration,
 	}
 
 	newCfg.FeatureGates["PodLevelResources"] = kubeletArguments.enablePodLevelResources
-	// InPlacePodLevelResourcesVerticalScaling is only supported when PodLevelResources is enabled
+	// InPlacePodLevelResourcesVerticalScaling and PodLevelResourcesFixKubeletQOSClass are only supported when PodLevelResources is enabled
 	if !kubeletArguments.enablePodLevelResources {
 		newCfg.FeatureGates["InPlacePodLevelResourcesVerticalScaling"] = kubeletArguments.enablePodLevelResources
+		newCfg.FeatureGates["PodLevelResourcesFixKubeletQOSClass"] = kubeletArguments.enablePodLevelResources
 	}
 	newCfg.FeatureGates["PodLevelResourceManagers"] = kubeletArguments.enablePodLevelResourceManagers
 


### PR DESCRIPTION

#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:


With https://github.com/kubernetes/kubernetes/pull/137150, PodLevelResourcesFixKubeletQOSClass should depend on PodLevelResources. 

#### Which issue(s) this PR is related to:

Fixes #140628

#### Special notes for your reviewer:

In the two test cases here, we set PodLevelResources to false, while PodLevelResourcesFixKubeletQOSClass is by default true. It makes the kubelet panic.


> I0716 22:20:06.768674   44966 feature_gate.go:477] "Warning: setting GA feature gate. It will be removed in a future release." featureGate="CustomCPUCFSQuotaPeriod" value=false
> panic: failed to merge global and in-flight KubeletConfiguration while setting defaults, error: PodLevelResourcesFixKubeletQOSClass is enabled, but depends on features that are disabled: [PodLevelResources]

For instance: https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-node-crio-swap-serial/2077851676416413696/artifacts/e2-standard-2-fedora-coreos-44-20260621-3-1-gcp-x86-64-ae042d69/kubelet.log


#### Does this PR introduce a user-facing change?

```release-note
None
```
