### PR TITLE
Do not get PVC for released volume

### DIFF
--- a/pkg/controller/volume/persistentvolume/delete_test.go
+++ b/pkg/controller/volume/persistentvolume/delete_test.go
@@ -236,6 +236,21 @@ func TestDeleteSync(t *testing.T) {
 			errors:          noerrors,
 			test:            wrapTestWithReclaimCalls(operationDelete, []error{nil}, testSyncVolume),
 		},
+		{
+			// A retained volume is already Released and its bound claim was
+			// deleted and recreated with the same name but a different UID. The
+			// controller must not re-check the recreated claim against the
+			// apiserver: doing so on every sync (every 15s per released PV) is
+			// pure load.
+			name:            "8-14 - released retained volume with recreated claim is not re-checked",
+			initialVolumes:  newVolumeArray("volume8-14", "1Gi", "uid8-14", "claim8-14", v1.VolumeReleased, v1.PersistentVolumeReclaimRetain, classEmpty, volume.AnnBoundByController),
+			expectedVolumes: newVolumeArray("volume8-14", "1Gi", "uid8-14", "claim8-14", v1.VolumeReleased, v1.PersistentVolumeReclaimRetain, classEmpty, volume.AnnBoundByController),
+			initialClaims:   newClaimArray("claim8-14", "uid8-14-x", "10Gi", "", v1.ClaimPending, nil),
+			expectedClaims:  newClaimArray("claim8-14", "uid8-14-x", "10Gi", "", v1.ClaimPending, nil),
+			expectedEvents:  noevents,
+			errors:          []pvtesting.ReactorError{{Verb: "get", Resource: "persistentvolumeclaims", Error: errors.New("unexpected GET of recreated claim for released volume")}},
+			test:            testSyncVolume,
+		},
 	}
 	runSyncTests(t, ctx, tests, []*storage.StorageClass{}, []*v1.Pod{})
 }

--- a/pkg/controller/volume/persistentvolume/delete_test.go
+++ b/pkg/controller/volume/persistentvolume/delete_test.go
@@ -235,6 +235,21 @@ func TestDeleteSync(t *testing.T) {
 			errors:          noerrors,
 			test:            wrapTestWithReclaimCalls(operationDelete, []error{nil}, testSyncVolume),
 		},
+		{
+			// A retained volume is already Released and its bound claim was
+			// deleted and recreated with the same name but a different UID. The
+			// controller must not re-check the recreated claim against the
+			// apiserver: doing so on every sync (every 15s per released PV) is
+			// pure load.
+			name:            "8-14 - released retained volume with recreated claim is not re-checked",
+			initialVolumes:  newVolumeArray("volume8-14", "1Gi", "uid8-14", "claim8-14", v1.VolumeReleased, v1.PersistentVolumeReclaimRetain, classEmpty, volume.AnnBoundByController),
+			expectedVolumes: newVolumeArray("volume8-14", "1Gi", "uid8-14", "claim8-14", v1.VolumeReleased, v1.PersistentVolumeReclaimRetain, classEmpty, volume.AnnBoundByController),
+			initialClaims:   newClaimArray("claim8-14", "uid8-14-x", "10Gi", "", v1.ClaimPending, nil),
+			expectedClaims:  newClaimArray("claim8-14", "uid8-14-x", "10Gi", "", v1.ClaimPending, nil),
+			expectedEvents:  noevents,
+			errors:          []pvtesting.ReactorError{{Verb: "get", Resource: "persistentvolumeclaims", Error: errors.New("unexpected GET of recreated claim for released volume")}},
+			test:            testSyncVolume,
+		},
 	}
 	runSyncTests(t, ctx, tests, []*storage.StorageClass{}, []*v1.Pod{})
 }

--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -604,61 +604,56 @@ func (ctrl *PersistentVolumeController) syncVolume(ctx context.Context, volume *
 		if err != nil {
 			return err
 		}
-		if !found {
-			// If the PV was created by an external PV provisioner or
-			// bound by external PV binder (e.g. kube-scheduler), it's
-			// possible under heavy load that the corresponding PVC is not synced to
-			// controller local cache yet. So we need to double-check PVC in
-			//   1) informer cache
-			//   2) apiserver if not found in informer cache
-			// to make sure we will not reclaim a PV wrongly.
-			// Note that only non-released and non-failed volumes will be
-			// updated to Released state when PVC does not exist.
-			if volume.Status.Phase != v1.VolumeReleased && volume.Status.Phase != v1.VolumeFailed {
-				obj, err = ctrl.claimLister.PersistentVolumeClaims(volume.Spec.ClaimRef.Namespace).Get(volume.Spec.ClaimRef.Name)
-				if err != nil && !apierrors.IsNotFound(err) {
-					return err
-				}
-				found = !apierrors.IsNotFound(err)
-				if !found {
-					obj, err = ctrl.kubeClient.CoreV1().PersistentVolumeClaims(volume.Spec.ClaimRef.Namespace).Get(ctx, volume.Spec.ClaimRef.Name, metav1.GetOptions{})
-					if err != nil && !apierrors.IsNotFound(err) {
-						return err
-					}
-					found = !apierrors.IsNotFound(err)
-				}
-			}
-		}
-		if !found {
-			logger.V(4).Info("Synchronizing PersistentVolume, claim not found", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name), "volumeName", volume.Name)
-			// Fall through with claim = nil
-		} else {
+		if found {
 			var ok bool
 			claim, ok = obj.(*v1.PersistentVolumeClaim)
 			if !ok {
-				return fmt.Errorf("cannot convert object from volume cache to volume %q!?: %#v", claim.Spec.VolumeName, obj)
+				return fmt.Errorf("cannot convert object from volume cache to claim %q!?: %#v", claimName, obj)
 			}
-			logger.V(4).Info("Synchronizing PersistentVolume, claim found", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name), "claimStatus", getClaimStatusForLogging(claim), "volumeName", volume.Name)
 		}
-		if claim != nil && claim.UID != volume.Spec.ClaimRef.UID {
-			// The claim that the PV was pointing to was deleted, and another
-			// with the same name created.
-			// in some cases, the cached claim is not the newest, and the volume.Spec.ClaimRef.UID is newer than cached.
-			// so we should double check by calling apiserver and get the newest claim, then compare them.
-			logger.V(4).Info("Maybe cached claim is not the newest one, we should fetch it from apiserver", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name))
-
-			claim, err = ctrl.kubeClient.CoreV1().PersistentVolumeClaims(volume.Spec.ClaimRef.Namespace).Get(ctx, volume.Spec.ClaimRef.Name, metav1.GetOptions{})
+		// discardStaleClaim drops the claim if it is not the one the PV is bound
+		// to: the claim the PV was pointing to was deleted and another one with the
+		// same name but a different UID was created. Note the apiserver Get below
+		// returns a non-nil empty claim (with an empty UID) on NotFound, which this
+		// treats as stale as well.
+		discardStaleClaim := func() {
+			if claim != nil && claim.UID != volume.Spec.ClaimRef.UID {
+				logger.V(4).Info("Synchronizing PersistentVolume, claim has a different UID than pv.ClaimRef, the bound one must have been deleted", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name), "volumeName", volume.Name)
+				claim = nil
+			}
+		}
+		discardStaleClaim()
+		// A released or failed volume was already reclaimed, so skip the
+		// double-check below - otherwise a retained PV bound to a recreated
+		// same-name PVC would GET it from the apiserver on every sync (15s).
+		alreadyReleased := volume.Status.Phase == v1.VolumeReleased || volume.Status.Phase == v1.VolumeFailed
+		if claim == nil && !alreadyReleased {
+			// If the PV was created by an external PV provisioner or
+			// bound by external PV binder (e.g. kube-scheduler), it's
+			// possible under heavy load that the corresponding PVC is not synced to
+			// controller local cache yet, or the cache holds a stale claim with an outdated UID.
+			// So we need to double-check PVC in
+			//   1) informer cache
+			//   2) apiserver if not confirmed by the informer cache
+			// to make sure we will not reclaim a PV wrongly.
+			claim, err = ctrl.claimLister.PersistentVolumeClaims(volume.Spec.ClaimRef.Namespace).Get(volume.Spec.ClaimRef.Name)
 			if err != nil && !apierrors.IsNotFound(err) {
 				return err
-			} else if claim != nil {
-				// Treat the volume as bound to a missing claim.
-				if claim.UID != volume.Spec.ClaimRef.UID {
-					logger.V(4).Info("Synchronizing PersistentVolume, claim has a newer UID than pv.ClaimRef, the old one must have been deleted", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name), "volumeName", volume.Name)
-					claim = nil
-				} else {
-					logger.V(4).Info("Synchronizing PersistentVolume, claim has a same UID with pv.ClaimRef", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name), "volumeName", volume.Name)
-				}
 			}
+			discardStaleClaim()
+			if claim == nil {
+				claim, err = ctrl.kubeClient.CoreV1().PersistentVolumeClaims(volume.Spec.ClaimRef.Namespace).Get(ctx, volume.Spec.ClaimRef.Name, metav1.GetOptions{})
+				if err != nil && !apierrors.IsNotFound(err) {
+					return err
+				}
+				discardStaleClaim()
+			}
+		}
+		if claim == nil {
+			logger.V(4).Info("Synchronizing PersistentVolume, claim not found", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name), "volumeName", volume.Name)
+			// Fall through with claim = nil
+		} else {
+			logger.V(4).Info("Synchronizing PersistentVolume, claim found", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name), "claimStatus", getClaimStatusForLogging(claim), "volumeName", volume.Name)
 		}
 
 		if claim == nil {
@@ -669,7 +664,7 @@ func (ctrl *PersistentVolumeController) syncVolume(ctx context.Context, volume *
 			// Do not overwrite previous Failed state - let the user see that
 			// something went wrong, while we still re-try to reclaim the
 			// volume.
-			if volume.Status.Phase != v1.VolumeReleased && volume.Status.Phase != v1.VolumeFailed {
+			if !alreadyReleased {
 				// Also, log this only once:
 				logger.V(2).Info("Volume is released and reclaim policy will be executed", "volumeName", volume.Name, "reclaimPolicy", volume.Spec.PersistentVolumeReclaimPolicy)
 				if volume, err = ctrl.updateVolumePhase(ctx, volume, v1.VolumeReleased, ""); err != nil {

--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -592,53 +592,45 @@ func (ctrl *PersistentVolumeController) syncVolume(ctx context.Context, volume *
 		logger.V(4).Info("Synchronizing PersistentVolume, volume is bound to claim", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name), "volumeName", volume.Name)
 		// Get the PVC by _name_
 		claimName := claimrefToClaimKey(volume.Spec.ClaimRef)
-		claim, err := ctrl.claims.Get(claimName)
-		if err != nil && !apierrors.IsNotFound(err) {
+		checkUID := func(claim *v1.PersistentVolumeClaim, err error) (*v1.PersistentVolumeClaim, error) {
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					return nil, nil
+				} else {
+					return nil, err
+				}
+			} else if volume.Spec.ClaimRef.UID != "" && claim.UID != volume.Spec.ClaimRef.UID {
+				logger.V(4).Info("Synchronizing PersistentVolume, claim has a different UID than pv.ClaimRef, the bound one must have been deleted", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name), "volumeName", volume.Name)
+				return nil, nil
+			} else {
+				return claim, nil
+			}
+		}
+		claim, err := checkUID(ctrl.claims.Get(claimName))
+		if err != nil {
 			return err
 		}
-		found := err == nil
-		if !found {
+		// A released or failed volume was already reclaimed, so skip the
+		// double-check below - otherwise a retained PV bound to a recreated
+		// same-name PVC would GET it from the apiserver on every sync (15s).
+		alreadyReleased := volume.Status.Phase == v1.VolumeReleased || volume.Status.Phase == v1.VolumeFailed
+		if claim == nil && !alreadyReleased {
 			// If the PV was created by an external PV provisioner or
 			// bound by external PV binder (e.g. kube-scheduler), it's
 			// possible under heavy load that the corresponding PVC is not synced to
-			// controller local cache yet. So we need to double-check PVC in apiserver
+			// controller local cache yet, or the cache holds a stale claim with an outdated UID.
+			// So we need to double-check PVC in apiserver
 			// to make sure we will not reclaim a PV wrongly.
-			// Note that only non-released and non-failed volumes will be
-			// updated to Released state when PVC does not exist.
-			if volume.Status.Phase != v1.VolumeReleased && volume.Status.Phase != v1.VolumeFailed {
-				claim, err = ctrl.kubeClient.CoreV1().PersistentVolumeClaims(volume.Spec.ClaimRef.Namespace).Get(ctx, volume.Spec.ClaimRef.Name, metav1.GetOptions{})
-				if err != nil && !apierrors.IsNotFound(err) {
-					return err
-				}
-				found = !apierrors.IsNotFound(err)
+			claim, err = checkUID(ctrl.kubeClient.CoreV1().PersistentVolumeClaims(volume.Spec.ClaimRef.Namespace).Get(ctx, volume.Spec.ClaimRef.Name, metav1.GetOptions{}))
+			if err != nil {
+				return err
 			}
 		}
-		if !found {
+		if claim == nil {
 			logger.V(4).Info("Synchronizing PersistentVolume, claim not found", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name), "volumeName", volume.Name)
-			claim = nil
 			// Fall through with claim = nil
 		} else {
 			logger.V(4).Info("Synchronizing PersistentVolume, claim found", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name), "claimStatus", getClaimStatusForLogging(claim), "volumeName", volume.Name)
-		}
-		if claim != nil && claim.UID != volume.Spec.ClaimRef.UID {
-			// The claim that the PV was pointing to was deleted, and another
-			// with the same name created.
-			// in some cases, the cached claim is not the newest, and the volume.Spec.ClaimRef.UID is newer than cached.
-			// so we should double check by calling apiserver and get the newest claim, then compare them.
-			logger.V(4).Info("Maybe cached claim is not the newest one, we should fetch it from apiserver", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name))
-
-			claim, err = ctrl.kubeClient.CoreV1().PersistentVolumeClaims(volume.Spec.ClaimRef.Namespace).Get(ctx, volume.Spec.ClaimRef.Name, metav1.GetOptions{})
-			if err != nil && !apierrors.IsNotFound(err) {
-				return err
-			} else if claim != nil {
-				// Treat the volume as bound to a missing claim.
-				if claim.UID != volume.Spec.ClaimRef.UID {
-					logger.V(4).Info("Synchronizing PersistentVolume, claim has a newer UID than pv.ClaimRef, the old one must have been deleted", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name), "volumeName", volume.Name)
-					claim = nil
-				} else {
-					logger.V(4).Info("Synchronizing PersistentVolume, claim has a same UID with pv.ClaimRef", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name), "volumeName", volume.Name)
-				}
-			}
 		}
 
 		if claim == nil {
@@ -649,7 +641,7 @@ func (ctrl *PersistentVolumeController) syncVolume(ctx context.Context, volume *
 			// Do not overwrite previous Failed state - let the user see that
 			// something went wrong, while we still re-try to reclaim the
 			// volume.
-			if volume.Status.Phase != v1.VolumeReleased && volume.Status.Phase != v1.VolumeFailed {
+			if !alreadyReleased {
 				// Also, log this only once:
 				logger.V(2).Info("Volume is released and reclaim policy will be executed", "volumeName", volume.Name, "reclaimPolicy", volume.Spec.PersistentVolumeReclaimPolicy)
 				if volume, err = ctrl.updateVolumePhase(ctx, volume, v1.VolumeReleased, ""); err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`syncVolume` looks up the bound PVC by _name_ only. When a Released or Failed PV references a PVC name that was deleted and recreated with a different UID — for example a **Retain** PV whose same-name PVC was recreated — the cached claim's UID differs from `pv.Spec.ClaimRef.UID`, which triggered a live PVC `GET` against the apiserver on every sync.

The PV controller re-enqueues **every** PV each `PVClaimBinderSyncPeriod` (default **15s**), and a Retain PV's `ClaimRef.UID` never changes, so every such released PV costs one PVC `GET` every 15s indefinitely — wasted API traffic that scales linearly with the number of such released PVs. This is the remaining half of #118545 (the PV-side GET was fixed in #134290; this is the PVC-side GET).

The double-check against the informer/apiserver only exists to avoid reclaiming a PV whose PVC has not yet synced to the controller's local cache. A volume that is already Released or Failed has already been reclaimed, so the check is unnecessary for it. This PR guards the double-check — **including** the UID-mismatch path, which previously had no such guard — with the same Released/Failed condition already used for the phase update.

While here, the two double-check paths (not-found and UID-mismatch) are merged into one that consults the informer lister before the apiserver in both cases. ~As a side benefit, a non-Released volume with a stale cached claim can now be confirmed straight from the informer without an apiserver GET.~
Update: since #140691 got merged, this PR is updated to take the fix from #140721. The check with informer is gone, since the new AssumeCache from #140691 is always up-to-date with informer.

Verified on a live cluster: before the fix, a Released Retain PV with a recreated same-name PVC produced exactly one KCM PVC GET every 15s (baseline was 0); after the fix, zero. A regression test (`8-14` in `delete_test.go`) injects a `get persistentvolumeclaims` error as a tripwire — it fails on the old code (the unnecessary GET fires) and passes with the fix.

#### Which issue(s) this PR is related to:

Fixes #118545

#### Special notes for your reviewer:

- This is a different bug from the PV-side GET that #134290 already fixed, with a smaller blast radius. That one ran in `deleteVolumeOperation` via `scheduleOperation` (one unbounded goroutine per PV), so N released Delete PVs fired ~N parallel `PersistentVolumes().Get()` calls that saturated the client-side rate limiter and starved writes — the throttled PUT in the original report. This PVC-side GET runs in the single `volumeWorker`, so it is serialized and does not starve writes or delay binding (binding happens in the separate `claimWorker`); it is simply steady wasted API traffic, one GET/15s per affected released PV.
- Behavior is otherwise preserved: `reclaimVolume()` still runs unconditionally on every sync (so failed Delete/Recycle ops keep retrying), and only the double-check GET and the `updateVolumePhase(Released)` are gated on `!alreadyReleased`.
- The lister-then-apiserver ordering and the "cached claim may be staler than `ClaimRef.UID`" race handling are retained — `discardStaleClaim()` runs after each lookup, so a stale-UID lister hit still falls through to the apiserver.
- Note the clientset `Get` returns a non-nil empty claim (empty UID) on NotFound, which `checkUID()` correctly treats as stale; the informer lister returns nil.

#### Does this PR introduce a user-facing change?

```release-note
kube-controller-manager: the PV controller no longer issues a PersistentVolumeClaim GET to the API server on every sync (every 15s by default) for a Released or Failed PersistentVolume whose bound PVC was deleted and recreated with the same name but a different UID. This reduces API traffic in clusters that accumulate such released PVs (e.g. retained PVs with recreated same-name PVCs).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
