### PR TITLE
client-go/rest/watch: add tests for decoder and encoder error paths

### DIFF
--- a/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
+++ b/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
@@ -138,7 +138,9 @@ func TestDecoder_Errors(t *testing.T) {
 				if _, err := in.Write([]byte(testCase.input + "\n")); err != nil {
 					t.Errorf("Unexpected error %v", err)
 				}
-				in.Close()
+				if err := in.Close(); err != nil {
+					t.Errorf("Unexpected error %v", err)
+				}
 			}()
 
 			done := make(chan struct{})

--- a/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
+++ b/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -107,20 +108,24 @@ func TestDecoder(t *testing.T) {
 
 func TestDecoder_Errors(t *testing.T) {
 	testCases := []struct {
-		name  string
-		input string
+		name        string
+		input       string
+		expectedErr string
 	}{
 		{
-			name:  "wrong decoded type",
-			input: `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"foo"}}`,
+			name:        "wrong decoded type",
+			input:       `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"foo"}}`,
+			expectedErr: "unable to decode to metav1.WatchEvent",
 		},
 		{
-			name:  "invalid watch event type",
-			input: `{"type":"INVALID","object":{"apiVersion":"v1","kind":"Pod","metadata":{"name":"foo"}}}`,
+			name:        "invalid watch event type",
+			input:       `{"type":"INVALID","object":{"apiVersion":"v1","kind":"Pod","metadata":{"name":"foo"}}}`,
+			expectedErr: "got invalid watch event type",
 		},
 		{
-			name:  "undecodable embedded object",
-			input: `{"type":"ADDED","object":{"apiVersion":"v1","kind":"DoesNotExist"}}`,
+			name:        "undecodable embedded object",
+			input:       `{"type":"ADDED","object":{"apiVersion":"v1","kind":"DoesNotExist"}}`,
+			expectedErr: "unable to decode watch event",
 		},
 	}
 	for _, testCase := range testCases {
@@ -139,8 +144,11 @@ func TestDecoder_Errors(t *testing.T) {
 			done := make(chan struct{})
 			go func() {
 				defer close(done)
-				if _, _, err := decoder.Decode(); err == nil {
-					t.Errorf("Expected error, got nil")
+				_, _, err := decoder.Decode()
+				if err == nil {
+					t.Errorf("Expected error containing %q, got nil", testCase.expectedErr)
+				} else if !strings.Contains(err.Error(), testCase.expectedErr) {
+					t.Errorf("Expected error containing %q, got %q", testCase.expectedErr, err.Error())
 				}
 			}()
 

--- a/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
+++ b/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
@@ -105,6 +105,54 @@ func TestDecoder(t *testing.T) {
 	}
 }
 
+func TestDecoder_Errors(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "wrong decoded type",
+			input: `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"foo"}}`,
+		},
+		{
+			name:  "invalid watch event type",
+			input: `{"type":"INVALID","object":{"apiVersion":"v1","kind":"Pod","metadata":{"name":"foo"}}}`,
+		},
+		{
+			name:  "undecodable embedded object",
+			input: `{"type":"ADDED","object":{"apiVersion":"v1","kind":"DoesNotExist"}}`,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			out, in := io.Pipe()
+			decoder := NewDecoder(streaming.NewDecoder(out, getDecoder()), getDecoder())
+			defer decoder.Close()
+
+			go func() {
+				if _, err := in.Write([]byte(testCase.input + "\n")); err != nil {
+					t.Errorf("Unexpected error %v", err)
+				}
+				in.Close()
+			}()
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				if _, _, err := decoder.Decode(); err == nil {
+					t.Errorf("Expected error, got nil")
+				}
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(wait.ForeverTestTimeout):
+				t.Error("Timeout")
+			}
+		})
+	}
+}
+
 func TestDecoder_SourceClose(t *testing.T) {
 	out, in := io.Pipe()
 	decoder := NewDecoder(streaming.NewDecoder(out, getDecoder()), getDecoder())

--- a/staging/src/k8s.io/client-go/rest/watch/encoder_test.go
+++ b/staging/src/k8s.io/client-go/rest/watch/encoder_test.go
@@ -25,6 +25,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	runtimejson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	"k8s.io/apimachinery/pkg/watch"
@@ -82,5 +83,22 @@ func TestEncodeDecodeRoundTrip(t *testing.T) {
 		if event != testCase.Type {
 			t.Errorf("%d: unexpected type: %#v", i, event)
 		}
+	}
+}
+
+// unencodableObject implements runtime.Object but cannot be serialized to JSON
+// because of the channel field.
+type unencodableObject struct {
+	Ch chan int `json:"ch"`
+}
+
+func (*unencodableObject) GetObjectKind() schema.ObjectKind { return schema.EmptyObjectKind }
+func (o *unencodableObject) DeepCopyObject() runtime.Object { return o }
+
+func TestEncode_EmbeddedEncodeError(t *testing.T) {
+	buf := &bytes.Buffer{}
+	encoder := NewEncoder(streaming.NewEncoder(buf, getEncoder()), getEncoder())
+	if err := encoder.Encode(&watch.Event{Type: watch.Added, Object: &unencodableObject{}}); err == nil {
+		t.Errorf("Expected error encoding unencodable object, got nil")
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds unit tests for the untested error paths in `k8s.io/client-go/rest/watch`, raising package statement coverage from 78.9% to 100%:

- `TestDecoder_Errors` (table-driven) covers the three error branches in `Decoder.Decode`:
  - the streaming decoder returning a non-`WatchEvent` object (fed a bare Pod JSON)
  - an invalid watch event type (`"INVALID"`)
  - an embedded object that fails to decode (unknown kind)
- `TestEncode_EmbeddedEncodeError` covers the embedded-encoder failure branch in `Encoder.Encode`, using an object with a channel field that cannot be JSON-serialized.

No production code changes — test-only.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

An unregistered scheme type was not sufficient to make `Encoder.Encode` fail, because the no-conversion JSON serializer encodes arbitrary objects; the test instead uses a type whose JSON marshaling fails.

Verified locally: `go test -count=5 -race ./rest/watch/` passes; `gofmt` and `go vet` clean.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
