### PR TITLE
DRA: reject unusable consumable-capacity validRange bounds

### DIFF
--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"regexp"
 	"slices"
 	"strconv"
@@ -1193,7 +1194,10 @@ func validateRequestPolicyRange(defaultValue apiresource.Quantity, maxCapacity a
 	}
 	useMilli := false
 	if utilfeature.DefaultFeatureGate.Enabled(features.DRAFractionalCapacityRange) {
-		useMilli = rangeHasFractional(valueRange)
+		// The default is not part of the range, so rangeHasFractional does not see it.
+		// A fractional default with an integer range must still use the milli path, or the
+		// integer path reads default.Value() (which rounds) and accepts a non-multiple.
+		useMilli = rangeHasFractional(valueRange) || isFractionalQuantity(defaultValue)
 		// Overflow guards apply when DRAFractionalCapacityRange is enabled and the incoming
 		// range has fractional values.
 		if useMilli {
@@ -1231,11 +1235,38 @@ func validateRequestPolicyRange(defaultValue apiresource.Quantity, maxCapacity a
 			if added.Cmp(maxCapacity) > 0 {
 				allErrs = append(allErrs, field.Invalid(fldPath.Child("step"), valueRange.Step.String(), fmt.Sprintf("one step %s is larger than capacity value: %s", added.String(), maxCapacity.String())))
 			}
-			// Use milli-value arithmetic whenever any field is fractional to preserve.
-			// useMilli is set only when the DRAFractionalCapacityRange feature gate is enabled.
-			allErrs = append(allErrs, validateRequestPolicyRangeStep(defaultValue, *valueRange.Min, *valueRange.Step, useMilli, fldPath.Child("step"))...)
-			if valueRange.Max != nil {
-				allErrs = append(allErrs, validateRequestPolicyRangeStep(*valueRange.Max, *valueRange.Min, *valueRange.Step, useMilli, fldPath.Child("step"))...)
+			// The integer path of validateRequestPolicyRangeStep below reads step,
+			// min, max and the default value with Quantity.Value(), which only holds
+			// in [0, MaxInt64]: above it a positive multiple of 2^64 reads as 0 and the
+			// step check divides by zero, and a negative decimal-backed bound can read
+			// back positive. Reject those before the arithmetic. The milli path is
+			// bounded by the hasUnsafeValue check above instead.
+			hasUnsafeValue := false
+			if !useMilli {
+				for _, pair := range []struct {
+					q    *apiresource.Quantity
+					name string
+				}{
+					{&defaultValue, "default"},
+					{valueRange.Min, "min"},
+					{valueRange.Max, "max"},
+					{valueRange.Step, "step"},
+				} {
+					if pair.q != nil {
+						if errs := validateInt64Range(*pair.q, fldPath.Child(pair.name)); len(errs) > 0 {
+							allErrs = append(allErrs, errs...)
+							hasUnsafeValue = true
+						}
+					}
+				}
+			}
+			if !hasUnsafeValue {
+				// Use milli-value arithmetic whenever any field is fractional.
+				// useMilli is set only when the DRAFractionalCapacityRange gate is on.
+				allErrs = append(allErrs, validateRequestPolicyRangeStep(defaultValue, *valueRange.Min, *valueRange.Step, useMilli, fldPath.Child("step"))...)
+				if valueRange.Max != nil {
+					allErrs = append(allErrs, validateRequestPolicyRangeStep(*valueRange.Max, *valueRange.Min, *valueRange.Step, useMilli, fldPath.Child("step"))...)
+				}
 			}
 		}
 	}
@@ -1261,6 +1292,26 @@ func validateRequestPolicyRangeStep(value, min, step apiresource.Quantity, useMi
 	}
 	if (val-minVal)%stepVal != 0 {
 		return field.ErrorList{field.Invalid(fldPath, value.String(), fmt.Sprintf("value is not a multiple of a given step (%s) from (%s)", step.String(), min.String()))}
+	}
+	return nil
+}
+
+// boundOverInt64Message is the field error for a consumable-capacity validRange
+// bound above the range where Quantity.Value() is usable.
+const boundOverInt64Message = "must not be larger than 9223372036854775807"
+
+// validateInt64Range reports whether q is in [0, MaxInt64], the range where
+// Quantity.Value() returns a number the bound can be reasoned about with. Above
+// MaxInt64 it overflows, so a positive multiple of 2^64 reads back as 0; below
+// zero it does not round as documented once the quantity is decimal-backed and
+// can read back with the wrong sign (#110653). Sign() alone misses the first
+// case and CmpInt64 alone misses the second, so the check needs both.
+func validateInt64Range(q apiresource.Quantity, fldPath *field.Path) field.ErrorList {
+	if q.Sign() < 0 {
+		return field.ErrorList{field.Invalid(fldPath, q.String(), apimachineryvalidation.IsNegativeErrorMsg)}
+	}
+	if q.CmpInt64(math.MaxInt64) > 0 {
+		return field.ErrorList{field.Invalid(fldPath, q.String(), boundOverInt64Message)}
 	}
 	return nil
 }

--- a/pkg/apis/resource/validation/validation_device_capacity_test.go
+++ b/pkg/apis/resource/validation/validation_device_capacity_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package validation
 
 import (
+	"math"
 	"testing"
 
 	apiresource "k8s.io/apimachinery/pkg/api/resource"
@@ -65,6 +66,13 @@ func TestValidateDeviceCapacity(t *testing.T) {
 	two := apiresource.MustParse("2Gi")
 	maxCapacity := apiresource.MustParse("10Gi")
 	overCapacity := apiresource.MustParse("20Gi")
+
+	zero := apiresource.MustParse("0")
+	negOne := apiresource.MustParse("-1")
+	maxInt64Q := *apiresource.NewQuantity(math.MaxInt64, apiresource.DecimalSI) // MaxInt64: the largest bound Value() reads faithfully
+	maxInt64Plus1 := maxInt64Q.DeepCopy()                                       // MaxInt64+1: the first bound that does not fit int64
+	maxInt64Plus1.Add(*apiresource.NewQuantity(1, apiresource.DecimalSI))
+	twoPow64 := apiresource.MustParse("18446744073709551616") // a positive multiple of 2^64, whose Value() reads as 0
 
 	capacityField := field.NewPath("spec", "devices", "capacity")
 	policyField := capacityField.Child("requestPolicy")
@@ -179,6 +187,47 @@ func TestValidateDeviceCapacity(t *testing.T) {
 				field.Invalid(validRangeField.Child("step"), "2Gi", "value is not a multiple of a given step (2Gi) from (1Gi)"),
 				field.Invalid(validRangeField.Child("step"), "10Gi", "value is not a multiple of a given step (2Gi) from (1Gi)"),
 			},
+		},
+		"range-step-multiple-of-2^64": {
+			// step is a positive multiple of 2^64, whose Value() reads as 0; the
+			// step-multiple check used to divide by zero on it. Reject it before that.
+			capacity: testDeviceCapacity(twoPow64, testCapacityRequestPolicy(ptr.To(zero), nil, testValidRange(ptr.To(zero), nil, ptr.To(twoPow64)))),
+			wantFailures: field.ErrorList{
+				field.Invalid(validRangeField.Child("step"), "18446744073709551616", "must not be larger than 9223372036854775807"),
+			},
+		},
+		"range-step-at-int64-max": {
+			// MaxInt64 is the largest step Value() reads faithfully and must be accepted.
+			capacity: testDeviceCapacity(maxInt64Q, testCapacityRequestPolicy(ptr.To(zero), nil, testValidRange(ptr.To(zero), nil, ptr.To(maxInt64Q)))),
+		},
+		"range-step-int64-max-plus-one": {
+			// One past MaxInt64 is the first step that does not fit int64 and must be rejected.
+			capacity: testDeviceCapacity(maxInt64Plus1, testCapacityRequestPolicy(ptr.To(zero), nil, testValidRange(ptr.To(zero), nil, ptr.To(maxInt64Plus1)))),
+			wantFailures: field.ErrorList{
+				field.Invalid(validRangeField.Child("step"), "9223372036854775808", "must not be larger than 9223372036854775807"),
+			},
+		},
+		"range-negative-min-with-step": {
+			// A negative min with a step reaches the int64 arithmetic, where a
+			// decimal-backed negative can read back positive; reject it.
+			capacity: testDeviceCapacity(maxCapacity, testCapacityRequestPolicy(ptr.To(zero), nil, testValidRange(ptr.To(negOne), nil, ptr.To(one)))),
+			wantFailures: field.ErrorList{
+				field.Invalid(validRangeField.Child("min"), "-1", "must be greater than or equal to 0"),
+			},
+		},
+		"range-fractional-default-integer-range": {
+			// A fractional default with an otherwise-integer range must still take the
+			// milli path; the integer path rounds the default and accepts a non-multiple.
+			capacity:                    testDeviceCapacity(maxCapacity, testCapacityRequestPolicy(ptr.To(hundredMilli), nil, testValidRange(ptr.To(zero), nil, ptr.To(oneUnit)))),
+			fractionalCapacityRangeGate: true,
+			wantFailures: field.ErrorList{
+				field.Invalid(validRangeField.Child("step"), "100m", "value is not a multiple of a given step (1) from (0)"),
+			},
+		},
+		"range-no-step-negative-bounds-accepted": {
+			// With no step nothing reads the bounds as an int64, so a negative min and
+			// default are accepted, consistently with the pre-existing behavior.
+			capacity: testDeviceCapacity(maxCapacity, testCapacityRequestPolicy(ptr.To(negOne), nil, testValidRange(ptr.To(negOne), nil, nil))),
 		},
 		"valid-range-fractional-step": {
 			// min=0.2, step=0.1, max=1, default=0.2, capacity=1: 0.2 = min+0*0.1, 1.0 = min+8*0.1

--- a/pkg/apis/resource/validation/validation_resourceslice_test.go
+++ b/pkg/apis/resource/validation/validation_resourceslice_test.go
@@ -1853,6 +1853,35 @@ func TestValidateResourceSliceUpdate(t *testing.T) {
 			}(),
 			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice { return slice },
 		},
+		"consumable-capacity-valid-range-out-of-int64-bound": {
+			consumableCapacityFeatureGate: true,
+			wantFailures:                  field.ErrorList{field.Invalid(consumeableCapacityPath(0).Child("requestPolicy", "validRange", "min"), "-1", "must be greater than or equal to 0")},
+			oldResourceSlice:              testResourceSliceWithConsumableCapacity(name, name, name, 1),
+			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice {
+				updateConsumableCapacity(slice, 0, func(cap *resourceapi.DeviceCapacity) {
+					cap.RequestPolicy = &resourceapi.CapacityRequestPolicy{
+						Default:    new(resource.MustParse("0")),
+						ValidRange: &resourceapi.CapacityRequestPolicyRange{Min: new(resource.MustParse("-1")), Step: new(resource.MustParse("1"))},
+					}
+				})
+				return slice
+			},
+		},
+		"consumable-capacity-valid-range-out-of-int64-bound-okay-if-stored": {
+			consumableCapacityFeatureGate: true,
+			wantFailures:                  nil,
+			oldResourceSlice: func() *resourceapi.ResourceSlice {
+				slice := testResourceSliceWithConsumableCapacity(name, name, name, 1)
+				updateConsumableCapacity(slice, 0, func(cap *resourceapi.DeviceCapacity) {
+					cap.RequestPolicy = &resourceapi.CapacityRequestPolicy{
+						Default:    new(resource.MustParse("0")),
+						ValidRange: &resourceapi.CapacityRequestPolicyRange{Min: new(resource.MustParse("-1")), Step: new(resource.MustParse("1"))},
+					}
+				})
+				return slice
+			}(),
+			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice { return slice },
+		},
 		"consumable-capacity-valid-values-milli-values": {
 			consumableCapacityFeatureGate:      true,
 			fractionalCapacityRangeFeatureGate: true,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig node
/wg device-management

**What this PR does / why we need it**:

The consumable-capacity `validRange` step-multiple check in `validateRequestPolicyRangeStep` reads `min`, `step` and the `default`/`max` value with `Quantity.Value()`. That only reads a bound back faithfully in `[0, MaxInt64]`, and today nothing keeps the bounds inside it. A DRA driver publishes them in a `ResourceSlice`.

**Above the range**, `Value()` overflows. A bound that is a positive multiple of `2^64` (for example `18446744073709551616`) has `Sign() == 1`, so it passes the step > 0 guard added in #139698, but reads as `0`: a `step` divides by zero (an apiserver panic on admission), and a `min`, `max` or `default` compares against a value the bound does not hold, which is both a false accept and a false reject.

**Below the range**, `Value()` does not round as documented once the quantity is decimal-backed, and can read back with the wrong sign: a `min` of `-9.5Gi` reads as `+8246196746`. That is #110653, open since 2022 and confirmed by @yliaog, with a fix up in #138510. Only `step` is sign-checked today (`Sign() <= 0`), so a negative `min`, `max` or `default` reaches the arithmetic.

This rejects a `step`, `min`, `max` or `default` outside `[0, MaxInt64]` with a field error before the arithmetic runs. `Sign()` alone misses the high end and `CmpInt64` alone misses the low end, so the check needs both.

**Which issue(s) this PR fixes**:

Fixes #140472

Related to #140441: this is the validation half of the `.Value()` overflow follow-up, matching @pohly's note on #140161 that "TODO (#140441) also applies here" for the integer range. The allocator half is #140442.

**Special notes for your reviewer**:

- **The `>= 0` half is yours** (https://github.com/kubernetes/kubernetes/pull/140161#discussion_r3519117147): *"Verify that the quantities are >= 0 before extracting them and `Value() <= MaxMilliValue`"*. This does both halves for the integer path, which is the completeness gap you flagged on #140161 (https://github.com/kubernetes/kubernetes/pull/140161#discussion_r3601958130). The milli guard there is nested under the feature gate and a fractional range, so it does not cover this path.
- **This does not fix `Value()` itself**, and does not need to: rejecting the bound up front means the reads never see an unusable one. #138510 is the fix for the reads, and I have reviewed it.
- **What `min >= 0` buys on the allocator side.** `roundUpRange` reads three values, and the third is the request from the claim, which nothing validates. It does not need its own bound: the function already clamps a request below `min` with `Cmp`, which is exact, so once `min >= 0` holds a request can never be negative by the time `Value()` reads it. I checked `-9.5Gi`, `-1` and `-1E30` against `min: 0` and all three clamp to `min`. The high end is #140442's guard.
- **The bound checks sit under `Step != nil`, next to the reads they protect.** `min`, `max` and `default` are only read with `Value()` when a `step` is present (`roundUpRange` returns before reading when `Step == nil`, and `violateValidRange` reads them only inside `if Step != nil`), so that is where the guard runs. A side effect: a negative or over-range `min`, `max` or `default` with no `step` is accepted, since without a `step` nothing then reads it as an int64. If you would rather reject a negative capacity bound unconditionally as a general invariant, like `step` and `allocationMultiplier` already are, I can hoist the sign check out; I kept it scoped to the reads to stay within the arithmetic-safety fix.
- **`Value()` still rounds a fractional bound up inside `[0, MaxInt64]`**, so a `step` of `1.5` is read as `2` and `3` is reported as not a multiple of it. That is pre-existing and is what the milli path in #140161 is for; this PR only keeps the reads in range and does not claim to make them exact.
- **On rejecting negative bounds being a behavior change**: it is, in the same way the out-of-range rejection is. Since #140161 merged, `validateMultiAllocatableDeviceCapacity` runs under its `DeepEqual(oldDevice.Capacity, device.Capacity)` ratcheting gate, so an existing slice with such a bound is re-checked only when its capacity changes. A negative capacity bound is not meaningful, and the same function already rejects `step` with `Sign() <= 0` and `allocationMultiplier` with `Sign() <= 0`, so `min`/`max`/`default` having no sign check reads as an omission rather than a decision. Say the word if you would rather split it out.
- `validValues` had the same `Quantity.Value()` collision in `quantityKey` (#140457); #140161 has since fixed it by keying on `AsDec().String()` when the feature gate is on.
- The decimal path ends in `big.Int.Int64()`, which Go documents as undefined out of range, so the `0` above is what it happens to return rather than a contract. Rejecting the bound avoids depending on it either way.

**Does this PR introduce a user-facing change?**

```release-note
Fixed a panic (integer divide by zero) and incorrect validation in ResourceSlice
admission when a DRA consumable-capacity validRange step, min, max or default is
negative or larger than 9223372036854775807.
```

