### PR TITLE
Increase test coverage of apimachinery watch package to 99%

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/watch/mux_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/mux_test.go
@@ -246,6 +246,168 @@ func TestBroadcasterSendEventAfterShutdown(t *testing.T) {
 	assert.EqualError(t, err, "broadcaster already stopped", "ActionOrDrop should report error id broadcaster is shutdown")
 }
 
+func TestNewLongQueueBroadcaster(t *testing.T) {
+	m := NewLongQueueBroadcaster(10, WaitIfChannelFull)
+
+	w, err := m.Watch()
+	if err != nil {
+		t.Fatalf("Unable start event watcher: '%v' (will not retry!)", err)
+	}
+
+	event := Event{Type: Added, Object: &myType{"foo", "hello world"}}
+	if err := m.Action(event.Type, event.Object); err != nil {
+		t.Fatalf("error sending event: %v", err)
+	}
+
+	got, ok := <-w.ResultChan()
+	if !ok {
+		t.Fatalf("closed early")
+	}
+	if !reflect.DeepEqual(event, got) {
+		t.Errorf("Expected (%v, %#v), got (%v, %#v)", event.Type, event.Object, got.Type, got.Object)
+	}
+
+	m.Shutdown()
+	if _, open := <-w.ResultChan(); open {
+		t.Errorf("Shutdown didn't work?")
+	}
+}
+
+func TestBroadcasterWatchWithPrefix(t *testing.T) {
+	prefix := []Event{
+		{Type: Added, Object: &myType{"foo", "hello world 1"}},
+		{Type: Modified, Object: &myType{"foo", "hello world 2"}},
+	}
+	event := Event{Type: Deleted, Object: &myType{"foo", "hello world 3"}}
+
+	// Use a watch queue length smaller than len(prefix)+1 to exercise the
+	// queue-length adjustment in WatchWithPrefix.
+	m := NewBroadcaster(1, WaitIfChannelFull)
+
+	w, err := m.WatchWithPrefix(prefix)
+	if err != nil {
+		t.Fatalf("Unable start event watcher: '%v' (will not retry!)", err)
+	}
+
+	if err := m.Action(event.Type, event.Object); err != nil {
+		t.Fatalf("error sending event: %v", err)
+	}
+
+	for i, expect := range append(prefix, event) {
+		got, ok := <-w.ResultChan()
+		if !ok {
+			t.Fatalf("closed early at event %d", i)
+		}
+		if !reflect.DeepEqual(expect, got) {
+			t.Errorf("Event %d: Expected (%v, %#v), got (%v, %#v)",
+				i, expect.Type, expect.Object, got.Type, got.Object)
+		}
+	}
+
+	m.Shutdown()
+	if _, open := <-w.ResultChan(); open {
+		t.Errorf("Shutdown didn't work?")
+	}
+}
+
+func TestBroadcasterActionOrDrop(t *testing.T) {
+	event1 := Event{Type: Added, Object: &myType{"foo", "hello world 1"}}
+	event2 := Event{Type: Added, Object: &myType{"bar", "hello world 2"}}
+
+	// The incoming queue has capacity 1.
+	m := NewLongQueueBroadcaster(1, WaitIfChannelFull)
+
+	w, err := m.Watch()
+	if err != nil {
+		t.Fatalf("Unable start event watcher: '%v' (will not retry!)", err)
+	}
+
+	// Park the distribution loop so that events accumulate in m.incoming.
+	started := make(chan struct{})
+	release := make(chan struct{})
+	m.incoming <- Event{
+		Type: internalRunFunctionMarker,
+		Object: functionFakeRuntimeObject(func() {
+			close(started)
+			<-release
+		}),
+	}
+	<-started
+
+	// The first event fills the incoming queue, the second is dropped.
+	sent, err := m.ActionOrDrop(event1.Type, event1.Object)
+	if err != nil {
+		t.Fatalf("error sending event: %v", err)
+	}
+	if !sent {
+		t.Errorf("event unexpectedly dropped")
+	}
+	sent, err = m.ActionOrDrop(event2.Type, event2.Object)
+	if err != nil {
+		t.Fatalf("error sending event: %v", err)
+	}
+	if sent {
+		t.Errorf("event unexpectedly sent on a full queue")
+	}
+
+	// Resume distribution and verify only the first event was delivered.
+	close(release)
+	got, ok := <-w.ResultChan()
+	if !ok {
+		t.Fatalf("closed early")
+	}
+	if !reflect.DeepEqual(event1, got) {
+		t.Errorf("Expected (%v, %#v), got (%v, %#v)", event1.Type, event1.Object, got.Type, got.Object)
+	}
+
+	m.Shutdown()
+	if _, open := <-w.ResultChan(); open {
+		t.Errorf("Shutdown didn't work?")
+	}
+}
+
+func TestBroadcasterStopWatchingUnknownID(t *testing.T) {
+	m := NewBroadcaster(0, WaitIfChannelFull)
+
+	w, err := m.Watch()
+	if err != nil {
+		t.Fatalf("Unable start event watcher: '%v' (will not retry!)", err)
+	}
+
+	// Stopping an unknown watcher is a no-op.
+	m.stopWatching(12345)
+
+	// The broadcaster still distributes events.
+	event := Event{Type: Added, Object: &myType{"foo", "hello world"}}
+	if err := m.Action(event.Type, event.Object); err != nil {
+		t.Fatalf("error sending event: %v", err)
+	}
+	got, ok := <-w.ResultChan()
+	if !ok {
+		t.Fatalf("closed early")
+	}
+	if !reflect.DeepEqual(event, got) {
+		t.Errorf("Expected (%v, %#v), got (%v, %#v)", event.Type, event.Object, got.Type, got.Object)
+	}
+
+	m.Shutdown()
+}
+
+func TestFunctionFakeRuntimeObject(t *testing.T) {
+	obj := functionFakeRuntimeObject(func() {})
+	if got := obj.GetObjectKind(); got != schema.EmptyObjectKind {
+		t.Errorf("expected EmptyObjectKind, got %#v", got)
+	}
+	if obj.DeepCopyObject() == nil {
+		t.Errorf("expected non-nil copy of non-nil function")
+	}
+
+	var nilObj functionFakeRuntimeObject
+	if got := nilObj.DeepCopyObject(); got != nil {
+		t.Errorf("expected nil copy of nil function, got %#v", got)
+	}
+}
+
 // Test this since we see usage patterns where the broadcaster and watchers are
 // stopped simultaneously leading to races.
 func TestBroadcasterShutdownRace(t *testing.T) {

--- a/staging/src/k8s.io/apimachinery/pkg/watch/mux_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/mux_test.go
@@ -323,8 +323,12 @@ func TestBroadcasterActionOrDrop(t *testing.T) {
 	}
 
 	// Park the distribution loop so that events accumulate in m.incoming.
+	// blockQueue can't be used here because it would wait for the parked
+	// function to finish, so send the marker directly while holding
+	// incomingBlock, matching blockQueue's send-side locking.
 	started := make(chan struct{})
 	release := make(chan struct{})
+	m.incomingBlock.Lock()
 	m.incoming <- Event{
 		Type: internalRunFunctionMarker,
 		Object: functionFakeRuntimeObject(func() {
@@ -332,6 +336,7 @@ func TestBroadcasterActionOrDrop(t *testing.T) {
 			<-release
 		}),
 	}
+	m.incomingBlock.Unlock()
 	<-started
 
 	// The first event fills the incoming queue, the second is dropped.

--- a/staging/src/k8s.io/apimachinery/pkg/watch/streamwatcher_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/streamwatcher_test.go
@@ -109,6 +109,42 @@ func TestStreamWatcherError(t *testing.T) {
 	}
 }
 
+// timeoutError implements net.Error with Timeout() == true.
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "i/o timeout" }
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return false }
+
+func TestStreamWatcherClosesQuietly(t *testing.T) {
+	table := []struct {
+		name string
+		err  error
+	}{
+		{"unexpected EOF", io.ErrUnexpectedEOF},
+		{"probable EOF", fmt.Errorf("read: connection reset by peer")},
+		{"timeout", timeoutError{}},
+	}
+
+	for _, item := range table {
+		t.Run(item.name, func(t *testing.T) {
+			fd := fakeDecoder{err: item.err}
+			fr := &fakeReporter{}
+			//nolint:logcheck // Intentionally uses the old API.
+			sw := NewStreamWatcher(fd, fr)
+			// The result channel closes without an Error event being sent.
+			evt, ok := <-sw.ResultChan()
+			if ok {
+				t.Fatalf("unexpected event: %#v", evt)
+			}
+			if fr.err != nil {
+				t.Fatalf("unexpected error reported: %v", fr.err)
+			}
+			sw.Stop()
+		})
+	}
+}
+
 func TestStreamWatcherRace(t *testing.T) {
 	fd := fakeDecoder{err: fmt.Errorf("test error")}
 	fr := &fakeReporter{}

--- a/staging/src/k8s.io/apimachinery/pkg/watch/watch_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/watch_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	. "k8s.io/apimachinery/pkg/watch"
@@ -29,6 +30,21 @@ type testType string
 
 func (obj testType) GetObjectKind() schema.ObjectKind { return schema.EmptyObjectKind }
 func (obj testType) DeepCopyObject() runtime.Object   { return obj }
+
+// testPtrType is a pointer-based runtime.Object whose DeepCopyObject returns a
+// distinct pointer, so tests can verify that objects are actually deep-copied.
+type testPtrType struct {
+	Value string
+}
+
+func (obj *testPtrType) GetObjectKind() schema.ObjectKind { return schema.EmptyObjectKind }
+func (obj *testPtrType) DeepCopyObject() runtime.Object {
+	if obj == nil {
+		return nil
+	}
+	clone := *obj
+	return &clone
+}
 
 func TestFake(t *testing.T) {
 	f := NewFake()
@@ -199,26 +215,17 @@ func TestRaceFreeFakeWatcherLifecycle(t *testing.T) {
 }
 
 func TestRaceFreeFakeWatcherPanicsWhenFull(t *testing.T) {
-	expectPanic := func(name string, fn func()) {
-		defer func() {
-			if r := recover(); r == nil {
-				t.Errorf("%s: expected panic on full channel", name)
-			}
-		}()
-		fn()
-	}
-
 	f := NewRaceFreeFake()
 	// Fill the buffered channel without a consumer.
 	for i := int32(0); i < DefaultChanSize; i++ {
 		f.Add(testType("foo"))
 	}
 
-	expectPanic("Add", func() { f.Add(testType("foo")) })
-	expectPanic("Modify", func() { f.Modify(testType("foo")) })
-	expectPanic("Delete", func() { f.Delete(testType("foo")) })
-	expectPanic("Error", func() { f.Error(testType("foo")) })
-	expectPanic("Action", func() { f.Action(Added, testType("foo")) })
+	assert.PanicsWithError(t, "channel full", func() { f.Add(testType("foo")) }, "Add")
+	assert.PanicsWithError(t, "channel full", func() { f.Modify(testType("foo")) }, "Modify")
+	assert.PanicsWithError(t, "channel full", func() { f.Delete(testType("foo")) }, "Delete")
+	assert.PanicsWithError(t, "channel full", func() { f.Error(testType("foo")) }, "Error")
+	assert.PanicsWithError(t, "channel full", func() { f.Action(Added, testType("foo")) }, "Action")
 }
 
 func TestEmpty(t *testing.T) {
@@ -298,10 +305,13 @@ func TestMockWatcher(t *testing.T) {
 }
 
 func TestEventDeepCopy(t *testing.T) {
-	e := Event{Type: Added, Object: testType("foo")}
+	e := Event{Type: Added, Object: &testPtrType{Value: "foo"}}
 	c := e.DeepCopy()
 	if !reflect.DeepEqual(e, *c) {
 		t.Errorf("expected %#v, got %#v", e, *c)
+	}
+	if c.Object == e.Object {
+		t.Errorf("expected Object to be deep-copied, got the same pointer")
 	}
 
 	empty := Event{}

--- a/staging/src/k8s.io/apimachinery/pkg/watch/watch_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/watch_test.go
@@ -163,6 +163,19 @@ func TestFakeWatcherLifecycle(t *testing.T) {
 		t.Errorf("unexpected stopped watcher after reset")
 	}
 
+	// The fresh channel is open and empty. Checking this first also keeps
+	// the Add goroutine below from panicking on a closed channel if Reset
+	// ever regresses, which would crash the test binary without a clean
+	// failure message.
+	select {
+	case _, ok := <-f.ResultChan():
+		if !ok {
+			t.Fatalf("channel still closed after reset")
+		}
+		t.Fatalf("unexpected event after reset")
+	default:
+	}
+
 	// Events flow again on the fresh channel.
 	go f.Add(testType("baz"))
 	got, ok := <-f.ResultChan()
@@ -294,7 +307,7 @@ func TestMockWatcher(t *testing.T) {
 		ResultChanFunc: func() <-chan Event { return ch },
 	}
 
-	if got := w.ResultChan(); got != (<-chan Event)(ch) {
+	if got := w.ResultChan(); got != ch {
 		t.Errorf("expected ResultChan to return the provided channel")
 	}
 

--- a/staging/src/k8s.io/apimachinery/pkg/watch/watch_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/watch_test.go
@@ -124,6 +124,103 @@ func TestRaceFreeFake(t *testing.T) {
 	consumer(f)
 }
 
+func TestFakeWatcherLifecycle(t *testing.T) {
+	f := NewFakeWithChanSize(2, false)
+
+	if f.IsStopped() {
+		t.Errorf("unexpected stopped watcher")
+	}
+
+	// The buffered channel accepts events without a consumer.
+	f.Add(testType("foo"))
+	f.Add(testType("bar"))
+
+	f.Stop()
+	if !f.IsStopped() {
+		t.Errorf("expected watcher to be stopped")
+	}
+	// Stop is idempotent.
+	f.Stop()
+
+	f.Reset()
+	if f.IsStopped() {
+		t.Errorf("unexpected stopped watcher after reset")
+	}
+
+	// Events flow again on the fresh channel.
+	go f.Add(testType("baz"))
+	got, ok := <-f.ResultChan()
+	if !ok {
+		t.Fatalf("closed early")
+	}
+	if e, a := (Event{Added, testType("baz")}), got; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+}
+
+func TestRaceFreeFakeWatcherLifecycle(t *testing.T) {
+	f := NewRaceFreeFake()
+
+	if f.IsStopped() {
+		t.Errorf("unexpected stopped watcher")
+	}
+
+	f.Stop()
+	if !f.IsStopped() {
+		t.Errorf("expected watcher to be stopped")
+	}
+	// Stop is idempotent.
+	f.Stop()
+
+	// Sending on a stopped watcher is a silent no-op.
+	f.Add(testType("foo"))
+	f.Modify(testType("foo"))
+	f.Delete(testType("foo"))
+	f.Error(testType("foo"))
+	f.Action(Added, testType("foo"))
+	if _, ok := <-f.ResultChan(); ok {
+		t.Errorf("unexpected event on stopped watcher")
+	}
+
+	f.Reset()
+	if f.IsStopped() {
+		t.Errorf("unexpected stopped watcher after reset")
+	}
+
+	// Events flow again on the fresh channel.
+	f.Add(testType("baz"))
+	got, ok := <-f.ResultChan()
+	if !ok {
+		t.Fatalf("closed early")
+	}
+	if e, a := (Event{Added, testType("baz")}), got; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+}
+
+func TestRaceFreeFakeWatcherPanicsWhenFull(t *testing.T) {
+	expectPanic := func(name string, fn func()) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("%s: expected panic on full channel", name)
+			}
+		}()
+		fn()
+	}
+
+	f := NewRaceFreeFake()
+	// Fill the buffered channel without a consumer.
+	for i := int32(0); i < DefaultChanSize; i++ {
+		f.Add(testType("foo"))
+	}
+
+	expectPanic("Add", func() { f.Add(testType("foo")) })
+	expectPanic("Modify", func() { f.Modify(testType("foo")) })
+	expectPanic("Delete", func() { f.Delete(testType("foo")) })
+	expectPanic("Error", func() { f.Error(testType("foo")) })
+	expectPanic("Action", func() { f.Action(Added, testType("foo")) })
+}
+
 func TestEmpty(t *testing.T) {
 	w := NewEmptyWatch()
 	_, ok := <-w.ResultChan()
@@ -161,7 +258,15 @@ func TestProxyWatcher(t *testing.T) {
 		}
 	}
 
+	if w.Stopping() {
+		t.Errorf("unexpected stopping watcher")
+	}
+
 	w.Stop()
+
+	if !w.Stopping() {
+		t.Errorf("expected watcher to be stopping")
+	}
 
 	select {
 	// Closed channel always reads immediately
@@ -172,4 +277,35 @@ func TestProxyWatcher(t *testing.T) {
 
 	// Test double close
 	w.Stop()
+}
+
+func TestMockWatcher(t *testing.T) {
+	stopped := false
+	ch := make(chan Event)
+	w := MockWatcher{
+		StopFunc:       func() { stopped = true },
+		ResultChanFunc: func() <-chan Event { return ch },
+	}
+
+	if got := w.ResultChan(); got != (<-chan Event)(ch) {
+		t.Errorf("expected ResultChan to return the provided channel")
+	}
+
+	w.Stop()
+	if !stopped {
+		t.Errorf("expected Stop to call StopFunc")
+	}
+}
+
+func TestEventDeepCopy(t *testing.T) {
+	e := Event{Type: Added, Object: testType("foo")}
+	c := e.DeepCopy()
+	if !reflect.DeepEqual(e, *c) {
+		t.Errorf("expected %#v, got %#v", e, *c)
+	}
+
+	empty := Event{}
+	if got := empty.DeepCopy(); !reflect.DeepEqual(empty, *got) {
+		t.Errorf("expected %#v, got %#v", empty, *got)
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Increases unit test coverage of `k8s.io/apimachinery/pkg/watch` from **74.2%** to **99.1%** of statements. Only test files are changed.

New tests cover previously untested code:

- **watch.go**: `NewFakeWithChanSize`, `FakeWatcher.IsStopped`/`Reset`, `RaceFreeFakeWatcher.IsStopped`/`Reset`, the panic-on-full-channel branch of all five `RaceFreeFakeWatcher` send methods, `ProxyWatcher.Stopping`, and `MockWatcher`.
- **mux.go**: `NewLongQueueBroadcaster`, the `WatchWithPrefix` success path (including the queue-length adjustment when the prefix exceeds the watch queue length), the send/drop branches of `ActionOrDrop`, the unknown-id branch of `stopWatching`, and `functionFakeRuntimeObject.GetObjectKind`/`DeepCopyObject`.
- **streamwatcher.go**: the quiet-close branches of `receive` (`io.ErrUnexpectedEOF`, probable-EOF errors, and network timeout errors close the result channel without emitting an `Error` event).
- **zz_generated.deepcopy.go**: `Event.DeepCopy`/`DeepCopyInto`, including the nil-`Object` branch.

The `ActionOrDrop` drop branch is tested deterministically by parking the broadcaster's distribution loop with an injected `internalRunFunctionMarker` function event, rather than racing the consumer.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Verified with `go test -race -count=5 ./pkg/watch/...` from `staging/src/k8s.io/apimachinery` (all passing), plus `gofmt` and `go vet`.

Remaining uncovered statements are not practically reachable from tests: the nil-receiver branch of the generated `Event.DeepCopy` and one timing-dependent select case in `StreamWatcher.receive` (`emptyWatch.Stop` is a zero-statement block that always reports 0%).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
