### PR TITLE
Add CPG cycle detection, depth validation in cache, and extend test coverage of CPGs

### DIFF
--- a/pkg/scheduler/backend/cache/cache.go
+++ b/pkg/scheduler/backend/cache/cache.go
@@ -1312,7 +1312,12 @@ func (cache *cacheImpl) BuildHierarchySnapshotFromPod(pod *v1.Pod) (fwk.PodGroup
 
 	if cache.compositePodGroupEnabled && pg.Spec.ParentCompositePodGroupName != nil {
 		currentKey = fwk.CompositePodGroupKey(pod.Namespace, *pg.Spec.ParentCompositePodGroupName)
+		visited := sets.New[fwk.EntityKey]()
 		for range schedulingv1alpha3.WorkloadMaxTreeDepth - 1 {
+			if visited.Has(currentKey) {
+				return nil, fmt.Errorf("cycle detected in composite pod group hierarchy: %s", currentKey.String())
+			}
+			visited.Insert(currentKey)
 			cpgs, exists := cache.compositePodGroupStates[currentKey]
 			if !exists {
 				return nil, fmt.Errorf("parent composite pod group state not found for %s", currentKey.String())
@@ -1325,6 +1330,11 @@ func (cache *cacheImpl) BuildHierarchySnapshotFromPod(pod *v1.Pod) (fwk.PodGroup
 				break
 			}
 			currentKey = fwk.CompositePodGroupKey(pod.Namespace, *cpg.Spec.ParentCompositePodGroupName)
+		}
+
+		cpgs, exists := cache.compositePodGroupStates[currentKey]
+		if exists && cpgs.compositePodGroup != nil && cpgs.compositePodGroup.Spec.ParentCompositePodGroupName != nil {
+			return nil, fmt.Errorf("workload tree depth exceeds max depth %d", schedulingv1alpha3.WorkloadMaxTreeDepth)
 		}
 	}
 

--- a/pkg/scheduler/backend/cache/cache.go
+++ b/pkg/scheduler/backend/cache/cache.go
@@ -1265,7 +1265,17 @@ func (cache *cacheImpl) BuildHierarchySnapshotFromPod(pod *v1.Pod) (fwk.PodGroup
 
 	if cache.compositePodGroupEnabled && pg.Spec.ParentCompositePodGroupName != nil {
 		currentKey = fwk.CompositePodGroupKey(pod.Namespace, *pg.Spec.ParentCompositePodGroupName)
-		for range schedulingv1alpha3.WorkloadMaxTreeDepth - 1 {
+		visited := sets.New[fwk.EntityKey]()
+		depth := 1
+		for {
+			depth++
+			if depth > schedulingv1alpha3.WorkloadMaxTreeDepth {
+				return nil, fmt.Errorf("workload tree depth exceeds max depth %d", schedulingv1alpha3.WorkloadMaxTreeDepth)
+			}
+			if visited.Has(currentKey) {
+				return nil, fmt.Errorf("cycle detected in composite pod group hierarchy: %s", currentKey.String())
+			}
+			visited.Insert(currentKey)
 			cpgs, exists := cache.compositePodGroupStates[currentKey]
 			if !exists {
 				return nil, fmt.Errorf("parent composite pod group state not found for %s", currentKey.String())

--- a/pkg/scheduler/backend/cache/cache_test.go
+++ b/pkg/scheduler/backend/cache/cache_test.go
@@ -1155,6 +1155,7 @@ func Test_UpdatePodGroup(t *testing.T) {
 	}{
 		{
 			name:                   "update pod group with GenericWorkload disabled should be no-op",
+			initPodGroup:           oldPodGroup,
 			oldPodGroup:            oldPodGroup,
 			newPodGroup:            newPodGroup,
 			genericWorkloadEnabled: false,
@@ -1162,10 +1163,19 @@ func Test_UpdatePodGroup(t *testing.T) {
 		},
 		{
 			name:                   "update pod group with GenericWorkload enabled",
+			initPodGroup:           oldPodGroup,
 			oldPodGroup:            oldPodGroup,
 			newPodGroup:            newPodGroup,
 			genericWorkloadEnabled: true,
 			expectPodGroup:         newPodGroup,
+		},
+		{
+			name:                   "update pod group that does not exist",
+			initPodGroup:           nil, // Do not add it
+			oldPodGroup:            oldPodGroup,
+			newPodGroup:            newPodGroup,
+			genericWorkloadEnabled: true,
+			expectPodGroup:         nil,
 		},
 	}
 
@@ -1174,7 +1184,9 @@ func Test_UpdatePodGroup(t *testing.T) {
 			t.Run(fmt.Sprintf("%v, cpgEnabled=%v", tt.name, cpgEnabled), func(t *testing.T) {
 				logger, ctx := ktesting.NewTestContext(t)
 				cache := newCache(ctx, time.Second, nil, tt.genericWorkloadEnabled, cpgEnabled)
-				cache.AddPodGroup(tt.oldPodGroup)
+				if tt.initPodGroup != nil {
+					cache.AddPodGroup(tt.initPodGroup)
+				}
 
 				cache.UpdatePodGroup(logger, tt.oldPodGroup, tt.newPodGroup)
 
@@ -1264,6 +1276,21 @@ func Test_RemovePodGroup(t *testing.T) {
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				cpg1Key: sets.New(fwk.CompositePodGroupKey("ns1", "cpgChild")),
 			},
+		},
+		{
+			name:                     "remove pod group that does not exist in state",
+			podGroupToDelete:         podGroup,
+			genericWorkloadEnabled:   true,
+			compositePodGroupEnabled: true,
+		},
+		{
+			name:                     "delete pod group with parent, parent becomes empty",
+			genericWorkloadEnabled:   true,
+			compositePodGroupEnabled: true,
+			initialPodGroups:         []*schedulingv1beta1.PodGroup{pg3WithParent},
+			podGroupToDelete:         pg3WithParent,
+			wantPodGroups:            map[fwk.EntityKey]*schedulingv1beta1.PodGroup{},
+			wantChildren:             map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 	}
 
@@ -3402,6 +3429,69 @@ func Test_AddCompositePodGroup(t *testing.T) {
 	}
 }
 
+func Test_UpdateCompositePodGroup(t *testing.T) {
+	oldCPG := st.MakeCompositePodGroup().Namespace("ns").Name("cpg").Obj()
+	newCPG := st.MakeCompositePodGroup().Namespace("ns").Name("cpg").Obj()
+
+	tests := []struct {
+		name                     string
+		initCPG                  *schedulingv1alpha3.CompositePodGroup
+		oldCPG                   *schedulingv1alpha3.CompositePodGroup
+		newCPG                   *schedulingv1alpha3.CompositePodGroup
+		compositePodGroupEnabled bool
+		expectCPG                *schedulingv1alpha3.CompositePodGroup
+	}{
+		{
+			name:                     "update cpg with feature disabled should be no-op",
+			initCPG:                  oldCPG,
+			oldCPG:                   oldCPG,
+			newCPG:                   newCPG,
+			compositePodGroupEnabled: false,
+			expectCPG:                nil,
+		},
+		{
+			name:                     "update cpg with feature enabled",
+			initCPG:                  oldCPG,
+			oldCPG:                   oldCPG,
+			newCPG:                   newCPG,
+			compositePodGroupEnabled: true,
+			expectCPG:                newCPG,
+		},
+		{
+			name:                     "update cpg that does not exist",
+			initCPG:                  nil,
+			oldCPG:                   oldCPG,
+			newCPG:                   newCPG,
+			compositePodGroupEnabled: true,
+			expectCPG:                nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			cache := newCache(ctx, time.Second, nil, true, tt.compositePodGroupEnabled)
+			if tt.initCPG != nil {
+				cache.AddCompositePodGroup(logger, tt.initCPG)
+			}
+
+			cache.UpdateCompositePodGroup(logger, tt.oldCPG, tt.newCPG)
+
+			gotCPG, err := cache.CompositePodGroups().Get(tt.newCPG.Namespace, tt.newCPG.Name)
+			if tt.expectCPG != nil {
+				if err != nil {
+					t.Fatalf("Expected cpg to exist, but got error: %v", err)
+				}
+				if diff := cmp.Diff(tt.expectCPG, gotCPG); diff != "" {
+					t.Errorf("Unexpected cpg (-want, +got):\n%s", diff)
+				}
+			} else if err == nil {
+				t.Error("Expected error getting cpg, but got none")
+			}
+		})
+	}
+}
+
 func Test_RemoveCompositePodGroup(t *testing.T) {
 	cpg1 := st.MakeCompositePodGroup().Name("cpg1").Namespace("ns1").Obj()
 	cpg3WithParent := st.MakeCompositePodGroup().Name("cpg3").Namespace("ns1").ParentCompositePodGroup("cpg1").Obj()
@@ -3416,25 +3506,28 @@ func Test_RemoveCompositePodGroup(t *testing.T) {
 	cpgMidKey := fwk.CompositePodGroupKey("ns1", "cpgMid")
 
 	tests := []struct {
-		name         string
-		initialPGs   []*schedulingv1beta1.PodGroup
-		initialCPGs  []*schedulingv1alpha3.CompositePodGroup
-		cpgToDelete  *schedulingv1alpha3.CompositePodGroup
-		wantCPGs     map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup
-		wantChildren map[fwk.EntityKey]sets.Set[fwk.EntityKey]
+		name                     string
+		initialPGs               []*schedulingv1beta1.PodGroup
+		initialCPGs              []*schedulingv1alpha3.CompositePodGroup
+		cpgToDelete              *schedulingv1alpha3.CompositePodGroup
+		compositePodGroupEnabled bool
+		wantCPGs                 map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup
+		wantChildren             map[fwk.EntityKey]sets.Set[fwk.EntityKey]
 	}{
 		{
-			name:         "delete composite pod group with parent, cleans up children map",
-			initialCPGs:  []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent},
-			cpgToDelete:  cpg3WithParent,
-			wantCPGs:     map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{},
-			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
+			name:                     "delete composite pod group with parent, cleans up children map",
+			initialCPGs:              []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent},
+			cpgToDelete:              cpg3WithParent,
+			compositePodGroupEnabled: true,
+			wantCPGs:                 map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{},
+			wantChildren:             map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 		{
-			name:        "delete composite pod group with parent, parent has both other pg and cpg children",
-			initialPGs:  []*schedulingv1beta1.PodGroup{pgChild},
-			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent, cpg4WithParent},
-			cpgToDelete: cpg3WithParent,
+			name:                     "delete composite pod group with parent, parent has both other pg and cpg children",
+			initialPGs:               []*schedulingv1beta1.PodGroup{pgChild},
+			initialCPGs:              []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent, cpg4WithParent},
+			cpgToDelete:              cpg3WithParent,
+			compositePodGroupEnabled: true,
 			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
 				fwk.CompositePodGroupKey("ns1", "cpg4"): cpg4WithParent,
 			},
@@ -3446,10 +3539,11 @@ func Test_RemoveCompositePodGroup(t *testing.T) {
 			},
 		},
 		{
-			name:        "delete mid cpg from root-mid-leaf hierarchy",
-			initialPGs:  []*schedulingv1beta1.PodGroup{pgLeaf},
-			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg1, cpgMid},
-			cpgToDelete: cpgMid,
+			name:                     "delete mid cpg from root-mid-leaf hierarchy",
+			initialPGs:               []*schedulingv1beta1.PodGroup{pgLeaf},
+			initialCPGs:              []*schedulingv1alpha3.CompositePodGroup{cpg1, cpgMid},
+			cpgToDelete:              cpgMid,
+			compositePodGroupEnabled: true,
 			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
 				cpg1Key: cpg1,
 			},
@@ -3457,12 +3551,28 @@ func Test_RemoveCompositePodGroup(t *testing.T) {
 				cpgMidKey: sets.New(fwk.PodGroupKey("ns1", "pgLeaf")),
 			},
 		},
+		{
+			name:                     "delete cpg with feature disabled should be no-op",
+			initialCPGs:              []*schedulingv1alpha3.CompositePodGroup{cpg1},
+			cpgToDelete:              cpg1,
+			compositePodGroupEnabled: false,
+			wantCPGs:                 nil,
+			wantChildren:             nil,
+		},
+		{
+			name:                     "delete non-existent cpg",
+			initialCPGs:              nil,
+			cpgToDelete:              cpg1,
+			compositePodGroupEnabled: true,
+			wantCPGs:                 map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{},
+			wantChildren:             map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
-			cache := newCache(ctx, time.Second, nil, true, true)
+			cache := newCache(ctx, time.Second, nil, true, tt.compositePodGroupEnabled)
 			logger := klog.Background()
 
 			for _, pg := range tt.initialPGs {
@@ -3476,6 +3586,10 @@ func Test_RemoveCompositePodGroup(t *testing.T) {
 
 			gotCPGs := make(map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup)
 			gotChildren := make(map[fwk.EntityKey]sets.Set[fwk.EntityKey])
+
+			if tt.wantCPGs == nil && tt.wantChildren == nil {
+				return
+			}
 
 			for k, cpgs := range cache.compositePodGroupStates {
 				if cpgs.compositePodGroup != nil {
@@ -3511,6 +3625,14 @@ func Test_BuildHierarchySnapshotFromPod(t *testing.T) {
 	cpg2 := st.MakeCompositePodGroup().Name("cpg2").Namespace("ns1").ParentCompositePodGroup("cpg3").Obj()
 	cpg3 := st.MakeCompositePodGroup().Name("cpg3").Namespace("ns1").Obj()
 
+	cpgDeep1 := st.MakeCompositePodGroup().Name("cpg-deep-1").Namespace("ns1").Obj()
+	cpgDeep2 := st.MakeCompositePodGroup().Name("cpg-deep-2").Namespace("ns1").ParentCompositePodGroup("cpg-deep-1").Obj()
+	cpgDeep3 := st.MakeCompositePodGroup().Name("cpg-deep-3").Namespace("ns1").ParentCompositePodGroup("cpg-deep-2").Obj()
+	cpgDeep4 := st.MakeCompositePodGroup().Name("cpg-deep-4").Namespace("ns1").ParentCompositePodGroup("cpg-deep-3").Obj()
+	cpgDeep5 := st.MakeCompositePodGroup().Name("cpg-deep-5").Namespace("ns1").ParentCompositePodGroup("cpg-deep-4").Obj()
+	pgDeep := st.MakePodGroup().Name("pg-deep").Namespace("ns1").UID("pg-deep").ParentCompositePodGroup("cpg-deep-5").Obj()
+	podDeep := st.MakePod().Name("pod-deep").Namespace("ns1").UID("pod-deep").PodGroupName("pg-deep").Obj()
+
 	podCycle := st.MakePod().Name("pCycle").Namespace("ns1").UID("pCycle").PodGroupName("pgCycle").Obj()
 	pgCycle := st.MakePodGroup().Name("pgCycle").Namespace("ns1").UID("pgCycle").ParentCompositePodGroup("cycle1").Obj()
 	cpgCycle1 := st.MakeCompositePodGroup().Name("cycle1").Namespace("ns1").ParentCompositePodGroup("cycle2").Obj()
@@ -3526,6 +3648,7 @@ func Test_BuildHierarchySnapshotFromPod(t *testing.T) {
 		wantErr                  bool
 		wantPGKeys               []fwk.EntityKey
 		wantCPGKeys              []fwk.EntityKey
+		setupCache               func(c *cacheImpl)
 	}{
 		{
 			name:                   "pod without scheduling group",
@@ -3587,6 +3710,15 @@ func Test_BuildHierarchySnapshotFromPod(t *testing.T) {
 			wantErr:                  true,
 		},
 		{
+			name:                     "max tree depth exceeded",
+			pod:                      podDeep,
+			initialPGs:               []*schedulingv1beta1.PodGroup{pgDeep},
+			initialCPGs:              []*schedulingv1alpha3.CompositePodGroup{cpgDeep1, cpgDeep2, cpgDeep3, cpgDeep4, cpgDeep5},
+			genericWorkloadEnabled:   true,
+			compositePodGroupEnabled: true,
+			wantErr:                  true,
+		},
+		{
 			name:                     "pod group with parent CPG but feature disabled",
 			pod:                      pod2,
 			initialPGs:               []*schedulingv1beta1.PodGroup{pg2},
@@ -3596,7 +3728,35 @@ func Test_BuildHierarchySnapshotFromPod(t *testing.T) {
 			wantPGKeys: []fwk.EntityKey{
 				fwk.PodGroupKey("ns1", "pg2"),
 			},
-			wantCPGKeys: nil,
+		},
+		{
+			name:                   "pod group state exists but pod group object is nil",
+			pod:                    pod1,
+			genericWorkloadEnabled: true,
+			wantErr:                true,
+			setupCache: func(c *cacheImpl) {
+				c.addPodGroupMember(pod1)
+			},
+		},
+		{
+			name:                     "parent composite pod group state not found",
+			pod:                      pod2,
+			initialPGs:               []*schedulingv1beta1.PodGroup{pg2},
+			genericWorkloadEnabled:   true,
+			compositePodGroupEnabled: true,
+			wantErr:                  true,
+			setupCache: func(c *cacheImpl) {
+				parentKey := fwk.CompositePodGroupKey("ns1", "cpg1")
+				delete(c.compositePodGroupStates, parentKey)
+			},
+		},
+		{
+			name:                     "composite pod group object not found in state",
+			pod:                      pod2,
+			initialPGs:               []*schedulingv1beta1.PodGroup{pg2},
+			genericWorkloadEnabled:   true,
+			compositePodGroupEnabled: true,
+			wantErr:                  true,
 		},
 	}
 
@@ -3611,6 +3771,9 @@ func Test_BuildHierarchySnapshotFromPod(t *testing.T) {
 			}
 			for _, cpg := range tt.initialCPGs {
 				cache.AddCompositePodGroup(logger, cpg)
+			}
+			if tt.setupCache != nil {
+				tt.setupCache(cache)
 			}
 
 			snapshot, err := cache.BuildHierarchySnapshotFromPod(tt.pod)
@@ -3665,6 +3828,9 @@ func TestCache_GetRootKeyForGroup(t *testing.T) {
 
 		pod1 := st.MakePod().Name("pod1").Namespace("ns1").PodGroupName("pg1").Obj()
 		c.podStates["ns1/pod1"] = &podState{pod: pod1}
+
+		c.podGroupStates[fwk.PodGroupKey("ns1", "pg_nil")] = &podGroupState{podGroupStateData: podGroupStateData{podGroup: nil}}
+		c.compositePodGroupStates[fwk.CompositePodGroupKey("ns1", "cpg_nil")] = &compositePodGroupState{compositePodGroupStateData: compositePodGroupStateData{compositePodGroup: nil}}
 
 		return c
 	}
@@ -3722,6 +3888,34 @@ func TestCache_GetRootKeyForGroup(t *testing.T) {
 			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
 			key:                      fwk.PodGroupKey("ns1", "pg_cycle"),
+			wantErr:                  true,
+		},
+		{
+			name:                     "pg state exists but pg object is nil",
+			genericWorkloadEnabled:   true,
+			compositePodGroupEnabled: true,
+			key:                      fwk.PodGroupKey("ns1", "pg_nil"),
+			wantOk:                   false,
+		},
+		{
+			name:                     "cpg state exists but cpg object is nil",
+			genericWorkloadEnabled:   true,
+			compositePodGroupEnabled: true,
+			key:                      fwk.CompositePodGroupKey("ns1", "cpg_nil"),
+			wantOk:                   false,
+		},
+		{
+			name:                     "pg state does not exist",
+			genericWorkloadEnabled:   true,
+			compositePodGroupEnabled: true,
+			key:                      fwk.PodGroupKey("ns1", "pg_not_exists"),
+			wantOk:                   false,
+		},
+		{
+			name:                     "unsupported pod key type",
+			genericWorkloadEnabled:   true,
+			compositePodGroupEnabled: true,
+			key:                      fwk.EntityKey{Type: fwk.PodKeyType, Namespace: "ns1", Name: "pod1"},
 			wantErr:                  true,
 		},
 	}

--- a/pkg/scheduler/backend/cache/cache_test.go
+++ b/pkg/scheduler/backend/cache/cache_test.go
@@ -1122,17 +1122,33 @@ func Test_UpdatePodGroup(t *testing.T) {
 	newPodGroup := st.MakePodGroup().Namespace("ns").Name("pg").MinCount(2).Obj()
 
 	tests := []struct {
-		name           string
-		initPodGroup   *schedulingv1beta1.PodGroup
-		oldPodGroup    *schedulingv1beta1.PodGroup
-		newPodGroup    *schedulingv1beta1.PodGroup
-		expectPodGroup *schedulingv1beta1.PodGroup
+		name                   string
+		initPodGroup           *schedulingv1beta1.PodGroup
+		oldPodGroup            *schedulingv1beta1.PodGroup
+		newPodGroup            *schedulingv1beta1.PodGroup
+		genericWorkloadEnabled bool
+		expectPodGroup         *schedulingv1beta1.PodGroup
 	}{
 		{
-			name:           "update pod group with GenericWorkload enabled",
-			oldPodGroup:    oldPodGroup,
-			newPodGroup:    newPodGroup,
-			expectPodGroup: newPodGroup,
+			name:                   "update pod group with GenericWorkload disabled should be no-op",
+			initPodGroup:           oldPodGroup,
+			oldPodGroup:            oldPodGroup,
+			newPodGroup:            newPodGroup,
+			genericWorkloadEnabled: false,
+		},
+		{
+			name:                   "update pod group with GenericWorkload enabled",
+			initPodGroup:           oldPodGroup,
+			oldPodGroup:            oldPodGroup,
+			newPodGroup:            newPodGroup,
+			genericWorkloadEnabled: true,
+			expectPodGroup:         newPodGroup,
+		},
+		{
+			name:                   "update pod group that does not exist",
+			oldPodGroup:            oldPodGroup,
+			newPodGroup:            newPodGroup,
+			genericWorkloadEnabled: true,
 		},
 	}
 
@@ -1140,8 +1156,10 @@ func Test_UpdatePodGroup(t *testing.T) {
 		for _, cpgEnabled := range []bool{true, false} {
 			t.Run(fmt.Sprintf("%v, cpgEnabled=%v", tt.name, cpgEnabled), func(t *testing.T) {
 				logger, ctx := ktesting.NewTestContext(t)
-				cache := newCache(ctx, time.Second, nil, true, cpgEnabled)
-				cache.AddGenericPodGroup(fwk.NewGenericPodGroup(tt.oldPodGroup))
+				cache := newCache(ctx, time.Second, nil, tt.genericWorkloadEnabled, cpgEnabled)
+				if tt.initPodGroup != nil {
+					cache.AddGenericPodGroup(fwk.NewGenericPodGroup(tt.initPodGroup))
+				}
 
 				cache.UpdateGenericPodGroup(logger, fwk.NewGenericPodGroup(tt.newPodGroup))
 
@@ -1220,6 +1238,19 @@ func Test_RemovePodGroup(t *testing.T) {
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				cpg1Key: sets.New(fwk.CompositePodGroupKey("ns1", "cpgChild")),
 			},
+		},
+		{
+			name:                     "remove pod group that does not exist in state",
+			podGroupToDelete:         podGroup,
+			compositePodGroupEnabled: true,
+		},
+		{
+			name:                     "delete pod group with parent, parent becomes empty",
+			compositePodGroupEnabled: true,
+			initialPodGroups:         []*schedulingv1beta1.PodGroup{pg3WithParent},
+			podGroupToDelete:         pg3WithParent,
+			wantPodGroups:            map[fwk.EntityKey]*schedulingv1beta1.PodGroup{},
+			wantChildren:             map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 	}
 
@@ -3354,6 +3385,66 @@ func Test_AddCompositePodGroup(t *testing.T) {
 	}
 }
 
+func Test_UpdateCompositePodGroup(t *testing.T) {
+	oldCPG := st.MakeCompositePodGroup().Namespace("ns").Name("cpg").Obj()
+	newCPG := st.MakeCompositePodGroup().Namespace("ns").Name("cpg").Obj()
+
+	tests := []struct {
+		name                     string
+		initCPG                  *schedulingv1alpha3.CompositePodGroup
+		oldCPG                   *schedulingv1alpha3.CompositePodGroup
+		newCPG                   *schedulingv1alpha3.CompositePodGroup
+		compositePodGroupEnabled bool
+		expectCPG                *schedulingv1alpha3.CompositePodGroup
+	}{
+		{
+			name:                     "update cpg with feature disabled should be no-op",
+			initCPG:                  oldCPG,
+			oldCPG:                   oldCPG,
+			newCPG:                   newCPG,
+			compositePodGroupEnabled: false,
+		},
+		{
+			name:                     "update cpg with feature enabled",
+			initCPG:                  oldCPG,
+			oldCPG:                   oldCPG,
+			newCPG:                   newCPG,
+			compositePodGroupEnabled: true,
+			expectCPG:                newCPG,
+		},
+		{
+			name:                     "update cpg that does not exist",
+			oldCPG:                   oldCPG,
+			newCPG:                   newCPG,
+			compositePodGroupEnabled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			cache := newCache(ctx, time.Second, nil, true, tt.compositePodGroupEnabled)
+			if tt.initCPG != nil {
+				cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(tt.initCPG))
+			}
+
+			cache.UpdateGenericPodGroup(logger, fwk.NewGenericCompositePodGroup(tt.newCPG))
+
+			gotCPG, err := cache.CompositePodGroups().Get(tt.newCPG.Namespace, tt.newCPG.Name)
+			if tt.expectCPG != nil {
+				if err != nil {
+					t.Fatalf("Expected cpg to exist, but got error: %v", err)
+				}
+				if diff := cmp.Diff(tt.expectCPG, gotCPG); diff != "" {
+					t.Errorf("Unexpected cpg (-want, +got):\n%s", diff)
+				}
+			} else if err == nil {
+				t.Error("Expected error getting cpg, but got none")
+			}
+		})
+	}
+}
+
 func Test_RemoveCompositePodGroup(t *testing.T) {
 	cpg1 := st.MakeCompositePodGroup().Name("cpg1").Namespace("ns1").Obj()
 	cpg3WithParent := st.MakeCompositePodGroup().Name("cpg3").Namespace("ns1").ParentCompositePodGroup("cpg1").Obj()
@@ -3368,25 +3459,28 @@ func Test_RemoveCompositePodGroup(t *testing.T) {
 	cpgMidKey := fwk.CompositePodGroupKey("ns1", "cpgMid")
 
 	tests := []struct {
-		name         string
-		initialPGs   []*schedulingv1beta1.PodGroup
-		initialCPGs  []*schedulingv1alpha3.CompositePodGroup
-		cpgToDelete  *schedulingv1alpha3.CompositePodGroup
-		wantCPGs     map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup
-		wantChildren map[fwk.EntityKey]sets.Set[fwk.EntityKey]
+		name                     string
+		initialPGs               []*schedulingv1beta1.PodGroup
+		initialCPGs              []*schedulingv1alpha3.CompositePodGroup
+		cpgToDelete              *schedulingv1alpha3.CompositePodGroup
+		compositePodGroupEnabled bool
+		wantCPGs                 map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup
+		wantChildren             map[fwk.EntityKey]sets.Set[fwk.EntityKey]
 	}{
 		{
-			name:         "delete composite pod group with parent, cleans up children map",
-			initialCPGs:  []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent},
-			cpgToDelete:  cpg3WithParent,
-			wantCPGs:     map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{},
-			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
+			name:                     "delete composite pod group with parent, cleans up children map",
+			initialCPGs:              []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent},
+			cpgToDelete:              cpg3WithParent,
+			compositePodGroupEnabled: true,
+			wantCPGs:                 map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{},
+			wantChildren:             map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 		{
-			name:        "delete composite pod group with parent, parent has both other pg and cpg children",
-			initialPGs:  []*schedulingv1beta1.PodGroup{pgChild},
-			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent, cpg4WithParent},
-			cpgToDelete: cpg3WithParent,
+			name:                     "delete composite pod group with parent, parent has both other pg and cpg children",
+			initialPGs:               []*schedulingv1beta1.PodGroup{pgChild},
+			initialCPGs:              []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent, cpg4WithParent},
+			cpgToDelete:              cpg3WithParent,
+			compositePodGroupEnabled: true,
 			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
 				fwk.CompositePodGroupKey("ns1", "cpg4"): cpg4WithParent,
 			},
@@ -3398,10 +3492,11 @@ func Test_RemoveCompositePodGroup(t *testing.T) {
 			},
 		},
 		{
-			name:        "delete mid cpg from root-mid-leaf hierarchy",
-			initialPGs:  []*schedulingv1beta1.PodGroup{pgLeaf},
-			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg1, cpgMid},
-			cpgToDelete: cpgMid,
+			name:                     "delete mid cpg from root-mid-leaf hierarchy",
+			initialPGs:               []*schedulingv1beta1.PodGroup{pgLeaf},
+			initialCPGs:              []*schedulingv1alpha3.CompositePodGroup{cpg1, cpgMid},
+			cpgToDelete:              cpgMid,
+			compositePodGroupEnabled: true,
 			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
 				cpg1Key: cpg1,
 			},
@@ -3409,12 +3504,25 @@ func Test_RemoveCompositePodGroup(t *testing.T) {
 				cpgMidKey: sets.New(fwk.PodGroupKey("ns1", "pgLeaf")),
 			},
 		},
+		{
+			name:                     "delete cpg with feature disabled should be no-op",
+			initialCPGs:              []*schedulingv1alpha3.CompositePodGroup{cpg1},
+			cpgToDelete:              cpg1,
+			compositePodGroupEnabled: false,
+		},
+		{
+			name:                     "delete non-existent cpg",
+			cpgToDelete:              cpg1,
+			compositePodGroupEnabled: true,
+			wantCPGs:                 map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{},
+			wantChildren:             map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
-			cache := newCache(ctx, time.Second, nil, true, true)
+			cache := newCache(ctx, time.Second, nil, true, tt.compositePodGroupEnabled)
 			for _, pg := range tt.initialPGs {
 				cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg))
 			}
@@ -3436,11 +3544,20 @@ func Test_RemoveCompositePodGroup(t *testing.T) {
 				}
 			}
 
-			if diff := cmp.Diff(tt.wantCPGs, gotCPGs); diff != "" {
-				t.Errorf("Unexpected compositePodGroups (-want,+got)\\n%s", diff)
+			wantCPGs := tt.wantCPGs
+			if wantCPGs == nil {
+				wantCPGs = make(map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup)
 			}
-			if diff := cmp.Diff(tt.wantChildren, gotChildren); diff != "" {
-				t.Errorf("Unexpected children (-want,+got)\\n%s", diff)
+			wantChildren := tt.wantChildren
+			if wantChildren == nil {
+				wantChildren = make(map[fwk.EntityKey]sets.Set[fwk.EntityKey])
+			}
+
+			if diff := cmp.Diff(wantCPGs, gotCPGs); diff != "" {
+				t.Errorf("Unexpected compositePodGroups (-want,+got)\n%s", diff)
+			}
+			if diff := cmp.Diff(wantChildren, gotChildren); diff != "" {
+				t.Errorf("Unexpected children (-want,+got)\n%s", diff)
 			}
 		})
 	}
@@ -3461,6 +3578,13 @@ func Test_BuildHierarchySnapshotFromPod(t *testing.T) {
 	cpg2 := st.MakeCompositePodGroup().Name("cpg2").Namespace("ns1").ParentCompositePodGroup("cpg3").Obj()
 	cpg3 := st.MakeCompositePodGroup().Name("cpg3").Namespace("ns1").Obj()
 
+	cpgDeep1 := st.MakeCompositePodGroup().Name("cpg-deep-1").Namespace("ns1").Obj()
+	cpgDeep2 := st.MakeCompositePodGroup().Name("cpg-deep-2").Namespace("ns1").ParentCompositePodGroup("cpg-deep-1").Obj()
+	cpgDeep3 := st.MakeCompositePodGroup().Name("cpg-deep-3").Namespace("ns1").ParentCompositePodGroup("cpg-deep-2").Obj()
+	cpgDeep4 := st.MakeCompositePodGroup().Name("cpg-deep-4").Namespace("ns1").ParentCompositePodGroup("cpg-deep-3").Obj()
+	pgDeep := st.MakePodGroup().Name("pg-deep").Namespace("ns1").UID("pg-deep").ParentCompositePodGroup("cpg-deep-4").Obj()
+	podDeep := st.MakePod().Name("pod-deep").Namespace("ns1").UID("pod-deep").PodGroupName("pg-deep").Obj()
+
 	podCycle := st.MakePod().Name("pCycle").Namespace("ns1").UID("pCycle").PodGroupName("pgCycle").Obj()
 	pgCycle := st.MakePodGroup().Name("pgCycle").Namespace("ns1").UID("pgCycle").ParentCompositePodGroup("cycle1").Obj()
 	cpgCycle1 := st.MakeCompositePodGroup().Name("cycle1").Namespace("ns1").ParentCompositePodGroup("cycle2").Obj()
@@ -3476,6 +3600,7 @@ func Test_BuildHierarchySnapshotFromPod(t *testing.T) {
 		wantErr                  bool
 		wantPGKeys               []fwk.EntityKey
 		wantCPGKeys              []fwk.EntityKey
+		setupCache               func(c *cacheImpl)
 	}{
 		{
 			name:                   "pod without scheduling group",
@@ -3537,6 +3662,15 @@ func Test_BuildHierarchySnapshotFromPod(t *testing.T) {
 			wantErr:                  true,
 		},
 		{
+			name:                     "max tree depth exceeded",
+			pod:                      podDeep,
+			initialPGs:               []*schedulingv1beta1.PodGroup{pgDeep},
+			initialCPGs:              []*schedulingv1alpha3.CompositePodGroup{cpgDeep1, cpgDeep2, cpgDeep3, cpgDeep4},
+			genericWorkloadEnabled:   true,
+			compositePodGroupEnabled: true,
+			wantErr:                  true,
+		},
+		{
 			name:                     "pod group with parent CPG but feature disabled",
 			pod:                      pod2,
 			initialPGs:               []*schedulingv1beta1.PodGroup{pg2},
@@ -3546,7 +3680,35 @@ func Test_BuildHierarchySnapshotFromPod(t *testing.T) {
 			wantPGKeys: []fwk.EntityKey{
 				fwk.PodGroupKey("ns1", "pg2"),
 			},
-			wantCPGKeys: nil,
+		},
+		{
+			name:                   "pod group state exists but pod group object is nil",
+			pod:                    pod1,
+			genericWorkloadEnabled: true,
+			wantErr:                true,
+			setupCache: func(c *cacheImpl) {
+				c.addPodGroupMember(pod1)
+			},
+		},
+		{
+			name:                     "parent composite pod group state not found",
+			pod:                      pod2,
+			initialPGs:               []*schedulingv1beta1.PodGroup{pg2},
+			genericWorkloadEnabled:   true,
+			compositePodGroupEnabled: true,
+			wantErr:                  true,
+			setupCache: func(c *cacheImpl) {
+				parentKey := fwk.CompositePodGroupKey("ns1", "cpg1")
+				delete(c.compositePodGroupStates, parentKey)
+			},
+		},
+		{
+			name:                     "composite pod group object not found in state",
+			pod:                      pod2,
+			initialPGs:               []*schedulingv1beta1.PodGroup{pg2},
+			genericWorkloadEnabled:   true,
+			compositePodGroupEnabled: true,
+			wantErr:                  true,
 		},
 	}
 
@@ -3559,6 +3721,9 @@ func Test_BuildHierarchySnapshotFromPod(t *testing.T) {
 			}
 			for _, cpg := range tt.initialCPGs {
 				cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
+			}
+			if tt.setupCache != nil {
+				tt.setupCache(cache)
 			}
 
 			snapshot, err := cache.BuildHierarchySnapshotFromPod(tt.pod)
@@ -3613,6 +3778,9 @@ func TestCache_GetRootKeyForGroup(t *testing.T) {
 
 		pod1 := st.MakePod().Name("pod1").Namespace("ns1").PodGroupName("pg1").Obj()
 		c.podStates["ns1/pod1"] = &podState{pod: pod1}
+
+		c.podGroupStates[fwk.PodGroupKey("ns1", "pg_nil")] = newPodGroupState()
+		c.compositePodGroupStates[fwk.CompositePodGroupKey("ns1", "cpg_nil")] = newCompositePodGroupState()
 
 		return c
 	}
@@ -3670,6 +3838,34 @@ func TestCache_GetRootKeyForGroup(t *testing.T) {
 			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
 			key:                      fwk.PodGroupKey("ns1", "pg_cycle"),
+			wantErr:                  true,
+		},
+		{
+			name:                     "pg state exists but pg object is nil",
+			genericWorkloadEnabled:   true,
+			compositePodGroupEnabled: true,
+			key:                      fwk.PodGroupKey("ns1", "pg_nil"),
+			wantOk:                   false,
+		},
+		{
+			name:                     "cpg state exists but cpg object is nil",
+			genericWorkloadEnabled:   true,
+			compositePodGroupEnabled: true,
+			key:                      fwk.CompositePodGroupKey("ns1", "cpg_nil"),
+			wantOk:                   false,
+		},
+		{
+			name:                     "pg state does not exist",
+			genericWorkloadEnabled:   true,
+			compositePodGroupEnabled: true,
+			key:                      fwk.PodGroupKey("ns1", "pg_not_exists"),
+			wantOk:                   false,
+		},
+		{
+			name:                     "unsupported pod key type",
+			genericWorkloadEnabled:   true,
+			compositePodGroupEnabled: true,
+			key:                      fwk.EntityKey{Type: fwk.PodKeyType, Namespace: "ns1", Name: "pod1"},
 			wantErr:                  true,
 		},
 	}

--- a/pkg/scheduler/backend/cache/snapshot_test.go
+++ b/pkg/scheduler/backend/cache/snapshot_test.go
@@ -1989,6 +1989,8 @@ func TestSnapshot_GetRootKeyForGroup(t *testing.T) {
 		s.compositePodGroupStates[fwk.CompositePodGroupKey("ns1", "cpg_cycle_2")] = &compositePodGroupStateSnapshot{compositePodGroupStateData: compositePodGroupStateData{compositePodGroup: st.MakeCompositePodGroup().Name("cpg_cycle_2").Namespace("ns1").ParentCompositePodGroup("cpg_cycle_1").Obj()}}
 
 		s.podGroupStates[fwk.PodGroupKey("ns1", "pg_missing_parent")] = &podGroupStateSnapshot{podGroupStateData: podGroupStateData{podGroup: st.MakePodGroup().Name("pg_missing_parent").Namespace("ns1").ParentCompositePodGroup("non-existent").Obj()}}
+		s.podGroupStates[fwk.PodGroupKey("ns1", "pg_nil")] = &podGroupStateSnapshot{podGroupStateData: podGroupStateData{podGroup: nil}}
+		s.compositePodGroupStates[fwk.CompositePodGroupKey("ns1", "cpg_nil")] = &compositePodGroupStateSnapshot{compositePodGroupStateData: compositePodGroupStateData{compositePodGroup: nil}}
 
 		return s
 	}
@@ -2063,6 +2065,27 @@ func TestSnapshot_GetRootKeyForGroup(t *testing.T) {
 			compositePodGroupEnabled: true,
 			key:                      fwk.PodKey("ns1", "pod1"),
 			wantErr:                  true,
+		},
+		{
+			name:                     "pg state exists but pg object is nil",
+			genericWorkloadEnabled:   true,
+			compositePodGroupEnabled: true,
+			key:                      fwk.PodGroupKey("ns1", "pg_nil"),
+			wantOk:                   false,
+		},
+		{
+			name:                     "cpg state exists but cpg object is nil",
+			genericWorkloadEnabled:   true,
+			compositePodGroupEnabled: true,
+			key:                      fwk.CompositePodGroupKey("ns1", "cpg_nil"),
+			wantOk:                   false,
+		},
+		{
+			name:                     "pg state does not exist",
+			genericWorkloadEnabled:   true,
+			compositePodGroupEnabled: true,
+			key:                      fwk.PodGroupKey("ns1", "pg_not_exists"),
+			wantOk:                   false,
 		},
 	}
 

--- a/pkg/scheduler/backend/cache/snapshot_test.go
+++ b/pkg/scheduler/backend/cache/snapshot_test.go
@@ -1989,6 +1989,8 @@ func TestSnapshot_GetRootKeyForGroup(t *testing.T) {
 		s.compositePodGroupStates[fwk.CompositePodGroupKey("ns1", "cpg_cycle_2")] = &compositePodGroupStateSnapshot{compositePodGroupStateData: compositePodGroupStateData{compositePodGroup: st.MakeCompositePodGroup().Name("cpg_cycle_2").Namespace("ns1").ParentCompositePodGroup("cpg_cycle_1").Obj()}}
 
 		s.podGroupStates[fwk.PodGroupKey("ns1", "pg_missing_parent")] = &podGroupStateSnapshot{podGroupStateData: podGroupStateData{podGroup: st.MakePodGroup().Name("pg_missing_parent").Namespace("ns1").ParentCompositePodGroup("non-existent").Obj()}}
+		s.podGroupStates[fwk.PodGroupKey("ns1", "pg_nil")] = &podGroupStateSnapshot{}
+		s.compositePodGroupStates[fwk.CompositePodGroupKey("ns1", "cpg_nil")] = &compositePodGroupStateSnapshot{}
 
 		return s
 	}
@@ -2063,6 +2065,27 @@ func TestSnapshot_GetRootKeyForGroup(t *testing.T) {
 			compositePodGroupEnabled: true,
 			key:                      fwk.PodKey("ns1", "pod1"),
 			wantErr:                  true,
+		},
+		{
+			name:                     "pg state exists but pg object is nil",
+			genericWorkloadEnabled:   true,
+			compositePodGroupEnabled: true,
+			key:                      fwk.PodGroupKey("ns1", "pg_nil"),
+			wantOk:                   false,
+		},
+		{
+			name:                     "cpg state exists but cpg object is nil",
+			genericWorkloadEnabled:   true,
+			compositePodGroupEnabled: true,
+			key:                      fwk.CompositePodGroupKey("ns1", "cpg_nil"),
+			wantOk:                   false,
+		},
+		{
+			name:                     "pg state does not exist",
+			genericWorkloadEnabled:   true,
+			compositePodGroupEnabled: true,
+			key:                      fwk.PodGroupKey("ns1", "pg_not_exists"),
+			wantOk:                   false,
 		},
 	}
 

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -8294,6 +8294,7 @@ func TestPriorityQueue_AddCompositePodGroup(t *testing.T) {
 		expectedActiveQ        map[string][]string
 		expectedIncompletePods []string
 		expectedPendingPods    []string
+		disableCPG             bool
 	}{
 		{
 			name: "Root with pods",
@@ -8317,6 +8318,20 @@ func TestPriorityQueue_AddCompositePodGroup(t *testing.T) {
 			expectedActiveQ:        map[string][]string{},
 			expectedIncompletePods: []string{},
 			expectedPendingPods:    []string{},
+		},
+		{
+			name: "Feature gate disabled",
+			initialPodGroups: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("pod1").Namespace("ns1").UID("uid1").PodGroupName("pg1").Obj(),
+			},
+			cpgToAdd:               st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
+			expectedActiveQ:        map[string][]string{"podgroup/pg1": {"pod1"}},
+			expectedIncompletePods: []string{},
+			expectedPendingPods:    []string{},
+			disableCPG:             true,
 		},
 		{
 			name: "Root when another root exists",
@@ -8447,7 +8462,7 @@ func TestPriorityQueue_AddCompositePodGroup(t *testing.T) {
 			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
 				features.GenericWorkload:                 true,
 				features.TopologyAwareWorkloadScheduling: true,
-				features.CompositePodGroup:               true,
+				features.CompositePodGroup:               !tt.disableCPG,
 			})
 			logger, ctx := ktesting.NewTestContext(t)
 
@@ -8501,11 +8516,62 @@ func TestPriorityQueue_UpdateCompositePodGroup(t *testing.T) {
 		initialCPGs            []*schedulingv1alpha3.CompositePodGroup
 		initialPodGroups       []*schedulingv1beta1.PodGroup
 		initialPods            []*v1.Pod
+		beforeUpdate           func(ctx context.Context, q *PriorityQueue)
 		cpgToUpdate            *schedulingv1alpha3.CompositePodGroup
 		expectedActiveQ        map[string][]string
 		expectedIncompletePods []string
 		expectedPendingPods    []string
+		disableCPG             bool
 	}{
+		{
+			name: "Feature gate disabled",
+			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").MinGroupCount(3).Obj(),
+			},
+			initialPodGroups: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("pod1").Namespace("ns1").UID("uid1").PodGroupName("pg1").Obj(),
+			},
+			cpgToUpdate:            st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").MinGroupCount(5).Obj(),
+			expectedActiveQ:        map[string][]string{"podgroup/pg1": {"pod1"}},
+			expectedIncompletePods: []string{},
+			expectedPendingPods:    []string{},
+			disableCPG:             true,
+		},
+		{
+			name: "Root missing",
+			initialPodGroups: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("pod1").Namespace("ns1").UID("uid1").PodGroupName("pg1").Obj(),
+			},
+			cpgToUpdate:            st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").MinGroupCount(5).Obj(),
+			expectedActiveQ:        map[string][]string{},
+			expectedIncompletePods: []string{"pod1"},
+			expectedPendingPods:    []string{},
+		},
+		{
+			name: "Entity nil (in-flight)",
+			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").MinGroupCount(3).Obj(),
+			},
+			initialPodGroups: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("pod1").Namespace("ns1").UID("uid1").PodGroupName("pg1").Obj(),
+			},
+			beforeUpdate: func(ctx context.Context, q *PriorityQueue) {
+				_, _ = q.Pop(klog.FromContext(ctx))
+			},
+			cpgToUpdate:            st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").MinGroupCount(5).Obj(),
+			expectedActiveQ:        map[string][]string{},
+			expectedIncompletePods: []string{},
+			expectedPendingPods:    []string{},
+		},
 		{
 			name: "Root when minCount is updated",
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
@@ -8546,7 +8612,7 @@ func TestPriorityQueue_UpdateCompositePodGroup(t *testing.T) {
 			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
 				features.GenericWorkload:                 true,
 				features.TopologyAwareWorkloadScheduling: true,
-				features.CompositePodGroup:               true,
+				features.CompositePodGroup:               !tt.disableCPG,
 			})
 			logger, ctx := ktesting.NewTestContext(t)
 
@@ -8561,6 +8627,10 @@ func TestPriorityQueue_UpdateCompositePodGroup(t *testing.T) {
 			}
 			for _, pod := range tt.initialPods {
 				q.Add(ctx, pod)
+			}
+
+			if tt.beforeUpdate != nil {
+				tt.beforeUpdate(ctx, q)
 			}
 
 			q.UpdateCompositePodGroup(logger, tt.cpgToUpdate)
@@ -8589,10 +8659,12 @@ func TestPriorityQueue_UpdateCompositePodGroup(t *testing.T) {
 			}
 
 			entity := findPodGroupInfoInActiveQ(q, tt.cpgToUpdate.Namespace, tt.cpgToUpdate.Name, fwk.CompositePodGroupKeyType)
-			if entity == nil || entity.CompositePodGroup == nil {
-				t.Errorf("Expected CPG %s/%s in active queue hierarchy, but not found", tt.cpgToUpdate.Namespace, tt.cpgToUpdate.Name)
-			} else if diff := cmp.Diff(tt.cpgToUpdate, entity.CompositePodGroup); diff != "" {
-				t.Errorf("Updated CompositePodGroup mismatch (-want,+got):\n%s", diff)
+			if !tt.disableCPG && len(tt.expectedActiveQ) > 0 {
+				if entity == nil || entity.CompositePodGroup == nil {
+					t.Errorf("Expected CPG %s/%s in active queue hierarchy, but not found", tt.cpgToUpdate.Namespace, tt.cpgToUpdate.Name)
+				} else if diff := cmp.Diff(tt.cpgToUpdate, entity.CompositePodGroup); diff != "" {
+					t.Errorf("Updated CompositePodGroup mismatch (-want,+got):\n%s", diff)
+				}
 			}
 		})
 	}
@@ -8609,7 +8681,64 @@ func TestPriorityQueue_DeleteCompositePodGroup(t *testing.T) {
 		expectedActiveQ        map[string][]string
 		expectedIncompletePods []string
 		expectedPendingPods    []string
+		disableCPG             bool
 	}{
+		{
+			name: "Feature gate disabled",
+			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
+			},
+			initialPodGroups: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("pod1").Namespace("ns1").UID("uid1").PodGroupName("pg1").Obj(),
+			},
+			cpgToDelete:            st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
+			expectedActiveQ:        map[string][]string{"podgroup/pg1": {"pod1"}},
+			expectedIncompletePods: []string{},
+			expectedPendingPods:    []string{},
+			disableCPG:             true,
+		},
+		{
+			name: "Root not in queue and not in-flight",
+			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
+			},
+			initialPodGroups: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
+			},
+			cpgToDelete:            st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
+			expectedActiveQ:        map[string][]string{},
+			expectedIncompletePods: []string{},
+			expectedPendingPods:    []string{},
+		},
+		{
+			name: "Non-root with pending pods staysPending true for other branches",
+			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
+				st.MakeCompositePodGroup().Name("child-cpg").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
+			},
+			initialPodGroups: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("child-cpg").Obj(),
+				st.MakePodGroup().Name("pg2").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("pod1").Namespace("ns1").UID("uid1").PodGroupName("pg1").Obj(),
+				st.MakePod().Name("pod2").Namespace("ns1").UID("uid2").PodGroupName("pg2").Obj(),
+			},
+			beforeDelete: func(ctx context.Context, q *PriorityQueue) {
+				_, _ = q.Pop(klog.FromContext(ctx)) // Pop root-cpg
+				pod3 := st.MakePod().Name("pod3").Namespace("ns1").UID("uid3").PodGroupName("pg1").Obj()
+				pod4 := st.MakePod().Name("pod4").Namespace("ns1").UID("uid4").PodGroupName("pg2").Obj()
+				q.Add(ctx, pod3) // Goes to pending for pg1
+				q.Add(ctx, pod4) // Goes to pending for pg2
+			},
+			cpgToDelete:            st.MakeCompositePodGroup().Name("child-cpg").Namespace("ns1").Obj(),
+			expectedActiveQ:        map[string][]string{},
+			expectedIncompletePods: []string{"pod3"},
+			expectedPendingPods:    []string{"pod4"},
+		},
 		{
 			name: "Non-root when parent is root and is already in activeQ with another pod",
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
@@ -8774,7 +8903,7 @@ func TestPriorityQueue_DeleteCompositePodGroup(t *testing.T) {
 			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
 				features.GenericWorkload:                 true,
 				features.TopologyAwareWorkloadScheduling: true,
-				features.CompositePodGroup:               true,
+				features.CompositePodGroup:               !tt.disableCPG,
 			})
 			logger, ctx := ktesting.NewTestContext(t)
 
@@ -8834,6 +8963,7 @@ func TestPriorityQueue_AddPodGroup_Hierarchical(t *testing.T) {
 		expectedActiveQ        map[string][]string
 		expectedIncompletePods []string
 		expectedPendingPods    []string
+		disableCPG             bool
 	}{
 		{
 			name: "Root with pods",
@@ -9059,7 +9189,18 @@ func TestPriorityQueue_UpdatePodGroup_Hierarchical(t *testing.T) {
 		expectedActiveQ        map[string][]string
 		expectedIncompletePods []string
 		expectedPendingPods    []string
+		disableCPG             bool
 	}{
+		{
+			name: "Root missing",
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("pod1").Namespace("ns1").UID("uid1").PodGroupName("pg1").Obj(),
+			},
+			pgToUpdate:             st.MakePodGroup().Name("pg1").Namespace("ns1").MinCount(3).Obj(),
+			expectedActiveQ:        map[string][]string{},
+			expectedIncompletePods: []string{"pod1"},
+			expectedPendingPods:    []string{},
+		},
 		{
 			name: "Root when minCount is updated",
 			initialPodGroups: []*schedulingv1beta1.PodGroup{
@@ -9153,10 +9294,12 @@ func TestPriorityQueue_UpdatePodGroup_Hierarchical(t *testing.T) {
 			}
 
 			entity := findPodGroupInfoInActiveQ(q, tt.pgToUpdate.Namespace, tt.pgToUpdate.Name, fwk.PodGroupKeyType)
-			if entity == nil || entity.PodGroup == nil {
-				t.Errorf("Expected PodGroup %s/%s in active queue hierarchy, but not found", tt.pgToUpdate.Namespace, tt.pgToUpdate.Name)
-			} else if diff := cmp.Diff(tt.pgToUpdate, entity.PodGroup); diff != "" {
-				t.Errorf("Updated PodGroup mismatch (-want,+got):\n%s", diff)
+			if len(tt.expectedActiveQ) > 0 {
+				if entity == nil || entity.PodGroup == nil {
+					t.Errorf("Expected PodGroup %s/%s in active queue hierarchy, but not found", tt.pgToUpdate.Namespace, tt.pgToUpdate.Name)
+				} else if diff := cmp.Diff(tt.pgToUpdate, entity.PodGroup); diff != "" {
+					t.Errorf("Updated PodGroup mismatch (-want,+got):\n%s", diff)
+				}
 			}
 		})
 	}
@@ -9174,6 +9317,7 @@ func TestPriorityQueue_DeletePodGroup_Hierarchical(t *testing.T) {
 		expectedActiveQ        map[string][]string
 		expectedIncompletePods []string
 		expectedPendingPods    []string
+		disableCPG             bool
 	}{
 		{
 			name: "Non-root when parent is root and is already in activeQ with another pod",

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -8999,6 +8999,7 @@ func TestPriorityQueue_AddCompositePodGroup(t *testing.T) {
 		expectedActiveQ        map[string][]string
 		expectedIncompletePods []string
 		expectedPendingPods    []string
+		disableCPG             bool
 	}{
 		{
 			name: "Root with pods",
@@ -9022,6 +9023,20 @@ func TestPriorityQueue_AddCompositePodGroup(t *testing.T) {
 			expectedActiveQ:        map[string][]string{},
 			expectedIncompletePods: []string{},
 			expectedPendingPods:    []string{},
+		},
+		{
+			name: "Feature gate disabled",
+			initialPodGroups: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("pod1").Namespace("ns1").UID("uid1").PodGroupName("pg1").Obj(),
+			},
+			cpgToAdd:               st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
+			expectedActiveQ:        map[string][]string{"podgroup/pg1": {"pod1"}},
+			expectedIncompletePods: []string{},
+			expectedPendingPods:    []string{},
+			disableCPG:             true,
 		},
 		{
 			name: "Root when another root exists",
@@ -9152,7 +9167,7 @@ func TestPriorityQueue_AddCompositePodGroup(t *testing.T) {
 			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
 				features.GenericWorkload:                 true,
 				features.TopologyAwareWorkloadScheduling: true,
-				features.CompositePodGroup:               true,
+				features.CompositePodGroup:               !tt.disableCPG,
 			})
 			logger, ctx := ktesting.NewTestContext(t)
 
@@ -9206,11 +9221,62 @@ func TestPriorityQueue_UpdateCompositePodGroup(t *testing.T) {
 		initialCPGs            []*schedulingv1alpha3.CompositePodGroup
 		initialPodGroups       []*schedulingv1beta1.PodGroup
 		initialPods            []*v1.Pod
+		beforeUpdate           func(ctx context.Context, q *PriorityQueue)
 		cpgToUpdate            *schedulingv1alpha3.CompositePodGroup
 		expectedActiveQ        map[string][]string
 		expectedIncompletePods []string
 		expectedPendingPods    []string
+		disableCPG             bool
 	}{
+		{
+			name: "Feature gate disabled",
+			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").MinGroupCount(3).Obj(),
+			},
+			initialPodGroups: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("pod1").Namespace("ns1").UID("uid1").PodGroupName("pg1").Obj(),
+			},
+			cpgToUpdate:            st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").MinGroupCount(5).Obj(),
+			expectedActiveQ:        map[string][]string{"podgroup/pg1": {"pod1"}},
+			expectedIncompletePods: []string{},
+			expectedPendingPods:    []string{},
+			disableCPG:             true,
+		},
+		{
+			name: "Root missing",
+			initialPodGroups: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("pod1").Namespace("ns1").UID("uid1").PodGroupName("pg1").Obj(),
+			},
+			cpgToUpdate:            st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").MinGroupCount(5).Obj(),
+			expectedActiveQ:        map[string][]string{},
+			expectedIncompletePods: []string{"pod1"},
+			expectedPendingPods:    []string{},
+		},
+		{
+			name: "Entity nil (in-flight)",
+			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").MinGroupCount(3).Obj(),
+			},
+			initialPodGroups: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("pod1").Namespace("ns1").UID("uid1").PodGroupName("pg1").Obj(),
+			},
+			beforeUpdate: func(ctx context.Context, q *PriorityQueue) {
+				_, _ = q.Pop(klog.FromContext(ctx))
+			},
+			cpgToUpdate:            st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").MinGroupCount(5).Obj(),
+			expectedActiveQ:        map[string][]string{},
+			expectedIncompletePods: []string{},
+			expectedPendingPods:    []string{},
+		},
 		{
 			name: "Root when minCount is updated",
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
@@ -9251,7 +9317,7 @@ func TestPriorityQueue_UpdateCompositePodGroup(t *testing.T) {
 			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
 				features.GenericWorkload:                 true,
 				features.TopologyAwareWorkloadScheduling: true,
-				features.CompositePodGroup:               true,
+				features.CompositePodGroup:               !tt.disableCPG,
 			})
 			logger, ctx := ktesting.NewTestContext(t)
 
@@ -9266,6 +9332,10 @@ func TestPriorityQueue_UpdateCompositePodGroup(t *testing.T) {
 			}
 			for _, pod := range tt.initialPods {
 				q.Add(ctx, pod)
+			}
+
+			if tt.beforeUpdate != nil {
+				tt.beforeUpdate(ctx, q)
 			}
 
 			q.UpdateGenericPodGroup(logger, fwk.NewGenericCompositePodGroup(tt.cpgToUpdate))
@@ -9294,10 +9364,12 @@ func TestPriorityQueue_UpdateCompositePodGroup(t *testing.T) {
 			}
 
 			entity := findPodGroupInfoInActiveQ(q, tt.cpgToUpdate.Namespace, tt.cpgToUpdate.Name, fwk.CompositePodGroupKeyType)
-			if entity == nil || entity.CompositePodGroup == nil {
-				t.Errorf("Expected CPG %s/%s in active queue hierarchy, but not found", tt.cpgToUpdate.Namespace, tt.cpgToUpdate.Name)
-			} else if diff := cmp.Diff(tt.cpgToUpdate, entity.CompositePodGroup); diff != "" {
-				t.Errorf("Updated CompositePodGroup mismatch (-want,+got):\n%s", diff)
+			if !tt.disableCPG && len(tt.expectedActiveQ) > 0 {
+				if entity == nil || entity.CompositePodGroup == nil {
+					t.Errorf("Expected CPG %s/%s in active queue hierarchy, but not found", tt.cpgToUpdate.Namespace, tt.cpgToUpdate.Name)
+				} else if diff := cmp.Diff(tt.cpgToUpdate, entity.CompositePodGroup); diff != "" {
+					t.Errorf("Updated CompositePodGroup mismatch (-want,+got):\n%s", diff)
+				}
 			}
 		})
 	}
@@ -9314,7 +9386,64 @@ func TestPriorityQueue_DeleteCompositePodGroup(t *testing.T) {
 		expectedActiveQ        map[string][]string
 		expectedIncompletePods []string
 		expectedPendingPods    []string
+		disableCPG             bool
 	}{
+		{
+			name: "Feature gate disabled",
+			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
+			},
+			initialPodGroups: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("pod1").Namespace("ns1").UID("uid1").PodGroupName("pg1").Obj(),
+			},
+			cpgToDelete:            st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
+			expectedActiveQ:        map[string][]string{"podgroup/pg1": {"pod1"}},
+			expectedIncompletePods: []string{},
+			expectedPendingPods:    []string{},
+			disableCPG:             true,
+		},
+		{
+			name: "Root not in queue and not in-flight",
+			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
+			},
+			initialPodGroups: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
+			},
+			cpgToDelete:            st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
+			expectedActiveQ:        map[string][]string{},
+			expectedIncompletePods: []string{},
+			expectedPendingPods:    []string{},
+		},
+		{
+			name: "Non-root with pending pods staysPending true for other branches",
+			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
+				st.MakeCompositePodGroup().Name("child-cpg").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
+			},
+			initialPodGroups: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("child-cpg").Obj(),
+				st.MakePodGroup().Name("pg2").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("pod1").Namespace("ns1").UID("uid1").PodGroupName("pg1").Obj(),
+				st.MakePod().Name("pod2").Namespace("ns1").UID("uid2").PodGroupName("pg2").Obj(),
+			},
+			beforeDelete: func(ctx context.Context, q *PriorityQueue) {
+				_, _ = q.Pop(klog.FromContext(ctx)) // Pop root-cpg
+				pod3 := st.MakePod().Name("pod3").Namespace("ns1").UID("uid3").PodGroupName("pg1").Obj()
+				pod4 := st.MakePod().Name("pod4").Namespace("ns1").UID("uid4").PodGroupName("pg2").Obj()
+				q.Add(ctx, pod3) // Goes to pending for pg1
+				q.Add(ctx, pod4) // Goes to pending for pg2
+			},
+			cpgToDelete:            st.MakeCompositePodGroup().Name("child-cpg").Namespace("ns1").Obj(),
+			expectedActiveQ:        map[string][]string{},
+			expectedIncompletePods: []string{"pod3"},
+			expectedPendingPods:    []string{"pod4"},
+		},
 		{
 			name: "Non-root when parent is root and is already in activeQ with another pod",
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
@@ -9479,7 +9608,7 @@ func TestPriorityQueue_DeleteCompositePodGroup(t *testing.T) {
 			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
 				features.GenericWorkload:                 true,
 				features.TopologyAwareWorkloadScheduling: true,
-				features.CompositePodGroup:               true,
+				features.CompositePodGroup:               !tt.disableCPG,
 			})
 			logger, ctx := ktesting.NewTestContext(t)
 
@@ -9766,6 +9895,16 @@ func TestPriorityQueue_UpdatePodGroup_Hierarchical(t *testing.T) {
 		expectedPendingPods    []string
 	}{
 		{
+			name: "Root missing",
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("pod1").Namespace("ns1").UID("uid1").PodGroupName("pg1").Obj(),
+			},
+			pgToUpdate:             st.MakePodGroup().Name("pg1").Namespace("ns1").MinCount(3).Obj(),
+			expectedActiveQ:        map[string][]string{},
+			expectedIncompletePods: []string{"pod1"},
+			expectedPendingPods:    []string{},
+		},
+		{
 			name: "Root when minCount is updated",
 			initialPodGroups: []*schedulingv1beta1.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").MinCount(2).Obj(),
@@ -9858,10 +9997,12 @@ func TestPriorityQueue_UpdatePodGroup_Hierarchical(t *testing.T) {
 			}
 
 			entity := findPodGroupInfoInActiveQ(q, tt.pgToUpdate.Namespace, tt.pgToUpdate.Name, fwk.PodGroupKeyType)
-			if entity == nil || entity.PodGroup == nil {
-				t.Errorf("Expected PodGroup %s/%s in active queue hierarchy, but not found", tt.pgToUpdate.Namespace, tt.pgToUpdate.Name)
-			} else if diff := cmp.Diff(tt.pgToUpdate, entity.PodGroup); diff != "" {
-				t.Errorf("Updated PodGroup mismatch (-want,+got):\n%s", diff)
+			if len(tt.expectedActiveQ) > 0 {
+				if entity == nil || entity.PodGroup == nil {
+					t.Errorf("Expected PodGroup %s/%s in active queue hierarchy, but not found", tt.pgToUpdate.Namespace, tt.pgToUpdate.Name)
+				} else if diff := cmp.Diff(tt.pgToUpdate, entity.PodGroup); diff != "" {
+					t.Errorf("Updated PodGroup mismatch (-want,+got):\n%s", diff)
+				}
 			}
 		})
 	}

--- a/pkg/scheduler/backend/queue/workload_forest_test.go
+++ b/pkg/scheduler/backend/queue/workload_forest_test.go
@@ -590,6 +590,13 @@ func TestWorkloadForest_DeleteCompositePodGroup(t *testing.T) {
 		wantChildren map[fwk.EntityKey]sets.Set[fwk.EntityKey]
 	}{
 		{
+			name:         "delete non-existent composite pod group",
+			initialCPGs:  []*schedulingv1alpha3.CompositePodGroup{},
+			cpgToDelete:  cpg1,
+			wantCPGs:     map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{},
+			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
+		},
+		{
 			name:         "delete existing composite pod group without parent",
 			initialCPGs:  []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			cpgToDelete:  cpg1,
@@ -1002,6 +1009,26 @@ func TestWorkloadForest_GetLeafPodGroups(t *testing.T) {
 		isCompositePodGroupEnabled bool
 	}{
 		{
+			name: "cpg not found",
+			rootLookupInfo: &framework.QueuedPodGroupInfo{
+				PodGroupInfo: &framework.PodGroupInfo{Namespace: "ns1", Name: "cpg-missing", Type: fwk.CompositePodGroupKeyType},
+			},
+			wantLeaves:                 nil,
+			isCompositePodGroupEnabled: true,
+		},
+		{
+			name: "cpg with cycle",
+			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Name("cpg1").Namespace("ns1").ParentCompositePodGroup("cpg2").Obj(),
+				st.MakeCompositePodGroup().Name("cpg2").Namespace("ns1").ParentCompositePodGroup("cpg1").Obj(),
+			},
+			rootLookupInfo: &framework.QueuedPodGroupInfo{
+				PodGroupInfo: &framework.PodGroupInfo{Namespace: "ns1", Name: "cpg1", Type: fwk.CompositePodGroupKeyType},
+			},
+			wantLeaves:                 nil,
+			isCompositePodGroupEnabled: true,
+		},
+		{
 			name:             "single pod group lookup",
 			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
 			rootLookupInfo: &framework.QueuedPodGroupInfo{
@@ -1106,6 +1133,7 @@ func TestWorkloadForest_BuildPodGroupInfoForPG(t *testing.T) {
 		initialPodGroups           []*schedulingv1beta1.PodGroup
 		pg                         *schedulingv1beta1.PodGroup
 		wantInfo                   *framework.PodGroupInfo
+		visited                    sets.Set[fwk.EntityKey]
 		isCompositePodGroupEnabled bool
 	}{
 		{
@@ -1134,6 +1162,14 @@ func TestWorkloadForest_BuildPodGroupInfoForPG(t *testing.T) {
 			},
 			isCompositePodGroupEnabled: false,
 		},
+		{
+			name:                       "build info with cycle detected",
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1},
+			pg:                         pg1,
+			wantInfo:                   nil,
+			visited:                    sets.New(fwk.PodGroupKey(pg1.Namespace, pg1.Name)),
+			isCompositePodGroupEnabled: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1144,7 +1180,10 @@ func TestWorkloadForest_BuildPodGroupInfoForPG(t *testing.T) {
 			}
 
 			logger, _ := ktesting.NewTestContext(t)
-			visited := sets.New[fwk.EntityKey]()
+			visited := tt.visited
+			if visited == nil {
+				visited = sets.New[fwk.EntityKey]()
+			}
 			gotInfo := wf.buildPodGroupInfoForPG(logger, tt.pg, visited)
 
 			if diff := cmp.Diff(tt.wantInfo, gotInfo); diff != "" {
@@ -1164,6 +1203,7 @@ func TestWorkloadForest_BuildPodGroupInfoForCPG(t *testing.T) {
 		initialCPGs                []*schedulingv1alpha3.CompositePodGroup
 		cpg                        *schedulingv1alpha3.CompositePodGroup
 		wantInfo                   *framework.PodGroupInfo
+		visited                    sets.Set[fwk.EntityKey]
 		isCompositePodGroupEnabled bool
 	}{
 		{
@@ -1202,6 +1242,15 @@ func TestWorkloadForest_BuildPodGroupInfoForCPG(t *testing.T) {
 			},
 			isCompositePodGroupEnabled: false,
 		},
+		{
+			name:                       "build info with cycle detected",
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1WithParent},
+			initialCPGs:                []*schedulingv1alpha3.CompositePodGroup{cpg1},
+			cpg:                        cpg1,
+			wantInfo:                   nil,
+			visited:                    sets.New(fwk.CompositePodGroupKey(cpg1.Namespace, cpg1.Name)),
+			isCompositePodGroupEnabled: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1215,7 +1264,10 @@ func TestWorkloadForest_BuildPodGroupInfoForCPG(t *testing.T) {
 			}
 
 			logger, _ := ktesting.NewTestContext(t)
-			visited := sets.New[fwk.EntityKey]()
+			visited := tt.visited
+			if visited == nil {
+				visited = sets.New[fwk.EntityKey]()
+			}
 			gotInfo := wf.buildPodGroupInfoForCPG(logger, tt.cpg, visited)
 
 			// Note: Children are sorted by name in buildPodGroupInfoForCPG, so it is deterministic.

--- a/pkg/scheduler/backend/queue/workload_forest_test.go
+++ b/pkg/scheduler/backend/queue/workload_forest_test.go
@@ -611,6 +611,13 @@ func TestWorkloadForest_DeleteCompositePodGroup(t *testing.T) {
 		wantChildren  map[fwk.EntityKey]sets.Set[fwk.EntityKey]
 	}{
 		{
+			name:          "delete non-existent composite pod group",
+			initialCPGs:   []*schedulingv1alpha3.CompositePodGroup{},
+			cpgToDelete:   cpg1,
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{},
+			wantChildren:  map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
+		},
+		{
 			name:          "delete existing composite pod group without parent",
 			initialCPGs:   []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			cpgToDelete:   cpg1,
@@ -752,7 +759,6 @@ func TestWorkloadForest_GetRootLookupInfoForPod(t *testing.T) {
 			name:                       "pod belongs to non-existent pod group",
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1},
 			pod:                        podWithNonExistentPG,
-			wantInfo:                   nil,
 			isCompositePodGroupEnabled: true,
 		},
 		{
@@ -782,7 +788,6 @@ func TestWorkloadForest_GetRootLookupInfoForPod(t *testing.T) {
 			name:                       "pod belongs to non-existent pod group (CPG=false)",
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1},
 			pod:                        podWithNonExistentPG,
-			wantInfo:                   nil,
 			isCompositePodGroupEnabled: false,
 		},
 	}
@@ -850,14 +855,12 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 			name:                       "pod group with non-existent parent cpg",
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg3WithNonExistentParent},
 			podGroup:                   pg3WithNonExistentParent,
-			wantInfo:                   nil,
 			isCompositePodGroupEnabled: true,
 		},
 		{
 			name:                       "non-existent pod group",
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{},
 			podGroup:                   pg1,
-			wantInfo:                   nil,
 			isCompositePodGroupEnabled: true,
 		},
 		{
@@ -898,7 +901,6 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 			name:                       "non-existent pod group (CPG=false)",
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{},
 			podGroup:                   pg1,
-			wantInfo:                   nil,
 			isCompositePodGroupEnabled: false,
 		},
 	}
@@ -960,13 +962,11 @@ func TestWorkloadForest_GetRootLookupInfoForCPG(t *testing.T) {
 			name:        "cpg with parent missing",
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg2WithParent},
 			cpg:         cpg2WithParent,
-			wantInfo:    nil,
 		},
 		{
 			name:        "cpg cycle detection",
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg3WithCycle, cpg4WithCycle},
 			cpg:         cpg3WithCycle,
-			wantInfo:    nil, // cycle returns nil, false
 		},
 	}
 
@@ -1005,6 +1005,20 @@ func TestWorkloadForest_GetLeafPodGroups(t *testing.T) {
 		isCompositePodGroupEnabled bool
 	}{
 		{
+			name:                       "cpg not found",
+			rootLookupInfo:             newQueuedPodGroupInfoForLookup("ns1", "cpg-missing", fwk.CompositePodGroupKeyType),
+			isCompositePodGroupEnabled: true,
+		},
+		{
+			name: "cpg with cycle",
+			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Name("cpg1").Namespace("ns1").ParentCompositePodGroup("cpg2").Obj(),
+				st.MakeCompositePodGroup().Name("cpg2").Namespace("ns1").ParentCompositePodGroup("cpg1").Obj(),
+			},
+			rootLookupInfo:             newQueuedPodGroupInfoForLookup("ns1", "cpg1", fwk.CompositePodGroupKeyType),
+			isCompositePodGroupEnabled: true,
+		},
+		{
 			name:                       "single pod group lookup",
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1},
 			rootLookupInfo:             newQueuedPodGroupInfoForLookup("ns1", "pg1", fwk.PodGroupKeyType),
@@ -1031,7 +1045,6 @@ func TestWorkloadForest_GetLeafPodGroups(t *testing.T) {
 			name:                       "missing root",
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{},
 			rootLookupInfo:             newQueuedPodGroupInfoForLookup("ns1", "missing", fwk.CompositePodGroupKeyType),
-			wantLeaves:                 nil,
 			isCompositePodGroupEnabled: true,
 		},
 		{
@@ -1053,7 +1066,6 @@ func TestWorkloadForest_GetLeafPodGroups(t *testing.T) {
 			name:                       "missing root (CPG=false)",
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{},
 			rootLookupInfo:             newQueuedPodGroupInfoForLookup("ns1", "missing", fwk.CompositePodGroupKeyType),
-			wantLeaves:                 nil,
 			isCompositePodGroupEnabled: false,
 		},
 	}
@@ -1087,20 +1099,26 @@ func TestWorkloadForest_GetLeafPodGroups(t *testing.T) {
 	}
 }
 
-func TestWorkloadForest_BuildPodGroupInfoForPG(t *testing.T) {
+func TestWorkloadForest_BuildPodGroupInfo(t *testing.T) {
 	pg1 := st.MakePodGroup().Name("pg1").Namespace("ns1").UID("uid1").Obj()
+	pg1WithParent := st.MakePodGroup().Name("pg1").Namespace("ns1").UID("uid1").MinCount(2).ParentCompositePodGroup("cpg1").Obj()
+	cpg1 := st.MakeCompositePodGroup().Name("cpg1").Namespace("ns1").MinGroupCount(1).Obj()
+	cpg2WithCycle := st.MakeCompositePodGroup().Name("cpg2").Namespace("ns1").ParentCompositePodGroup("cpg3").Obj()
+	cpg3WithCycle := st.MakeCompositePodGroup().Name("cpg3").Namespace("ns1").ParentCompositePodGroup("cpg2").Obj()
 
 	tests := []struct {
 		name                       string
 		initialPodGroups           []*schedulingv1beta1.PodGroup
-		pg                         *schedulingv1beta1.PodGroup
+		initialCPGs                []*schedulingv1alpha3.CompositePodGroup
+		target                     *fwk.GenericPodGroup
 		wantInfo                   *framework.PodGroupInfo
+		visited                    sets.Set[fwk.EntityKey]
 		isCompositePodGroupEnabled bool
 	}{
 		{
-			name:             "build info for existing pod group",
+			name:             "standalone pod group",
 			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
-			pg:               pg1,
+			target:           fwk.NewGenericPodGroup(pg1),
 			wantInfo: &framework.PodGroupInfo{
 				GenericPodGroup: fwk.NewGenericPodGroup(pg1),
 				Children:        []*framework.PodGroupInfo{},
@@ -1108,52 +1126,20 @@ func TestWorkloadForest_BuildPodGroupInfoForPG(t *testing.T) {
 			isCompositePodGroupEnabled: true,
 		},
 		{
-			name:             "build info for existing pod group (CPG=false)",
+			name:             "standalone pod group (CPG=false)",
 			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
-			pg:               pg1,
+			target:           fwk.NewGenericPodGroup(pg1),
 			wantInfo: &framework.PodGroupInfo{
 				GenericPodGroup: fwk.NewGenericPodGroup(pg1),
 				Children:        []*framework.PodGroupInfo{},
 			},
 			isCompositePodGroupEnabled: false,
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			wf := newWorkloadForest(tt.isCompositePodGroupEnabled)
-			for _, pg := range tt.initialPodGroups {
-				wf.addGenericPodGroup(fwk.NewGenericPodGroup(pg))
-			}
-
-			logger, _ := ktesting.NewTestContext(t)
-			visited := sets.New[fwk.EntityKey]()
-			gotInfo := wf.buildPodGroupInfo(logger, fwk.NewGenericPodGroup(tt.pg), visited)
-
-			if diff := cmp.Diff(tt.wantInfo, gotInfo); diff != "" {
-				t.Errorf("Unexpected PodGroupInfo (-want,+got)\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestWorkloadForest_BuildPodGroupInfoForCPG(t *testing.T) {
-	pg1WithParent := st.MakePodGroup().Name("pg1").Namespace("ns1").UID("uid1").MinCount(2).ParentCompositePodGroup("cpg1").Obj()
-	cpg1 := st.MakeCompositePodGroup().Name("cpg1").Namespace("ns1").MinGroupCount(1).Obj()
-
-	tests := []struct {
-		name                       string
-		initialPodGroups           []*schedulingv1beta1.PodGroup
-		initialCPGs                []*schedulingv1alpha3.CompositePodGroup
-		cpg                        *schedulingv1alpha3.CompositePodGroup
-		wantInfo                   *framework.PodGroupInfo
-		isCompositePodGroupEnabled bool
-	}{
 		{
-			name:             "build info for cpg with child pg",
+			name:             "cpg with child pg",
 			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1WithParent},
 			initialCPGs:      []*schedulingv1alpha3.CompositePodGroup{cpg1},
-			cpg:              cpg1,
+			target:           fwk.NewGenericCompositePodGroup(cpg1),
 			wantInfo: &framework.PodGroupInfo{
 				GenericPodGroup: fwk.NewGenericCompositePodGroup(cpg1),
 				Children: []*framework.PodGroupInfo{
@@ -1166,15 +1152,38 @@ func TestWorkloadForest_BuildPodGroupInfoForCPG(t *testing.T) {
 			isCompositePodGroupEnabled: true,
 		},
 		{
-			name:             "build info for cpg with child pg (CPG=false)",
+			name:             "cpg with child pg (CPG=false)",
 			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1WithParent},
 			initialCPGs:      []*schedulingv1alpha3.CompositePodGroup{cpg1},
-			cpg:              cpg1,
+			target:           fwk.NewGenericCompositePodGroup(cpg1),
 			wantInfo: &framework.PodGroupInfo{
 				GenericPodGroup: fwk.NewGenericCompositePodGroup(cpg1),
 				Children:        []*framework.PodGroupInfo{},
 			},
 			isCompositePodGroupEnabled: false,
+		},
+		{
+			name:                       "build info with cycle detected",
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1WithParent},
+			initialCPGs:                []*schedulingv1alpha3.CompositePodGroup{cpg1},
+			target:                     fwk.NewGenericCompositePodGroup(cpg1),
+			visited:                    sets.New(fwk.CompositePodGroupKey(cpg1.Namespace, cpg1.Name)),
+			isCompositePodGroupEnabled: true,
+		},
+		{
+			name:        "cpg with mutual cycle detected",
+			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg2WithCycle, cpg3WithCycle},
+			target:      fwk.NewGenericCompositePodGroup(cpg2WithCycle),
+			wantInfo: &framework.PodGroupInfo{
+				GenericPodGroup: fwk.NewGenericCompositePodGroup(cpg2WithCycle),
+				Children: []*framework.PodGroupInfo{
+					{
+						GenericPodGroup: fwk.NewGenericCompositePodGroup(cpg3WithCycle),
+						Children:        []*framework.PodGroupInfo{},
+					},
+				},
+			},
+			isCompositePodGroupEnabled: true,
 		},
 	}
 
@@ -1189,10 +1198,12 @@ func TestWorkloadForest_BuildPodGroupInfoForCPG(t *testing.T) {
 			}
 
 			logger, _ := ktesting.NewTestContext(t)
-			visited := sets.New[fwk.EntityKey]()
-			gotInfo := wf.buildPodGroupInfo(logger, fwk.NewGenericCompositePodGroup(tt.cpg), visited)
+			visited := tt.visited
+			if visited == nil {
+				visited = sets.New[fwk.EntityKey]()
+			}
+			gotInfo := wf.buildPodGroupInfo(logger, tt.target, visited)
 
-			// Note: Children are sorted by name in buildPodGroupInfoForCPG, so it is deterministic.
 			if diff := cmp.Diff(tt.wantInfo, gotInfo); diff != "" {
 				t.Errorf("Unexpected PodGroupInfo (-want,+got)\n%s", diff)
 			}

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -1865,6 +1865,13 @@ func TestDeleteCompositePodGroup(t *testing.T) {
 			expectStillExists: false,
 		},
 		{
+			name:              "delete DeletedFinalStateUnknown tombstone with invalid type",
+			initCPG:           cpg,
+			cpgToDelete:       cache.DeletedFinalStateUnknown{Obj: "invalid-type"},
+			cpgEnabled:        true,
+			expectStillExists: true,
+		},
+		{
 			name:              "delete composite pod group with invalid type",
 			initCPG:           cpg,
 			cpgToDelete:       "invalid-type",

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -1965,6 +1965,13 @@ func TestDeleteCompositePodGroup(t *testing.T) {
 			expectStillExists: false,
 		},
 		{
+			name:              "delete DeletedFinalStateUnknown tombstone with invalid type",
+			initCPG:           cpg,
+			cpgToDelete:       cache.DeletedFinalStateUnknown{Obj: "invalid-type"},
+			cpgEnabled:        true,
+			expectStillExists: true,
+		},
+		{
 			name:              "delete composite pod group with invalid type",
 			initCPG:           cpg,
 			cpgToDelete:       "invalid-type",

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -25,7 +25,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -843,33 +842,23 @@ func TestGangSchedulingFlow(t *testing.T) {
 
 	nonGangPod := st.MakePod().Namespace("ns1").Name("non-gang").UID("non-gang").Obj()
 
-	cpgRoot := &schedulingv1alpha3.CompositePodGroup{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "cpg-root"},
-		Spec: schedulingv1alpha3.CompositePodGroupSpec{
-			SchedulingPolicy: schedulingv1alpha3.CompositePodGroupSchedulingPolicy{Gang: &schedulingv1alpha3.CompositeGangSchedulingPolicy{MinGroupCount: 2}},
-		},
-	}
-	cpgSub1 := &schedulingv1alpha3.CompositePodGroup{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "cpg-sub1"},
-		Spec: schedulingv1alpha3.CompositePodGroupSpec{
-			ParentCompositePodGroupName: new("cpg-root"),
-			SchedulingPolicy:            schedulingv1alpha3.CompositePodGroupSchedulingPolicy{Gang: &schedulingv1alpha3.CompositeGangSchedulingPolicy{MinGroupCount: 2}},
-		},
-	}
-	cpgSub2 := &schedulingv1alpha3.CompositePodGroup{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "cpg-sub2"},
-		Spec: schedulingv1alpha3.CompositePodGroupSpec{
-			ParentCompositePodGroupName: new("cpg-root"),
-			SchedulingPolicy:            schedulingv1alpha3.CompositePodGroupSchedulingPolicy{Basic: &schedulingv1alpha3.CompositeBasicSchedulingPolicy{}},
-		},
-	}
-	cpgSub3 := &schedulingv1alpha3.CompositePodGroup{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "cpg-sub3"},
-		Spec: schedulingv1alpha3.CompositePodGroupSpec{
-			ParentCompositePodGroupName: new("cpg-root"),
-			SchedulingPolicy:            schedulingv1alpha3.CompositePodGroupSchedulingPolicy{Gang: &schedulingv1alpha3.CompositeGangSchedulingPolicy{MinGroupCount: 2}},
-		},
-	}
+	cpgRoot := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-root").MinGroupCount(2).Obj()
+	cpgSub1 := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-sub1").ParentCompositePodGroup("cpg-root").MinGroupCount(2).Obj()
+	cpgSub2 := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-sub2").ParentCompositePodGroup("cpg-root").BasicPolicy().Obj()
+	cpgDeep1 := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-deep-1").MinGroupCount(1).Obj()
+	cpgDeep2 := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-deep-2").ParentCompositePodGroup("cpg-deep-1").MinGroupCount(1).Obj()
+	cpgDeep3 := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-deep-3").ParentCompositePodGroup("cpg-deep-2").MinGroupCount(1).Obj()
+	cpgDeep4 := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-deep-4").ParentCompositePodGroup("cpg-deep-3").MinGroupCount(1).Obj()
+	cpgDeep5 := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-deep-5").ParentCompositePodGroup("cpg-deep-4").MinGroupCount(1).Obj()
+	pgDeep := st.MakePodGroup().Namespace("ns1").Name("pg-deep").ParentCompositePodGroup("cpg-deep-5").MinCount(1).Obj()
+	podDeep := st.MakePod().Namespace("ns1").Name("pod-deep").UID("pod-deep").PodGroupName("pg-deep").Obj()
+
+	cpgCycle1 := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-cycle-1").ParentCompositePodGroup("cpg-cycle-2").MinGroupCount(1).Obj()
+	cpgCycle2 := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-cycle-2").ParentCompositePodGroup("cpg-cycle-1").MinGroupCount(1).Obj()
+	pgCycle := st.MakePodGroup().Namespace("ns1").Name("pg-cycle").ParentCompositePodGroup("cpg-cycle-1").MinCount(1).Obj()
+	podCycle := st.MakePod().Namespace("ns1").Name("pod-cycle").UID("pod-cycle").PodGroupName("pg-cycle").Obj()
+
+	cpgSub3 := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-sub3").ParentCompositePodGroup("cpg-root").MinGroupCount(2).Obj()
 
 	pg1 := st.MakePodGroup().Namespace("ns1").Name("pg1-cpg").ParentCompositePodGroup("cpg-sub1").MinCount(1).Obj()
 	pg2 := st.MakePodGroup().Namespace("ns1").Name("pg2-cpg").ParentCompositePodGroup("cpg-sub1").MinCount(1).Obj()
@@ -884,12 +873,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 	p4CPG := st.MakePod().Namespace("ns1").Name("p4-cpg").UID("p4-cpg").PodGroupName("pg4-cpg").Obj()
 	p6CPG := st.MakePod().Namespace("ns1").Name("p6-cpg").UID("p6-cpg").PodGroupName("pg6-cpg").Obj()
 
-	cpgBasicRoot := &schedulingv1alpha3.CompositePodGroup{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "cpg-basic-root"},
-		Spec: schedulingv1alpha3.CompositePodGroupSpec{
-			SchedulingPolicy: schedulingv1alpha3.CompositePodGroupSchedulingPolicy{Basic: &schedulingv1alpha3.CompositeBasicSchedulingPolicy{}},
-		},
-	}
+	cpgBasicRoot := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-basic-root").BasicPolicy().Obj()
 	pgBasic1 := st.MakePodGroup().Namespace("ns1").Name("pg-basic-1").ParentCompositePodGroup("cpg-basic-root").MinCount(2).Obj()
 	pgBasic2 := st.MakePodGroup().Namespace("ns1").Name("pg-basic-2").ParentCompositePodGroup("cpg-basic-root").MinCount(2).Obj()
 	p1_1 := st.MakePod().Namespace("ns1").Name("p1_1").UID("p1_1").PodGroupName("pg-basic-1").Obj()
@@ -910,7 +894,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 		wantActivatedPods               []*v1.Pod
 		wantAllowedPods                 []types.UID
 	}
-	baseTests := []testCase{
+	tests := []testCase{
 		{
 			name:                       "non-gang pod succeeds immediately (CPG=false)",
 			pod:                        nonGangPod,
@@ -1116,9 +1100,45 @@ func TestGangSchedulingFlow(t *testing.T) {
 			wantPreEnqueueStatus:       nil,
 			wantPermitStatus:           nil,
 		},
+		{
+			name:                       "CPG_Max_Depth_Exceeded_(CPG=false)",
+			pod:                        podDeep,
+			isCompositePodGroupEnabled: false,
+			initialPods:                []*v1.Pod{},
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pgDeep},
+			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgDeep1, cpgDeep2, cpgDeep3, cpgDeep4, cpgDeep5},
+			wantPreEnqueueStatus:       nil,
+		},
+		{
+			name:                       "CPG_Max_Depth_Exceeded_(CPG=true)",
+			pod:                        podDeep,
+			isCompositePodGroupEnabled: true,
+			initialPods:                []*v1.Pod{},
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pgDeep},
+			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgDeep1, cpgDeep2, cpgDeep3, cpgDeep4, cpgDeep5},
+			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "failed to build hierarchy snapshot: workload tree depth exceeds max depth 4"),
+		},
+		{
+			name:                       "CPG_Cycle_Detection_(CPG=false)",
+			pod:                        podCycle,
+			isCompositePodGroupEnabled: false,
+			initialPods:                []*v1.Pod{},
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pgCycle},
+			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgCycle1, cpgCycle2},
+			wantPreEnqueueStatus:       nil,
+		},
+		{
+			name:                       "CPG_Cycle_Detection_(CPG=true)",
+			pod:                        podCycle,
+			isCompositePodGroupEnabled: true,
+			initialPods:                []*v1.Pod{},
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pgCycle},
+			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgCycle1, cpgCycle2},
+			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "failed to build hierarchy snapshot: cycle detected in composite pod group hierarchy: compositepodgroup/ns1/cpg-cycle-1"),
+		},
 	}
 
-	for _, tt := range baseTests {
+	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
 			if tt.isCompositePodGroupEnabled {
@@ -1763,15 +1783,13 @@ func TestPlacementFeasible(t *testing.T) {
 			var objs []runtime.Object
 
 			if tc.isCPG {
-				cpg := &schedulingv1alpha3.CompositePodGroup{
-					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pgName},
-					Spec:       schedulingv1alpha3.CompositePodGroupSpec{},
-				}
+				cpgBuilder := st.MakeCompositePodGroup().Namespace(namespace).Name(pgName)
 				if tc.minCount > 0 {
-					cpg.Spec.SchedulingPolicy.Gang = &schedulingv1alpha3.CompositeGangSchedulingPolicy{MinGroupCount: tc.minCount}
+					cpgBuilder.MinGroupCount(tc.minCount)
 				} else {
-					cpg.Spec.SchedulingPolicy.Basic = &schedulingv1alpha3.CompositeBasicSchedulingPolicy{}
+					cpgBuilder.BasicPolicy()
 				}
+				cpg := cpgBuilder.Obj()
 				pgInfo.groupType = fwk.CompositePodGroupKeyType
 				pgInfo.cpg = cpg
 				objs = append(objs, cpg)

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -649,6 +649,18 @@ func TestPreEnqueue(t *testing.T) {
 	cpgRoot := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-root").MinGroupCount(2).Obj()
 	cpgSub1 := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-sub1").ParentCompositePodGroup("cpg-root").MinGroupCount(2).Obj()
 	cpgSub2 := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-sub2").ParentCompositePodGroup("cpg-root").BasicPolicy().Obj()
+	cpgDeep1 := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-deep-1").MinGroupCount(1).Obj()
+	cpgDeep2 := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-deep-2").ParentCompositePodGroup("cpg-deep-1").MinGroupCount(1).Obj()
+	cpgDeep3 := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-deep-3").ParentCompositePodGroup("cpg-deep-2").MinGroupCount(1).Obj()
+	cpgDeep4 := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-deep-4").ParentCompositePodGroup("cpg-deep-3").MinGroupCount(1).Obj()
+	pgDeep := st.MakePodGroup().Namespace("ns1").Name("pg-deep").ParentCompositePodGroup("cpg-deep-4").MinCount(1).Obj()
+	podDeep := st.MakePod().Namespace("ns1").Name("pod-deep").UID("pod-deep").PodGroupName("pg-deep").Obj()
+
+	cpgCycle1 := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-cycle-1").ParentCompositePodGroup("cpg-cycle-2").MinGroupCount(1).Obj()
+	cpgCycle2 := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-cycle-2").ParentCompositePodGroup("cpg-cycle-1").MinGroupCount(1).Obj()
+	pgCycle := st.MakePodGroup().Namespace("ns1").Name("pg-cycle").ParentCompositePodGroup("cpg-cycle-1").MinCount(1).Obj()
+	podCycle := st.MakePod().Namespace("ns1").Name("pod-cycle").UID("pod-cycle").PodGroupName("pg-cycle").Obj()
+
 	cpgSub3 := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-sub3").ParentCompositePodGroup("cpg-root").MinGroupCount(2).Obj()
 
 	pg1CPG := st.MakePodGroup().Namespace("ns1").Name("pg1-cpg").ParentCompositePodGroup("cpg-sub1").MinCount(1).Obj()
@@ -799,6 +811,42 @@ func TestPreEnqueue(t *testing.T) {
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pgBasic1CPG, pgBasic2CPG},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgBasicRoot},
 			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for minCount pods from a gang to appear in scheduling queue"),
+		},
+		{
+			name:                       "CPG Max Depth Exceeded (CPG=true)",
+			isCompositePodGroupEnabled: []bool{true},
+			pod:                        podDeep,
+			initialPods:                []*v1.Pod{},
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pgDeep},
+			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgDeep1, cpgDeep2, cpgDeep3, cpgDeep4},
+			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "failed to build hierarchy snapshot: workload tree depth exceeds max depth 4"),
+		},
+		{
+			name:                       "CPG Max Depth Exceeded (CPG=false)",
+			isCompositePodGroupEnabled: []bool{false},
+			pod:                        podDeep,
+			initialPods:                []*v1.Pod{},
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pgDeep},
+			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgDeep1, cpgDeep2, cpgDeep3, cpgDeep4},
+			wantPreEnqueueStatus:       nil,
+		},
+		{
+			name:                       "CPG Cycle Detection (CPG=true)",
+			isCompositePodGroupEnabled: []bool{true},
+			pod:                        podCycle,
+			initialPods:                []*v1.Pod{},
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pgCycle},
+			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgCycle1, cpgCycle2},
+			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "failed to build hierarchy snapshot: cycle detected in composite pod group hierarchy: compositepodgroup/ns1/cpg-cycle-1"),
+		},
+		{
+			name:                       "CPG Cycle Detection (CPG=false)",
+			isCompositePodGroupEnabled: []bool{false},
+			pod:                        podCycle,
+			initialPods:                []*v1.Pod{},
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pgCycle},
+			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgCycle1, cpgCycle2},
+			wantPreEnqueueStatus:       nil,
 		},
 	}
 

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -3636,6 +3636,20 @@ func TestQueuedPodGroupInfo_AddCompositePodGroup(t *testing.T) {
 			},
 		},
 		{
+			name:       "Add duplicate child CPG to root",
+			initialCPG: cpgRoot,
+			cpgToAdd:   cpgChild,
+			subtree:    &PodGroupInfo{CompositePodGroup: cpgChild, Name: "cpg-child", Namespace: "ns1", Type: fwk.CompositePodGroupKeyType, Children: make([]*PodGroupInfo, 0)},
+			setup: func(qpgi *QueuedPodGroupInfo) {
+				qpgi.PodGroupInfo.Children = append(qpgi.PodGroupInfo.Children, &PodGroupInfo{CompositePodGroup: cpgChild, Name: "cpg-child", Namespace: "ns1", Type: fwk.CompositePodGroupKeyType, Children: make([]*PodGroupInfo, 0)})
+			},
+			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
+				if len(qpgi.PodGroupInfo.Children) != 1 {
+					t.Errorf("Duplicate CPG added")
+				}
+			},
+		},
+		{
 			name:       "Add CPG subtree with nested CPGs",
 			initialCPG: cpgRoot,
 			cpgToAdd:   cpgChild,
@@ -3903,6 +3917,7 @@ func TestQueuedPodGroupInfo_AddPodGroup(t *testing.T) {
 		name       string
 		initialCPG *schedulingv1alpha3.CompositePodGroup
 		pgToAdd    *schedulingv1beta1.PodGroup
+		setup      func(*QueuedPodGroupInfo)
 		verify     func(*testing.T, *QueuedPodGroupInfo)
 	}{
 		{
@@ -3915,6 +3930,19 @@ func TestQueuedPodGroupInfo_AddPodGroup(t *testing.T) {
 				}
 				if qpgi.PodGroupInfo.Children[0].Type != fwk.PodGroupKeyType {
 					t.Errorf("Child PG has wrong key type")
+				}
+			},
+		},
+		{
+			name:       "Add duplicate child PG to root CPG",
+			initialCPG: cpgRoot,
+			pgToAdd:    pgChild,
+			setup: func(qpgi *QueuedPodGroupInfo) {
+				qpgi.PodGroupInfo.Children = append(qpgi.PodGroupInfo.Children, &PodGroupInfo{PodGroup: pgChild, Name: pgChild.Name, Namespace: pgChild.Namespace, Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0)})
+			},
+			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
+				if len(qpgi.PodGroupInfo.Children) != 1 {
+					t.Errorf("Duplicate PG added")
 				}
 			},
 		},
@@ -3951,6 +3979,9 @@ func TestQueuedPodGroupInfo_AddPodGroup(t *testing.T) {
 					Children:          make([]*PodGroupInfo, 0),
 				},
 				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
+			}
+			if tt.setup != nil {
+				tt.setup(qpgi)
 			}
 			qpgi.AddPodGroup(tt.pgToAdd)
 			tt.verify(t, qpgi)
@@ -4104,6 +4135,20 @@ func TestQueuedPodGroupInfo_RemovePodGroup(t *testing.T) {
 				}
 				if len(qpgi.QueuedPodInfos[podKeyStandalone]) != 0 {
 					t.Errorf("Pod not removed from QueuedPodInfos map")
+				}
+			},
+		},
+		{
+			name:     "Remove non-existent PG (node == nil)",
+			removePG: st.MakePodGroup().Name("pg-nonexistent").Namespace("ns1").Obj(),
+			setup: func(qpgi *QueuedPodGroupInfo) {
+				qpgi.PodGroupInfo = &PodGroupInfo{
+					PodGroup: pgStandalone, Name: pgStandalone.Name, Namespace: pgStandalone.Namespace, Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0),
+				}
+			},
+			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo, removed []*QueuedPodInfo) {
+				if len(removed) != 0 {
+					t.Errorf("Expected nil/empty removed pods for non-existent PG")
 				}
 			},
 		},
@@ -4422,6 +4467,53 @@ func TestPodGroupInfo_GetUnscheduledPods(t *testing.T) {
 			got := tt.pgi.GetUnscheduledPods()
 			if diff := cmp.Diff(tt.expected, got); diff != "" {
 				t.Errorf("GetUnscheduledPods() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestQueuedPodGroupInfo_HasQueuedPodInfos(t *testing.T) {
+	tests := []struct {
+		name string
+		qpgi *QueuedPodGroupInfo
+		want bool
+	}{
+		{
+			name: "QueuedPodInfos is nil",
+			qpgi: &QueuedPodGroupInfo{},
+			want: false,
+		},
+		{
+			name: "QueuedPodInfos is empty map",
+			qpgi: &QueuedPodGroupInfo{
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
+			},
+			want: false,
+		},
+		{
+			name: "QueuedPodInfos map contains empty lists",
+			qpgi: &QueuedPodGroupInfo{
+				QueuedPodInfos: map[fwk.EntityKey][]*QueuedPodInfo{
+					fwk.PodGroupKey("ns", "name"): {},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "QueuedPodInfos has queued pods",
+			qpgi: &QueuedPodGroupInfo{
+				QueuedPodInfos: map[fwk.EntityKey][]*QueuedPodInfo{
+					fwk.PodGroupKey("ns", "name"): {{}},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.qpgi.HasQueuedPodInfos(); got != tt.want {
+				t.Errorf("HasQueuedPodInfos() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -366,11 +366,11 @@ func TestQueuedEntityInfo_HasPodsWithPendingPlugins(t *testing.T) {
 	}
 	podWithPending1 := &QueuedPodInfo{
 		PodInfo:        &PodInfo{Pod: st.MakePod().Namespace("default").Name("pod2").PodGroupName("pg1").Obj()},
-		PendingPlugins: sets.New("pluginA"),
+		QueueingParams: QueueingParams{PendingPlugins: sets.New("pluginA")},
 	}
 	podWithPending2 := &QueuedPodInfo{
 		PodInfo:        &PodInfo{Pod: st.MakePod().Namespace("default").Name("pod3").PodGroupName("pg1").Obj()},
-		PendingPlugins: sets.New("pluginB"),
+		QueueingParams: QueueingParams{PendingPlugins: sets.New("pluginB")},
 	}
 	nonExistentPod := &QueuedPodInfo{
 		PodInfo: &PodInfo{Pod: st.MakePod().Namespace("default").Name("nonexistent").PodGroupName("pg1").Obj()},
@@ -390,25 +390,25 @@ func TestQueuedEntityInfo_HasPodsWithPendingPlugins(t *testing.T) {
 
 	podChild1WithPending := &QueuedPodInfo{
 		PodInfo:        &PodInfo{Pod: st.MakePod().Namespace("default").Name("pod-c1").PodGroupName("pg-child1").Obj()},
-		PendingPlugins: sets.New("pluginA"),
+		QueueingParams: QueueingParams{PendingPlugins: sets.New("pluginA")},
 	}
 	podChild1WithoutPending := &QueuedPodInfo{
 		PodInfo: &PodInfo{Pod: st.MakePod().Namespace("default").Name("pod-c1-np").PodGroupName("pg-child1").Obj()},
 	}
 	podChild2WithPending := &QueuedPodInfo{
 		PodInfo:        &PodInfo{Pod: st.MakePod().Namespace("default").Name("pod-c2").PodGroupName("pg-child2").Obj()},
-		PendingPlugins: sets.New("pluginB"),
+		QueueingParams: QueueingParams{PendingPlugins: sets.New("pluginB")},
 	}
 	podChild2WithoutPending := &QueuedPodInfo{
 		PodInfo: &PodInfo{Pod: st.MakePod().Namespace("default").Name("pod-c2-np").PodGroupName("pg-child2").Obj()},
 	}
 	podLeaf1WithPending := &QueuedPodInfo{
 		PodInfo:        &PodInfo{Pod: st.MakePod().Namespace("default").Name("pod-l1").PodGroupName("pg-leaf1").Obj()},
-		PendingPlugins: sets.New("pluginA"),
+		QueueingParams: QueueingParams{PendingPlugins: sets.New("pluginA")},
 	}
 	podLeaf2WithPending := &QueuedPodInfo{
 		PodInfo:        &PodInfo{Pod: st.MakePod().Namespace("default").Name("pod-l2").PodGroupName("pg-leaf2").Obj()},
-		PendingPlugins: sets.New("pluginB"),
+		QueueingParams: QueueingParams{PendingPlugins: sets.New("pluginB")},
 	}
 	podLeaf2WithoutPending := &QueuedPodInfo{
 		PodInfo: &PodInfo{Pod: st.MakePod().Namespace("default").Name("pod-l2-np").PodGroupName("pg-leaf2").Obj()},
@@ -4162,6 +4162,21 @@ func TestQueuedPodGroupInfo_AddCompositePodGroup(t *testing.T) {
 			},
 		},
 		{
+			name: "Add duplicate child CPG to root",
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo: newCompositePodGroupInfoForTest(cpgRoot,
+					newCompositePodGroupInfoForTest(cpgChild),
+				),
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
+			},
+			subtree: newCompositePodGroupInfoForTest(cpgChild),
+			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
+				if len(qpgi.PodGroupInfo.Children) != 1 {
+					t.Errorf("Duplicate CPG added")
+				}
+			},
+		},
+		{
 			name: "Add CPG subtree with nested CPGs",
 			qpgi: &QueuedPodGroupInfo{
 				PodGroupInfo:   newCompositePodGroupInfoForTest(cpgRoot),
@@ -4459,6 +4474,21 @@ func TestQueuedPodGroupInfo_AddPodGroup(t *testing.T) {
 			},
 		},
 		{
+			name: "Add duplicate child PG to root CPG",
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo: newCompositePodGroupInfoForTest(cpgRoot,
+					newPodGroupInfoForTest(pgChild),
+				),
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
+			},
+			pgToAdd: pgChild,
+			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
+				if len(qpgi.PodGroupInfo.Children) != 1 {
+					t.Errorf("Duplicate PG added")
+				}
+			},
+		},
+		{
 			name: "Add standalone PG (should be ignored by hierarchy builder as it's the root itself)",
 			qpgi: &QueuedPodGroupInfo{
 				PodGroupInfo:   newCompositePodGroupInfoForTest(cpgRoot),
@@ -4689,6 +4719,19 @@ func TestQueuedPodGroupInfo_RemovePodGroup(t *testing.T) {
 				}
 				if len(qpgi.QueuedPodInfos[fwk.PodGroupKey("ns1", "pg-nested")]) != 1 {
 					t.Errorf("CPG's nested pods should not have been removed")
+				}
+			},
+		},
+		{
+			name:     "Remove non-existent PG (node == nil)",
+			removePG: st.MakePodGroup().Name("pg-nonexistent").Namespace("ns1").Obj(),
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo:   newPodGroupInfoForTest(pgStandalone),
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
+			},
+			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo, removed []*QueuedPodInfo) {
+				if len(removed) != 0 {
+					t.Errorf("Expected nil/empty removed pods for non-existent PG")
 				}
 			},
 		},
@@ -5053,5 +5096,52 @@ func newCompositePodGroupInfoForTest(cpg *schedulingv1alpha3.CompositePodGroup, 
 	return &PodGroupInfo{
 		GenericPodGroup: fwk.NewGenericCompositePodGroup(cpg),
 		Children:        children,
+	}
+}
+
+func TestQueuedPodGroupInfo_HasQueuedPodInfos(t *testing.T) {
+	tests := []struct {
+		name string
+		qpgi *QueuedPodGroupInfo
+		want bool
+	}{
+		{
+			name: "QueuedPodInfos is nil",
+			qpgi: &QueuedPodGroupInfo{},
+			want: false,
+		},
+		{
+			name: "QueuedPodInfos is empty map",
+			qpgi: &QueuedPodGroupInfo{
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
+			},
+			want: false,
+		},
+		{
+			name: "QueuedPodInfos map contains empty lists",
+			qpgi: &QueuedPodGroupInfo{
+				QueuedPodInfos: map[fwk.EntityKey][]*QueuedPodInfo{
+					fwk.PodGroupKey("ns", "name"): {},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "QueuedPodInfos has queued pods",
+			qpgi: &QueuedPodGroupInfo{
+				QueuedPodInfos: map[fwk.EntityKey][]*QueuedPodInfo{
+					fwk.PodGroupKey("ns", "name"): {{}},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.qpgi.HasQueuedPodInfos(); got != tt.want {
+				t.Errorf("HasQueuedPodInfos() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -4587,954 +4587,577 @@ func TestScheduleOnePodGroup_SchedulerNameMismatchUpdatesStatus(t *testing.T) {
 	}
 }
 
-func TestCPGHierarchicalScheduling_ScheduleOnePodGroup(t *testing.T) {
+func TestCPGHierarchicalScheduling(t *testing.T) {
 	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
 		features.CompositePodGroup:               true,
 		features.GenericWorkload:                 true,
 		features.TopologyAwareWorkloadScheduling: true,
 	})
 
-	// Tree structure:
-	//                  cpg-root (Gang, MinGroupCount: 2)
-	//                  /       |       \
-	//                pg1      pg2      pg3
-	//               (Min:1)  (Min:1)  (Min:1)
-	//
-	// We will schedule cpg-root.
-	// Since MinGroupCount: 2, if 2 out of 3 child pod groups are schedulable, it should succeed!
+	type cpgSpec struct {
+		name     string
+		minCount int32
+		parent   *string
+	}
+	type pgSpec struct {
+		name     string
+		minCount int32
+		parent   *string
+	}
+	type podSpec struct {
+		count       int
+		schedulable bool
+	}
 
-	namespace := "default"
+	type phaseSpec struct {
+		cpgs        []cpgSpec
+		pgs         []pgSpec
+		pods        map[string]podSpec
+		successPods []string
+		failPods    []string
+	}
 
-	cpgRoot := &schedulingv1alpha3.CompositePodGroup{
-		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "cpg-root"},
-		Spec: schedulingv1alpha3.CompositePodGroupSpec{
-			SchedulingPolicy: schedulingv1alpha3.CompositePodGroupSchedulingPolicy{
-				Gang: &schedulingv1alpha3.CompositeGangSchedulingPolicy{MinGroupCount: 2},
-			},
+	tests := []struct {
+		name   string
+		nodes  []*v1.Node
+		phases []phaseSpec
+	}{
+		{
+			name:  "ScheduleOnePodGroup",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{{
+				cpgs:        []cpgSpec{{"cpg-root", 2, nil}},
+				pgs:         []pgSpec{{"pg1", 1, new("cpg-root")}, {"pg2", 1, new("cpg-root")}, {"pg3", 1, new("cpg-root")}},
+				pods:        map[string]podSpec{"pg1": {1, true}, "pg2": {1, true}, "pg3": {1, false}},
+				successPods: []string{"pg1-pod-0", "pg2-pod-0"},
+				failPods:    []string{"pg3-pod-0"},
+			}},
 		},
-	}
-
-	pg1 := st.MakePodGroup().Name("pg1").Namespace(namespace).ParentCompositePodGroup("cpg-root").MinCount(1).Obj()
-	pg2 := st.MakePodGroup().Name("pg2").Namespace(namespace).ParentCompositePodGroup("cpg-root").MinCount(1).Obj()
-	pg3 := st.MakePodGroup().Name("pg3").Namespace(namespace).ParentCompositePodGroup("cpg-root").MinCount(1).Obj()
-
-	p1 := st.MakePod().Name("p1").UID("p1").PodGroupName("pg1").SchedulerName("test-scheduler").Obj()
-	p2 := st.MakePod().Name("p2").UID("p2").PodGroupName("pg2").SchedulerName("test-scheduler").Obj()
-	p3 := st.MakePod().Name("p3").UID("p3").PodGroupName("pg3").SchedulerName("test-scheduler").Obj()
-
-	qInfo1 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p1}}
-	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
-	qInfo3 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p3}}
-	queuedPodInfosMap := map[fwk.EntityKey][]*framework.QueuedPodInfo{
-		fwk.MustParseEntityKey("podgroup/default/pg1"): {qInfo1},
-		fwk.MustParseEntityKey("podgroup/default/pg2"): {qInfo2},
-		fwk.MustParseEntityKey("podgroup/default/pg3"): {qInfo3},
-	}
-
-	cpgRootInfo := &framework.QueuedPodGroupInfo{
-		QueuedPodInfos: queuedPodInfosMap,
-		PodGroupInfo: &framework.PodGroupInfo{
-			Namespace:         namespace,
-			Name:              "cpg-root",
-			Type:              fwk.CompositePodGroupKeyType,
-			CompositePodGroup: cpgRoot,
-			UnscheduledPods:   []*v1.Pod{p1, p2, p3},
-			Children: []*framework.PodGroupInfo{
+		{
+			name:  "Internal Complex Hierarchy",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "100"}).Obj()},
+			phases: []phaseSpec{{
+				cpgs:        []cpgSpec{{"cpg-root", 2, nil}, {"cpg-sub1", 2, new("cpg-root")}, {"cpg-sub2", 0, new("cpg-root")}, {"cpg-sub3", 2, new("cpg-root")}},
+				pgs:         []pgSpec{{"pg1", 3, new("cpg-sub1")}, {"pg2", 3, new("cpg-sub1")}, {"pg3", 3, new("cpg-sub1")}, {"pg4", 0, new("cpg-sub2")}, {"pg5", 3, new("cpg-sub2")}, {"pg6", 3, new("cpg-sub3")}, {"pg7", 3, new("cpg-sub3")}},
+				pods:        map[string]podSpec{"pg1": {3, true}, "pg2": {3, true}, "pg3": {3, false}, "pg4": {3, true}, "pg5": {3, true}, "pg6": {3, true}, "pg7": {3, false}},
+				successPods: []string{"pg1-pod-0", "pg1-pod-1", "pg1-pod-2", "pg2-pod-0", "pg2-pod-1", "pg2-pod-2", "pg4-pod-0", "pg4-pod-1", "pg4-pod-2", "pg5-pod-0", "pg5-pod-1", "pg5-pod-2"},
+				failPods:    []string{"pg3-pod-0", "pg3-pod-1", "pg3-pod-2", "pg6-pod-0", "pg6-pod-1", "pg6-pod-2", "pg7-pod-0", "pg7-pod-1", "pg7-pod-2"},
+			}},
+		},
+		{
+			name:  "MinGroupCount",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{{
+				cpgs:        []cpgSpec{{"cpg-root", 2, nil}},
+				pgs:         []pgSpec{{"pg1", 3, new("cpg-root")}, {"pg2", 3, new("cpg-root")}, {"pg3", 3, new("cpg-root")}},
+				pods:        map[string]podSpec{"pg1": {3, true}, "pg2": {3, true}, "pg3": {3, false}},
+				successPods: []string{"pg1-pod-0", "pg1-pod-1", "pg1-pod-2", "pg2-pod-0", "pg2-pod-1", "pg2-pod-2"},
+				failPods:    []string{"pg3-pod-0", "pg3-pod-1", "pg3-pod-2"},
+			}},
+		},
+		{
+			name:  "BasicWithGangChildren",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{{
+				cpgs:        []cpgSpec{{"cpg-root", 0, nil}},
+				pgs:         []pgSpec{{"pg1", 3, new("cpg-root")}, {"pg2", 3, new("cpg-root")}},
+				pods:        map[string]podSpec{"pg1": {3, true}, "pg2": {3, false}},
+				successPods: []string{"pg1-pod-0", "pg1-pod-1", "pg1-pod-2"},
+				failPods:    []string{"pg2-pod-0", "pg2-pod-1", "pg2-pod-2"},
+			}},
+		},
+		{
+			name:  "MinGroupCountUnreachable",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{{
+				cpgs:        []cpgSpec{{"cpg-root", 3, nil}},
+				pgs:         []pgSpec{{"pg1", 1, new("cpg-root")}, {"pg2", 1, new("cpg-root")}},
+				pods:        map[string]podSpec{"pg1": {1, true}, "pg2": {1, true}},
+				successPods: []string{},
+				failPods:    []string{"pg1-pod-0", "pg2-pod-0"},
+			}},
+		},
+		{
+			name:  "RootCPGBasicNoChild",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{{
+				cpgs: []cpgSpec{{"cpg-root", 0, nil}},
+			}},
+		},
+		{
+			name:  "RootCPGGangNoChild",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{{
+				cpgs: []cpgSpec{{"cpg-root", 1, nil}},
+			}},
+		},
+		{
+			name:  "CPGBasicOnePGSchedulable",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{{
+				cpgs:        []cpgSpec{{"cpg-root", 0, nil}},
+				pgs:         []pgSpec{{"pg1", 1, new("cpg-root")}},
+				pods:        map[string]podSpec{"pg1": {1, true}},
+				successPods: []string{"pg1-pod-0"},
+			}},
+		},
+		{
+			name:  "CPGBasicOnePGUnschedulable",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{{
+				cpgs:     []cpgSpec{{"cpg-root", 0, nil}},
+				pgs:      []pgSpec{{"pg1", 1, new("cpg-root")}},
+				pods:     map[string]podSpec{"pg1": {1, false}},
+				failPods: []string{"pg1-pod-0"},
+			}},
+		},
+		{
+			name:  "CPGBasicTwoPGSchedulable",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{{
+				cpgs:        []cpgSpec{{"cpg-root", 0, nil}},
+				pgs:         []pgSpec{{"pg1", 1, new("cpg-root")}, {"pg2", 1, new("cpg-root")}},
+				pods:        map[string]podSpec{"pg1": {1, true}, "pg2": {1, true}},
+				successPods: []string{"pg1-pod-0", "pg2-pod-0"},
+			}},
+		},
+		{
+			name:  "CPGGangTwoPGSchedulable",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{{
+				cpgs:        []cpgSpec{{"cpg-root", 2, nil}},
+				pgs:         []pgSpec{{"pg1", 1, new("cpg-root")}, {"pg2", 1, new("cpg-root")}},
+				pods:        map[string]podSpec{"pg1": {1, true}, "pg2": {1, true}},
+				successPods: []string{"pg1-pod-0", "pg2-pod-0"},
+			}},
+		},
+		{
+			name:  "CPGMixesCPGAndPGBasic",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{{
+				cpgs:        []cpgSpec{{"cpg-root", 0, nil}, {"cpg-sub", 0, new("cpg-root")}},
+				pgs:         []pgSpec{{"pg1", 1, new("cpg-sub")}, {"pg2", 1, new("cpg-root")}},
+				pods:        map[string]podSpec{"pg1": {1, true}, "pg2": {1, true}},
+				successPods: []string{"pg1-pod-0", "pg2-pod-0"},
+			}},
+		},
+		{
+			name:  "CPGMixesCPGAndPGGang",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{{
+				cpgs:        []cpgSpec{{"cpg-root", 2, nil}, {"cpg-sub", 1, new("cpg-root")}},
+				pgs:         []pgSpec{{"pg1", 1, new("cpg-sub")}, {"pg2", 1, new("cpg-root")}},
+				pods:        map[string]podSpec{"pg1": {1, true}, "pg2": {1, true}},
+				successPods: []string{"pg1-pod-0", "pg2-pod-0"},
+			}},
+		},
+		{
+			name:  "RescheduleCPGHierarchyAfterPodsPgsCpgsAdded",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{
 				{
-					Name:            "pg1",
-					Namespace:       "default",
-					Type:            fwk.PodGroupKeyType,
-					PodGroup:        pg1,
-					UnscheduledPods: []*v1.Pod{p1},
+					cpgs:     []cpgSpec{{"cpg-root", 3, nil}, {"cpg-sub1", 1, new("cpg-root")}, {"cpg-sub2", 1, new("cpg-root")}},
+					pgs:      []pgSpec{{"pg1", 1, new("cpg-sub1")}, {"pg2", 1, new("cpg-sub2")}},
+					pods:     map[string]podSpec{"pg1": {1, false}, "pg2": {1, true}},
+					failPods: []string{"pg1-pod-0", "pg2-pod-0"},
 				},
 				{
-					Name:            "pg2",
-					Namespace:       "default",
-					Type:            fwk.PodGroupKeyType,
-					PodGroup:        pg2,
-					UnscheduledPods: []*v1.Pod{p2},
-				},
-				{
-					Name:            "pg3",
-					Namespace:       "default",
-					Type:            fwk.PodGroupKeyType,
-					PodGroup:        pg3,
-					UnscheduledPods: []*v1.Pod{p3},
+					cpgs:        []cpgSpec{{"cpg-sub3", 1, new("cpg-root")}},
+					pgs:         []pgSpec{{"pg3", 1, new("cpg-sub3")}, {"pg4", 1, new("cpg-root")}},
+					pods:        map[string]podSpec{"pg3": {1, true}, "pg4": {1, true}},
+					successPods: []string{"pg2-pod-0", "pg3-pod-0", "pg4-pod-0"},
+					failPods:    []string{"pg1-pod-0"},
 				},
 			},
 		},
-		QueueingParams: framework.QueueingParams{
-			Timestamp: time.Now(),
-		},
-	}
-
-	logger, ctx := ktesting.NewTestContext(t)
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	// Mock PlacementFeasible plugin
-	fakeGS := &fakePlacementFeasiblePlugin{}
-	fakeGS.placementFeasibleStatuses = [][]fwk.Code{
-		// Four distinct scheduling cycles:
-		// 1. cpg-root (success, 1 call: before children scheduling, evaluated=0)
-		// 2. pg1 scheduling (success, 2 calls: before and after p1, evaluated=0 and 1)
-		// 3. pg2 scheduling (success, 2 calls: before and after p2, evaluated=0 and 1)
-		// 4. pg3 scheduling (fails early on Evaluated=0)
-		{fwk.Success},
-		{fwk.Success, fwk.Success},
-		{fwk.Success, fwk.Success, fwk.Success},
-		{fwk.Unschedulable},
-	}
-
-	registry := frameworkruntime.Registry{
-		queuesort.Name:     queuesort.New,
-		defaultbinder.Name: defaultbinder.New,
-		names.GangScheduling: func(ctx context.Context, obj runtime.Object, handle fwk.Handle) (fwk.Plugin, error) {
-			return fakeGS, nil
-		},
-	}
-
-	profileCfg := config.KubeSchedulerProfile{
-		SchedulerName: "test-scheduler",
-		Plugins: &config.Plugins{
-			QueueSort: config.PluginSet{
-				Enabled: []config.Plugin{{Name: queuesort.Name}},
-			},
-			Bind: config.PluginSet{
-				Enabled: []config.Plugin{{Name: defaultbinder.Name}},
-			},
-			// Enable GangScheduling to run PlacementFeasible
-			Permit: config.PluginSet{
-				Enabled: []config.Plugin{{Name: names.GangScheduling}},
-			},
-		},
-	}
-
-	client := clientsetfake.NewSimpleClientset(cpgRoot, pg1, pg2, pg3)
-	informerFactory := informers.NewSharedInformerFactory(client, 0)
-	informerFactory.Start(ctx.Done())
-	informerFactory.WaitForCacheSync(ctx.Done())
-
-	schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
-		frameworkruntime.WithInformerFactory(informerFactory),
-		frameworkruntime.WithClientSet(client),
-		frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
-	)
-	if err != nil {
-		t.Fatalf("Failed to create framework: %v", err)
-	}
-
-	cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
-	cache.AddCompositePodGroup(logger, cpgRoot)
-	cache.AddPodGroup(pg1)
-	cache.AddPodGroup(pg2)
-	cache.AddPodGroup(pg3)
-
-	sched := &Scheduler{
-		Profiles:         profile.Map{"test-scheduler": schedFwk},
-		Cache:            cache,
-		nodeInfoSnapshot: internalcache.NewEmptySnapshot(),
-		client:           client,
-		SchedulingQueue:  internalqueue.NewTestQueue(ctx, nil),
-	}
-
-	// Mock SchedulePod to return success for all pods
-	sched.SchedulePod = func(ctx context.Context, fwk framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (ScheduleResult, error) {
-		return ScheduleResult{SuggestedHost: "node1"}, nil
-	}
-
-	// Prepare nodeInfoSnapshot which matches Cache
-	if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
-		t.Fatalf("Failed to update snapshot: %v", err)
-	}
-
-	// Run podGroupSchedulingRecursiveAlgorithm
-	res := map[fwk.EntityKey]*podGroupAlgorithmResult{}
-	result, _ := sched.podGroupSchedulingRecursiveAlgorithm(ctx, schedFwk, framework.NewCycleState(), cpgRootInfo, cpgRootInfo.PodGroupInfo, res)
-
-	status := result.status
-	if status.Code() != fwk.Success {
-		t.Errorf("Expected recursive scheduling algorithm status to be Success, got: %v", status)
-	}
-
-	// Verify that exactly the successful child pod groups (pg1 and pg2) are in the scheduled pod results
-	// pg3 should NOT be in the results because its placement was not feasible!
-	var successPodNames []string
-	for _, childRes := range res {
-		if childRes.podGroupInfo.CompositePodGroup != nil {
-			continue
-		}
-		for _, pr := range childRes.podResults {
-			if childRes.status.IsSuccess() && pr.status.IsSuccess() {
-				successPodNames = append(successPodNames, pr.podInfo.Pod.Name)
-			}
-		}
-	}
-
-	scheduledPodNames := sets.New(successPodNames...)
-	if scheduledPodNames.Len() != 2 {
-		t.Errorf("Expected 2 scheduled pod results, got %d", scheduledPodNames.Len())
-	}
-
-	if !scheduledPodNames.Has("p1") || !scheduledPodNames.Has("p2") {
-		t.Errorf("Expected p1 and p2 to be scheduled, got: %v", scheduledPodNames.UnsortedList())
-	}
-	if scheduledPodNames.Has("p3") {
-		t.Errorf("Expected p3 NOT to be scheduled, but got in results")
-	}
-}
-
-// TestCPGHierarchicalScheduling_Internal tests a complex, multi-level hierarchy of CompositePodGroups.
-// It verifies that Gang and Basic scheduling semantics apply correctly at each level.
-//
-// Tree structure:
-//
-//	                   cpg-root (Gang, MinGroup: 2)
-//	                /               |                \
-//	      cpg-sub1               cpg-sub2             cpg-sub3
-//	(Gang, MinGroup: 2)          (Basic)         (Gang, MinGroup: 2)
-//	    /    |    \               /     \              /     \
-//	  pg1   pg2   pg3           pg4     pg5          pg6     pg7
-//	  (S)   (S)   (F)           (S)     (S)          (S->F)  (F)
-//
-// (S) = Success
-// (F) = Fail (filter unschedulable)
-// (S->F) = Success initially, but fails because its parent cpg-sub3 (MinGroup: 2) fails.
-//
-// Results:
-// - cpg-sub1 succeeds (2 out of 3 groups succeed: pg1, pg2).
-// - cpg-sub2 succeeds (Basic, so pg4 and pg5 succeed independently).
-// - cpg-sub3 fails (only 1 group, pg6, succeeds, which is < MinGroup: 2. pg7 fails).
-// - cpg-root succeeds (2 out of 3 sub-groups succeed: cpg-sub1, cpg-sub2).
-func TestCPGHierarchicalScheduling_Internal(t *testing.T) {
-	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
-		features.CompositePodGroup:               true,
-		features.GenericWorkload:                 true,
-		features.TopologyAwareWorkloadScheduling: true,
-	})
-
-	testNode := st.MakeNode().Name("node1").UID("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "100", v1.ResourceMemory: "100Gi", v1.ResourcePods: "100"}).Obj()
-	testNode.Status.Allocatable = testNode.Status.Capacity
-
-	logger, ctx := ktesting.NewTestContext(t)
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
-	cache.AddNode(logger, testNode)
-
-	ns := "default"
-
-	// Helper function to create PodGroups
-	createPG := func(name string, minCount int32, parentCPG string) *schedulingv1beta1.PodGroup {
-		var policy schedulingv1beta1.PodGroupSchedulingPolicy
-		if minCount > 0 {
-			policy = schedulingv1beta1.PodGroupSchedulingPolicy{
-				Gang: &schedulingv1beta1.GangSchedulingPolicy{MinCount: minCount},
-			}
-		} else {
-			policy = schedulingv1beta1.PodGroupSchedulingPolicy{
-				Basic: &schedulingv1beta1.BasicSchedulingPolicy{},
-			}
-		}
-		pg := &schedulingv1beta1.PodGroup{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
-			Spec: schedulingv1beta1.PodGroupSpec{
-				SchedulingPolicy:            policy,
-				ParentCompositePodGroupName: new(parentCPG),
-			},
-		}
-		cache.AddPodGroup(pg)
-		return pg
-	}
-
-	createCPG := func(name string, minCount int32, parentCPG *string) *schedulingv1alpha3.CompositePodGroup {
-		var policy schedulingv1alpha3.CompositePodGroupSchedulingPolicy
-		if minCount > 0 {
-			policy = schedulingv1alpha3.CompositePodGroupSchedulingPolicy{
-				Gang: &schedulingv1alpha3.CompositeGangSchedulingPolicy{MinGroupCount: minCount},
-			}
-		} else {
-			policy = schedulingv1alpha3.CompositePodGroupSchedulingPolicy{
-				Basic: &schedulingv1alpha3.CompositeBasicSchedulingPolicy{},
-			}
-		}
-		cpg := &schedulingv1alpha3.CompositePodGroup{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
-			Spec: schedulingv1alpha3.CompositePodGroupSpec{
-				SchedulingPolicy:            policy,
-				ParentCompositePodGroupName: parentCPG,
-			},
-		}
-		cache.AddCompositePodGroup(logger, cpg)
-		return cpg
-	}
-
-	rootCPG := createCPG("cpg-root", 2, nil)
-	cpgSub1 := createCPG("cpg-sub1", 2, new("cpg-root"))
-	cpgSub2 := createCPG("cpg-sub2", 0, new("cpg-root"))
-	cpgSub3 := createCPG("cpg-sub3", 2, new("cpg-root"))
-
-	pg1 := createPG("pg1", 3, "cpg-sub1")
-	pg2 := createPG("pg2", 3, "cpg-sub1")
-	pg3 := createPG("pg3", 3, "cpg-sub1")
-
-	pg4 := createPG("pg4", 0, "cpg-sub2")
-	pg5 := createPG("pg5", 3, "cpg-sub2")
-
-	pg6 := createPG("pg6", 3, "cpg-sub3")
-	pg7 := createPG("pg7", 3, "cpg-sub3")
-
-	var allPods []*v1.Pod
-	queuedPodInfos := make(map[fwk.EntityKey][]*framework.QueuedPodInfo)
-	pgPods := make(map[string][]*v1.Pod)
-
-	createPods := func(pgName string, count int) {
-		for i := range count {
-			pod := st.MakePod().Namespace(ns).Name(fmt.Sprintf("%s-pod-%d", pgName, i)).
-				UID(fmt.Sprintf("%s-pod-%d", pgName, i)).
-				PodGroupName(pgName).Priority(100).SchedulerName("test-scheduler").Obj()
-
-			allPods = append(allPods, pod)
-			key := fwk.PodGroupKey(ns, pgName)
-			queuedPodInfos[key] = append(queuedPodInfos[key], &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: pod}})
-			pgPods[pgName] = append(pgPods[pgName], pod)
-			cache.AddPodGroupMember(pod)
-		}
-	}
-
-	createPods("pg1", 3)
-	createPods("pg2", 3)
-	createPods("pg3", 3)
-	createPods("pg4", 3)
-	createPods("pg5", 3)
-	createPods("pg6", 3)
-	createPods("pg7", 3)
-
-	podGroupInfo := &framework.QueuedPodGroupInfo{
-		QueuedPodInfos: queuedPodInfos,
-		PodGroupInfo: &framework.PodGroupInfo{
-			Namespace:         ns,
-			Name:              "cpg-root",
-			Type:              fwk.CompositePodGroupKeyType,
-			UnscheduledPods:   allPods,
-			CompositePodGroup: rootCPG,
-			Children: []*framework.PodGroupInfo{
+		{
+			name:  "SchedulableCPGHierarchyAddPGs",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{
 				{
+					cpgs:        []cpgSpec{{"cpg-root", 1, nil}},
+					pgs:         []pgSpec{{"pg1", 1, new("cpg-root")}},
+					pods:        map[string]podSpec{"pg1": {1, true}},
+					successPods: []string{"pg1-pod-0"},
+				},
+				{
+					pgs:         []pgSpec{{"pg2", 1, new("cpg-root")}},
+					pods:        map[string]podSpec{"pg2": {1, true}},
+					successPods: []string{"pg2-pod-0"},
+				},
+			},
+		},
+		{
+			name:  "SchedulableCPGHierarchyAddCPGs",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{
+				{
+					cpgs:        []cpgSpec{{"cpg-root", 1, nil}},
+					pgs:         []pgSpec{{"pg1", 1, new("cpg-root")}},
+					pods:        map[string]podSpec{"pg1": {1, true}},
+					successPods: []string{"pg1-pod-0"},
+				},
+				{
+					cpgs:        []cpgSpec{{"cpg-sub1", 1, new("cpg-root")}},
+					pgs:         []pgSpec{{"pg2", 1, new("cpg-sub1")}},
+					pods:        map[string]podSpec{"pg2": {1, true}},
+					successPods: []string{"pg2-pod-0"},
+				},
+			},
+		},
+		{
+			name:  "SchedulableCPGHierarchyAddPods",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{
+				{
+					cpgs:     []cpgSpec{{"cpg-root", 1, nil}},
+					pgs:      []pgSpec{{"pg1", 2, new("cpg-root")}},
+					pods:     map[string]podSpec{"pg1": {1, true}},
+					failPods: []string{"pg1-pod-0"},
+				},
+				{
+					pods:        map[string]podSpec{"pg1": {1, true}},
+					successPods: []string{"pg1-pod-0", "pg1-pod-1"},
+				},
+			},
+		},
+		{
+			name:  "CPGQuorumReductionUnblocksHierarchy",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{
+				{
+					cpgs:     []cpgSpec{{"cpg-root", 3, nil}},
+					pgs:      []pgSpec{{"pg1", 1, new("cpg-root")}, {"pg2", 1, new("cpg-root")}},
+					pods:     map[string]podSpec{"pg1": {1, true}, "pg2": {1, true}},
+					failPods: []string{"pg1-pod-0", "pg2-pod-0"},
+				},
+				{
+					cpgs:        []cpgSpec{{"cpg-root", 2, nil}},
+					successPods: []string{"pg1-pod-0", "pg2-pod-0"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			logger := klog.FromContext(ctx)
+
+			ns := "default"
+			cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
+			for _, node := range tt.nodes {
+				if node.Status.Allocatable == nil {
+					node.Status.Allocatable = node.Status.Capacity
+				}
+				cache.AddNode(logger, node)
+			}
+
+			var allCpgSpecs []cpgSpec
+			var allPgSpecs []pgSpec
+			var rootCPGName string
+
+			queuedPodInfos := make(map[fwk.EntityKey][]*framework.QueuedPodInfo)
+			pgPods := make(map[string][]*v1.Pod)
+			var allPods []*v1.Pod
+			filterStatus := make(map[string]*fwk.Status)
+			podIndexMap := make(map[string]int)
+
+			createCPG := func(name string, minCount int32, parentCPG *string) *schedulingv1alpha3.CompositePodGroup {
+				w := st.MakeCompositePodGroup().Name(name).Namespace(ns)
+				if minCount > 0 {
+					w.MinGroupCount(minCount)
+				} else {
+					w.BasicPolicy()
+				}
+				if parentCPG != nil {
+					w.ParentCompositePodGroup(*parentCPG)
+				}
+				cpg := w.Obj()
+				cache.AddCompositePodGroup(logger, cpg)
+				return cpg
+			}
+
+			createPG := func(name string, minCount int32, parentCPG *string) *schedulingv1beta1.PodGroup {
+				w := st.MakePodGroup().Name(name).Namespace(ns)
+				if minCount > 0 {
+					w.MinCount(minCount)
+				} else {
+					w.BasicPolicy()
+				}
+				if parentCPG != nil {
+					w.ParentCompositePodGroup(*parentCPG)
+				}
+				pg := w.Obj()
+				cache.AddPodGroup(pg)
+				return pg
+			}
+
+			createPods := func(podsMap map[string]podSpec) {
+				for pgName, spec := range podsMap {
+					startIndex := podIndexMap[pgName]
+					for i := 0; i < spec.count; i++ {
+						podIdx := startIndex + i
+						podName := fmt.Sprintf("%s-pod-%d", pgName, podIdx)
+						pod := st.MakePod().Namespace(ns).Name(podName).UID(podName).
+							PodGroupName(pgName).Priority(100).SchedulerName("test-scheduler").Obj()
+
+						if !spec.schedulable && i == 0 {
+							pod.Spec.Containers = []v1.Container{{
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("100")},
+								},
+							}}
+							filterStatus[podName] = fwk.NewStatus(fwk.Unschedulable, "insufficient cpu")
+						} else {
+							pod.Spec.Containers = []v1.Container{{
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
+								},
+							}}
+							filterStatus[podName] = nil
+						}
+
+						key := fwk.PodGroupKey(ns, pgName)
+						queuedPodInfos[key] = append(queuedPodInfos[key], &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: pod}})
+						pgPods[pgName] = append(pgPods[pgName], pod)
+						allPods = append(allPods, pod)
+						cache.AddPodGroupMember(pod)
+					}
+					podIndexMap[pgName] = startIndex + spec.count
+				}
+			}
+
+			var buildPodGroupInfo func(cpgName string) *framework.PodGroupInfo
+			buildPodGroupInfo = func(cpgName string) *framework.PodGroupInfo {
+				var cpg *cpgSpec
+				for i := range allCpgSpecs {
+					if allCpgSpecs[i].name == cpgName {
+						cpg = &allCpgSpecs[i]
+						break
+					}
+				}
+				if cpg == nil {
+					return nil
+				}
+
+				cpgObj, _ := cache.CompositePodGroups().Get(ns, cpg.name)
+				info := &framework.PodGroupInfo{
 					Namespace:         ns,
-					Name:              "cpg-sub1",
+					Name:              cpg.name,
 					Type:              fwk.CompositePodGroupKeyType,
-					CompositePodGroup: cpgSub1,
-					Children: []*framework.PodGroupInfo{
-						{Namespace: ns, Name: "pg1", Type: fwk.PodGroupKeyType, PodGroup: pg1, UnscheduledPods: pgPods["pg1"]},
-						{Namespace: ns, Name: "pg2", Type: fwk.PodGroupKeyType, PodGroup: pg2, UnscheduledPods: pgPods["pg2"]},
-						{Namespace: ns, Name: "pg3", Type: fwk.PodGroupKeyType, PodGroup: pg3, UnscheduledPods: pgPods["pg3"]},
-					},
+					CompositePodGroup: cpgObj,
+					UnscheduledPods:   nil,
+				}
+
+				for _, child := range allCpgSpecs {
+					if child.parent != nil && *child.parent == cpgName {
+						childInfo := buildPodGroupInfo(child.name)
+						if childInfo != nil {
+							info.Children = append(info.Children, childInfo)
+							info.UnscheduledPods = append(info.UnscheduledPods, childInfo.UnscheduledPods...)
+						}
+					}
+				}
+
+				for _, pg := range allPgSpecs {
+					if pg.parent != nil && *pg.parent == cpgName {
+						pods := pgPods[pg.name]
+						pgObj, _ := cache.PodGroups().Get(ns, pg.name)
+						childInfo := &framework.PodGroupInfo{
+							Namespace:       ns,
+							Name:            pg.name,
+							Type:            fwk.PodGroupKeyType,
+							PodGroup:        pgObj,
+							UnscheduledPods: pods,
+						}
+						info.Children = append(info.Children, childInfo)
+						info.UnscheduledPods = append(info.UnscheduledPods, pods...)
+					}
+				}
+				return info
+			}
+
+			snapshot := internalcache.NewEmptySnapshot()
+			clientObjs := []runtime.Object{}
+			for _, node := range tt.nodes {
+				clientObjs = append(clientObjs, node)
+			}
+			client := clientsetfake.NewSimpleClientset(clientObjs...)
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+
+			fakePlugin := &fakePodGroupPlugin{
+				filterStatus: filterStatus,
+			}
+
+			gangPluginFactory := func(ctx context.Context, obj runtime.Object, handle fwk.Handle) (fwk.Plugin, error) {
+				return gangscheduling.New(ctx, obj, handle, feature.Features{EnableTopologyAwareWorkloadScheduling: true, EnableCompositePodGroup: true})
+			}
+
+			registry := []tf.RegisterPluginFunc{
+				tf.RegisterFilterPlugin(fakePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+					return fakePlugin, nil
+				}),
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				tf.RegisterPermitPlugin(gangscheduling.Name, gangPluginFactory),
+				tf.RegisterPluginAsExtensions(gangscheduling.Name, gangPluginFactory, "PlacementFeasible"),
+			}
+
+			queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
+			schedFwk, err := tf.NewFramework(ctx, registry, "test-scheduler",
+				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithPodNominator(queue),
+				frameworkruntime.WithPodActivator(queue),
+				frameworkruntime.WithClientSet(client),
+				frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
+				frameworkruntime.WithWaitingPods(frameworkruntime.NewWaitingPodsMap()),
+				frameworkruntime.WithPodsInPreBind(frameworkruntime.NewPodsInPreBindMap()),
+				frameworkruntime.WithPodGroupManager(cache),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create new framework: %v", err)
+			}
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
+
+			handledPods := make(map[string]*fwk.Status)
+			var lock sync.Mutex
+
+			sched := &Scheduler{
+				Profiles:         profile.Map{"test-scheduler": schedFwk},
+				SchedulingQueue:  internalqueue.NewTestQueue(ctx, nil),
+				Cache:            cache,
+				client:           client,
+				nodeInfoSnapshot: snapshot,
+				FailureHandler: func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *fwk.NominatingInfo, start time.Time) {
+					lock.Lock()
+					defer lock.Unlock()
+					handledPods[p.Pod.Name] = status
 				},
-				{
-					Namespace:         ns,
-					Name:              "cpg-sub2",
-					Type:              fwk.CompositePodGroupKeyType,
-					CompositePodGroup: cpgSub2,
-					Children: []*framework.PodGroupInfo{
-						{Namespace: ns, Name: "pg4", Type: fwk.PodGroupKeyType, PodGroup: pg4, UnscheduledPods: pgPods["pg4"]},
-						{Namespace: ns, Name: "pg5", Type: fwk.PodGroupKeyType, PodGroup: pg5, UnscheduledPods: pgPods["pg5"]},
-					},
-				},
-				{
-					Namespace:         ns,
-					Name:              "cpg-sub3",
-					Type:              fwk.CompositePodGroupKeyType,
-					CompositePodGroup: cpgSub3,
-					Children: []*framework.PodGroupInfo{
-						{Namespace: ns, Name: "pg6", Type: fwk.PodGroupKeyType, PodGroup: pg6, UnscheduledPods: pgPods["pg6"]},
-						{Namespace: ns, Name: "pg7", Type: fwk.PodGroupKeyType, PodGroup: pg7, UnscheduledPods: pgPods["pg7"]},
-					},
-				},
-			},
-		},
-	}
-
-	fakePlugin := &fakePodGroupPlugin{
-		filterStatus: map[string]*fwk.Status{
-			"pg3-pod-0": fwk.NewStatus(fwk.Unschedulable),
-			"pg3-pod-1": fwk.NewStatus(fwk.Unschedulable),
-			"pg3-pod-2": fwk.NewStatus(fwk.Unschedulable),
-			"pg7-pod-0": fwk.NewStatus(fwk.Unschedulable),
-			"pg7-pod-1": fwk.NewStatus(fwk.Unschedulable),
-			"pg7-pod-2": fwk.NewStatus(fwk.Unschedulable),
-			"pg1-pod-0": nil,
-			"pg1-pod-1": nil,
-			"pg1-pod-2": nil,
-			"pg2-pod-0": nil,
-			"pg2-pod-1": nil,
-			"pg2-pod-2": nil,
-			"pg4-pod-0": nil,
-			"pg4-pod-1": nil,
-			"pg4-pod-2": nil,
-			"pg5-pod-0": nil,
-			"pg5-pod-1": nil,
-			"pg5-pod-2": nil,
-			"pg6-pod-0": nil,
-			"pg6-pod-1": nil,
-			"pg6-pod-2": nil,
-		},
-	}
-
-	gangPluginFactory := func(ctx context.Context, obj runtime.Object, handle fwk.Handle) (fwk.Plugin, error) {
-		return gangscheduling.New(ctx, obj, handle, feature.Features{EnableTopologyAwareWorkloadScheduling: true, EnableCompositePodGroup: true})
-	}
-
-	registry := []tf.RegisterPluginFunc{
-		tf.RegisterFilterPlugin(fakePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
-			return fakePlugin, nil
-		}),
-		tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
-		tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
-		tf.RegisterPermitPlugin(gangscheduling.Name, gangPluginFactory),
-		tf.RegisterPluginAsExtensions(gangscheduling.Name, gangPluginFactory, "PlacementFeasible"),
-	}
-
-	clientObjs := []runtime.Object{testNode, rootCPG, cpgSub1, cpgSub2, cpgSub3, pg1, pg2, pg3, pg4, pg5, pg6, pg7}
-	for _, pod := range allPods {
-		clientObjs = append(clientObjs, pod)
-	}
-	client := clientsetfake.NewSimpleClientset(clientObjs...)
-	informerFactory := informers.NewSharedInformerFactory(client, 0)
-
-	informerFactory.Start(ctx.Done())
-	informerFactory.WaitForCacheSync(ctx.Done())
-	queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
-	snapshot := internalcache.NewEmptySnapshot()
-
-	schedFwk, err := tf.NewFramework(ctx, registry, "test-scheduler",
-		frameworkruntime.WithInformerFactory(informerFactory),
-		frameworkruntime.WithSnapshotSharedLister(snapshot),
-		frameworkruntime.WithPodNominator(queue),
-		frameworkruntime.WithPodActivator(queue),
-		frameworkruntime.WithClientSet(client),
-		frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
-		frameworkruntime.WithWaitingPods(frameworkruntime.NewWaitingPodsMap()),
-		frameworkruntime.WithPodsInPreBind(frameworkruntime.NewPodsInPreBindMap()),
-		frameworkruntime.WithPodGroupManager(cache),
-	)
-	informerFactory.Start(ctx.Done())
-	informerFactory.WaitForCacheSync(ctx.Done())
-	if err != nil {
-		t.Fatalf("Failed to create new framework: %v", err)
-	}
-
-	handledPods := make(map[string]*fwk.Status)
-	var lock sync.Mutex
-
-	sched := &Scheduler{
-		Profiles:         profile.Map{"test-scheduler": schedFwk},
-		SchedulingQueue:  internalqueue.NewTestQueue(ctx, nil),
-		Cache:            cache,
-		client:           client,
-		nodeInfoSnapshot: snapshot, // will be updated by UpdateSnapshot
-		FailureHandler: func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *fwk.NominatingInfo, start time.Time) {
-			lock.Lock()
-			defer lock.Unlock()
-			handledPods[p.Pod.Name] = status
-		},
-	}
-	sched.SchedulePod = sched.schedulePod
-
-	// Run the scheduling cycle
-	if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
-		t.Fatalf("Failed to update snapshot: %v", err)
-	}
-	t.Logf("Node info list size: %d", func() int { l, _ := snapshot.NodeInfos().List(); return len(l) }())
-	podGroupCycleState := framework.NewCycleState()
-	podGroupCycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
-	sched.podGroupCycle(ctx, schedFwk, podGroupCycleState, podGroupInfo, time.Now())
-
-	lock.Lock()
-	defer lock.Unlock()
-
-	// Verify the results
-	successPods := []string{
-		"pg1-pod-0", "pg1-pod-1", "pg1-pod-2",
-		"pg2-pod-0", "pg2-pod-1", "pg2-pod-2",
-		"pg4-pod-0", "pg4-pod-1", "pg4-pod-2",
-		"pg5-pod-0", "pg5-pod-1", "pg5-pod-2",
-	}
-
-	failPods := []string{
-		"pg3-pod-0", "pg3-pod-1", "pg3-pod-2",
-		"pg6-pod-0", "pg6-pod-1", "pg6-pod-2",
-		"pg7-pod-0", "pg7-pod-1", "pg7-pod-2",
-	}
-
-	for _, p := range successPods {
-		if status, ok := handledPods[p]; ok {
-			t.Errorf("Expected pod %s to be scheduled successfully, but got error: %v", p, status.AsError())
-		}
-	}
-
-	for _, p := range failPods {
-		if _, ok := handledPods[p]; !ok {
-			t.Errorf("Expected pod %s to fail, but it was scheduled successfully", p)
-		}
-	}
-}
-
-// TestCPGMinGroupCount_Internal verifies that a Gang CompositePodGroup schedules its children
-// if at least MinGroupCount of them are fully schedulable.
-//
-// Tree structure:
-//
-//	   cpg-root (Gang, MinGroup: 2)
-//	  /             |              \
-//	pg1            pg2            pg3
-//	(S)            (S)            (F)
-//
-// (S) = Success
-// (F) = Fail
-func TestCPGMinGroupCount_Internal(t *testing.T) {
-	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
-		features.CompositePodGroup:               true,
-		features.GenericWorkload:                 true,
-		features.TopologyAwareWorkloadScheduling: true,
-	})
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	logger := klog.FromContext(ctx)
-
-	// Capacity matches 2 groups. pg3 pods fail.
-	testNode := st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()
-	cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
-	cache.AddNode(logger, testNode)
-
-	ns := "default"
-
-	createCPG := func(name string, minCount int32, parentCPG *string) *schedulingv1alpha3.CompositePodGroup {
-		var policy schedulingv1alpha3.CompositePodGroupSchedulingPolicy
-		if minCount > 0 {
-			policy = schedulingv1alpha3.CompositePodGroupSchedulingPolicy{
-				Gang: &schedulingv1alpha3.CompositeGangSchedulingPolicy{MinGroupCount: minCount},
 			}
-		} else {
-			policy = schedulingv1alpha3.CompositePodGroupSchedulingPolicy{
-				Basic: &schedulingv1alpha3.CompositeBasicSchedulingPolicy{},
+			sched.SchedulePod = sched.schedulePod
+
+			for phaseIdx, phase := range tt.phases {
+				if phaseIdx > 0 {
+					prevPhase := tt.phases[phaseIdx-1]
+					for _, p := range prevPhase.successPods {
+						for key, list := range queuedPodInfos {
+							var newList []*framework.QueuedPodInfo
+							for _, info := range list {
+								if info.Pod.Name != p {
+									newList = append(newList, info)
+								}
+							}
+							queuedPodInfos[key] = newList
+						}
+						var newAllPods []*v1.Pod
+						for _, pod := range allPods {
+							if pod.Name != p {
+								newAllPods = append(newAllPods, pod)
+							}
+						}
+						allPods = newAllPods
+						for pgName, list := range pgPods {
+							var newList []*v1.Pod
+							for _, pod := range list {
+								if pod.Name != p {
+									newList = append(newList, pod)
+								}
+							}
+							pgPods[pgName] = newList
+						}
+					}
+
+					lock.Lock()
+					handledPods = make(map[string]*fwk.Status)
+					lock.Unlock()
+				}
+
+				allCpgSpecs = append(allCpgSpecs, phase.cpgs...)
+				allPgSpecs = append(allPgSpecs, phase.pgs...)
+
+				for _, cpg := range allCpgSpecs {
+					if cpg.parent == nil {
+						rootCPGName = cpg.name
+						break
+					}
+				}
+
+				for _, cpg := range phase.cpgs {
+					createCPG(cpg.name, cpg.minCount, cpg.parent)
+					obj, _ := cache.CompositePodGroups().Get(ns, cpg.name)
+					if err := client.Tracker().Add(obj); err != nil {
+						if err := client.Tracker().Update(schedulingv1alpha3.SchemeGroupVersion.WithResource("compositepodgroups"), obj, ns); err != nil {
+							t.Fatalf("Phase %d: Failed to add or update CPG %s in tracker: %v", phaseIdx, cpg.name, err)
+						}
+					}
+				}
+				for _, pg := range phase.pgs {
+					createPG(pg.name, pg.minCount, pg.parent)
+					obj, _ := cache.PodGroups().Get(ns, pg.name)
+					if err := client.Tracker().Add(obj); err != nil {
+						if err := client.Tracker().Update(schedulingv1beta1.SchemeGroupVersion.WithResource("podgroups"), obj, ns); err != nil {
+							t.Fatalf("Phase %d: Failed to add or update PodGroup %s in tracker: %v", phaseIdx, pg.name, err)
+						}
+					}
+				}
+				createPods(phase.pods)
+
+				for pgName, spec := range phase.pods {
+					startIndex := podIndexMap[pgName] - spec.count
+					for i := 0; i < spec.count; i++ {
+						podName := fmt.Sprintf("%s-pod-%d", pgName, startIndex+i)
+						var pod *v1.Pod
+						for _, p := range allPods {
+							if p.Name == podName {
+								pod = p
+								break
+							}
+						}
+						if pod != nil {
+							if err := client.Tracker().Add(pod); err != nil {
+								if err := client.Tracker().Update(v1.SchemeGroupVersion.WithResource("pods"), pod, ns); err != nil {
+									t.Fatalf("Phase %d: Failed to add or update Pod %s in tracker: %v", phaseIdx, pod.Name, err)
+								}
+							}
+						}
+					}
+				}
+
+				if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
+					t.Fatalf("Phase %d: Failed to update snapshot: %v", phaseIdx, err)
+				}
+
+				podGroupInfo := &framework.QueuedPodGroupInfo{
+					QueuedPodInfos: queuedPodInfos,
+					PodGroupInfo:   buildPodGroupInfo(rootCPGName),
+				}
+
+				podGroupCycleState := framework.NewCycleState()
+				podGroupCycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
+
+				sched.podGroupCycle(ctx, schedFwk, podGroupCycleState, podGroupInfo, time.Now())
+
+				lock.Lock()
+				for _, p := range phase.successPods {
+					if status, ok := handledPods[p]; ok {
+						t.Errorf("Phase %d: Expected pod %s to be scheduled successfully, but got error: %v", phaseIdx, p, status.AsError())
+					}
+				}
+
+				for _, p := range phase.failPods {
+					if status, ok := handledPods[p]; !ok {
+						t.Errorf("Phase %d: Expected pod %s to fail scheduling, but it was scheduled successfully", phaseIdx, p)
+					} else if status.Code() == fwk.Success {
+						t.Errorf("Phase %d: Expected pod %s to fail scheduling, but got status Success", phaseIdx, p)
+					}
+				}
+				lock.Unlock()
 			}
-		}
-		cpg := &schedulingv1alpha3.CompositePodGroup{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
-			Spec: schedulingv1alpha3.CompositePodGroupSpec{
-				SchedulingPolicy:            policy,
-				ParentCompositePodGroupName: parentCPG,
-			},
-		}
-		cache.AddCompositePodGroup(logger, cpg)
-		return cpg
-	}
-
-	createPG := func(name string, minCount int32, parentCPG string) *schedulingv1beta1.PodGroup {
-		var policy schedulingv1beta1.PodGroupSchedulingPolicy
-		if minCount > 0 {
-			policy = schedulingv1beta1.PodGroupSchedulingPolicy{
-				Gang: &schedulingv1beta1.GangSchedulingPolicy{MinCount: minCount},
-			}
-		} else {
-			policy = schedulingv1beta1.PodGroupSchedulingPolicy{
-				Basic: &schedulingv1beta1.BasicSchedulingPolicy{},
-			}
-		}
-		pg := &schedulingv1beta1.PodGroup{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
-			Spec: schedulingv1beta1.PodGroupSpec{
-				SchedulingPolicy:            policy,
-				ParentCompositePodGroupName: new(parentCPG),
-			},
-		}
-		cache.AddPodGroup(pg)
-		return pg
-	}
-
-	rootCPG := createCPG("cpg-root", 2, nil)
-
-	pg1 := createPG("pg1", 3, "cpg-root")
-	pg2 := createPG("pg2", 3, "cpg-root")
-	pg3 := createPG("pg3", 3, "cpg-root")
-
-	queuedPodInfos := make(map[fwk.EntityKey][]*framework.QueuedPodInfo)
-	pgPods := make(map[string][]*v1.Pod)
-	var allPods []*v1.Pod
-
-	createPods := func(pgName string, count int, schedulable bool) {
-		for i := range count {
-			pod := st.MakePod().Namespace(ns).Name(fmt.Sprintf("%s-pod-%d", pgName, i)).UID(fmt.Sprintf("%s-pod-%d", pgName, i)).
-				PodGroupName(pgName).Priority(100).Obj()
-
-			if !schedulable && i == 0 {
-				pod.Spec.Containers = []v1.Container{{
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("100")},
-					},
-				}}
-			} else {
-				pod.Spec.Containers = []v1.Container{{
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
-					},
-				}}
-			}
-
-			podInfo := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: pod}}
-			key := fwk.PodGroupKey(ns, pgName)
-			queuedPodInfos[key] = append(queuedPodInfos[key], podInfo)
-			pgPods[pgName] = append(pgPods[pgName], pod)
-			allPods = append(allPods, pod)
-			cache.AddPodGroupMember(pod)
-		}
-	}
-
-	createPods("pg1", 3, true)
-	createPods("pg2", 3, true)
-	createPods("pg3", 3, false)
-
-	snapshot := internalcache.NewEmptySnapshot()
-	clientObjs := []runtime.Object{testNode, rootCPG, pg1, pg2, pg3}
-	for _, pod := range allPods {
-		clientObjs = append(clientObjs, pod)
-	}
-	client := clientsetfake.NewSimpleClientset(clientObjs...)
-	informerFactory := informers.NewSharedInformerFactory(client, 0)
-
-	fakePlugin := &fakePodGroupPlugin{
-		filterStatus: map[string]*fwk.Status{
-			"pg1-pod-0": nil,
-			"pg1-pod-1": nil,
-			"pg1-pod-2": nil,
-			"pg2-pod-0": nil,
-			"pg2-pod-1": nil,
-			"pg2-pod-2": nil,
-			"pg3-pod-0": fwk.NewStatus(fwk.Unschedulable, "insufficient cpu"),
-			"pg3-pod-1": fwk.NewStatus(fwk.Unschedulable, "insufficient cpu"),
-			"pg3-pod-2": fwk.NewStatus(fwk.Unschedulable, "insufficient cpu"),
-		},
-	}
-
-	gangPluginFactory := func(ctx context.Context, obj runtime.Object, handle fwk.Handle) (fwk.Plugin, error) {
-		return gangscheduling.New(ctx, obj, handle, feature.Features{EnableTopologyAwareWorkloadScheduling: true, EnableCompositePodGroup: true})
-	}
-
-	registry := []tf.RegisterPluginFunc{
-		tf.RegisterFilterPlugin(fakePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
-			return fakePlugin, nil
-		}),
-		tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
-		tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
-		tf.RegisterPermitPlugin(gangscheduling.Name, gangPluginFactory),
-		tf.RegisterPluginAsExtensions(gangscheduling.Name, gangPluginFactory, "PlacementFeasible"),
-	}
-
-	queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
-	schedFwk, err := tf.NewFramework(ctx, registry, "test-scheduler",
-		frameworkruntime.WithInformerFactory(informerFactory),
-		frameworkruntime.WithSnapshotSharedLister(snapshot),
-		frameworkruntime.WithPodNominator(queue),
-		frameworkruntime.WithPodActivator(queue),
-		frameworkruntime.WithClientSet(client),
-		frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
-		frameworkruntime.WithWaitingPods(frameworkruntime.NewWaitingPodsMap()),
-		frameworkruntime.WithPodsInPreBind(frameworkruntime.NewPodsInPreBindMap()),
-		frameworkruntime.WithPodGroupManager(cache),
-	)
-	informerFactory.Start(ctx.Done())
-	informerFactory.WaitForCacheSync(ctx.Done())
-	if err != nil {
-		t.Fatalf("Failed to create new framework: %v", err)
-	}
-
-	handledPods := make(map[string]*fwk.Status)
-	var lock sync.Mutex
-
-	sched := &Scheduler{
-		Profiles:         profile.Map{"test-scheduler": schedFwk},
-		SchedulingQueue:  internalqueue.NewTestQueue(ctx, nil),
-		Cache:            cache,
-		client:           client,
-		nodeInfoSnapshot: snapshot,
-		FailureHandler: func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *fwk.NominatingInfo, start time.Time) {
-			lock.Lock()
-			defer lock.Unlock()
-			handledPods[p.Pod.Name] = status
-		},
-	}
-	sched.SchedulePod = sched.schedulePod
-
-	podGroupInfo := &framework.QueuedPodGroupInfo{
-		QueuedPodInfos: queuedPodInfos,
-		PodGroupInfo: &framework.PodGroupInfo{
-			Namespace:         ns,
-			Name:              "cpg-root",
-			Type:              fwk.CompositePodGroupKeyType,
-			UnscheduledPods:   allPods,
-			CompositePodGroup: rootCPG,
-			Children: []*framework.PodGroupInfo{
-				{Namespace: ns, Name: "pg1", Type: fwk.PodGroupKeyType, PodGroup: pg1, UnscheduledPods: pgPods["pg1"]},
-				{Namespace: ns, Name: "pg2", Type: fwk.PodGroupKeyType, PodGroup: pg2, UnscheduledPods: pgPods["pg2"]},
-				{Namespace: ns, Name: "pg3", Type: fwk.PodGroupKeyType, PodGroup: pg3, UnscheduledPods: pgPods["pg3"]},
-			},
-		},
-	}
-
-	if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
-		t.Fatalf("Failed to update snapshot: %v", err)
-	}
-	sched.podGroupCycle(ctx, schedFwk, framework.NewCycleState(), podGroupInfo, time.Now())
-
-	lock.Lock()
-	defer lock.Unlock()
-
-	successPods := []string{
-		"pg1-pod-0", "pg1-pod-1", "pg1-pod-2",
-		"pg2-pod-0", "pg2-pod-1", "pg2-pod-2",
-	}
-
-	for _, p := range successPods {
-		if status, ok := handledPods[p]; ok {
-			t.Errorf("Expected pod %s to be scheduled successfully, but got error: %v", p, status.AsError())
-		}
-	}
-
-	failPods := []string{
-		"pg3-pod-0", "pg3-pod-1", "pg3-pod-2",
-	}
-
-	for _, p := range failPods {
-		if _, ok := handledPods[p]; !ok {
-			t.Errorf("Expected pod %s to fail scheduling, but it was scheduled successfully", p)
-		}
-	}
-}
-
-// TestCPGBasicWithGangChildren_Internal verifies that a Basic CompositePodGroup allows its ready
-// child Gang groups to schedule independently of each other.
-//
-// Tree structure:
-//
-//	   cpg-root (Basic)
-//	  /            \
-//	pg1            pg2
-//	(S)            (F)
-//
-// (S) = Success
-// (F) = Fail
-func TestCPGBasicWithGangChildren_Internal(t *testing.T) {
-	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
-		features.CompositePodGroup:               true,
-		features.GenericWorkload:                 true,
-		features.TopologyAwareWorkloadScheduling: true,
-	})
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	logger := klog.FromContext(ctx)
-
-	testNode := st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()
-	cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
-	cache.AddNode(logger, testNode)
-
-	ns := "default"
-
-	createCPG := func(name string, minCount int32, parentCPG *string) *schedulingv1alpha3.CompositePodGroup {
-		var policy schedulingv1alpha3.CompositePodGroupSchedulingPolicy
-		if minCount > 0 {
-			policy = schedulingv1alpha3.CompositePodGroupSchedulingPolicy{
-				Gang: &schedulingv1alpha3.CompositeGangSchedulingPolicy{MinGroupCount: minCount},
-			}
-		} else {
-			policy = schedulingv1alpha3.CompositePodGroupSchedulingPolicy{
-				Basic: &schedulingv1alpha3.CompositeBasicSchedulingPolicy{},
-			}
-		}
-		cpg := &schedulingv1alpha3.CompositePodGroup{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
-			Spec: schedulingv1alpha3.CompositePodGroupSpec{
-				SchedulingPolicy:            policy,
-				ParentCompositePodGroupName: parentCPG,
-			},
-		}
-		cache.AddCompositePodGroup(logger, cpg)
-		return cpg
-	}
-
-	createPG := func(name string, minCount int32, parentCPG string) *schedulingv1beta1.PodGroup {
-		var policy schedulingv1beta1.PodGroupSchedulingPolicy
-		if minCount > 0 {
-			policy = schedulingv1beta1.PodGroupSchedulingPolicy{
-				Gang: &schedulingv1beta1.GangSchedulingPolicy{MinCount: minCount},
-			}
-		} else {
-			policy = schedulingv1beta1.PodGroupSchedulingPolicy{
-				Basic: &schedulingv1beta1.BasicSchedulingPolicy{},
-			}
-		}
-		pg := &schedulingv1beta1.PodGroup{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
-			Spec: schedulingv1beta1.PodGroupSpec{
-				SchedulingPolicy:            policy,
-				ParentCompositePodGroupName: new(parentCPG),
-			},
-		}
-		cache.AddPodGroup(pg)
-		return pg
-	}
-
-	rootCPG := createCPG("cpg-root", 0, nil)
-
-	pg1 := createPG("pg1", 3, "cpg-root")
-	pg2 := createPG("pg2", 3, "cpg-root")
-
-	queuedPodInfos := make(map[fwk.EntityKey][]*framework.QueuedPodInfo)
-	pgPods := make(map[string][]*v1.Pod)
-	var allPods []*v1.Pod
-
-	createPods := func(pgName string, count int, schedulable bool) {
-		for i := range count {
-			pod := st.MakePod().Namespace(ns).Name(fmt.Sprintf("%s-pod-%d", pgName, i)).UID(fmt.Sprintf("%s-pod-%d", pgName, i)).
-				PodGroupName(pgName).Priority(100).Obj()
-
-			if !schedulable && i == 0 {
-				pod.Spec.Containers = []v1.Container{{
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("100")},
-					},
-				}}
-			} else {
-				pod.Spec.Containers = []v1.Container{{
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
-					},
-				}}
-			}
-
-			podInfo := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: pod}}
-			key := fwk.PodGroupKey(ns, pgName)
-			queuedPodInfos[key] = append(queuedPodInfos[key], podInfo)
-			pgPods[pgName] = append(pgPods[pgName], pod)
-			allPods = append(allPods, pod)
-			cache.AddPodGroupMember(pod)
-		}
-	}
-
-	createPods("pg1", 3, true)
-	createPods("pg2", 3, false)
-
-	snapshot := internalcache.NewEmptySnapshot()
-	clientObjs := []runtime.Object{testNode, rootCPG, pg1, pg2}
-	for _, pod := range allPods {
-		clientObjs = append(clientObjs, pod)
-	}
-	client := clientsetfake.NewSimpleClientset(clientObjs...)
-	informerFactory := informers.NewSharedInformerFactory(client, 0)
-
-	fakePlugin := &fakePodGroupPlugin{
-		filterStatus: map[string]*fwk.Status{
-			"pg1-pod-0": nil,
-			"pg1-pod-1": nil,
-			"pg1-pod-2": nil,
-			"pg2-pod-0": fwk.NewStatus(fwk.Unschedulable, "insufficient cpu"),
-			"pg2-pod-1": fwk.NewStatus(fwk.Unschedulable, "insufficient cpu"),
-			"pg2-pod-2": fwk.NewStatus(fwk.Unschedulable, "insufficient cpu"),
-		},
-	}
-
-	gangPluginFactory := func(ctx context.Context, obj runtime.Object, handle fwk.Handle) (fwk.Plugin, error) {
-		return gangscheduling.New(ctx, obj, handle, feature.Features{EnableTopologyAwareWorkloadScheduling: true, EnableCompositePodGroup: true})
-	}
-
-	registry := []tf.RegisterPluginFunc{
-		tf.RegisterFilterPlugin(fakePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
-			return fakePlugin, nil
-		}),
-		tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
-		tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
-		tf.RegisterPermitPlugin(gangscheduling.Name, gangPluginFactory),
-		tf.RegisterPluginAsExtensions(gangscheduling.Name, gangPluginFactory, "PlacementFeasible"),
-	}
-
-	queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
-	schedFwk, err := tf.NewFramework(ctx, registry, "test-scheduler",
-		frameworkruntime.WithInformerFactory(informerFactory),
-		frameworkruntime.WithSnapshotSharedLister(snapshot),
-		frameworkruntime.WithPodNominator(queue),
-		frameworkruntime.WithPodActivator(queue),
-		frameworkruntime.WithClientSet(client),
-		frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
-		frameworkruntime.WithWaitingPods(frameworkruntime.NewWaitingPodsMap()),
-		frameworkruntime.WithPodsInPreBind(frameworkruntime.NewPodsInPreBindMap()),
-		frameworkruntime.WithPodGroupManager(cache),
-	)
-	informerFactory.Start(ctx.Done())
-	informerFactory.WaitForCacheSync(ctx.Done())
-	if err != nil {
-		t.Fatalf("Failed to create new framework: %v", err)
-	}
-
-	handledPods := make(map[string]*fwk.Status)
-	var lock sync.Mutex
-
-	sched := &Scheduler{
-		Profiles:         profile.Map{"test-scheduler": schedFwk},
-		SchedulingQueue:  internalqueue.NewTestQueue(ctx, nil),
-		Cache:            cache,
-		client:           client,
-		nodeInfoSnapshot: snapshot,
-		FailureHandler: func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *fwk.NominatingInfo, start time.Time) {
-			lock.Lock()
-			defer lock.Unlock()
-			handledPods[p.Pod.Name] = status
-		},
-	}
-	sched.SchedulePod = sched.schedulePod
-
-	podGroupInfo := &framework.QueuedPodGroupInfo{
-		QueuedPodInfos: queuedPodInfos,
-		PodGroupInfo: &framework.PodGroupInfo{
-			Namespace:         ns,
-			Name:              "cpg-root",
-			Type:              fwk.CompositePodGroupKeyType,
-			UnscheduledPods:   allPods,
-			CompositePodGroup: rootCPG,
-			Children: []*framework.PodGroupInfo{
-				{Namespace: ns, Name: "pg1", Type: fwk.PodGroupKeyType, PodGroup: pg1, UnscheduledPods: pgPods["pg1"]},
-				{Namespace: ns, Name: "pg2", Type: fwk.PodGroupKeyType, PodGroup: pg2, UnscheduledPods: pgPods["pg2"]},
-			},
-		},
-	}
-
-	if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
-		t.Fatalf("Failed to update snapshot: %v", err)
-	}
-	sched.podGroupCycle(ctx, schedFwk, framework.NewCycleState(), podGroupInfo, time.Now())
-
-	lock.Lock()
-	defer lock.Unlock()
-
-	successPods := []string{
-		"pg1-pod-0", "pg1-pod-1", "pg1-pod-2",
-	}
-
-	for _, p := range successPods {
-		if status, ok := handledPods[p]; ok {
-			t.Errorf("Expected pod %s to be scheduled successfully, but got error: %v", p, status.AsError())
-		}
-	}
-
-	failPods := []string{
-		"pg2-pod-0", "pg2-pod-1", "pg2-pod-2",
-	}
-
-	for _, p := range failPods {
-		if _, ok := handledPods[p]; !ok {
-			t.Errorf("Expected pod %s to fail scheduling, but it was scheduled successfully", p)
-		}
+		})
 	}
 }
 

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -5262,895 +5262,601 @@ func TestScheduleOnePodGroup_PodGroupStateAvailability(t *testing.T) {
 	}
 }
 
-func TestCPGHierarchicalScheduling_RecursiveAlgorithm(t *testing.T) {
+func TestCPGHierarchicalScheduling(t *testing.T) {
 	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
 		features.CompositePodGroup:               true,
 		features.GenericWorkload:                 true,
 		features.TopologyAwareWorkloadScheduling: true,
 	})
 
-	// Tree structure:
-	//                  cpg-root (Gang, MinGroupCount: 2)
-	//                  /       |       \
-	//                pg1      pg2      pg3
-	//               (Min:1)  (Min:1)  (Min:1)
-	//
-	// We will schedule cpg-root.
-	// Since MinGroupCount: 2, if 2 out of 3 child pod groups are schedulable, it should succeed!
-
-	namespace := "default"
-
-	cpgRoot := &schedulingv1alpha3.CompositePodGroup{
-		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "cpg-root"},
-		Spec: schedulingv1alpha3.CompositePodGroupSpec{
-			SchedulingPolicy: schedulingv1alpha3.CompositePodGroupSchedulingPolicy{
-				Gang: &schedulingv1alpha3.CompositeGangSchedulingPolicy{MinGroupCount: 2},
-			},
-		},
+	type cpgSpec struct {
+		name     string
+		minCount int32
+		parent   *string
+	}
+	type pgSpec struct {
+		name     string
+		minCount int32
+		parent   *string
+	}
+	type podSpec struct {
+		count       int
+		schedulable bool
 	}
 
-	pg1 := st.MakePodGroup().Name("pg1").Namespace(namespace).ParentCompositePodGroup("cpg-root").MinCount(1).Obj()
-	pg2 := st.MakePodGroup().Name("pg2").Namespace(namespace).ParentCompositePodGroup("cpg-root").MinCount(1).Obj()
-	pg3 := st.MakePodGroup().Name("pg3").Namespace(namespace).ParentCompositePodGroup("cpg-root").MinCount(1).Obj()
+	type phaseSpec struct {
+		// Workloads and pods introduced or updated in this phase.
+		cpgs []cpgSpec
+		pgs  []pgSpec
+		pods map[string]podSpec
 
-	p1 := st.MakePod().Name("p1").UID("p1").PodGroupName("pg1").SchedulerName("test-scheduler").Obj()
-	p2 := st.MakePod().Name("p2").UID("p2").PodGroupName("pg2").SchedulerName("test-scheduler").Obj()
-	p3 := st.MakePod().Name("p3").UID("p3").PodGroupName("pg3").SchedulerName("test-scheduler").Obj()
-
-	qInfo1 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p1}}
-	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
-	qInfo3 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p3}}
-	queuedPodInfosMap := map[fwk.EntityKey][]*framework.QueuedPodInfo{
-		fwk.PodGroupKey("default", "pg1"): {qInfo1},
-		fwk.PodGroupKey("default", "pg2"): {qInfo2},
-		fwk.PodGroupKey("default", "pg3"): {qInfo3},
+		// Expected scheduling outcomes for pods in this phase.
+		wantSuccessPods []string
+		wantFailPods    []string
 	}
 
-	cpgRootInfo := &framework.QueuedPodGroupInfo{
-		QueuedPodInfos: queuedPodInfosMap,
-		PodGroupInfo: &framework.PodGroupInfo{GenericPodGroup: fwk.NewGenericCompositePodGroup(cpgRoot), UnscheduledPods: []*v1.Pod{p1, p2, p3}, Children: []*framework.PodGroupInfo{
-			{GenericPodGroup: fwk.NewGenericPodGroup(pg1), UnscheduledPods: []*v1.Pod{p1}},
-			{GenericPodGroup: fwk.NewGenericPodGroup(pg2), UnscheduledPods: []*v1.Pod{p2}},
-			{GenericPodGroup: fwk.NewGenericPodGroup(pg3), UnscheduledPods: []*v1.Pod{p3}},
-		},
-		},
-		QueueingParams: framework.QueueingParams{
-			Timestamp: time.Now(),
-		},
-	}
-
-	logger, ctx := ktesting.NewTestContext(t)
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	// Mock PlacementFeasible plugin
-	fakePlacementFeasible := &fakePlacementFeasiblePlugin{}
-	fakePlacementFeasible.placementFeasibleStatuses = [][]fwk.Code{
-		// Four distinct scheduling cycles:
-		// 1. cpg-root (success, 1 call: before children scheduling, evaluated=0)
-		// 2. pg1 scheduling (success, 2 calls: before and after p1, evaluated=0 and 1)
-		// 3. pg2 scheduling (success, 2 calls: before and after p2, evaluated=0 and 1)
-		// 4. pg3 scheduling (fails early on Evaluated=0)
-		{fwk.Success},
-		{fwk.Success, fwk.Success},
-		{fwk.Success, fwk.Success, fwk.Success},
-		{fwk.Unschedulable},
-	}
-
-	registry := frameworkruntime.Registry{
-		queuesort.Name:     queuesort.New,
-		defaultbinder.Name: defaultbinder.New,
-		fakePlacementFeasible.Name(): func(ctx context.Context, obj runtime.Object, handle fwk.Handle) (fwk.Plugin, error) {
-			return fakePlacementFeasible, nil
-		},
-	}
-
-	profileCfg := config.KubeSchedulerProfile{
-		SchedulerName: "test-scheduler",
-		Plugins: &config.Plugins{
-			QueueSort: config.PluginSet{
-				Enabled: []config.Plugin{{Name: queuesort.Name}},
-			},
-			Bind: config.PluginSet{
-				Enabled: []config.Plugin{{Name: defaultbinder.Name}},
-			},
-			PlacementFeasible: config.PluginSet{
-				Enabled: []config.Plugin{{Name: fakePlacementFeasible.Name()}},
-			},
-		},
-	}
-
-	client := clientsetfake.NewSimpleClientset(cpgRoot, pg1, pg2, pg3)
-	informerFactory := informers.NewSharedInformerFactory(client, 0)
-	informerFactory.Start(ctx.Done())
-	informerFactory.WaitForCacheSync(ctx.Done())
-
-	schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
-		frameworkruntime.WithInformerFactory(informerFactory),
-		frameworkruntime.WithClientSet(client),
-		frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
-	)
-	if err != nil {
-		t.Fatalf("Failed to create framework: %v", err)
-	}
-
-	cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
-	cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(cpgRoot))
-	cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg1))
-	cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg2))
-	cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg3))
-
-	sched := &Scheduler{
-		Profiles:         profile.Map{"test-scheduler": schedFwk},
-		Cache:            cache,
-		nodeInfoSnapshot: internalcache.NewEmptySnapshot(),
-		client:           client,
-		SchedulingQueue:  internalqueue.NewTestQueue(ctx, nil),
-	}
-	sched.initAlgorithm()
-	schedFwk.SetPodNominator(sched.SchedulingQueue)
-
-	// Mock SchedulePod to return success for all pods
-	sched.SchedulePod = func(ctx context.Context, fwk framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (ScheduleResult, error) {
-		return ScheduleResult{SuggestedHost: "node1"}, nil
-	}
-
-	// Prepare nodeInfoSnapshot which matches Cache
-	if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
-		t.Fatalf("Failed to update snapshot: %v", err)
-	}
-
-	// Run podGroupSchedulingRecursiveAlgorithm
-	res := map[fwk.EntityKey]*podGroupAlgorithmResult{}
-	result, _ := sched.podGroupSchedulingRecursiveAlgorithm(ctx, schedFwk, framework.NewCycleState(), cpgRootInfo, cpgRootInfo.PodGroupInfo, res)
-
-	status := result.status
-	if status.Code() != fwk.Success {
-		t.Errorf("Expected recursive scheduling algorithm status to be Success, got: %v", status)
-	}
-
-	// Verify that exactly the successful child pod groups (pg1 and pg2) are in the scheduled pod results
-	// pg3 should NOT be in the results because its placement was not feasible!
-	var successPodNames []string
-	for _, childRes := range res {
-		if childRes.podGroupInfo.CompositePodGroup != nil {
-			continue
-		}
-		for _, pr := range childRes.podResults {
-			if childRes.status.IsSuccess() && pr.status.IsSuccess() {
-				successPodNames = append(successPodNames, pr.podInfo.Pod.Name)
-			}
-		}
-	}
-
-	scheduledPodNames := sets.New(successPodNames...)
-	if scheduledPodNames.Len() != 2 {
-		t.Errorf("Expected 2 scheduled pod results, got %d", scheduledPodNames.Len())
-	}
-
-	if !scheduledPodNames.Has("p1") || !scheduledPodNames.Has("p2") {
-		t.Errorf("Expected p1 and p2 to be scheduled, got: %v", scheduledPodNames.UnsortedList())
-	}
-	if scheduledPodNames.Has("p3") {
-		t.Errorf("Expected p3 NOT to be scheduled, but got in results")
-	}
-}
-
-// TestCPGHierarchicalScheduling_Internal tests a complex, multi-level hierarchy of CompositePodGroups.
-// It verifies that Gang and Basic scheduling semantics apply correctly at each level.
-//
-// Tree structure:
-//
-//	                   cpg-root (Gang, MinGroup: 2)
-//	                /               |                \
-//	      cpg-sub1               cpg-sub2             cpg-sub3
-//	(Gang, MinGroup: 2)          (Basic)         (Gang, MinGroup: 2)
-//	    /    |    \               /     \              /     \
-//	  pg1   pg2   pg3           pg4     pg5          pg6     pg7
-//	  (S)   (S)   (F)           (S)     (S)          (S->F)  (F)
-//
-// (S) = Success
-// (F) = Fail (filter unschedulable)
-// (S->F) = Success initially, but fails because its parent cpg-sub3 (MinGroup: 2) fails.
-//
-// Results:
-// - cpg-sub1 succeeds (2 out of 3 groups succeed: pg1, pg2).
-// - cpg-sub2 succeeds (Basic, so pg4 and pg5 succeed independently).
-// - cpg-sub3 fails (only 1 group, pg6, succeeds, which is < MinGroup: 2. pg7 fails).
-// - cpg-root succeeds (2 out of 3 sub-groups succeed: cpg-sub1, cpg-sub2).
-func TestCPGHierarchicalScheduling_Internal(t *testing.T) {
-	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
-		features.CompositePodGroup:               true,
-		features.GenericWorkload:                 true,
-		features.TopologyAwareWorkloadScheduling: true,
-	})
-
-	testNode := st.MakeNode().Name("node1").UID("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "100", v1.ResourceMemory: "100Gi", v1.ResourcePods: "100"}).Obj()
-	testNode.Status.Allocatable = testNode.Status.Capacity
-
-	logger, ctx := ktesting.NewTestContext(t)
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
-	cache.AddNode(logger, testNode)
-
-	ns := "default"
-
-	// Helper function to create PodGroups
-	createPG := func(name string, minCount int32, parentCPG string) *schedulingv1beta1.PodGroup {
-		var policy schedulingv1beta1.PodGroupSchedulingPolicy
-		if minCount > 0 {
-			policy = schedulingv1beta1.PodGroupSchedulingPolicy{
-				Gang: &schedulingv1beta1.GangSchedulingPolicy{MinCount: minCount},
-			}
+	createCPG := func(t *testing.T, cache internalcache.Cache, client *clientsetfake.Clientset, ns string, allCPGSpecs *[]cpgSpec, cpg cpgSpec) *schedulingv1alpha3.CompositePodGroup {
+		t.Helper()
+		w := st.MakeCompositePodGroup().Name(cpg.name).Namespace(ns)
+		if cpg.minCount > 0 {
+			w.MinGroupCount(cpg.minCount)
 		} else {
-			policy = schedulingv1beta1.PodGroupSchedulingPolicy{
-				Basic: &schedulingv1beta1.BasicSchedulingPolicy{},
+			w.BasicPolicy()
+		}
+		if cpg.parent != nil {
+			w.ParentCompositePodGroup(*cpg.parent)
+		}
+		obj := w.Obj()
+		cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(obj))
+		if err := client.Tracker().Add(obj); err != nil {
+			if err := client.Tracker().Update(schedulingv1alpha3.SchemeGroupVersion.WithResource("compositepodgroups"), obj, ns); err != nil {
+				t.Fatalf("Failed to add or update CPG %s in tracker: %v", obj.Name, err)
 			}
 		}
-		pg := &schedulingv1beta1.PodGroup{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
-			Spec: schedulingv1beta1.PodGroupSpec{
-				SchedulingPolicy:            policy,
-				ParentCompositePodGroupName: new(parentCPG),
-			},
+		if allCPGSpecs != nil {
+			found := false
+			for i, existing := range *allCPGSpecs {
+				if existing.name == cpg.name {
+					(*allCPGSpecs)[i] = cpg
+					found = true
+					break
+				}
+			}
+			if !found {
+				*allCPGSpecs = append(*allCPGSpecs, cpg)
+			}
 		}
-		cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg))
-		return pg
+		return obj
 	}
 
-	createCPG := func(name string, minCount int32, parentCPG *string) *schedulingv1alpha3.CompositePodGroup {
-		var policy schedulingv1alpha3.CompositePodGroupSchedulingPolicy
-		if minCount > 0 {
-			policy = schedulingv1alpha3.CompositePodGroupSchedulingPolicy{
-				Gang: &schedulingv1alpha3.CompositeGangSchedulingPolicy{MinGroupCount: minCount},
-			}
+	createPG := func(t *testing.T, cache internalcache.Cache, client *clientsetfake.Clientset, ns string, allPGSpecs *[]pgSpec, pg pgSpec) *schedulingv1beta1.PodGroup {
+		t.Helper()
+		w := st.MakePodGroup().Name(pg.name).Namespace(ns)
+		if pg.minCount > 0 {
+			w.MinCount(pg.minCount)
 		} else {
-			policy = schedulingv1alpha3.CompositePodGroupSchedulingPolicy{
-				Basic: &schedulingv1alpha3.CompositeBasicSchedulingPolicy{},
+			w.BasicPolicy()
+		}
+		if pg.parent != nil {
+			w.ParentCompositePodGroup(*pg.parent)
+		}
+		obj := w.Obj()
+		cache.AddGenericPodGroup(fwk.NewGenericPodGroup(obj))
+		if err := client.Tracker().Add(obj); err != nil {
+			if err := client.Tracker().Update(schedulingv1beta1.SchemeGroupVersion.WithResource("podgroups"), obj, ns); err != nil {
+				t.Fatalf("Failed to add or update PodGroup %s in tracker: %v", obj.Name, err)
 			}
 		}
-		cpg := &schedulingv1alpha3.CompositePodGroup{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
-			Spec: schedulingv1alpha3.CompositePodGroupSpec{
-				SchedulingPolicy:            policy,
-				ParentCompositePodGroupName: parentCPG,
-			},
-		}
-		cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
-		return cpg
-	}
-
-	rootCPG := createCPG("cpg-root", 2, nil)
-	cpgSub1 := createCPG("cpg-sub1", 2, new("cpg-root"))
-	cpgSub2 := createCPG("cpg-sub2", 0, new("cpg-root"))
-	cpgSub3 := createCPG("cpg-sub3", 2, new("cpg-root"))
-
-	pg1 := createPG("pg1", 3, "cpg-sub1")
-	pg2 := createPG("pg2", 3, "cpg-sub1")
-	pg3 := createPG("pg3", 3, "cpg-sub1")
-
-	pg4 := createPG("pg4", 0, "cpg-sub2")
-	pg5 := createPG("pg5", 3, "cpg-sub2")
-
-	pg6 := createPG("pg6", 3, "cpg-sub3")
-	pg7 := createPG("pg7", 3, "cpg-sub3")
-
-	var allPods []*v1.Pod
-	queuedPodInfos := make(map[fwk.EntityKey][]*framework.QueuedPodInfo)
-	pgPods := make(map[string][]*v1.Pod)
-
-	createPods := func(pgName string, count int) {
-		for i := range count {
-			pod := st.MakePod().Namespace(ns).Name(fmt.Sprintf("%s-pod-%d", pgName, i)).
-				UID(fmt.Sprintf("%s-pod-%d", pgName, i)).
-				PodGroupName(pgName).Priority(100).SchedulerName("test-scheduler").Obj()
-
-			allPods = append(allPods, pod)
-			key := fwk.PodGroupKey(ns, pgName)
-			queuedPodInfos[key] = append(queuedPodInfos[key], &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: pod}})
-			pgPods[pgName] = append(pgPods[pgName], pod)
-			cache.AddPodGroupMember(pod)
-		}
-	}
-
-	createPods("pg1", 3)
-	createPods("pg2", 3)
-	createPods("pg3", 3)
-	createPods("pg4", 3)
-	createPods("pg5", 3)
-	createPods("pg6", 3)
-	createPods("pg7", 3)
-
-	podGroupInfo := &framework.QueuedPodGroupInfo{
-		QueuedPodInfos: queuedPodInfos,
-		PodGroupInfo: &framework.PodGroupInfo{GenericPodGroup: fwk.NewGenericCompositePodGroup(rootCPG), UnscheduledPods: allPods, Children: []*framework.PodGroupInfo{
-			{GenericPodGroup: fwk.NewGenericCompositePodGroup(cpgSub1), Children: []*framework.PodGroupInfo{
-				{GenericPodGroup: fwk.NewGenericPodGroup(pg1), UnscheduledPods: pgPods["pg1"]},
-				{GenericPodGroup: fwk.NewGenericPodGroup(pg2), UnscheduledPods: pgPods["pg2"]},
-				{GenericPodGroup: fwk.NewGenericPodGroup(pg3), UnscheduledPods: pgPods["pg3"]},
-			},
-			},
-			{GenericPodGroup: fwk.NewGenericCompositePodGroup(cpgSub2), Children: []*framework.PodGroupInfo{
-				{GenericPodGroup: fwk.NewGenericPodGroup(pg4), UnscheduledPods: pgPods["pg4"]},
-				{GenericPodGroup: fwk.NewGenericPodGroup(pg5), UnscheduledPods: pgPods["pg5"]},
-			},
-			},
-			{GenericPodGroup: fwk.NewGenericCompositePodGroup(cpgSub3), Children: []*framework.PodGroupInfo{
-				{GenericPodGroup: fwk.NewGenericPodGroup(pg6), UnscheduledPods: pgPods["pg6"]},
-				{GenericPodGroup: fwk.NewGenericPodGroup(pg7), UnscheduledPods: pgPods["pg7"]},
-			},
-			},
-		},
-		},
-	}
-
-	fakePlugin := &fakePodGroupPlugin{
-		filterStatus: map[string]*fwk.Status{
-			"pg3-pod-0": fwk.NewStatus(fwk.Unschedulable),
-			"pg3-pod-1": fwk.NewStatus(fwk.Unschedulable),
-			"pg3-pod-2": fwk.NewStatus(fwk.Unschedulable),
-			"pg7-pod-0": fwk.NewStatus(fwk.Unschedulable),
-			"pg7-pod-1": fwk.NewStatus(fwk.Unschedulable),
-			"pg7-pod-2": fwk.NewStatus(fwk.Unschedulable),
-			"pg1-pod-0": nil,
-			"pg1-pod-1": nil,
-			"pg1-pod-2": nil,
-			"pg2-pod-0": nil,
-			"pg2-pod-1": nil,
-			"pg2-pod-2": nil,
-			"pg4-pod-0": nil,
-			"pg4-pod-1": nil,
-			"pg4-pod-2": nil,
-			"pg5-pod-0": nil,
-			"pg5-pod-1": nil,
-			"pg5-pod-2": nil,
-			"pg6-pod-0": nil,
-			"pg6-pod-1": nil,
-			"pg6-pod-2": nil,
-		},
-	}
-
-	gangPluginFactory := func(ctx context.Context, obj runtime.Object, handle fwk.Handle) (fwk.Plugin, error) {
-		return gangscheduling.New(ctx, obj, handle, feature.Features{EnableTopologyAwareWorkloadScheduling: true, EnableCompositePodGroup: true})
-	}
-
-	registry := []tf.RegisterPluginFunc{
-		tf.RegisterFilterPlugin(fakePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
-			return fakePlugin, nil
-		}),
-		tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
-		tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
-		tf.RegisterPlacementFeasiblePlugin(gangscheduling.Name, gangPluginFactory),
-	}
-
-	clientObjs := []runtime.Object{testNode, rootCPG, cpgSub1, cpgSub2, cpgSub3, pg1, pg2, pg3, pg4, pg5, pg6, pg7}
-	for _, pod := range allPods {
-		clientObjs = append(clientObjs, pod)
-	}
-	client := clientsetfake.NewSimpleClientset(clientObjs...)
-	informerFactory := informers.NewSharedInformerFactory(client, 0)
-
-	informerFactory.Start(ctx.Done())
-	informerFactory.WaitForCacheSync(ctx.Done())
-	queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
-	snapshot := internalcache.NewEmptySnapshot()
-
-	schedFwk, err := tf.NewFramework(ctx, registry, "test-scheduler",
-		frameworkruntime.WithInformerFactory(informerFactory),
-		frameworkruntime.WithSnapshotSharedLister(snapshot),
-		frameworkruntime.WithPodNominator(queue),
-		frameworkruntime.WithPodActivator(queue),
-		frameworkruntime.WithClientSet(client),
-		frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
-		frameworkruntime.WithWaitingPods(frameworkruntime.NewWaitingPodsMap()),
-		frameworkruntime.WithPodsInPreBind(frameworkruntime.NewPodsInPreBindMap()),
-		frameworkruntime.WithPodGroupManager(cache),
-	)
-	informerFactory.Start(ctx.Done())
-	informerFactory.WaitForCacheSync(ctx.Done())
-	if err != nil {
-		t.Fatalf("Failed to create new framework: %v", err)
-	}
-
-	handledPods := make(map[string]*fwk.Status)
-	var lock sync.Mutex
-
-	sched := &Scheduler{
-		Profiles:         profile.Map{"test-scheduler": schedFwk},
-		SchedulingQueue:  internalqueue.NewTestQueue(ctx, nil),
-		Cache:            cache,
-		client:           client,
-		nodeInfoSnapshot: snapshot, // will be updated by UpdateSnapshot
-		FailureHandler: func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *fwk.NominatingInfo, start time.Time) {
-			lock.Lock()
-			defer lock.Unlock()
-			handledPods[p.Pod.Name] = status
-		},
-	}
-	initTestAlgorithm(sched)
-
-	// Run the scheduling cycle
-	if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
-		t.Fatalf("Failed to update snapshot: %v", err)
-	}
-	t.Logf("Node info list size: %d", func() int { l, _ := snapshot.NodeInfos().List(); return len(l) }())
-	podGroupCycleState := framework.NewCycleState()
-	podGroupCycleState.SetPodGroupCycleState(podGroupCycleState)
-	sched.podGroupCycle(ctx, schedFwk, podGroupCycleState, podGroupInfo, time.Now())
-
-	lock.Lock()
-	defer lock.Unlock()
-
-	// Verify the results
-	successPods := []string{
-		"pg1-pod-0", "pg1-pod-1", "pg1-pod-2",
-		"pg2-pod-0", "pg2-pod-1", "pg2-pod-2",
-		"pg4-pod-0", "pg4-pod-1", "pg4-pod-2",
-		"pg5-pod-0", "pg5-pod-1", "pg5-pod-2",
-	}
-
-	failPods := []string{
-		"pg3-pod-0", "pg3-pod-1", "pg3-pod-2",
-		"pg6-pod-0", "pg6-pod-1", "pg6-pod-2",
-		"pg7-pod-0", "pg7-pod-1", "pg7-pod-2",
-	}
-
-	for _, p := range successPods {
-		if status, ok := handledPods[p]; ok {
-			t.Errorf("Expected pod %s to be scheduled successfully, but got error: %v", p, status.AsError())
-		}
-	}
-
-	for _, p := range failPods {
-		if _, ok := handledPods[p]; !ok {
-			t.Errorf("Expected pod %s to fail, but it was scheduled successfully", p)
-		}
-	}
-}
-
-// TestCPGMinGroupCount_Internal verifies that a Gang CompositePodGroup schedules its children
-// if at least MinGroupCount of them are fully schedulable.
-//
-// Tree structure:
-//
-//	   cpg-root (Gang, MinGroup: 2)
-//	  /             |              \
-//	pg1            pg2            pg3
-//	(S)            (S)            (F)
-//
-// (S) = Success
-// (F) = Fail
-func TestCPGMinGroupCount_Internal(t *testing.T) {
-	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
-		features.CompositePodGroup:               true,
-		features.GenericWorkload:                 true,
-		features.TopologyAwareWorkloadScheduling: true,
-	})
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	logger := klog.FromContext(ctx)
-
-	// Capacity matches 2 groups. pg3 pods fail.
-	testNode := st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()
-	cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
-	cache.AddNode(logger, testNode)
-
-	ns := "default"
-
-	createCPG := func(name string, minCount int32, parentCPG *string) *schedulingv1alpha3.CompositePodGroup {
-		var policy schedulingv1alpha3.CompositePodGroupSchedulingPolicy
-		if minCount > 0 {
-			policy = schedulingv1alpha3.CompositePodGroupSchedulingPolicy{
-				Gang: &schedulingv1alpha3.CompositeGangSchedulingPolicy{MinGroupCount: minCount},
+		if allPGSpecs != nil {
+			found := false
+			for i, existing := range *allPGSpecs {
+				if existing.name == pg.name {
+					(*allPGSpecs)[i] = pg
+					found = true
+					break
+				}
 			}
-		} else {
-			policy = schedulingv1alpha3.CompositePodGroupSchedulingPolicy{
-				Basic: &schedulingv1alpha3.CompositeBasicSchedulingPolicy{},
+			if !found {
+				*allPGSpecs = append(*allPGSpecs, pg)
 			}
 		}
-		cpg := &schedulingv1alpha3.CompositePodGroup{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
-			Spec: schedulingv1alpha3.CompositePodGroupSpec{
-				SchedulingPolicy:            policy,
-				ParentCompositePodGroupName: parentCPG,
+		return obj
+	}
+
+	tests := []struct {
+		name   string
+		nodes  []*v1.Node
+		phases []phaseSpec
+	}{
+		{
+			name:  "root CPG with gang policy schedules satisfied child PodGroups while unschedulable PodGroup fails",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{{
+				cpgs:            []cpgSpec{{"cpg-root", 2, nil}},
+				pgs:             []pgSpec{{"pg1", 1, new("cpg-root")}, {"pg2", 1, new("cpg-root")}, {"pg3", 1, new("cpg-root")}},
+				pods:            map[string]podSpec{"pg1": {1, true}, "pg2": {1, true}, "pg3": {1, false}},
+				wantSuccessPods: []string{"pg1-pod-0", "pg2-pod-0"},
+				wantFailPods:    []string{"pg3-pod-0"},
+			}},
+		},
+		{
+			name:  "multi-level CPG hierarchy schedules satisfied sub-CPGs and fails unsatisfied sub-CPG",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "100"}).Obj()},
+			phases: []phaseSpec{{
+				cpgs:            []cpgSpec{{"cpg-root", 2, nil}, {"cpg-sub1", 2, new("cpg-root")}, {"cpg-sub2", 0, new("cpg-root")}, {"cpg-sub3", 2, new("cpg-root")}},
+				pgs:             []pgSpec{{"pg1", 3, new("cpg-sub1")}, {"pg2", 3, new("cpg-sub1")}, {"pg3", 3, new("cpg-sub1")}, {"pg4", 0, new("cpg-sub2")}, {"pg5", 3, new("cpg-sub2")}, {"pg6", 3, new("cpg-sub3")}, {"pg7", 3, new("cpg-sub3")}},
+				pods:            map[string]podSpec{"pg1": {3, true}, "pg2": {3, true}, "pg3": {3, false}, "pg4": {3, true}, "pg5": {3, true}, "pg6": {3, true}, "pg7": {3, false}},
+				wantSuccessPods: []string{"pg1-pod-0", "pg1-pod-1", "pg1-pod-2", "pg2-pod-0", "pg2-pod-1", "pg2-pod-2", "pg4-pod-0", "pg4-pod-1", "pg4-pod-2", "pg5-pod-0", "pg5-pod-1", "pg5-pod-2"},
+				wantFailPods:    []string{"pg3-pod-0", "pg3-pod-1", "pg3-pod-2", "pg6-pod-0", "pg6-pod-1", "pg6-pod-2", "pg7-pod-0", "pg7-pod-1", "pg7-pod-2"},
+			}},
+		},
+		{
+			name:  "root CPG with minGroupCount=2 schedules 2 valid PodGroups and fails 1 unschedulable PodGroup",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{{
+				cpgs:            []cpgSpec{{"cpg-root", 2, nil}},
+				pgs:             []pgSpec{{"pg1", 3, new("cpg-root")}, {"pg2", 3, new("cpg-root")}, {"pg3", 3, new("cpg-root")}},
+				pods:            map[string]podSpec{"pg1": {3, true}, "pg2": {3, true}, "pg3": {3, false}},
+				wantSuccessPods: []string{"pg1-pod-0", "pg1-pod-1", "pg1-pod-2", "pg2-pod-0", "pg2-pod-1", "pg2-pod-2"},
+				wantFailPods:    []string{"pg3-pod-0", "pg3-pod-1", "pg3-pod-2"},
+			}},
+		},
+		{
+			name:  "root CPG with basic policy schedules valid gang PodGroup and fails unschedulable gang PodGroup independently",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{{
+				cpgs:            []cpgSpec{{"cpg-root", 0, nil}},
+				pgs:             []pgSpec{{"pg1", 3, new("cpg-root")}, {"pg2", 3, new("cpg-root")}},
+				pods:            map[string]podSpec{"pg1": {3, true}, "pg2": {3, false}},
+				wantSuccessPods: []string{"pg1-pod-0", "pg1-pod-1", "pg1-pod-2"},
+				wantFailPods:    []string{"pg2-pod-0", "pg2-pod-1", "pg2-pod-2"},
+			}},
+		},
+		{
+			name:  "root CPG fails all child PodGroups when total available child groups is less than minGroupCount",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{{
+				cpgs:            []cpgSpec{{"cpg-root", 3, nil}},
+				pgs:             []pgSpec{{"pg1", 1, new("cpg-root")}, {"pg2", 1, new("cpg-root")}},
+				pods:            map[string]podSpec{"pg1": {1, true}, "pg2": {1, true}},
+				wantSuccessPods: nil,
+				wantFailPods:    []string{"pg1-pod-0", "pg2-pod-0"},
+			}},
+		},
+		{
+			// Verifies that scheduling an empty root CPG with BasicPolicy does not fail or panic when no children exist.
+			name:  "empty root CPG with basic policy and no children schedules cleanly without error",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{{
+				cpgs:            []cpgSpec{{"cpg-root", 0, nil}},
+				wantSuccessPods: nil,
+				wantFailPods:    nil,
+			}},
+		},
+		{
+			// Verifies that scheduling an empty root CPG with MinGroupCount=1 does not panic when no children exist.
+			name:  "empty root CPG with gang policy (minGroupCount=1) and no children schedules cleanly without error",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{{
+				cpgs:            []cpgSpec{{"cpg-root", 1, nil}},
+				wantSuccessPods: nil,
+				wantFailPods:    nil,
+			}},
+		},
+		{
+			name:  "root CPG with basic policy schedules single schedulable child PodGroup",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{{
+				cpgs:            []cpgSpec{{"cpg-root", 0, nil}},
+				pgs:             []pgSpec{{"pg1", 1, new("cpg-root")}},
+				pods:            map[string]podSpec{"pg1": {1, true}},
+				wantSuccessPods: []string{"pg1-pod-0"},
+				wantFailPods:    nil,
+			}},
+		},
+		{
+			name:  "root CPG with basic policy fails when single child PodGroup is unschedulable",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{{
+				cpgs:            []cpgSpec{{"cpg-root", 0, nil}},
+				pgs:             []pgSpec{{"pg1", 1, new("cpg-root")}},
+				pods:            map[string]podSpec{"pg1": {1, false}},
+				wantSuccessPods: nil,
+				wantFailPods:    []string{"pg1-pod-0"},
+			}},
+		},
+		{
+			name:  "root CPG with basic policy schedules multiple schedulable child PodGroups",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{{
+				cpgs:            []cpgSpec{{"cpg-root", 0, nil}},
+				pgs:             []pgSpec{{"pg1", 1, new("cpg-root")}, {"pg2", 1, new("cpg-root")}},
+				pods:            map[string]podSpec{"pg1": {1, true}, "pg2": {1, true}},
+				wantSuccessPods: []string{"pg1-pod-0", "pg2-pod-0"},
+				wantFailPods:    nil,
+			}},
+		},
+		{
+			name:  "root CPG with gang policy (minGroupCount=2) schedules all child PodGroups when all are schedulable",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{{
+				cpgs:            []cpgSpec{{"cpg-root", 2, nil}},
+				pgs:             []pgSpec{{"pg1", 1, new("cpg-root")}, {"pg2", 1, new("cpg-root")}},
+				pods:            map[string]podSpec{"pg1": {1, true}, "pg2": {1, true}},
+				wantSuccessPods: []string{"pg1-pod-0", "pg2-pod-0"},
+				wantFailPods:    nil,
+			}},
+		},
+		{
+			name:  "hierarchical CPG with intermediate CPG and direct PodGroup under basic policy schedules successfully",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{{
+				cpgs:            []cpgSpec{{"cpg-root", 0, nil}, {"cpg-sub", 0, new("cpg-root")}},
+				pgs:             []pgSpec{{"pg1", 1, new("cpg-sub")}, {"pg2", 1, new("cpg-root")}},
+				pods:            map[string]podSpec{"pg1": {1, true}, "pg2": {1, true}},
+				wantSuccessPods: []string{"pg1-pod-0", "pg2-pod-0"},
+				wantFailPods:    nil,
+			}},
+		},
+		{
+			name:  "hierarchical CPG with intermediate CPG and direct PodGroup under gang policy schedules successfully",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{{
+				cpgs:            []cpgSpec{{"cpg-root", 2, nil}, {"cpg-sub", 1, new("cpg-root")}},
+				pgs:             []pgSpec{{"pg1", 1, new("cpg-sub")}, {"pg2", 1, new("cpg-root")}},
+				pods:            map[string]podSpec{"pg1": {1, true}, "pg2": {1, true}},
+				wantSuccessPods: []string{"pg1-pod-0", "pg2-pod-0"},
+				wantFailPods:    nil,
+			}},
+		},
+		{
+			name:  "multi-phase: unsatisfiable CPG hierarchy fails initially and succeeds after adding more child CPGs and PodGroups",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{
+				{
+					cpgs:            []cpgSpec{{"cpg-root", 3, nil}, {"cpg-sub1", 1, new("cpg-root")}, {"cpg-sub2", 1, new("cpg-root")}},
+					pgs:             []pgSpec{{"pg1", 1, new("cpg-sub1")}, {"pg2", 1, new("cpg-sub2")}},
+					pods:            map[string]podSpec{"pg1": {1, false}, "pg2": {1, true}},
+					wantSuccessPods: nil,
+					wantFailPods:    []string{"pg1-pod-0", "pg2-pod-0"},
+				},
+				{
+					cpgs:            []cpgSpec{{"cpg-sub3", 1, new("cpg-root")}},
+					pgs:             []pgSpec{{"pg3", 1, new("cpg-sub3")}, {"pg4", 1, new("cpg-root")}},
+					pods:            map[string]podSpec{"pg3": {1, true}, "pg4": {1, true}},
+					wantSuccessPods: []string{"pg2-pod-0", "pg3-pod-0", "pg4-pod-0"},
+					wantFailPods:    []string{"pg1-pod-0"},
+				},
 			},
-		}
-		cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
-		return cpg
-	}
-
-	createPG := func(name string, minCount int32, parentCPG string) *schedulingv1beta1.PodGroup {
-		var policy schedulingv1beta1.PodGroupSchedulingPolicy
-		if minCount > 0 {
-			policy = schedulingv1beta1.PodGroupSchedulingPolicy{
-				Gang: &schedulingv1beta1.GangSchedulingPolicy{MinCount: minCount},
-			}
-		} else {
-			policy = schedulingv1beta1.PodGroupSchedulingPolicy{
-				Basic: &schedulingv1beta1.BasicSchedulingPolicy{},
-			}
-		}
-		pg := &schedulingv1beta1.PodGroup{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
-			Spec: schedulingv1beta1.PodGroupSpec{
-				SchedulingPolicy:            policy,
-				ParentCompositePodGroupName: new(parentCPG),
+		},
+		{
+			name:  "multi-phase: schedulable root CPG schedules initial PodGroup and subsequently added PodGroup",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{
+				{
+					cpgs:            []cpgSpec{{"cpg-root", 1, nil}},
+					pgs:             []pgSpec{{"pg1", 1, new("cpg-root")}},
+					pods:            map[string]podSpec{"pg1": {1, true}},
+					wantSuccessPods: []string{"pg1-pod-0"},
+					wantFailPods:    nil,
+				},
+				{
+					pgs:             []pgSpec{{"pg2", 1, new("cpg-root")}},
+					pods:            map[string]podSpec{"pg2": {1, true}},
+					wantSuccessPods: []string{"pg2-pod-0"},
+					wantFailPods:    nil,
+				},
 			},
-		}
-		cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg))
-		return pg
-	}
-
-	rootCPG := createCPG("cpg-root", 2, nil)
-
-	pg1 := createPG("pg1", 3, "cpg-root")
-	pg2 := createPG("pg2", 3, "cpg-root")
-	pg3 := createPG("pg3", 3, "cpg-root")
-
-	queuedPodInfos := make(map[fwk.EntityKey][]*framework.QueuedPodInfo)
-	pgPods := make(map[string][]*v1.Pod)
-	var allPods []*v1.Pod
-
-	createPods := func(pgName string, count int, schedulable bool) {
-		for i := range count {
-			pod := st.MakePod().Namespace(ns).Name(fmt.Sprintf("%s-pod-%d", pgName, i)).UID(fmt.Sprintf("%s-pod-%d", pgName, i)).
-				PodGroupName(pgName).Priority(100).Obj()
-
-			if !schedulable && i == 0 {
-				pod.Spec.Containers = []v1.Container{{
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("100")},
-					},
-				}}
-			} else {
-				pod.Spec.Containers = []v1.Container{{
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
-					},
-				}}
-			}
-
-			podInfo := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: pod}}
-			key := fwk.PodGroupKey(ns, pgName)
-			queuedPodInfos[key] = append(queuedPodInfos[key], podInfo)
-			pgPods[pgName] = append(pgPods[pgName], pod)
-			allPods = append(allPods, pod)
-			cache.AddPodGroupMember(pod)
-		}
-	}
-
-	createPods("pg1", 3, true)
-	createPods("pg2", 3, true)
-	createPods("pg3", 3, false)
-
-	snapshot := internalcache.NewEmptySnapshot()
-	clientObjs := []runtime.Object{testNode, rootCPG, pg1, pg2, pg3}
-	for _, pod := range allPods {
-		clientObjs = append(clientObjs, pod)
-	}
-	client := clientsetfake.NewSimpleClientset(clientObjs...)
-	informerFactory := informers.NewSharedInformerFactory(client, 0)
-
-	fakePlugin := &fakePodGroupPlugin{
-		filterStatus: map[string]*fwk.Status{
-			"pg1-pod-0": nil,
-			"pg1-pod-1": nil,
-			"pg1-pod-2": nil,
-			"pg2-pod-0": nil,
-			"pg2-pod-1": nil,
-			"pg2-pod-2": nil,
-			"pg3-pod-0": fwk.NewStatus(fwk.Unschedulable, "insufficient cpu"),
-			"pg3-pod-1": fwk.NewStatus(fwk.Unschedulable, "insufficient cpu"),
-			"pg3-pod-2": fwk.NewStatus(fwk.Unschedulable, "insufficient cpu"),
 		},
-	}
-
-	gangPluginFactory := func(ctx context.Context, obj runtime.Object, handle fwk.Handle) (fwk.Plugin, error) {
-		return gangscheduling.New(ctx, obj, handle, feature.Features{EnableTopologyAwareWorkloadScheduling: true, EnableCompositePodGroup: true})
-	}
-
-	registry := []tf.RegisterPluginFunc{
-		tf.RegisterFilterPlugin(fakePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
-			return fakePlugin, nil
-		}),
-		tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
-		tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
-		tf.RegisterPlacementFeasiblePlugin(gangscheduling.Name, gangPluginFactory),
-	}
-
-	queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
-	schedFwk, err := tf.NewFramework(ctx, registry, "test-scheduler",
-		frameworkruntime.WithInformerFactory(informerFactory),
-		frameworkruntime.WithSnapshotSharedLister(snapshot),
-		frameworkruntime.WithPodNominator(queue),
-		frameworkruntime.WithPodActivator(queue),
-		frameworkruntime.WithClientSet(client),
-		frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
-		frameworkruntime.WithWaitingPods(frameworkruntime.NewWaitingPodsMap()),
-		frameworkruntime.WithPodsInPreBind(frameworkruntime.NewPodsInPreBindMap()),
-		frameworkruntime.WithPodGroupManager(cache),
-	)
-	informerFactory.Start(ctx.Done())
-	informerFactory.WaitForCacheSync(ctx.Done())
-	if err != nil {
-		t.Fatalf("Failed to create new framework: %v", err)
-	}
-
-	handledPods := make(map[string]*fwk.Status)
-	var lock sync.Mutex
-
-	sched := &Scheduler{
-		Profiles:         profile.Map{"test-scheduler": schedFwk},
-		SchedulingQueue:  internalqueue.NewTestQueue(ctx, nil),
-		Cache:            cache,
-		client:           client,
-		nodeInfoSnapshot: snapshot,
-		FailureHandler: func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *fwk.NominatingInfo, start time.Time) {
-			lock.Lock()
-			defer lock.Unlock()
-			handledPods[p.Pod.Name] = status
-		},
-	}
-	initTestAlgorithm(sched)
-
-	podGroupInfo := &framework.QueuedPodGroupInfo{
-		QueuedPodInfos: queuedPodInfos,
-		PodGroupInfo: &framework.PodGroupInfo{GenericPodGroup: fwk.NewGenericCompositePodGroup(rootCPG), UnscheduledPods: allPods, Children: []*framework.PodGroupInfo{
-			{GenericPodGroup: fwk.NewGenericPodGroup(pg1), UnscheduledPods: pgPods["pg1"]},
-			{GenericPodGroup: fwk.NewGenericPodGroup(pg2), UnscheduledPods: pgPods["pg2"]},
-			{GenericPodGroup: fwk.NewGenericPodGroup(pg3), UnscheduledPods: pgPods["pg3"]},
-		},
-		},
-	}
-
-	if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
-		t.Fatalf("Failed to update snapshot: %v", err)
-	}
-	sched.podGroupCycle(ctx, schedFwk, framework.NewCycleState(), podGroupInfo, time.Now())
-
-	lock.Lock()
-	defer lock.Unlock()
-
-	successPods := []string{
-		"pg1-pod-0", "pg1-pod-1", "pg1-pod-2",
-		"pg2-pod-0", "pg2-pod-1", "pg2-pod-2",
-	}
-
-	for _, p := range successPods {
-		if status, ok := handledPods[p]; ok {
-			t.Errorf("Expected pod %s to be scheduled successfully, but got error: %v", p, status.AsError())
-		}
-	}
-
-	failPods := []string{
-		"pg3-pod-0", "pg3-pod-1", "pg3-pod-2",
-	}
-
-	for _, p := range failPods {
-		if _, ok := handledPods[p]; !ok {
-			t.Errorf("Expected pod %s to fail scheduling, but it was scheduled successfully", p)
-		}
-	}
-}
-
-// TestCPGBasicWithGangChildren_Internal verifies that a Basic CompositePodGroup allows its ready
-// child Gang groups to schedule independently of each other.
-//
-// Tree structure:
-//
-//	   cpg-root (Basic)
-//	  /            \
-//	pg1            pg2
-//	(S)            (F)
-//
-// (S) = Success
-// (F) = Fail
-func TestCPGBasicWithGangChildren_Internal(t *testing.T) {
-	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
-		features.CompositePodGroup:               true,
-		features.GenericWorkload:                 true,
-		features.TopologyAwareWorkloadScheduling: true,
-	})
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	logger := klog.FromContext(ctx)
-
-	testNode := st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()
-	cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
-	cache.AddNode(logger, testNode)
-
-	ns := "default"
-
-	createCPG := func(name string, minCount int32, parentCPG *string) *schedulingv1alpha3.CompositePodGroup {
-		var policy schedulingv1alpha3.CompositePodGroupSchedulingPolicy
-		if minCount > 0 {
-			policy = schedulingv1alpha3.CompositePodGroupSchedulingPolicy{
-				Gang: &schedulingv1alpha3.CompositeGangSchedulingPolicy{MinGroupCount: minCount},
-			}
-		} else {
-			policy = schedulingv1alpha3.CompositePodGroupSchedulingPolicy{
-				Basic: &schedulingv1alpha3.CompositeBasicSchedulingPolicy{},
-			}
-		}
-		cpg := &schedulingv1alpha3.CompositePodGroup{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
-			Spec: schedulingv1alpha3.CompositePodGroupSpec{
-				SchedulingPolicy:            policy,
-				ParentCompositePodGroupName: parentCPG,
+		{
+			name:  "multi-phase: schedulable root CPG schedules initial PodGroup and subsequently added child CPG hierarchy",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{
+				{
+					cpgs:            []cpgSpec{{"cpg-root", 1, nil}},
+					pgs:             []pgSpec{{"pg1", 1, new("cpg-root")}},
+					pods:            map[string]podSpec{"pg1": {1, true}},
+					wantSuccessPods: []string{"pg1-pod-0"},
+					wantFailPods:    nil,
+				},
+				{
+					cpgs:            []cpgSpec{{"cpg-sub1", 1, new("cpg-root")}},
+					pgs:             []pgSpec{{"pg2", 1, new("cpg-sub1")}},
+					pods:            map[string]podSpec{"pg2": {1, true}},
+					wantSuccessPods: []string{"pg2-pod-0"},
+					wantFailPods:    nil,
+				},
 			},
-		}
-		cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
-		return cpg
-	}
-
-	createPG := func(name string, minCount int32, parentCPG string) *schedulingv1beta1.PodGroup {
-		var policy schedulingv1beta1.PodGroupSchedulingPolicy
-		if minCount > 0 {
-			policy = schedulingv1beta1.PodGroupSchedulingPolicy{
-				Gang: &schedulingv1beta1.GangSchedulingPolicy{MinCount: minCount},
-			}
-		} else {
-			policy = schedulingv1beta1.PodGroupSchedulingPolicy{
-				Basic: &schedulingv1beta1.BasicSchedulingPolicy{},
-			}
-		}
-		pg := &schedulingv1beta1.PodGroup{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
-			Spec: schedulingv1beta1.PodGroupSpec{
-				SchedulingPolicy:            policy,
-				ParentCompositePodGroupName: new(parentCPG),
+		},
+		{
+			name:  "multi-phase: gang PodGroup under CPG fails when under-replicated and succeeds after remaining pods arrive",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{
+				{
+					cpgs:            []cpgSpec{{"cpg-root", 1, nil}},
+					pgs:             []pgSpec{{"pg1", 2, new("cpg-root")}},
+					pods:            map[string]podSpec{"pg1": {1, true}},
+					wantSuccessPods: nil,
+					wantFailPods:    []string{"pg1-pod-0"},
+				},
+				{
+					pods:            map[string]podSpec{"pg1": {1, true}},
+					wantSuccessPods: []string{"pg1-pod-0", "pg1-pod-1"},
+					wantFailPods:    nil,
+				},
 			},
-		}
-		cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg))
-		return pg
+		},
+		{
+			name:  "multi-phase: unsatisfied CPG hierarchy becomes schedulable after root minGroupCount is reduced",
+			nodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+			phases: []phaseSpec{
+				{
+					cpgs:            []cpgSpec{{"cpg-root", 3, nil}},
+					pgs:             []pgSpec{{"pg1", 1, new("cpg-root")}, {"pg2", 1, new("cpg-root")}},
+					pods:            map[string]podSpec{"pg1": {1, true}, "pg2": {1, true}},
+					wantSuccessPods: nil,
+					wantFailPods:    []string{"pg1-pod-0", "pg2-pod-0"},
+				},
+				{
+					cpgs:            []cpgSpec{{"cpg-root", 2, nil}},
+					wantSuccessPods: []string{"pg1-pod-0", "pg2-pod-0"},
+					wantFailPods:    nil,
+				},
+			},
+		},
 	}
 
-	rootCPG := createCPG("cpg-root", 0, nil)
-
-	pg1 := createPG("pg1", 3, "cpg-root")
-	pg2 := createPG("pg2", 3, "cpg-root")
-
-	queuedPodInfos := make(map[fwk.EntityKey][]*framework.QueuedPodInfo)
-	pgPods := make(map[string][]*v1.Pod)
-	var allPods []*v1.Pod
-
-	createPods := func(pgName string, count int, schedulable bool) {
-		for i := range count {
-			pod := st.MakePod().Namespace(ns).Name(fmt.Sprintf("%s-pod-%d", pgName, i)).UID(fmt.Sprintf("%s-pod-%d", pgName, i)).
-				PodGroupName(pgName).Priority(100).Obj()
-
-			if !schedulable && i == 0 {
-				pod.Spec.Containers = []v1.Container{{
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("100")},
-					},
-				}}
-			} else {
-				pod.Spec.Containers = []v1.Container{{
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
-					},
-				}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ns := "default"
+			cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
+			for _, node := range tt.nodes {
+				if node.Status.Allocatable == nil {
+					node.Status.Allocatable = node.Status.Capacity
+				}
+				cache.AddNode(logger, node)
 			}
 
-			podInfo := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: pod}}
-			key := fwk.PodGroupKey(ns, pgName)
-			queuedPodInfos[key] = append(queuedPodInfos[key], podInfo)
-			pgPods[pgName] = append(pgPods[pgName], pod)
-			allPods = append(allPods, pod)
-			cache.AddPodGroupMember(pod)
-		}
-	}
+			var allCPGSpecs []cpgSpec
+			var allPGSpecs []pgSpec
+			var rootCPGName string
 
-	createPods("pg1", 3, true)
-	createPods("pg2", 3, false)
+			queuedPodInfos := make(map[fwk.EntityKey][]*framework.QueuedPodInfo)
+			pgPods := make(map[string][]*v1.Pod)
+			var allPods []*v1.Pod
+			filterStatus := make(map[string]*fwk.Status)
+			podIndexMap := make(map[string]int)
 
-	snapshot := internalcache.NewEmptySnapshot()
-	clientObjs := []runtime.Object{testNode, rootCPG, pg1, pg2}
-	for _, pod := range allPods {
-		clientObjs = append(clientObjs, pod)
-	}
-	client := clientsetfake.NewSimpleClientset(clientObjs...)
-	informerFactory := informers.NewSharedInformerFactory(client, 0)
+			clientObjs := []runtime.Object{}
+			for _, node := range tt.nodes {
+				clientObjs = append(clientObjs, node)
+			}
+			client := clientsetfake.NewSimpleClientset(clientObjs...)
 
-	fakePlugin := &fakePodGroupPlugin{
-		filterStatus: map[string]*fwk.Status{
-			"pg1-pod-0": nil,
-			"pg1-pod-1": nil,
-			"pg1-pod-2": nil,
-			"pg2-pod-0": fwk.NewStatus(fwk.Unschedulable, "insufficient cpu"),
-			"pg2-pod-1": fwk.NewStatus(fwk.Unschedulable, "insufficient cpu"),
-			"pg2-pod-2": fwk.NewStatus(fwk.Unschedulable, "insufficient cpu"),
-		},
-	}
+			createPods := func(podsMap map[string]podSpec) {
+				for pgName, spec := range podsMap {
+					startIndex := podIndexMap[pgName]
+					for i := 0; i < spec.count; i++ {
+						podIdx := startIndex + i
+						podName := fmt.Sprintf("%s-pod-%d", pgName, podIdx)
+						pod := st.MakePod().Namespace(ns).Name(podName).UID(podName).
+							PodGroupName(pgName).Priority(100).SchedulerName("test-scheduler").Obj()
 
-	gangPluginFactory := func(ctx context.Context, obj runtime.Object, handle fwk.Handle) (fwk.Plugin, error) {
-		return gangscheduling.New(ctx, obj, handle, feature.Features{EnableTopologyAwareWorkloadScheduling: true, EnableCompositePodGroup: true})
-	}
+						if !spec.schedulable && i == 0 {
+							pod.Spec.Containers = []v1.Container{{
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("100")},
+								},
+							}}
+							filterStatus[podName] = fwk.NewStatus(fwk.Unschedulable, "insufficient cpu")
+						} else {
+							pod.Spec.Containers = []v1.Container{{
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
+								},
+							}}
+							filterStatus[podName] = nil
+						}
 
-	registry := []tf.RegisterPluginFunc{
-		tf.RegisterFilterPlugin(fakePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
-			return fakePlugin, nil
-		}),
-		tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
-		tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
-		tf.RegisterPlacementFeasiblePlugin(gangscheduling.Name, gangPluginFactory),
-	}
+						key := fwk.PodGroupKey(ns, pgName)
+						queuedPodInfos[key] = append(queuedPodInfos[key], &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: pod}})
+						pgPods[pgName] = append(pgPods[pgName], pod)
+						allPods = append(allPods, pod)
+						cache.AddPodGroupMember(pod)
+						if err := client.Tracker().Add(pod); err != nil {
+							if err := client.Tracker().Update(v1.SchemeGroupVersion.WithResource("pods"), pod, ns); err != nil {
+								t.Fatalf("Failed to add or update Pod %s in tracker: %v", pod.Name, err)
+							}
+						}
+					}
+					podIndexMap[pgName] = startIndex + spec.count
+				}
+			}
 
-	queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
-	schedFwk, err := tf.NewFramework(ctx, registry, "test-scheduler",
-		frameworkruntime.WithInformerFactory(informerFactory),
-		frameworkruntime.WithSnapshotSharedLister(snapshot),
-		frameworkruntime.WithPodNominator(queue),
-		frameworkruntime.WithPodActivator(queue),
-		frameworkruntime.WithClientSet(client),
-		frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
-		frameworkruntime.WithWaitingPods(frameworkruntime.NewWaitingPodsMap()),
-		frameworkruntime.WithPodsInPreBind(frameworkruntime.NewPodsInPreBindMap()),
-		frameworkruntime.WithPodGroupManager(cache),
-	)
-	informerFactory.Start(ctx.Done())
-	informerFactory.WaitForCacheSync(ctx.Done())
-	if err != nil {
-		t.Fatalf("Failed to create new framework: %v", err)
-	}
+			var buildPodGroupInfo func(cpgName string) *framework.PodGroupInfo
+			buildPodGroupInfo = func(cpgName string) *framework.PodGroupInfo {
+				var cpg *cpgSpec
+				for i := range allCPGSpecs {
+					if allCPGSpecs[i].name == cpgName {
+						cpg = &allCPGSpecs[i]
+						break
+					}
+				}
+				if cpg == nil {
+					return nil
+				}
 
-	handledPods := make(map[string]*fwk.Status)
-	var lock sync.Mutex
+				cpgObj, _ := cache.CompositePodGroups().Get(ns, cpg.name)
+				info := &framework.PodGroupInfo{
+					GenericPodGroup: fwk.NewGenericCompositePodGroup(cpgObj),
+				}
 
-	sched := &Scheduler{
-		Profiles:         profile.Map{"test-scheduler": schedFwk},
-		SchedulingQueue:  internalqueue.NewTestQueue(ctx, nil),
-		Cache:            cache,
-		client:           client,
-		nodeInfoSnapshot: snapshot,
-		FailureHandler: func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *fwk.NominatingInfo, start time.Time) {
-			lock.Lock()
-			defer lock.Unlock()
-			handledPods[p.Pod.Name] = status
-		},
-	}
-	initTestAlgorithm(sched)
+				for _, child := range allCPGSpecs {
+					if child.parent != nil && *child.parent == cpgName {
+						childInfo := buildPodGroupInfo(child.name)
+						if childInfo != nil {
+							info.Children = append(info.Children, childInfo)
+							info.UnscheduledPods = append(info.UnscheduledPods, childInfo.UnscheduledPods...)
+						}
+					}
+				}
 
-	podGroupInfo := &framework.QueuedPodGroupInfo{
-		QueuedPodInfos: queuedPodInfos,
-		PodGroupInfo: &framework.PodGroupInfo{GenericPodGroup: fwk.NewGenericCompositePodGroup(rootCPG), UnscheduledPods: allPods, Children: []*framework.PodGroupInfo{
-			{GenericPodGroup: fwk.NewGenericPodGroup(pg1), UnscheduledPods: pgPods["pg1"]},
-			{GenericPodGroup: fwk.NewGenericPodGroup(pg2), UnscheduledPods: pgPods["pg2"]},
-		},
-		},
-	}
+				for _, pg := range allPGSpecs {
+					if pg.parent != nil && *pg.parent == cpgName {
+						pods := pgPods[pg.name]
+						pgObj, _ := cache.PodGroups().Get(ns, pg.name)
+						childInfo := &framework.PodGroupInfo{
+							GenericPodGroup: fwk.NewGenericPodGroup(pgObj),
+							UnscheduledPods: pods,
+						}
+						info.Children = append(info.Children, childInfo)
+						info.UnscheduledPods = append(info.UnscheduledPods, pods...)
+					}
+				}
+				return info
+			}
 
-	if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
-		t.Fatalf("Failed to update snapshot: %v", err)
-	}
-	sched.podGroupCycle(ctx, schedFwk, framework.NewCycleState(), podGroupInfo, time.Now())
+			snapshot := internalcache.NewEmptySnapshot()
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
 
-	lock.Lock()
-	defer lock.Unlock()
+			fakePlugin := &fakePodGroupPlugin{
+				filterStatus: filterStatus,
+			}
 
-	successPods := []string{
-		"pg1-pod-0", "pg1-pod-1", "pg1-pod-2",
-	}
+			gangPluginFactory := func(ctx context.Context, obj runtime.Object, handle fwk.Handle) (fwk.Plugin, error) {
+				return gangscheduling.New(ctx, obj, handle, feature.Features{EnableTopologyAwareWorkloadScheduling: true, EnableCompositePodGroup: true})
+			}
 
-	for _, p := range successPods {
-		if status, ok := handledPods[p]; ok {
-			t.Errorf("Expected pod %s to be scheduled successfully, but got error: %v", p, status.AsError())
-		}
-	}
+			registry := []tf.RegisterPluginFunc{
+				tf.RegisterFilterPlugin(fakePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+					return fakePlugin, nil
+				}),
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				tf.RegisterPreEnqueuePlugin(gangscheduling.Name, gangPluginFactory),
+				tf.RegisterPlacementFeasiblePlugin(gangscheduling.Name, gangPluginFactory),
+			}
 
-	failPods := []string{
-		"pg2-pod-0", "pg2-pod-1", "pg2-pod-2",
-	}
+			queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
+			schedFwk, err := tf.NewFramework(ctx, registry, "test-scheduler",
+				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithPodNominator(queue),
+				frameworkruntime.WithPodActivator(queue),
+				frameworkruntime.WithClientSet(client),
+				frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
+				frameworkruntime.WithWaitingPods(frameworkruntime.NewWaitingPodsMap()),
+				frameworkruntime.WithPodsInPreBind(frameworkruntime.NewPodsInPreBindMap()),
+				frameworkruntime.WithPodGroupManager(cache),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create new framework: %v", err)
+			}
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
 
-	for _, p := range failPods {
-		if _, ok := handledPods[p]; !ok {
-			t.Errorf("Expected pod %s to fail scheduling, but it was scheduled successfully", p)
-		}
+			handledPods := make(map[string]*fwk.Status)
+			var lock sync.Mutex
+
+			sched := &Scheduler{
+				Profiles:         profile.Map{"test-scheduler": schedFwk},
+				SchedulingQueue:  internalqueue.NewTestQueue(ctx, nil),
+				Cache:            cache,
+				client:           client,
+				nodeInfoSnapshot: snapshot,
+				FailureHandler: func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *fwk.NominatingInfo, start time.Time) {
+					lock.Lock()
+					defer lock.Unlock()
+					handledPods[p.Pod.Name] = status
+				},
+			}
+			initTestAlgorithm(sched)
+
+			for phaseIdx, phase := range tt.phases {
+				if phaseIdx > 0 {
+					prevPhase := tt.phases[phaseIdx-1]
+					for _, p := range prevPhase.wantSuccessPods {
+						for key, list := range queuedPodInfos {
+							var newList []*framework.QueuedPodInfo
+							for _, info := range list {
+								if info.Pod.Name != p {
+									newList = append(newList, info)
+								}
+							}
+							queuedPodInfos[key] = newList
+						}
+						var newAllPods []*v1.Pod
+						for _, pod := range allPods {
+							if pod.Name != p {
+								newAllPods = append(newAllPods, pod)
+							}
+						}
+						allPods = newAllPods
+						for pgName, list := range pgPods {
+							var newList []*v1.Pod
+							for _, pod := range list {
+								if pod.Name != p {
+									newList = append(newList, pod)
+								}
+							}
+							pgPods[pgName] = newList
+						}
+					}
+
+					lock.Lock()
+					handledPods = make(map[string]*fwk.Status)
+					lock.Unlock()
+				}
+
+				for _, cpg := range phase.cpgs {
+					createCPG(t, cache, client, ns, &allCPGSpecs, cpg)
+				}
+
+				for _, pg := range phase.pgs {
+					createPG(t, cache, client, ns, &allPGSpecs, pg)
+				}
+
+				for _, cpg := range allCPGSpecs {
+					if cpg.parent == nil {
+						rootCPGName = cpg.name
+						break
+					}
+				}
+
+				createPods(phase.pods)
+
+				if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
+					t.Fatalf("Phase %d: Failed to update snapshot: %v", phaseIdx, err)
+				}
+
+				podGroupInfo := &framework.QueuedPodGroupInfo{
+					QueuedPodInfos: queuedPodInfos,
+					PodGroupInfo:   buildPodGroupInfo(rootCPGName),
+				}
+
+				podGroupCycleState := framework.NewCycleState()
+				podGroupCycleState.SetPodGroupCycleState(podGroupCycleState)
+
+				sched.podGroupCycle(ctx, schedFwk, podGroupCycleState, podGroupInfo, time.Now())
+
+				lock.Lock()
+				for _, p := range phase.wantSuccessPods {
+					if status, ok := handledPods[p]; ok {
+						t.Errorf("Phase %d: Expected pod %s to be scheduled successfully, but got error: %v", phaseIdx, p, status.AsError())
+					}
+				}
+
+				for _, p := range phase.wantFailPods {
+					if status, ok := handledPods[p]; !ok {
+						t.Errorf("Phase %d: Expected pod %s to fail scheduling, but it was scheduled successfully", phaseIdx, p)
+					} else if status.Code() == fwk.Success {
+						t.Errorf("Phase %d: Expected pod %s to fail scheduling, but got status Success", phaseIdx, p)
+					}
+				}
+				lock.Unlock()
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/sig scheduling 
/wg workload-aware-scheduling

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- Adds cycle detection and maximum tree depth validation when building CompositePodGroup hierarchy snapshots in [pkg/scheduler/backend/cache/cache.go](file:///usr/local/google/home/jdzikowski/gke-internal-kubernetes/src/k8s.io/multiple-placement-generators/pkg/scheduler/backend/cache/cache.go).
- Expands unit and scenario test coverage across cache snapshotting, scheduling queue, workload forest, and gang scheduling for CompositePodGroups.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-scheduler: added cycle detection and max tree depth validation when building composite pod group hierarchy snapshots in the scheduler cache.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/6012
```

#### AI was used to craft and iterate on the PR
