### PR TITLE
Fix status wiping api definition test and fix gaps

### DIFF
--- a/pkg/registry/certificates/podcertificaterequest/storage/storage.go
+++ b/pkg/registry/certificates/podcertificaterequest/storage/storage.go
@@ -56,9 +56,10 @@ func NewREST(optsGetter generic.RESTOptionsGetter, authorizer authorizer.Uncondi
 		DefaultQualifiedResource:  api.Resource("podcertificaterequests"),
 		SingularQualifiedResource: api.Resource("podcertificaterequest"),
 
-		CreateStrategy: strategy,
-		UpdateStrategy: strategy,
-		DeleteStrategy: strategy,
+		CreateStrategy:      strategy,
+		UpdateStrategy:      strategy,
+		DeleteStrategy:      strategy,
+		ResetFieldsStrategy: strategy,
 
 		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)},
 	}

--- a/pkg/registry/certificates/podcertificaterequest/strategy.go
+++ b/pkg/registry/certificates/podcertificaterequest/strategy.go
@@ -60,6 +60,16 @@ func (s *Strategy) NamespaceScoped() bool {
 	return true
 }
 
+// GetResetFields returns the set of fields that get reset by the strategy
+// and should not be modified by the user.
+func (s *Strategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
+	return map[fieldpath.APIVersion]*fieldpath.Set{
+		"certificates.k8s.io/v1beta1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("status"),
+		),
+	}
+}
+
 func (s *Strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 	req := obj.(*certificates.PodCertificateRequest)
 	req.Status = certificates.PodCertificateRequestStatus{}

--- a/pkg/registry/scheduling/compositepodgroup/storage/storage.go
+++ b/pkg/registry/scheduling/compositepodgroup/storage/storage.go
@@ -46,9 +46,10 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
 		DefaultQualifiedResource:  scheduling.Resource("compositepodgroups"),
 		SingularQualifiedResource: scheduling.Resource("compositepodgroup"),
 
-		CreateStrategy: strategy,
-		UpdateStrategy: strategy,
-		DeleteStrategy: strategy,
+		CreateStrategy:      strategy,
+		UpdateStrategy:      strategy,
+		DeleteStrategy:      strategy,
+		ResetFieldsStrategy: strategy,
 
 		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)},
 	}

--- a/pkg/registry/scheduling/podgroup/storage/storage.go
+++ b/pkg/registry/scheduling/podgroup/storage/storage.go
@@ -46,9 +46,10 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
 		DefaultQualifiedResource:  scheduling.Resource("podgroups"),
 		SingularQualifiedResource: scheduling.Resource("podgroup"),
 
-		CreateStrategy: strategy,
-		UpdateStrategy: strategy,
-		DeleteStrategy: strategy,
+		CreateStrategy:      strategy,
+		UpdateStrategy:      strategy,
+		DeleteStrategy:      strategy,
+		ResetFieldsStrategy: strategy,
 
 		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)},
 	}

--- a/test/integration/apiserver/apidefinitions/fields_wiping_test.go
+++ b/test/integration/apiserver/apidefinitions/fields_wiping_test.go
@@ -86,6 +86,16 @@ func TestFieldsWipingConsistency(t *testing.T) {
 		}
 		createWipesStatus := !checkPatch(t, status, "status", created.Object)
 
+		// Infer main-endpoint GetResetFields behavior from the created object's
+		// managedFields, before the status apply below (Force: true) steals
+		// ownership of the status fields and destroys the evidence.
+		ssaMainResetsStatus := true
+		for _, mf := range created.GetManagedFields() {
+			if mf.Manager == "spec-manager" && mf.Subresource == "" {
+				ssaMainResetsStatus = !managedFieldsOwnTopLevelField(t, mf.FieldsV1, "status")
+			}
+		}
+
 		// Apply to /status endpoint with mutated spec, status and metadata field changes.
 		statusObj := TestObj(t, api.StorageData.Stub, status, api.Mapping.GroupVersionKind)
 		if api.StorageData.MutatedStub != "" {
@@ -114,13 +124,9 @@ func TestFieldsWipingConsistency(t *testing.T) {
 		baselineSpec := baseline.Object["spec"]
 
 		// Infer GetResetFields behavior from managedFields.
-		ssaMainResetsStatus := true
 		ssaStatusResetsSpec := true
 		ssaStatusResetsMetadata := true
 		for _, mf := range baseline.GetManagedFields() {
-			if mf.Manager == "spec-manager" && mf.Subresource == "" {
-				ssaMainResetsStatus = !managedFieldsOwnTopLevelField(t, mf.FieldsV1, "status")
-			}
 			if mf.Manager == "status-manager" && mf.Subresource == "status" {
 				ssaStatusResetsSpec = !managedFieldsOwnTopLevelField(t, mf.FieldsV1, "spec")
 				ssaStatusResetsMetadata = !managedFieldsOwnLabel(t, mf.FieldsV1, "test-status-ssa")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This fixes an ordering bug that caused the API definitions tests to fail to notice incorrect `GetResetFields` implementations.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Server-side apply now correctly drops status changes when tracking field owership for PodGroup, PodCompositeGroup and PodCertificateRequest.
```

/sig api-machinery