### PR TITLE
windows-failing: fix scheduler pod group test ordering

### DIFF
--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -61,6 +61,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/profile"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	tf "k8s.io/kubernetes/pkg/scheduler/testing/framework"
+	testingclock "k8s.io/utils/clock/testing"
 )
 
 // fakePodGroupPlugin simulates Filter, PostFilter, Permit and PodGroupPostFilter behaviors for PodGroup scheduling testing.
@@ -1986,7 +1987,8 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			informerFactory.Start(ctx.Done())
 			informerFactory.WaitForCacheSync(ctx.Done())
 
-			schedulingQueue := internalqueue.NewTestQueue(ctx, schedFwk.QueueSortFunc())
+			fakeClock := testingclock.NewFakeClock(time.Now())
+			schedulingQueue := internalqueue.NewTestQueue(ctx, schedFwk.QueueSortFunc(), internalqueue.WithClock(fakeClock))
 			sched := &Scheduler{
 				client:          client,
 				Cache:           cache,
@@ -2008,8 +2010,11 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 
 			// Create the pod group and add the pods to queue and pop the group to set up internal queue state correctly.
 			schedulingQueue.AddPodGroup(logger, pg)
+			// Advance the clock between additions to keep pod ordering deterministic.
 			schedulingQueue.Add(ctx, p1)
+			fakeClock.Step(time.Second)
 			schedulingQueue.Add(ctx, p2)
+			fakeClock.Step(time.Second)
 			schedulingQueue.Add(ctx, p3)
 			entity, err := schedulingQueue.Pop(logger)
 			if err != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test
/sig windows

#### What this PR does / why we need it:

failing on https://testgrid.k8s.io/sig-windows-signal#windows-unit-master
- no failure on https://testgrid.k8s.io/sig-release-master-blocking#ci-kubernetes-unit

```
{Failed  === RUN   TestSubmitPodGroupAlgorithmResult/PodGroup_waiting_on_preemption_uses_nominating_info_instead_of_suggested_host_for_successfully_evaluated_pods
    schedule_one_podgroup_test.go:2001: Unexpected preempting pods (-want, +got):
          map[string]string{
        - 	"p1": "node2",
        + 	"p3": "node2",
          }
    schedule_one_podgroup_test.go:2004: Expected failed pods: map[p2:{} p3:{}], but got: map[p1:{} p2:{}]
--- FAIL: TestSubmitPodGroupAlgorithmResult/PodGroup_waiting_on_preemption_uses_nominating_info_instead_of_suggested_host_for_successfully_evaluated_pods (1.29s)
```

The order is different on windows. 

#### Which issue(s) this PR is related to:

Fixes #140645

#### Special notes for your reviewer:

https://github.com/kubernetes/kubernetes/blob/6d5610685c55faf1eab630ed7f6cd9f6d4accd13/pkg/scheduler/framework/types.go#L910-L933

On Windows, consecutive calls to `time.Now()` may return identical timestamps because of the lower clock resolution. 


#### Does this PR introduce a user-facing change?

```release-note
None
```
