### PR TITLE
DRA: fix int64 overflow in consumable-capacity range arithmetic

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/consumable_capacity.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/consumable_capacity.go
@@ -18,7 +18,9 @@ package experimental
 
 import (
 	"errors"
+	"math"
 
+	inf "gopkg.in/inf.v0"
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/ptr"
@@ -118,17 +120,59 @@ func roundUpRange(requestedVal *resource.Quantity, validRange *resourceapi.Capac
 	if validRange.Step == nil {
 		return *requestedVal
 	}
-	requestedInt64 := requestedVal.Value()
-	step := validRange.Step.Value()
-	min := validRange.Min.Value()
-	added := (requestedInt64 - min)
-	n := added / step
-	mod := added % step
-	if mod != 0 {
-		n += 1
+	// Integer arithmetic fast path, guarded against int64 overflow and against a
+	// step whose Value() is 0 (a quantity larger than MaxInt64, for example "100E",
+	// which would otherwise divide by zero). Fall back to exact arithmetic when a
+	// value does not fit int64 or when min+step*n would overflow.
+	if fitsInt64Value(requestedVal) && fitsInt64Value(validRange.Min) && fitsInt64Value(validRange.Step) {
+		if step := validRange.Step.Value(); step > 0 {
+			requestedInt64 := requestedVal.Value()
+			min := validRange.Min.Value()
+			added := requestedInt64 - min
+			n := added / step
+			if added%step != 0 {
+				n++
+			}
+			if val, ok := safeMinPlusStepN(min, step, n); ok {
+				return *resource.NewQuantity(val, resource.BinarySI)
+			}
+		}
 	}
-	val := min + step*n
-	return *resource.NewQuantity(val, resource.BinarySI)
+	return roundUpRangeArbitrary(requestedVal, validRange.Min, validRange.Step)
+}
+
+// fitsInt64Value reports whether q is non-negative and small enough that q.Value()
+// is exact. A quantity larger than MaxInt64 wraps, for example "100E".Value() == 0.
+func fitsInt64Value(q *resource.Quantity) bool {
+	return q.Sign() >= 0 && q.CmpInt64(math.MaxInt64) <= 0
+}
+
+// safeMinPlusStepN returns base+step*n and reports whether that int64 computation
+// stays within range. base, step and n are assumed non-negative.
+func safeMinPlusStepN(base, step, n int64) (int64, bool) {
+	if n != 0 && step > (math.MaxInt64-base)/n {
+		return 0, false
+	}
+	return base + step*n, true
+}
+
+// roundUpRangeArbitrary rounds requestedVal up to minVal+ceil((requestedVal-minVal)/step)*step
+// with arbitrary precision, for the cases the int64 fast path cannot represent
+// without overflowing or dividing by zero.
+func roundUpRangeArbitrary(requestedVal, minVal, step *resource.Quantity) resource.Quantity {
+	added := new(inf.Dec).Sub(requestedVal.AsDec(), minVal.AsDec())
+	n := new(inf.Dec).QuoRound(added, step.AsDec(), 0, inf.RoundCeil)
+	result := new(inf.Dec).Add(minVal.AsDec(), new(inf.Dec).Mul(n, step.AsDec()))
+	return *resource.NewDecimalQuantity(*result, step.Format)
+}
+
+// isStepMultiple reports whether requestedVal-minVal is an exact multiple of step,
+// using arbitrary precision so it neither overflows nor divides by zero.
+func isStepMultiple(requestedVal, minVal, step *resource.Quantity) bool {
+	added := new(inf.Dec).Sub(requestedVal.AsDec(), minVal.AsDec())
+	n := new(inf.Dec).QuoRound(added, step.AsDec(), 0, inf.RoundDown)
+	remainder := new(inf.Dec).Sub(added, new(inf.Dec).Mul(n, step.AsDec()))
+	return remainder.Sign() == 0
 }
 
 // roundUpValidValues returns the first value in validValues that is greater than or equal to requestedVal.
@@ -188,15 +232,16 @@ func violateValidRange(requestedVal resource.Quantity, validRange resourceapi.Ca
 		return true
 	}
 	if validRange.Step != nil {
-		requestedInt64 := requestedVal.Value()
-		step := validRange.Step.Value()
-		min := validRange.Min.Value()
-		added := (requestedInt64 - min)
-		mod := added % step
-		// must be a multiply of step
-		if mod != 0 {
-			return true
+		// Guard against int64 overflow and against a step whose Value() is 0 (a
+		// quantity larger than MaxInt64); fall back to exact arithmetic otherwise.
+		if fitsInt64Value(&requestedVal) && fitsInt64Value(validRange.Min) && fitsInt64Value(validRange.Step) {
+			if step := validRange.Step.Value(); step > 0 {
+				added := requestedVal.Value() - validRange.Min.Value()
+				return added%step != 0
+			}
 		}
+		// must be a multiple of step
+		return !isStepMultiple(&requestedVal, validRange.Min, validRange.Step)
 	}
 	return false
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/consumable_capacity_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/consumable_capacity_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package experimental
 
 import (
+	"math"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -113,6 +114,51 @@ func TestConsumableCapacity(t *testing.T) {
 
 	t.Run("calculate-consumed-capacity", testCalculateConsumedCapacity)
 
+	t.Run("round-up-range-overflow", testRoundUpRangeOverflow)
+
+}
+
+// testRoundUpRangeOverflow checks that roundUpRange does not overflow int64 or
+// divide by zero for large capacity requests.
+func testRoundUpRangeOverflow(t *testing.T) {
+	g := NewWithT(t)
+
+	// Min and Step fit int64 and pass field validation, but a request near
+	// MaxInt64 makes the integer path compute min+step*n past MaxInt64. Before the
+	// guard this wrapped to a negative value below the request.
+	req := resource.NewQuantity(math.MaxInt64, resource.BinarySI)
+	overflowRange := &resourceapi.CapacityRequestPolicyRange{
+		Min:  ptr.To(resource.MustParse("0")),
+		Step: ptr.To(resource.MustParse("100")),
+	}
+	got := roundUpRange(req, overflowRange)
+	g.Expect(got.Cmp(resource.MustParse("9223372036854775900"))).To(Equal(0),
+		"MaxInt64 rounded up to the next multiple of 100 is 9223372036854775900, got %s", got.String())
+
+	// A step whose Value() is 0 (a quantity larger than MaxInt64, for example
+	// 100E) divided by zero in the integer path. It must fall back to exact
+	// arithmetic rather than panic.
+	bigReq := ptr.To(resource.MustParse("1E"))
+	divZeroRange := &resourceapi.CapacityRequestPolicyRange{
+		Min:  ptr.To(resource.MustParse("0")),
+		Step: ptr.To(resource.MustParse("100E")),
+	}
+	var bigGot resource.Quantity
+	g.Expect(func() { bigGot = roundUpRange(bigReq, divZeroRange) }).ToNot(Panic(),
+		"roundUpRange must not divide by zero when step.Value() is 0")
+	g.Expect(bigGot.Cmp(resource.MustParse("100E"))).To(Equal(0),
+		"1E rounded up to the next multiple of 100E is 100E, got %s", bigGot.String())
+
+	// violateValidRange does the same integer division; a step whose Value() is 0
+	// divides by zero. It must fall back to exact arithmetic rather than panic.
+	var violated bool
+	g.Expect(func() {
+		violated = violateValidRange(resource.MustParse("50"), resourceapi.CapacityRequestPolicyRange{
+			Min:  ptr.To(resource.MustParse("0")),
+			Step: ptr.To(resource.MustParse("100E")),
+		})
+	}).ToNot(Panic(), "violateValidRange must not divide by zero when step.Value() is 0")
+	g.Expect(violated).To(BeTrue(), "50 is not a multiple of 100E, so it violates the range")
 }
 
 func testViolateCapacityRequestPolicy(t *testing.T) {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/consumable_capacity.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/consumable_capacity.go
@@ -18,7 +18,9 @@ package incubating
 
 import (
 	"errors"
+	"math"
 
+	inf "gopkg.in/inf.v0"
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/ptr"
@@ -118,17 +120,59 @@ func roundUpRange(requestedVal *resource.Quantity, validRange *resourceapi.Capac
 	if validRange.Step == nil {
 		return *requestedVal
 	}
-	requestedInt64 := requestedVal.Value()
-	step := validRange.Step.Value()
-	min := validRange.Min.Value()
-	added := (requestedInt64 - min)
-	n := added / step
-	mod := added % step
-	if mod != 0 {
-		n += 1
+	// Integer arithmetic fast path, guarded against int64 overflow and against a
+	// step whose Value() is 0 (a quantity larger than MaxInt64, for example "100E",
+	// which would otherwise divide by zero). Fall back to exact arithmetic when a
+	// value does not fit int64 or when min+step*n would overflow.
+	if fitsInt64Value(requestedVal) && fitsInt64Value(validRange.Min) && fitsInt64Value(validRange.Step) {
+		if step := validRange.Step.Value(); step > 0 {
+			requestedInt64 := requestedVal.Value()
+			min := validRange.Min.Value()
+			added := requestedInt64 - min
+			n := added / step
+			if added%step != 0 {
+				n++
+			}
+			if val, ok := safeMinPlusStepN(min, step, n); ok {
+				return *resource.NewQuantity(val, resource.BinarySI)
+			}
+		}
 	}
-	val := min + step*n
-	return *resource.NewQuantity(val, resource.BinarySI)
+	return roundUpRangeArbitrary(requestedVal, validRange.Min, validRange.Step)
+}
+
+// fitsInt64Value reports whether q is non-negative and small enough that q.Value()
+// is exact. A quantity larger than MaxInt64 wraps, for example "100E".Value() == 0.
+func fitsInt64Value(q *resource.Quantity) bool {
+	return q.Sign() >= 0 && q.CmpInt64(math.MaxInt64) <= 0
+}
+
+// safeMinPlusStepN returns base+step*n and reports whether that int64 computation
+// stays within range. base, step and n are assumed non-negative.
+func safeMinPlusStepN(base, step, n int64) (int64, bool) {
+	if n != 0 && step > (math.MaxInt64-base)/n {
+		return 0, false
+	}
+	return base + step*n, true
+}
+
+// roundUpRangeArbitrary rounds requestedVal up to minVal+ceil((requestedVal-minVal)/step)*step
+// with arbitrary precision, for the cases the int64 fast path cannot represent
+// without overflowing or dividing by zero.
+func roundUpRangeArbitrary(requestedVal, minVal, step *resource.Quantity) resource.Quantity {
+	added := new(inf.Dec).Sub(requestedVal.AsDec(), minVal.AsDec())
+	n := new(inf.Dec).QuoRound(added, step.AsDec(), 0, inf.RoundCeil)
+	result := new(inf.Dec).Add(minVal.AsDec(), new(inf.Dec).Mul(n, step.AsDec()))
+	return *resource.NewDecimalQuantity(*result, step.Format)
+}
+
+// isStepMultiple reports whether requestedVal-minVal is an exact multiple of step,
+// using arbitrary precision so it neither overflows nor divides by zero.
+func isStepMultiple(requestedVal, minVal, step *resource.Quantity) bool {
+	added := new(inf.Dec).Sub(requestedVal.AsDec(), minVal.AsDec())
+	n := new(inf.Dec).QuoRound(added, step.AsDec(), 0, inf.RoundDown)
+	remainder := new(inf.Dec).Sub(added, new(inf.Dec).Mul(n, step.AsDec()))
+	return remainder.Sign() == 0
 }
 
 // roundUpValidValues returns the first value in validValues that is greater than or equal to requestedVal.
@@ -188,15 +232,16 @@ func violateValidRange(requestedVal resource.Quantity, validRange resourceapi.Ca
 		return true
 	}
 	if validRange.Step != nil {
-		requestedInt64 := requestedVal.Value()
-		step := validRange.Step.Value()
-		min := validRange.Min.Value()
-		added := (requestedInt64 - min)
-		mod := added % step
-		// must be a multiply of step
-		if mod != 0 {
-			return true
+		// Guard against int64 overflow and against a step whose Value() is 0 (a
+		// quantity larger than MaxInt64); fall back to exact arithmetic otherwise.
+		if fitsInt64Value(&requestedVal) && fitsInt64Value(validRange.Min) && fitsInt64Value(validRange.Step) {
+			if step := validRange.Step.Value(); step > 0 {
+				added := requestedVal.Value() - validRange.Min.Value()
+				return added%step != 0
+			}
 		}
+		// must be a multiple of step
+		return !isStepMultiple(&requestedVal, validRange.Min, validRange.Step)
 	}
 	return false
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/consumable_capacity_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/consumable_capacity_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package incubating
 
 import (
+	"math"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -113,6 +114,51 @@ func TestConsumableCapacity(t *testing.T) {
 
 	t.Run("calculate-consumed-capacity", testCalculateConsumedCapacity)
 
+	t.Run("round-up-range-overflow", testRoundUpRangeOverflow)
+
+}
+
+// testRoundUpRangeOverflow checks that roundUpRange does not overflow int64 or
+// divide by zero for large capacity requests.
+func testRoundUpRangeOverflow(t *testing.T) {
+	g := NewWithT(t)
+
+	// Min and Step fit int64 and pass field validation, but a request near
+	// MaxInt64 makes the integer path compute min+step*n past MaxInt64. Before the
+	// guard this wrapped to a negative value below the request.
+	req := resource.NewQuantity(math.MaxInt64, resource.BinarySI)
+	overflowRange := &resourceapi.CapacityRequestPolicyRange{
+		Min:  ptr.To(resource.MustParse("0")),
+		Step: ptr.To(resource.MustParse("100")),
+	}
+	got := roundUpRange(req, overflowRange)
+	g.Expect(got.Cmp(resource.MustParse("9223372036854775900"))).To(Equal(0),
+		"MaxInt64 rounded up to the next multiple of 100 is 9223372036854775900, got %s", got.String())
+
+	// A step whose Value() is 0 (a quantity larger than MaxInt64, for example
+	// 100E) divided by zero in the integer path. It must fall back to exact
+	// arithmetic rather than panic.
+	bigReq := ptr.To(resource.MustParse("1E"))
+	divZeroRange := &resourceapi.CapacityRequestPolicyRange{
+		Min:  ptr.To(resource.MustParse("0")),
+		Step: ptr.To(resource.MustParse("100E")),
+	}
+	var bigGot resource.Quantity
+	g.Expect(func() { bigGot = roundUpRange(bigReq, divZeroRange) }).ToNot(Panic(),
+		"roundUpRange must not divide by zero when step.Value() is 0")
+	g.Expect(bigGot.Cmp(resource.MustParse("100E"))).To(Equal(0),
+		"1E rounded up to the next multiple of 100E is 100E, got %s", bigGot.String())
+
+	// violateValidRange does the same integer division; a step whose Value() is 0
+	// divides by zero. It must fall back to exact arithmetic rather than panic.
+	var violated bool
+	g.Expect(func() {
+		violated = violateValidRange(resource.MustParse("50"), resourceapi.CapacityRequestPolicyRange{
+			Min:  ptr.To(resource.MustParse("0")),
+			Step: ptr.To(resource.MustParse("100E")),
+		})
+	}).ToNot(Panic(), "violateValidRange must not divide by zero when step.Value() is 0")
+	g.Expect(violated).To(BeTrue(), "50 is not a multiple of 100E, so it violates the range")
 }
 
 func testViolateCapacityRequestPolicy(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig node
/wg device-management

**What this PR does / why we need it**:

The consumable-capacity allocator does range arithmetic on int64 values from
`Quantity.Value()`, which overflows.

`roundUpRange` computes `min + step*ceil((request-min)/step)`. A request near
`MaxInt64` with a valid step (for example `100`) makes `min + step*n` exceed
`MaxInt64` and wrap negative: a `MaxInt64` request returns `-9223372036854775716`,
below the request, which defeats the `Cmp(capacity)` check. The requested capacity
is not magnitude-validated, so an ordinary user can trigger this.

The same functions also divide by zero on a step whose `Value()` is `0` (a quantity
larger than int64, for example `100E`): `roundUpRange` and `violateValidRange` both
compute `added / step` or `added % step`.

The fix keeps the int64 fast path for values that fit, guarded so it neither
overflows nor divides by zero, and falls back to exact arbitrary-precision
arithmetic otherwise. Representable inputs keep their existing result. Both
`roundUpRange` and `violateValidRange` are fixed, in the incubating and experimental
variants, each with a regression test.

**Which issue(s) this PR fixes**:

Fixes #140441

**Special notes for your reviewer**:

- Split out of the #140161 review at @pohly's suggestion, kept as a plain bug fix
  with no feature gate (the non-fractional `Value()` path). @sunya-ch handles the
  fractional milli-value overflow in #140161.
- The int64 fast path is unchanged for representable inputs; only the fits/overflow
  guard and the arbitrary-precision fallback are new.
- The step-larger-than-int64 divide-by-zero is guarded here as defense in depth; the
  same input is also rejected earlier by API validation.

**Does this PR introduce a user-facing change?**

```release-note
Fixed an int64 overflow in the DRA consumable-capacity allocator that let a
capacity request near MaxInt64 wrap to a negative value and bypass the capacity
check, and a related divide-by-zero on a device capacity Step larger than int64.
```
