### PR TITLE
admission/namespace/lifecycle: allow updates to resources in deleted namespaces

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission.go
@@ -102,6 +102,11 @@ func (l *Lifecycle) Admit(ctx context.Context, a admission.Attributes, o admissi
 		return nil
 	}
 
+	// always allow updates to other resources
+	if a.GetOperation() == admission.Update {
+		return nil
+	}
+
 	// always allow access review checks.  Returning status about the namespace would be leaking information
 	if isAccessReview(a) {
 		return nil

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission_test.go
@@ -149,13 +149,52 @@ func TestAdmissionNamespaceDoesNotExist(t *testing.T) {
 		t.Errorf("Expected error rejecting creates in a namespace when it is missing")
 	}
 
-	// verify update operations in the namespace cause an error
+	// verify update operations in the namespace can proceed
 	err = handler.Admit(context.TODO(), admission.NewAttributesRecord(&pod, nil, v1.SchemeGroupVersion.WithKind("Pod").GroupKind().WithVersion("version"), pod.Namespace, pod.Name, v1.Resource("pods").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil), nil)
-	if err == nil {
-		t.Errorf("Expected error rejecting updates in a namespace when it is missing")
+	if err != nil {
+		t.Errorf("Unexpected error rejecting updates in a namespace when it is missing: %v", err)
 	}
 
 	// verify delete operations in the namespace can proceed
+	err = handler.Admit(context.TODO(), admission.NewAttributesRecord(nil, nil, v1.SchemeGroupVersion.WithKind("Pod").GroupKind().WithVersion("version"), pod.Namespace, pod.Name, v1.Resource("pods").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil), nil)
+	if err != nil {
+		t.Errorf("Unexpected error returned from admission handler: %v", err)
+	}
+}
+
+// TestAdmissionNamespaceFullyDeleted verifies that when a namespace has been
+// fully deleted from storage (not just Terminating), Creates are rejected but
+// Updates are allowed. Objects may outlive their namespace in storage, and
+// controllers that list across all namespaces may need to update them. The
+// storage layer validates object existence. Create-on-update is safe because
+// the storage layer re-runs the admission chain with a Create operation.
+func TestAdmissionNamespaceFullyDeleted(t *testing.T) {
+	namespace := "test"
+	mockClient := newMockClientForTest(map[string]v1.NamespacePhase{})
+	mockClient.AddReactor("get", "namespaces", func(action core.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.NewNotFound(v1.Resource("namespaces"), namespace)
+	})
+	handler, informerFactory, err := newHandlerForTest(mockClient)
+	if err != nil {
+		t.Errorf("unexpected error initializing handler: %v", err)
+	}
+	informerFactory.Start(wait.NeverStop)
+
+	pod := newPod(namespace)
+
+	// verify create is rejected
+	err = handler.Admit(context.TODO(), admission.NewAttributesRecord(&pod, nil, v1.SchemeGroupVersion.WithKind("Pod").GroupKind().WithVersion("version"), pod.Namespace, pod.Name, v1.Resource("pods").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil), nil)
+	if err == nil {
+		t.Errorf("Expected error rejecting creates in a fully deleted namespace")
+	}
+
+	// verify update is allowed
+	err = handler.Admit(context.TODO(), admission.NewAttributesRecord(&pod, nil, v1.SchemeGroupVersion.WithKind("Pod").GroupKind().WithVersion("version"), pod.Namespace, pod.Name, v1.Resource("pods").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil), nil)
+	if err != nil {
+		t.Errorf("Unexpected error rejecting updates in a fully deleted namespace: %v", err)
+	}
+
+	// verify delete is allowed
 	err = handler.Admit(context.TODO(), admission.NewAttributesRecord(nil, nil, v1.SchemeGroupVersion.WithKind("Pod").GroupKind().WithVersion("version"), pod.Namespace, pod.Name, v1.Resource("pods").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil), nil)
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler: %v", err)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission_test.go
@@ -149,7 +149,7 @@ func TestAdmissionNamespaceDoesNotExist(t *testing.T) {
 		t.Errorf("Expected error rejecting creates in a namespace when it is missing")
 	}
 
-	// verify update operations in the namespace can proceed
+	// verify update operations in the namespace with no old object can proceed
 	err = handler.Admit(context.TODO(), admission.NewAttributesRecord(&pod, nil, v1.SchemeGroupVersion.WithKind("Pod").GroupKind().WithVersion("version"), pod.Namespace, pod.Name, v1.Resource("pods").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil), nil)
 	if err != nil {
 		t.Errorf("Unexpected error rejecting updates in a namespace when it is missing: %v", err)

--- a/test/integration/namespace/ns_conditions_test.go
+++ b/test/integration/namespace/ns_conditions_test.go
@@ -159,6 +159,79 @@ func TestNamespaceLabels(t *testing.T) {
 	}
 }
 
+// TestUpdateResourceInDeletedNamespace verifies that when a namespace has been
+// fully deleted from storage but child objects remain (orphaned), Update
+// operations on those objects succeed through the full API server admission
+// chain, while Create operations are correctly rejected.
+func TestUpdateResourceInDeletedNamespace(t *testing.T) {
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
+	defer server.TearDownFn()
+
+	kubeClient, err := clientset.NewForConfig(server.ClientConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nsName := "test-orphaned-ns"
+	ctx := context.Background()
+
+	// Create a namespace and a configmap inside it.
+	_, err = kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: nsName},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cm, err := kubeClient.CoreV1().ConfigMaps(nsName).Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "orphaned-cm"},
+		Data:       map[string]string{"key": "original"},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete the namespace object directly from etcd, bypassing the API
+	// server and namespace controller. This leaves the configmap orphaned
+	// in storage with no parent namespace.
+	nsKey := "/" + server.EtcdStoragePrefix + "/namespaces/" + nsName
+	_, err = server.EtcdClient.Delete(ctx, nsKey)
+	if err != nil {
+		t.Fatalf("failed to delete namespace from etcd: %v", err)
+	}
+
+	// Verify the namespace is gone from the API.
+	_, err = kubeClient.CoreV1().Namespaces().Get(ctx, nsName, metav1.GetOptions{})
+	if err == nil {
+		t.Fatal("expected namespace to be gone from API after etcd deletion")
+	}
+
+	// Update the orphaned configmap. This should succeed because
+	// NamespaceLifecycle allows updates regardless of namespace state.
+	cm.Data["key"] = "updated"
+	_, err = kubeClient.CoreV1().ConfigMaps(nsName).Update(ctx, cm, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("expected update of orphaned configmap to succeed, got: %v", err)
+	}
+
+	// Create a new configmap in the deleted namespace. This should fail
+	// because NamespaceLifecycle rejects creates in non-existent namespaces.
+	_, err = kubeClient.CoreV1().ConfigMaps(nsName).Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "new-cm"},
+		Data:       map[string]string{"key": "value"},
+	}, metav1.CreateOptions{})
+	if err == nil {
+		t.Fatal("expected create of new configmap in deleted namespace to be rejected")
+	}
+
+	// Delete the orphaned configmap. This should succeed because
+	// NamespaceLifecycle allows deletes regardless of namespace state.
+	err = kubeClient.CoreV1().ConfigMaps(nsName).Delete(ctx, "orphaned-cm", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("expected delete of orphaned configmap to succeed, got: %v", err)
+	}
+}
+
 // JSONToUnstructured converts a JSON stub to unstructured.Unstructured and
 // returns a dynamic resource client that can be used to interact with it
 func jsonToUnstructured(stub, version, kind string) (*unstructured.Unstructured, error) {


### PR DESCRIPTION
## Problem

The NamespaceLifecycle admission plugin rejects both Create and Update requests when the target namespace has been fully deleted from storage. While blocking Creates is correct (no new content should appear in a deleted namespace), blocking Updates prevents controllers from re-writing objects that still exist in etcd.

This causes a bug in the storage version migrator (#140655): when orphaned objects remain in etcd after their namespace is deleted, the migrator's Patch is rejected with NotFound by NamespaceLifecycle. The migrator treats NotFound as "object deleted, safe to skip" and reports migration as complete, even though the object was never re-written.

## Fix

Allow Update operations through early, alongside Delete, which is already allowed regardless of namespace state (line 101). The storage layer validates object existence and will reject the Update if the object itself is gone.

Only Create operations now proceed to the namespace existence check. Patches that would create new objects are classified as Create operations by the admission layer and remain blocked.

## Note on admission webhooks

Admission webhooks that match Update operations will now receive requests for objects in deleted namespaces. This is consistent with Delete operations, which already bypass the namespace existence check. Webhooks that look up the namespace should already handle the missing-namespace case gracefully, since they must do so for Deletes.

## Test

- Updated `TestAdmissionNamespaceDoesNotExist`: Update assertion flipped from "expect error" to "expect allowed"
- New `TestAdmissionNamespaceFullyDeleted`: verifies Create is rejected, Update is allowed, and Delete is allowed when the namespace is fully deleted (live lookup returns NotFound)
- Mutation tested: reverting the fix causes both Update assertions to fail

## Context

Per discussion in #140655, @liggitt suggested fixing this at the admission layer rather than in the migrator. This PR implements his option 2: allow the update of the orphaned object if the object still exists.

/sig api-machinery
/kind bug

```release-note
Fixes handling of admission to allow updates to namespaced objects that exist after their namespace was deleted.
```