### PR TITLE
Return succes from podgroup preemption if one is ongoing

### DIFF
--- a/pkg/scheduler/framework/preemption/podgrouppreemption.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption.go
@@ -60,19 +60,11 @@ func NewPodGroupEvaluator(fh fwk.Handle, executor *Executor, enablePodGroupPreem
 }
 
 // evaluate determines the victims for preemption, without actuation.
-func (ev *PodGroupEvaluator) evaluate(ctx context.Context, preemptor *podGroupPreemptor, podGroupSchedulingFunc fwk.PodGroupSchedulingFunc) (res *selectVictimsResult, status *fwk.Status) {
+func (ev *PodGroupEvaluator) evaluate(ctx context.Context, preemptor *podGroupPreemptor, domain *domain, podGroupSchedulingFunc fwk.PodGroupSchedulingFunc) (res *selectVictimsResult, status *fwk.Status) {
 	startTime := time.Now()
 	defer func() {
 		metrics.PreemptionEvaluationDuration.WithLabelValues("podgroup", status.Code().String()).Observe(metrics.SinceInSeconds(startTime))
 	}()
-
-	// In case of workload-aware preemption, the domain is whole cluster.
-	// We do not make a snapshot of node info. Those nodes will be shared
-	// with the PodGroup scheduling algorithm passed as podGroupSchedulingFunc.
-	domain, err := newDomainForWorkloadPreemption(ev.Handle.MutableSnapshotSharedLister(), ev.podGroupSnapshot, "cluster-domain")
-	if err != nil {
-		return nil, fwk.AsStatus(fmt.Errorf("failed to create domain: %w", err))
-	}
 
 	pdbs, err := getPodDisruptionBudgets(ev.pdbLister)
 	if err != nil {
@@ -96,8 +88,27 @@ func (ev *PodGroupEvaluator) evaluate(ctx context.Context, preemptor *podGroupPr
 // The caller is expected to backup the NodeInfo before calling this function
 // And rollback the state to the backup after function is finished.
 func (ev *PodGroupEvaluator) Preempt(ctx context.Context, pg *schedulingapi.PodGroup, pods []*v1.Pod, podGroupSchedulingFunc fwk.PodGroupSchedulingFunc) (*fwk.PodGroupPostFilterResult, *fwk.Status) {
+	logger := klog.FromContext(ctx)
+	// In case of workload-aware preemption, the domain is whole cluster.
+	// We do not make a snapshot of node info. Those nodes will be shared
+	// with the PodGroup scheduling algorithm passed as podGroupSchedulingFunc.
+	domain, err := newDomainForWorkloadPreemption(ev.Handle.MutableSnapshotSharedLister(), ev.podGroupSnapshot, "cluster-domain")
+	if err != nil {
+		return nil, fwk.AsStatus(fmt.Errorf("failed to create domain: %w", err))
+	}
 	preemptor := newPodGroupPreemptor(pg, pods, ev.enablePodGroupPreemptionPolicy)
-	res, status := ev.evaluate(ctx, preemptor, podGroupSchedulingFunc)
+
+	// Ensure the preemptor is eligible to preempt other pods.
+	if ok, msg := ev.preemptorEligibleToPreemptOthers(ctx, preemptor); !ok {
+		logger.V(5).Info("Preemptor is not eligible for preemption", "preemptor", klog.KObj(preemptor.podGroup), "reason", msg)
+		return nil, fwk.NewStatus(fwk.Unschedulable, msg)
+	}
+
+	if ev.isOngoingPreemption(ctx, preemptor, domain.Nodes()) {
+		return &fwk.PodGroupPostFilterResult{NominatingInfos: buildCurrentNominatingInfos(preemptor)}, fwk.NewStatus(fwk.Success, "ongoing preemption on nominated nodes")
+	}
+
+	res, status := ev.evaluate(ctx, preemptor, domain, podGroupSchedulingFunc)
 	if !status.IsSuccess() {
 		return nil, status
 	}
@@ -130,18 +141,9 @@ func (ev *PodGroupEvaluator) selectVictimsOnDomain(
 	podGroupSchedulingFunc fwk.PodGroupSchedulingFunc) (*selectVictimsResult, *fwk.Status) {
 	logger := klog.FromContext(ctx)
 
-	nameToNode := make(map[string]fwk.NodeInfo)
-	for _, nodeInfo := range domain.Nodes() {
-		nameToNode[nodeInfo.Node().Name] = nodeInfo
-	}
+	nameToNode := domain.Nodes()
 
 	mutableLister := ev.Handle.MutableSnapshotSharedLister()
-
-	// Ensure the preemptor is eligible to preempt other pods.
-	if ok, msg := ev.preemptorEligibleToPreemptOthers(ctx, preemptor, nameToNode); !ok {
-		logger.V(5).Info("Preemptor is not eligible for preemption", "preemptor", klog.KObj(preemptor.podGroup), "reason", msg)
-		return nil, fwk.NewStatus(fwk.Unschedulable, msg)
-	}
 
 	// removePods removes all victims from the snapshot.
 	// This is called before the podGroupSchedulingFunc so it does not have
@@ -373,11 +375,17 @@ func (ev *PodGroupEvaluator) isPreemptionAllowed(victim Victim, preemptor *podGr
 // preemptorEligibleToPreemptOthers returns one bool and one string. The bool
 // indicates whether this preemptor should be considered for preempting other pods or
 // not. The string includes the reason if this preemptor isn't eligible.
-func (ev *PodGroupEvaluator) preemptorEligibleToPreemptOthers(_ context.Context, preemptor *podGroupPreemptor, nameToNode map[string]fwk.NodeInfo) (bool, string) {
+func (ev *PodGroupEvaluator) preemptorEligibleToPreemptOthers(_ context.Context, preemptor *podGroupPreemptor) (bool, string) {
 	if preemptor.PreemptionPolicy() == schedulingapi.PreemptNever {
 		return false, "not eligible due to preemptionPolicy=Never."
 	}
 
+	return true, ""
+}
+
+// isOngoingPreemption checks whether there is an ongoing preemption on the
+// nominated nodes for pods from this pod group.
+func (ev *PodGroupEvaluator) isOngoingPreemption(_ context.Context, preemptor *podGroupPreemptor, nameToNode map[string]fwk.NodeInfo) bool {
 	nominatedNodes := sets.New[string]()
 	for _, pod := range preemptor.Members() {
 		if len(pod.Status.NominatedNodeName) > 0 {
@@ -389,11 +397,25 @@ func (ev *PodGroupEvaluator) preemptorEligibleToPreemptOthers(_ context.Context,
 		if nodeInfo, exists := nameToNode[nomNodeName]; exists {
 			for _, p := range nodeInfo.GetPods() {
 				if GetPodPriority(p.GetPod(), ev.podGroupSnapshot) < preemptor.Priority() && PodTerminatingByPreemption(p.GetPod()) {
-					return false, "not eligible due to a terminating pod on the nominated node."
+					return true
 				}
 			}
 		}
 	}
 
-	return true, ""
+	return false
+}
+
+// buildCurrentNominatingInfos builds a map of nominating infos based on
+// currently set NNN for the preemptor pods
+func buildCurrentNominatingInfos(preemptor *podGroupPreemptor) map[types.NamespacedName]*fwk.NominatingInfo {
+	n := make(map[types.NamespacedName]*fwk.NominatingInfo)
+	for _, pod := range preemptor.Members() {
+		podKey := types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
+		n[podKey] = &fwk.NominatingInfo{
+			NominatingMode:    fwk.ModeOverride,
+			NominatedNodeName: pod.Status.NominatedNodeName,
+		}
+	}
+	return n
 }

--- a/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
@@ -356,67 +356,6 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 			expectedStatus:  fwk.NewStatus(fwk.Success),
 		},
 		{
-			name: "PodGroup preemptor with PreemptNever policy does not perform preemption",
-			nodes: []*v1.Node{
-				st.MakeNode().Name("node1").Obj(),
-				st.MakeNode().Name("node2").Obj(),
-				st.MakeNode().Name("node3").Obj(),
-			},
-			initPods: []*v1.Pod{
-				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
-				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).PodGroupName("pg1").Obj(),
-				st.MakePod().Name("p3").UID("v3").Node("node3").Priority(lowPriority).PodGroupName("pg2").Obj(),
-			},
-			preemptor: makePodGroupPreemptorWithPreemptionPolicy(
-				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
-				[]*v1.Pod{
-					st.MakePod().Name("p-1").UID("p-1").Priority(highPriority).Obj(),
-					st.MakePod().Name("p-2").UID("p-2").Priority(highPriority).Obj(),
-				},
-				schedulingapi.PreemptNever,
-			),
-			nodeCapacities: []nodeCapacity{
-				{
-					nodeName: "node1",
-					capacity: 100,
-				},
-				{
-					nodeName: "node2",
-					capacity: 100,
-				},
-				{
-					nodeName: "node3",
-					capacity: 100,
-				},
-			},
-			expectedVictims: []string{},
-			expectedStatus:  fwk.NewStatus(fwk.Unschedulable),
-		},
-		{
-			name: "Preemptor group is not eligible if any member has nominated node with terminating pods",
-			nodes: []*v1.Node{
-				st.MakeNode().Name("node1").Obj(),
-			},
-			initPods: []*v1.Pod{
-				st.MakePod().Name("victim").UID("v1").Node("node1").Priority(lowPriority).Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByScheduler).Terminating().Obj(),
-			},
-			preemptor: makePodGroupPreemptor(
-				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
-				[]*v1.Pod{
-					st.MakePod().Name("p1").UID("p1").Priority(highPriority).Obj(),
-					st.MakePod().Name("p2").UID("p2").Priority(highPriority).NominatedNodeName("node1").Obj(),
-				},
-			),
-			nodeCapacities: []nodeCapacity{
-				{
-					nodeName: "node1",
-					capacity: 100,
-				},
-			},
-			expectedVictims: []string{}, // no victims when preemptor is not eligible for preemption
-			expectedStatus:  fwk.NewStatus(fwk.Unschedulable, "not eligible due to a terminating pod on the nominated node."),
-		},
-		{
 			name: "Preemptor group is eligible if terminating pods are on non-nominated nodes",
 			nodes: []*v1.Node{
 				st.MakeNode().Name("node1").Obj(),
@@ -446,33 +385,6 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 			},
 			expectedVictims: []string{"other-victim", "victim"},
 			expectedStatus:  fwk.NewStatus(fwk.Success),
-		},
-		{
-			name: "Preemptor group is not eligible if nominated node has terminating pod belonging to a pod group of lower priority",
-			nodes: []*v1.Node{
-				st.MakeNode().Name("node1").Obj(),
-			},
-			initPods: []*v1.Pod{
-				st.MakePod().Name("victim").UID("v1").Node("node1").Priority(highPriority).PodGroupName("victim-pg").Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByScheduler).Terminating().Obj(),
-			},
-			initPodGroups: []*schedulingapi.PodGroup{
-				st.MakePodGroup().Name("victim-pg").UID("victim-pg").Priority(lowPriority).DisruptionModeAll().Obj(),
-			},
-			preemptor: makePodGroupPreemptor(
-				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
-				[]*v1.Pod{
-					st.MakePod().Name("p1").UID("p1").Priority(highPriority).Obj(),
-					st.MakePod().Name("p2").UID("p2").Priority(highPriority).NominatedNodeName("node1").Obj(),
-				},
-			),
-			nodeCapacities: []nodeCapacity{
-				{
-					nodeName: "node1",
-					capacity: 100,
-				},
-			},
-			expectedVictims: []string{},
-			expectedStatus:  fwk.NewStatus(fwk.Unschedulable, "not eligible due to a terminating pod on the nominated node."),
 		},
 		{
 			name: "Preemptor group is eligible if nominated node has terminating pod belonging to a pod group of higher priority",
@@ -506,33 +418,6 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 			},
 			expectedVictims: []string{"other-victim"},
 			expectedStatus:  fwk.NewStatus(fwk.Success),
-		},
-		{
-			name: "Preemptor group is not eligible if nominated node has terminating pod belonging to a pod group of lower priority with DisruptionModePod",
-			nodes: []*v1.Node{
-				st.MakeNode().Name("node1").Obj(),
-			},
-			initPods: []*v1.Pod{
-				st.MakePod().Name("victim").UID("v1").Node("node1").Priority(highPriority).PodGroupName("victim-pg").Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByScheduler).Terminating().Obj(),
-			},
-			initPodGroups: []*schedulingapi.PodGroup{
-				st.MakePodGroup().Name("victim-pg").UID("victim-pg").Priority(lowPriority).DisruptionModeSingle().Obj(),
-			},
-			preemptor: makePodGroupPreemptor(
-				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
-				[]*v1.Pod{
-					st.MakePod().Name("p1").UID("p1").Priority(highPriority).Obj(),
-					st.MakePod().Name("p2").UID("p2").Priority(highPriority).NominatedNodeName("node1").Obj(),
-				},
-			),
-			nodeCapacities: []nodeCapacity{
-				{
-					nodeName: "node1",
-					capacity: 100,
-				},
-			},
-			expectedVictims: []string{},
-			expectedStatus:  fwk.NewStatus(fwk.Unschedulable, "not eligible due to a terminating pod on the nominated node."),
 		},
 		{
 			name: "Preemptor group is eligible if nominated node has terminating pod belonging to a pod group of higher priority with nil DisruptionMode",
@@ -746,38 +631,6 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 			},
 			expectedVictims: []string{"p1"},
 			expectedStatus:  fwk.NewStatus(fwk.Success),
-		},
-		{
-			name: "PodGroup preemptor with PreemptNever preemption policy does not perform preemption with PodGroup victims",
-			nodes: []*v1.Node{
-				st.MakeNode().Name("node1").Obj(),
-				st.MakeNode().Name("node2").Obj(),
-				st.MakeNode().Name("node3").Obj(),
-			},
-			initPods: []*v1.Pod{
-				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
-				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).PodGroupName("pg1").Obj(),
-				st.MakePod().Name("p3").UID("v3").Node("node3").Priority(lowPriority).PodGroupName("pg2").Obj(),
-			},
-			initPodGroups: []*schedulingapi.PodGroup{
-				st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeSingle().Priority(lowPriority).Obj(),
-				st.MakePodGroup().Name("pg2").UID("pg2").DisruptionModeSingle().Priority(lowPriority).Obj(),
-			},
-			preemptor: makePodGroupPreemptorWithPreemptionPolicy(
-				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
-				[]*v1.Pod{
-					st.MakePod().Name("p-1").UID("p-1").Priority(highPriority).Obj(),
-					st.MakePod().Name("p-2").UID("p-2").Priority(highPriority).Obj(),
-				},
-				schedulingapi.PreemptNever,
-			),
-			nodeCapacities: []nodeCapacity{
-				{nodeName: "node1", capacity: 1},
-				{nodeName: "node2", capacity: 1},
-				{nodeName: "node3", capacity: 1},
-			},
-			expectedVictims: []string{},
-			expectedStatus:  fwk.NewStatus(fwk.Unschedulable, "not eligible due to preemptionPolicy=Never."),
 		},
 		{
 			name: "PDB: Prefer lower priority pod for preemption, when preemption without pdb violation is not possible",
@@ -1567,6 +1420,197 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain_NominatedNodes(t *testing.T) {
 	}
 }
 
+func TestPodGroupEvaluator_Preempt(t *testing.T) {
+	tests := []struct {
+		name               string
+		nodes              []*v1.Node
+		initPods           []*v1.Pod
+		initPodGroups      []*schedulingapi.PodGroup
+		preemptorPodGroup  *schedulingapi.PodGroup
+		preemptorPods      []*v1.Pod
+		expectedStatus     *fwk.Status
+		expectedNominating map[types.NamespacedName]*fwk.NominatingInfo
+	}{
+		{
+			name: "Preemptor group returns success with current nominating infos if member has nominated node with terminating pods",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+			},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("victim").UID("v1").Node("node1").Priority(lowPriority).Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByScheduler).Terminating().Obj(),
+			},
+			preemptorPodGroup: st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("p1").UID("p1").Priority(highPriority).Obj(),
+				st.MakePod().Name("p2").UID("p2").Priority(highPriority).NominatedNodeName("node1").Obj(),
+			},
+			expectedStatus: fwk.NewStatus(fwk.Success, "ongoing preemption on nominated nodes"),
+			expectedNominating: map[types.NamespacedName]*fwk.NominatingInfo{
+				{Namespace: "", Name: "p1"}: {NominatingMode: fwk.ModeOverride, NominatedNodeName: ""},
+				{Namespace: "", Name: "p2"}: {NominatingMode: fwk.ModeOverride, NominatedNodeName: "node1"},
+			},
+		},
+		{
+			name: "Preemptor group returns success with current nominating infos if nominated node has terminating pod belonging to a pod group of lower priority",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+			},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("victim").UID("v1").Node("node1").Priority(highPriority).PodGroupName("victim-pg").Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByScheduler).Terminating().Obj(),
+			},
+			initPodGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("victim-pg").UID("victim-pg").Priority(lowPriority).DisruptionModeAll().Obj(),
+			},
+			preemptorPodGroup: st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("p1").UID("p1").Priority(highPriority).Obj(),
+				st.MakePod().Name("p2").UID("p2").Priority(highPriority).NominatedNodeName("node1").Obj(),
+			},
+			expectedStatus: fwk.NewStatus(fwk.Success, "ongoing preemption on nominated nodes"),
+			expectedNominating: map[types.NamespacedName]*fwk.NominatingInfo{
+				{Namespace: "", Name: "p1"}: {NominatingMode: fwk.ModeOverride, NominatedNodeName: ""},
+				{Namespace: "", Name: "p2"}: {NominatingMode: fwk.ModeOverride, NominatedNodeName: "node1"},
+			},
+		},
+		{
+			name: "Preemptor group returns success with current nominating infos if nominated node has terminating pod belonging to a pod group of lower priority with DisruptionModePod",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+			},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("victim").UID("v1").Node("node1").Priority(highPriority).PodGroupName("victim-pg").Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByScheduler).Terminating().Obj(),
+			},
+			initPodGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("victim-pg").UID("victim-pg").Priority(lowPriority).DisruptionModeSingle().Obj(),
+			},
+			preemptorPodGroup: st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("p1").UID("p1").Priority(highPriority).Obj(),
+				st.MakePod().Name("p2").UID("p2").Priority(highPriority).NominatedNodeName("node1").Obj(),
+			},
+			expectedStatus: fwk.NewStatus(fwk.Success, "ongoing preemption on nominated nodes"),
+			expectedNominating: map[types.NamespacedName]*fwk.NominatingInfo{
+				{Namespace: "", Name: "p1"}: {NominatingMode: fwk.ModeOverride, NominatedNodeName: ""},
+				{Namespace: "", Name: "p2"}: {NominatingMode: fwk.ModeOverride, NominatedNodeName: "node1"},
+			},
+		},
+		{
+			name: "PodGroup preemptor with PreemptNever policy does not perform preemption",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+				st.MakeNode().Name("node3").Obj(),
+			},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
+				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).PodGroupName("pg1").Obj(),
+				st.MakePod().Name("p3").UID("v3").Node("node3").Priority(lowPriority).PodGroupName("pg2").Obj(),
+			},
+			preemptorPodGroup: st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).PreemptionPolicy(schedulingapi.PreemptNever).Obj(),
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("p-1").UID("p-1").Priority(highPriority).Obj(),
+				st.MakePod().Name("p-2").UID("p-2").Priority(highPriority).Obj(),
+			},
+			expectedStatus: fwk.NewStatus(fwk.Unschedulable, "not eligible due to preemptionPolicy=Never."),
+		},
+		{
+			name: "PodGroup preemptor with PreemptNever preemption policy does not perform preemption with PodGroup victims",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+				st.MakeNode().Name("node3").Obj(),
+			},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
+				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).PodGroupName("pg1").Obj(),
+				st.MakePod().Name("p3").UID("v3").Node("node3").Priority(lowPriority).PodGroupName("pg2").Obj(),
+			},
+			initPodGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeSingle().Priority(lowPriority).Obj(),
+				st.MakePodGroup().Name("pg2").UID("pg2").DisruptionModeSingle().Priority(lowPriority).Obj(),
+			},
+			preemptorPodGroup: st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).PreemptionPolicy(schedulingapi.PreemptNever).Obj(),
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("p-1").UID("p-1").Priority(highPriority).Obj(),
+				st.MakePod().Name("p-2").UID("p-2").Priority(highPriority).Obj(),
+			},
+			expectedStatus: fwk.NewStatus(fwk.Unschedulable, "not eligible due to preemptionPolicy=Never."),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodGroupPreemptionPolicy, true)
+			logger, ctx := ktesting.NewTestContext(t)
+
+			var objs []runtime.Object
+			for _, p := range append(tt.initPods, tt.preemptorPods...) {
+				objs = append(objs, p)
+			}
+			for _, n := range tt.nodes {
+				objs = append(objs, n)
+			}
+			informerFactory := informers.NewSharedInformerFactory(clientsetfake.NewClientset(objs...), 0)
+			registeredPlugins := []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+			}
+			snapshot := internalcache.NewTestSnapshotWithPodGroups(tt.initPods, tt.nodes, tt.initPodGroups)
+			f, err := tf.NewFramework(
+				ctx,
+				registeredPlugins, "",
+				frameworkruntime.WithPodNominator(internalqueue.NewSchedulingQueue(nil, informerFactory)),
+				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithMutableSnapshotLister(snapshot),
+				frameworkruntime.WithLogger(logger),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
+
+			podGroups := make(map[string]*schedulingapi.PodGroup)
+			for _, pg := range tt.initPodGroups {
+				podGroups[pg.Name] = pg
+			}
+
+			pgLister := &mockPodGroupLister{podGroups: podGroups}
+			pl := &PodGroupEvaluator{
+				Handle:                         f,
+				podGroupSnapshot:               pgLister,
+				pdbLister:                      informerFactory.Policy().V1().PodDisruptionBudgets().Lister(),
+				enablePodGroupPreemptionPolicy: true,
+			}
+
+			mockSchedulingFunc := func(ctx context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
+				t.Fatal("podGroupSchedulingFunc should not be called when ongoing preemption is detected")
+				return nil, fwk.NewStatus(fwk.Error)
+			}
+
+			gotResult, gotStatus := pl.Preempt(ctx, tt.preemptorPodGroup, tt.preemptorPods, mockSchedulingFunc)
+			if gotStatus.Code() != tt.expectedStatus.Code() || gotStatus.Message() != tt.expectedStatus.Message() {
+				t.Errorf("Status mismatch. Want status code %v with message %q, Got code %v with message %q",
+					tt.expectedStatus.Code(), tt.expectedStatus.Message(), gotStatus.Code(), gotStatus.Message())
+			}
+			if gotStatus.Code() != fwk.Success {
+				return
+			}
+
+			if gotResult == nil {
+				t.Fatalf("expected non-nil result")
+			}
+
+			if diff := cmp.Diff(tt.expectedNominating, gotResult.NominatingInfos); diff != "" {
+				t.Errorf("NominatingInfos mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 type mockProposedAssignment struct {
 	nodeName   string
 	pod        *v1.Pod
@@ -1667,14 +1711,17 @@ func TestPodGroupPreemptionEvaluationDurationMetric(t *testing.T) {
 				}
 				return nil, tt.evaluationStatus
 			}
-
+			domain, err := newDomainForWorkloadPreemption(snapshot, pgLister, "test-domain")
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
 			expectedStatus := tt.evaluationStatus.Code().String()
 			stateBefore := captureEvaluationDurationMetric(testRegistry, "podgroup", expectedStatus)
 
 			if err := pl.Handle.MutableSnapshotSharedLister().StartMutations(); err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
-			pl.evaluate(ctx, preemptor, mockSchedulingFunc)
+			pl.evaluate(ctx, preemptor, domain, mockSchedulingFunc)
 			if err := pl.Handle.MutableSnapshotSharedLister().EndMutations(); err != nil {
 				t.Errorf("Unexpected error: %v", err)
 			}

--- a/pkg/scheduler/framework/preemption/types.go
+++ b/pkg/scheduler/framework/preemption/types.go
@@ -89,15 +89,15 @@ func (p *podGroupPreemptor) PreemptionPolicy() schedulingapi.PreemptionPolicy {
 // It abstracts the scheduling domain, which can range from a single Node (for standard Pod preemption)
 // to a group of Nodes or the entire Cluster (for PodGroup preemption).
 type domain struct {
-	nodes              []fwk.NodeInfo
+	nodes              map[string]fwk.NodeInfo
 	name               string
 	allPossibleVictims []*DomainVictim
 }
 
-// Nodes returns a list of NodeInfo objects that belong to this domain.
+// Nodes returns a map of NodeInfo objects by node name that belong to this domain.
 // The preemption logic uses this to check feasibility and resource availability
 // within the specific scope.
-func (d *domain) Nodes() []fwk.NodeInfo {
+func (d *domain) Nodes() map[string]fwk.NodeInfo {
 	return d.nodes
 }
 
@@ -164,8 +164,15 @@ func newDomainForWorkloadPreemption(snapshot fwk.SharedLister, podGroupSnapshot 
 		return nil, err
 	}
 
+	nodesMap := make(map[string]fwk.NodeInfo, len(nodes))
+	for _, nodeInfo := range nodes {
+		if nodeInfo != nil && nodeInfo.Node() != nil {
+			nodesMap[nodeInfo.Node().Name] = nodeInfo
+		}
+	}
+
 	return &domain{
-		nodes:              nodes,
+		nodes:              nodesMap,
 		allPossibleVictims: allPossibleVictims,
 		name:               name,
 	}, nil

--- a/test/integration/scheduler/preemption/podgrouppreemption_test.go
+++ b/test/integration/scheduler/preemption/podgrouppreemption_test.go
@@ -18,6 +18,7 @@ package preemption
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
@@ -1263,6 +1264,172 @@ func TestPodGroupPreemptionStatus(t *testing.T) {
 	if err != nil {
 		t.Logf("Failed to verify PodGroup condition: %v", err)
 		t.Fatalf("Last observed podGroup condition: Status=%s, Reason=%s, Message=%q", cond.Status, cond.Reason, cond.Message)
+	}
+}
+
+func TestPodGroupPreemption_NominatedNodeNameRespected(t *testing.T) {
+	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+		features.GenericWorkload: true,
+	})
+
+	mockScorePlugin := "mockScorePlugin"
+	registry := make(frameworkruntime.Registry)
+	err := registry.Register(mockScorePlugin, newPresetScorePlugin(map[string]int64{"node1": 100, "node2": 0}))
+	if err != nil {
+		t.Fatalf("Failed to register custom score plugin: %v", err)
+	}
+
+	cfg := configtesting.V1ToInternalWithDefaults(t, configv1.KubeSchedulerConfiguration{
+		Profiles: []configv1.KubeSchedulerProfile{{
+			SchedulerName: ptr.To(v1.DefaultSchedulerName),
+			Plugins: &configv1.Plugins{
+				Score: configv1.PluginSet{
+					Enabled: []configv1.Plugin{
+						{Name: mockScorePlugin},
+					},
+				},
+			},
+		}},
+	})
+
+	testCtx := testutils.InitTestSchedulerWithNS(t, "pg-preemption-nnn",
+		scheduler.WithProfiles(cfg.Profiles...),
+		scheduler.WithFrameworkOutOfTreeRegistry(registry),
+		scheduler.WithPodMaxBackoffSeconds(1),
+		scheduler.WithPodInitialBackoffSeconds(0),
+	)
+	cs, ns := testCtx.ClientSet, testCtx.NS.Name
+
+	// 1. Create 3 nodes
+	nodes := []*v1.Node{
+		st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+		st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+		st.MakeNode().Name("node3").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+	}
+	for _, node := range nodes {
+		if _, err := cs.CoreV1().Nodes().Create(testCtx.Ctx, node, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Failed to create node %s: %v", node.Name, err)
+		}
+	}
+
+	// 2. Create PodGroup with minCount=2
+	pg := st.MakePodGroup().Name("pg1").Namespace(ns).Priority(50).MinCount(2).Obj()
+	if _, err := cs.SchedulingV1alpha3().PodGroups(ns).Create(testCtx.Ctx, pg, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create pod group pg1: %v", err)
+	}
+
+	// 3. Create initial pods: pod1 on node1 (high priority), pod2 on node2 & pod3 on node3 (low priority with default grace period)
+	initialPods := []*v1.Pod{
+		st.MakePod().Name("pod1").Namespace(ns).Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").Priority(100).ZeroTerminationGracePeriod().Node("node1").Obj(),
+		st.MakePod().Name("pod2").Namespace(ns).Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").Priority(10).Node("node2").Obj(),
+		st.MakePod().Name("pod3").Namespace(ns).Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").Priority(10).Node("node3").Obj(),
+	}
+	for _, pod := range initialPods {
+		if _, err := cs.CoreV1().Pods(ns).Create(testCtx.Ctx, pod, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Failed to create pod %s: %v", pod.Name, err)
+		}
+	}
+
+	// Wait for initial pods to be scheduled
+	for _, pod := range initialPods {
+		if err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 10*time.Second, false, testutils.PodScheduled(cs, ns, pod.Name)); err != nil {
+			t.Fatalf("Failed to wait for initial pod %s to schedule: %v", pod.Name, err)
+		}
+	}
+
+	// 4. Create preemptor pods belonging to pg1
+	preemptorPods := []*v1.Pod{
+		st.MakePod().Name("preemptor-1").Namespace(ns).Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg1").Priority(50).Obj(),
+		st.MakePod().Name("preemptor-2").Namespace(ns).Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg1").Priority(50).Obj(),
+	}
+	for _, pod := range preemptorPods {
+		if _, err := cs.CoreV1().Pods(ns).Create(testCtx.Ctx, pod, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Failed to create preemptor pod %s: %v", pod.Name, err)
+		}
+	}
+
+	// 5. Wait for preemption to occur and verify that NominatedNodeName is set on both preemptor pods
+	initialNNNs := make(map[string]string)
+	for _, pod := range preemptorPods {
+		podName := pod.Name
+		err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 10*time.Second, false, func(ctx context.Context) (bool, error) {
+			p, err := cs.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			if p.Status.NominatedNodeName != "" {
+				initialNNNs[podName] = p.Status.NominatedNodeName
+				return true, nil
+			}
+			return false, nil
+		})
+		if err != nil {
+			t.Fatalf("Timed out waiting for NominatedNodeName on %s: %v", podName, err)
+		}
+	}
+
+	for podName, nodeName := range initialNNNs {
+		if nodeName == "node1" {
+			t.Errorf("Expected preemptor pod %s NNN to be node2 or node3, got %s", podName, nodeName)
+		}
+	}
+
+	// 6. Remove pod1 from node1
+	if err := cs.CoreV1().Pods(ns).Delete(testCtx.Ctx, "pod1", metav1.DeleteOptions{GracePeriodSeconds: new(int64(0))}); err != nil {
+		t.Fatalf("Failed to delete pod1: %v", err)
+	}
+
+	// Wait for pod1 to be completely removed from API server
+	err = wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 10*time.Second, false, func(ctx context.Context) (bool, error) {
+		_, err := cs.CoreV1().Pods(ns).Get(ctx, "pod1", metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("Timed out waiting for pod1 to be deleted: %v", err)
+	}
+
+	// 7. Verify that nominated node names did not change to node1 despite node1 having free space and higher score from preferNode1ScorePlugin
+	err = wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 3*time.Second, false, func(ctx context.Context) (bool, error) {
+		_, err := cs.CoreV1().Pods(ns).Get(ctx, "pod2", metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			t.Fatalf("pod2 got removed")
+		}
+		_, err = cs.CoreV1().Pods(ns).Get(ctx, "pod3", metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			t.Fatalf("pod3 got removed")
+		}
+
+		for _, pod := range preemptorPods {
+			events, err := cs.CoreV1().Events(ns).List(ctx, metav1.ListOptions{
+				FieldSelector: "involvedObject.name=" + pod.Name,
+			})
+			if err != nil {
+				return false, err
+			}
+			for _, event := range events.Items {
+				t.Logf("Event: %v", event.Message)
+			}
+
+			p, err := cs.CoreV1().Pods(ns).Get(ctx, pod.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			if p.Spec.NodeName == "node1" {
+				t.Errorf("Pod %s was incorrectly scheduled to node1", pod.Name)
+				return false, nil
+			}
+			if p.Status.NominatedNodeName != initialNNNs[pod.Name] {
+				t.Errorf("Pod %s NominatedNodeName changed from %s to %s. NodeName = %s", pod.Name, initialNNNs[pod.Name], p.Status.NominatedNodeName, p.Spec.NodeName)
+				return false, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil && !errors.Is(err, context.DeadlineExceeded) && !wait.Interrupted(err) {
+		t.Fatalf("Unexpected error while checking NNN persistence: %v", err)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR changes return type for a case where pod group preemption detects ongoing preemption. Instead of returning Unschedulable we return Success with the current nominating info. With that SubmitPodGroupAlgorithmResult will not override the nominating info for pods with empty nodes. 

#### Which issue(s) this PR is related to:
 
https://github.com/kubernetes/enhancements/issues/5710

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixed an issue where a PodGroup preemption that detected ongoing preemption would clear NNN of pod group pods.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
